### PR TITLE
liquidation and better error reporting for queued operations

### DIFF
--- a/solidity/contracts/peripherals/PriceOracleManagerAndOperatorQueuer.sol
+++ b/solidity/contracts/peripherals/PriceOracleManagerAndOperatorQueuer.sol
@@ -37,7 +37,7 @@ contract PriceOracleManagerAndOperatorQueuer {
 	OpenOracle public immutable openOracle;
 
 	event PriceReported(uint256 reportId, uint256 price);
-	event ExecutetedQueuedOperation(uint256 operationId, OperationType operation, bool success);
+	event ExecutetedQueuedOperation(uint256 operationId, OperationType operation, bool success, string errorMessage);
 
 	// operation queuing
 	uint256 public previousQueuedOperationId;
@@ -129,25 +129,25 @@ contract PriceOracleManagerAndOperatorQueuer {
 
 	function executeQueuedOperation(uint256 operationId) public {
 		require(queuedOperations[operationId].amount > 0, 'no such operation or already executed');
-		require(isPriceValid());
+		require(isPriceValid(), 'price is not valid to execute');
 		// todo, we should allow these operations here to fail, but solidity try catch doesnt work inside the same contract
 		if (queuedOperations[operationId].operation == OperationType.Liquidation) {
 			try securityPool.performLiquidation(queuedOperations[operationId].initiatorVault, queuedOperations[operationId].targetVault, queuedOperations[operationId].amount) {
-				emit ExecutetedQueuedOperation(operationId, queuedOperations[operationId].operation, true);
-			} catch {
-				emit ExecutetedQueuedOperation(operationId, queuedOperations[operationId].operation, false);
+				emit ExecutetedQueuedOperation(operationId, queuedOperations[operationId].operation, true, '');
+			} catch Error(string memory reason) {
+				emit ExecutetedQueuedOperation(operationId, queuedOperations[operationId].operation, false, reason);
 			}
 		} else if(queuedOperations[operationId].operation == OperationType.WithdrawRep) {
 			try securityPool.performWithdrawRep(queuedOperations[operationId].initiatorVault, queuedOperations[operationId].amount) {
-				emit ExecutetedQueuedOperation(operationId, queuedOperations[operationId].operation, true);
-			} catch {
-				emit ExecutetedQueuedOperation(operationId, queuedOperations[operationId].operation, false);
+				emit ExecutetedQueuedOperation(operationId, queuedOperations[operationId].operation, true, '');
+			} catch Error(string memory reason) {
+				emit ExecutetedQueuedOperation(operationId, queuedOperations[operationId].operation, false, reason);
 			}
 		} else {
 			try securityPool.performSetSecurityBondsAllowance(queuedOperations[operationId].initiatorVault, queuedOperations[operationId].amount) {
-				emit ExecutetedQueuedOperation(operationId, queuedOperations[operationId].operation, true);
-			} catch {
-				emit ExecutetedQueuedOperation(operationId, queuedOperations[operationId].operation, false);
+				emit ExecutetedQueuedOperation(operationId, queuedOperations[operationId].operation, true, '');
+			} catch Error(string memory reason) {
+				emit ExecutetedQueuedOperation(operationId, queuedOperations[operationId].operation, false, reason);
 			}
 		}
 		queuedOperations[operationId].amount = 0;

--- a/solidity/ts/testsuite/simulator/utils/peripheralsTestUtils.ts
+++ b/solidity/ts/testsuite/simulator/utils/peripheralsTestUtils.ts
@@ -63,7 +63,7 @@ export const triggerFork = async(client: WriteClient, mockWindow: MockWindowEthe
 	}
 }
 
-export const requestPrice = async(client: WriteClient, mockWindow: MockWindowEthereum, priceOracleManagerAndOperatorQueuer: `0x${ string }`, operation: OperationType, targetVault: `0x${ string }`, amount: bigint) => {
+export const requestPrice = async(client: WriteClient, mockWindow: MockWindowEthereum, priceOracleManagerAndOperatorQueuer: `0x${ string }`, operation: OperationType, targetVault: `0x${ string }`, amount: bigint, forceRepEthPriceTo: bigint = PRICE_PRECISION) => {
 	await requestPriceIfNeededAndQueueOperation(client, priceOracleManagerAndOperatorQueuer, operation, targetVault, amount)
 
 	const pendingReportId = await getPendingReportId(client, priceOracleManagerAndOperatorQueuer)
@@ -77,7 +77,7 @@ export const requestPrice = async(client: WriteClient, mockWindow: MockWindowEth
 
 	// initial report
 	const amount1 = reportMeta.exactToken1Report
-	const amount2 = amount1
+	const amount2 = amount1 * PRICE_PRECISION / forceRepEthPriceTo
 
 	const openOracle = getInfraContractAddresses().openOracle
 	await approveToken(client, addressString(GENESIS_REPUTATION_TOKEN), openOracle)
@@ -93,4 +93,6 @@ export const requestPrice = async(client: WriteClient, mockWindow: MockWindowEth
 
 	await openOracleSettle(client, pendingReportId)
 }
+
+export const canLiquidate = (lastPrice: bigint, securityBondAllowance: bigint, stakedRep: bigint, securityMultiplier: bigint) => securityBondAllowance * lastPrice * securityMultiplier > stakedRep * PRICE_PRECISION
 


### PR DESCRIPTION
- Now vaults can be liquidated by taking x% of debt out and x% rep out to a different vault
- emit errors on queued calls on failures