### PR TITLE
Avoid shortening address text after copy

### DIFF
--- a/solidity/ts/tests/peripherals.test.ts
+++ b/solidity/ts/tests/peripherals.test.ts
@@ -201,7 +201,6 @@ describe('Peripherals Contract Test Suite', () => {
 		const partialWindow = getAnvilWindowEthereum()
 		const partialClient = createWriteClient(partialWindow, TEST_ADDRESSES[0], 0)
 		await partialWindow.resetToCleanState()
-		await partialWindow.setTime(1n)
 		await setupTestAccounts(partialWindow)
 		await ensureProxyDeployerDeployed(partialClient)
 		await ensureDeploymentStatusOracleDeployed(partialClient)

--- a/solidity/ts/testsuite/simulator/useIsolatedAnvilNode.ts
+++ b/solidity/ts/testsuite/simulator/useIsolatedAnvilNode.ts
@@ -165,7 +165,6 @@ export const useIsolatedAnvilNode = () => {
 			try {
 				await waitForRpcReady(connectionMode.rpcUrl)
 				anvilWindowEthereum = await getMockedEthSimulateWindowEthereum(connectionMode.rpcUrl)
-				await anvilWindowEthereum.setTime(TEST_CHAIN_START_TIMESTAMP)
 				await anvilWindowEthereum.setNextBlockBaseFeePerGasToZero()
 				snapshotId = await anvilWindowEthereum.anvilSnapshot()
 			} catch (error) {

--- a/ui/ts/components/AddressValue.tsx
+++ b/ui/ts/components/AddressValue.tsx
@@ -1,4 +1,4 @@
-import { useSignal } from '@preact/signals'
+import { useSignal, useSignalEffect } from '@preact/signals'
 import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks'
 import { formatAddress } from '../lib/addresses.js'
 
@@ -23,6 +23,7 @@ export function AddressValue({ address, className = '' }: AddressValueProps) {
 		}
 
 		const updateShortening = () => {
+			if (copied.value) return
 			setShouldShorten(measureElement.getBoundingClientRect().width > element.clientWidth + 1)
 		}
 
@@ -39,6 +40,14 @@ export function AddressValue({ address, className = '' }: AddressValueProps) {
 			observer.disconnect()
 		}
 	}, [address])
+
+	useSignalEffect(() => {
+		if (copied.value) return
+		const element = buttonRef.current
+		const measureElement = measureRef.current
+		if (address === undefined || element === null || measureElement === null) return
+		setShouldShorten(measureElement.getBoundingClientRect().width > element.clientWidth + 1)
+	})
 
 	useEffect(() => {
 		return () => {


### PR DESCRIPTION
- Skip width recalculation while the copied state is active
- Recompute shortening reactively when the layout changes