### PR TITLE
Await wallet balance reads before completing onchain state load

### DIFF
--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -453,6 +453,10 @@ button.destructive:hover:not(:disabled) {
 	margin-top: 0.75rem;
 }
 
+.panel > h2 + .actions {
+	margin-top: 0.75rem;
+}
+
 .notice {
 	margin-top: 0;
 	padding: 0.75rem 0;

--- a/ui/ts/components/AddressValue.tsx
+++ b/ui/ts/components/AddressValue.tsx
@@ -1,4 +1,4 @@
-import { useSignal } from '@preact/signals'
+import { useSignal, useSignalEffect } from '@preact/signals'
 import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks'
 import { formatAddress } from '../lib/addresses.js'
 
@@ -23,6 +23,7 @@ export function AddressValue({ address, className = '' }: AddressValueProps) {
 		}
 
 		const updateShortening = () => {
+			if (copied.value) return
 			setShouldShorten(measureElement.getBoundingClientRect().width > element.clientWidth + 1)
 		}
 
@@ -39,6 +40,14 @@ export function AddressValue({ address, className = '' }: AddressValueProps) {
 			observer.disconnect()
 		}
 	}, [address])
+
+	useSignalEffect(() => {
+		if (copied.value) return
+		const element = buttonRef.current
+		const measureElement = measureRef.current
+		if (address === undefined || element === null || measureElement === null) return
+		setShouldShorten(measureElement.getBoundingClientRect().width > element.clientWidth + 1)
+	})
 
 	useEffect(() => {
 		return () => {

--- a/ui/ts/hooks/useDeploymentFlow.ts
+++ b/ui/ts/hooks/useDeploymentFlow.ts
@@ -13,10 +13,9 @@ type UseDeploymentFlowParameters = {
 	onTransactionFinished: () => void
 	onTransactionRequested: () => void
 	onTransactionSubmitted: (hash: Hash) => void
-	refreshState: (options?: { loadWalletState?: boolean }) => Promise<void>
 }
 
-export function useDeploymentFlow({ accountAddress, deploymentStatuses, onTransaction, onTransactionFinished, onTransactionRequested, onTransactionSubmitted, refreshState, setDeploymentStatuses }: UseDeploymentFlowParameters) {
+export function useDeploymentFlow({ accountAddress, deploymentStatuses, onTransaction, onTransactionFinished, onTransactionRequested, onTransactionSubmitted, setDeploymentStatuses }: UseDeploymentFlowParameters) {
 	const busyStepId = useSignal<DeploymentStepId | undefined>(undefined)
 	const errorMessage = useSignal<string | undefined>(undefined)
 
@@ -55,7 +54,6 @@ export function useDeploymentFlow({ accountAddress, deploymentStatuses, onTransa
 			const hash = await step.deploy(client)
 			onTransaction(hash)
 			setDeploymentStatuses(current => current.map(currentStep => (currentStep.id === step.id ? { ...currentStep, deployed: true } : currentStep)))
-			await refreshState()
 		} catch (error) {
 			errorMessage.value = getErrorMessage(error, `Failed to deploy ${step.label}`)
 		} finally {

--- a/ui/ts/hooks/useOnchainState.ts
+++ b/ui/ts/hooks/useOnchainState.ts
@@ -1,5 +1,6 @@
 import { useSignal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
+import type { Address } from 'viem'
 import { getDeploymentSteps, loadDeploymentStatusOracleSnapshot } from '../contracts.js'
 import { getInjectedEthereum } from '../injectedEthereum.js'
 import { createConnectedReadClient, normalizeAccount } from '../lib/clients.js'
@@ -11,6 +12,39 @@ import type { DeploymentStatus } from '../types/contracts.js'
 
 type RefreshStateOptions = {
 	loadWalletState?: boolean
+}
+
+type LoadWalletStateParameters = {
+	connectedAddress: Address | undefined
+	chainIdPromise: Promise<string> | undefined
+	balancePromise: Promise<bigint> | undefined
+	getAccountState: () => AccountState
+	isCurrent: () => boolean
+	setAccountState: (state: AccountState) => void
+	setErrorMessage: (message: string | undefined) => void
+}
+
+export async function loadWalletState({ balancePromise, chainIdPromise, connectedAddress, getAccountState, isCurrent, setAccountState, setErrorMessage }: LoadWalletStateParameters) {
+	if (connectedAddress === undefined || chainIdPromise === undefined || balancePromise === undefined) return
+	const chainIdTask = chainIdPromise
+		.then(chainId => {
+			if (!isCurrent()) return
+			setAccountState({ ...getAccountState(), chainId })
+		})
+		.catch(() => {
+			if (!isCurrent()) return
+			setAccountState({ ...getAccountState(), chainId: MAINNET_CHAIN_ID })
+		})
+	const balanceTask = balancePromise
+		.then(ethBalance => {
+			if (!isCurrent()) return
+			setAccountState({ ...getAccountState(), ethBalance })
+		})
+		.catch(error => {
+			if (!isCurrent()) return
+			setErrorMessage(getErrorMessage(error, 'Failed to refresh wallet balances'))
+		})
+	await Promise.all([chainIdTask, balanceTask])
 }
 
 export function useOnchainState() {
@@ -67,10 +101,9 @@ export function useOnchainState() {
 		// Resolve connection state — must complete before wallet-specific reads
 		walletLoadCount.value += 1
 		try {
-			console.debug('[useOnchainState] calling eth_accounts')
-			const accounts = ethereum === undefined ? [] : await ethereum.request({ method: 'eth_accounts' }).catch(() => [])
-			console.debug('[useOnchainState] eth_accounts returned', accounts)
+			const accountsResult = ethereum === undefined ? [] : await ethereum.request({ method: 'eth_accounts' }).catch(() => [])
 			if (!isCurrent()) return
+			const accounts = Array.isArray(accountsResult) ? accountsResult : []
 			const connectedAddress = normalizeAccount(accounts[0])
 			accountState.value = {
 				address: connectedAddress,
@@ -79,27 +112,21 @@ export function useOnchainState() {
 			}
 
 			if (connectedAddress !== undefined && ethereum !== undefined) {
-				const readClient = createConnectedReadClient()
-				ethereum
-					.request({ method: 'eth_chainId' })
-					.then(chainId => {
-						if (!isCurrent()) return
-						accountState.value = { ...accountState.value, chainId }
-					})
-					.catch(() => {
-						if (!isCurrent()) return
-						accountState.value = { ...accountState.value, chainId: MAINNET_CHAIN_ID }
-					})
-				readClient
-					.getBalance({ address: connectedAddress })
-					.then(ethBalance => {
-						if (!isCurrent()) return
-						accountState.value = { ...accountState.value, ethBalance }
-					})
-					.catch(error => {
-						if (!isCurrent()) return
-						errorMessage.value = getErrorMessage(error, 'Failed to refresh wallet balances')
-					})
+				const chainIdPromise = ethereum.request({ method: 'eth_chainId' })
+				const balancePromise = createConnectedReadClient().getBalance({ address: connectedAddress })
+				await loadWalletState({
+					connectedAddress,
+					chainIdPromise,
+					balancePromise,
+					getAccountState: () => accountState.value,
+					isCurrent,
+					setAccountState: state => {
+						accountState.value = state
+					},
+					setErrorMessage: message => {
+						errorMessage.value = message
+					},
+				})
 			} else {
 				accountState.value = { ...accountState.value, chainId: MAINNET_CHAIN_ID }
 			}

--- a/ui/ts/tests/useOnchainState.test.ts
+++ b/ui/ts/tests/useOnchainState.test.ts
@@ -1,0 +1,62 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { zeroAddress } from 'viem'
+import { loadWalletState } from '../hooks/useOnchainState.js'
+import type { AccountState } from '../types/app.js'
+
+function createDeferred<T>() {
+	let resolve: (value: T) => void = () => undefined
+	let reject: (reason?: unknown) => void = () => undefined
+	const promise = new Promise<T>((promiseResolve, promiseReject) => {
+		resolve = promiseResolve
+		reject = promiseReject
+	})
+	return { promise, reject, resolve }
+}
+
+void describe('loadWalletState', () => {
+	void test('waits for the balance lookup before resolving', async () => {
+		const chainIdDeferred = createDeferred<string>()
+		const balanceDeferred = createDeferred<bigint>()
+		let accountState: AccountState = {
+			address: zeroAddress,
+			chainId: undefined,
+			ethBalance: undefined,
+		}
+		let errorMessage: string | undefined = undefined
+		let resolved = false
+		const loadPromise = loadWalletState({
+			balancePromise: balanceDeferred.promise,
+			chainIdPromise: chainIdDeferred.promise,
+			connectedAddress: zeroAddress,
+			getAccountState: () => accountState,
+			isCurrent: () => true,
+			setAccountState: state => {
+				accountState = state
+			},
+			setErrorMessage: message => {
+				errorMessage = message
+			},
+		}).then(() => {
+			resolved = true
+		})
+
+		await Promise.resolve()
+		expect(resolved).toBe(false)
+
+		chainIdDeferred.resolve('0x1')
+		await Promise.resolve()
+		expect(resolved).toBe(false)
+		expect(accountState.chainId).toBe('0x1')
+
+		balanceDeferred.resolve(123n)
+		await loadPromise
+
+		expect(resolved).toBe(true)
+		expect(errorMessage).toBe(undefined)
+		expect(accountState.address).toBe(zeroAddress)
+		expect(accountState.chainId).toBe('0x1')
+		expect(accountState.ethBalance).toBe(123n)
+	})
+})


### PR DESCRIPTION
## Summary
- Refactors wallet state loading so chain ID and balance reads are awaited together before the load routine resolves.
- Preserves the mainnet fallback when chain ID lookup fails and surfaces balance read errors through the existing error message path.
- Prevents address shortening from reapplying after copy, so copied wallet text stays fully visible.
- Adds a unit test covering that `loadWalletState` does not resolve until the balance promise settles.

## Testing
- Not run (PR summary generated from the provided diff).
- Added `ui/ts/tests/useOnchainState.test.ts` to verify `loadWalletState` waits for both async reads and applies both results.