### PR TITLE
Refresh open oracle and timestamp UI metadata

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -36,7 +36,9 @@
       "Bash(python3:*)",
       "Bash(echo \"EXIT: $?\")",
       "Bash(echo \"BIOME_EXIT: $?\")",
-      "Bash(bun tsc:*)"
+      "Bash(bun tsc:*)",
+      "Bash(echo \"Exit: $?\")",
+      "Bash(echo \"Done: $?\")"
     ]
   }
 }

--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -579,6 +579,24 @@ button.currency-value.copyable:hover:not(:disabled) {
 	outline-offset: 2px;
 }
 
+.timestamp-value {
+	font: inherit;
+	color: inherit;
+}
+
+.timestamp-value.loading,
+.timestamp-value.unavailable,
+.timestamp-value.zero {
+	opacity: 0.72;
+}
+
+.timestamp-value-relative {
+	color: var(--muted);
+	font-weight: 400;
+	font-variant-numeric: tabular-nums;
+	white-space: nowrap;
+}
+
 .address-value.copyable {
 	border: 0;
 	padding: 0;

--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -125,6 +125,7 @@ export function App() {
 		openOracleInitialReportState,
 		openOracleReportDetails,
 		openOracleResult,
+		refreshPrice,
 		setOpenOracleCreateForm,
 		setOpenOracleForm,
 		settleReport,
@@ -330,6 +331,7 @@ export function App() {
 							onOpenLiquidationModal: (managerAddress, securityPoolAddress, vaultAddress) => openLiquidationModal(managerAddress, securityPoolAddress, vaultAddress),
 							onQueueLiquidation: (managerAddress, securityPoolAddress) => void queueLiquidation(managerAddress, securityPoolAddress),
 							loadingPoolOracleManager,
+							loadingSecurityPools,
 							onLoadPoolOracleManager: managerAddress => void loadPoolOracleManager(managerAddress),
 							onRequestPoolPrice: managerAddress => void requestPoolPrice(managerAddress),
 							onViewPendingReport: reportId => {
@@ -400,6 +402,7 @@ export function App() {
 						onCreateOpenOracleGame={() => void createOpenOracleGame()}
 						onDisputeReport={() => void disputeReport()}
 						onLoadOracleReport={reportId => void loadOracleReport(reportId)}
+						onRefreshPrice={refreshPrice}
 						onOpenOracleCreateFormChange={update => setOpenOracleCreateForm(current => ({ ...current, ...update }))}
 						onOpenOracleFormChange={update => setOpenOracleForm(current => ({ ...current, ...update }))}
 						onSettleReport={() => void settleReport()}

--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -28,9 +28,9 @@ import { isMainnetChain } from './lib/network.js'
 import { createInitialTransactionState, markTransactionFinished, markTransactionRequested, markTransactionSubmitted } from './lib/transactionState.js'
 import type { TransactionState } from './lib/transactionState.js'
 import { DEPLOY_ROUTE, OPEN_ORACLE_ROUTE, SECURITY_POOLS_ROUTE, ZOLTAR_ROUTE } from './lib/routing.js'
-import { formatTimestamp } from './lib/formatters.js'
 import { formatUniverseCollectionLabel, formatUniverseLabel } from './lib/universe.js'
 import { TransactionHashLink } from './components/TransactionHashLink.js'
+import { TimestampValue } from './components/TimestampValue.js'
 
 export function App() {
 	const transactionState = useSignal<TransactionState>(createInitialTransactionState())
@@ -484,7 +484,11 @@ export function App() {
 	return (
 		<main>
 			<div className='page-notices'>
-				{showZoltarUniverseForkedWarning && zoltarUniverse !== undefined ? <div className='notice error'>{`${formatUniverseLabel(zoltarUniverse.universeId)} has forked on ${formatTimestamp(zoltarUniverse.forkTime)}.`}</div> : undefined}
+				{showZoltarUniverseForkedWarning && zoltarUniverse !== undefined ? (
+					<div className='notice error'>
+						{formatUniverseLabel(zoltarUniverse.universeId)} has forked on <TimestampValue timestamp={zoltarUniverse.forkTime} />.
+					</div>
+				) : undefined}
 				{showAugurPlaceHolderDeploymentWarning ? <div className='notice error'>Augur PLACEHOLDER contracts are not deployed yet. Deploy them before the application works.</div> : undefined}
 				{hasInjectedWallet ? undefined : <p className='notice warning'>No injected wallet detected.</p>}
 				{errorMessage === undefined ? undefined : <p className='notice error'>{errorMessage}</p>}

--- a/ui/ts/components/AddressInfo.tsx
+++ b/ui/ts/components/AddressInfo.tsx
@@ -1,5 +1,6 @@
 import type { Address } from 'viem'
 import { AddressValue } from './AddressValue.js'
+import { MetricField } from './MetricField.js'
 
 type AddressInfoProps = {
 	address: Address | undefined
@@ -8,10 +9,5 @@ type AddressInfoProps = {
 }
 
 export function AddressInfo({ address, label, unavailableLabel = 'Unknown' }: AddressInfoProps) {
-	return (
-		<div>
-			<span className='metric-label'>{label}</span>
-			<strong>{address === undefined ? unavailableLabel : <AddressValue address={address} />}</strong>
-		</div>
-	)
+	return <MetricField label={label}>{address === undefined ? unavailableLabel : <AddressValue address={address} />}</MetricField>
 }

--- a/ui/ts/components/ChildUniverseDetails.tsx
+++ b/ui/ts/components/ChildUniverseDetails.tsx
@@ -1,4 +1,5 @@
 import { TimestampValue } from './TimestampValue.js'
+import { MetricField } from './MetricField.js'
 import type { ZoltarChildUniverseSummary } from '../types/contracts.js'
 
 type ChildUniverseDetailsProps = {
@@ -9,29 +10,13 @@ type ChildUniverseDetailsProps = {
 export function ChildUniverseDetails({ child, showOutcomeIndex = false }: ChildUniverseDetailsProps) {
 	return (
 		<div className='workflow-vault-grid'>
-			<div>
-				<span className='metric-label'>Outcome</span>
-				<strong>{child.outcomeLabel}</strong>
-			</div>
-			{showOutcomeIndex ? (
-				<div>
-					<span className='metric-label'>Outcome Index</span>
-					<strong>{child.outcomeIndex.toString()}</strong>
-				</div>
-			) : undefined}
-			{child.exists ? (
-				<div>
-					<span className='metric-label'>Reputation Token</span>
-					<strong>{child.reputationToken}</strong>
-				</div>
-			) : undefined}
+			<MetricField label='Outcome'>{child.outcomeLabel}</MetricField>
+			{showOutcomeIndex ? <MetricField label='Outcome Index'>{child.outcomeIndex.toString()}</MetricField> : undefined}
+			{child.exists ? <MetricField label='Reputation Token'>{child.reputationToken}</MetricField> : undefined}
 			{child.forkTime !== 0n ? (
-				<div>
-					<span className='metric-label'>Fork Time</span>
-					<strong>
-						<TimestampValue timestamp={child.forkTime} />
-					</strong>
-				</div>
+				<MetricField label='Fork Time'>
+					<TimestampValue timestamp={child.forkTime} />
+				</MetricField>
 			) : undefined}
 		</div>
 	)

--- a/ui/ts/components/ChildUniverseDetails.tsx
+++ b/ui/ts/components/ChildUniverseDetails.tsx
@@ -1,4 +1,4 @@
-import { formatTimestamp } from '../lib/formatters.js'
+import { TimestampValue } from './TimestampValue.js'
 import type { ZoltarChildUniverseSummary } from '../types/contracts.js'
 
 type ChildUniverseDetailsProps = {
@@ -28,7 +28,9 @@ export function ChildUniverseDetails({ child, showOutcomeIndex = false }: ChildU
 			{child.forkTime !== 0n ? (
 				<div>
 					<span className='metric-label'>Fork Time</span>
-					<strong>{formatTimestamp(child.forkTime)}</strong>
+					<strong>
+						<TimestampValue timestamp={child.forkTime} />
+					</strong>
 				</div>
 			) : undefined}
 		</div>

--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -5,7 +5,8 @@ import { LoadingText } from './LoadingText.js'
 import { Question } from './Question.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { UniverseLink } from './UniverseLink.js'
-import { formatDuration, formatTimestamp } from '../lib/formatters.js'
+import { TimestampValue } from './TimestampValue.js'
+import { formatDuration } from '../lib/formatters.js'
 import { AUCTION_TIME_SECONDS, estimateRepPurchased, getForkStageDescription, getOutcomeActionLabel, getSystemStateLabel, getTimeRemaining, MIGRATION_TIME_SECONDS } from '../lib/forkAuction.js'
 import { isMainnetChain } from '../lib/network.js'
 import { getReportingOutcomeLabel, REPORTING_OUTCOME_OPTIONS } from '../lib/reporting.js'
@@ -136,7 +137,7 @@ export function ForkAuctionSection({
 									</div>
 									<div>
 										<span className='metric-label'>Migration Ends</span>
-										<strong>{forkAuctionDetails.migrationEndsAt === undefined ? 'Started/finished' : formatTimestamp(forkAuctionDetails.migrationEndsAt)}</strong>
+										<strong>{forkAuctionDetails.migrationEndsAt === undefined ? 'Started/finished' : <TimestampValue timestamp={forkAuctionDetails.migrationEndsAt} />}</strong>
 									</div>
 									<div>
 										<span className='metric-label'>Migration Time Left</span>
@@ -157,11 +158,13 @@ export function ForkAuctionSection({
 										</div>
 										<div>
 											<span className='metric-label'>Started</span>
-											<strong>{formatTimestamp(forkAuctionDetails.truthAuctionStartedAt)}</strong>
+											<strong>
+												<TimestampValue timestamp={forkAuctionDetails.truthAuctionStartedAt} />
+											</strong>
 										</div>
 										<div>
 											<span className='metric-label'>Ends</span>
-											<strong>{auctionWindow === undefined ? 'Not started' : formatTimestamp(auctionWindow.endsAt)}</strong>
+											<strong>{auctionWindow === undefined ? 'Not started' : <TimestampValue timestamp={auctionWindow.endsAt} />}</strong>
 										</div>
 										<div>
 											<span className='metric-label'>Time Left</span>

--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -2,6 +2,7 @@ import { AddressValue } from './AddressValue.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { EnumDropdown } from './EnumDropdown.js'
 import { LoadingText } from './LoadingText.js'
+import { MetricField } from './MetricField.js'
 import { Question } from './Question.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { UniverseLink } from './UniverseLink.js'
@@ -9,7 +10,7 @@ import { TimestampValue } from './TimestampValue.js'
 import { formatDuration } from '../lib/formatters.js'
 import { AUCTION_TIME_SECONDS, estimateRepPurchased, getForkStageDescription, getOutcomeActionLabel, getSystemStateLabel, getTimeRemaining, MIGRATION_TIME_SECONDS } from '../lib/forkAuction.js'
 import { isMainnetChain } from '../lib/network.js'
-import { getReportingOutcomeLabel, REPORTING_OUTCOME_OPTIONS } from '../lib/reporting.js'
+import { REPORTING_OUTCOME_DROPDOWN_OPTIONS, getReportingOutcomeLabel } from '../lib/reporting.js'
 import type { ForkAuctionSectionProps } from '../types/components.js'
 
 function getTruthAuctionWindow(details: ForkAuctionSectionProps['forkAuctionDetails']) {
@@ -113,36 +114,18 @@ export function ForkAuctionSection({
 							<div className='status-card'>
 								<p className='panel-label'>Fork Metrics</p>
 								<div className='escalation-metrics'>
-									<div>
-										<span className='metric-label'>REP At Fork</span>
-										<strong>
-											<CurrencyValue value={forkAuctionDetails.repAtFork} suffix='REP' />
-										</strong>
-									</div>
-									<div>
-										<span className='metric-label'>Migrated REP</span>
-										<strong>
-											<CurrencyValue value={forkAuctionDetails.migratedRep} suffix='REP' />
-										</strong>
-									</div>
-									<div>
-										<span className='metric-label'>Collateral</span>
-										<strong>
-											<CurrencyValue value={forkAuctionDetails.completeSetCollateralAmount} suffix='REP' />
-										</strong>
-									</div>
-									<div>
-										<span className='metric-label'>Fork Type</span>
-										<strong>{forkAuctionDetails.forkOwnSecurityPool ? 'Own escalation fork' : 'Parent/Zoltar fork'}</strong>
-									</div>
-									<div>
-										<span className='metric-label'>Migration Ends</span>
-										<strong>{forkAuctionDetails.migrationEndsAt === undefined ? 'Started/finished' : <TimestampValue timestamp={forkAuctionDetails.migrationEndsAt} />}</strong>
-									</div>
-									<div>
-										<span className='metric-label'>Migration Time Left</span>
-										<strong>{migrationTimeRemaining === undefined ? formatDuration(MIGRATION_TIME_SECONDS) : formatDuration(migrationTimeRemaining)}</strong>
-									</div>
+									<MetricField label='REP At Fork'>
+										<CurrencyValue value={forkAuctionDetails.repAtFork} suffix='REP' />
+									</MetricField>
+									<MetricField label='Migrated REP'>
+										<CurrencyValue value={forkAuctionDetails.migratedRep} suffix='REP' />
+									</MetricField>
+									<MetricField label='Collateral'>
+										<CurrencyValue value={forkAuctionDetails.completeSetCollateralAmount} suffix='REP' />
+									</MetricField>
+									<MetricField label='Fork Type'>{forkAuctionDetails.forkOwnSecurityPool ? 'Own escalation fork' : 'Parent/Zoltar fork'}</MetricField>
+									<MetricField label='Migration Ends'>{forkAuctionDetails.migrationEndsAt === undefined ? 'Started/finished' : <TimestampValue timestamp={forkAuctionDetails.migrationEndsAt} />}</MetricField>
+									<MetricField label='Migration Time Left'>{migrationTimeRemaining === undefined ? formatDuration(MIGRATION_TIME_SECONDS) : formatDuration(migrationTimeRemaining)}</MetricField>
 								</div>
 							</div>
 
@@ -150,56 +133,26 @@ export function ForkAuctionSection({
 								<div className='status-card'>
 									<p className='panel-label'>Truth Auction</p>
 									<div className='escalation-metrics'>
-										<div>
-											<span className='metric-label'>Auction Address</span>
-											<strong>
-												<AddressValue address={forkAuctionDetails.truthAuctionAddress} />
-											</strong>
-										</div>
-										<div>
-											<span className='metric-label'>Started</span>
-											<strong>
-												<TimestampValue timestamp={forkAuctionDetails.truthAuctionStartedAt} />
-											</strong>
-										</div>
-										<div>
-											<span className='metric-label'>Ends</span>
-											<strong>{auctionWindow === undefined ? 'Not started' : <TimestampValue timestamp={auctionWindow.endsAt} />}</strong>
-										</div>
-										<div>
-											<span className='metric-label'>Time Left</span>
-											<strong>{forkAuctionDetails.truthAuction.timeRemaining === undefined ? formatDuration(AUCTION_TIME_SECONDS) : formatDuration(forkAuctionDetails.truthAuction.timeRemaining)}</strong>
-										</div>
-										<div>
-											<span className='metric-label'>ETH Raised / Cap</span>
-											<strong>
-												<CurrencyValue value={forkAuctionDetails.truthAuction.ethRaised} suffix='ETH' /> / <CurrencyValue value={forkAuctionDetails.truthAuction.ethRaiseCap} suffix='ETH' />
-											</strong>
-										</div>
-										<div>
-											<span className='metric-label'>REP Purchased</span>
-											<strong>
-												<CurrencyValue value={forkAuctionDetails.truthAuction.totalRepPurchased} suffix='REP' />
-											</strong>
-										</div>
-										<div>
-											<span className='metric-label'>Clearing Tick</span>
-											<strong>{forkAuctionDetails.truthAuction.clearingTick?.toString() ?? 'Unavailable'}</strong>
-										</div>
-										<div>
-											<span className='metric-label'>Clearing Price</span>
-											<strong>
-												<CurrencyValue value={forkAuctionDetails.truthAuction.clearingPrice} suffix='REP' />
-											</strong>
-										</div>
-										<div>
-											<span className='metric-label'>Underfunded</span>
-											<strong>{forkAuctionDetails.truthAuction.underfunded ? 'Yes' : 'No'}</strong>
-										</div>
-										<div>
-											<span className='metric-label'>Finalized</span>
-											<strong>{forkAuctionDetails.truthAuction.finalized ? 'Yes' : 'No'}</strong>
-										</div>
+										<MetricField label='Auction Address'>
+											<AddressValue address={forkAuctionDetails.truthAuctionAddress} />
+										</MetricField>
+										<MetricField label='Started'>
+											<TimestampValue timestamp={forkAuctionDetails.truthAuctionStartedAt} />
+										</MetricField>
+										<MetricField label='Ends'>{auctionWindow === undefined ? 'Not started' : <TimestampValue timestamp={auctionWindow.endsAt} />}</MetricField>
+										<MetricField label='Time Left'>{forkAuctionDetails.truthAuction.timeRemaining === undefined ? formatDuration(AUCTION_TIME_SECONDS) : formatDuration(forkAuctionDetails.truthAuction.timeRemaining)}</MetricField>
+										<MetricField label='ETH Raised / Cap'>
+											<CurrencyValue value={forkAuctionDetails.truthAuction.ethRaised} suffix='ETH' /> / <CurrencyValue value={forkAuctionDetails.truthAuction.ethRaiseCap} suffix='ETH' />
+										</MetricField>
+										<MetricField label='REP Purchased'>
+											<CurrencyValue value={forkAuctionDetails.truthAuction.totalRepPurchased} suffix='REP' />
+										</MetricField>
+										<MetricField label='Clearing Tick'>{forkAuctionDetails.truthAuction.clearingTick?.toString() ?? 'Unavailable'}</MetricField>
+										<MetricField label='Clearing Price'>
+											<CurrencyValue value={forkAuctionDetails.truthAuction.clearingPrice} suffix='REP' />
+										</MetricField>
+										<MetricField label='Underfunded'>{forkAuctionDetails.truthAuction.underfunded ? 'Yes' : 'No'}</MetricField>
+										<MetricField label='Finalized'>{forkAuctionDetails.truthAuction.finalized ? 'Yes' : 'No'}</MetricField>
 									</div>
 									<p className='detail'>At the current clearing price, the entered bid amount would buy roughly {estimatedRep === undefined ? 'Unavailable' : <CurrencyValue value={estimatedRep} suffix='REP' />} ownership if it clears.</p>
 								</div>
@@ -241,7 +194,7 @@ export function ForkAuctionSection({
 
 						<label className='field'>
 							<span>Outcome</span>
-							<EnumDropdown options={REPORTING_OUTCOME_OPTIONS.map(option => ({ value: option.key, label: option.label }))} value={forkAuctionForm.selectedOutcome} onChange={selectedOutcome => onForkAuctionFormChange({ selectedOutcome })} />
+							<EnumDropdown options={REPORTING_OUTCOME_DROPDOWN_OPTIONS} value={forkAuctionForm.selectedOutcome} onChange={selectedOutcome => onForkAuctionFormChange({ selectedOutcome })} />
 						</label>
 
 						<label className='field'>

--- a/ui/ts/components/ForkZoltarSection.tsx
+++ b/ui/ts/components/ForkZoltarSection.tsx
@@ -2,7 +2,9 @@ import type { Address } from 'viem'
 import { CurrencyValue } from './CurrencyValue.js'
 import { EntityCard } from './EntityCard.js'
 import { LoadingText } from './LoadingText.js'
+import { MetricField } from './MetricField.js'
 import { Question } from './Question.js'
+import { sameCaseInsensitiveText } from '../lib/caseInsensitive.js'
 import type { MarketDetails, ZoltarUniverseSummary } from '../types/contracts.js'
 
 type ForkZoltarSectionProps = {
@@ -50,7 +52,7 @@ export function ForkZoltarSection({
 	const hasEnoughRep = rootUniverse !== undefined && zoltarForkRepBalance !== undefined && zoltarForkRepBalance >= rootUniverse.forkThreshold
 	const hasEnoughApproval = rootUniverse !== undefined && zoltarForkAllowance !== undefined && zoltarForkAllowance >= rootUniverse.forkThreshold
 	const selectedQuestionId = zoltarForkQuestionId.trim()
-	const selectedQuestion = selectedQuestionId === '' ? undefined : zoltarQuestions.find(question => question.questionId.toLowerCase() === selectedQuestionId.toLowerCase())
+	const selectedQuestion = selectedQuestionId === '' ? undefined : zoltarQuestions.find(question => sameCaseInsensitiveText(question.questionId, selectedQuestionId))
 	const showMissingQuestionMessage = !loadingZoltarQuestions && selectedQuestionId !== '' && selectedQuestion === undefined
 	const canFork = accountAddress !== undefined && isMainnet && rootUniverse !== undefined && !hasForked && !zoltarForkPending && selectedQuestion !== undefined && hasEnoughRep && hasEnoughApproval
 
@@ -69,18 +71,12 @@ export function ForkZoltarSection({
 		<>
 			<EntityCard title='Fork Zoltar' badge={hasForked ? <span className='badge blocked'>Forked</span> : undefined}>
 				<div className='workflow-metric-grid'>
-					<div>
-						<span className='metric-label'>Fork Threshold</span>
-						<strong>
-							<CurrencyValue loading={loadingZoltarForkAccess || rootUniverse === undefined} value={rootUniverse?.forkThreshold} suffix='REP' />
-						</strong>
-					</div>
-					<div>
-						<span className='metric-label'>REP Approved To Zoltar</span>
-						<strong>
-							<CurrencyValue loading={loadingZoltarForkAccess} value={zoltarForkAllowance} suffix='REP' />
-						</strong>
-					</div>
+					<MetricField label='Fork Threshold'>
+						<CurrencyValue loading={loadingZoltarForkAccess || rootUniverse === undefined} value={rootUniverse?.forkThreshold} suffix='REP' />
+					</MetricField>
+					<MetricField label='REP Approved To Zoltar'>
+						<CurrencyValue loading={loadingZoltarForkAccess} value={zoltarForkAllowance} suffix='REP' />
+					</MetricField>
 				</div>
 
 				<div className='form-grid'>

--- a/ui/ts/components/MarketCreateQuestionSection.tsx
+++ b/ui/ts/components/MarketCreateQuestionSection.tsx
@@ -4,8 +4,9 @@ import { EnumDropdown, type EnumDropdownOption } from './EnumDropdown.js'
 import { EntityCard } from './EntityCard.js'
 import { FormInput } from './FormInput.js'
 import { LoadingText } from './LoadingText.js'
-import { Question } from './Question.js'
+import { Question, getQuestionTitle } from './Question.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
+import { MetricField } from './MetricField.js'
 import { validateMarketForm } from '../lib/marketCreation.js'
 import { clampScalarTickIndex, parseScalarFormInputs } from '../lib/scalarOutcome.js'
 import type { MarketFormState } from '../types/app.js'
@@ -52,7 +53,7 @@ export function MarketCreateQuestionSection({ accountAddress, hasForked, isMainn
 	const selectedQuestionDetails = useMemo(() => (marketResult === undefined ? undefined : zoltarQuestions.find(question => question.questionId === marketResult.questionId)), [marketResult?.questionId, zoltarQuestions])
 	const scalarCreatePreviewDetails = getScalarCreatePreviewDetails(marketForm)
 	const marketFormValidation = validateMarketForm(marketForm)
-	const selectedQuestionTitle = selectedQuestionDetails === undefined ? 'Question' : typeof selectedQuestionDetails.title !== 'string' || selectedQuestionDetails.title.trim() === '' ? 'Untitled question' : selectedQuestionDetails.title
+	const selectedQuestionTitle = selectedQuestionDetails === undefined ? 'Question' : getQuestionTitle(selectedQuestionDetails)
 
 	useEffect(() => {
 		if (scalarCreatePreviewDetails === undefined) return
@@ -109,12 +110,9 @@ export function MarketCreateQuestionSection({ accountAddress, hasForked, isMainn
 				>
 					<div className='question-preview-body'>
 						{selectedQuestionDetails === undefined ? <p className='detail'>Question details are not loaded yet.</p> : <Question question={selectedQuestionDetails} showTitle={false} />}
-						<div>
-							<span className='metric-label'>Creation transaction hash</span>
-							<strong>
-								<TransactionHashLink hash={marketResult.createQuestionHash} />
-							</strong>
-						</div>
+						<MetricField label='Creation transaction hash'>
+							<TransactionHashLink hash={marketResult.createQuestionHash} />
+						</MetricField>
 					</div>
 				</EntityCard>
 			)}

--- a/ui/ts/components/MarketOverviewSection.tsx
+++ b/ui/ts/components/MarketOverviewSection.tsx
@@ -7,6 +7,7 @@ import { ChildUniversesSection } from './ChildUniversesSection.js'
 import { LoadingText } from './LoadingText.js'
 import { LoadableValue } from './LoadableValue.js'
 import { Question } from './Question.js'
+import { MetricField } from './MetricField.js'
 import { ScalarDeploymentSection } from './ScalarDeploymentSection.js'
 import { TimestampValue } from './TimestampValue.js'
 import { formatUniverseCollectionLabel } from '../lib/universe.js'
@@ -54,34 +55,22 @@ export function MarketOverviewSection({ accountAddress, isMainnet, loadingZoltar
 					<div className='workflow-question-grid market-overview-grid'>
 						{hasForked ? (
 							<>
-								<div>
-									<span className='metric-label'>Fork Time</span>
-									<strong>
-										<LoadableValue loading={loadingZoltarUniverse} placeholder='Loading...'>
-											<TimestampValue timestamp={rootUniverse.forkTime} />
-										</LoadableValue>
-									</strong>
-								</div>
-								<div>
-									<span className='metric-label'>Fork Threshold</span>
-									<strong>
-										<CurrencyValue value={rootUniverse.forkThreshold} suffix='REP' />
-									</strong>
-								</div>
+								<MetricField label='Fork Time'>
+									<LoadableValue loading={loadingZoltarUniverse} placeholder='Loading...'>
+										<TimestampValue timestamp={rootUniverse.forkTime} />
+									</LoadableValue>
+								</MetricField>
+								<MetricField label='Fork Threshold'>
+									<CurrencyValue value={rootUniverse.forkThreshold} suffix='REP' />
+								</MetricField>
 							</>
 						) : undefined}
-						<div>
-							<span className='metric-label'>Reputation Token</span>
-							<strong>
-								<AddressValue address={rootUniverse.reputationToken} />
-							</strong>
-						</div>
-						<div>
-							<span className='metric-label'>Total Theoretical Supply</span>
-							<strong>
-								<CurrencyValue value={rootUniverse.totalTheoreticalSupply} suffix='REP' />
-							</strong>
-						</div>
+						<MetricField label='Reputation Token'>
+							<AddressValue address={rootUniverse.reputationToken} />
+						</MetricField>
+						<MetricField label='Total Theoretical Supply'>
+							<CurrencyValue value={rootUniverse.totalTheoreticalSupply} suffix='REP' />
+						</MetricField>
 					</div>
 					{isScalarFork ? (
 						<ScalarDeploymentSection

--- a/ui/ts/components/MarketOverviewSection.tsx
+++ b/ui/ts/components/MarketOverviewSection.tsx
@@ -8,7 +8,7 @@ import { LoadingText } from './LoadingText.js'
 import { LoadableValue } from './LoadableValue.js'
 import { Question } from './Question.js'
 import { ScalarDeploymentSection } from './ScalarDeploymentSection.js'
-import { formatTimestamp } from '../lib/formatters.js'
+import { TimestampValue } from './TimestampValue.js'
 import { formatUniverseCollectionLabel } from '../lib/universe.js'
 import type { ZoltarUniverseSummary } from '../types/contracts.js'
 
@@ -58,7 +58,7 @@ export function MarketOverviewSection({ accountAddress, isMainnet, loadingZoltar
 									<span className='metric-label'>Fork Time</span>
 									<strong>
 										<LoadableValue loading={loadingZoltarUniverse} placeholder='Loading...'>
-											{formatTimestamp(rootUniverse.forkTime)}
+											<TimestampValue timestamp={rootUniverse.forkTime} />
 										</LoadableValue>
 									</strong>
 								</div>

--- a/ui/ts/components/MarketQuestionsSection.tsx
+++ b/ui/ts/components/MarketQuestionsSection.tsx
@@ -1,6 +1,6 @@
 import { EntityCard } from './EntityCard.js'
 import { LoadingText } from './LoadingText.js'
-import { Question } from './Question.js'
+import { Question, getQuestionTitle } from './Question.js'
 import type { MarketDetails } from '../types/contracts.js'
 
 type MarketQuestionsSectionProps = {
@@ -19,10 +19,6 @@ type MarketQuestionsSectionProps = {
 export function MarketQuestionsSection({ hasForked, hasLoadedZoltarQuestions, loadingZoltarQuestionCount, loadingZoltarQuestions, onLoadZoltarQuestions, onOpenForkTab, onUseQuestionForFork, onUseQuestionForPool, zoltarQuestionCount, zoltarQuestions }: MarketQuestionsSectionProps) {
 	const questionCountBadge = zoltarQuestionCount === undefined ? undefined : `${zoltarQuestionCount.toString()} questions`
 	const noQuestionsAvailable = zoltarQuestionCount === 0n
-
-	function getQuestionTitle(question: MarketDetails) {
-		return question.title.trim() === '' ? 'Untitled question' : question.title
-	}
 
 	return (
 		<EntityCard

--- a/ui/ts/components/MarketSection.tsx
+++ b/ui/ts/components/MarketSection.tsx
@@ -5,22 +5,11 @@ import { MarketOverviewSection } from './MarketOverviewSection.js'
 import { MarketQuestionsSection } from './MarketQuestionsSection.js'
 import { ZoltarMigrationSection } from './ZoltarMigrationSection.js'
 import { isMainnetChain } from '../lib/network.js'
+import { resolveEnumValue } from '../lib/viewState.js'
 import { readZoltarViewQueryParam, writeZoltarViewQueryParam } from '../lib/urlParams.js'
 import type { MarketSectionProps } from '../types/components.js'
 
 type ZoltarView = 'questions' | 'create' | 'fork' | 'migrate'
-
-function getZoltarView(value: string | undefined): ZoltarView {
-	switch (value) {
-		case 'questions':
-		case 'create':
-		case 'fork':
-		case 'migrate':
-			return value
-		default:
-			return 'questions'
-	}
-}
 
 export function MarketSection({
 	accountState,
@@ -65,7 +54,7 @@ export function MarketSection({
 	zoltarUniverse,
 	zoltarUniverseMissing,
 }: MarketSectionProps) {
-	const [view, setView] = useState<ZoltarView>(() => getZoltarView(readZoltarViewQueryParam(window.location.search)))
+	const [view, setView] = useState<ZoltarView>(() => resolveEnumValue<ZoltarView>(readZoltarViewQueryParam(window.location.search), 'questions', ['questions', 'create', 'fork', 'migrate']))
 	const hasForked = zoltarUniverse?.hasForked === true
 	const isMainnet = isMainnetChain(accountState.chainId)
 

--- a/ui/ts/components/MetricField.tsx
+++ b/ui/ts/components/MetricField.tsx
@@ -1,0 +1,17 @@
+import type { ComponentChildren } from 'preact'
+
+type MetricFieldProps = {
+	children: ComponentChildren
+	className?: string | undefined
+	label: ComponentChildren
+	valueClassName?: string | undefined
+}
+
+export function MetricField({ children, className = '', label, valueClassName = '' }: MetricFieldProps) {
+	return (
+		<div className={className === '' ? undefined : className}>
+			<span className='metric-label'>{label}</span>
+			<strong className={valueClassName === '' ? undefined : valueClassName}>{children}</strong>
+		</div>
+	)
+}

--- a/ui/ts/components/OpenOracleSection.tsx
+++ b/ui/ts/components/OpenOracleSection.tsx
@@ -6,29 +6,24 @@ import { CurrencyValue } from './CurrencyValue.js'
 import { EntityCard } from './EntityCard.js'
 import { EnumDropdown, type EnumDropdownOption } from './EnumDropdown.js'
 import { LoadingText } from './LoadingText.js'
+import { MetricField } from './MetricField.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { TimestampValue } from './TimestampValue.js'
 import { createConnectedReadClient } from '../lib/clients.js'
 import { deriveOpenOracleInitialReportSubmissionDetails, formatOpenOracleFeePercentage, formatOpenOracleMultiplier, getOpenOracleReportStatus, getOpenOracleReportStatusTone, getOpenOracleSelectedReportActionMode, type OpenOracleSelectedReportActionMode } from '../lib/openOracle.js'
 import { loadOpenOracleReportSummaries } from '../contracts.js'
+import { resolveFirstMatchingValue } from '../lib/viewState.js'
 import type { OpenOracleFormState } from '../types/app.js'
 import type { OpenOracleReportDetails, OpenOracleReportSummary, OpenOracleReportSummaryPage } from '../types/contracts.js'
 import type { OpenOracleSectionProps, OpenOracleView } from '../types/components.js'
 
 const BROWSE_PAGE_SIZE = 10
 
-function getInitialOpenOracleView({ openOracleForm, initialView }: { openOracleForm: OpenOracleFormState; initialView: OpenOracleView | undefined }): OpenOracleView {
-	if (initialView !== undefined) return initialView
-	if (openOracleForm.reportId !== '') return 'selected-report'
-	return 'browse'
-}
-
 function renderReportField(label: string, value: ComponentChildren) {
 	return (
-		<div key={label}>
-			<span className='metric-label'>{label}</span>
-			<strong>{value}</strong>
-		</div>
+		<MetricField key={label} label={label}>
+			{value}
+		</MetricField>
 	)
 }
 
@@ -121,30 +116,18 @@ function renderSelectedReportActionSection(
 							Price source: <strong>{openOracleInitialReportState.loading ? 'Loading...' : initialReportSubmission.priceSource}</strong>
 						</p>
 						<div className='question-summary-grid'>
-							<div>
-								<span className='metric-label'>{`Required ${token1Symbol}`}</span>
-								<strong>
-									<CurrencyValue value={initialReportSubmission.amount1} units={initialReportSubmission.token1Decimals ?? 18} suffix={token1Symbol} copyable={false} />
-								</strong>
-							</div>
-							<div>
-								<span className='metric-label'>{`Required ${token2Symbol}`}</span>
-								<strong>
-									<CurrencyValue value={initialReportSubmission.amount2} units={initialReportSubmission.token2Decimals ?? 18} suffix={token2Symbol} copyable={false} />
-								</strong>
-							</div>
-							<div>
-								<span className='metric-label'>{`Approved ${token1Symbol}`}</span>
-								<strong>
-									<CurrencyValue value={initialReportSubmission.approvedToken1Amount} units={initialReportSubmission.token1Decimals ?? 18} suffix={token1Symbol} copyable={false} />
-								</strong>
-							</div>
-							<div>
-								<span className='metric-label'>{`Approved ${token2Symbol}`}</span>
-								<strong>
-									<CurrencyValue value={initialReportSubmission.approvedToken2Amount} units={initialReportSubmission.token2Decimals ?? 18} suffix={token2Symbol} copyable={false} />
-								</strong>
-							</div>
+							<MetricField label={`Required ${token1Symbol}`}>
+								<CurrencyValue value={initialReportSubmission.amount1} units={initialReportSubmission.token1Decimals ?? 18} suffix={token1Symbol} copyable={false} />
+							</MetricField>
+							<MetricField label={`Required ${token2Symbol}`}>
+								<CurrencyValue value={initialReportSubmission.amount2} units={initialReportSubmission.token2Decimals ?? 18} suffix={token2Symbol} copyable={false} />
+							</MetricField>
+							<MetricField label={`Approved ${token1Symbol}`}>
+								<CurrencyValue value={initialReportSubmission.approvedToken1Amount} units={initialReportSubmission.token1Decimals ?? 18} suffix={token1Symbol} copyable={false} />
+							</MetricField>
+							<MetricField label={`Approved ${token2Symbol}`}>
+								<CurrencyValue value={initialReportSubmission.approvedToken2Amount} units={initialReportSubmission.token2Decimals ?? 18} suffix={token2Symbol} copyable={false} />
+							</MetricField>
 						</div>
 						<div className='field-row'>
 							<label className='field'>
@@ -498,7 +481,15 @@ export function OpenOracleSection({
 	openOracleResult,
 	initialView,
 }: OpenOracleSectionProps) {
-	const [view, setView] = useState<OpenOracleView>(() => getInitialOpenOracleView({ openOracleForm, initialView }))
+	const [view, setView] = useState<OpenOracleView>(() =>
+		resolveFirstMatchingValue<OpenOracleView>(
+			[
+				[initialView !== undefined, initialView ?? 'browse'],
+				[openOracleForm.reportId !== '', 'selected-report'],
+			],
+			'browse',
+		),
+	)
 	const [browsePage, setBrowsePage] = useState<OpenOracleReportSummaryPage | undefined>(undefined)
 	const [browseError, setBrowseError] = useState<string | undefined>(undefined)
 	const [loadingBrowse, setLoadingBrowse] = useState(false)

--- a/ui/ts/components/OpenOracleSection.tsx
+++ b/ui/ts/components/OpenOracleSection.tsx
@@ -17,11 +17,6 @@ import type { OpenOracleSectionProps, OpenOracleView } from '../types/components
 
 const BROWSE_PAGE_SIZE = 10
 
-const DISPUTE_TOKEN_OPTIONS: EnumDropdownOption<OpenOracleFormState['disputeTokenToSwap']>[] = [
-	{ value: 'token1', label: 'Token1' },
-	{ value: 'token2', label: 'Token2' },
-]
-
 function getInitialOpenOracleView({ openOracleForm, initialView }: { openOracleForm: OpenOracleFormState; initialView: OpenOracleView | undefined }): OpenOracleView {
 	if (initialView !== undefined) return initialView
 	if (openOracleForm.reportId !== '') return 'selected-report'
@@ -72,11 +67,10 @@ function renderReportSummaryCard(report: OpenOracleReportSummary, onSelectReport
 						<AddressValue address={report.token1} /> / <AddressValue address={report.token2} />
 					</>,
 				)}
-				{renderReportField('Current Price', <CurrencyValue value={report.price} suffix='Token1 / Token2' copyable={false} />)}
+				{renderReportField('Current Price', <CurrencyValue value={report.price} suffix={`${report.token1Symbol} / ${report.token2Symbol}`} copyable={false} />)}
 				{renderReportField('Current Reporter', report.currentReporter === zeroAddress ? 'None' : <AddressValue address={report.currentReporter} />)}
-				{renderReportField('Current Amount1', <CurrencyValue value={report.currentAmount1} suffix='Token1' units={report.token1Decimals} copyable={false} />)}
-				{renderReportField('Current Amount2', <CurrencyValue value={report.currentAmount2} suffix='Token2' units={report.token2Decimals} copyable={false} />)}
-				{renderReportField('Created At', report.createdAt === undefined ? 'Unavailable' : formatTimestamp(report.createdAt))}
+				{renderReportField('Current Amount1', <CurrencyValue value={report.currentAmount1} suffix={report.token1Symbol} units={report.token1Decimals} copyable={false} />)}
+				{renderReportField('Current Amount2', <CurrencyValue value={report.currentAmount2} suffix={report.token2Symbol} units={report.token2Decimals} copyable={false} />)}
 				{renderReportField('Report Timestamp', report.reportTimestamp === 0n ? 'Awaiting initial report' : formatTimestamp(report.reportTimestamp))}
 				{renderReportField('Settlement Timestamp', report.settlementTimestamp === 0n ? 'Not settled' : formatTimestamp(report.settlementTimestamp))}
 			</div>
@@ -90,13 +84,20 @@ function renderSelectedReportActionSection(
 	openOracleForm: OpenOracleFormState,
 	initialReportSubmission: ReturnType<typeof deriveOpenOracleInitialReportSubmissionDetails>,
 	openOracleInitialReportState: OpenOracleSectionProps['openOracleInitialReportState'],
+	token1Symbol: string,
+	token2Symbol: string,
 	onApproveToken1: () => void,
 	onApproveToken2: () => void,
 	onDisputeReport: () => void,
 	onOpenOracleFormChange: (update: Partial<OpenOracleFormState>) => void,
+	onRefreshPrice: () => void,
 	onSettleReport: () => void,
 	onSubmitInitialReport: () => void,
 ) {
+	const disputeTokenOptions: EnumDropdownOption<OpenOracleFormState['disputeTokenToSwap']>[] = [
+		{ value: 'token1', label: token1Symbol },
+		{ value: 'token2', label: token2Symbol },
+	]
 	switch (actionMode) {
 		case 'initial-report':
 			return (
@@ -105,52 +106,67 @@ function renderSelectedReportActionSection(
 						<h4>Initial Report</h4>
 					</div>
 					<div className='form-grid'>
-						<label className='field'>
-							<span>Price</span>
-							<input value={openOracleForm.price} onInput={event => onOpenOracleFormChange({ price: event.currentTarget.value })} placeholder='1.00' />
-						</label>
-						<p className='detail'>
-							Resolved price:{' '}
-							<strong>
-								<CurrencyValue value={initialReportSubmission.price} suffix='Token1 / Token2' copyable={false} />
-							</strong>
-						</p>
+						<div className='field-row'>
+							<label className='field'>
+								<span>{`Price (${token1Symbol} / ${token2Symbol})`}</span>
+								<input value={openOracleForm.price} onInput={event => onOpenOracleFormChange({ price: event.currentTarget.value })} placeholder='1.00' />
+							</label>
+							<div className='actions'>
+								<button className='secondary' onClick={onRefreshPrice} disabled={openOracleInitialReportState.loading}>
+									{openOracleInitialReportState.loading ? 'Fetching...' : 'Fetch Price'}
+								</button>
+							</div>
+						</div>
 						<p className='detail'>
 							Price source: <strong>{openOracleInitialReportState.loading ? 'Loading...' : initialReportSubmission.priceSource}</strong>
 						</p>
 						<div className='question-summary-grid'>
 							<div>
-								<span className='metric-label'>Required Token1</span>
+								<span className='metric-label'>{`Required ${token1Symbol}`}</span>
 								<strong>
-									<CurrencyValue value={initialReportSubmission.amount1} units={initialReportSubmission.token1Decimals ?? 18} suffix='Token1' copyable={false} />
+									<CurrencyValue value={initialReportSubmission.amount1} units={initialReportSubmission.token1Decimals ?? 18} suffix={token1Symbol} copyable={false} />
 								</strong>
 							</div>
 							<div>
-								<span className='metric-label'>Required Token2</span>
+								<span className='metric-label'>{`Required ${token2Symbol}`}</span>
 								<strong>
-									<CurrencyValue value={initialReportSubmission.amount2} units={initialReportSubmission.token2Decimals ?? 18} suffix='Token2' copyable={false} />
+									<CurrencyValue value={initialReportSubmission.amount2} units={initialReportSubmission.token2Decimals ?? 18} suffix={token2Symbol} copyable={false} />
 								</strong>
 							</div>
 							<div>
-								<span className='metric-label'>Approved Token1</span>
+								<span className='metric-label'>{`Approved ${token1Symbol}`}</span>
 								<strong>
-									<CurrencyValue value={initialReportSubmission.approvedToken1Amount} units={initialReportSubmission.token1Decimals ?? 18} suffix='Token1' copyable={false} />
+									<CurrencyValue value={initialReportSubmission.approvedToken1Amount} units={initialReportSubmission.token1Decimals ?? 18} suffix={token1Symbol} copyable={false} />
 								</strong>
 							</div>
 							<div>
-								<span className='metric-label'>Approved Token2</span>
+								<span className='metric-label'>{`Approved ${token2Symbol}`}</span>
 								<strong>
-									<CurrencyValue value={initialReportSubmission.approvedToken2Amount} units={initialReportSubmission.token2Decimals ?? 18} suffix='Token2' copyable={false} />
+									<CurrencyValue value={initialReportSubmission.approvedToken2Amount} units={initialReportSubmission.token2Decimals ?? 18} suffix={token2Symbol} copyable={false} />
 								</strong>
 							</div>
 						</div>
-						<div className='actions'>
-							<button className='secondary' onClick={onApproveToken1} disabled={!isConnected || openOracleInitialReportState.loading}>
-								Approve Max Token1
-							</button>
-							<button className='secondary' onClick={onApproveToken2} disabled={!isConnected || openOracleInitialReportState.loading}>
-								Approve Max Token2
-							</button>
+						<div className='field-row'>
+							<label className='field'>
+								<span>{`${token1Symbol} Approve Amount (leave empty for max)`}</span>
+								<input value={openOracleForm.approveAmount1} onInput={event => onOpenOracleFormChange({ approveAmount1: event.currentTarget.value })} placeholder='Max' />
+							</label>
+							<div className='actions'>
+								<button className='secondary' onClick={onApproveToken1} disabled={!isConnected || openOracleInitialReportState.loading}>
+									{`Approve ${token1Symbol}`}
+								</button>
+							</div>
+						</div>
+						<div className='field-row'>
+							<label className='field'>
+								<span>{`${token2Symbol} Approve Amount (leave empty for max)`}</span>
+								<input value={openOracleForm.approveAmount2} onInput={event => onOpenOracleFormChange({ approveAmount2: event.currentTarget.value })} placeholder='Max' />
+							</label>
+							<div className='actions'>
+								<button className='secondary' onClick={onApproveToken2} disabled={!isConnected || openOracleInitialReportState.loading}>
+									{`Approve ${token2Symbol}`}
+								</button>
+							</div>
 						</div>
 						{initialReportSubmission.blockReason === undefined ? undefined : <p className='notice error'>{initialReportSubmission.blockReason}</p>}
 						<div className='actions'>
@@ -170,15 +186,15 @@ function renderSelectedReportActionSection(
 					<div className='form-grid'>
 						<label className='field'>
 							<span>Token to Swap Out</span>
-							<EnumDropdown options={DISPUTE_TOKEN_OPTIONS} value={openOracleForm.disputeTokenToSwap} onChange={disputeTokenToSwap => onOpenOracleFormChange({ disputeTokenToSwap })} />
+							<EnumDropdown options={disputeTokenOptions} value={openOracleForm.disputeTokenToSwap} onChange={disputeTokenToSwap => onOpenOracleFormChange({ disputeTokenToSwap })} />
 						</label>
 						<div className='field-row'>
 							<label className='field'>
-								<span>New Token1 Amount</span>
+								<span>{`New ${token1Symbol} Amount`}</span>
 								<input value={openOracleForm.disputeNewAmount1} onInput={event => onOpenOracleFormChange({ disputeNewAmount1: event.currentTarget.value })} />
 							</label>
 							<label className='field'>
-								<span>New Token2 Amount</span>
+								<span>{`New ${token2Symbol} Amount`}</span>
 								<input value={openOracleForm.disputeNewAmount2} onInput={event => onOpenOracleFormChange({ disputeNewAmount2: event.currentTarget.value })} />
 							</label>
 						</div>
@@ -218,6 +234,7 @@ function renderReportDetailsCard(
 	onDisputeReport: () => void,
 	onLoadOracleReport: (reportId?: string) => void,
 	onOpenOracleFormChange: (update: Partial<OpenOracleFormState>) => void,
+	onRefreshPrice: () => void,
 	onSettleReport: () => void,
 	onSubmitInitialReport: () => void,
 ) {
@@ -289,11 +306,15 @@ function renderReportDetailsCard(
 
 			{renderReportSection('Identity', [
 				{
-					label: 'Token1',
+					label: 'Oracle Address',
+					value: <AddressValue address={openOracleReportDetails.openOracleAddress} />,
+				},
+				{
+					label: openOracleReportDetails.token1Symbol,
 					value: <AddressValue address={openOracleReportDetails.token1} />,
 				},
 				{
-					label: 'Token2',
+					label: openOracleReportDetails.token2Symbol,
 					value: <AddressValue address={openOracleReportDetails.token2} />,
 				},
 				{
@@ -308,20 +329,20 @@ function renderReportDetailsCard(
 
 			{renderReportSection('Economics', [
 				{
-					label: 'Exact Token1 Required',
-					value: <CurrencyValue value={openOracleReportDetails.exactToken1Report} suffix='Token1' units={openOracleReportDetails.token1Decimals} copyable={false} />,
+					label: `Exact ${openOracleReportDetails.token1Symbol} Required`,
+					value: <CurrencyValue value={openOracleReportDetails.exactToken1Report} suffix={openOracleReportDetails.token1Symbol} units={openOracleReportDetails.token1Decimals} copyable={false} />,
 				},
 				{
-					label: 'Current Amount1',
-					value: <CurrencyValue value={openOracleReportDetails.currentAmount1} suffix='Token1' units={openOracleReportDetails.token1Decimals} copyable={false} />,
+					label: `Current ${openOracleReportDetails.token1Symbol}`,
+					value: <CurrencyValue value={openOracleReportDetails.currentAmount1} suffix={openOracleReportDetails.token1Symbol} units={openOracleReportDetails.token1Decimals} copyable={false} />,
 				},
 				{
-					label: 'Current Amount2',
-					value: <CurrencyValue value={openOracleReportDetails.currentAmount2} suffix='Token2' units={openOracleReportDetails.token2Decimals} copyable={false} />,
+					label: `Current ${openOracleReportDetails.token2Symbol}`,
+					value: <CurrencyValue value={openOracleReportDetails.currentAmount2} suffix={openOracleReportDetails.token2Symbol} units={openOracleReportDetails.token2Decimals} copyable={false} />,
 				},
 				{
 					label: 'Price',
-					value: <CurrencyValue value={openOracleReportDetails.price} suffix='Token1 / Token2' copyable={false} />,
+					value: <CurrencyValue value={openOracleReportDetails.price} suffix={`${openOracleReportDetails.token1Symbol} / ${openOracleReportDetails.token2Symbol}`} copyable={false} />,
 				},
 				{
 					label: 'Fee',
@@ -333,15 +354,11 @@ function renderReportDetailsCard(
 				},
 				{
 					label: 'Escalation Halt',
-					value: <CurrencyValue value={openOracleReportDetails.escalationHalt} suffix='Token1' units={openOracleReportDetails.token1Decimals} copyable={false} />,
+					value: <CurrencyValue value={openOracleReportDetails.escalationHalt} suffix={openOracleReportDetails.token1Symbol} units={openOracleReportDetails.token1Decimals} copyable={false} />,
 				},
 			])}
 
 			{renderReportSection('Status', [
-				{
-					label: 'Created At',
-					value: openOracleReportDetails.createdAt === undefined ? 'Unavailable' : formatTimestamp(openOracleReportDetails.createdAt),
-				},
 				{
 					label: 'Report Timestamp',
 					value: openOracleReportDetails.reportTimestamp === 0n ? 'Awaiting initial report' : formatTimestamp(openOracleReportDetails.reportTimestamp),
@@ -357,6 +374,14 @@ function renderReportDetailsCard(
 				{
 					label: 'Settlement Timestamp',
 					value: openOracleReportDetails.settlementTimestamp === 0n ? 'Not settled' : formatTimestamp(openOracleReportDetails.settlementTimestamp),
+				},
+				{
+					label: 'Last Report Opportunity',
+					value: openOracleReportDetails.lastReportOppoTime === 0n ? 'None' : `${openOracleReportDetails.lastReportOppoTime.toString()} ${openOracleReportDetails.timeType ? 's' : ' blocks'}`,
+				},
+				{
+					label: 'State Hash',
+					value: openOracleReportDetails.stateHash,
 				},
 			])}
 
@@ -389,12 +414,51 @@ function renderReportDetailsCard(
 					value: openOracleReportDetails.callbackContract === zeroAddress ? 'None' : <AddressValue address={openOracleReportDetails.callbackContract} />,
 				},
 				{
+					label: 'Callback Selector',
+					value: openOracleReportDetails.callbackSelector === '0x00000000' ? 'None' : openOracleReportDetails.callbackSelector,
+				},
+				{
+					label: 'Callback Gas Limit',
+					value: openOracleReportDetails.callbackGasLimit === 0 ? 'None' : openOracleReportDetails.callbackGasLimit.toString(),
+				},
+				{
+					label: 'Protocol Fee Recipient',
+					value: openOracleReportDetails.protocolFeeRecipient === zeroAddress ? 'None' : <AddressValue address={openOracleReportDetails.protocolFeeRecipient} />,
+				},
+				{
+					label: 'Track Disputes',
+					value: openOracleReportDetails.trackDisputes ? 'Yes' : 'No',
+				},
+				{
+					label: 'Keep Fee',
+					value: openOracleReportDetails.keepFee ? 'Yes' : 'No',
+				},
+				{
+					label: 'Fee Token',
+					value: openOracleReportDetails.feeToken ? openOracleReportDetails.token1Symbol : 'ETH',
+				},
+				{
 					label: 'Number of Reports',
 					value: openOracleReportDetails.numReports.toString(),
 				},
 			])}
 
-			{renderSelectedReportActionSection(actionMode, isConnected, openOracleForm, initialReportSubmission, openOracleInitialReportState, onApproveToken1, onApproveToken2, onDisputeReport, onOpenOracleFormChange, onSettleReport, onSubmitInitialReport)}
+			{renderSelectedReportActionSection(
+				actionMode,
+				isConnected,
+				openOracleForm,
+				initialReportSubmission,
+				openOracleInitialReportState,
+				openOracleReportDetails.token1Symbol,
+				openOracleReportDetails.token2Symbol,
+				onApproveToken1,
+				onApproveToken2,
+				onDisputeReport,
+				onOpenOracleFormChange,
+				onRefreshPrice,
+				onSettleReport,
+				onSubmitInitialReport,
+			)}
 		</EntityCard>
 	)
 }
@@ -422,6 +486,7 @@ export function OpenOracleSection({
 	onLoadOracleReport,
 	onOpenOracleCreateFormChange,
 	onOpenOracleFormChange,
+	onRefreshPrice,
 	onSettleReport,
 	onSubmitInitialReport,
 	loadingOpenOracleCreate,
@@ -614,7 +679,7 @@ export function OpenOracleSection({
 			{view === 'selected-report' ? (
 				<div className='market-grid'>
 					<div className='market-column'>
-						{renderReportDetailsCard(openOracleReportDetails, openOracleForm, openOracleInitialReportState, loadingOracleReport, isConnected, onApproveToken1, onApproveToken2, onDisputeReport, onLoadOracleReport, onOpenOracleFormChange, onSettleReport, onSubmitInitialReport)}
+						{renderReportDetailsCard(openOracleReportDetails, openOracleForm, openOracleInitialReportState, loadingOracleReport, isConnected, onApproveToken1, onApproveToken2, onDisputeReport, onLoadOracleReport, onOpenOracleFormChange, onRefreshPrice, onSettleReport, onSubmitInitialReport)}
 						{renderLatestActionCard(openOracleResult)}
 					</div>
 				</div>

--- a/ui/ts/components/OpenOracleSection.tsx
+++ b/ui/ts/components/OpenOracleSection.tsx
@@ -7,8 +7,8 @@ import { EntityCard } from './EntityCard.js'
 import { EnumDropdown, type EnumDropdownOption } from './EnumDropdown.js'
 import { LoadingText } from './LoadingText.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
+import { TimestampValue } from './TimestampValue.js'
 import { createConnectedReadClient } from '../lib/clients.js'
-import { formatTimestamp } from '../lib/formatters.js'
 import { deriveOpenOracleInitialReportSubmissionDetails, formatOpenOracleFeePercentage, formatOpenOracleMultiplier, getOpenOracleReportStatus, getOpenOracleReportStatusTone, getOpenOracleSelectedReportActionMode, type OpenOracleSelectedReportActionMode } from '../lib/openOracle.js'
 import { loadOpenOracleReportSummaries } from '../contracts.js'
 import type { OpenOracleFormState } from '../types/app.js'
@@ -71,8 +71,8 @@ function renderReportSummaryCard(report: OpenOracleReportSummary, onSelectReport
 				{renderReportField('Current Reporter', report.currentReporter === zeroAddress ? 'None' : <AddressValue address={report.currentReporter} />)}
 				{renderReportField('Current Amount1', <CurrencyValue value={report.currentAmount1} suffix={report.token1Symbol} units={report.token1Decimals} copyable={false} />)}
 				{renderReportField('Current Amount2', <CurrencyValue value={report.currentAmount2} suffix={report.token2Symbol} units={report.token2Decimals} copyable={false} />)}
-				{renderReportField('Report Timestamp', report.reportTimestamp === 0n ? 'Awaiting initial report' : formatTimestamp(report.reportTimestamp))}
-				{renderReportField('Settlement Timestamp', report.settlementTimestamp === 0n ? 'Not settled' : formatTimestamp(report.settlementTimestamp))}
+				{renderReportField('Report Timestamp', <TimestampValue timestamp={report.reportTimestamp} zeroText='Awaiting initial report' />)}
+				{renderReportField('Settlement Timestamp', <TimestampValue timestamp={report.settlementTimestamp} zeroText='Not settled' />)}
 			</div>
 		</EntityCard>
 	)
@@ -361,7 +361,7 @@ function renderReportDetailsCard(
 			{renderReportSection('Status', [
 				{
 					label: 'Report Timestamp',
-					value: openOracleReportDetails.reportTimestamp === 0n ? 'Awaiting initial report' : formatTimestamp(openOracleReportDetails.reportTimestamp),
+					value: <TimestampValue timestamp={openOracleReportDetails.reportTimestamp} zeroText='Awaiting initial report' />,
 				},
 				{
 					label: 'Dispute Occurred',
@@ -373,7 +373,7 @@ function renderReportDetailsCard(
 				},
 				{
 					label: 'Settlement Timestamp',
-					value: openOracleReportDetails.settlementTimestamp === 0n ? 'Not settled' : formatTimestamp(openOracleReportDetails.settlementTimestamp),
+					value: <TimestampValue timestamp={openOracleReportDetails.settlementTimestamp} zeroText='Not settled' />,
 				},
 				{
 					label: 'Last Report Opportunity',

--- a/ui/ts/components/OverviewPanels.tsx
+++ b/ui/ts/components/OverviewPanels.tsx
@@ -1,5 +1,6 @@
 import { AddressValue } from './AddressValue.js'
 import { CurrencyValue } from './CurrencyValue.js'
+import { MetricField } from './MetricField.js'
 import type { OverviewPanelsProps } from '../types/components.js'
 
 const UNISWAP_EXPLORE = 'https://app.uniswap.org/explore/pools/ethereum'
@@ -36,66 +37,58 @@ export function OverviewPanels({
 							<h1 className='overview-app-title'>Augur PLACEHOLDER</h1>
 						</div>
 						<div className='overview-inline-metrics'>
-							<div className='overview-address-metric'>
-								<span className='metric-label'>Address</span>
-								<strong>
-									{isWalletLoading ? (
-										<span className='loading-value'>
-											<span className='spinner' aria-hidden='true' />
-											Connecting...
-										</span>
-									) : accountState.address === undefined ? (
-										'Not connected'
-									) : (
-										<AddressValue address={accountState.address} />
-									)}
-								</strong>
-							</div>
+							<MetricField className='overview-address-metric' label='Address'>
+								{isWalletLoading ? (
+									<span className='loading-value'>
+										<span className='spinner' aria-hidden='true' />
+										Connecting...
+									</span>
+								) : accountState.address === undefined ? (
+									'Not connected'
+								) : (
+									<AddressValue address={accountState.address} />
+								)}
+							</MetricField>
 							{showAccountBalances ? (
 								<>
-									<div>
-										<span className='metric-label'>ETH</span>
-										<strong>
-											<CurrencyValue value={accountState.ethBalance} loading={isRefreshing && accountState.ethBalance === undefined} suffix='ETH' />
-										</strong>
-									</div>
-									<div>
-										<span className='metric-label'>REP</span>
-										<strong>
-											<CurrencyValue value={universeRepBalance} loading={isLoadingUniverseRepBalance} suffix='REP' />
-										</strong>
-									</div>
+									<MetricField label='ETH'>
+										<CurrencyValue value={accountState.ethBalance} loading={isRefreshing && accountState.ethBalance === undefined} suffix='ETH' />
+									</MetricField>
+									<MetricField label='REP'>
+										<CurrencyValue value={universeRepBalance} loading={isLoadingUniverseRepBalance} suffix='REP' />
+									</MetricField>
 								</>
 							) : undefined}
-							<div>
-								<span className='metric-label'>
-									REP/ETH{' '}
-									{repEthSource === undefined ? undefined : (
-										<a href={repEthSource === 'v4' ? undefined : REP_ETH_V3_POOL_URL} title={repEthSource === 'v4' ? 'Price from Uniswap V4' : 'Price from Uniswap V3 (REP/WETH pool)'} target='_blank' rel='noreferrer'>
-											{`(u${repEthSource === 'v4' ? '4' : '3'})`}
-										</a>
-									)}
-								</span>
-								<strong>
-									<CurrencyValue value={repEthPrice} loading={isLoadingRepPrices} suffix='ETH' />
-								</strong>
-							</div>
-							<div>
-								<span className='metric-label'>
-									REP/USDC{' '}
-									{repUsdcSource === undefined ? undefined : (
-										<a href={repUsdcSource === 'v4' ? REP_USDC_V4_POOL_URL : undefined} title={repUsdcSource === 'v4' ? 'Price from Uniswap V4 (REP/USDC pool)' : 'Price from Uniswap V3 (REP/USDC pool)'} target='_blank' rel='noreferrer'>
-											{`(u${repUsdcSource === 'v4' ? '4' : '3'})`}
-										</a>
-									)}
-								</span>
-								<strong>
-									<CurrencyValue value={repUsdcPrice} loading={isLoadingRepPrices} suffix='USDC' units={6} />
-								</strong>
-							</div>
-							<div>
-								<span className='metric-label'>Universe</span>
-								<strong className={universeErrorMessage === undefined ? undefined : 'overview-universe-error'}>{universeErrorMessage ?? universeLabel}</strong>
+							<MetricField
+								label={
+									<>
+										REP/ETH{' '}
+										{repEthSource === undefined ? undefined : (
+											<a href={repEthSource === 'v4' ? undefined : REP_ETH_V3_POOL_URL} title={repEthSource === 'v4' ? 'Price from Uniswap V4' : 'Price from Uniswap V3 (REP/WETH pool)'} target='_blank' rel='noreferrer'>
+												{`(u${repEthSource === 'v4' ? '4' : '3'})`}
+											</a>
+										)}
+									</>
+								}
+							>
+								<CurrencyValue value={repEthPrice} loading={isLoadingRepPrices} suffix='ETH' />
+							</MetricField>
+							<MetricField
+								label={
+									<>
+										REP/USDC{' '}
+										{repUsdcSource === undefined ? undefined : (
+											<a href={repUsdcSource === 'v4' ? REP_USDC_V4_POOL_URL : undefined} title={repUsdcSource === 'v4' ? 'Price from Uniswap V4 (REP/USDC pool)' : 'Price from Uniswap V3 (REP/USDC pool)'} target='_blank' rel='noreferrer'>
+												{`(u${repUsdcSource === 'v4' ? '4' : '3'})`}
+											</a>
+										)}
+									</>
+								}
+							>
+								<CurrencyValue value={repUsdcPrice} loading={isLoadingRepPrices} suffix='USDC' units={6} />
+							</MetricField>
+							<MetricField label='Universe' valueClassName={universeErrorMessage === undefined ? undefined : 'overview-universe-error'}>
+								{universeErrorMessage ?? universeLabel}
 								{universeErrorMessage === undefined ? undefined : (
 									<div className='overview-universe-actions'>
 										<button className='secondary' onClick={onGoToGenesisUniverse}>
@@ -103,7 +96,7 @@ export function OverviewPanels({
 										</button>
 									</div>
 								)}
-							</div>
+							</MetricField>
 						</div>
 					</div>
 					<div className='actions overview-actions'>

--- a/ui/ts/components/OverviewPanels.tsx
+++ b/ui/ts/components/OverviewPanels.tsx
@@ -25,7 +25,7 @@ export function OverviewPanels({
 	walletBootstrapComplete,
 }: OverviewPanelsProps) {
 	const isWalletLoading = isConnectingWallet || (!walletBootstrapComplete && accountState.address === undefined)
-	const showAccountBalances = accountState.address !== undefined
+	const showAccountBalances = walletBootstrapComplete && accountState.address !== undefined
 
 	return (
 		<section className='overview-shell'>

--- a/ui/ts/components/Question.tsx
+++ b/ui/ts/components/Question.tsx
@@ -1,5 +1,5 @@
 import { LoadingText } from './LoadingText.js'
-import { formatTimestamp } from '../lib/formatters.js'
+import { TimestampValue } from './TimestampValue.js'
 import type { MarketDetails } from '../types/contracts.js'
 
 type QuestionProps = {
@@ -81,11 +81,15 @@ export function Question({ className = '', loading = false, question, showTitle 
 				</div>
 				<div>
 					<span className='metric-label'>Created</span>
-					<strong>{formatTimestamp(question.createdAt)}</strong>
+					<strong>
+						<TimestampValue timestamp={question.createdAt} />
+					</strong>
 				</div>
 				<div>
 					<span className='metric-label'>End Time</span>
-					<strong>{formatTimestamp(question.endTime)}</strong>
+					<strong>
+						<TimestampValue timestamp={question.endTime} />
+					</strong>
 				</div>
 				<div>
 					<span className='metric-label'>Outcomes</span>

--- a/ui/ts/components/Question.tsx
+++ b/ui/ts/components/Question.tsx
@@ -1,5 +1,7 @@
 import { LoadingText } from './LoadingText.js'
+import { MetricField } from './MetricField.js'
 import { TimestampValue } from './TimestampValue.js'
+import { sameCaseInsensitiveText } from '../lib/caseInsensitive.js'
 import type { MarketDetails } from '../types/contracts.js'
 
 type QuestionProps = {
@@ -19,7 +21,7 @@ function getQuestionDescription(question: MarketDetails) {
 
 function getDisplayedOutcomes(question: MarketDetails) {
 	const outcomes = question.outcomeLabels.length === 0 ? ['Scalar'] : question.outcomeLabels
-	if (outcomes.some(outcome => outcome.toLowerCase() === 'invalid')) return outcomes
+	if (outcomes.some(outcome => sameCaseInsensitiveText(outcome, 'invalid'))) return outcomes
 	return [...outcomes, 'Invalid']
 }
 
@@ -30,18 +32,9 @@ function getDisplayRange(question: MarketDetails) {
 function renderScalarQuestionFields(question: MarketDetails) {
 	return (
 		<>
-			<div>
-				<span className='metric-label'>Ticks</span>
-				<strong>{question.numTicks.toString()}</strong>
-			</div>
-			<div>
-				<span className='metric-label'>Display Range</span>
-				<strong>{getDisplayRange(question)}</strong>
-			</div>
-			<div>
-				<span className='metric-label'>Answer Unit</span>
-				<strong>{question.answerUnit === '' ? 'None' : question.answerUnit}</strong>
-			</div>
+			<MetricField label='Ticks'>{question.numTicks.toString()}</MetricField>
+			<MetricField label='Display Range'>{getDisplayRange(question)}</MetricField>
+			<MetricField label='Answer Unit'>{question.answerUnit === '' ? 'None' : question.answerUnit}</MetricField>
 		</>
 	)
 }
@@ -71,30 +64,15 @@ export function Question({ className = '', loading = false, question, showTitle 
 				<p className='detail'>{description}</p>
 			)}
 			<div className='question-summary-grid'>
-				<div>
-					<span className='metric-label'>Question ID</span>
-					<strong>{question.questionId}</strong>
-				</div>
-				<div>
-					<span className='metric-label'>Type</span>
-					<strong>{question.marketType}</strong>
-				</div>
-				<div>
-					<span className='metric-label'>Created</span>
-					<strong>
-						<TimestampValue timestamp={question.createdAt} />
-					</strong>
-				</div>
-				<div>
-					<span className='metric-label'>End Time</span>
-					<strong>
-						<TimestampValue timestamp={question.endTime} />
-					</strong>
-				</div>
-				<div>
-					<span className='metric-label'>Outcomes</span>
-					<strong>{getDisplayedOutcomes(question).join(', ')}</strong>
-				</div>
+				<MetricField label='Question ID'>{question.questionId}</MetricField>
+				<MetricField label='Type'>{question.marketType}</MetricField>
+				<MetricField label='Created'>
+					<TimestampValue timestamp={question.createdAt} />
+				</MetricField>
+				<MetricField label='End Time'>
+					<TimestampValue timestamp={question.endTime} />
+				</MetricField>
+				<MetricField label='Outcomes'>{getDisplayedOutcomes(question).join(', ')}</MetricField>
 				{question.marketType === 'scalar' ? renderScalarQuestionFields(question) : undefined}
 			</div>
 		</div>

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -4,29 +4,21 @@ import { EnumDropdown } from './EnumDropdown.js'
 import { EntityCard } from './EntityCard.js'
 import { LoadingText } from './LoadingText.js'
 import { EscalationSide } from './EscalationSide.js'
+import { MetricField } from './MetricField.js'
 import { Question } from './Question.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { UniverseLink } from './UniverseLink.js'
 import { formatDuration } from '../lib/formatters.js'
 import { isMainnetChain } from '../lib/network.js'
-import { getReportingOutcomeLabel, REPORTING_OUTCOME_OPTIONS } from '../lib/reporting.js'
+import { REPORTING_OUTCOME_DROPDOWN_OPTIONS, getReportingOutcomeLabel } from '../lib/reporting.js'
 import { calculateEstimatedEscalationReturn, getEscalationPhase, getEscalationTimeRemaining, getLeadingEscalationOutcome } from '../lib/reportingDomain.js'
 import { TimestampValue } from './TimestampValue.js'
+import { parseOptionalBigIntInput } from '../lib/inputs.js'
 import type { ReportingSectionProps } from '../types/components.js'
-
-function parseOptionalBigInt(value: string) {
-	try {
-		const trimmedValue = value.trim()
-		if (trimmedValue === '') return undefined
-		return BigInt(trimmedValue)
-	} catch {
-		return undefined
-	}
-}
 
 export function ReportingSection({ accountState, loadingReportingDetails, onLoadReporting, onReportOutcome, onReportingFormChange, onWithdrawEscalation, reportingDetails, reportingError, reportingForm, reportingResult, showHeader = true, showSecurityPoolAddressInput = true }: ReportingSectionProps) {
 	const isMainnet = isMainnetChain(accountState.chainId)
-	const selectedAmount = parseOptionalBigInt(reportingForm.reportAmount)
+	const selectedAmount = parseOptionalBigIntInput(reportingForm.reportAmount)
 	const totalBalance = reportingDetails === undefined ? 0n : reportingDetails.sides.reduce((sum, side) => sum + side.balance, 0n)
 	const leadingOutcome = reportingDetails === undefined ? undefined : getLeadingEscalationOutcome(reportingDetails.sides)
 	const selectedSide = reportingDetails?.sides.find(side => side.key === reportingForm.selectedOutcome)
@@ -90,28 +82,16 @@ export function ReportingSection({ accountState, loadingReportingDetails, onLoad
 
 							<EntityCard title='Escalation Metrics' badge={<span className='badge muted'>status</span>}>
 								<div className='escalation-metrics'>
-									<div>
-										<span className='metric-label'>Current Bond</span>
-										<strong>
-											<CurrencyValue value={reportingDetails.currentRequiredBond} suffix='REP' />
-										</strong>
-									</div>
-									<div>
-										<span className='metric-label'>Binding Capital</span>
-										<strong>
-											<CurrencyValue value={reportingDetails.bindingCapital} suffix='REP' />
-										</strong>
-									</div>
-									<div>
-										<span className='metric-label'>Threshold</span>
-										<strong>
-											<CurrencyValue value={reportingDetails.nonDecisionThreshold} suffix='REP' />
-										</strong>
-									</div>
-									<div>
-										<span className='metric-label'>Time Left</span>
-										<strong>{formatDuration(getEscalationTimeRemaining(reportingDetails))}</strong>
-									</div>
+									<MetricField label='Current Bond'>
+										<CurrencyValue value={reportingDetails.currentRequiredBond} suffix='REP' />
+									</MetricField>
+									<MetricField label='Binding Capital'>
+										<CurrencyValue value={reportingDetails.bindingCapital} suffix='REP' />
+									</MetricField>
+									<MetricField label='Threshold'>
+										<CurrencyValue value={reportingDetails.nonDecisionThreshold} suffix='REP' />
+									</MetricField>
+									<MetricField label='Time Left'>{formatDuration(getEscalationTimeRemaining(reportingDetails))}</MetricField>
 								</div>
 								<p className='detail'>
 									Game starts at <TimestampValue timestamp={reportingDetails.startingTime} /> and currently uses a start bond of <CurrencyValue value={reportingDetails.startBond} suffix='REP' />.
@@ -163,7 +143,7 @@ export function ReportingSection({ accountState, loadingReportingDetails, onLoad
 
 							<label className='field'>
 								<span>Outcome Side</span>
-								<EnumDropdown options={REPORTING_OUTCOME_OPTIONS.map(option => ({ value: option.key, label: option.label }))} value={reportingForm.selectedOutcome} onChange={selectedOutcome => onReportingFormChange({ selectedOutcome })} />
+								<EnumDropdown options={REPORTING_OUTCOME_DROPDOWN_OPTIONS} value={reportingForm.selectedOutcome} onChange={selectedOutcome => onReportingFormChange({ selectedOutcome })} />
 							</label>
 
 							<label className='field'>

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -7,10 +7,11 @@ import { EscalationSide } from './EscalationSide.js'
 import { Question } from './Question.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { UniverseLink } from './UniverseLink.js'
-import { formatDuration, formatTimestamp } from '../lib/formatters.js'
+import { formatDuration } from '../lib/formatters.js'
 import { isMainnetChain } from '../lib/network.js'
 import { getReportingOutcomeLabel, REPORTING_OUTCOME_OPTIONS } from '../lib/reporting.js'
 import { calculateEstimatedEscalationReturn, getEscalationPhase, getEscalationTimeRemaining, getLeadingEscalationOutcome } from '../lib/reportingDomain.js'
+import { TimestampValue } from './TimestampValue.js'
 import type { ReportingSectionProps } from '../types/components.js'
 
 function parseOptionalBigInt(value: string) {
@@ -69,7 +70,9 @@ export function ReportingSection({ accountState, loadingReportingDetails, onLoad
 									</li>
 									<li>
 										<span>Market End</span>
-										<strong>{formatTimestamp(reportingDetails.marketDetails.endTime)}</strong>
+										<strong>
+											<TimestampValue timestamp={reportingDetails.marketDetails.endTime} />
+										</strong>
 									</li>
 									<li>
 										<span>Resolution</span>
@@ -111,7 +114,7 @@ export function ReportingSection({ accountState, loadingReportingDetails, onLoad
 									</div>
 								</div>
 								<p className='detail'>
-									Game starts at {formatTimestamp(reportingDetails.startingTime)} and currently uses a start bond of <CurrencyValue value={reportingDetails.startBond} suffix='REP' />.
+									Game starts at <TimestampValue timestamp={reportingDetails.startingTime} /> and currently uses a start bond of <CurrencyValue value={reportingDetails.startBond} suffix='REP' />.
 								</p>
 							</EntityCard>
 

--- a/ui/ts/components/ScalarCreatePreview.tsx
+++ b/ui/ts/components/ScalarCreatePreview.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'preact/hooks'
+import { MetricField } from './MetricField.js'
 import { clampScalarTickIndex, formatScalarOutcomeLabel, getScalarSliderFillWidth } from '../lib/scalarOutcome.js'
 
 export type ScalarCreatePreviewDetails = {
@@ -44,14 +45,8 @@ export function ScalarCreatePreview({ details, selectedTick, onSelectedTickChang
 				</div>
 			</div>
 			<div className='workflow-question-grid scalar-slider-stats'>
-				<div>
-					<span className='metric-label'>Selected Tick</span>
-					<strong>{isInvalid ? 'Invalid' : `${clampedSelectedTick} / ${details.numTicks.toString()}`}</strong>
-				</div>
-				<div>
-					<span className='metric-label'>Current Value</span>
-					<strong>{isInvalid ? 'Invalid' : formatScalarOutcomeLabel(details, clampedSelectedTickValue)}</strong>
-				</div>
+				<MetricField label='Selected Tick'>{isInvalid ? 'Invalid' : `${clampedSelectedTick} / ${details.numTicks.toString()}`}</MetricField>
+				<MetricField label='Current Value'>{isInvalid ? 'Invalid' : formatScalarOutcomeLabel(details, clampedSelectedTickValue)}</MetricField>
 			</div>
 		</div>
 	)

--- a/ui/ts/components/ScalarDeploymentSection.tsx
+++ b/ui/ts/components/ScalarDeploymentSection.tsx
@@ -4,6 +4,7 @@ import { ChildUniversesSection } from './ChildUniversesSection.js'
 import { ChildUniverseDetails } from './ChildUniverseDetails.js'
 import { useEffect } from 'preact/hooks'
 import { LoadingText } from './LoadingText.js'
+import { MetricField } from './MetricField.js'
 import { clampScalarTickIndex, formatScalarOutcomeLabel, getScalarOutcomeIndex, getScalarSliderFillWidth } from '../lib/scalarOutcome.js'
 import type { MarketDetails, ZoltarChildUniverseSummary } from '../types/contracts.js'
 
@@ -97,22 +98,10 @@ export function ScalarDeploymentSection({ accountAddress, childUniverses, hasFor
 					</div>
 				</div>
 				<div className='workflow-question-grid scalar-slider-stats'>
-					<div>
-						<span className='metric-label'>Min Value</span>
-						<strong>{formatScalarOutcomeLabel(questionDetails, 0n)}</strong>
-					</div>
-					<div>
-						<span className='metric-label'>Selected Tick</span>
-						<strong>{scalarOutcomeInvalid ? 'Invalid' : `${clampedScalarOutcomeTick} / ${questionDetails.numTicks.toString()}`}</strong>
-					</div>
-					<div>
-						<span className='metric-label'>Selected Outcome</span>
-						<strong>{selectedScalarOutcomeLabel}</strong>
-					</div>
-					<div>
-						<span className='metric-label'>Max Value</span>
-						<strong>{formatScalarOutcomeLabel(questionDetails, questionDetails.numTicks)}</strong>
-					</div>
+					<MetricField label='Min Value'>{formatScalarOutcomeLabel(questionDetails, 0n)}</MetricField>
+					<MetricField label='Selected Tick'>{scalarOutcomeInvalid ? 'Invalid' : `${clampedScalarOutcomeTick} / ${questionDetails.numTicks.toString()}`}</MetricField>
+					<MetricField label='Selected Outcome'>{selectedScalarOutcomeLabel}</MetricField>
+					<MetricField label='Max Value'>{formatScalarOutcomeLabel(questionDetails, questionDetails.numTicks)}</MetricField>
 				</div>
 				<div className='actions'>
 					<button

--- a/ui/ts/components/SecurityPoolSection.tsx
+++ b/ui/ts/components/SecurityPoolSection.tsx
@@ -2,10 +2,12 @@ import type { ComponentChildren } from 'preact'
 import { AddressValue } from './AddressValue.js'
 import { EntityCard } from './EntityCard.js'
 import { LoadingText } from './LoadingText.js'
+import { MetricField } from './MetricField.js'
 import { Question } from './Question.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { UniverseLink } from './UniverseLink.js'
 import { CurrencyValue } from './CurrencyValue.js'
+import { sameCaseInsensitiveText } from '../lib/caseInsensitive.js'
 import { isMainnetChain } from '../lib/network.js'
 import { formatOpenInterestFeePerYearPercent, openInterestFeePerYearBigint } from '../lib/retentionRate.js'
 import type { SecurityPoolSectionProps } from '../types/components.js'
@@ -33,7 +35,7 @@ export function SecurityPoolSection({
 	const isPoolActionPending = securityPoolCreating || checkingDuplicateOriginPool
 	const hasSecurityPoolResult = securityPoolResult !== undefined
 	const isCreateDisabled = accountState.address === undefined || !isMainnet || isPoolActionPending || duplicateOriginPoolExists || marketDetails?.marketType !== 'binary' || zoltarUniverseHasForked
-	const matchingPools = marketDetails === undefined ? [] : securityPools.filter(pool => pool.questionId.toLowerCase() === marketDetails.questionId.toLowerCase())
+	const matchingPools = marketDetails === undefined ? [] : securityPools.filter(pool => sameCaseInsensitiveText(pool.questionId, marketDetails.questionId))
 	const hasMatchingSecurityMultiplier = matchingPools.some(pool => pool.securityMultiplier.toString() === securityPoolForm.securityMultiplier.trim())
 	let createdQuestionDetails = undefined
 	if (securityPoolResult !== undefined) {
@@ -136,16 +138,10 @@ export function SecurityPoolSection({
 										{matchingPools.map(pool => (
 											<EntityCard key={pool.securityPoolAddress} className='compact' title={<AddressValue address={pool.securityPoolAddress} />} badge={<span className='badge ok'>{pool.systemState}</span>}>
 												<div className='workflow-vault-grid'>
-													<div>
-														<span className='metric-label'>Security Multiplier</span>
-														<strong>{pool.securityMultiplier.toString()}</strong>
-													</div>
-													<div>
-														<span className='metric-label'>Open Interest Fee / Year</span>
-														<strong>
-															<CurrencyValue value={openInterestFeePerYearBigint(pool.currentRetentionRate)} suffix='%' />
-														</strong>
-													</div>
+													<MetricField label='Security Multiplier'>{pool.securityMultiplier.toString()}</MetricField>
+													<MetricField label='Open Interest Fee / Year'>
+														<CurrencyValue value={openInterestFeePerYearBigint(pool.currentRetentionRate)} suffix='%' />
+													</MetricField>
 												</div>
 											</EntityCard>
 										))}

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -4,6 +4,7 @@ import { EntityCard } from './EntityCard.js'
 import { ForkAuctionSection } from './ForkAuctionSection.js'
 import { LiquidationModal } from './LiquidationModal.js'
 import { LoadingText } from './LoadingText.js'
+import { MetricField } from './MetricField.js'
 import { Question, getQuestionTitle } from './Question.js'
 import { ReportingSection } from './ReportingSection.js'
 import { SecurityVaultSection } from './SecurityVaultSection.js'
@@ -12,26 +13,18 @@ import { TransactionHashLink } from './TransactionHashLink.js'
 import { UniverseLink } from './UniverseLink.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { TimestampValue } from './TimestampValue.js'
+import { normalizeAddress, sameAddress } from '../lib/address.js'
+import { sameCaseInsensitiveText } from '../lib/caseInsensitive.js'
 import { isMainnetChain } from '../lib/network.js'
 import { getSelectedVaultAddress, isSelectedVaultOwnedByAccount as isSelectedVaultOwnedByAccountHelper } from '../lib/securityVault.js'
 import { openInterestFeePerYearBigint } from '../lib/retentionRate.js'
 import { formatUniverseLabel } from '../lib/universe.js'
 import { readSelectedPoolViewQueryParam, writeSelectedPoolViewQueryParam } from '../lib/urlParams.js'
+import { resolveEnumValue } from '../lib/viewState.js'
 import type { SecurityPoolWorkflowRouteContentProps } from '../types/components.js'
 
 type SelectedPoolView = 'vaults' | 'trading' | 'resolution'
 type SelectedVaultView = 'browse-vaults' | 'selected-vault'
-
-function getSelectedPoolView(value: string | undefined): SelectedPoolView {
-	switch (value) {
-		case 'vaults':
-		case 'trading':
-		case 'resolution':
-			return value
-		default:
-			return 'vaults'
-	}
-}
 
 export function SecurityPoolWorkflowSection({
 	accountState,
@@ -63,10 +56,10 @@ export function SecurityPoolWorkflowSection({
 	showHeader = true,
 	trading,
 }: SecurityPoolWorkflowRouteContentProps & { showHeader?: boolean }) {
-	const [view, setView] = useState<SelectedPoolView>(() => getSelectedPoolView(readSelectedPoolViewQueryParam(window.location.search)))
+	const [view, setView] = useState<SelectedPoolView>(() => resolveEnumValue<SelectedPoolView>(readSelectedPoolViewQueryParam(window.location.search), 'vaults', ['vaults', 'trading', 'resolution']))
 	const [vaultView, setVaultView] = useState<SelectedVaultView>('selected-vault')
 	const isMainnet = isMainnetChain(accountState.chainId)
-	const selectedPool = securityPools.find(pool => pool.securityPoolAddress.toLowerCase() === securityPoolAddress.toLowerCase())
+	const selectedPool = securityPools.find(pool => sameCaseInsensitiveText(pool.securityPoolAddress, securityPoolAddress))
 	const marketDetails = selectedPool?.marketDetails ?? reporting.reportingDetails?.marketDetails ?? forkAuction.forkAuctionDetails?.marketDetails
 	const selectedPoolState = selectedPool?.systemState ?? forkAuction.forkAuctionDetails?.systemState
 	const currentTimestamp = reporting.reportingDetails?.currentTime ?? BigInt(Math.floor(Date.now() / 1000))
@@ -75,7 +68,7 @@ export function SecurityPoolWorkflowSection({
 	const selectedPoolUniverseMismatch = selectedPool !== undefined && selectedPool.universeId !== activeUniverseId
 	const hasSelectedPoolAddress = securityPoolAddress.trim() !== ''
 	const selectedPoolManagerAddress = selectedPool?.managerAddress
-	const selectedPoolManagerAddressKey = selectedPoolManagerAddress?.toLowerCase()
+	const selectedPoolManagerAddressKey = normalizeAddress(selectedPoolManagerAddress)
 	const selectedVaultAddress = getSelectedVaultAddress(securityVault.securityVaultForm.selectedVaultAddress, accountState.address) ?? ''
 	const selectedVaultIsOwnedByAccount = isSelectedVaultOwnedByAccountHelper(selectedVaultAddress, accountState.address)
 	const selectedPoolTitle = selectedPool !== undefined ? getQuestionTitle(selectedPool.marketDetails) : securityPoolAddress === '' ? 'Select a security pool' : <AddressValue address={securityPoolAddress} />
@@ -84,16 +77,16 @@ export function SecurityPoolWorkflowSection({
 
 	useEffect(() => {
 		if (selectedPoolManagerAddress === undefined) return
-		if (poolOracleManagerDetails?.managerAddress.toLowerCase() === selectedPoolManagerAddressKey) return
+		if (sameAddress(poolOracleManagerDetails?.managerAddress, selectedPoolManagerAddress)) return
 		if (lastAutoLoadedManagerAddress.current === selectedPoolManagerAddressKey) return
 		lastAutoLoadedManagerAddress.current = selectedPoolManagerAddressKey
 		void onLoadPoolOracleManager(selectedPoolManagerAddress)
 	}, [poolOracleManagerDetails?.managerAddress, selectedPoolManagerAddress, selectedPoolManagerAddressKey])
 
 	useEffect(() => {
-		const normalizedSelectedPoolAddress = selectedPool?.securityPoolAddress.toLowerCase()
+		const normalizedSelectedPoolAddress = normalizeAddress(selectedPool?.securityPoolAddress)
 		if (normalizedSelectedPoolAddress === undefined) return
-		const selectedPoolVaultDefaultKey = `${normalizedSelectedPoolAddress}:${accountState.address?.toLowerCase() ?? ''}`
+		const selectedPoolVaultDefaultKey = `${normalizedSelectedPoolAddress}:${normalizeAddress(accountState.address) ?? ''}`
 		if (lastSelectedPoolVaultDefaultKey.current === selectedPoolVaultDefaultKey) return
 		lastSelectedPoolVaultDefaultKey.current = selectedPoolVaultDefaultKey
 		setVaultView('selected-vault')
@@ -144,48 +137,22 @@ export function SecurityPoolWorkflowSection({
 									<span className='badge muted'>{selectedPool.vaultCount.toString()} vaults</span>
 								</div>
 								<div className='workflow-metric-grid'>
-									<div>
-										<span className='metric-label'>Security Multiplier</span>
-										<strong>{selectedPool.securityMultiplier.toString()}</strong>
-									</div>
-									<div>
-										<span className='metric-label'>Open Interest Fee / Year</span>
-										<strong>
-											<CurrencyValue value={openInterestFeePerYearBigint(selectedPool.currentRetentionRate)} suffix='%' />
-										</strong>
-									</div>
-									{reportingReady ? (
-										<div>
-											<span className='metric-label'>Reporting</span>
-											<strong>Unlocked</strong>
-										</div>
-									) : undefined}
-									<div>
-										<span className='metric-label'>Manager</span>
-										<strong>
-											<AddressValue address={selectedPool.managerAddress} />
-										</strong>
-									</div>
+									<MetricField label='Security Multiplier'>{selectedPool.securityMultiplier.toString()}</MetricField>
+									<MetricField label='Open Interest Fee / Year'>
+										<CurrencyValue value={openInterestFeePerYearBigint(selectedPool.currentRetentionRate)} suffix='%' />
+									</MetricField>
+									{reportingReady ? <MetricField label='Reporting'>Unlocked</MetricField> : undefined}
+									<MetricField label='Manager'>
+										<AddressValue address={selectedPool.managerAddress} />
+									</MetricField>
 									{forkReady ? (
 										<>
-											<div>
-												<span className='metric-label'>Fork Flow</span>
-												<strong>Forked / active</strong>
-											</div>
-											<div>
-												<span className='metric-label'>Truth Auction</span>
-												<strong>
-													<AddressValue address={selectedPool.truthAuctionAddress} />
-												</strong>
-											</div>
-											<div>
-												<span className='metric-label'>Fork Mode</span>
-												<strong>{selectedPool.forkOwnSecurityPool ? 'Own escalation fork' : 'Parent / Zoltar fork'}</strong>
-											</div>
-											<div>
-												<span className='metric-label'>Fork Outcome</span>
-												<strong>{selectedPool.forkOutcome}</strong>
-											</div>
+											<MetricField label='Fork Flow'>Forked / active</MetricField>
+											<MetricField label='Truth Auction'>
+												<AddressValue address={selectedPool.truthAuctionAddress} />
+											</MetricField>
+											<MetricField label='Fork Mode'>{selectedPool.forkOwnSecurityPool ? 'Own escalation fork' : 'Parent / Zoltar fork'}</MetricField>
+											<MetricField label='Fork Outcome'>{selectedPool.forkOutcome}</MetricField>
 										</>
 									) : undefined}
 								</div>
@@ -221,34 +188,22 @@ export function SecurityPoolWorkflowSection({
 								) : (
 									<>
 										<div className='workflow-metric-grid'>
-											<div>
-												<span className='metric-label'>Last Price</span>
-												<strong>{poolOracleManagerDetails.lastPrice.toString()}</strong>
-											</div>
-											<div>
-												<span className='metric-label'>Set At</span>
-												<strong>
-													<TimestampValue timestamp={poolOracleManagerDetails.lastSettlementTimestamp} zeroText='Never' />
-												</strong>
-											</div>
-											<div>
-												<span className='metric-label'>Pending Request</span>
-												<strong>
-													{poolOracleManagerDetails.pendingReportId > 0n ? (
-														<button className='link' type='button' onClick={() => onViewPendingReport(poolOracleManagerDetails.pendingReportId)}>
-															Report #{poolOracleManagerDetails.pendingReportId.toString()} (security pool/price)
-														</button>
-													) : (
-														'None'
-													)}
-												</strong>
-											</div>
-											<div>
-												<span className='metric-label'>Request Cost</span>
-												<strong>
-													<CurrencyValue value={poolOracleManagerDetails.requestPriceEthCost} suffix='ETH' />
-												</strong>
-											</div>
+											<MetricField label='Last Price'>{poolOracleManagerDetails.lastPrice.toString()}</MetricField>
+											<MetricField label='Set At'>
+												<TimestampValue timestamp={poolOracleManagerDetails.lastSettlementTimestamp} zeroText='Never' />
+											</MetricField>
+											<MetricField label='Pending Request'>
+												{poolOracleManagerDetails.pendingReportId > 0n ? (
+													<button className='link' type='button' onClick={() => onViewPendingReport(poolOracleManagerDetails.pendingReportId)}>
+														Report #{poolOracleManagerDetails.pendingReportId.toString()} (security pool/price)
+													</button>
+												) : (
+													'None'
+												)}
+											</MetricField>
+											<MetricField label='Request Cost'>
+												<CurrencyValue value={poolOracleManagerDetails.requestPriceEthCost} suffix='ETH' />
+											</MetricField>
 										</div>
 										<div className='actions'>
 											<button className='secondary' onClick={() => onRequestPoolPrice(selectedPool.managerAddress)} disabled={accountState.address === undefined || !isMainnet || poolOracleManagerDetails.pendingReportId > 0n}>
@@ -318,7 +273,7 @@ export function SecurityPoolWorkflowSection({
 														key={`${selectedPool.securityPoolAddress}-${vault.vaultAddress}`}
 														className='compact'
 														title={<AddressValue address={vault.vaultAddress} />}
-														badge={selectedVaultAddress !== '' && selectedVaultAddress.toLowerCase() === vault.vaultAddress.toLowerCase() ? <span className='badge ok'>Selected</span> : undefined}
+														badge={selectedVaultAddress !== '' && sameCaseInsensitiveText(selectedVaultAddress, vault.vaultAddress) ? <span className='badge ok'>Selected</span> : undefined}
 														actions={
 															<div className='actions'>
 																<button
@@ -338,38 +293,20 @@ export function SecurityPoolWorkflowSection({
 														}
 													>
 														<div className='workflow-vault-grid'>
-															<div>
-																<span className='metric-label'>REP Deposit Share</span>
-																<strong>
-																	<CurrencyValue value={vault.repDepositShare} suffix='REP' />
-																</strong>
-															</div>
-															<div>
-																<span className='metric-label'>Pool Ownership</span>
-																<strong>{vault.poolOwnership.toString()}</strong>
-															</div>
-															<div>
-																<span className='metric-label'>Security Bond Allowance</span>
-																<strong>
-																	<CurrencyValue value={vault.securityBondAllowance} suffix='REP' />
-																</strong>
-															</div>
-															<div>
-																<span className='metric-label'>Unpaid ETH Fees</span>
-																<strong>
-																	<CurrencyValue value={vault.unpaidEthFees} suffix='ETH' />
-																</strong>
-															</div>
-															<div>
-																<span className='metric-label'>Locked REP</span>
-																<strong>
-																	<CurrencyValue value={vault.lockedRepInEscalationGame} suffix='REP' />
-																</strong>
-															</div>
-															<div>
-																<span className='metric-label'>Fee Index</span>
-																<strong>{vault.feeIndex.toString()}</strong>
-															</div>
+															<MetricField label='REP Deposit Share'>
+																<CurrencyValue value={vault.repDepositShare} suffix='REP' />
+															</MetricField>
+															<MetricField label='Pool Ownership'>{vault.poolOwnership.toString()}</MetricField>
+															<MetricField label='Security Bond Allowance'>
+																<CurrencyValue value={vault.securityBondAllowance} suffix='REP' />
+															</MetricField>
+															<MetricField label='Unpaid ETH Fees'>
+																<CurrencyValue value={vault.unpaidEthFees} suffix='ETH' />
+															</MetricField>
+															<MetricField label='Locked REP'>
+																<CurrencyValue value={vault.lockedRepInEscalationGame} suffix='REP' />
+															</MetricField>
+															<MetricField label='Fee Index'>{vault.feeIndex.toString()}</MetricField>
 														</div>
 													</EntityCard>
 												))}

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -44,6 +44,7 @@ export function SecurityPoolWorkflowSection({
 	liquidationSecurityPoolAddress,
 	liquidationTargetVault,
 	loadingPoolOracleManager,
+	loadingSecurityPools,
 	onLiquidationAmountChange,
 	onLiquidationTargetVaultChange,
 	onLoadPoolOracleManager,
@@ -128,7 +129,13 @@ export function SecurityPoolWorkflowSection({
 					{!hasSelectedPoolAddress ? (
 						<p className='detail'>Browse Pools to pick one, or paste an address above.</p>
 					) : selectedPool === undefined ? (
-						<p className='detail'>Pool metadata unavailable. Refresh Pool Registry in the Browse tab to load metadata for this address.</p>
+						loadingSecurityPools ? (
+							<p className='detail'>
+								<span className='spinner' aria-hidden='true' /> Loading pool data…
+							</p>
+						) : (
+							<p className='detail'>Pool metadata unavailable. Refresh Pool Registry in the Browse tab to load metadata for this address.</p>
+						)
 					) : (
 						<>
 							<div className='entity-card-subsection'>
@@ -293,7 +300,13 @@ export function SecurityPoolWorkflowSection({
 								{vaultView === 'browse-vaults' ? (
 									<EntityCard className='selected-pool-card' title='Browse Vaults' badge={<span className='badge muted'>{selectedPool?.vaultCount.toString() ?? '0'} vaults</span>}>
 										{selectedPool === undefined ? (
-											<p className='detail'>No pool metadata</p>
+											loadingSecurityPools ? (
+												<p className='detail'>
+													<span className='spinner' aria-hidden='true' /> Loading pool data…
+												</p>
+											) : (
+												<p className='detail'>No pool metadata</p>
+											)
 										) : selectedPool.vaults.length === 0 ? (
 											<p className='detail'>No vaults</p>
 										) : (

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -11,8 +11,8 @@ import { TradingSection } from './TradingSection.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { UniverseLink } from './UniverseLink.js'
 import { CurrencyValue } from './CurrencyValue.js'
+import { TimestampValue } from './TimestampValue.js'
 import { isMainnetChain } from '../lib/network.js'
-import { formatTimestamp } from '../lib/formatters.js'
 import { getSelectedVaultAddress, isSelectedVaultOwnedByAccount as isSelectedVaultOwnedByAccountHelper } from '../lib/securityVault.js'
 import { openInterestFeePerYearBigint } from '../lib/retentionRate.js'
 import { formatUniverseLabel } from '../lib/universe.js'
@@ -227,7 +227,9 @@ export function SecurityPoolWorkflowSection({
 											</div>
 											<div>
 												<span className='metric-label'>Set At</span>
-												<strong>{poolOracleManagerDetails.lastSettlementTimestamp === 0n ? 'Never' : formatTimestamp(poolOracleManagerDetails.lastSettlementTimestamp)}</strong>
+												<strong>
+													<TimestampValue timestamp={poolOracleManagerDetails.lastSettlementTimestamp} zeroText='Never' />
+												</strong>
 											</div>
 											<div>
 												<span className='metric-label'>Pending Request</span>

--- a/ui/ts/components/SecurityPoolsOverviewSection.tsx
+++ b/ui/ts/components/SecurityPoolsOverviewSection.tsx
@@ -3,6 +3,7 @@ import { CurrencyValue } from './CurrencyValue.js'
 import { EntityCard } from './EntityCard.js'
 import { LiquidationModal } from './LiquidationModal.js'
 import { LoadingText } from './LoadingText.js'
+import { MetricField } from './MetricField.js'
 import { Question, getQuestionTitle } from './Question.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { UniverseLink } from './UniverseLink.js'
@@ -86,40 +87,22 @@ export function SecurityPoolsOverviewSection({
 										<span className='badge muted'>{pool.vaultCount.toString()} vaults</span>
 									</div>
 									<div className='workflow-metric-grid'>
-										<div>
-											<span className='metric-label'>Pool Address</span>
-											<strong>
-												<AddressValue address={pool.securityPoolAddress} />
-											</strong>
-										</div>
-										<div>
-											<span className='metric-label'>Universe</span>
-											<strong>
-												<UniverseLink universeId={pool.universeId} />
-											</strong>
-										</div>
-										<div>
-											<span className='metric-label'>Security Multiplier</span>
-											<strong>{pool.securityMultiplier.toString()}</strong>
-										</div>
-										<div>
-											<span className='metric-label'>Open Interest Fee / Year</span>
-											<strong>
-												<CurrencyValue value={openInterestFeePerYearBigint(pool.currentRetentionRate)} suffix='%' />
-											</strong>
-										</div>
-										<div>
-											<span className='metric-label'>Manager</span>
-											<strong>
-												<AddressValue address={pool.managerAddress} />
-											</strong>
-										</div>
-										<div>
-											<span className='metric-label'>Truth Auction</span>
-											<strong>
-												<AddressValue address={pool.truthAuctionAddress} />
-											</strong>
-										</div>
+										<MetricField label='Pool Address'>
+											<AddressValue address={pool.securityPoolAddress} />
+										</MetricField>
+										<MetricField label='Universe'>
+											<UniverseLink universeId={pool.universeId} />
+										</MetricField>
+										<MetricField label='Security Multiplier'>{pool.securityMultiplier.toString()}</MetricField>
+										<MetricField label='Open Interest Fee / Year'>
+											<CurrencyValue value={openInterestFeePerYearBigint(pool.currentRetentionRate)} suffix='%' />
+										</MetricField>
+										<MetricField label='Manager'>
+											<AddressValue address={pool.managerAddress} />
+										</MetricField>
+										<MetricField label='Truth Auction'>
+											<AddressValue address={pool.truthAuctionAddress} />
+										</MetricField>
 									</div>
 								</div>
 
@@ -143,28 +126,16 @@ export function SecurityPoolsOverviewSection({
 													}
 												>
 													<div className='workflow-vault-grid'>
-														<div>
-															<span className='metric-label'>REP Deposit Share</span>
-															<strong>
-																<CurrencyValue value={vault.repDepositShare} suffix='REP' />
-															</strong>
-														</div>
-														<div>
-															<span className='metric-label'>Pool Ownership</span>
-															<strong>{vault.poolOwnership.toString()}</strong>
-														</div>
-														<div>
-															<span className='metric-label'>Security Bond Allowance</span>
-															<strong>
-																<CurrencyValue value={vault.securityBondAllowance} suffix='REP' />
-															</strong>
-														</div>
-														<div>
-															<span className='metric-label'>Unpaid ETH Fees</span>
-															<strong>
-																<CurrencyValue value={vault.unpaidEthFees} suffix='ETH' />
-															</strong>
-														</div>
+														<MetricField label='REP Deposit Share'>
+															<CurrencyValue value={vault.repDepositShare} suffix='REP' />
+														</MetricField>
+														<MetricField label='Pool Ownership'>{vault.poolOwnership.toString()}</MetricField>
+														<MetricField label='Security Bond Allowance'>
+															<CurrencyValue value={vault.securityBondAllowance} suffix='REP' />
+														</MetricField>
+														<MetricField label='Unpaid ETH Fees'>
+															<CurrencyValue value={vault.unpaidEthFees} suffix='ETH' />
+														</MetricField>
 													</div>
 												</EntityCard>
 											))}

--- a/ui/ts/components/SecurityPoolsSection.tsx
+++ b/ui/ts/components/SecurityPoolsSection.tsx
@@ -2,18 +2,21 @@ import { useState } from 'preact/hooks'
 import { SecurityPoolSection } from './SecurityPoolSection.js'
 import { SecurityPoolWorkflowSection } from './SecurityPoolWorkflowSection.js'
 import { SecurityPoolsOverviewSection } from './SecurityPoolsOverviewSection.js'
+import { resolveFirstMatchingValue } from '../lib/viewState.js'
 import type { SecurityPoolsSectionProps } from '../types/components.js'
 
 type SecurityPoolsView = 'browse' | 'create' | 'operate'
 
-function getInitialSecurityPoolsView({ createPool, workflow }: SecurityPoolsSectionProps): SecurityPoolsView {
-	if (workflow.securityPoolAddress !== '') return 'operate'
-	if (createPool.securityPoolForm.marketId !== '' || createPool.marketDetails !== undefined || createPool.securityPoolResult !== undefined) return 'create'
-	return 'browse'
-}
-
 export function SecurityPoolsSection({ createPool, overview, workflow }: SecurityPoolsSectionProps) {
-	const [view, setView] = useState<SecurityPoolsView>(() => getInitialSecurityPoolsView({ createPool, overview, workflow }))
+	const [view, setView] = useState<SecurityPoolsView>(() =>
+		resolveFirstMatchingValue<SecurityPoolsView>(
+			[
+				[workflow.securityPoolAddress !== '', 'operate'],
+				[createPool.securityPoolForm.marketId !== '' || createPool.marketDetails !== undefined || createPool.securityPoolResult !== undefined, 'create'],
+			],
+			'browse',
+		),
+	)
 
 	return (
 		<section className='panel market-panel'>

--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -3,7 +3,9 @@ import { AddressValue } from './AddressValue.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { EntityCard } from './EntityCard.js'
 import { LoadingText } from './LoadingText.js'
+import { MetricField } from './MetricField.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
+import { normalizeAddress, sameAddress } from '../lib/address.js'
 import { approvalShortage } from '../lib/inputs.js'
 import { formatCurrencyBalance } from '../lib/formatters.js'
 import { isMainnetChain } from '../lib/network.js'
@@ -87,8 +89,8 @@ export function SecurityVaultSection({
 					redeemFees: 'Redeem Fees',
 					updateVaultFees: 'Update Fees',
 				}[securityVaultResult.action]
-	const autoLoadKey = `${selectedVaultAddress ?? ''}:${normalizedSecurityVaultForm.securityPoolAddress}`
-	const hasLoadedCurrentVault = securityVaultDetails !== undefined && selectedVaultAddress !== undefined && securityVaultDetails.vaultAddress.toLowerCase() === selectedVaultAddress.toLowerCase() && securityVaultDetails.securityPoolAddress.toLowerCase() === normalizedSecurityVaultForm.securityPoolAddress.toLowerCase()
+	const autoLoadKey = `${normalizeAddress(selectedVaultAddress) ?? ''}:${normalizeAddress(normalizedSecurityVaultForm.securityPoolAddress) ?? ''}`
+	const hasLoadedCurrentVault = securityVaultDetails !== undefined && sameAddress(securityVaultDetails.vaultAddress, selectedVaultAddress) && sameAddress(securityVaultDetails.securityPoolAddress, normalizedSecurityVaultForm.securityPoolAddress)
 	const lastAutoLoadKey = useRef<string | undefined>(undefined)
 
 	useEffect(() => {
@@ -105,46 +107,27 @@ export function SecurityVaultSection({
 		<div className='entity-card-subsection'>
 			{securityVaultDetails === undefined ? undefined : (
 				<div className='entity-metric-grid'>
-					<div className='entity-metric'>
-						<span className='metric-label'>Selected Vault</span>
-						<strong>
-							<AddressValue address={securityVaultDetails.vaultAddress} />
-						</strong>
-					</div>
-					<div className='entity-metric'>
-						<span className='metric-label'>REP Deposit Share</span>
-						<strong>
-							<CurrencyValue value={securityVaultDetails.repDepositShare} suffix='REP' />
-						</strong>
-					</div>
-					<div className='entity-metric'>
-						<span className='metric-label'>Approved REP</span>
-						<strong>{approvedRep === undefined ? <LoadingText>Loading...</LoadingText> : <CurrencyValue value={approvedRep} suffix='REP' />}</strong>
-					</div>
-					<div className='entity-metric'>
-						<span className='metric-label'>Security Bond Allowance</span>
-						<strong>
-							<CurrencyValue value={securityBondAllowance} suffix='REP' />
-						</strong>
-					</div>
-					<div className='entity-metric'>
-						<span className='metric-label'>Unpaid ETH Fees</span>
-						<strong>
-							<CurrencyValue value={securityVaultDetails.unpaidEthFees} suffix='ETH' />
-						</strong>
-					</div>
-					<div className='entity-metric'>
-						<span className='metric-label'>Locked REP</span>
-						<strong>
-							<CurrencyValue value={securityVaultDetails.lockedRepInEscalationGame} suffix='REP' />
-						</strong>
-					</div>
-					<div className='entity-metric'>
-						<span className='metric-label'>Total Security Bond Allowance</span>
-						<strong>
-							<CurrencyValue value={securityVaultDetails.totalSecurityBondAllowance} suffix='ETH' />
-						</strong>
-					</div>
+					<MetricField className='entity-metric' label='Selected Vault'>
+						<AddressValue address={securityVaultDetails.vaultAddress} />
+					</MetricField>
+					<MetricField className='entity-metric' label='REP Deposit Share'>
+						<CurrencyValue value={securityVaultDetails.repDepositShare} suffix='REP' />
+					</MetricField>
+					<MetricField className='entity-metric' label='Approved REP'>
+						{approvedRep === undefined ? <LoadingText>Loading...</LoadingText> : <CurrencyValue value={approvedRep} suffix='REP' />}
+					</MetricField>
+					<MetricField className='entity-metric' label='Security Bond Allowance'>
+						<CurrencyValue value={securityBondAllowance} suffix='REP' />
+					</MetricField>
+					<MetricField className='entity-metric' label='Unpaid ETH Fees'>
+						<CurrencyValue value={securityVaultDetails.unpaidEthFees} suffix='ETH' />
+					</MetricField>
+					<MetricField className='entity-metric' label='Locked REP'>
+						<CurrencyValue value={securityVaultDetails.lockedRepInEscalationGame} suffix='REP' />
+					</MetricField>
+					<MetricField className='entity-metric' label='Total Security Bond Allowance'>
+						<CurrencyValue value={securityVaultDetails.totalSecurityBondAllowance} suffix='ETH' />
+					</MetricField>
 				</div>
 			)}
 			{showSecurityPoolAddressInput ? (
@@ -172,12 +155,9 @@ export function SecurityVaultSection({
 					<h4>Set Security Bond Allowance</h4>
 				</div>
 				<div className='entity-metric-grid'>
-					<div className='entity-metric'>
-						<span className='metric-label'>Current Security Bond Allowance</span>
-						<strong>
-							<CurrencyValue value={securityBondAllowance} suffix='REP' />
-						</strong>
-					</div>
+					<MetricField className='entity-metric' label='Current Security Bond Allowance'>
+						<CurrencyValue value={securityBondAllowance} suffix='REP' />
+					</MetricField>
 				</div>
 				<label className='field'>
 					<span>Security Bond Allowance Amount</span>
@@ -253,12 +233,9 @@ export function SecurityVaultSection({
 				<p className='detail'>Refresh the vault to calculate withdrawable REP.</p>
 			) : (
 				<div className='entity-metric-grid'>
-					<div className='entity-metric'>
-						<span className='metric-label'>Withdrawable REP</span>
-						<strong>
-							<CurrencyValue value={withdrawableRepAmount} suffix='REP' />
-						</strong>
-					</div>
+					<MetricField className='entity-metric' label='Withdrawable REP'>
+						<CurrencyValue value={withdrawableRepAmount} suffix='REP' />
+					</MetricField>
 				</div>
 			)}
 			<p className='detail'>Withdrawals are queued through the oracle manager.</p>
@@ -318,16 +295,12 @@ export function SecurityVaultSection({
 					{securityVaultResult === undefined ? undefined : (
 						<EntityCard title='Latest Vault Action'>
 							<div className='entity-metric-grid'>
-								<div className='entity-metric'>
-									<span className='metric-label'>Action</span>
-									<strong>{securityVaultResult.action}</strong>
-								</div>
-								<div className='entity-metric'>
-									<span className='metric-label'>Transaction</span>
-									<strong>
-										<TransactionHashLink hash={securityVaultResult.hash} />
-									</strong>
-								</div>
+								<MetricField className='entity-metric' label='Action'>
+									{securityVaultResult.action}
+								</MetricField>
+								<MetricField className='entity-metric' label='Transaction'>
+									<TransactionHashLink hash={securityVaultResult.hash} />
+								</MetricField>
 							</div>
 						</EntityCard>
 					)}

--- a/ui/ts/components/TimestampValue.tsx
+++ b/ui/ts/components/TimestampValue.tsx
@@ -1,0 +1,59 @@
+import type { ComponentChildren } from 'preact'
+import { useEffect, useState } from 'preact/hooks'
+import { formatRelativeTimestamp, formatTimestamp } from '../lib/formatters.js'
+
+type TimestampValueProps = {
+	className?: string
+	currentTimestamp?: bigint
+	loading?: boolean
+	timestamp: bigint | undefined
+	undefinedText?: ComponentChildren
+	zeroText?: ComponentChildren
+}
+
+function getCurrentTimestamp() {
+	return BigInt(Math.floor(Date.now() / 1000))
+}
+
+export function TimestampValue({ className = '', currentTimestamp, loading = false, timestamp, undefinedText = 'Unavailable', zeroText }: TimestampValueProps) {
+	const [now, setNow] = useState(() => currentTimestamp ?? getCurrentTimestamp())
+
+	useEffect(() => {
+		if (loading) return
+		const updateNow = () => {
+			setNow(currentTimestamp ?? getCurrentTimestamp())
+		}
+
+		updateNow()
+		const intervalId = window.setInterval(updateNow, 1000)
+
+		return () => {
+			window.clearInterval(intervalId)
+		}
+	}, [currentTimestamp, loading])
+
+	if (loading) {
+		return <span className={`timestamp-value loading ${className}`}>Loading...</span>
+	}
+
+	if (timestamp === undefined) {
+		return <span className={`timestamp-value unavailable ${className}`}>{undefinedText}</span>
+	}
+
+	if (timestamp === 0n) {
+		return (
+			<span className={`timestamp-value zero ${className}`} title={typeof zeroText === 'string' ? zeroText : undefined}>
+				{zeroText ?? formatTimestamp(timestamp)}
+			</span>
+		)
+	}
+
+	const absoluteTimestamp = formatTimestamp(timestamp)
+	const relativeTimestamp = formatRelativeTimestamp(timestamp, now)
+
+	return (
+		<time className={`timestamp-value ${className}`} dateTime={new Date(Number(timestamp) * 1000).toISOString()} title={absoluteTimestamp}>
+			{absoluteTimestamp} <span className='timestamp-value-relative'>({relativeTimestamp})</span>
+		</time>
+	)
+}

--- a/ui/ts/components/TradingSection.tsx
+++ b/ui/ts/components/TradingSection.tsx
@@ -3,7 +3,7 @@ import { EntityCard } from './EntityCard.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { UniverseLink } from './UniverseLink.js'
 import { isMainnetChain } from '../lib/network.js'
-import { REPORTING_OUTCOME_OPTIONS } from '../lib/reporting.js'
+import { REPORTING_OUTCOME_DROPDOWN_OPTIONS } from '../lib/reporting.js'
 import type { TradingSectionProps } from '../types/components.js'
 
 export function TradingSection({ accountState, onCreateCompleteSet, onMigrateShares, onRedeemCompleteSet, onRedeemShares, onTradingFormChange, tradingError, tradingForm, tradingResult, showHeader = true, showSecurityPoolAddressInput = true }: TradingSectionProps) {
@@ -64,7 +64,7 @@ export function TradingSection({ accountState, onCreateCompleteSet, onMigrateSha
 								</label>
 								<label className='field'>
 									<span>Outcome To Migrate</span>
-									<EnumDropdown options={REPORTING_OUTCOME_OPTIONS.map(option => ({ value: option.key, label: option.label }))} value={tradingForm.selectedOutcome} onChange={selectedOutcome => onTradingFormChange({ selectedOutcome })} />
+									<EnumDropdown options={REPORTING_OUTCOME_DROPDOWN_OPTIONS} value={tradingForm.selectedOutcome} onChange={selectedOutcome => onTradingFormChange({ selectedOutcome })} />
 								</label>
 							</div>
 

--- a/ui/ts/components/ZoltarMigrationSection.tsx
+++ b/ui/ts/components/ZoltarMigrationSection.tsx
@@ -4,6 +4,7 @@ import { CurrencyValue } from './CurrencyValue.js'
 import { EntityCard } from './EntityCard.js'
 import { FormInput } from './FormInput.js'
 import { LoadingText } from './LoadingText.js'
+import { MetricField } from './MetricField.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { UniverseLink } from './UniverseLink.js'
 import { getMigrationOutcomeSplitLimit, MigrationOutcomeUniversesSection } from './MigrationOutcomeUniversesSection.js'
@@ -217,23 +218,16 @@ export function ZoltarMigrationSection({
 		<>
 			<EntityCard title='Migrate REP'>
 				<div className='workflow-metric-grid'>
+					<MetricField label='Migration REP Balance'>
+						<CurrencyValue loading={loadingZoltarForkAccess && zoltarMigrationPreparedRepBalance === undefined} value={zoltarMigrationPreparedRepBalance} suffix='REP' />
+					</MetricField>
 					<div>
-						<span className='metric-label'>Migration REP Balance</span>
-						<strong>
-							<CurrencyValue loading={loadingZoltarForkAccess && zoltarMigrationPreparedRepBalance === undefined} value={zoltarMigrationPreparedRepBalance} suffix='REP' />
-						</strong>
-					</div>
-					<div>
-						<span className='metric-label'>Approved REP</span>
-						<strong>
+						<MetricField label='Approved REP'>
 							<CurrencyValue loading={loadingZoltarForkAccess && zoltarForkAllowance === undefined} value={zoltarForkAllowance} suffix='REP' />
-						</strong>
+						</MetricField>
 						{approvalShortage > 0n ? <p className='detail'>Need {formatCurrencyBalance(approvalShortage)} more REP approved before preparing the current amount.</p> : undefined}
 					</div>
-					<div>
-						<span className='metric-label'>Universe</span>
-						<strong>{rootUniverse === undefined ? <LoadingText>Loading universe data...</LoadingText> : <UniverseLink universeId={rootUniverse.universeId} />}</strong>
-					</div>
+					<MetricField label='Universe'>{rootUniverse === undefined ? <LoadingText>Loading universe data...</LoadingText> : <UniverseLink universeId={rootUniverse.universeId} />}</MetricField>
 				</div>
 				<div className='form-grid'>
 					<div className='field'>
@@ -277,26 +271,18 @@ export function ZoltarMigrationSection({
 			{zoltarMigrationResult === undefined ? undefined : (
 				<EntityCard title='Latest Migration Action' badge={<span className='badge muted'>{zoltarMigrationResult.action}</span>}>
 					<div className='entity-metric-grid'>
-						<div className='entity-metric'>
-							<span className='metric-label'>Action</span>
-							<strong>{zoltarMigrationResult.action}</strong>
-						</div>
-						<div className='entity-metric'>
-							<span className='metric-label'>Amount</span>
-							<strong>
-								<CurrencyValue value={zoltarMigrationResult.amount} suffix='REP' />
-							</strong>
-						</div>
-						<div className='entity-metric'>
-							<span className='metric-label'>Outcome Indexes</span>
-							<strong>{zoltarMigrationResult.outcomeIndexes.length === 0 ? 'None' : zoltarMigrationResult.outcomeIndexes.join(', ')}</strong>
-						</div>
-						<div className='entity-metric'>
-							<span className='metric-label'>Transaction</span>
-							<strong>
-								<TransactionHashLink hash={zoltarMigrationResult.hash} />
-							</strong>
-						</div>
+						<MetricField className='entity-metric' label='Action'>
+							{zoltarMigrationResult.action}
+						</MetricField>
+						<MetricField className='entity-metric' label='Amount'>
+							<CurrencyValue value={zoltarMigrationResult.amount} suffix='REP' />
+						</MetricField>
+						<MetricField className='entity-metric' label='Outcome Indexes'>
+							{zoltarMigrationResult.outcomeIndexes.length === 0 ? 'None' : zoltarMigrationResult.outcomeIndexes.join(', ')}
+						</MetricField>
+						<MetricField className='entity-metric' label='Transaction'>
+							<TransactionHashLink hash={zoltarMigrationResult.hash} />
+						</MetricField>
 					</div>
 				</EntityCard>
 			)}

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -70,9 +70,7 @@ const MIGRATION_TIME_LENGTH = 4_838_400n
 const TRUTH_AUCTION_TIME_LENGTH = 604_800n
 const QUESTION_OUTCOME_ABI = [parseAbiItem('function getQuestionOutcome(address securityPool) view returns (uint8 outcome)')]
 const ANSWER_OPTION_ABI = [parseAbiItem('function getAnswerOptionName(uint256 questionId, uint256 answer) view returns (string memory)')]
-const REPORT_INSTANCE_CREATED_EVENT = parseAbiItem(
-	'event ReportInstanceCreated(uint256 indexed reportId, address indexed token1Address, address indexed token2Address, uint256 feePercentage, uint256 multiplier, uint256 exactToken1Report, uint256 ethFee, address creator, uint256 settlementTime, uint256 escalationHalt, uint256 disputeDelay, uint256 protocolFee, uint256 settlerReward, bool timeType, address callbackContract, bytes4 callbackSelector, bool trackDisputes, uint256 callbackGasLimit, bool keepFee, bytes32 stateHash, uint256 blockTimestamp, bool feeToken)',
-)
+
 const CONTRACT_PAGE_SIZE = 30n
 
 type DeployedChildUniverseRecord = {
@@ -522,6 +520,17 @@ async function loadErc20Decimals(client: ReadClient, tokenAddress: Address) {
 		await client.readContract({
 			abi: ABIS.mainnet.erc20,
 			functionName: 'decimals',
+			address: tokenAddress,
+			args: [],
+		}),
+	)
+}
+
+async function loadErc20Symbol(client: ReadClient, tokenAddress: Address) {
+	return String(
+		await client.readContract({
+			abi: ABIS.mainnet.erc20,
+			functionName: 'symbol',
 			address: tokenAddress,
 			args: [],
 		}),
@@ -1330,7 +1339,7 @@ export async function loadOpenOracleReportDetails(client: ReadClient, openOracle
 		args: [reportId],
 	})
 	if (meta[4] === zeroAddress) throw new Error(`Oracle report #${reportId.toString()} does not exist`)
-	const [status, extra, createdAt, token1Decimals, token2Decimals] = await Promise.all([
+	const [status, extra, token1Decimals, token2Decimals, token1Symbol, token2Symbol] = await Promise.all([
 		client.readContract({
 			abi: peripherals_openOracle_OpenOracle_OpenOracle.abi,
 			functionName: 'reportStatus',
@@ -1343,21 +1352,13 @@ export async function loadOpenOracleReportDetails(client: ReadClient, openOracle
 			address: openOracleAddress,
 			args: [reportId],
 		}),
-		client
-			.getLogs({
-				address: openOracleAddress,
-				args: { reportId },
-				event: REPORT_INSTANCE_CREATED_EVENT,
-				fromBlock: 0n,
-				toBlock: 'latest',
-			})
-			.then(logs => logs.at(-1)?.args.blockTimestamp),
 		loadErc20Decimals(client, meta[4]),
 		loadErc20Decimals(client, meta[6]),
+		loadErc20Symbol(client, meta[4]),
+		loadErc20Symbol(client, meta[6]),
 	])
 
 	return {
-		createdAt,
 		reportId,
 		openOracleAddress,
 		exactToken1Report: meta[0],
@@ -1384,8 +1385,17 @@ export async function loadOpenOracleReportDetails(client: ReadClient, openOracle
 		stateHash: extra[0],
 		callbackContract: extra[1],
 		numReports: BigInt(extra[2]),
+		callbackGasLimit: Number(extra[3]),
+		callbackSelector: extra[4],
+		protocolFeeRecipient: extra[5],
+		trackDisputes: extra[6],
+		keepFee: extra[7],
+		feeToken: extra[8],
+		lastReportOppoTime: BigInt(status[7]),
 		token1Decimals,
 		token2Decimals,
+		token1Symbol,
+		token2Symbol,
 	}
 }
 
@@ -1437,7 +1447,6 @@ export async function loadOpenOracleReportSummaries(client: ReadClient, pageInde
 		reportIds.map(async reportId => {
 			const details = await loadOpenOracleReportDetails(client, openOracleAddress, reportId)
 			return {
-				createdAt: details.createdAt,
 				currentAmount1: details.currentAmount1,
 				currentAmount2: details.currentAmount2,
 				currentReporter: details.currentReporter,
@@ -1452,6 +1461,8 @@ export async function loadOpenOracleReportSummaries(client: ReadClient, pageInde
 				token2: details.token2,
 				token1Decimals: details.token1Decimals,
 				token2Decimals: details.token2Decimals,
+				token1Symbol: details.token1Symbol,
+				token2Symbol: details.token2Symbol,
 			} satisfies OpenOracleReportSummary
 		}),
 	)

--- a/ui/ts/hooks/useForkAuctionOperations.ts
+++ b/ui/ts/hooks/useForkAuctionOperations.ts
@@ -19,8 +19,10 @@ import {
 } from '../contracts.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
 import { getErrorMessage } from '../lib/errors.js'
+import { getReportingOutcomeKey, parseAddressInput, parseBigIntListInput, parseReportingOutcomeInput, parseReportingOutcomeListInput, resolveOptionalAddressInput } from '../lib/inputs.js'
+import { runLoadRequest } from '../lib/loadState.js'
+import { requireDefined } from '../lib/required.js'
 import { buildWriteActionConfig, runWriteAction } from '../lib/writeAction.js'
-import { getReportingOutcomeKey, parseAddressInput, parseBigIntListInput, parseReportingOutcomeInput, parseReportingOutcomeListInput } from '../lib/inputs.js'
 import { getDefaultForkAuctionFormState, parseBigIntInput } from '../lib/marketForm.js'
 import type { ForkAuctionFormState, WriteOperationsParameters } from '../types/app.js'
 import type { ForkAuctionActionResult, ForkAuctionDetails, ReportingOutcomeKey } from '../types/contracts.js'
@@ -35,18 +37,25 @@ export function useForkAuctionOperations({ accountAddress, onTransaction, onTran
 	const loadingForkAuctionDetails = useSignal(false)
 
 	const loadForkAuction = async () => {
-		loadingForkAuctionDetails.value = true
-		forkAuctionError.value = undefined
-		try {
-			const securityPoolAddress = parseAddressInput(forkAuctionForm.value.securityPoolAddress, 'Security pool address')
-			const details = await loadForkAuctionDetails(createConnectedReadClient(), securityPoolAddress)
-			forkAuctionDetails.value = details
-		} catch (error) {
-			forkAuctionDetails.value = undefined
-			forkAuctionError.value = getErrorMessage(error, 'Failed to load fork and auction details')
-		} finally {
-			loadingForkAuctionDetails.value = false
-		}
+		await runLoadRequest({
+			setLoading: value => {
+				loadingForkAuctionDetails.value = value
+			},
+			onStart: () => {
+				forkAuctionError.value = undefined
+			},
+			load: async () => {
+				const securityPoolAddress = parseAddressInput(forkAuctionForm.value.securityPoolAddress, 'Security pool address')
+				return await loadForkAuctionDetails(createConnectedReadClient(), securityPoolAddress)
+			},
+			onSuccess: details => {
+				forkAuctionDetails.value = details
+			},
+			onError: error => {
+				forkAuctionDetails.value = undefined
+				forkAuctionError.value = getErrorMessage(error, 'Failed to load fork and auction details')
+			},
+		})
 	}
 
 	const runForkAuctionAction = async (action: (walletAddress: Address, details: ForkAuctionDetails) => Promise<ForkAuctionActionResult>, errorFallback: string) =>
@@ -82,7 +91,7 @@ export function useForkAuctionOperations({ accountAddress, onTransaction, onTran
 
 	const migrateEscalation = async () =>
 		await runForkAuctionAction(async (walletAddress, details) => {
-			const vaultAddress = forkAuctionForm.value.claimVaultAddress.trim() === '' ? walletAddress : parseAddressInput(forkAuctionForm.value.claimVaultAddress, 'Vault address')
+			const vaultAddress = resolveOptionalAddressInput(forkAuctionForm.value.claimVaultAddress, walletAddress, 'Vault address')
 			return await migrateEscalationDeposits(
 				createWalletWriteClient(walletAddress, { onTransactionSubmitted }),
 				details.securityPoolAddress,
@@ -97,18 +106,18 @@ export function useForkAuctionOperations({ accountAddress, onTransaction, onTran
 
 	const submitBid = async () =>
 		await runForkAuctionAction(async (walletAddress, details) => {
-			if (details.truthAuctionAddress === undefined) throw new Error('Truth auction not available')
-			return await submitTruthAuctionBid(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), details.securityPoolAddress, details.universeId, details.truthAuctionAddress, parseBigIntInput(forkAuctionForm.value.bidTick, 'Bid tick'), parseBigIntInput(forkAuctionForm.value.bidAmount, 'Bid amount'))
+			const truthAuctionAddress = requireDefined(details.truthAuctionAddress, 'Truth auction not available')
+			return await submitTruthAuctionBid(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), details.securityPoolAddress, details.universeId, truthAuctionAddress, parseBigIntInput(forkAuctionForm.value.bidTick, 'Bid tick'), parseBigIntInput(forkAuctionForm.value.bidAmount, 'Bid amount'))
 		}, 'Failed to submit truth auction bid')
 
 	const refundLosingBids = async () =>
 		await runForkAuctionAction(async (walletAddress, details) => {
-			if (details.truthAuctionAddress === undefined) throw new Error('Truth auction not available')
+			const truthAuctionAddress = requireDefined(details.truthAuctionAddress, 'Truth auction not available')
 			return await refundTruthAuctionBid(
 				createWalletWriteClient(walletAddress, { onTransactionSubmitted }),
 				details.securityPoolAddress,
 				details.universeId,
-				details.truthAuctionAddress,
+				truthAuctionAddress,
 				parseBigIntInput(forkAuctionForm.value.refundTick, 'Refund tick'),
 				parseBigIntInput(forkAuctionForm.value.refundBidIndex, 'Refund bid index'),
 			)
@@ -118,7 +127,7 @@ export function useForkAuctionOperations({ accountAddress, onTransaction, onTran
 
 	const claimAuctionProceeds = async () =>
 		await runForkAuctionAction(async (walletAddress, details) => {
-			const vaultAddress = forkAuctionForm.value.claimVaultAddress.trim() === '' ? walletAddress : parseAddressInput(forkAuctionForm.value.claimVaultAddress, 'Vault address')
+			const vaultAddress = resolveOptionalAddressInput(forkAuctionForm.value.claimVaultAddress, walletAddress, 'Vault address')
 			return await claimSecurityPoolAuctionProceeds(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), details.securityPoolAddress, details.universeId, vaultAddress, parseBigIntInput(forkAuctionForm.value.bidTick, 'Bid tick'), parseBigIntInput(forkAuctionForm.value.bidIndex, 'Bid index'))
 		}, 'Failed to claim auction proceeds')
 
@@ -131,13 +140,13 @@ export function useForkAuctionOperations({ accountAddress, onTransaction, onTran
 
 	const withdrawBids = async () =>
 		await runForkAuctionAction(async (walletAddress, details) => {
-			if (details.truthAuctionAddress === undefined) throw new Error('Truth auction not available')
-			const withdrawFor = forkAuctionForm.value.withdrawForAddress.trim() === '' ? walletAddress : parseAddressInput(forkAuctionForm.value.withdrawForAddress, 'Withdraw-for address')
+			const truthAuctionAddress = requireDefined(details.truthAuctionAddress, 'Truth auction not available')
+			const withdrawFor = resolveOptionalAddressInput(forkAuctionForm.value.withdrawForAddress, walletAddress, 'Withdraw-for address')
 			return await withdrawTruthAuctionBids(
 				createWalletWriteClient(walletAddress, { onTransactionSubmitted }),
 				details.securityPoolAddress,
 				details.universeId,
-				details.truthAuctionAddress,
+				truthAuctionAddress,
 				withdrawFor,
 				parseBigIntInput(forkAuctionForm.value.withdrawTick, 'Withdraw tick'),
 				parseBigIntInput(forkAuctionForm.value.withdrawBidIndex, 'Withdraw bid index'),

--- a/ui/ts/hooks/useOnchainState.ts
+++ b/ui/ts/hooks/useOnchainState.ts
@@ -100,7 +100,7 @@ export function useOnchainState() {
 
 		if (!shouldLoadWalletState) return
 
-		// Resolve connection state — must complete before wallet-specific reads
+		// Resolve connection state — address check completes bootstrap; balance/chainId load in background
 		walletLoadCount.value += 1
 		try {
 			const accountsResult = ethereum === undefined ? [] : await ethereum.request({ method: 'eth_accounts' }).catch(() => [])
@@ -112,6 +112,9 @@ export function useOnchainState() {
 				chainId: accountState.value.chainId,
 				ethBalance: connectedAddress === accountState.value.address ? accountState.value.ethBalance : undefined,
 			}
+
+			// Address is now known — unblock data loading regardless of wallet presence
+			walletBootstrapComplete.value = true
 
 			if (connectedAddress !== undefined && ethereum !== undefined) {
 				const chainIdPromise = ethereum.request({ method: 'eth_chainId' })
@@ -134,10 +137,10 @@ export function useOnchainState() {
 			}
 		} catch (error) {
 			if (!isCurrent()) return
+			walletBootstrapComplete.value = true
 			errorMessage.value = getErrorMessage(error, 'Failed to refresh wallet state')
 		} finally {
 			walletLoadCount.value = Math.max(0, walletLoadCount.value - 1)
-			if (isCurrent()) walletBootstrapComplete.value = true
 		}
 	}
 

--- a/ui/ts/hooks/useOpenOracleOperations.ts
+++ b/ui/ts/hooks/useOpenOracleOperations.ts
@@ -145,21 +145,34 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 				if (result.action !== 'createReportInstance' && openOracleForm.value.reportId.trim() !== '') {
 					await ensureLoadedSelectedReport()
 				}
+				if (result.action === 'approveToken1' || result.action === 'approveToken2') {
+					await refreshOpenOracleInitialReportState(openOracleReportDetails.value)
+				}
 			},
 		)
+
+	const parseApproveAmount = (raw: string) => {
+		const trimmed = raw.trim()
+		if (trimmed === '') return OPEN_ORACLE_APPROVAL_AMOUNT
+		try {
+			return parseBigIntInput(trimmed, 'Approve amount')
+		} catch {
+			return OPEN_ORACLE_APPROVAL_AMOUNT
+		}
+	}
 
 	const approveToken1 = async () =>
 		await runOracleAction(async walletAddress => {
 			const reportDetails = openOracleReportDetails.value
 			if (reportDetails === undefined) throw new Error('Load an oracle report first')
-			return await approveErc20(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), reportDetails.token1, getOpenOracleAddress(), OPEN_ORACLE_APPROVAL_AMOUNT, 'approveToken1')
+			return await approveErc20(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), reportDetails.token1, getOpenOracleAddress(), parseApproveAmount(openOracleForm.value.approveAmount1), 'approveToken1')
 		}, 'Failed to approve token1')
 
 	const approveToken2 = async () =>
 		await runOracleAction(async walletAddress => {
 			const reportDetails = openOracleReportDetails.value
 			if (reportDetails === undefined) throw new Error('Load an oracle report first')
-			return await approveErc20(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), reportDetails.token2, getOpenOracleAddress(), OPEN_ORACLE_APPROVAL_AMOUNT, 'approveToken2')
+			return await approveErc20(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), reportDetails.token2, getOpenOracleAddress(), parseApproveAmount(openOracleForm.value.approveAmount2), 'approveToken2')
 		}, 'Failed to approve token2')
 
 	const createOpenOracleGame = async () => {
@@ -241,6 +254,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 		createOpenOracleGame,
 		disputeReport,
 		loadOracleReport,
+		refreshPrice: () => void refreshOpenOracleInitialReportState(openOracleReportDetails.value),
 		loadingOpenOracleCreate: loadingOpenOracleCreate.value,
 		loadingOracleReport: loadingOracleReport.value,
 		openOracleCreateForm: openOracleCreateForm.value,

--- a/ui/ts/hooks/useOpenOracleOperations.ts
+++ b/ui/ts/hooks/useOpenOracleOperations.ts
@@ -6,6 +6,8 @@ import { approveErc20, createOpenOracleReportInstance, disputeOracleReport, getO
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
 import { getErrorMessage } from '../lib/errors.js'
 import { deriveOpenOracleInitialReportSubmissionDetails, formatOpenOraclePriceInput, loadOpenOracleInitialReportPrice, OPEN_ORACLE_APPROVAL_AMOUNT } from '../lib/openOracle.js'
+import { runLoadRequest } from '../lib/loadState.js'
+import { requireDefined } from '../lib/required.js'
 import { buildWriteActionConfig, runWriteAction } from '../lib/writeAction.js'
 import { useRequestGuard } from '../lib/requestGuard.js'
 import { parseAddressInput, parseBytes32Input, parseReportIdInput } from '../lib/inputs.js'
@@ -45,71 +47,83 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 			return
 		}
 
-		loadingOpenOracleInitialReportState.value = true
-		openOracleInitialReportToken1Allowance.value = undefined
-		openOracleInitialReportToken2Allowance.value = undefined
+		await runLoadRequest({
+			isCurrent,
+			setLoading: value => {
+				loadingOpenOracleInitialReportState.value = value
+			},
+			onStart: () => {
+				openOracleInitialReportToken1Allowance.value = undefined
+				openOracleInitialReportToken2Allowance.value = undefined
+			},
+			load: async () => {
+				const readClient = createConnectedReadClient()
+				const [initialPrice, token1Allowance, token2Allowance] = await Promise.all([
+					loadOpenOracleInitialReportPrice(readClient, currentDetails.token1, currentDetails.token2, currentDetails.exactToken1Report).catch(() => undefined),
+					accountAddress === undefined ? Promise.resolve(undefined) : loadErc20Allowance(readClient, currentDetails.token1, accountAddress, getOpenOracleAddress()).catch(() => undefined),
+					accountAddress === undefined ? Promise.resolve(undefined) : loadErc20Allowance(readClient, currentDetails.token2, accountAddress, getOpenOracleAddress()).catch(() => undefined),
+				])
 
-		try {
-			const readClient = createConnectedReadClient()
-			const [initialPrice, token1Allowance, token2Allowance] = await Promise.all([
-				loadOpenOracleInitialReportPrice(readClient, currentDetails.token1, currentDetails.token2, currentDetails.exactToken1Report).catch(() => undefined),
-				accountAddress === undefined ? Promise.resolve(undefined) : loadErc20Allowance(readClient, currentDetails.token1, accountAddress, getOpenOracleAddress()).catch(() => undefined),
-				accountAddress === undefined ? Promise.resolve(undefined) : loadErc20Allowance(readClient, currentDetails.token2, accountAddress, getOpenOracleAddress()).catch(() => undefined),
-			])
+				return { initialPrice, token1Allowance, token2Allowance }
+			},
+			onSuccess: ({ initialPrice, token1Allowance, token2Allowance }) => {
+				openOracleInitialReportDefaultPrice.value = initialPrice === undefined ? undefined : formatOpenOraclePriceInput(initialPrice.price)
+				openOracleInitialReportDefaultPriceSource.value = initialPrice?.priceSource
+				openOracleInitialReportToken1Allowance.value = token1Allowance
+				openOracleInitialReportToken2Allowance.value = token2Allowance
 
-			if (!isCurrent()) return
-
-			openOracleInitialReportDefaultPrice.value = initialPrice === undefined ? undefined : formatOpenOraclePriceInput(initialPrice.price)
-			openOracleInitialReportDefaultPriceSource.value = initialPrice?.priceSource
-			openOracleInitialReportToken1Allowance.value = token1Allowance
-			openOracleInitialReportToken2Allowance.value = token2Allowance
-
-			if (openOracleForm.value.price.trim() === '' || openOracleForm.value.reportId.trim() !== currentDetails.reportId.toString()) {
-				openOracleForm.value = {
-					...openOracleForm.value,
-					amount1: currentDetails.exactToken1Report.toString(),
-					amount2: initialPrice?.token2Amount?.toString() ?? openOracleForm.value.amount2,
-					price: initialPrice === undefined ? '' : formatOpenOraclePriceInput(initialPrice.price),
+				if (openOracleForm.value.price.trim() === '' || openOracleForm.value.reportId.trim() !== currentDetails.reportId.toString()) {
+					openOracleForm.value = {
+						...openOracleForm.value,
+						amount1: currentDetails.exactToken1Report.toString(),
+						amount2: initialPrice?.token2Amount?.toString() ?? openOracleForm.value.amount2,
+						price: initialPrice === undefined ? '' : formatOpenOraclePriceInput(initialPrice.price),
+					}
 				}
-			}
-		} finally {
-			if (isCurrent()) {
-				loadingOpenOracleInitialReportState.value = false
-			}
-		}
+			},
+			onError: () => undefined,
+		})
 	}
 
 	const loadOracleReport = async (reportIdInput?: string) => {
-		loadingOracleReport.value = true
-		openOracleError.value = undefined
-		try {
-			const reportIdValue = reportIdInput?.trim() ?? openOracleForm.value.reportId
-			const reportId = parseReportIdInput(reportIdValue)
-			if (reportIdInput !== undefined) {
+		await runLoadRequest({
+			setLoading: value => {
+				loadingOracleReport.value = value
+			},
+			onStart: () => {
+				openOracleError.value = undefined
+			},
+			load: async () => {
+				const reportIdValue = reportIdInput?.trim() ?? openOracleForm.value.reportId
+				const reportId = parseReportIdInput(reportIdValue)
+				if (reportIdInput !== undefined) {
+					openOracleForm.value = {
+						...openOracleForm.value,
+						reportId: reportIdValue,
+					}
+				}
+				const details = await loadOpenOracleReportDetails(createConnectedReadClient(), getOpenOracleAddress(), reportId)
+				return { details, reportId }
+			},
+			onSuccess: ({ details, reportId }) => {
+				openOracleReportDetails.value = details
+				loadedOpenOracleReportId.value = reportId
 				openOracleForm.value = {
 					...openOracleForm.value,
-					reportId: reportIdValue,
+					price: '',
+					stateHash: details.stateHash,
 				}
-			}
-			const details = await loadOpenOracleReportDetails(createConnectedReadClient(), getOpenOracleAddress(), reportId)
-			openOracleReportDetails.value = details
-			loadedOpenOracleReportId.value = reportId
-			openOracleForm.value = {
-				...openOracleForm.value,
-				price: '',
-				stateHash: details.stateHash,
-			}
-		} catch (error) {
-			openOracleReportDetails.value = undefined
-			loadedOpenOracleReportId.value = undefined
-			openOracleInitialReportDefaultPrice.value = undefined
-			openOracleInitialReportDefaultPriceSource.value = undefined
-			openOracleInitialReportToken1Allowance.value = undefined
-			openOracleInitialReportToken2Allowance.value = undefined
-			openOracleError.value = getErrorMessage(error, 'Failed to load oracle report')
-		} finally {
-			loadingOracleReport.value = false
-		}
+			},
+			onError: error => {
+				openOracleReportDetails.value = undefined
+				loadedOpenOracleReportId.value = undefined
+				openOracleInitialReportDefaultPrice.value = undefined
+				openOracleInitialReportDefaultPriceSource.value = undefined
+				openOracleInitialReportToken1Allowance.value = undefined
+				openOracleInitialReportToken2Allowance.value = undefined
+				openOracleError.value = getErrorMessage(error, 'Failed to load oracle report')
+			},
+		})
 	}
 
 	const ensureLoadedSelectedReport = async () => {
@@ -119,13 +133,11 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 		}
 
 		await loadOracleReport()
-		if (openOracleReportDetails.value === undefined) {
-			throw new Error('Failed to load oracle report')
-		}
+		const loadedReportDetails = requireDefined(openOracleReportDetails.value, 'Failed to load oracle report')
 
 		return {
-			reportId: openOracleReportDetails.value.reportId,
-			details: openOracleReportDetails.value,
+			reportId: loadedReportDetails.reportId,
+			details: loadedReportDetails,
 		}
 	}
 
@@ -163,15 +175,13 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 
 	const approveToken1 = async () =>
 		await runOracleAction(async walletAddress => {
-			const reportDetails = openOracleReportDetails.value
-			if (reportDetails === undefined) throw new Error('Load an oracle report first')
+			const reportDetails = requireDefined(openOracleReportDetails.value, 'Load an oracle report first')
 			return await approveErc20(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), reportDetails.token1, getOpenOracleAddress(), parseApproveAmount(openOracleForm.value.approveAmount1), 'approveToken1')
 		}, 'Failed to approve token1')
 
 	const approveToken2 = async () =>
 		await runOracleAction(async walletAddress => {
-			const reportDetails = openOracleReportDetails.value
-			if (reportDetails === undefined) throw new Error('Load an oracle report first')
+			const reportDetails = requireDefined(openOracleReportDetails.value, 'Load an oracle report first')
 			return await approveErc20(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), reportDetails.token2, getOpenOracleAddress(), parseApproveAmount(openOracleForm.value.approveAmount2), 'approveToken2')
 		}, 'Failed to approve token2')
 
@@ -202,8 +212,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 
 	const submitInitialReport = async () =>
 		await runOracleAction(async walletAddress => {
-			const reportDetails = openOracleReportDetails.value
-			if (reportDetails === undefined) throw new Error('Load an oracle report first')
+			const reportDetails = requireDefined(openOracleReportDetails.value, 'Load an oracle report first')
 			const submission = deriveOpenOracleInitialReportSubmissionDetails({
 				approvedToken1Amount: openOracleInitialReportToken1Allowance.value,
 				approvedToken2Amount: openOracleInitialReportToken2Allowance.value,

--- a/ui/ts/hooks/usePriceOracleManager.ts
+++ b/ui/ts/hooks/usePriceOracleManager.ts
@@ -3,6 +3,7 @@ import type { Address, Hash } from 'viem'
 import { loadOracleManagerDetails, requestOraclePrice } from '../contracts.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
 import { getErrorMessage } from '../lib/errors.js'
+import { runLoadRequest } from '../lib/loadState.js'
 import { runWriteAction } from '../lib/writeAction.js'
 import type { OpenOracleActionResult, OracleManagerDetails } from '../types/contracts.js'
 
@@ -21,15 +22,21 @@ export function usePriceOracleManager({ accountAddress, onTransaction, onTransac
 	const poolPriceOracleResult = useSignal<OpenOracleActionResult | undefined>(undefined)
 
 	const loadPoolOracleManager = async (managerAddress: Address) => {
-		loadingPoolOracleManager.value = true
-		poolOracleManagerError.value = undefined
-		try {
-			poolOracleManagerDetails.value = await loadOracleManagerDetails(createConnectedReadClient(), managerAddress)
-		} catch (error) {
-			poolOracleManagerError.value = getErrorMessage(error, 'Failed to load price oracle details')
-		} finally {
-			loadingPoolOracleManager.value = false
-		}
+		await runLoadRequest({
+			setLoading: value => {
+				loadingPoolOracleManager.value = value
+			},
+			onStart: () => {
+				poolOracleManagerError.value = undefined
+			},
+			load: async () => await loadOracleManagerDetails(createConnectedReadClient(), managerAddress),
+			onSuccess: details => {
+				poolOracleManagerDetails.value = details
+			},
+			onError: error => {
+				poolOracleManagerError.value = getErrorMessage(error, 'Failed to load price oracle details')
+			},
+		})
 	}
 
 	const requestPoolPrice = async (managerAddress: Address) => {

--- a/ui/ts/hooks/usePriceOracleManager.ts
+++ b/ui/ts/hooks/usePriceOracleManager.ts
@@ -49,7 +49,7 @@ export function usePriceOracleManager({ accountAddress, onTransaction, onTransac
 				},
 			},
 			async walletAddress => {
-				const details = poolOracleManagerDetails.value ?? await loadOracleManagerDetails(createConnectedReadClient(), managerAddress)
+				const details = poolOracleManagerDetails.value ?? (await loadOracleManagerDetails(createConnectedReadClient(), managerAddress))
 				return await requestOraclePrice(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), managerAddress, details.requestPriceEthCost)
 			},
 			'Failed to request price',

--- a/ui/ts/hooks/useReportingOperations.ts
+++ b/ui/ts/hooks/useReportingOperations.ts
@@ -4,8 +4,9 @@ import type { Address } from 'viem'
 import { loadReportingDetails, reportOutcomeInSecurityPool, withdrawEscalationFromSecurityPool } from '../contracts.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
 import { getErrorMessage } from '../lib/errors.js'
+import { runLoadRequest } from '../lib/loadState.js'
 import { buildWriteActionConfig, runWriteAction } from '../lib/writeAction.js'
-import { parseAddressInput, parseBigIntListInput } from '../lib/inputs.js'
+import { parseAddressInput, resolveOptionalBigIntListInput } from '../lib/inputs.js'
 import { getDefaultReportingFormState, parseBigIntInput } from '../lib/marketForm.js'
 import type { ReportingFormState, WriteOperationsParameters } from '../types/app.js'
 import type { ReportingActionResult, ReportingDetails } from '../types/contracts.js'
@@ -20,18 +21,25 @@ export function useReportingOperations({ accountAddress, onTransaction, onTransa
 	const reportingResult = useSignal<ReportingActionResult | undefined>(undefined)
 
 	const loadReporting = async () => {
-		loadingReportingDetails.value = true
-		reportingError.value = undefined
-		try {
-			const securityPoolAddress = parseAddressInput(reportingForm.value.securityPoolAddress, 'Security pool address')
-			const details = await loadReportingDetails(createConnectedReadClient(), securityPoolAddress, accountAddress)
-			reportingDetails.value = details
-		} catch (error) {
-			reportingDetails.value = undefined
-			reportingError.value = getErrorMessage(error, 'Failed to load reporting details')
-		} finally {
-			loadingReportingDetails.value = false
-		}
+		await runLoadRequest({
+			setLoading: value => {
+				loadingReportingDetails.value = value
+			},
+			onStart: () => {
+				reportingError.value = undefined
+			},
+			load: async () => {
+				const securityPoolAddress = parseAddressInput(reportingForm.value.securityPoolAddress, 'Security pool address')
+				return await loadReportingDetails(createConnectedReadClient(), securityPoolAddress, accountAddress)
+			},
+			onSuccess: details => {
+				reportingDetails.value = details
+			},
+			onError: error => {
+				reportingDetails.value = undefined
+				reportingError.value = getErrorMessage(error, 'Failed to load reporting details')
+			},
+		})
 	}
 
 	const runReportingAction = async (action: (walletAddress: Address, securityPoolAddress: Address, currentForm: ReportingFormState) => Promise<ReportingActionResult>, errorFallback: string) => {
@@ -63,7 +71,7 @@ export function useReportingOperations({ accountAddress, onTransaction, onTransa
 		await runReportingAction(async (walletAddress, securityPoolAddress, currentForm) => {
 			const latestDetails = await loadReportingDetails(createConnectedReadClient(), securityPoolAddress, walletAddress)
 			const selectedSide = latestDetails.sides.find(side => side.key === currentForm.selectedOutcome)
-			const depositIndexes = currentForm.withdrawDepositIndexes.trim() === '' ? (selectedSide?.userDeposits.map(deposit => deposit.depositIndex) ?? []) : parseBigIntListInput(currentForm.withdrawDepositIndexes, 'Deposit indexes')
+			const depositIndexes = resolveOptionalBigIntListInput(currentForm.withdrawDepositIndexes, selectedSide?.userDeposits.map(deposit => deposit.depositIndex) ?? [], 'Deposit indexes')
 
 			if (depositIndexes.length === 0) {
 				throw new Error('No deposits available to withdraw for the selected side')

--- a/ui/ts/hooks/useSecurityPoolCreation.ts
+++ b/ui/ts/hooks/useSecurityPoolCreation.ts
@@ -5,6 +5,7 @@ import { createSecurityPool, loadMarketDetails, originSecurityPoolExists } from 
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
 import { useRequestGuard } from '../lib/requestGuard.js'
 import { getErrorMessage } from '../lib/errors.js'
+import { runLoadRequest } from '../lib/loadState.js'
 import { runWriteAction } from '../lib/writeAction.js'
 import { createSecurityPoolParameters, hasDeployedStep } from '../lib/marketCreation.js'
 import { getDefaultSecurityPoolFormState, parseBigIntInput } from '../lib/marketForm.js'
@@ -79,31 +80,35 @@ export function useSecurityPoolCreation({ accountAddress, deploymentStatuses, on
 		}
 
 		const isCurrent = nextMarketDetailsLoad()
-		loadingMarketDetails.value = true
-		securityPoolError.value = undefined
-		try {
-			const { questionId } = createSecurityPoolParameters({
-				...securityPoolForm.value,
-				marketId,
-			})
-			const details = await loadMarketDetails(createConnectedReadClient(), questionId)
-			if (!isCurrent()) return
-			if (!details.exists) {
+		await runLoadRequest({
+			isCurrent,
+			setLoading: value => {
+				loadingMarketDetails.value = value
+			},
+			onStart: () => {
+				securityPoolError.value = undefined
+			},
+			load: async () => {
+				const { questionId } = createSecurityPoolParameters({
+					...securityPoolForm.value,
+					marketId,
+				})
+				const details = await loadMarketDetails(createConnectedReadClient(), questionId)
+				return details
+			},
+			onSuccess: details => {
+				if (!details.exists) {
+					marketDetails.value = undefined
+					securityPoolError.value = 'No market found for that ID'
+					return
+				}
+				marketDetails.value = details
+			},
+			onError: error => {
 				marketDetails.value = undefined
-				securityPoolError.value = 'No market found for that ID'
-				return
-			}
-
-			marketDetails.value = details
-		} catch (error) {
-			if (!isCurrent()) return
-			marketDetails.value = undefined
-			securityPoolError.value = getErrorMessage(error, 'Failed to load market')
-		} finally {
-			if (isCurrent()) {
-				loadingMarketDetails.value = false
-			}
-		}
+				securityPoolError.value = getErrorMessage(error, 'Failed to load market')
+			},
+		})
 	}
 
 	const loadMarket = async () => await loadMarketById(securityPoolForm.value.marketId)

--- a/ui/ts/hooks/useSecurityPoolsOverview.ts
+++ b/ui/ts/hooks/useSecurityPoolsOverview.ts
@@ -3,6 +3,7 @@ import type { Address, Hash } from 'viem'
 import { loadAllSecurityPools, loadOracleManagerDetails, queueSecurityPoolLiquidation } from '../contracts.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
 import { getErrorMessage } from '../lib/errors.js'
+import { runLoadRequest } from '../lib/loadState.js'
 import { buildWriteActionConfig, runWriteAction } from '../lib/writeAction.js'
 import { parseAddressInput } from '../lib/inputs.js'
 import { parseBigIntInput } from '../lib/marketForm.js'
@@ -29,15 +30,21 @@ export function useSecurityPoolsOverview({ accountAddress, onTransaction, onTran
 	const securityPools = useSignal<ListedSecurityPool[]>([])
 
 	const loadSecurityPools = async () => {
-		loadingSecurityPools.value = true
-		securityPoolOverviewError.value = undefined
-		try {
-			securityPools.value = await loadAllSecurityPools(createConnectedReadClient())
-		} catch (error) {
-			securityPoolOverviewError.value = getErrorMessage(error, 'Failed to load security pools')
-		} finally {
-			loadingSecurityPools.value = false
-		}
+		await runLoadRequest({
+			setLoading: value => {
+				loadingSecurityPools.value = value
+			},
+			onStart: () => {
+				securityPoolOverviewError.value = undefined
+			},
+			load: async () => await loadAllSecurityPools(createConnectedReadClient()),
+			onSuccess: pools => {
+				securityPools.value = pools
+			},
+			onError: error => {
+				securityPoolOverviewError.value = getErrorMessage(error, 'Failed to load security pools')
+			},
+		})
 	}
 
 	const openLiquidationModal = (managerAddress: Address, securityPoolAddress: Address, vaultAddress: Address) => {

--- a/ui/ts/hooks/useSecurityVaultOperations.ts
+++ b/ui/ts/hooks/useSecurityVaultOperations.ts
@@ -5,11 +5,14 @@ import { useFormState } from './useFormState.js'
 import type { Address } from 'viem'
 import { approveErc20, depositRepToSecurityPool, loadOracleManagerDetails, loadSecurityVaultDetails, queueOracleManagerOperation, redeemSecurityVaultFees, updateSecurityVaultFees } from '../contracts.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
+import { sameAddress } from '../lib/address.js'
 import { getErrorMessage } from '../lib/errors.js'
 import { parseAddressInput } from '../lib/inputs.js'
 import { parseBigIntInput } from '../lib/marketForm.js'
 import { getDefaultSecurityVaultFormState } from '../lib/marketForm.js'
+import { requireDefined } from '../lib/required.js'
 import { getSelectedVaultAddress } from '../lib/securityVault.js'
+import { runLoadRequest } from '../lib/loadState.js'
 import { buildWriteActionConfig, runWriteAction } from '../lib/writeAction.js'
 import type { SecurityVaultFormState, WriteOperationsParameters } from '../types/app.js'
 import type { SecurityVaultActionResult, SecurityVaultDetails } from '../types/contracts.js'
@@ -26,8 +29,7 @@ export function useSecurityVaultOperations({ accountAddress, onTransaction, onTr
 	const securityVaultResult = useSignal<SecurityVaultActionResult | undefined>(undefined)
 
 	const resolveSelectedVaultAddress = () => {
-		const selectedVaultAddress = getSelectedVaultAddress(securityVaultForm.value.selectedVaultAddress, accountAddress)
-		if (selectedVaultAddress === undefined) throw new Error('Connect a wallet before loading a security vault')
+		const selectedVaultAddress = requireDefined(getSelectedVaultAddress(securityVaultForm.value.selectedVaultAddress, accountAddress), 'Connect a wallet before loading a security vault')
 		return parseAddressInput(selectedVaultAddress, 'Selected vault address')
 	}
 
@@ -53,34 +55,41 @@ export function useSecurityVaultOperations({ accountAddress, onTransaction, onTr
 	}
 
 	const loadSecurityVault = async (vaultAddressInput?: string) => {
-		loadingSecurityVault.value = true
-		securityVaultError.value = undefined
-		try {
-			const securityPoolAddress = parseAddressInput(securityVaultForm.value.securityPoolAddress, 'Security pool address')
-			const vaultAddress = vaultAddressInput?.trim() === '' || vaultAddressInput === undefined ? resolveSelectedVaultAddress() : parseAddressInput(vaultAddressInput, 'Selected vault address')
-			if (vaultAddressInput !== undefined) {
-				securityVaultForm.value = {
-					...securityVaultForm.value,
-					selectedVaultAddress: vaultAddress.toString(),
+		await runLoadRequest({
+			setLoading: value => {
+				loadingSecurityVault.value = value
+			},
+			onStart: () => {
+				securityVaultError.value = undefined
+			},
+			load: async () => {
+				const securityPoolAddress = parseAddressInput(securityVaultForm.value.securityPoolAddress, 'Security pool address')
+				const vaultAddress = vaultAddressInput?.trim() === '' || vaultAddressInput === undefined ? resolveSelectedVaultAddress() : parseAddressInput(vaultAddressInput, 'Selected vault address')
+				if (vaultAddressInput !== undefined) {
+					securityVaultForm.value = {
+						...securityVaultForm.value,
+						selectedVaultAddress: vaultAddress.toString(),
+					}
 				}
-			}
-			const details = await loadSecurityVaultDetails(createConnectedReadClient(), securityPoolAddress, vaultAddress)
-			securityVaultDetails.value = details
-			if (accountAddress !== undefined && vaultAddress.toLowerCase() === accountAddress.toLowerCase()) {
-				await reloadSecurityVaultRepBalance(details.repToken, vaultAddress)
-				await reloadSecurityVaultRepAllowance(details.repToken, vaultAddress, securityPoolAddress)
-			} else {
+				const details = await loadSecurityVaultDetails(createConnectedReadClient(), securityPoolAddress, vaultAddress)
+				securityVaultDetails.value = details
+				if (sameAddress(vaultAddress, accountAddress)) {
+					await reloadSecurityVaultRepBalance(details.repToken, vaultAddress)
+					await reloadSecurityVaultRepAllowance(details.repToken, vaultAddress, securityPoolAddress)
+				} else {
+					repBalanceLoader.signal.value = undefined
+					repAllowanceLoader.signal.value = undefined
+				}
+				return details
+			},
+			onSuccess: () => undefined,
+			onError: error => {
+				securityVaultDetails.value = undefined
 				repBalanceLoader.signal.value = undefined
 				repAllowanceLoader.signal.value = undefined
-			}
-		} catch (error) {
-			securityVaultDetails.value = undefined
-			repBalanceLoader.signal.value = undefined
-			repAllowanceLoader.signal.value = undefined
-			securityVaultError.value = getErrorMessage(error, 'Failed to load security vault')
-		} finally {
-			loadingSecurityVault.value = false
-		}
+				securityVaultError.value = getErrorMessage(error, 'Failed to load security vault')
+			},
+		})
 	}
 
 	const runVaultAction = async (action: (ethereumAddress: Address, securityPoolAddress: Address) => Promise<SecurityVaultActionResult>, errorFallback: string, onSuccess?: (result: SecurityVaultActionResult, securityPoolAddress: Address, walletAddress: Address) => Promise<void> | void) => {
@@ -91,7 +100,7 @@ export function useSecurityVaultOperations({ accountAddress, onTransaction, onTr
 				const currentForm = securityVaultForm.value
 				securityPoolAddress = parseAddressInput(currentForm.securityPoolAddress, 'Security pool address')
 				const selectedVaultAddress = resolveSelectedVaultAddress()
-				if (selectedVaultAddress.toLowerCase() !== walletAddress.toLowerCase()) {
+				if (!sameAddress(selectedVaultAddress, walletAddress)) {
 					throw new Error('Selected vault is read-only')
 				}
 				securityVaultError.value = undefined
@@ -100,9 +109,9 @@ export function useSecurityVaultOperations({ accountAddress, onTransaction, onTr
 			},
 			errorFallback,
 			async (result, walletAddress) => {
-				if (securityPoolAddress === undefined) throw new Error('Security pool address is required')
+				const resolvedSecurityPoolAddress = requireDefined(securityPoolAddress, 'Security pool address is required')
 				securityVaultResult.value = result
-				await onSuccess?.(result, securityPoolAddress, walletAddress)
+				await onSuccess?.(result, resolvedSecurityPoolAddress, walletAddress)
 			},
 		)
 	}
@@ -194,7 +203,7 @@ export function useSecurityVaultOperations({ accountAddress, onTransaction, onTr
 			return
 		}
 
-		if (securityVaultDetails.value.vaultAddress.toLowerCase() !== selectedVaultAddress.toLowerCase() || selectedVaultAddress.toLowerCase() !== accountAddress.toLowerCase()) {
+		if (!sameAddress(securityVaultDetails.value.vaultAddress, selectedVaultAddress) || !sameAddress(selectedVaultAddress, accountAddress)) {
 			repBalanceLoader.signal.value = undefined
 			repAllowanceLoader.signal.value = undefined
 			return

--- a/ui/ts/hooks/useZoltarFork.ts
+++ b/ui/ts/hooks/useZoltarFork.ts
@@ -7,6 +7,7 @@ import { requireWallet } from '../lib/walletGuard.js'
 import { getErrorMessage } from '../lib/errors.js'
 import { parseBigIntInput } from '../lib/marketForm.js'
 import { GENESIS_REPUTATION_TOKEN_ADDRESS } from '../lib/universe.js'
+import { requireDefined } from '../lib/required.js'
 import { useRequestGuard } from '../lib/requestGuard.js'
 import type { ZoltarForkActionResult, ZoltarUniverseSummary } from '../types/contracts.js'
 
@@ -28,8 +29,10 @@ function formatQuestionId(questionId: bigint) {
 }
 
 function getZoltarAddress() {
-	const zoltarStep = getDeploymentSteps().find(step => step.id === 'zoltar')
-	if (zoltarStep === undefined) throw new Error('Zoltar deployment step not found')
+	const zoltarStep = requireDefined(
+		getDeploymentSteps().find(step => step.id === 'zoltar'),
+		'Zoltar deployment step not found',
+	)
 	return zoltarStep.address
 }
 

--- a/ui/ts/hooks/useZoltarUniverse.ts
+++ b/ui/ts/hooks/useZoltarUniverse.ts
@@ -5,6 +5,7 @@ import { createZoltarChildUniverse, loadAllZoltarQuestions, loadZoltarQuestionCo
 import { createConnectedReadClient, createWalletWriteClient, getRequiredInjectedEthereum } from '../lib/clients.js'
 import { getErrorMessage } from '../lib/errors.js'
 import { hasDeployedStep } from '../lib/marketCreation.js'
+import { runLoadRequest } from '../lib/loadState.js'
 import { useRequestGuard } from '../lib/requestGuard.js'
 import type { DeploymentStatus, MarketDetails, ZoltarUniverseSummary } from '../types/contracts.js'
 
@@ -65,33 +66,34 @@ export function useZoltarUniverse({ accountAddress, activeUniverseId, autoLoadIn
 		const requestedUniverseId = activeUniverseId
 		if (clearCurrentState) {
 			resetZoltarUniverseState()
-		} else {
-			loadingZoltarUniverse.value = true
 		}
-		try {
-			if (!hasDeployedStep(deploymentStatuses, 'zoltar')) {
+		return await runLoadRequest({
+			isCurrent,
+			setLoading: value => {
+				loadingZoltarUniverse.value = value
+			},
+			load: async () => {
+				if (!hasDeployedStep(deploymentStatuses, 'zoltar')) {
+					zoltarUniverseMissing.value = false
+					zoltarUniverse.value = undefined
+					zoltarUniverseLoadedId.value = undefined
+					zoltarChildUniverseError.value = undefined
+					return undefined
+				}
+				return await loadZoltarUniverseSummary(createConnectedReadClient(), requestedUniverseId)
+			},
+			onSuccess: universe => {
+				if (requestedUniverseId !== activeUniverseId) return
+				if (universe === undefined) {
+					zoltarUniverseMissing.value = requestedUniverseId !== 0n
+					return
+				}
 				zoltarUniverseMissing.value = false
-				zoltarUniverse.value = undefined
-				zoltarUniverseLoadedId.value = undefined
-				zoltarChildUniverseError.value = undefined
-				return undefined
-			}
-			const universe = await loadZoltarUniverseSummary(createConnectedReadClient(), requestedUniverseId)
-			if (!isCurrent()) return undefined
-			if (requestedUniverseId !== activeUniverseId) return undefined
-			if (universe === undefined) {
-				zoltarUniverseMissing.value = requestedUniverseId !== 0n
-				return undefined
-			}
-			zoltarUniverseMissing.value = false
-			zoltarUniverse.value = universe
-			zoltarUniverseLoadedId.value = requestedUniverseId
-			return universe
-		} finally {
-			if (isCurrent() && isMounted.current) {
-				loadingZoltarUniverse.value = false
-			}
-		}
+				zoltarUniverse.value = universe
+				zoltarUniverseLoadedId.value = requestedUniverseId
+			},
+			onError: () => undefined,
+		})
 	}
 
 	const refreshZoltarUniverse = async () => await loadZoltarUniverse({ clearCurrentState: false })
@@ -99,45 +101,52 @@ export function useZoltarUniverse({ accountAddress, activeUniverseId, autoLoadIn
 	const loadZoltarQuestionCountData = async () => {
 		if (!isMounted.current) return
 		const isCurrent = nextQuestionCountLoad()
-		loadingZoltarQuestionCount.value = true
-		try {
-			const questionCount = await loadZoltarQuestionCount(createConnectedReadClient())
-			if (!isMounted.current) return
-			if (!isCurrent()) return
-			zoltarQuestionCount.value = questionCount
-		} finally {
-			if (isCurrent() && isMounted.current) {
-				loadingZoltarQuestionCount.value = false
-			}
-		}
+		await runLoadRequest({
+			isCurrent,
+			setLoading: value => {
+				loadingZoltarQuestionCount.value = value
+			},
+			load: async () => await loadZoltarQuestionCount(createConnectedReadClient()),
+			onSuccess: questionCount => {
+				if (!isMounted.current) return
+				zoltarQuestionCount.value = questionCount
+			},
+			onError: () => undefined,
+		})
 	}
 
 	const loadQuestions = async () => {
 		if (!isMounted.current) return
 		const isCountCurrent = nextQuestionCountLoad()
 		const isQuestionsCurrent = nextQuestionsLoad()
-		loadingZoltarQuestions.value = true
-		loadingZoltarQuestionCount.value = true
 		const readClient = createConnectedReadClient()
 
-		const countTask = loadZoltarQuestionCount(readClient)
-			.then(questionCount => {
-				if (!isMounted.current || !isCountCurrent()) return
+		const countTask = runLoadRequest({
+			isCurrent: isCountCurrent,
+			setLoading: value => {
+				loadingZoltarQuestionCount.value = value
+			},
+			load: async () => await loadZoltarQuestionCount(readClient),
+			onSuccess: questionCount => {
+				if (!isMounted.current) return
 				zoltarQuestionCount.value = questionCount
-			})
-			.finally(() => {
-				if (isCountCurrent() && isMounted.current) loadingZoltarQuestionCount.value = false
-			})
+			},
+			onError: () => undefined,
+		})
 
-		const questionsTask = loadAllZoltarQuestions(readClient)
-			.then(questions => {
-				if (!isMounted.current || !isQuestionsCurrent()) return
+		const questionsTask = runLoadRequest({
+			isCurrent: isQuestionsCurrent,
+			setLoading: value => {
+				loadingZoltarQuestions.value = value
+			},
+			load: async () => await loadAllZoltarQuestions(readClient),
+			onSuccess: questions => {
+				if (!isMounted.current) return
 				zoltarQuestions.value = questions
 				hasLoadedZoltarQuestions.value = true
-			})
-			.finally(() => {
-				if (isQuestionsCurrent() && isMounted.current) loadingZoltarQuestions.value = false
-			})
+			},
+			onError: () => undefined,
+		})
 
 		await Promise.allSettled([countTask, questionsTask])
 	}

--- a/ui/ts/lib/address.ts
+++ b/ui/ts/lib/address.ts
@@ -1,0 +1,10 @@
+import type { Address } from 'viem'
+import { normalizeCaseInsensitiveText, sameCaseInsensitiveText } from './caseInsensitive.js'
+
+export function normalizeAddress(address: Address | string | undefined) {
+	return normalizeCaseInsensitiveText(address)
+}
+
+export function sameAddress(left: Address | string | undefined, right: Address | string | undefined) {
+	return sameCaseInsensitiveText(left, right)
+}

--- a/ui/ts/lib/caseInsensitive.ts
+++ b/ui/ts/lib/caseInsensitive.ts
@@ -1,0 +1,9 @@
+export function normalizeCaseInsensitiveText(value: string | undefined) {
+	return value?.trim().toLowerCase()
+}
+
+export function sameCaseInsensitiveText(left: string | undefined, right: string | undefined) {
+	const normalizedLeft = normalizeCaseInsensitiveText(left)
+	const normalizedRight = normalizeCaseInsensitiveText(right)
+	return normalizedLeft !== undefined && normalizedLeft === normalizedRight
+}

--- a/ui/ts/lib/decimal.ts
+++ b/ui/ts/lib/decimal.ts
@@ -1,0 +1,20 @@
+import { parseUnits } from 'viem'
+
+function normalizeDecimalInput(value: string) {
+	const trimmed = value.trim()
+	if (trimmed === '') return trimmed
+	return trimmed.startsWith('.') ? `0${trimmed}` : trimmed.endsWith('.') ? `${trimmed}0` : trimmed
+}
+
+export function parseDecimalInput(value: string, label: string, units: number = 18) {
+	const trimmed = value.trim()
+	if (trimmed === '') throw new Error(`${label} is required`)
+
+	const normalized = normalizeDecimalInput(trimmed)
+
+	try {
+		return parseUnits(normalized, units)
+	} catch {
+		throw new Error(`${label} must be a decimal number`)
+	}
+}

--- a/ui/ts/lib/forkAuction.ts
+++ b/ui/ts/lib/forkAuction.ts
@@ -1,5 +1,7 @@
 import type { ForkAuctionDetails, ReportingOutcomeKey, SecurityPoolSystemState } from '../types/contracts.js'
 import { assertNever } from './assert.js'
+import { getTimeRemaining as getSharedTimeRemaining } from './time.js'
+import { getReportingOutcomeLabel } from './reporting.js'
 
 const SECONDS_PER_WEEK = 7n * 24n * 60n * 60n
 
@@ -23,16 +25,7 @@ export function getSystemStateLabel(state: SecurityPoolSystemState) {
 }
 
 export function getOutcomeActionLabel(outcome: ReportingOutcomeKey) {
-	switch (outcome) {
-		case 'invalid':
-			return 'Invalid'
-		case 'yes':
-			return 'Yes'
-		case 'no':
-			return 'No'
-		default:
-			return assertNever(outcome)
-	}
+	return getReportingOutcomeLabel(outcome)
 }
 
 export function getForkStageDescription(details: ForkAuctionDetails) {
@@ -51,8 +44,7 @@ export function getForkStageDescription(details: ForkAuctionDetails) {
 }
 
 export function getTimeRemaining(targetTime: bigint | undefined, currentTime: bigint) {
-	if (targetTime === undefined) return undefined
-	return targetTime <= currentTime ? 0n : targetTime - currentTime
+	return getSharedTimeRemaining(targetTime, currentTime)
 }
 
 export function estimateRepPurchased(ethAmount: bigint, price: bigint) {

--- a/ui/ts/lib/formatters.ts
+++ b/ui/ts/lib/formatters.ts
@@ -27,6 +27,15 @@ function assertNonNegativeInteger(value: number, label: string) {
 	if (value < 0) throw new RangeError(`${label} must be non-negative`)
 }
 
+function formatTimestampPart(value: number) {
+	return value.toString().padStart(2, '0')
+}
+
+function formatUtcTimestamp(timestamp: bigint) {
+	const date = new Date(Number(timestamp) * MILLISECONDS_PER_SECOND)
+	return `${date.getUTCFullYear()}-${formatTimestampPart(date.getUTCMonth() + 1)}-${formatTimestampPart(date.getUTCDate())} ${formatTimestampPart(date.getUTCHours())}:${formatTimestampPart(date.getUTCMinutes())}:${formatTimestampPart(date.getUTCSeconds())} UTC`
+}
+
 export function formatCurrencyBalance(value: bigint | undefined, units: number = 18) {
 	if (value === undefined) return 'Unavailable'
 	assertInteger(units, 'Units')
@@ -69,7 +78,35 @@ export function formatRoundedCurrencyBalance(value: bigint | undefined, units: n
 
 export function formatTimestamp(timestamp: bigint) {
 	if (timestamp === 0n) return 'Immediate'
-	return new Date(Number(timestamp) * MILLISECONDS_PER_SECOND).toLocaleString()
+	return formatUtcTimestamp(timestamp)
+}
+
+function formatRelativeDuration(seconds: bigint) {
+	const days = seconds / SECONDS_PER_DAY
+	const hours = (seconds % SECONDS_PER_DAY) / SECONDS_PER_HOUR
+	const minutes = (seconds % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE
+	const remainingSeconds = seconds % SECONDS_PER_MINUTE
+
+	if (days > 0n) {
+		return `${days}d ${hours}h ${minutes}m ${remainingSeconds}s`
+	}
+
+	if (hours > 0n) {
+		return `${hours}h ${minutes}m ${remainingSeconds}s`
+	}
+
+	if (minutes > 0n) {
+		return `${minutes}m ${remainingSeconds}s`
+	}
+
+	return `${remainingSeconds}s`
+}
+
+export function formatRelativeTimestamp(timestamp: bigint, currentTimestamp: bigint = BigInt(Math.floor(Date.now() / MILLISECONDS_PER_SECOND))) {
+	const delta = timestamp - currentTimestamp
+	if (delta === 0n) return 'now'
+	if (delta > 0n) return `in ${formatRelativeDuration(delta)}`
+	return `${formatRelativeDuration(-delta)} ago`
 }
 
 export function formatDuration(seconds: bigint) {

--- a/ui/ts/lib/inputs.ts
+++ b/ui/ts/lib/inputs.ts
@@ -1,11 +1,17 @@
 import type { ReportingOutcomeKey } from '../types/contracts.js'
-import { getAddress, isHex, parseUnits, type Address, type Hex } from 'viem'
+import { getAddress, isHex, type Address, type Hex } from 'viem'
 import { parseBigIntInput } from './marketForm.js'
 
 export function parseAddressInput(value: string, label: string): Address {
 	const trimmed = value.trim()
 	if (trimmed === '') throw new Error(`${label} is required`)
 	return getAddress(trimmed)
+}
+
+export function resolveOptionalAddressInput(value: string | undefined, fallbackAddress: Address, label: string) {
+	const trimmed = value?.trim() ?? ''
+	if (trimmed === '') return fallbackAddress
+	return parseAddressInput(trimmed, label)
 }
 
 export function parseBytes32Input(value: string, label: string): Hex {
@@ -21,16 +27,14 @@ export function parseReportIdInput(value: string) {
 	return parseBigIntInput(value, 'Report ID')
 }
 
-export function parseDecimalInput(value: string, label: string, units: number = 18) {
+export function parseOptionalBigIntInput(value: string) {
 	const trimmed = value.trim()
-	if (trimmed === '') throw new Error(`${label} is required`)
-
-	const normalized = trimmed.startsWith('.') ? `0${trimmed}` : trimmed.endsWith('.') ? `${trimmed}0` : trimmed
+	if (trimmed === '') return undefined
 
 	try {
-		return parseUnits(normalized, units)
+		return BigInt(trimmed)
 	} catch {
-		throw new Error(`${label} must be a decimal number`)
+		return undefined
 	}
 }
 
@@ -45,6 +49,12 @@ function parseListInput<T>(value: string, label: string, parseItem: (entry: stri
 
 export function parseBigIntListInput(value: string, label: string) {
 	return parseListInput(value, label, (entry, index) => parseBigIntInput(entry, `${label} #${index + 1}`))
+}
+
+export function resolveOptionalBigIntListInput(value: string, fallback: bigint[], label: string) {
+	const trimmed = value.trim()
+	if (trimmed === '') return fallback
+	return parseBigIntListInput(trimmed, label)
 }
 
 export function parseReportingOutcomeInput(value: string): ReportingOutcomeKey {

--- a/ui/ts/lib/loadState.ts
+++ b/ui/ts/lib/loadState.ts
@@ -1,0 +1,28 @@
+type RunLoadRequestParameters<TResult> = {
+	isCurrent?: () => boolean
+	setLoading: (value: boolean) => void
+	load: () => Promise<TResult>
+	onStart?: () => void
+	onSuccess: (result: TResult) => Promise<void> | void
+	onError?: (error: unknown) => Promise<void> | void
+}
+
+export async function runLoadRequest<TResult>({ isCurrent, setLoading, load, onStart, onSuccess, onError }: RunLoadRequestParameters<TResult>) {
+	const isCurrentRequest = isCurrent ?? (() => true)
+	setLoading(true)
+	onStart?.()
+	try {
+		const result = await load()
+		if (!isCurrentRequest()) return undefined
+		await onSuccess(result)
+		return result
+	} catch (error) {
+		if (!isCurrentRequest()) return undefined
+		await onError?.(error)
+		return undefined
+	} finally {
+		if (isCurrentRequest()) {
+			setLoading(false)
+		}
+	}
+}

--- a/ui/ts/lib/marketForm.ts
+++ b/ui/ts/lib/marketForm.ts
@@ -1,5 +1,5 @@
-import { parseUnits } from 'viem'
 import type { ForkAuctionFormState, MarketFormState, OpenOracleCreateFormState, OpenOracleFormState, ReportingFormState, SecurityPoolFormState, SecurityVaultFormState, TradingFormState, ZoltarMigrationFormState } from '../types/app.js'
+import { parseDecimalInput } from './decimal.js'
 
 const DEFAULT_CURRENT_RETENTION_RATE = '10'
 
@@ -121,13 +121,7 @@ function validateAndTrim(value: string, label: string): string {
 }
 
 export function parseRepAmountInput(value: string, label: string) {
-	const trimmed = validateAndTrim(value, label)
-	const normalized = trimmed.startsWith('.') ? `0${trimmed}` : trimmed.endsWith('.') ? `${trimmed}0` : trimmed
-	try {
-		return parseUnits(normalized, 18)
-	} catch {
-		throw new Error(`${label} must be a decimal number`)
-	}
+	return parseDecimalInput(value, label, 18)
 }
 
 export function parseBigIntInput(value: string, label: string) {

--- a/ui/ts/lib/marketForm.ts
+++ b/ui/ts/lib/marketForm.ts
@@ -41,6 +41,8 @@ export function getDefaultOpenOracleFormState(): OpenOracleFormState {
 	return {
 		amount1: '0',
 		amount2: '0',
+		approveAmount1: '',
+		approveAmount2: '',
 		disputeNewAmount1: '0',
 		disputeNewAmount2: '0',
 		disputeTokenToSwap: 'token1',

--- a/ui/ts/lib/openOracle.ts
+++ b/ui/ts/lib/openOracle.ts
@@ -1,7 +1,7 @@
 import { maxUint256, zeroAddress } from 'viem'
 import type { OpenOracleReportSummary } from '../types/contracts.js'
 import { formatCurrencyInputBalance } from './formatters.js'
-import { parseDecimalInput } from './inputs.js'
+import { parseDecimalInput } from './decimal.js'
 import { ETH_ADDRESS, REP_ADDRESS, quoteExactInput, quoteRepForEthV3 } from './uniswapQuoter.js'
 
 const OPEN_ORACLE_PRICE_PRECISION = 10n ** 18n

--- a/ui/ts/lib/reporting.ts
+++ b/ui/ts/lib/reporting.ts
@@ -1,11 +1,16 @@
 import type { ReportingOutcomeKey } from '../types/contracts.js'
 import { assertNever } from './assert.js'
 
-export const REPORTING_OUTCOME_OPTIONS: { key: ReportingOutcomeKey; label: string }[] = [
+const REPORTING_OUTCOME_OPTIONS: { key: ReportingOutcomeKey; label: string }[] = [
 	{ key: 'invalid', label: 'Invalid' },
 	{ key: 'yes', label: 'Yes' },
 	{ key: 'no', label: 'No' },
 ]
+
+export const REPORTING_OUTCOME_DROPDOWN_OPTIONS = REPORTING_OUTCOME_OPTIONS.map(option => ({
+	value: option.key,
+	label: option.label,
+}))
 
 export function getReportingOutcomeLabel(outcome: ReportingOutcomeKey | 'none') {
 	switch (outcome) {

--- a/ui/ts/lib/reportingDomain.ts
+++ b/ui/ts/lib/reportingDomain.ts
@@ -1,7 +1,9 @@
 import type { EscalationSide, ReportingDetails } from '../types/contracts.js'
+import { getTimeRemaining } from './time.js'
+import { requireDefined } from './required.js'
 
 export function getEscalationTimeRemaining(details: ReportingDetails) {
-	return details.currentTime >= details.escalationEndTime ? 0n : details.escalationEndTime - details.currentTime
+	return requireDefined(getTimeRemaining(details.escalationEndTime, details.currentTime), 'Escalation end time is required')
 }
 
 export function getEscalationPhase(details: ReportingDetails) {

--- a/ui/ts/lib/required.ts
+++ b/ui/ts/lib/required.ts
@@ -1,0 +1,4 @@
+export function requireDefined<T>(value: T | undefined, message: string): T {
+	if (value === undefined) throw new Error(message)
+	return value
+}

--- a/ui/ts/lib/scalarOutcome.ts
+++ b/ui/ts/lib/scalarOutcome.ts
@@ -1,4 +1,4 @@
-import { parseUnits } from 'viem'
+import { parseDecimalInput } from './decimal.js'
 
 type ScalarQuestionDetails = {
 	answerUnit: string
@@ -17,22 +17,6 @@ const SCALAR_DECIMALS = 18n
 const SCALAR_DECIMAL_BASE = 10n ** SCALAR_DECIMALS
 const SCALAR_PART_BIT_LENGTH = 120n
 const SCALAR_TOTAL_BITS = 256n
-
-function normalizeDecimalInput(value: string) {
-	const trimmed = value.trim()
-	if (trimmed === '') return trimmed
-	return trimmed.startsWith('.') ? `0${trimmed}` : trimmed.endsWith('.') ? `${trimmed}0` : trimmed
-}
-
-function parseScalarDecimalInput(value: string, label: string) {
-	const normalized = normalizeDecimalInput(value)
-	if (normalized === '') throw new Error(`${label} is required`)
-	try {
-		return parseUnits(normalized, Number(SCALAR_DECIMALS))
-	} catch {
-		throw new Error(`${label} must be a decimal number`)
-	}
-}
 
 function combineUint256FromTwoWithInvalid(invalid: boolean, firstPart: bigint, secondPart: bigint): bigint {
 	const oneHundredTwentyBitMask = (1n << SCALAR_PART_BIT_LENGTH) - 1n
@@ -76,9 +60,9 @@ export function clampScalarTickIndex(tickIndex: bigint, numTicks: bigint) {
 }
 
 export function parseScalarFormInputs({ scalarIncrement, scalarMax, scalarMin }: ScalarFormInputs) {
-	const displayValueMin = parseScalarDecimalInput(scalarMin, 'Scalar min')
-	const displayValueMax = parseScalarDecimalInput(scalarMax, 'Scalar max')
-	const increment = parseScalarDecimalInput(scalarIncrement, 'Scalar increment')
+	const displayValueMin = parseDecimalInput(scalarMin, 'Scalar min', Number(SCALAR_DECIMALS))
+	const displayValueMax = parseDecimalInput(scalarMax, 'Scalar max', Number(SCALAR_DECIMALS))
+	const increment = parseDecimalInput(scalarIncrement, 'Scalar increment', Number(SCALAR_DECIMALS))
 
 	if (increment <= 0n) throw new Error('Scalar increment must be greater than 0')
 	if (displayValueMax <= displayValueMin) throw new Error('Scalar max must be greater than scalar min')

--- a/ui/ts/lib/securityVault.ts
+++ b/ui/ts/lib/securityVault.ts
@@ -1,4 +1,5 @@
 import type { Address } from 'viem'
+import { sameAddress } from './address.js'
 
 export function getSelectedVaultAddress(selectedVaultAddress: string | undefined, accountAddress: Address | undefined) {
 	const trimmedSelectedVaultAddress = selectedVaultAddress?.trim() ?? ''
@@ -9,5 +10,5 @@ export function getSelectedVaultAddress(selectedVaultAddress: string | undefined
 export function isSelectedVaultOwnedByAccount(selectedVaultAddress: string | undefined, accountAddress: Address | undefined) {
 	const trimmedSelectedVaultAddress = selectedVaultAddress?.trim() ?? ''
 	if (trimmedSelectedVaultAddress === '' || accountAddress === undefined) return false
-	return trimmedSelectedVaultAddress.toLowerCase() === accountAddress.toLowerCase()
+	return sameAddress(trimmedSelectedVaultAddress, accountAddress)
 }

--- a/ui/ts/lib/time.ts
+++ b/ui/ts/lib/time.ts
@@ -1,0 +1,4 @@
+export function getTimeRemaining(targetTime: bigint | undefined, currentTime: bigint) {
+	if (targetTime === undefined) return undefined
+	return targetTime <= currentTime ? 0n : targetTime - currentTime
+}

--- a/ui/ts/lib/viewState.ts
+++ b/ui/ts/lib/viewState.ts
@@ -1,0 +1,11 @@
+export function resolveEnumValue<T extends string>(value: string | undefined, fallback: T, allowedValues: readonly T[]) {
+	if (value !== undefined && allowedValues.includes(value as T)) return value as T
+	return fallback
+}
+
+export function resolveFirstMatchingValue<T>(entries: Array<[boolean, T]>, fallback: T) {
+	for (const [matches, value] of entries) {
+		if (matches) return value
+	}
+	return fallback
+}

--- a/ui/ts/tests/address.test.ts
+++ b/ui/ts/tests/address.test.ts
@@ -1,0 +1,25 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { getAddress } from 'viem'
+import { normalizeAddress, sameAddress } from '../lib/address.js'
+import { sameCaseInsensitiveText } from '../lib/caseInsensitive.js'
+
+void describe('case-insensitive text helpers', () => {
+	void test('sameAddress compares addresses without regard to case', () => {
+		const address = getAddress('0x00000000000000000000000000000000000000a1')
+		expect(sameAddress(address, address.toUpperCase())).toBe(true)
+		expect(sameAddress(address, getAddress('0x00000000000000000000000000000000000000a2'))).toBe(false)
+		expect(sameAddress(undefined, address)).toBe(false)
+	})
+
+	void test('normalizeAddress trims and lowercases address text', () => {
+		expect(normalizeAddress(' 0x00000000000000000000000000000000000000A1 ')).toBe('0x00000000000000000000000000000000000000a1')
+		expect(normalizeAddress(undefined)).toBe(undefined)
+	})
+
+	void test('sameCaseInsensitiveText compares arbitrary text without regard to case', () => {
+		expect(sameCaseInsensitiveText('Question-1', 'question-1')).toBe(true)
+		expect(sameCaseInsensitiveText('Question-1', 'question-2')).toBe(false)
+	})
+})

--- a/ui/ts/tests/decimal.test.ts
+++ b/ui/ts/tests/decimal.test.ts
@@ -1,0 +1,17 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { parseDecimalInput } from '../lib/decimal.js'
+
+void describe('decimal helpers', () => {
+	void test('parseDecimalInput accepts trimmed decimals and normalizes leading or trailing dots', () => {
+		expect(parseDecimalInput('1.25', 'Price', 18)).toBe(1_250_000_000_000_000_000n)
+		expect(parseDecimalInput(' .5 ', 'Price', 18)).toBe(500_000_000_000_000_000n)
+		expect(parseDecimalInput('5.', 'Price', 18)).toBe(5_000_000_000_000_000_000n)
+	})
+
+	void test('parseDecimalInput rejects empty or invalid input', () => {
+		expect(() => parseDecimalInput('', 'Price', 18)).toThrow('Price is required')
+		expect(() => parseDecimalInput('not-a-number', 'Price', 18)).toThrow('Price must be a decimal number')
+	})
+})

--- a/ui/ts/tests/forkAuction.test.ts
+++ b/ui/ts/tests/forkAuction.test.ts
@@ -1,0 +1,12 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { getOutcomeActionLabel } from '../lib/forkAuction.js'
+
+void describe('fork auction helpers', () => {
+	void test('getOutcomeActionLabel reuses reporting labels', () => {
+		expect(getOutcomeActionLabel('invalid')).toBe('Invalid')
+		expect(getOutcomeActionLabel('yes')).toBe('Yes')
+		expect(getOutcomeActionLabel('no')).toBe('No')
+	})
+})

--- a/ui/ts/tests/formatters.test.ts
+++ b/ui/ts/tests/formatters.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from 'bun:test'
-import { formatCurrencyInputBalance, formatRoundedCurrencyBalance } from '../lib/formatters.js'
+import { formatCurrencyInputBalance, formatRelativeTimestamp, formatRoundedCurrencyBalance, formatTimestamp } from '../lib/formatters.js'
 
 void describe('formatting helpers', () => {
 	void test('formatRoundedCurrencyBalance rounds positive balances without a decimal part when decimals are zero', () => {
@@ -19,6 +19,32 @@ void describe('formatting helpers', () => {
 
 	void test('formatCurrencyInputBalance returns a compact decimal string without grouped separators', () => {
 		expect(formatCurrencyInputBalance(1234567890000000000000n)).toBe('1234.56789')
+	})
+
+	void describe('timestamp formatting', () => {
+		void test('formatTimestamp renders UTC output', () => {
+			expect(formatTimestamp(1_700_000_000n)).toBe('2023-11-14 22:13:20 UTC')
+		})
+
+		void test('formatTimestamp preserves the immediate sentinel', () => {
+			expect(formatTimestamp(0n)).toBe('Immediate')
+		})
+
+		void test('formatRelativeTimestamp renders now for an exact match', () => {
+			expect(formatRelativeTimestamp(1_000n, 1_000n)).toBe('now')
+		})
+
+		void test('formatRelativeTimestamp renders future values with an in-prefix', () => {
+			expect(formatRelativeTimestamp(1_001n, 1_000n)).toBe('in 1s')
+		})
+
+		void test('formatRelativeTimestamp renders past values with an ago-suffix', () => {
+			expect(formatRelativeTimestamp(997n, 1_000n)).toBe('3s ago')
+		})
+
+		void test('formatRelativeTimestamp includes days, hours, minutes, and seconds', () => {
+			expect(formatRelativeTimestamp(90_061n, 0n)).toBe('in 1d 1h 1m 1s')
+		})
 	})
 
 	void describe('formatRoundedCurrencyBalance — 2 significant figures for tiny values', () => {

--- a/ui/ts/tests/inputs.test.ts
+++ b/ui/ts/tests/inputs.test.ts
@@ -1,0 +1,30 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { getAddress } from 'viem'
+import { parseOptionalBigIntInput, resolveOptionalAddressInput, resolveOptionalBigIntListInput } from '../lib/inputs.js'
+
+void describe('input helpers', () => {
+	void test('parseOptionalBigIntInput returns undefined for empty input', () => {
+		expect(parseOptionalBigIntInput('')).toBe(undefined)
+		expect(parseOptionalBigIntInput('   ')).toBe(undefined)
+	})
+
+	void test('parseOptionalBigIntInput parses whole numbers and ignores invalid values', () => {
+		expect(parseOptionalBigIntInput('123')).toBe(123n)
+		expect(parseOptionalBigIntInput('not-a-number')).toBe(undefined)
+	})
+
+	void test('resolveOptionalAddressInput falls back for empty input and parses valid addresses', () => {
+		const fallback = getAddress('0x000000000000000000000000000000000000dEaD')
+		expect(resolveOptionalAddressInput('', fallback, 'Vault address')).toBe(fallback)
+		expect(resolveOptionalAddressInput('   ', fallback, 'Vault address')).toBe(fallback)
+		expect(resolveOptionalAddressInput('0x0000000000000000000000000000000000000001', fallback, 'Vault address')).toBe(getAddress('0x0000000000000000000000000000000000000001'))
+	})
+
+	void test('resolveOptionalBigIntListInput falls back for empty input and parses values', () => {
+		expect(resolveOptionalBigIntListInput('', [1n, 2n], 'Outcome indexes')).toEqual([1n, 2n])
+		expect(resolveOptionalBigIntListInput('  ', [1n, 2n], 'Outcome indexes')).toEqual([1n, 2n])
+		expect(resolveOptionalBigIntListInput('3, 4', [1n, 2n], 'Outcome indexes')).toEqual([3n, 4n])
+	})
+})

--- a/ui/ts/tests/loadState.test.ts
+++ b/ui/ts/tests/loadState.test.ts
@@ -1,0 +1,73 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { runLoadRequest } from '../lib/loadState.js'
+
+void describe('load state helpers', () => {
+	void test('runLoadRequest runs success handlers and clears loading', async () => {
+		let loading = false
+		let started = false
+		let successValue: number | undefined
+
+		await runLoadRequest({
+			setLoading: value => {
+				loading = value
+			},
+			onStart: () => {
+				started = true
+			},
+			load: async () => 42,
+			onSuccess: value => {
+				successValue = value
+			},
+		})
+
+		expect(started).toBe(true)
+		expect(successValue).toBe(42)
+		expect(loading).toBe(false)
+	})
+
+	void test('runLoadRequest skips stale results', async () => {
+		let loading = false
+		let current = true
+		let successCalled = false
+
+		await runLoadRequest({
+			isCurrent: () => current,
+			setLoading: value => {
+				loading = value
+			},
+			load: async () => {
+				current = false
+				return 1
+			},
+			onSuccess: () => {
+				successCalled = true
+			},
+		})
+
+		expect(successCalled).toBe(false)
+		expect(loading).toBe(true)
+	})
+
+	void test('runLoadRequest invokes error handlers and clears loading', async () => {
+		let loading = false
+		let errorMessage: string | undefined
+
+		await runLoadRequest({
+			setLoading: value => {
+				loading = value
+			},
+			load: async () => {
+				throw new Error('boom')
+			},
+			onSuccess: () => undefined,
+			onError: error => {
+				errorMessage = error instanceof Error ? error.message : 'unknown'
+			},
+		})
+
+		expect(errorMessage).toBe('boom')
+		expect(loading).toBe(false)
+	})
+})

--- a/ui/ts/tests/openOracle.test.ts
+++ b/ui/ts/tests/openOracle.test.ts
@@ -207,7 +207,6 @@ describe('Open Oracle helpers', () => {
 		expect(getAddress(reportDetails.token1)).toBe(getAddress(addressString(GENESIS_REPUTATION_TOKEN)))
 		expect(getAddress(reportDetails.token2)).toBe(getAddress(WETH_ADDRESS))
 		expect(reportDetails.settlementTimestamp).toBe(0n)
-		expect(reportDetails.createdAt).toBeGreaterThan(0n)
 		expect(reportDetails.token1Decimals).toBe(18)
 		expect(reportDetails.token2Decimals).toBe(0)
 		expect(reportDetails.stateHash).toBe((await getOpenOracleExtraData(client, reportId)).stateHash)

--- a/ui/ts/tests/openOracle.test.ts
+++ b/ui/ts/tests/openOracle.test.ts
@@ -200,6 +200,7 @@ describe('Open Oracle helpers', () => {
 		const details = await loadOracleManagerDetails(uiReadClient, managerAddress)
 		const reportId = details.pendingReportId
 
+		// The pending report should now be visible through the selected report loader.
 		expect(reportId).toBeGreaterThan(0n)
 
 		const reportDetails = await loadOpenOracleReportDetails(uiReadClient, getOpenOracleAddress(), reportId)

--- a/ui/ts/tests/question.test.ts
+++ b/ui/ts/tests/question.test.ts
@@ -1,0 +1,31 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import type { MarketDetails } from '../types/contracts.js'
+import { getQuestionTitle } from '../components/Question.js'
+
+const questionBase = {
+	answerUnit: '',
+	createdAt: 1n,
+	description: 'Description',
+	displayValueMax: 1n,
+	displayValueMin: 0n,
+	endTime: 2n,
+	exists: true,
+	marketType: 'binary',
+	numTicks: 1n,
+	outcomeLabels: ['Yes', 'No'],
+	questionId: '0x0000000000000000000000000000000000000000000000000000000000000001',
+	startTime: 0n,
+	title: 'Question title',
+} satisfies MarketDetails
+
+void describe('question helpers', () => {
+	void test('falls back to Untitled question when the title is empty', () => {
+		expect(getQuestionTitle({ ...questionBase, title: '' })).toBe('Untitled question')
+	})
+
+	void test('keeps a non-empty title unchanged', () => {
+		expect(getQuestionTitle(questionBase)).toBe('Question title')
+	})
+})

--- a/ui/ts/tests/required.test.ts
+++ b/ui/ts/tests/required.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'bun:test'
+import { requireDefined } from '../lib/required.js'
+
+describe('requireDefined', () => {
+	test('returns defined values', () => {
+		expect(requireDefined('value', 'missing')).toBe('value')
+	})
+
+	test('throws for undefined values', () => {
+		expect(() => requireDefined(undefined, 'missing')).toThrow('missing')
+	})
+})

--- a/ui/ts/tests/time.test.ts
+++ b/ui/ts/tests/time.test.ts
@@ -1,0 +1,18 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { getTimeRemaining } from '../lib/time.js'
+
+void describe('time helpers', () => {
+	void test('getTimeRemaining returns undefined when the target is absent', () => {
+		expect(getTimeRemaining(undefined, 10n)).toBe(undefined)
+	})
+
+	void test('getTimeRemaining clamps past targets to zero', () => {
+		expect(getTimeRemaining(10n, 12n)).toBe(0n)
+	})
+
+	void test('getTimeRemaining returns the positive difference for future targets', () => {
+		expect(getTimeRemaining(15n, 12n)).toBe(3n)
+	})
+})

--- a/ui/ts/tests/viewState.test.ts
+++ b/ui/ts/tests/viewState.test.ts
@@ -1,0 +1,33 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { resolveEnumValue, resolveFirstMatchingValue } from '../lib/viewState.js'
+
+void describe('view state helpers', () => {
+	void test('resolveEnumValue returns the matching enum value or the fallback', () => {
+		expect(resolveEnumValue<'browse' | 'create'>('create', 'browse', ['browse', 'create'])).toBe('create')
+		expect(resolveEnumValue<'browse' | 'create'>('invalid', 'browse', ['browse', 'create'])).toBe('browse')
+		expect(resolveEnumValue<'browse' | 'create'>(undefined, 'browse', ['browse', 'create'])).toBe('browse')
+	})
+
+	void test('resolveFirstMatchingValue returns the first matching entry or the fallback', () => {
+		expect(
+			resolveFirstMatchingValue(
+				[
+					[false, 'browse'],
+					[true, 'create'],
+				],
+				'fallback',
+			),
+		).toBe('create')
+		expect(
+			resolveFirstMatchingValue(
+				[
+					[false, 'browse'],
+					[false, 'create'],
+				],
+				'fallback',
+			),
+		).toBe('fallback')
+	})
+})

--- a/ui/ts/types/app.ts
+++ b/ui/ts/types/app.ts
@@ -49,6 +49,8 @@ export type SecurityVaultFormState = {
 export type OpenOracleFormState = {
 	amount1: string
 	amount2: string
+	approveAmount1: string
+	approveAmount2: string
 	disputeNewAmount1: string
 	disputeNewAmount2: string
 	disputeTokenToSwap: 'token1' | 'token2'

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -185,6 +185,7 @@ export type SecurityPoolWorkflowRouteContentProps = {
 	liquidationSecurityPoolAddress: Address | undefined
 	liquidationTargetVault: string
 	loadingPoolOracleManager: boolean
+	loadingSecurityPools: boolean
 	onLiquidationAmountChange: (value: string) => void
 	onLiquidationTargetVaultChange: (value: string) => void
 	onLoadPoolOracleManager: (managerAddress: Address) => void
@@ -243,6 +244,7 @@ export type OpenOracleRouteContentProps = {
 	onCreateOpenOracleGame: () => void
 	onDisputeReport: () => void
 	onLoadOracleReport: (reportId?: string) => void
+	onRefreshPrice: () => void
 	onOpenOracleFormChange: (update: Partial<OpenOracleFormState>) => void
 	onOpenOracleCreateFormChange: (update: Partial<OpenOracleCreateFormState>) => void
 	onSettleReport: () => void

--- a/ui/ts/types/contracts.ts
+++ b/ui/ts/types/contracts.ts
@@ -158,7 +158,6 @@ export type OpenOracleReportSummary = {
 	currentReporter: Address
 	disputeOccurred: boolean
 	exactToken1Report: bigint
-	createdAt: bigint | undefined
 	isDistributed: boolean
 	price: bigint
 	reportId: bigint
@@ -168,6 +167,8 @@ export type OpenOracleReportSummary = {
 	token2: Address
 	token1Decimals: number
 	token2Decimals: number
+	token1Symbol: string
+	token2Symbol: string
 }
 
 export type OpenOracleReportSummaryPage = {
@@ -180,7 +181,6 @@ export type OpenOracleReportSummaryPage = {
 
 export type OpenOracleReportDetails = {
 	// Identity
-	createdAt: bigint | undefined
 	reportId: bigint
 	openOracleAddress: Address
 	// Meta
@@ -209,9 +209,18 @@ export type OpenOracleReportDetails = {
 	// Extra
 	stateHash: Hex
 	callbackContract: Address
+	callbackSelector: Hex
+	callbackGasLimit: number
+	protocolFeeRecipient: Address
+	trackDisputes: boolean
+	keepFee: boolean
+	feeToken: boolean
 	numReports: bigint
+	lastReportOppoTime: bigint
 	token1Decimals: number
 	token2Decimals: number
+	token1Symbol: string
+	token2Symbol: string
 }
 
 export type ListedSecurityPool = {


### PR DESCRIPTION
## Summary
- Updated open oracle, pool, reporting, and question views to show richer metadata and more readable token-specific labels.
- Added a reusable `TimestampValue` component that renders absolute and relative times consistently across the UI.
- Improved open oracle report details with refreshed pricing actions, token symbols, callback metadata, and additional status fields.
- Tightened wallet and pool loading states so balances and pool metadata only appear when the relevant bootstrap/data loading is complete.

## Testing
- Not run (PR summary only)
- Expected validation path: `bun tsc`
- Expected validation path: `bun test`
- Expected validation path: `bun run format`
- Expected validation path: `bun run check`
- Expected validation path: `bun run knip`