### PR TITLE
Add dismissible wallet rejection errors

### DIFF
--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -502,6 +502,11 @@ button.destructive:hover:not(:disabled) {
 		0 10px 30px rgba(255, 112, 143, 0.08);
 }
 
+.notice.error.closeable {
+	position: relative;
+	padding-right: 4.4rem;
+}
+
 .notice.success {
 	border-top-color: var(--success-border);
 	border-bottom-color: var(--success-border);
@@ -517,6 +522,71 @@ button.destructive:hover:not(:disabled) {
 	font-family: "Courier New", monospace;
 	overflow-wrap: anywhere;
 	word-break: normal;
+}
+
+.notice-dismiss {
+	position: absolute;
+	top: 0.8rem;
+	right: 0.9rem;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 1.9rem;
+	height: 1.9rem;
+	min-width: 1.9rem;
+	padding: 0;
+	border: 1px solid color-mix(in srgb, var(--danger-border-strong) 78%, white 22%);
+	border-radius: 999px;
+	background: rgba(82, 16, 31, 0.18);
+	color: inherit;
+	line-height: 1;
+	opacity: 0.82;
+	transition:
+		opacity 140ms ease,
+		background-color 140ms ease,
+		border-color 140ms ease,
+		transform 140ms ease;
+}
+
+.notice-dismiss-icon {
+	position: relative;
+	display: block;
+	width: 0.8rem;
+	height: 0.8rem;
+}
+
+.notice-dismiss-icon::before,
+.notice-dismiss-icon::after {
+	content: "";
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	width: 0.9rem;
+	height: 2px;
+	border-radius: 999px;
+	background: currentColor;
+	transform-origin: center;
+}
+
+.notice-dismiss-icon::before {
+	transform: translate(-50%, -50%) rotate(45deg);
+}
+
+.notice-dismiss-icon::after {
+	transform: translate(-50%, -50%) rotate(-45deg);
+}
+
+.notice-dismiss:hover:not(:disabled) {
+	background: rgba(82, 16, 31, 0.28);
+	border-color: var(--danger-border-strong);
+	color: inherit;
+	opacity: 1;
+	transform: translateY(-1px);
+}
+
+.notice-dismiss:focus-visible {
+	outline: 2px solid color-mix(in srgb, var(--danger-border-strong) 72%, white 28%);
+	outline-offset: 2px;
 }
 
 .form-validation-inline {

--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -9,6 +9,7 @@ import { NotFoundSection } from './components/NotFoundSection.js'
 import { OpenOracleSection } from './components/OpenOracleSection.js'
 import { TabNavigation } from './components/TabNavigation.js'
 import { SecurityPoolsSection } from './components/SecurityPoolsSection.js'
+import { ErrorNotice } from './components/ErrorNotice.js'
 import { useDeploymentFlow } from './hooks/useDeploymentFlow.js'
 import { useForkAuctionOperations } from './hooks/useForkAuctionOperations.js'
 import { useHashRoute } from './hooks/useHashRoute.js'
@@ -491,7 +492,7 @@ export function App() {
 				) : undefined}
 				{showAugurPlaceHolderDeploymentWarning ? <div className='notice error'>Augur PLACEHOLDER contracts are not deployed yet. Deploy them before the application works.</div> : undefined}
 				{hasInjectedWallet ? undefined : <p className='notice warning'>No injected wallet detected.</p>}
-				{errorMessage === undefined ? undefined : <p className='notice error'>{errorMessage}</p>}
+				<ErrorNotice message={errorMessage} />
 				{transactionState.value.transactionInFlightCount > 0 ? (
 					<p className='notice success'>
 						<span className='spinner' aria-hidden='true' />

--- a/ui/ts/components/ErrorNotice.tsx
+++ b/ui/ts/components/ErrorNotice.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'preact/hooks'
+import { isCloseableErrorMessage } from '../lib/errors.js'
+
+type ErrorNoticeProps = {
+	message: string | undefined
+}
+
+export function ErrorNotice({ message }: ErrorNoticeProps) {
+	const [dismissed, setDismissed] = useState(false)
+	const isCloseable = isCloseableErrorMessage(message)
+
+	useEffect(() => {
+		setDismissed(false)
+	}, [message])
+
+	if (message === undefined) return undefined
+	if (isCloseable && dismissed) return undefined
+
+	return (
+		<div className={`notice error${isCloseable ? ' closeable' : ''}`}>
+			{isCloseable ? (
+				<button type='button' className='notice-dismiss' aria-label='Dismiss error' onClick={() => setDismissed(true)}>
+					<span className='notice-dismiss-icon' aria-hidden='true' />
+				</button>
+			) : undefined}
+			<p>{message}</p>
+		</div>
+	)
+}

--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -1,6 +1,7 @@
 import { AddressValue } from './AddressValue.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { EnumDropdown } from './EnumDropdown.js'
+import { ErrorNotice } from './ErrorNotice.js'
 import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
 import { Question } from './Question.js'
@@ -321,7 +322,7 @@ export function ForkAuctionSection({
 						</div>
 					</div>
 
-					{forkAuctionError === undefined ? undefined : <p className='notice error'>{forkAuctionError}</p>}
+					<ErrorNotice message={forkAuctionError} />
 				</div>
 			</div>
 		</section>

--- a/ui/ts/components/ForkZoltarSection.tsx
+++ b/ui/ts/components/ForkZoltarSection.tsx
@@ -1,6 +1,7 @@
 import type { Address } from 'viem'
 import { CurrencyValue } from './CurrencyValue.js'
 import { EntityCard } from './EntityCard.js'
+import { ErrorNotice } from './ErrorNotice.js'
 import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
 import { Question } from './Question.js'
@@ -62,7 +63,7 @@ export function ForkZoltarSection({
 				<EntityCard title='Fork Zoltar' badge={<span className='badge blocked'>Missing</span>}>
 					<p className='notice error'>The universe does not exist.</p>
 				</EntityCard>
-				{zoltarForkError === undefined ? undefined : <p className='notice error'>{zoltarForkError}</p>}
+				<ErrorNotice message={zoltarForkError} />
 			</>
 		)
 	}
@@ -116,7 +117,7 @@ export function ForkZoltarSection({
 				</div>
 			</EntityCard>
 
-			{zoltarForkError === undefined ? undefined : <p className='notice error'>{zoltarForkError}</p>}
+			<ErrorNotice message={zoltarForkError} />
 		</>
 	)
 }

--- a/ui/ts/components/MarketCreateQuestionSection.tsx
+++ b/ui/ts/components/MarketCreateQuestionSection.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'preact/hooks'
 import type { Address } from 'viem'
 import { EnumDropdown, type EnumDropdownOption } from './EnumDropdown.js'
 import { EntityCard } from './EntityCard.js'
+import { ErrorNotice } from './ErrorNotice.js'
 import { FormInput } from './FormInput.js'
 import { LoadingText } from './LoadingText.js'
 import { Question, getQuestionTitle } from './Question.js'
@@ -209,7 +210,7 @@ export function MarketCreateQuestionSection({ accountAddress, hasForked, isMainn
 				</EntityCard>
 			) : undefined}
 
-			{marketError === undefined ? undefined : <p className='notice error'>{marketError}</p>}
+			<ErrorNotice message={marketError} />
 		</>
 	)
 }

--- a/ui/ts/components/OpenOracleSection.tsx
+++ b/ui/ts/components/OpenOracleSection.tsx
@@ -5,6 +5,7 @@ import { AddressValue } from './AddressValue.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { EntityCard } from './EntityCard.js'
 import { EnumDropdown, type EnumDropdownOption } from './EnumDropdown.js'
+import { ErrorNotice } from './ErrorNotice.js'
 import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
@@ -151,7 +152,7 @@ function renderSelectedReportActionSection(
 								</button>
 							</div>
 						</div>
-						{initialReportSubmission.blockReason === undefined ? undefined : <p className='notice error'>{initialReportSubmission.blockReason}</p>}
+						<ErrorNotice message={initialReportSubmission.blockReason} />
 						<div className='actions'>
 							<button className='primary' onClick={onSubmitInitialReport} disabled={!isConnected || !initialReportSubmission.canSubmit || openOracleInitialReportState.loading}>
 								Submit Initial Report
@@ -564,7 +565,7 @@ export function OpenOracleSection({
 									<LoadingText>Loading report summaries...</LoadingText>
 								</p>
 							) : undefined}
-							{browseError === undefined ? undefined : <p className='notice error'>{browseError}</p>}
+							<ErrorNotice message={browseError} />
 							{browsePage === undefined || browsePage.reports.length === 0 ? <p className='detail'>No Open Oracle games found.</p> : <div className='entity-card-list'>{browsePage.reports.map(report => renderReportSummaryCard(report, reportId => void openBrowseReport(reportId)))}</div>}
 						</EntityCard>
 					</div>
@@ -662,7 +663,7 @@ export function OpenOracleSection({
 							</div>
 						</EntityCard>
 
-						{openOracleError === undefined ? undefined : <p className='notice error'>{openOracleError}</p>}
+						<ErrorNotice message={openOracleError} />
 					</div>
 				</div>
 			) : undefined}
@@ -676,7 +677,7 @@ export function OpenOracleSection({
 				</div>
 			) : undefined}
 
-			{openOracleError === undefined ? undefined : <p className='notice error'>{openOracleError}</p>}
+			<ErrorNotice message={openOracleError} />
 		</section>
 	)
 }

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -2,6 +2,7 @@ import { AddressValue } from './AddressValue.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { EnumDropdown } from './EnumDropdown.js'
 import { EntityCard } from './EntityCard.js'
+import { ErrorNotice } from './ErrorNotice.js'
 import { LoadingText } from './LoadingText.js'
 import { EscalationSide } from './EscalationSide.js'
 import { MetricField } from './MetricField.js'
@@ -178,7 +179,7 @@ export function ReportingSection({ accountState, loadingReportingDetails, onLoad
 						</div>
 					</EntityCard>
 
-					{reportingError === undefined ? undefined : <p className='notice error'>{reportingError}</p>}
+					<ErrorNotice message={reportingError} />
 				</div>
 			</div>
 		</section>

--- a/ui/ts/components/ScalarDeploymentSection.tsx
+++ b/ui/ts/components/ScalarDeploymentSection.tsx
@@ -2,6 +2,7 @@ import { useState } from 'preact/hooks'
 import type { Address } from 'viem'
 import { ChildUniversesSection } from './ChildUniversesSection.js'
 import { ChildUniverseDetails } from './ChildUniverseDetails.js'
+import { ErrorNotice } from './ErrorNotice.js'
 import { useEffect } from 'preact/hooks'
 import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
@@ -119,9 +120,9 @@ export function ScalarDeploymentSection({ accountAddress, childUniverses, hasFor
 						{selectedScalarChildExists ? 'Deployed' : scalarOutcomeInvalid ? 'Deploy Invalid Universe' : 'Deploy Universe'}
 					</button>
 				</div>
-				{scalarDeployError === undefined ? undefined : <p className='notice error'>{scalarDeployError}</p>}
+				<ErrorNotice message={scalarDeployError} />
 			</div>
-			{zoltarChildUniverseError === undefined ? undefined : <p className='notice error'>{zoltarChildUniverseError}</p>}
+			<ErrorNotice message={zoltarChildUniverseError} />
 		</div>
 	)
 }

--- a/ui/ts/components/SecurityPoolSection.tsx
+++ b/ui/ts/components/SecurityPoolSection.tsx
@@ -1,6 +1,7 @@
 import type { ComponentChildren } from 'preact'
 import { AddressValue } from './AddressValue.js'
 import { EntityCard } from './EntityCard.js'
+import { ErrorNotice } from './ErrorNotice.js'
 import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
 import { Question } from './Question.js'
@@ -190,7 +191,7 @@ export function SecurityPoolSection({
 							{!duplicateOriginPoolExists && !hasMatchingSecurityMultiplier ? undefined : <p className='detail'>A pool for this question and security multiplier already exists. Origin pool deployment is deterministic for that pair, so change the security multiplier to create a different pool.</p>}
 							{marketDetails !== undefined && marketDetails.marketType !== 'binary' ? <p className='notice error'>Security pools can only be created for binary markets. Load a binary market to proceed.</p> : undefined}
 							{zoltarUniverseHasForked ? <p className='notice error'>Security pools cannot be created after Zoltar has forked.</p> : undefined}
-							{securityPoolError === undefined ? undefined : <p className='notice error'>{securityPoolError}</p>}
+							<ErrorNotice message={securityPoolError} />
 						</div>
 					</>
 				)}

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { AddressValue } from './AddressValue.js'
 import { EntityCard } from './EntityCard.js'
+import { ErrorNotice } from './ErrorNotice.js'
 import { ForkAuctionSection } from './ForkAuctionSection.js'
 import { LiquidationModal } from './LiquidationModal.js'
 import { LoadingText } from './LoadingText.js'
@@ -173,7 +174,7 @@ export function SecurityPoolWorkflowSection({
 									<h4>Price Oracle</h4>
 									{poolOracleManagerDetails === undefined ? undefined : <span className={`badge ${poolOracleManagerDetails.isPriceValid ? 'ok' : 'error'}`}>{poolOracleManagerDetails.isPriceValid ? 'Valid' : 'Invalid'}</span>}
 								</div>
-								{poolOracleManagerError === undefined ? undefined : <p className='notice error'>{poolOracleManagerError}</p>}
+								<ErrorNotice message={poolOracleManagerError} />
 								{poolPriceOracleResult === undefined ? undefined : (
 									<p className='notice success'>
 										Requested price: <TransactionHashLink hash={poolPriceOracleResult.hash} />

--- a/ui/ts/components/SecurityPoolsOverviewSection.tsx
+++ b/ui/ts/components/SecurityPoolsOverviewSection.tsx
@@ -1,6 +1,7 @@
 import { AddressValue } from './AddressValue.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { EntityCard } from './EntityCard.js'
+import { ErrorNotice } from './ErrorNotice.js'
 import { LiquidationModal } from './LiquidationModal.js'
 import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
@@ -52,7 +53,7 @@ export function SecurityPoolsOverviewSection({
 						Queued liquidation for <AddressValue address={securityPoolOverviewResult.securityPoolAddress} />: <TransactionHashLink hash={securityPoolOverviewResult.hash} />
 					</p>
 				)}
-				{securityPoolOverviewError === undefined ? undefined : <p className='notice error'>{securityPoolOverviewError}</p>}
+				<ErrorNotice message={securityPoolOverviewError} />
 
 				{securityPools.length === 0 ? (
 					<EntityCard title='No Pools Loaded' badge={<span className='badge pending'>Empty</span>}>

--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'preact/hooks'
 import { AddressValue } from './AddressValue.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { EntityCard } from './EntityCard.js'
+import { ErrorNotice } from './ErrorNotice.js'
 import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
@@ -272,7 +273,7 @@ export function SecurityVaultSection({
 				{vaultDepositSection}
 				{securityBondAllowanceSection}
 				{vaultRepSection}
-				{securityVaultError === undefined ? undefined : <p className='notice error'>{securityVaultError}</p>}
+				<ErrorNotice message={securityVaultError} />
 			</>
 		)
 	}
@@ -313,7 +314,7 @@ export function SecurityVaultSection({
 						{vaultRepSection}
 					</EntityCard>
 
-					{securityVaultError === undefined ? undefined : <p className='notice error'>{securityVaultError}</p>}
+					<ErrorNotice message={securityVaultError} />
 				</div>
 			</div>
 		</section>

--- a/ui/ts/components/TradingSection.tsx
+++ b/ui/ts/components/TradingSection.tsx
@@ -1,5 +1,6 @@
 import { EnumDropdown } from './EnumDropdown.js'
 import { EntityCard } from './EntityCard.js'
+import { ErrorNotice } from './ErrorNotice.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { UniverseLink } from './UniverseLink.js'
 import { isMainnetChain } from '../lib/network.js'
@@ -85,7 +86,7 @@ export function TradingSection({ accountState, onCreateCompleteSet, onMigrateSha
 						</div>
 					</EntityCard>
 
-					{tradingError === undefined ? undefined : <p className='notice error'>{tradingError}</p>}
+					<ErrorNotice message={tradingError} />
 				</div>
 			</div>
 		</section>

--- a/ui/ts/components/ZoltarMigrationSection.tsx
+++ b/ui/ts/components/ZoltarMigrationSection.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'preact/hooks'
 import type { Address } from 'viem'
 import { CurrencyValue } from './CurrencyValue.js'
 import { EntityCard } from './EntityCard.js'
+import { ErrorNotice } from './ErrorNotice.js'
 import { FormInput } from './FormInput.js'
 import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
@@ -209,7 +210,7 @@ export function ZoltarMigrationSection({
 				<EntityCard title='Migrate REP' badge={<span className='badge blocked'>Missing</span>}>
 					<p className='notice error'>The universe does not exist.</p>
 				</EntityCard>
-				{zoltarMigrationError === undefined ? undefined : <p className='notice error'>{zoltarMigrationError}</p>}
+				<ErrorNotice message={zoltarMigrationError} />
 			</>
 		)
 	}
@@ -287,7 +288,7 @@ export function ZoltarMigrationSection({
 				</EntityCard>
 			)}
 
-			{zoltarMigrationError === undefined ? undefined : <p className='notice error'>{zoltarMigrationError}</p>}
+			<ErrorNotice message={zoltarMigrationError} />
 		</>
 	)
 }

--- a/ui/ts/lib/errors.ts
+++ b/ui/ts/lib/errors.ts
@@ -1,3 +1,5 @@
+const closeableErrorPatterns = ['user rejected the request', 'user rejected request', 'user denied transaction signature', 'user denied message signature', 'user denied account authorization']
+
 export function getErrorMessage(error: unknown, fallbackMessage: string) {
 	let detail: string | undefined
 
@@ -14,4 +16,13 @@ export function getErrorMessage(error: unknown, fallbackMessage: string) {
 	}
 
 	return detail === undefined || detail === '' ? fallbackMessage : `${fallbackMessage}: ${detail}`
+}
+
+export function isCloseableErrorMessage(message: string | undefined) {
+	if (message === undefined) return false
+
+	const normalizedMessage = message.toLowerCase()
+	if (normalizedMessage.includes('"code":4001') || normalizedMessage.includes("'code':4001") || normalizedMessage.includes('code 4001')) return true
+
+	return closeableErrorPatterns.some(pattern => normalizedMessage.includes(pattern))
 }

--- a/ui/ts/tests/errors.test.ts
+++ b/ui/ts/tests/errors.test.ts
@@ -1,0 +1,20 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { getErrorMessage, isCloseableErrorMessage } from '../lib/errors.js'
+
+void describe('error helpers', () => {
+	void test('marks user-rejected wallet errors as closeable', () => {
+		expect(isCloseableErrorMessage(getErrorMessage(new Error('User rejected the request.'), 'Failed to deploy SecurityPoolUtils'))).toBe(true)
+		expect(isCloseableErrorMessage('Wallet connection failed: User denied account authorization')).toBe(true)
+	})
+
+	void test('recognizes serialized EIP-1193 rejection codes', () => {
+		expect(isCloseableErrorMessage('Failed to deploy SecurityPoolUtils: {"code":4001,"message":"Request rejected"}')).toBe(true)
+	})
+
+	void test('keeps blocking guidance errors non-closeable', () => {
+		expect(isCloseableErrorMessage('Augur PLACEHOLDER contracts are not deployed yet. Deploy them before the application works.')).toBe(false)
+		expect(isCloseableErrorMessage('Deploy SecurityPoolUtils first')).toBe(false)
+	})
+})


### PR DESCRIPTION
## Summary
- Added a reusable `ErrorNotice` component to render error banners with an optional dismiss button.
- Wired the new notice into wallet- and workflow-related sections so rejection errors can be dismissed without clearing other guidance.
- Added error matching helpers and tests for common EIP-1193 rejection patterns and user-denied wallet messages.
- Styled closeable notices and the dismiss control to match the existing UI.

## Testing
- Not run (PR content only)
- Added unit coverage in `ui/ts/tests/errors.test.ts` for closeable and non-closeable error cases