### PR TITLE
Replace loading text with spinner placeholders in market views

### DIFF
--- a/ui/ts/components/MarketCreateQuestionSection.tsx
+++ b/ui/ts/components/MarketCreateQuestionSection.tsx
@@ -28,6 +28,7 @@ type MarketCreateQuestionSectionProps = {
 	marketError: string | undefined
 	marketForm: MarketFormState
 	marketResult: MarketCreationResult | undefined
+	loadingZoltarQuestions: boolean
 	onCreateMarket: () => void
 	onMarketFormChange: (update: Partial<MarketFormState>) => void
 	onOpenForkTab: () => void
@@ -49,7 +50,23 @@ function getScalarCreatePreviewDetails(marketForm: MarketFormState): ScalarCreat
 	}
 }
 
-export function MarketCreateQuestionSection({ accountAddress, hasForked, isMainnet, marketCreating, marketError, marketForm, marketResult, onCreateMarket, onMarketFormChange, onOpenForkTab, onResetMarket, onUseQuestionForFork, onUseQuestionForPool, zoltarQuestions }: MarketCreateQuestionSectionProps) {
+export function MarketCreateQuestionSection({
+	accountAddress,
+	hasForked,
+	isMainnet,
+	loadingZoltarQuestions,
+	marketCreating,
+	marketError,
+	marketForm,
+	marketResult,
+	onCreateMarket,
+	onMarketFormChange,
+	onOpenForkTab,
+	onResetMarket,
+	onUseQuestionForFork,
+	onUseQuestionForPool,
+	zoltarQuestions,
+}: MarketCreateQuestionSectionProps) {
 	const [scalarCreatePreviewTick, setScalarCreatePreviewTick] = useState('0')
 	const selectedQuestionDetails = useMemo(() => (marketResult === undefined ? undefined : zoltarQuestions.find(question => question.questionId === marketResult.questionId)), [marketResult?.questionId, zoltarQuestions])
 	const scalarCreatePreviewDetails = getScalarCreatePreviewDetails(marketForm)
@@ -110,7 +127,17 @@ export function MarketCreateQuestionSection({ accountAddress, hasForked, isMainn
 					}
 				>
 					<div className='question-preview-body'>
-						{selectedQuestionDetails === undefined ? <p className='detail'>Question details are not loaded yet.</p> : <Question question={selectedQuestionDetails} showTitle={false} />}
+						{selectedQuestionDetails === undefined ? (
+							loadingZoltarQuestions ? (
+								<span className='loading-value' role='status' aria-label='Loading question details'>
+									<span className='spinner' aria-hidden='true' />
+								</span>
+							) : (
+								<p className='detail'>Question details are not loaded yet.</p>
+							)
+						) : (
+							<Question question={selectedQuestionDetails} showTitle={false} />
+						)}
 						<MetricField label='Creation transaction hash'>
 							<TransactionHashLink hash={marketResult.createQuestionHash} />
 						</MetricField>

--- a/ui/ts/components/MarketOverviewSection.tsx
+++ b/ui/ts/components/MarketOverviewSection.tsx
@@ -4,7 +4,6 @@ import { CurrencyValue } from './CurrencyValue.js'
 import { ChildUniverseDetails } from './ChildUniverseDetails.js'
 import { EntityCard } from './EntityCard.js'
 import { ChildUniversesSection } from './ChildUniversesSection.js'
-import { LoadingText } from './LoadingText.js'
 import { LoadableValue } from './LoadableValue.js'
 import { Question } from './Question.js'
 import { MetricField } from './MetricField.js'
@@ -43,12 +42,25 @@ export function MarketOverviewSection({ accountAddress, isMainnet, loadingZoltar
 		<EntityCard className='market-overview-card' title={rootUniverse === undefined ? 'Universe' : (currentUniverseName ?? 'Universe')} badge={rootUniverse === undefined ? undefined : <span className='badge ok'>{hasForked ? 'Forked' : 'Unforked'}</span>}>
 			{rootUniverse === undefined ? (
 				<p className='detail'>
-					<LoadingText>Loading universe data...</LoadingText>
+					<span className='loading-value' role='status' aria-label='Loading universe data'>
+						<span className='spinner' aria-hidden='true' />
+					</span>
 				</p>
 			) : (
 				<>
 					{hasForked ? (
-						<EntityCard title='Fork Question' badge={<span className='badge muted'>{rootUniverse.forkQuestionDetails?.marketType ?? <LoadingText>Loading...</LoadingText>}</span>}>
+						<EntityCard
+							title='Fork Question'
+							badge={
+								<span className='badge muted'>
+									{rootUniverse.forkQuestionDetails?.marketType ?? (
+										<span className='loading-value' role='status' aria-label='Loading fork question type'>
+											<span className='spinner' aria-hidden='true' />
+										</span>
+									)}
+								</span>
+							}
+						>
 							<Question question={rootUniverse.forkQuestionDetails} loading={rootUniverse.forkQuestionDetails === undefined} />
 						</EntityCard>
 					) : undefined}

--- a/ui/ts/components/MarketSection.tsx
+++ b/ui/ts/components/MarketSection.tsx
@@ -120,6 +120,7 @@ export function MarketSection({
 						accountAddress={accountState.address}
 						hasForked={hasForked}
 						isMainnet={isMainnet}
+						loadingZoltarQuestions={loadingZoltarQuestions}
 						marketCreating={marketCreating}
 						marketError={marketError}
 						marketForm={marketForm}

--- a/ui/ts/components/OpenOracleSection.tsx
+++ b/ui/ts/components/OpenOracleSection.tsx
@@ -562,7 +562,9 @@ export function OpenOracleSection({
 							<p className='detail'>Browse every Open Oracle game and click a card to open its selected-report view.</p>
 							{loadingBrowse ? (
 								<p className='detail'>
-									<LoadingText>Loading report summaries...</LoadingText>
+									<span className='loading-value' role='status' aria-label='Loading report summaries'>
+										<span className='spinner' aria-hidden='true' />
+									</span>
 								</p>
 							) : undefined}
 							<ErrorNotice message={browseError} />

--- a/ui/ts/components/ZoltarMigrationSection.tsx
+++ b/ui/ts/components/ZoltarMigrationSection.tsx
@@ -54,8 +54,8 @@ function getMigrationAmountSource(preparedRepBalance: bigint | undefined, repBal
 function getMigrationGuardMessage(accountAddress: Address | undefined, isMainnet: boolean, rootUniverse: ZoltarUniverseSummary | undefined, loadingZoltarForkAccess: boolean, hasForked: boolean, loadingZoltarUniverse: boolean, notForkedAction: string): string | undefined {
 	if (accountAddress === undefined) return 'Connect a wallet before using REP migration actions.'
 	if (!isMainnet) return 'Switch your wallet to Ethereum mainnet.'
-	if (rootUniverse === undefined) return loadingZoltarUniverse ? 'Loading universe data...' : 'Load the universe first.'
-	if (loadingZoltarForkAccess) return 'Loading migration data...'
+	if (rootUniverse === undefined) return loadingZoltarUniverse ? undefined : 'Load the universe first.'
+	if (loadingZoltarForkAccess) return undefined
 	if (!hasForked) return notForkedAction
 	return undefined
 }
@@ -228,7 +228,15 @@ export function ZoltarMigrationSection({
 						</MetricField>
 						{approvalShortage > 0n ? <p className='detail'>Need {formatCurrencyBalance(approvalShortage)} more REP approved before preparing the current amount.</p> : undefined}
 					</div>
-					<MetricField label='Universe'>{rootUniverse === undefined ? <LoadingText>Loading universe data...</LoadingText> : <UniverseLink universeId={rootUniverse.universeId} />}</MetricField>
+					<MetricField label='Universe'>
+						{rootUniverse === undefined ? (
+							<span className='loading-value' role='status' aria-label='Loading universe data'>
+								<span className='spinner' aria-hidden='true' />
+							</span>
+						) : (
+							<UniverseLink universeId={rootUniverse.universeId} />
+						)}
+					</MetricField>
 				</div>
 				<div className='form-grid'>
 					<div className='field'>


### PR DESCRIPTION
## Summary
- Replaced several loading text states in market and oracle views with spinner-based placeholders for a more consistent loading experience.
- Added explicit loading handling for Zoltar question details in the market create flow.
- Simplified migration guard messaging so loading states no longer surface as blocking copy when the data is still being fetched.

## Testing
- Not run