### PR TITLE
Drop seconds from relative durations and add spinner placeholders

### DIFF
--- a/ui/ts/lib/formatters.ts
+++ b/ui/ts/lib/formatters.ts
@@ -82,24 +82,23 @@ export function formatTimestamp(timestamp: bigint) {
 }
 
 function formatRelativeDuration(seconds: bigint) {
+	if (seconds < SECONDS_PER_MINUTE) {
+		return 'less than a minute'
+	}
+
 	const days = seconds / SECONDS_PER_DAY
 	const hours = (seconds % SECONDS_PER_DAY) / SECONDS_PER_HOUR
 	const minutes = (seconds % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE
-	const remainingSeconds = seconds % SECONDS_PER_MINUTE
 
 	if (days > 0n) {
-		return `${days}d ${hours}h ${minutes}m ${remainingSeconds}s`
+		return `${days}d ${hours}h ${minutes}m`
 	}
 
 	if (hours > 0n) {
-		return `${hours}h ${minutes}m ${remainingSeconds}s`
+		return `${hours}h ${minutes}m`
 	}
 
-	if (minutes > 0n) {
-		return `${minutes}m ${remainingSeconds}s`
-	}
-
-	return `${remainingSeconds}s`
+	return `${minutes}m`
 }
 
 export function formatRelativeTimestamp(timestamp: bigint, currentTimestamp: bigint = BigInt(Math.floor(Date.now() / MILLISECONDS_PER_SECOND))) {
@@ -111,6 +110,7 @@ export function formatRelativeTimestamp(timestamp: bigint, currentTimestamp: big
 
 export function formatDuration(seconds: bigint) {
 	if (seconds <= 0n) return '0m'
+	if (seconds < SECONDS_PER_MINUTE) return 'less than a minute'
 
 	const days = seconds / SECONDS_PER_DAY
 	const hours = (seconds % SECONDS_PER_DAY) / SECONDS_PER_HOUR

--- a/ui/ts/tests/formatters.test.ts
+++ b/ui/ts/tests/formatters.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from 'bun:test'
-import { formatCurrencyInputBalance, formatRelativeTimestamp, formatRoundedCurrencyBalance, formatTimestamp } from '../lib/formatters.js'
+import { formatCurrencyInputBalance, formatDuration, formatRelativeTimestamp, formatRoundedCurrencyBalance, formatTimestamp } from '../lib/formatters.js'
 
 void describe('formatting helpers', () => {
 	void test('formatRoundedCurrencyBalance rounds positive balances without a decimal part when decimals are zero', () => {
@@ -34,16 +34,20 @@ void describe('formatting helpers', () => {
 			expect(formatRelativeTimestamp(1_000n, 1_000n)).toBe('now')
 		})
 
-		void test('formatRelativeTimestamp renders future values with an in-prefix', () => {
-			expect(formatRelativeTimestamp(1_001n, 1_000n)).toBe('in 1s')
+		void test('formatRelativeTimestamp renders sub-minute future values as less than a minute', () => {
+			expect(formatRelativeTimestamp(1_001n, 1_000n)).toBe('in less than a minute')
 		})
 
-		void test('formatRelativeTimestamp renders past values with an ago-suffix', () => {
-			expect(formatRelativeTimestamp(997n, 1_000n)).toBe('3s ago')
+		void test('formatRelativeTimestamp renders sub-minute past values as less than a minute ago', () => {
+			expect(formatRelativeTimestamp(997n, 1_000n)).toBe('less than a minute ago')
 		})
 
-		void test('formatRelativeTimestamp includes days, hours, minutes, and seconds', () => {
-			expect(formatRelativeTimestamp(90_061n, 0n)).toBe('in 1d 1h 1m 1s')
+		void test('formatRelativeTimestamp omits seconds for longer durations', () => {
+			expect(formatRelativeTimestamp(90_061n, 0n)).toBe('in 1d 1h 1m')
+		})
+
+		void test('formatDuration renders sub-minute values as less than a minute', () => {
+			expect(formatDuration(59n)).toBe('less than a minute')
 		})
 	})
 


### PR DESCRIPTION
## Summary
- Removed second-level precision from relative duration formatting and treated sub-minute values as "less than a minute".
- Updated formatter tests to cover the new wording and duration behavior.

## Testing
- Not run (PR summary only)