### PR TITLE
Hide read-only vault actions and swap market loading text for spinners

### DIFF
--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -11,7 +11,7 @@ import { approvalShortage } from '../lib/inputs.js'
 import { formatCurrencyBalance } from '../lib/formatters.js'
 import { isMainnetChain } from '../lib/network.js'
 import { parseRepAmountInput } from '../lib/marketForm.js'
-import { getSelectedVaultAddress, isSelectedVaultOwnedByAccount as isSelectedVaultOwnedByAccountHelper } from '../lib/securityVault.js'
+import { canManageSelectedVault, getSelectedVaultAddress } from '../lib/securityVault.js'
 import type { SecurityVaultSectionProps } from '../types/components.js'
 
 export function SecurityVaultSection({
@@ -45,7 +45,7 @@ export function SecurityVaultSection({
 	}
 	const selectedVaultAddress = getSelectedVaultAddress(normalizedSecurityVaultForm.selectedVaultAddress, accountState.address)
 	const hasWithdrawAmount = normalizedSecurityVaultForm.repWithdrawAmount.trim() !== '' && normalizedSecurityVaultForm.repWithdrawAmount.trim() !== '0'
-	const selectedVaultIsOwnedByAccount = isSelectedVaultOwnedByAccountHelper(selectedVaultAddress, accountState.address)
+	const selectedVaultIsOwnedByAccount = canManageSelectedVault(selectedVaultAddress, accountState.address)
 	const depositAmount = (() => {
 		try {
 			return parseRepAmountInput(normalizedSecurityVaultForm.depositAmount, 'REP deposit amount')
@@ -141,11 +141,13 @@ export function SecurityVaultSection({
 				<button className='secondary' onClick={() => onLoadSecurityVault()} disabled={loadingSecurityVault}>
 					{loadingSecurityVault ? <LoadingText>Refreshing...</LoadingText> : 'Refresh'}
 				</button>
-				<button className='primary' onClick={onRedeemFees} disabled={!canClaimFees}>
-					Claim Fees
-				</button>
+				{selectedVaultIsOwnedByAccount ? (
+					<button className='primary' onClick={onRedeemFees} disabled={!canClaimFees}>
+						Claim Fees
+					</button>
+				) : undefined}
 			</div>
-			{selectedVaultIsOwnedByAccount ? undefined : <p className='detail'>Read-only vault. Refresh is available, but write actions are disabled.</p>}
+			{selectedVaultIsOwnedByAccount ? undefined : <p className='detail'>Read-only vault. Refresh is available, but write actions are hidden.</p>}
 		</div>
 	)
 
@@ -270,9 +272,9 @@ export function SecurityVaultSection({
 			<>
 				{vaultSummarySection}
 				{latestAction}
-				{vaultDepositSection}
-				{securityBondAllowanceSection}
-				{vaultRepSection}
+				{selectedVaultIsOwnedByAccount ? vaultDepositSection : undefined}
+				{selectedVaultIsOwnedByAccount ? securityBondAllowanceSection : undefined}
+				{selectedVaultIsOwnedByAccount ? vaultRepSection : undefined}
 				<ErrorNotice message={securityVaultError} />
 			</>
 		)
@@ -308,11 +310,13 @@ export function SecurityVaultSection({
 				</div>
 
 				<div className='market-column'>
-					<EntityCard title='Vault Actions'>
-						{vaultDepositSection}
-						{securityBondAllowanceSection}
-						{vaultRepSection}
-					</EntityCard>
+					{selectedVaultIsOwnedByAccount ? (
+						<EntityCard title='Vault Actions'>
+							{vaultDepositSection}
+							{securityBondAllowanceSection}
+							{vaultRepSection}
+						</EntityCard>
+					) : undefined}
 
 					<ErrorNotice message={securityVaultError} />
 				</div>

--- a/ui/ts/lib/securityVault.ts
+++ b/ui/ts/lib/securityVault.ts
@@ -12,3 +12,7 @@ export function isSelectedVaultOwnedByAccount(selectedVaultAddress: string | und
 	if (trimmedSelectedVaultAddress === '' || accountAddress === undefined) return false
 	return sameAddress(trimmedSelectedVaultAddress, accountAddress)
 }
+
+export function canManageSelectedVault(selectedVaultAddress: string | undefined, accountAddress: Address | undefined) {
+	return isSelectedVaultOwnedByAccount(selectedVaultAddress, accountAddress)
+}

--- a/ui/ts/tests/securityVault.test.ts
+++ b/ui/ts/tests/securityVault.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, test } from 'bun:test'
 import { getAddress, zeroAddress } from 'viem'
-import { getSelectedVaultAddress, isSelectedVaultOwnedByAccount } from '../lib/securityVault.js'
+import { canManageSelectedVault, getSelectedVaultAddress, isSelectedVaultOwnedByAccount } from '../lib/securityVault.js'
 
 void describe('security vault helpers', () => {
 	void test('defaults to the connected wallet vault when no explicit vault is selected', () => {
@@ -20,5 +20,12 @@ void describe('security vault helpers', () => {
 		expect(isSelectedVaultOwnedByAccount(getAddress('0x00000000000000000000000000000000000000a2'), accountAddress)).toBe(false)
 		expect(isSelectedVaultOwnedByAccount('', accountAddress)).toBe(false)
 		expect(isSelectedVaultOwnedByAccount(undefined, zeroAddress)).toBe(false)
+	})
+
+	void test('only allows management controls for the connected wallet vault', () => {
+		const accountAddress = getAddress('0x00000000000000000000000000000000000000a1')
+		expect(canManageSelectedVault(accountAddress, accountAddress)).toBe(true)
+		expect(canManageSelectedVault(getAddress('0x00000000000000000000000000000000000000a2'), accountAddress)).toBe(false)
+		expect(canManageSelectedVault(undefined, accountAddress)).toBe(false)
 	})
 })


### PR DESCRIPTION
## Summary
- Hide vault management controls when the selected security vault is read-only, and update the read-only copy to match the new behavior.
- Replace several market and oracle loading messages with spinner placeholders for a more consistent loading state.
- Add and update security vault helper coverage for the management-access rules.
