### PR TITLE
Remove REP balance text from vault approval UI

### DIFF
--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -208,7 +208,6 @@ export function SecurityVaultSection({
 					</button>
 				</div>
 			</label>
-			<p className='detail'>Available REP: {securityVaultRepBalance === undefined ? selectedVaultIsOwnedByAccount ? 'Refresh the vault to fetch your balance.' : 'Unavailable for read-only vaults.' : <CurrencyValue value={securityVaultRepBalance} suffix='REP' copyable={false} />}</p>
 			<div className='actions'>
 				<button className='secondary' title={approveButtonTitle} onClick={() => onApproveRep(shortage)} disabled={!canApproveRep}>
 					{approveButtonLabel}


### PR DESCRIPTION
## Summary
- Removed the REP balance status line from the vault approval section.
- Kept the approve flow and related button behavior unchanged.

## Testing
- Not run (PR content only; no code changes made in this step).