### PR TITLE
Share deployment address logic across shared, UI, and simulator code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,12 +14,17 @@ solidity/types/contractArtifact.ts
 /ui/ts/contractArtifact.ts
 /ui/ts/deploymentArtifacts.ts
 /ui/ts/deploymentsArtifacts.ts
+/shared/js
 solidity/.contract-hash.json
 # Compiled output must never appear inside source directories
 solidity/ts/**/*.js
 solidity/ts/**/*.js.map
 solidity/ts/**/*.d.ts
 solidity/ts/**/*.d.ts.map
+shared/ts/**/*.js
+shared/ts/**/*.js.map
+shared/ts/**/*.d.ts
+shared/ts/**/*.d.ts.map
 ui/ts/**/*.js
 ui/ts/**/*.js.map
 ui/ts/**/*.d.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,5 +91,7 @@ This test-driven approach ensures:
 
 - - This is a TypeScript project. Do not inspect or work from `js/` files anywhere in the repository when there is a corresponding TypeScript source file.
 - - The project compiles TypeScript sources to JavaScript before testing (`bun tsc`). This happens automatically via the test scripts.
+- - The `shared/js/` directory is generated build output from `shared/ts/` and must not be committed. Build it via `bun run shared:build` or by using the existing top-level setup/build scripts, which now run that step for you.
+- - On a fresh checkout, use `bun install --frozen-lockfile && bun run setup` for the full local install. For UI-only work, `bun install --frozen-lockfile && bun run ui:build` is sufficient and will also regenerate `shared/js/`.
 - - The root `bun tsc` runs the full generation pipeline before type-checking. UI-only changes still need to emit JS so the watcher reloads correctly; use `bun x tsc` instead of `--noEmit`.
 - - Never edit files directly in any `js/` directory. Changes may be overwritten by TypeScript compilation. Always use the corresponding `.ts` or `.tsx` source files.

--- a/package.json
+++ b/package.json
@@ -23,10 +23,11 @@
 	"scripts": {
 		"preinstall": "bun ./scripts/link-shared-node-modules.mjs",
 		"install:anvil": "bash -lc 'if ! command -v anvil >/dev/null 2>&1; then curl -L https://foundry.paradigm.xyz | bash && export PATH=\"$HOME/.foundry/bin:$PATH\" && foundryup; fi'",
-		"setup": "bun install --frozen-lockfile && bun run setup-contracts && bun run ui:vendor && cd ui && bun install --frozen-lockfile && bun run build && bun run build:tests",
+		"shared:build": "bun x tsc --project shared/tsconfig.json",
+		"setup": "bun install --frozen-lockfile && bun run setup-contracts && bun run shared:build && bun run ui:vendor && cd ui && bun install --frozen-lockfile && bun run build && bun run build:tests",
 		"setup-contracts": "cd solidity && bun run setup",
 		"compile-contracts": "cd solidity && bun install --frozen-lockfile && bun x tsc --project tsconfig-compile.json && bun run ./js/compile.js",
-		"generate": "bun run compile-contracts && bun run ui:vendor",
+		"generate": "bun run compile-contracts && bun run shared:build && bun run ui:vendor",
 		"tsc": "bun x tsc --noEmit",
 		"ui:setup": "bun install --frozen-lockfile && cd solidity && bun install --frozen-lockfile && bun run setup && cd .. && bun run generate && cd ui && bun install --frozen-lockfile && bun run build && bun run build:tests",
 		"ui:build": "bun run generate && cd ui && bun install --frozen-lockfile && bun run build && bun run build:tests",

--- a/shared/ts/addressDerivation.ts
+++ b/shared/ts/addressDerivation.ts
@@ -1,0 +1,177 @@
+import { encodeAbiParameters, getAddress, getCreate2Address, keccak256, numberToBytes, zeroAddress, type Address, type Hex } from 'viem'
+
+type SecurityPoolAddressDerivationInputs = {
+	infraContracts: {
+		escalationGameFactory: Address
+		priceOracleManagerAndOperatorQueuerFactory: Address
+		securityPoolFactory: Address
+		shareTokenFactory: Address
+		uniformPriceDualCapBatchAuctionFactory: Address
+	}
+	parent: Address
+	getEscalationGameInitCode: (securityPool: Address) => Hex
+	getPriceOracleManagerAndOperatorQueuerInitCode: (repToken: Address) => Hex
+	repToken: Address
+	questionId: bigint
+	securityMultiplier: bigint
+	getSecurityPoolInitCode: (priceOracleManagerAndOperatorQueuer: Address, shareToken: Address, truthAuction: Address) => Hex
+	getShareTokenInitCode: () => Hex
+	getTruthAuctionInitCode: () => Hex
+	universeId: bigint
+}
+
+type AddressDerivationConfig = {
+	customGetRepTokenAddress?: (universeId: bigint) => Address
+	genesisRepTokenAddress: Address
+	getEscalationGameInitCode: (securityPool: Address) => Hex
+	getInfraContracts: () => SecurityPoolAddressDerivationInputs['infraContracts'] & {
+		openOracle: Address
+		securityPoolForker: Address
+		zoltar: Address
+		zoltarQuestionData: Address
+	}
+	getPriceOracleManagerAndOperatorQueuerInitCode: (openOracle: Address, repToken: Address) => Hex
+	getReputationTokenInitCode: (zoltarAddress: Address) => Hex
+	getSecurityPoolInitCode: (inputs: {
+		escalationGameFactory: Address
+		openOracle: Address
+		parent: Address
+		priceOracleManagerAndOperatorQueuer: Address
+		questionId: bigint
+		securityMultiplier: bigint
+		securityPoolFactory: Address
+		securityPoolForker: Address
+		shareToken: Address
+		truthAuction: Address
+		universeId: bigint
+		zoltar: Address
+		zoltarQuestionData: Address
+	}) => Hex
+	getShareTokenInitCode: (securityPoolFactory: Address, zoltarAddress: Address, questionId: bigint) => Hex
+	getTruthAuctionInitCode: (securityPoolForker: Address) => Hex
+	getZoltarAddress: () => Address
+}
+
+function deriveRepTokenAddress(universeId: bigint, genesisRepTokenAddress: Address, zoltarAddress: Address, reputationTokenInitCode: Hex): Address {
+	if (universeId === 0n) return getAddress(genesisRepTokenAddress)
+
+	return getCreate2Address({
+		from: zoltarAddress,
+		salt: numberToBytes(universeId, { size: 32 }),
+		bytecodeHash: keccak256(reputationTokenInitCode),
+	})
+}
+
+function getSecurityPoolSalt(parent: Address, universeId: bigint, questionId: bigint, securityMultiplier: bigint) {
+	return keccak256(encodeAbiParameters([{ type: 'address' }, { type: 'uint248' }, { type: 'uint256' }, { type: 'uint256' }], [parent, universeId, questionId, securityMultiplier]))
+}
+
+function getShareTokenSalt(questionId: bigint, securityMultiplier: bigint) {
+	return keccak256(encodeAbiParameters([{ type: 'uint256' }, { type: 'uint256' }], [securityMultiplier, questionId]))
+}
+
+function deriveSecurityPoolAddresses({
+	infraContracts,
+	parent,
+	getEscalationGameInitCode,
+	getPriceOracleManagerAndOperatorQueuerInitCode,
+	questionId,
+	repToken,
+	securityMultiplier,
+	getSecurityPoolInitCode,
+	getShareTokenInitCode,
+	getTruthAuctionInitCode,
+	universeId,
+}: SecurityPoolAddressDerivationInputs) {
+	const securityPoolSalt = getSecurityPoolSalt(parent, universeId, questionId, securityMultiplier)
+	const securityPoolSaltWithMsgSender = keccak256(encodeAbiParameters([{ type: 'address' }, { type: 'bytes32' }], [infraContracts.securityPoolFactory, securityPoolSalt]))
+
+	const priceOracleManagerAndOperatorQueuer = getCreate2Address({
+		bytecode: getPriceOracleManagerAndOperatorQueuerInitCode(repToken),
+		from: infraContracts.priceOracleManagerAndOperatorQueuerFactory,
+		salt: securityPoolSaltWithMsgSender,
+	})
+	const shareToken = getCreate2Address({
+		bytecode: getShareTokenInitCode(),
+		from: infraContracts.shareTokenFactory,
+		salt: getShareTokenSalt(questionId, securityMultiplier),
+	})
+	const truthAuction =
+		parent === zeroAddress
+			? zeroAddress
+			: getCreate2Address({
+					bytecode: getTruthAuctionInitCode(),
+					from: infraContracts.uniformPriceDualCapBatchAuctionFactory,
+					salt: securityPoolSalt,
+				})
+	const securityPool = getCreate2Address({
+		bytecode: getSecurityPoolInitCode(priceOracleManagerAndOperatorQueuer, shareToken, truthAuction),
+		from: infraContracts.securityPoolFactory,
+		salt: numberToBytes(0, { size: 32 }),
+	})
+	const escalationGame = getCreate2Address({
+		bytecode: getEscalationGameInitCode(securityPool),
+		from: infraContracts.escalationGameFactory,
+		salt: numberToBytes(0, { size: 32 }),
+	})
+
+	return {
+		escalationGame,
+		priceOracleManagerAndOperatorQueuer,
+		securityPool,
+		shareToken,
+		truthAuction,
+	}
+}
+
+export function createAddressDerivationHelpers(config: AddressDerivationConfig) {
+	const derivedGetRepTokenAddress = (universeId: bigint) => {
+		const zoltarAddress = config.getZoltarAddress()
+		return deriveRepTokenAddress(universeId, config.genesisRepTokenAddress, zoltarAddress, config.getReputationTokenInitCode(zoltarAddress))
+	}
+
+	const getRepTokenAddress = config.customGetRepTokenAddress ?? derivedGetRepTokenAddress
+
+	const getSecurityPoolAddresses = (parent: Address, universeId: bigint, questionId: bigint, securityMultiplier: bigint) => {
+		const infraContracts = config.getInfraContracts()
+		return deriveSecurityPoolAddresses({
+			infraContracts: {
+				escalationGameFactory: infraContracts.escalationGameFactory,
+				priceOracleManagerAndOperatorQueuerFactory: infraContracts.priceOracleManagerAndOperatorQueuerFactory,
+				securityPoolFactory: infraContracts.securityPoolFactory,
+				shareTokenFactory: infraContracts.shareTokenFactory,
+				uniformPriceDualCapBatchAuctionFactory: infraContracts.uniformPriceDualCapBatchAuctionFactory,
+			},
+			parent,
+			getEscalationGameInitCode: config.getEscalationGameInitCode,
+			getPriceOracleManagerAndOperatorQueuerInitCode: repToken => config.getPriceOracleManagerAndOperatorQueuerInitCode(infraContracts.openOracle, repToken),
+			getSecurityPoolInitCode: (priceOracleManagerAndOperatorQueuer, shareToken, truthAuction) =>
+				config.getSecurityPoolInitCode({
+					escalationGameFactory: infraContracts.escalationGameFactory,
+					openOracle: infraContracts.openOracle,
+					parent,
+					priceOracleManagerAndOperatorQueuer,
+					questionId,
+					securityMultiplier,
+					securityPoolFactory: infraContracts.securityPoolFactory,
+					securityPoolForker: infraContracts.securityPoolForker,
+					shareToken,
+					truthAuction,
+					universeId,
+					zoltar: infraContracts.zoltar,
+					zoltarQuestionData: infraContracts.zoltarQuestionData,
+				}),
+			getShareTokenInitCode: () => config.getShareTokenInitCode(infraContracts.securityPoolFactory, infraContracts.zoltar, questionId),
+			getTruthAuctionInitCode: () => config.getTruthAuctionInitCode(infraContracts.securityPoolForker),
+			repToken: getRepTokenAddress(universeId),
+			questionId,
+			securityMultiplier,
+			universeId,
+		})
+	}
+
+	return {
+		getRepTokenAddress,
+		getSecurityPoolAddresses,
+	}
+}

--- a/shared/ts/addressDerivation.ts
+++ b/shared/ts/addressDerivation.ts
@@ -1,37 +1,28 @@
 import { encodeAbiParameters, getAddress, getCreate2Address, keccak256, numberToBytes, zeroAddress, type Address, type Hex } from 'viem'
 
-type SecurityPoolAddressDerivationInputs = {
-	infraContracts: {
-		escalationGameFactory: Address
-		priceOracleManagerAndOperatorQueuerFactory: Address
-		securityPoolFactory: Address
-		shareTokenFactory: Address
-		uniformPriceDualCapBatchAuctionFactory: Address
-	}
-	parent: Address
-	getEscalationGameInitCode: (securityPool: Address) => Hex
-	getPriceOracleManagerAndOperatorQueuerInitCode: (repToken: Address) => Hex
-	repToken: Address
-	questionId: bigint
-	securityMultiplier: bigint
-	getSecurityPoolInitCode: (priceOracleManagerAndOperatorQueuer: Address, shareToken: Address, truthAuction: Address) => Hex
-	getShareTokenInitCode: () => Hex
-	getTruthAuctionInitCode: () => Hex
-	universeId: bigint
+type SecurityPoolCoreAddresses = {
+	escalationGameFactory: Address
+	openOracle: Address
+	priceOracleManagerAndOperatorQueuerFactory: Address
+	securityPoolFactory: Address
+	securityPoolForker: Address
+	shareTokenFactory: Address
+	uniformPriceDualCapBatchAuctionFactory: Address
+	zoltar: Address
+	zoltarQuestionData: Address
 }
 
-type AddressDerivationConfig = {
-	customGetRepTokenAddress?: (universeId: bigint) => Address
+type RepTokenAddressConfig = {
 	genesisRepTokenAddress: Address
-	getEscalationGameInitCode: (securityPool: Address) => Hex
-	getInfraContracts: () => SecurityPoolAddressDerivationInputs['infraContracts'] & {
-		openOracle: Address
-		securityPoolForker: Address
-		zoltar: Address
-		zoltarQuestionData: Address
-	}
-	getPriceOracleManagerAndOperatorQueuerInitCode: (openOracle: Address, repToken: Address) => Hex
 	getReputationTokenInitCode: (zoltarAddress: Address) => Hex
+	getZoltarAddress: () => Address
+}
+
+type SecurityPoolAddressConfig = {
+	getEscalationGameInitCode: (securityPool: Address) => Hex
+	getInfraContracts: () => SecurityPoolCoreAddresses
+	getPriceOracleManagerAndOperatorQueuerInitCode: (openOracle: Address, repToken: Address) => Hex
+	getRepTokenAddress: (universeId: bigint) => Address
 	getSecurityPoolInitCode: (inputs: {
 		escalationGameFactory: Address
 		openOracle: Address
@@ -49,7 +40,6 @@ type AddressDerivationConfig = {
 	}) => Hex
 	getShareTokenInitCode: (securityPoolFactory: Address, zoltarAddress: Address, questionId: bigint) => Hex
 	getTruthAuctionInitCode: (securityPoolForker: Address) => Hex
-	getZoltarAddress: () => Address
 }
 
 function deriveRepTokenAddress(universeId: bigint, genesisRepTokenAddress: Address, zoltarAddress: Address, reputationTokenInitCode: Hex): Address {
@@ -70,108 +60,77 @@ function getShareTokenSalt(questionId: bigint, securityMultiplier: bigint) {
 	return keccak256(encodeAbiParameters([{ type: 'uint256' }, { type: 'uint256' }], [securityMultiplier, questionId]))
 }
 
-function deriveSecurityPoolAddresses({
-	infraContracts,
-	parent,
-	getEscalationGameInitCode,
-	getPriceOracleManagerAndOperatorQueuerInitCode,
-	questionId,
-	repToken,
-	securityMultiplier,
-	getSecurityPoolInitCode,
-	getShareTokenInitCode,
-	getTruthAuctionInitCode,
-	universeId,
-}: SecurityPoolAddressDerivationInputs) {
-	const securityPoolSalt = getSecurityPoolSalt(parent, universeId, questionId, securityMultiplier)
-	const securityPoolSaltWithMsgSender = keccak256(encodeAbiParameters([{ type: 'address' }, { type: 'bytes32' }], [infraContracts.securityPoolFactory, securityPoolSalt]))
-
-	const priceOracleManagerAndOperatorQueuer = getCreate2Address({
-		bytecode: getPriceOracleManagerAndOperatorQueuerInitCode(repToken),
-		from: infraContracts.priceOracleManagerAndOperatorQueuerFactory,
-		salt: securityPoolSaltWithMsgSender,
-	})
-	const shareToken = getCreate2Address({
-		bytecode: getShareTokenInitCode(),
-		from: infraContracts.shareTokenFactory,
-		salt: getShareTokenSalt(questionId, securityMultiplier),
-	})
-	const truthAuction =
-		parent === zeroAddress
-			? zeroAddress
-			: getCreate2Address({
-					bytecode: getTruthAuctionInitCode(),
-					from: infraContracts.uniformPriceDualCapBatchAuctionFactory,
-					salt: securityPoolSalt,
-				})
-	const securityPool = getCreate2Address({
-		bytecode: getSecurityPoolInitCode(priceOracleManagerAndOperatorQueuer, shareToken, truthAuction),
-		from: infraContracts.securityPoolFactory,
-		salt: numberToBytes(0, { size: 32 }),
-	})
-	const escalationGame = getCreate2Address({
-		bytecode: getEscalationGameInitCode(securityPool),
-		from: infraContracts.escalationGameFactory,
-		salt: numberToBytes(0, { size: 32 }),
-	})
-
-	return {
-		escalationGame,
-		priceOracleManagerAndOperatorQueuer,
-		securityPool,
-		shareToken,
-		truthAuction,
-	}
-}
-
-export function createAddressDerivationHelpers(config: AddressDerivationConfig) {
-	const derivedGetRepTokenAddress = (universeId: bigint) => {
+export function createRepTokenAddressHelper(config: RepTokenAddressConfig) {
+	const getRepTokenAddress = (universeId: bigint) => {
 		const zoltarAddress = config.getZoltarAddress()
 		return deriveRepTokenAddress(universeId, config.genesisRepTokenAddress, zoltarAddress, config.getReputationTokenInitCode(zoltarAddress))
 	}
 
-	const getRepTokenAddress = config.customGetRepTokenAddress ?? derivedGetRepTokenAddress
+	return {
+		getRepTokenAddress,
+	}
+}
 
+export function createSecurityPoolAddressHelper(config: SecurityPoolAddressConfig) {
 	const getSecurityPoolAddresses = (parent: Address, universeId: bigint, questionId: bigint, securityMultiplier: bigint) => {
 		const infraContracts = config.getInfraContracts()
-		return deriveSecurityPoolAddresses({
-			infraContracts: {
-				escalationGameFactory: infraContracts.escalationGameFactory,
-				priceOracleManagerAndOperatorQueuerFactory: infraContracts.priceOracleManagerAndOperatorQueuerFactory,
-				securityPoolFactory: infraContracts.securityPoolFactory,
-				shareTokenFactory: infraContracts.shareTokenFactory,
-				uniformPriceDualCapBatchAuctionFactory: infraContracts.uniformPriceDualCapBatchAuctionFactory,
-			},
-			parent,
-			getEscalationGameInitCode: config.getEscalationGameInitCode,
-			getPriceOracleManagerAndOperatorQueuerInitCode: repToken => config.getPriceOracleManagerAndOperatorQueuerInitCode(infraContracts.openOracle, repToken),
-			getSecurityPoolInitCode: (priceOracleManagerAndOperatorQueuer, shareToken, truthAuction) =>
-				config.getSecurityPoolInitCode({
-					escalationGameFactory: infraContracts.escalationGameFactory,
-					openOracle: infraContracts.openOracle,
-					parent,
-					priceOracleManagerAndOperatorQueuer,
-					questionId,
-					securityMultiplier,
-					securityPoolFactory: infraContracts.securityPoolFactory,
-					securityPoolForker: infraContracts.securityPoolForker,
-					shareToken,
-					truthAuction,
-					universeId,
-					zoltar: infraContracts.zoltar,
-					zoltarQuestionData: infraContracts.zoltarQuestionData,
-				}),
-			getShareTokenInitCode: () => config.getShareTokenInitCode(infraContracts.securityPoolFactory, infraContracts.zoltar, questionId),
-			getTruthAuctionInitCode: () => config.getTruthAuctionInitCode(infraContracts.securityPoolForker),
-			repToken: getRepTokenAddress(universeId),
-			questionId,
-			securityMultiplier,
-			universeId,
+		const securityPoolSalt = getSecurityPoolSalt(parent, universeId, questionId, securityMultiplier)
+		const securityPoolSaltWithMsgSender = keccak256(encodeAbiParameters([{ type: 'address' }, { type: 'bytes32' }], [infraContracts.securityPoolFactory, securityPoolSalt]))
+
+		const repToken = config.getRepTokenAddress(universeId)
+		const priceOracleManagerAndOperatorQueuer = getCreate2Address({
+			bytecode: config.getPriceOracleManagerAndOperatorQueuerInitCode(infraContracts.openOracle, repToken),
+			from: infraContracts.priceOracleManagerAndOperatorQueuerFactory,
+			salt: securityPoolSaltWithMsgSender,
 		})
+		const shareToken = getCreate2Address({
+			bytecode: config.getShareTokenInitCode(infraContracts.securityPoolFactory, infraContracts.zoltar, questionId),
+			from: infraContracts.shareTokenFactory,
+			salt: getShareTokenSalt(questionId, securityMultiplier),
+		})
+		const truthAuction =
+			parent === zeroAddress
+				? zeroAddress
+				: getCreate2Address({
+						bytecode: config.getTruthAuctionInitCode(infraContracts.securityPoolForker),
+						from: infraContracts.uniformPriceDualCapBatchAuctionFactory,
+						salt: securityPoolSalt,
+					})
+		const securityPool = getCreate2Address({
+			bytecode: config.getSecurityPoolInitCode({
+				escalationGameFactory: infraContracts.escalationGameFactory,
+				openOracle: infraContracts.openOracle,
+				parent,
+				priceOracleManagerAndOperatorQueuer,
+				questionId,
+				securityMultiplier,
+				securityPoolFactory: infraContracts.securityPoolFactory,
+				securityPoolForker: infraContracts.securityPoolForker,
+				shareToken,
+				truthAuction,
+				universeId,
+				zoltar: infraContracts.zoltar,
+				zoltarQuestionData: infraContracts.zoltarQuestionData,
+			}),
+			from: infraContracts.securityPoolFactory,
+			salt: numberToBytes(0, { size: 32 }),
+		})
+		const escalationGame = getCreate2Address({
+			bytecode: config.getEscalationGameInitCode(securityPool),
+			from: infraContracts.escalationGameFactory,
+			salt: numberToBytes(0, { size: 32 }),
+		})
+
+		return {
+			escalationGame,
+			priceOracleManagerAndOperatorQueuer,
+			securityPool,
+			shareToken,
+			truthAuction,
+		}
 	}
 
 	return {
-		getRepTokenAddress,
 		getSecurityPoolAddresses,
 	}
 }

--- a/shared/ts/deploymentAddresses.ts
+++ b/shared/ts/deploymentAddresses.ts
@@ -1,0 +1,210 @@
+import { getCreate2Address, type Address, type Hex } from 'viem'
+
+type LibraryReplacement = {
+	address: Address
+	hash: string
+}
+
+type SecurityPoolFactoryAddressInputs = {
+	escalationGameFactory: Address
+	openOracle: Address
+	priceOracleManagerAndOperatorQueuerFactory: Address
+	securityPoolForker: Address
+	shareTokenFactory: Address
+	uniformPriceDualCapBatchAuctionFactory: Address
+	zoltar: Address
+	zoltarQuestionData: Address
+}
+
+type InfraContractAddressInputs = {
+	getEscalationGameFactoryByteCode: () => Hex
+	getSecurityPoolFactoryByteCode: (inputs: SecurityPoolFactoryAddressInputs) => Hex
+	getSecurityPoolForkerByteCode: (zoltarAddress: Address) => Hex
+	getShareTokenFactoryByteCode: (zoltarAddress: Address) => Hex
+	openOracleBytecode: Hex
+	priceOracleManagerAndOperatorQueuerFactoryBytecode: Hex
+	proxyDeployerAddress: Address
+	scalarOutcomesBytecode: Hex
+	securityPoolUtilsBytecode: Hex
+	uniformPriceDualCapBatchAuctionFactoryBytecode: Hex
+	zeroSalt: Hex
+	zoltar: Address
+	zoltarQuestionData: Address
+}
+
+type DeploymentStatusOracleAddressInputs = {
+	deploymentStatusOracleBytecode: Hex
+	proxyDeployerAddress: Address
+	zeroSalt: Hex
+}
+
+type ZoltarAddressInputs = {
+	getZoltarInitCode: (zoltarQuestionDataAddress: Address) => Hex
+	proxyDeployerAddress: Address
+	zeroSalt: Hex
+	zoltarQuestionDataAddress: Address
+}
+
+type ZoltarQuestionDataAddressInputs = {
+	proxyDeployerAddress: Address
+	zeroSalt: Hex
+	zoltarQuestionDataBytecode: Hex
+}
+
+type DeploymentAddressConfig = {
+	deploymentStatusOracleBytecode: () => Hex
+	getEscalationGameFactoryByteCode: () => Hex
+	getSecurityPoolFactoryByteCode: (inputs: SecurityPoolFactoryAddressInputs) => Hex
+	getSecurityPoolForkerByteCode: (zoltarAddress: Address) => Hex
+	getShareTokenFactoryByteCode: (zoltarAddress: Address) => Hex
+	getZoltarInitCode: (zoltarQuestionDataAddress: Address) => Hex
+	libraryReplacements: () => readonly LibraryReplacement[]
+	openOracleBytecode: Hex
+	priceOracleManagerAndOperatorQueuerFactoryBytecode: Hex
+	proxyDeployerAddress: Address
+	scalarOutcomesBytecode: Hex
+	securityPoolUtilsBytecode: Hex
+	uniformPriceDualCapBatchAuctionFactoryBytecode: Hex
+	zeroSalt: Hex
+	zoltarQuestionDataBytecode: () => Hex
+}
+
+export type InfraContractAddresses = {
+	escalationGameFactory: Address
+	openOracle: Address
+	priceOracleManagerAndOperatorQueuerFactory: Address
+	scalarOutcomes: Address
+	securityPoolFactory: Address
+	securityPoolForker: Address
+	securityPoolUtils: Address
+	shareTokenFactory: Address
+	uniformPriceDualCapBatchAuctionFactory: Address
+	zoltar: Address
+	zoltarQuestionData: Address
+}
+
+function getProxyDeployerCreate2Address(proxyDeployerAddress: Address, zeroSalt: Hex, bytecode: Hex) {
+	return getCreate2Address({
+		bytecode,
+		from: proxyDeployerAddress,
+		salt: zeroSalt,
+	})
+}
+
+export function applyLinkedLibraries(bytecode: string, replacements: readonly LibraryReplacement[]): Hex {
+	let updatedBytecode = bytecode
+	for (const { hash, address } of replacements) {
+		updatedBytecode = updatedBytecode.replaceAll(`__$${hash}$__`, address.slice(2).toLowerCase())
+	}
+	return `0x${updatedBytecode}`
+}
+
+function getZoltarQuestionDataAddressBase({ proxyDeployerAddress, zeroSalt, zoltarQuestionDataBytecode }: ZoltarQuestionDataAddressInputs): Address {
+	return getProxyDeployerCreate2Address(proxyDeployerAddress, zeroSalt, zoltarQuestionDataBytecode)
+}
+
+function getZoltarAddressBase({ getZoltarInitCode, proxyDeployerAddress, zeroSalt, zoltarQuestionDataAddress }: ZoltarAddressInputs): Address {
+	return getProxyDeployerCreate2Address(proxyDeployerAddress, zeroSalt, getZoltarInitCode(zoltarQuestionDataAddress))
+}
+
+function getInfraContractAddressesBase({
+	getEscalationGameFactoryByteCode,
+	getSecurityPoolFactoryByteCode,
+	getSecurityPoolForkerByteCode,
+	getShareTokenFactoryByteCode,
+	openOracleBytecode,
+	priceOracleManagerAndOperatorQueuerFactoryBytecode,
+	proxyDeployerAddress,
+	scalarOutcomesBytecode,
+	securityPoolUtilsBytecode,
+	uniformPriceDualCapBatchAuctionFactoryBytecode,
+	zeroSalt,
+	zoltar,
+	zoltarQuestionData,
+}: InfraContractAddressInputs): InfraContractAddresses {
+	const addresses = {
+		securityPoolUtils: getProxyDeployerCreate2Address(proxyDeployerAddress, zeroSalt, securityPoolUtilsBytecode),
+		openOracle: getProxyDeployerCreate2Address(proxyDeployerAddress, zeroSalt, openOracleBytecode),
+		zoltarQuestionData,
+		zoltar,
+		shareTokenFactory: getProxyDeployerCreate2Address(proxyDeployerAddress, zeroSalt, getShareTokenFactoryByteCode(zoltar)),
+		priceOracleManagerAndOperatorQueuerFactory: getProxyDeployerCreate2Address(proxyDeployerAddress, zeroSalt, priceOracleManagerAndOperatorQueuerFactoryBytecode),
+		securityPoolForker: getProxyDeployerCreate2Address(proxyDeployerAddress, zeroSalt, getSecurityPoolForkerByteCode(zoltar)),
+		escalationGameFactory: getProxyDeployerCreate2Address(proxyDeployerAddress, zeroSalt, getEscalationGameFactoryByteCode()),
+		scalarOutcomes: getProxyDeployerCreate2Address(proxyDeployerAddress, zeroSalt, scalarOutcomesBytecode),
+		uniformPriceDualCapBatchAuctionFactory: getProxyDeployerCreate2Address(proxyDeployerAddress, zeroSalt, uniformPriceDualCapBatchAuctionFactoryBytecode),
+	}
+
+	return {
+		...addresses,
+		securityPoolFactory: getProxyDeployerCreate2Address(
+			proxyDeployerAddress,
+			zeroSalt,
+			getSecurityPoolFactoryByteCode({
+				escalationGameFactory: addresses.escalationGameFactory,
+				openOracle: addresses.openOracle,
+				priceOracleManagerAndOperatorQueuerFactory: addresses.priceOracleManagerAndOperatorQueuerFactory,
+				securityPoolForker: addresses.securityPoolForker,
+				shareTokenFactory: addresses.shareTokenFactory,
+				uniformPriceDualCapBatchAuctionFactory: addresses.uniformPriceDualCapBatchAuctionFactory,
+				zoltar: addresses.zoltar,
+				zoltarQuestionData: addresses.zoltarQuestionData,
+			}),
+		),
+	}
+}
+
+function getDeploymentStatusOracleAddressBase({ deploymentStatusOracleBytecode, proxyDeployerAddress, zeroSalt }: DeploymentStatusOracleAddressInputs): Address {
+	return getProxyDeployerCreate2Address(proxyDeployerAddress, zeroSalt, deploymentStatusOracleBytecode)
+}
+
+export function createDeploymentAddressHelpers(config: DeploymentAddressConfig) {
+	const applyLinkedLibrariesToBytecode = (bytecode: string) => applyLinkedLibraries(bytecode, config.libraryReplacements())
+
+	const getZoltarQuestionDataAddress = () =>
+		getZoltarQuestionDataAddressBase({
+			proxyDeployerAddress: config.proxyDeployerAddress,
+			zeroSalt: config.zeroSalt,
+			zoltarQuestionDataBytecode: config.zoltarQuestionDataBytecode(),
+		})
+
+	const getZoltarAddress = () =>
+		getZoltarAddressBase({
+			getZoltarInitCode: config.getZoltarInitCode,
+			proxyDeployerAddress: config.proxyDeployerAddress,
+			zeroSalt: config.zeroSalt,
+			zoltarQuestionDataAddress: getZoltarQuestionDataAddress(),
+		})
+
+	const getInfraContractAddresses = () =>
+		getInfraContractAddressesBase({
+			getEscalationGameFactoryByteCode: config.getEscalationGameFactoryByteCode,
+			getSecurityPoolFactoryByteCode: config.getSecurityPoolFactoryByteCode,
+			getSecurityPoolForkerByteCode: config.getSecurityPoolForkerByteCode,
+			getShareTokenFactoryByteCode: config.getShareTokenFactoryByteCode,
+			openOracleBytecode: config.openOracleBytecode,
+			priceOracleManagerAndOperatorQueuerFactoryBytecode: config.priceOracleManagerAndOperatorQueuerFactoryBytecode,
+			proxyDeployerAddress: config.proxyDeployerAddress,
+			scalarOutcomesBytecode: config.scalarOutcomesBytecode,
+			securityPoolUtilsBytecode: config.securityPoolUtilsBytecode,
+			uniformPriceDualCapBatchAuctionFactoryBytecode: config.uniformPriceDualCapBatchAuctionFactoryBytecode,
+			zeroSalt: config.zeroSalt,
+			zoltar: getZoltarAddress(),
+			zoltarQuestionData: getZoltarQuestionDataAddress(),
+		})
+
+	const getDeploymentStatusOracleAddress = () =>
+		getDeploymentStatusOracleAddressBase({
+			deploymentStatusOracleBytecode: config.deploymentStatusOracleBytecode(),
+			proxyDeployerAddress: config.proxyDeployerAddress,
+			zeroSalt: config.zeroSalt,
+		})
+
+	return {
+		applyLinkedLibraries: applyLinkedLibrariesToBytecode,
+		getDeploymentStatusOracleAddress,
+		getInfraContractAddresses,
+		getZoltarAddress,
+		getZoltarQuestionDataAddress,
+	}
+}

--- a/shared/ts/deploymentAddresses.ts
+++ b/shared/ts/deploymentAddresses.ts
@@ -16,57 +16,33 @@ type SecurityPoolFactoryAddressInputs = {
 	zoltarQuestionData: Address
 }
 
-type InfraContractAddressInputs = {
-	getEscalationGameFactoryByteCode: () => Hex
-	getSecurityPoolFactoryByteCode: (inputs: SecurityPoolFactoryAddressInputs) => Hex
-	getSecurityPoolForkerByteCode: (zoltarAddress: Address) => Hex
-	getShareTokenFactoryByteCode: (zoltarAddress: Address) => Hex
-	openOracleBytecode: Hex
-	priceOracleManagerAndOperatorQueuerFactoryBytecode: Hex
-	proxyDeployerAddress: Address
-	scalarOutcomesBytecode: Hex
-	securityPoolUtilsBytecode: Hex
-	uniformPriceDualCapBatchAuctionFactoryBytecode: Hex
-	zeroSalt: Hex
-	zoltar: Address
-	zoltarQuestionData: Address
-}
-
-type DeploymentStatusOracleAddressInputs = {
-	deploymentStatusOracleBytecode: Hex
-	proxyDeployerAddress: Address
-	zeroSalt: Hex
-}
-
-type ZoltarAddressInputs = {
+type ZoltarAddressConfig = {
 	getZoltarInitCode: (zoltarQuestionDataAddress: Address) => Hex
 	proxyDeployerAddress: Address
-	zeroSalt: Hex
-	zoltarQuestionDataAddress: Address
-}
-
-type ZoltarQuestionDataAddressInputs = {
-	proxyDeployerAddress: Address
-	zeroSalt: Hex
-	zoltarQuestionDataBytecode: Hex
-}
-
-type DeploymentAddressConfig = {
-	deploymentStatusOracleBytecode: () => Hex
-	getEscalationGameFactoryByteCode: () => Hex
-	getSecurityPoolFactoryByteCode: (inputs: SecurityPoolFactoryAddressInputs) => Hex
-	getSecurityPoolForkerByteCode: (zoltarAddress: Address) => Hex
-	getShareTokenFactoryByteCode: (zoltarAddress: Address) => Hex
-	getZoltarInitCode: (zoltarQuestionDataAddress: Address) => Hex
-	libraryReplacements: () => readonly LibraryReplacement[]
-	openOracleBytecode: Hex
-	priceOracleManagerAndOperatorQueuerFactoryBytecode: Hex
-	proxyDeployerAddress: Address
-	scalarOutcomesBytecode: Hex
-	securityPoolUtilsBytecode: Hex
-	uniformPriceDualCapBatchAuctionFactoryBytecode: Hex
 	zeroSalt: Hex
 	zoltarQuestionDataBytecode: () => Hex
+}
+
+type InfraContractAddressConfig = {
+	getEscalationGameFactoryByteCode: () => Hex
+	getSecurityPoolFactoryByteCode: (inputs: SecurityPoolFactoryAddressInputs) => Hex
+	getSecurityPoolForkerByteCode: (zoltarAddress: Address) => Hex
+	getShareTokenFactoryByteCode: (zoltarAddress: Address) => Hex
+	openOracleBytecode: Hex
+	priceOracleManagerAndOperatorQueuerFactoryBytecode: Hex
+	proxyDeployerAddress: Address
+	scalarOutcomesBytecode: Hex
+	securityPoolUtilsBytecode: Hex
+	uniformPriceDualCapBatchAuctionFactoryBytecode: Hex
+	zeroSalt: Hex
+	getZoltarAddress: () => Address
+	getZoltarQuestionDataAddress: () => Address
+}
+
+type DeploymentStatusOracleAddressConfig = {
+	deploymentStatusOracleBytecode: () => Hex
+	proxyDeployerAddress: Address
+	zeroSalt: Hex
 }
 
 export type InfraContractAddresses = {
@@ -99,112 +75,71 @@ export function applyLinkedLibraries(bytecode: string, replacements: readonly Li
 	return `0x${updatedBytecode}`
 }
 
-function getZoltarQuestionDataAddressBase({ proxyDeployerAddress, zeroSalt, zoltarQuestionDataBytecode }: ZoltarQuestionDataAddressInputs): Address {
-	return getProxyDeployerCreate2Address(proxyDeployerAddress, zeroSalt, zoltarQuestionDataBytecode)
-}
-
-function getZoltarAddressBase({ getZoltarInitCode, proxyDeployerAddress, zeroSalt, zoltarQuestionDataAddress }: ZoltarAddressInputs): Address {
-	return getProxyDeployerCreate2Address(proxyDeployerAddress, zeroSalt, getZoltarInitCode(zoltarQuestionDataAddress))
-}
-
-function getInfraContractAddressesBase({
-	getEscalationGameFactoryByteCode,
-	getSecurityPoolFactoryByteCode,
-	getSecurityPoolForkerByteCode,
-	getShareTokenFactoryByteCode,
-	openOracleBytecode,
-	priceOracleManagerAndOperatorQueuerFactoryBytecode,
-	proxyDeployerAddress,
-	scalarOutcomesBytecode,
-	securityPoolUtilsBytecode,
-	uniformPriceDualCapBatchAuctionFactoryBytecode,
-	zeroSalt,
-	zoltar,
-	zoltarQuestionData,
-}: InfraContractAddressInputs): InfraContractAddresses {
-	const addresses = {
-		securityPoolUtils: getProxyDeployerCreate2Address(proxyDeployerAddress, zeroSalt, securityPoolUtilsBytecode),
-		openOracle: getProxyDeployerCreate2Address(proxyDeployerAddress, zeroSalt, openOracleBytecode),
-		zoltarQuestionData,
-		zoltar,
-		shareTokenFactory: getProxyDeployerCreate2Address(proxyDeployerAddress, zeroSalt, getShareTokenFactoryByteCode(zoltar)),
-		priceOracleManagerAndOperatorQueuerFactory: getProxyDeployerCreate2Address(proxyDeployerAddress, zeroSalt, priceOracleManagerAndOperatorQueuerFactoryBytecode),
-		securityPoolForker: getProxyDeployerCreate2Address(proxyDeployerAddress, zeroSalt, getSecurityPoolForkerByteCode(zoltar)),
-		escalationGameFactory: getProxyDeployerCreate2Address(proxyDeployerAddress, zeroSalt, getEscalationGameFactoryByteCode()),
-		scalarOutcomes: getProxyDeployerCreate2Address(proxyDeployerAddress, zeroSalt, scalarOutcomesBytecode),
-		uniformPriceDualCapBatchAuctionFactory: getProxyDeployerCreate2Address(proxyDeployerAddress, zeroSalt, uniformPriceDualCapBatchAuctionFactoryBytecode),
-	}
+export function createApplyLinkedLibrariesHelper(libraryReplacements: () => readonly LibraryReplacement[]) {
+	const applyLibraries = (bytecode: string) => applyLinkedLibraries(bytecode, libraryReplacements())
 
 	return {
-		...addresses,
-		securityPoolFactory: getProxyDeployerCreate2Address(
-			proxyDeployerAddress,
-			zeroSalt,
-			getSecurityPoolFactoryByteCode({
-				escalationGameFactory: addresses.escalationGameFactory,
-				openOracle: addresses.openOracle,
-				priceOracleManagerAndOperatorQueuerFactory: addresses.priceOracleManagerAndOperatorQueuerFactory,
-				securityPoolForker: addresses.securityPoolForker,
-				shareTokenFactory: addresses.shareTokenFactory,
-				uniformPriceDualCapBatchAuctionFactory: addresses.uniformPriceDualCapBatchAuctionFactory,
-				zoltar: addresses.zoltar,
-				zoltarQuestionData: addresses.zoltarQuestionData,
-			}),
-		),
+		applyLibraries,
 	}
 }
 
-function getDeploymentStatusOracleAddressBase({ deploymentStatusOracleBytecode, proxyDeployerAddress, zeroSalt }: DeploymentStatusOracleAddressInputs): Address {
-	return getProxyDeployerCreate2Address(proxyDeployerAddress, zeroSalt, deploymentStatusOracleBytecode)
-}
-
-export function createDeploymentAddressHelpers(config: DeploymentAddressConfig) {
-	const applyLinkedLibrariesToBytecode = (bytecode: string) => applyLinkedLibraries(bytecode, config.libraryReplacements())
-
+export function createZoltarAddressHelpers(config: ZoltarAddressConfig) {
 	const getZoltarQuestionDataAddress = () =>
-		getZoltarQuestionDataAddressBase({
-			proxyDeployerAddress: config.proxyDeployerAddress,
-			zeroSalt: config.zeroSalt,
-			zoltarQuestionDataBytecode: config.zoltarQuestionDataBytecode(),
-		})
+		getProxyDeployerCreate2Address(config.proxyDeployerAddress, config.zeroSalt, config.zoltarQuestionDataBytecode())
 
 	const getZoltarAddress = () =>
-		getZoltarAddressBase({
-			getZoltarInitCode: config.getZoltarInitCode,
-			proxyDeployerAddress: config.proxyDeployerAddress,
-			zeroSalt: config.zeroSalt,
-			zoltarQuestionDataAddress: getZoltarQuestionDataAddress(),
-		})
-
-	const getInfraContractAddresses = () =>
-		getInfraContractAddressesBase({
-			getEscalationGameFactoryByteCode: config.getEscalationGameFactoryByteCode,
-			getSecurityPoolFactoryByteCode: config.getSecurityPoolFactoryByteCode,
-			getSecurityPoolForkerByteCode: config.getSecurityPoolForkerByteCode,
-			getShareTokenFactoryByteCode: config.getShareTokenFactoryByteCode,
-			openOracleBytecode: config.openOracleBytecode,
-			priceOracleManagerAndOperatorQueuerFactoryBytecode: config.priceOracleManagerAndOperatorQueuerFactoryBytecode,
-			proxyDeployerAddress: config.proxyDeployerAddress,
-			scalarOutcomesBytecode: config.scalarOutcomesBytecode,
-			securityPoolUtilsBytecode: config.securityPoolUtilsBytecode,
-			uniformPriceDualCapBatchAuctionFactoryBytecode: config.uniformPriceDualCapBatchAuctionFactoryBytecode,
-			zeroSalt: config.zeroSalt,
-			zoltar: getZoltarAddress(),
-			zoltarQuestionData: getZoltarQuestionDataAddress(),
-		})
-
-	const getDeploymentStatusOracleAddress = () =>
-		getDeploymentStatusOracleAddressBase({
-			deploymentStatusOracleBytecode: config.deploymentStatusOracleBytecode(),
-			proxyDeployerAddress: config.proxyDeployerAddress,
-			zeroSalt: config.zeroSalt,
-		})
+		getProxyDeployerCreate2Address(config.proxyDeployerAddress, config.zeroSalt, config.getZoltarInitCode(getZoltarQuestionDataAddress()))
 
 	return {
-		applyLinkedLibraries: applyLinkedLibrariesToBytecode,
-		getDeploymentStatusOracleAddress,
-		getInfraContractAddresses,
 		getZoltarAddress,
 		getZoltarQuestionDataAddress,
+	}
+}
+
+export function createInfraContractAddressHelper(config: InfraContractAddressConfig) {
+	const getInfraContractAddresses = (): InfraContractAddresses => {
+		const addresses = {
+			securityPoolUtils: getProxyDeployerCreate2Address(config.proxyDeployerAddress, config.zeroSalt, config.securityPoolUtilsBytecode),
+			openOracle: getProxyDeployerCreate2Address(config.proxyDeployerAddress, config.zeroSalt, config.openOracleBytecode),
+			zoltarQuestionData: config.getZoltarQuestionDataAddress(),
+			zoltar: config.getZoltarAddress(),
+			shareTokenFactory: getProxyDeployerCreate2Address(config.proxyDeployerAddress, config.zeroSalt, config.getShareTokenFactoryByteCode(config.getZoltarAddress())),
+			priceOracleManagerAndOperatorQueuerFactory: getProxyDeployerCreate2Address(config.proxyDeployerAddress, config.zeroSalt, config.priceOracleManagerAndOperatorQueuerFactoryBytecode),
+			securityPoolForker: getProxyDeployerCreate2Address(config.proxyDeployerAddress, config.zeroSalt, config.getSecurityPoolForkerByteCode(config.getZoltarAddress())),
+			escalationGameFactory: getProxyDeployerCreate2Address(config.proxyDeployerAddress, config.zeroSalt, config.getEscalationGameFactoryByteCode()),
+			scalarOutcomes: getProxyDeployerCreate2Address(config.proxyDeployerAddress, config.zeroSalt, config.scalarOutcomesBytecode),
+			uniformPriceDualCapBatchAuctionFactory: getProxyDeployerCreate2Address(config.proxyDeployerAddress, config.zeroSalt, config.uniformPriceDualCapBatchAuctionFactoryBytecode),
+		}
+
+		return {
+			...addresses,
+			securityPoolFactory: getProxyDeployerCreate2Address(
+				config.proxyDeployerAddress,
+				config.zeroSalt,
+				config.getSecurityPoolFactoryByteCode({
+					escalationGameFactory: addresses.escalationGameFactory,
+					openOracle: addresses.openOracle,
+					priceOracleManagerAndOperatorQueuerFactory: addresses.priceOracleManagerAndOperatorQueuerFactory,
+					securityPoolForker: addresses.securityPoolForker,
+					shareTokenFactory: addresses.shareTokenFactory,
+					uniformPriceDualCapBatchAuctionFactory: addresses.uniformPriceDualCapBatchAuctionFactory,
+					zoltar: addresses.zoltar,
+					zoltarQuestionData: addresses.zoltarQuestionData,
+				}),
+			),
+		}
+	}
+
+	return {
+		getInfraContractAddresses,
+	}
+}
+
+export function createDeploymentStatusOracleAddressHelper(config: DeploymentStatusOracleAddressConfig) {
+	const getDeploymentStatusOracleAddress = () =>
+		getProxyDeployerCreate2Address(config.proxyDeployerAddress, config.zeroSalt, config.deploymentStatusOracleBytecode())
+
+	return {
+		getDeploymentStatusOracleAddress,
 	}
 }

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"rootDir": "ts",
+		"outDir": "js",
+		"sourceMap": false,
+		"inlineSources": false,
+		"declaration": true,
+		"declarationMap": false,
+		"noEmit": false,
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"esModuleInterop": true,
+		"lib": ["ESNext", "DOM"],
+		"skipLibCheck": true,
+		"types": ["bun-types"]
+	},
+	"include": [
+		"./ts/**/*.ts"
+	]
+}

--- a/solidity/ts/gas-costs.ts
+++ b/solidity/ts/gas-costs.ts
@@ -1,4 +1,5 @@
 import { zeroAddress } from 'viem'
+import type { Hash } from 'viem'
 import { Zoltar_Zoltar } from './types/contractArtifact'
 import { getMockedEthSimulateWindowEthereum } from './testsuite/simulator/AnvilWindowEthereum'
 import { submitBid, refundLosingBids } from './testsuite/simulator/utils/contracts/auction'
@@ -71,13 +72,13 @@ const bob = createWriteClient(anvil, TEST_ADDRESSES[1], 0)
 const carol = createWriteClient(anvil, TEST_ADDRESSES[2], 0)
 const dave = createWriteClient(anvil, TEST_ADDRESSES[3], 0)
 
-const waitForGas = async (client: WriteClient, txHashPromise: Promise<`0x${string}`>) => {
+const waitForGas = async (client: WriteClient, txHashPromise: Promise<Hash>) => {
 	const hash = await txHashPromise
 	const receipt = await client.waitForTransactionReceipt({ hash })
 	return receipt.gasUsed
 }
 
-const confirmTx = async (client: WriteClient, txHashPromise: Promise<`0x${string}`>) => {
+const confirmTx = async (client: WriteClient, txHashPromise: Promise<Hash>) => {
 	const hash = await txHashPromise
 	await client.waitForTransactionReceipt({ hash })
 }

--- a/solidity/ts/tests/auction.test.ts
+++ b/solidity/ts/tests/auction.test.ts
@@ -4,7 +4,7 @@ import { AnvilWindowEthereum } from '../testsuite/simulator/AnvilWindowEthereum'
 import { TEST_TIMEOUT_MS, useIsolatedAnvilNode } from '../testsuite/simulator/useIsolatedAnvilNode'
 import { TEST_ADDRESSES } from '../testsuite/simulator/utils/constants'
 import { contractExists, getETHBalance, setupTestAccounts } from '../testsuite/simulator/utils/utilities'
-import { Address } from 'viem'
+import type { Address } from 'viem'
 import { computeClearing, deployUniformPriceDualCapBatchAuction, finalize, getClearingTick, getMinBidSize, getTotalRepPurchased, simulateWithdrawBids, isFinalized, refundLosingBids, startAuction, submitBid, withdrawBids, getEthRaiseCap, getEthRaised } from '../testsuite/simulator/utils/contracts/auction'
 import { approximatelyEqual, ensureDefined, strictEqual18Decimal, strictEqualTypeSafe } from '../testsuite/simulator/utils/testUtils'
 import { priceToClosestTick, tickToPrice } from '../testsuite/simulator/utils/tickMath'
@@ -94,7 +94,7 @@ describe('Auction', () => {
 		await startAuction(client, auctionAddress, ethRaiseCapEth * ATTOETH_PER_ETH, maxRepBeingSold * ATTOETH_PER_ETH)
 	}
 
-	async function assertFairPayoutForUser(auctionCreator: WriteClient, auctionAddress: Address, userId: `0x${string}`, bids: { tick: bigint; bidSize: bigint; bidIndex: bigint }[], clearingTick: bigint, tolerance: bigint = DEFAULT_TOLERANCE): Promise<{ totalFilledRep: bigint; totalEthRefund: bigint }> {
+	async function assertFairPayoutForUser(auctionCreator: WriteClient, auctionAddress: Address, userId: Address, bids: { tick: bigint; bidSize: bigint; bidIndex: bigint }[], clearingTick: bigint, tolerance: bigint = DEFAULT_TOLERANCE): Promise<{ totalFilledRep: bigint; totalEthRefund: bigint }> {
 		const clearingPrice = tickToPrice(clearingTick)
 		let totalFilledRep = 0n
 		let totalEthRefund = 0n

--- a/solidity/ts/tests/deploymentStatusOracle.test.ts
+++ b/solidity/ts/tests/deploymentStatusOracle.test.ts
@@ -1,3 +1,4 @@
+import type { Hex } from 'viem'
 import { test, beforeEach, describe, setDefaultTimeout } from 'bun:test'
 import assert from 'node:assert'
 import { AnvilWindowEthereum } from '../testsuite/simulator/AnvilWindowEthereum'
@@ -18,7 +19,7 @@ describe('Deployment Status Oracle Test Suite', () => {
 	let mockWindow: AnvilWindowEthereum
 	let client: WriteClient
 
-	const deployViaProxy = async (bytecode: `0x${string}`) => {
+	const deployViaProxy = async (bytecode: Hex) => {
 		const hash = await client.sendTransaction({
 			to: addressString(PROXY_DEPLOYER_ADDRESS),
 			data: bytecode,

--- a/solidity/ts/tests/escalationGame.test.ts
+++ b/solidity/ts/tests/escalationGame.test.ts
@@ -1,4 +1,5 @@
 import { test, beforeEach, describe, setDefaultTimeout } from 'bun:test'
+import type { Address } from 'viem'
 import { AnvilWindowEthereum } from '../testsuite/simulator/AnvilWindowEthereum'
 import { TEST_TIMEOUT_MS, useIsolatedAnvilNode } from '../testsuite/simulator/useIsolatedAnvilNode'
 import { createWriteClient, WriteClient, writeContractAndWait } from '../testsuite/simulator/utils/viem'
@@ -22,7 +23,7 @@ describe('Escalation Game Test Suite', () => {
 	const reportBond = 1n * 10n ** 18n
 	const nonDecisionThreshold = 1000n * 10n ** 18n
 
-	const readIterativeAttritionCost = async (escalationGame: `0x${string}`, timeSinceStart: bigint) =>
+	const readIterativeAttritionCost = async (escalationGame: Address, timeSinceStart: bigint) =>
 		await client.readContract({
 			abi: peripherals_EscalationGame_EscalationGame.abi,
 			functionName: 'computeIterativeAttritionCost',
@@ -30,7 +31,7 @@ describe('Escalation Game Test Suite', () => {
 			args: [timeSinceStart],
 		})
 
-	const readTimeSinceStartFromAttritionCost = async (escalationGame: `0x${string}`, attritionCost: bigint) =>
+	const readTimeSinceStartFromAttritionCost = async (escalationGame: Address, attritionCost: bigint) =>
 		await client.readContract({
 			abi: peripherals_EscalationGame_EscalationGame.abi,
 			functionName: 'computeTimeSinceStartFromAttritionCost',

--- a/solidity/ts/tests/escalationGame_forkThreshold.test.ts
+++ b/solidity/ts/tests/escalationGame_forkThreshold.test.ts
@@ -1,4 +1,5 @@
 import { test, beforeEach, describe, setDefaultTimeout } from 'bun:test'
+import type { Address } from 'viem'
 import { AnvilWindowEthereum } from '../testsuite/simulator/AnvilWindowEthereum'
 import { TEST_TIMEOUT_MS, useIsolatedAnvilNode } from '../testsuite/simulator/useIsolatedAnvilNode'
 import { createWriteClient, WriteClient, writeContractAndWait } from '../testsuite/simulator/utils/viem'
@@ -24,7 +25,7 @@ const REP_TOTAL_SUPPLY_SLOT = '0x' + 5n.toString(16).padStart(64, '0')
 
 setDefaultTimeout(TEST_TIMEOUT_MS)
 
-const getUserRepClaim = async (client: WriteClient, securityPoolAddress: `0x${string}`) => {
+const getUserRepClaim = async (client: WriteClient, securityPoolAddress: Address) => {
 	const vault = await getSecurityVault(client, securityPoolAddress, client.account.address)
 	return await poolOwnershipToRep(client, securityPoolAddress, vault.repDepositShare)
 }
@@ -39,8 +40,8 @@ describe('Escalation Game Fork Threshold Test', () => {
 	const currentTimestamp = BigInt(Math.floor(Date.now() / 1000))
 	const questionEndDate = currentTimestamp + 365n * DAY
 	let securityPoolAddresses: {
-		securityPool: `0x${string}`
-		escalationGame: `0x${string}`
+		securityPool: Address
+		escalationGame: Address
 	}
 	let questionId: bigint
 

--- a/solidity/ts/tests/peripherals.test.ts
+++ b/solidity/ts/tests/peripherals.test.ts
@@ -1,5 +1,6 @@
 import { test, beforeEach, describe, setDefaultTimeout } from 'bun:test'
 import assert from 'node:assert'
+import type { Address, Hash } from 'viem'
 import { AnvilWindowEthereum } from '../testsuite/simulator/AnvilWindowEthereum'
 import { TEST_TIMEOUT_MS, useIsolatedAnvilNode } from '../testsuite/simulator/useIsolatedAnvilNode'
 import { createWriteClient, WriteClient } from '../testsuite/simulator/utils/viem'
@@ -53,11 +54,11 @@ describe('Peripherals Contract Test Suite', () => {
 	const PRICE_PRECISION = 1n * 10n ** 18n
 	const repDeposit = 1000n * 10n ** 18n
 	let securityPoolAddresses: {
-		securityPool: `0x${string}`
-		priceOracleManagerAndOperatorQueuer: `0x${string}`
-		shareToken: `0x${string}`
-		truthAuction: `0x${string}`
-		escalationGame: `0x${string}`
+		securityPool: Address
+		priceOracleManagerAndOperatorQueuer: Address
+		shareToken: Address
+		truthAuction: Address
+		escalationGame: Address
 	}
 	let questionEndDate: bigint
 	let questionData: {
@@ -79,7 +80,7 @@ describe('Peripherals Contract Test Suite', () => {
 	const outcomes = ['Yes', 'No']
 	let questionId: bigint
 
-	const sendEthAndWait = async (from: `0x${string}`, to: `0x${string}`, value: bigint) => {
+	const sendEthAndWait = async (from: Address, to: Address, value: bigint) => {
 		const hash = (await mockWindow.request({
 			method: 'eth_sendTransaction',
 			params: [
@@ -90,7 +91,7 @@ describe('Peripherals Contract Test Suite', () => {
 					gasPrice: '0x0',
 				},
 			],
-		})) as `0x${string}`
+		})) as Hash
 		await client.waitForTransactionReceipt({ hash })
 	}
 

--- a/solidity/ts/tests/priceOracleSecurity.test.ts
+++ b/solidity/ts/tests/priceOracleSecurity.test.ts
@@ -1,5 +1,6 @@
 import { test, beforeEach, describe, setDefaultTimeout } from 'bun:test'
 import assert from 'node:assert'
+import type { Address } from 'viem'
 import { AnvilWindowEthereum } from '../testsuite/simulator/AnvilWindowEthereum'
 import { TEST_TIMEOUT_MS, useIsolatedAnvilNode } from '../testsuite/simulator/useIsolatedAnvilNode'
 import { createWriteClient, WriteClient, writeContractAndWait } from '../testsuite/simulator/utils/viem'
@@ -22,7 +23,7 @@ describe('Price Oracle Refund Security Tests', () => {
 	const repDeposit = 1000n * 10n ** 18n
 	const currentTimestamp = dateToBigintSeconds(new Date())
 	const questionEndDate = currentTimestamp + 365n * DAY
-	let priceOracle: `0x${string}`
+	let priceOracle: Address
 	const genesisUniverse = 0n
 	const securityMultiplier = 2n
 	const startingRepEthPrice = 10n

--- a/solidity/ts/testsuite/simulator/types/types.ts
+++ b/solidity/ts/testsuite/simulator/types/types.ts
@@ -1,4 +1,6 @@
-export type AccountAddress = `0x${string}`
+import type { Address } from 'viem'
+
+export type AccountAddress = Address
 
 export enum QuestionOutcome {
 	Invalid,

--- a/solidity/ts/testsuite/simulator/utils/bigint.ts
+++ b/solidity/ts/testsuite/simulator/utils/bigint.ts
@@ -1,3 +1,5 @@
+import type { Address, Hex } from 'viem'
+
 export function bigintToDecimalString(value: bigint, power: bigint): string {
 	const sign = value < 0n ? '-' : ''
 	const magnitude = abs(value)
@@ -7,9 +9,9 @@ export function bigintToDecimalString(value: bigint, power: bigint): string {
 	return `${sign}${integerPart.toString(10)}.${fractionalPart.toString(10).padStart(Number(power), '0').replace(/0+$/, '')}`
 }
 
-export const addressString = (address: bigint): `0x${string}` => `0x${address.toString(16).padStart(40, '0')}`
+export const addressString = (address: bigint): Address => `0x${address.toString(16).padStart(40, '0')}`
 
-export const bytes32String = (bytes32: bigint): `0x${string}` => `0x${bytes32.toString(16).padStart(64, '0')}`
+export const bytes32String = (bytes32: bigint): Hex => `0x${bytes32.toString(16).padStart(64, '0')}`
 
 export const abs = (x: bigint) => (x < 0n ? -1n * x : x)
 

--- a/solidity/ts/testsuite/simulator/utils/contracts/auction.ts
+++ b/solidity/ts/testsuite/simulator/utils/contracts/auction.ts
@@ -1,9 +1,10 @@
 import { peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction, peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory } from '../../../../types/contractArtifact'
+import type { Address } from 'viem'
 import { bytes32String } from '../bigint'
 import { ReadClient, WriteClient, writeContractAndWait } from '../viem'
 import { getInfraContractAddresses } from './deployPeripherals'
 
-export const startAuction = async (client: WriteClient, auctionAddress: `0x${string}`, ethRaiseCap: bigint, maxRepBeingSold: bigint) =>
+export const startAuction = async (client: WriteClient, auctionAddress: Address, ethRaiseCap: bigint, maxRepBeingSold: bigint) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.abi,
@@ -13,7 +14,7 @@ export const startAuction = async (client: WriteClient, auctionAddress: `0x${str
 		}),
 	)
 
-export const submitBid = async (client: WriteClient, auctionAddress: `0x${string}`, tick: bigint, ethAmount: bigint) =>
+export const submitBid = async (client: WriteClient, auctionAddress: Address, tick: bigint, ethAmount: bigint) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.abi,
@@ -24,7 +25,7 @@ export const submitBid = async (client: WriteClient, auctionAddress: `0x${string
 		}),
 	)
 
-export const finalize = async (client: WriteClient, auctionAddress: `0x${string}`) =>
+export const finalize = async (client: WriteClient, auctionAddress: Address) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.abi,
@@ -34,7 +35,7 @@ export const finalize = async (client: WriteClient, auctionAddress: `0x${string}
 		}),
 	)
 
-export const computeClearing = async (client: ReadClient, auctionAddress: `0x${string}`) => {
+export const computeClearing = async (client: ReadClient, auctionAddress: Address) => {
 	const [hitCap, foundTick, accumulatedEth, ethAtClearingTick] = await client.readContract({
 		abi: peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.abi,
 		functionName: 'computeClearing',
@@ -44,7 +45,7 @@ export const computeClearing = async (client: ReadClient, auctionAddress: `0x${s
 	return { hitCap, foundTick, accumulatedEth, ethAtClearingTick }
 }
 
-export const refundLosingBids = async (client: WriteClient, auctionAddress: `0x${string}`, tickIndex: readonly { tick: bigint; bidIndex: bigint }[]) =>
+export const refundLosingBids = async (client: WriteClient, auctionAddress: Address, tickIndex: readonly { tick: bigint; bidIndex: bigint }[]) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.abi,
@@ -54,7 +55,7 @@ export const refundLosingBids = async (client: WriteClient, auctionAddress: `0x$
 		}),
 	)
 
-export const withdrawBids = async (client: WriteClient, auctionAddress: `0x${string}`, withdrawFor: `0x${string}`, tickIndex: readonly { tick: bigint; bidIndex: bigint }[]) =>
+export const withdrawBids = async (client: WriteClient, auctionAddress: Address, withdrawFor: Address, tickIndex: readonly { tick: bigint; bidIndex: bigint }[]) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.abi,
@@ -64,7 +65,7 @@ export const withdrawBids = async (client: WriteClient, auctionAddress: `0x${str
 		}),
 	)
 
-export const simulateWithdrawBids = async (client: ReadClient, auctionAddress: `0x${string}`, withdrawFor: `0x${string}`, tickIndex: readonly { tick: bigint; bidIndex: bigint }[]) => {
+export const simulateWithdrawBids = async (client: ReadClient, auctionAddress: Address, withdrawFor: Address, tickIndex: readonly { tick: bigint; bidIndex: bigint }[]) => {
 	const [totalFilledRep, totalEthRefund] = (
 		await client.simulateContract({
 			abi: peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.abi,
@@ -76,7 +77,7 @@ export const simulateWithdrawBids = async (client: ReadClient, auctionAddress: `
 	return { totalFilledRep, totalEthRefund }
 }
 
-export const isFinalized = async (client: ReadClient, auctionAddress: `0x${string}`) =>
+export const isFinalized = async (client: ReadClient, auctionAddress: Address) =>
 	await client.readContract({
 		abi: peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.abi,
 		functionName: 'finalized',
@@ -84,7 +85,7 @@ export const isFinalized = async (client: ReadClient, auctionAddress: `0x${strin
 		args: [],
 	})
 
-export const deployUniformPriceDualCapBatchAuction = async (client: WriteClient, owner: `0x${string}`) =>
+export const deployUniformPriceDualCapBatchAuction = async (client: WriteClient, owner: Address) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory.abi,
@@ -94,7 +95,7 @@ export const deployUniformPriceDualCapBatchAuction = async (client: WriteClient,
 		}),
 	)
 
-export const getClearingTick = async (client: ReadClient, auctionAddress: `0x${string}`) =>
+export const getClearingTick = async (client: ReadClient, auctionAddress: Address) =>
 	await client.readContract({
 		abi: peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.abi,
 		functionName: 'clearingTick',
@@ -102,7 +103,7 @@ export const getClearingTick = async (client: ReadClient, auctionAddress: `0x${s
 		args: [],
 	})
 
-export const getMinBidSize = async (client: ReadClient, auctionAddress: `0x${string}`) =>
+export const getMinBidSize = async (client: ReadClient, auctionAddress: Address) =>
 	await client.readContract({
 		abi: peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.abi,
 		functionName: 'minBidSize',
@@ -110,7 +111,7 @@ export const getMinBidSize = async (client: ReadClient, auctionAddress: `0x${str
 		args: [],
 	})
 
-export const getEthRaiseCap = async (client: ReadClient, auctionAddress: `0x${string}`) =>
+export const getEthRaiseCap = async (client: ReadClient, auctionAddress: Address) =>
 	await client.readContract({
 		abi: peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.abi,
 		functionName: 'ethRaiseCap',
@@ -118,7 +119,7 @@ export const getEthRaiseCap = async (client: ReadClient, auctionAddress: `0x${st
 		args: [],
 	})
 
-export const getEthRaised = async (client: ReadClient, auctionAddress: `0x${string}`) =>
+export const getEthRaised = async (client: ReadClient, auctionAddress: Address) =>
 	await client.readContract({
 		abi: peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.abi,
 		functionName: 'ethRaised',
@@ -126,7 +127,7 @@ export const getEthRaised = async (client: ReadClient, auctionAddress: `0x${stri
 		args: [],
 	})
 
-export const getTotalRepPurchased = async (client: ReadClient, auctionAddress: `0x${string}`) =>
+export const getTotalRepPurchased = async (client: ReadClient, auctionAddress: Address) =>
 	await client.readContract({
 		abi: peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.abi,
 		functionName: 'totalRepPurchased',

--- a/solidity/ts/testsuite/simulator/utils/contracts/deployPeripherals.ts
+++ b/solidity/ts/testsuite/simulator/utils/contracts/deployPeripherals.ts
@@ -1,7 +1,7 @@
 import 'viem/window'
-import { encodeDeployData, getCreate2Address, keccak256, toHex } from 'viem'
-import { createAddressDerivationHelpers } from '../../../../../../shared/js/addressDerivation.js'
-import { createDeploymentAddressHelpers } from '../../../../../../shared/js/deploymentAddresses.js'
+import { encodeDeployData, getCreate2Address, keccak256, type Address, type Hex, toHex } from 'viem'
+import { createSecurityPoolAddressHelper } from '../../../../../../shared/js/addressDerivation.js'
+import { createApplyLinkedLibrariesHelper, createDeploymentStatusOracleAddressHelper, createInfraContractAddressHelper, createZoltarAddressHelpers } from '../../../../../../shared/js/deploymentAddresses.js'
 import { WriteClient, writeContractAndWait } from '../viem'
 import { PROXY_DEPLOYER_ADDRESS } from '../constants'
 import { addressString } from '../bigint'
@@ -26,9 +26,9 @@ import {
 	peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction,
 } from '../../../../types/contractArtifact'
 import { objectEntries } from '../typescript'
-import { getRepTokenAddress, getZoltarAddress } from './zoltar'
+import { getRepTokenAddress } from './zoltar'
 
-const ZERO_SALT = toHex(0, { size: 32 })
+const ZERO_SALT: Hex = toHex(0, { size: 32 })
 
 const getSecurityPoolUtilsAddress = () => getCreate2Address({ bytecode: `0x${peripherals_SecurityPoolUtils_SecurityPoolUtils.evm.bytecode.object}`, from: addressString(PROXY_DEPLOYER_ADDRESS), salt: ZERO_SALT })
 
@@ -46,7 +46,7 @@ function getDeploymentStatusOracleByteCode() {
 	})
 }
 
-const getSecurityPoolForkerByteCode = (zoltar: `0x${string}`) =>
+const getSecurityPoolForkerByteCode = (zoltar: Address): Hex =>
 	encodeDeployData({
 		abi: peripherals_SecurityPoolForker_SecurityPoolForker.abi,
 		bytecode: applyLibraries(peripherals_SecurityPoolForker_SecurityPoolForker.evm.bytecode.object),
@@ -63,58 +63,66 @@ const getSecurityPoolFactoryByteCode = ({
 	zoltar,
 	zoltarQuestionData,
 }: {
-	escalationGameFactory: `0x${string}`
-	openOracle: `0x${string}`
-	priceOracleManagerAndOperatorQueuerFactory: `0x${string}`
-	securityPoolForker: `0x${string}`
-	shareTokenFactory: `0x${string}`
-	uniformPriceDualCapBatchAuctionFactory: `0x${string}`
-	zoltar: `0x${string}`
-	zoltarQuestionData: `0x${string}`
-}) =>
+	escalationGameFactory: Address
+	openOracle: Address
+	priceOracleManagerAndOperatorQueuerFactory: Address
+	securityPoolForker: Address
+	shareTokenFactory: Address
+	uniformPriceDualCapBatchAuctionFactory: Address
+	zoltar: Address
+	zoltarQuestionData: Address
+}): Hex =>
 	encodeDeployData({
 		abi: peripherals_factories_SecurityPoolFactory_SecurityPoolFactory.abi,
 		bytecode: applyLibraries(peripherals_factories_SecurityPoolFactory_SecurityPoolFactory.evm.bytecode.object),
 		args: [securityPoolForker, zoltarQuestionData, escalationGameFactory, openOracle, zoltar, shareTokenFactory, uniformPriceDualCapBatchAuctionFactory, priceOracleManagerAndOperatorQueuerFactory],
 	})
 
-const getShareTokenFactoryByteCode = (zoltar: `0x${string}`) =>
+const getShareTokenFactoryByteCode = (zoltar: Address): Hex =>
 	encodeDeployData({
 		abi: peripherals_factories_ShareTokenFactory_ShareTokenFactory.abi,
 		bytecode: `0x${peripherals_factories_ShareTokenFactory_ShareTokenFactory.evm.bytecode.object}`,
 		args: [zoltar],
 	})
 
-const getEscalationGameFactoryByteCode = () =>
+const getEscalationGameFactoryByteCode = (): Hex =>
 	encodeDeployData({
 		abi: peripherals_factories_EscalationGameFactory_EscalationGameFactory.abi,
 		bytecode: `0x${peripherals_factories_EscalationGameFactory_EscalationGameFactory.evm.bytecode.object}`,
 	})
 
-const getZoltarInitCode = (zoltarQuestionDataAddress: `0x${string}`) =>
+const getZoltarInitCode = (zoltarQuestionDataAddress: Address): Hex =>
 	encodeDeployData({
 		abi: Zoltar_Zoltar.abi,
 		bytecode: `0x${Zoltar_Zoltar.evm.bytecode.object}`,
 		args: [zoltarQuestionDataAddress],
 	})
 
-const getZoltarQuestionDataByteCode = () =>
+const getZoltarQuestionDataByteCode = (): Hex =>
 	encodeDeployData({
 		abi: ZoltarQuestionData_ZoltarQuestionData.abi,
 		bytecode: applyLibraries(ZoltarQuestionData_ZoltarQuestionData.evm.bytecode.object),
 	})
 
-const deploymentAddressHelpers = createDeploymentAddressHelpers({
-	deploymentStatusOracleBytecode: getDeploymentStatusOracleByteCode,
+export const { applyLibraries } = createApplyLinkedLibrariesHelper(() => [
+	{ hash: keccak256(toHex('contracts/ScalarOutcomes.sol:ScalarOutcomes')).slice(2, 36), address: getScalarOutcomesAddress() },
+	{ hash: keccak256(toHex('contracts/peripherals/SecurityPoolUtils.sol:SecurityPoolUtils')).slice(2, 36), address: getSecurityPoolUtilsAddress() },
+])
+
+const { getZoltarAddress, getZoltarQuestionDataAddress } = createZoltarAddressHelpers({
+	getZoltarInitCode,
+	proxyDeployerAddress: addressString(PROXY_DEPLOYER_ADDRESS),
+	zeroSalt: ZERO_SALT,
+	zoltarQuestionDataBytecode: getZoltarQuestionDataByteCode,
+})
+
+export const { getInfraContractAddresses } = createInfraContractAddressHelper({
 	getEscalationGameFactoryByteCode,
 	getSecurityPoolFactoryByteCode,
 	getSecurityPoolForkerByteCode,
 	getShareTokenFactoryByteCode,
-	getZoltarInitCode,
-	libraryReplacements: () => [
-		{ hash: keccak256(toHex('contracts/ScalarOutcomes.sol:ScalarOutcomes')).slice(2, 36), address: getScalarOutcomesAddress() },
-		{ hash: keccak256(toHex('contracts/peripherals/SecurityPoolUtils.sol:SecurityPoolUtils')).slice(2, 36), address: getSecurityPoolUtilsAddress() },
-	],
+	getZoltarAddress,
+	getZoltarQuestionDataAddress,
 	openOracleBytecode: `0x${peripherals_openOracle_OpenOracle_OpenOracle.evm.bytecode.object}`,
 	priceOracleManagerAndOperatorQueuerFactoryBytecode: `0x${peripherals_factories_PriceOracleManagerAndOperatorQueuerFactory_PriceOracleManagerAndOperatorQueuerFactory.evm.bytecode.object}`,
 	proxyDeployerAddress: addressString(PROXY_DEPLOYER_ADDRESS),
@@ -122,14 +130,15 @@ const deploymentAddressHelpers = createDeploymentAddressHelpers({
 	securityPoolUtilsBytecode: `0x${peripherals_SecurityPoolUtils_SecurityPoolUtils.evm.bytecode.object}`,
 	uniformPriceDualCapBatchAuctionFactoryBytecode: `0x${peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory.evm.bytecode.object}`,
 	zeroSalt: ZERO_SALT,
-	zoltarQuestionDataBytecode: getZoltarQuestionDataByteCode,
 })
 
-export const { applyLinkedLibraries: applyLibraries, getDeploymentStatusOracleAddress, getInfraContractAddresses } = deploymentAddressHelpers
+export const { getDeploymentStatusOracleAddress } = createDeploymentStatusOracleAddressHelper({
+	deploymentStatusOracleBytecode: getDeploymentStatusOracleByteCode,
+	proxyDeployerAddress: addressString(PROXY_DEPLOYER_ADDRESS),
+	zeroSalt: ZERO_SALT,
+})
 
-export const { getSecurityPoolAddresses } = createAddressDerivationHelpers({
-	customGetRepTokenAddress: universeId => getRepTokenAddress(universeId),
-	genesisRepTokenAddress: '0x0000000000000000000000000000000000000000',
+export const { getSecurityPoolAddresses } = createSecurityPoolAddressHelper({
 	getEscalationGameInitCode: securityPool =>
 		encodeDeployData({
 			abi: peripherals_EscalationGame_EscalationGame.abi,
@@ -143,7 +152,7 @@ export const { getSecurityPoolAddresses } = createAddressDerivationHelpers({
 			bytecode: `0x${peripherals_PriceOracleManagerAndOperatorQueuer_PriceOracleManagerAndOperatorQueuer.evm.bytecode.object}`,
 			args: [openOracle, repToken],
 		}),
-	getReputationTokenInitCode: () => '0x',
+	getRepTokenAddress,
 	getSecurityPoolInitCode: ({ escalationGameFactory, openOracle, parent, priceOracleManagerAndOperatorQueuer, questionId, securityMultiplier, securityPoolFactory, securityPoolForker, shareToken, truthAuction, universeId, zoltar, zoltarQuestionData }) =>
 		encodeDeployData({
 			abi: peripherals_SecurityPool_SecurityPool.abi,
@@ -162,7 +171,6 @@ export const { getSecurityPoolAddresses } = createAddressDerivationHelpers({
 			bytecode: `0x${peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.evm.bytecode.object}`,
 			args: [securityPoolForker],
 		}),
-	getZoltarAddress: () => getZoltarAddress(),
 })
 
 export async function loadDeploymentStatusOracleMask(client: Pick<WriteClient, 'readContract'>): Promise<bigint> {
@@ -228,7 +236,7 @@ async function getInfraDeployedInformation(client: WriteClient): Promise<{ [key 
 export async function ensureInfraDeployed(client: WriteClient): Promise<void> {
 	const contractAddresses = getInfraContractAddresses()
 
-	const deployBytecode = async (bytecode: `0x${string}`) => {
+	const deployBytecode = async (bytecode: Hex) => {
 		const hash = await client.sendTransaction({ to: addressString(PROXY_DEPLOYER_ADDRESS), data: bytecode })
 		await client.waitForTransactionReceipt({ hash })
 	}

--- a/solidity/ts/testsuite/simulator/utils/contracts/deployPeripherals.ts
+++ b/solidity/ts/testsuite/simulator/utils/contracts/deployPeripherals.ts
@@ -1,5 +1,7 @@
 import 'viem/window'
-import { encodeDeployData, getCreate2Address, keccak256, numberToBytes, toHex, zeroAddress, encodeAbiParameters } from 'viem'
+import { encodeDeployData, getCreate2Address, keccak256, toHex } from 'viem'
+import { createAddressDerivationHelpers } from '../../../../../../shared/js/addressDerivation.js'
+import { createDeploymentAddressHelpers } from '../../../../../../shared/js/deploymentAddresses.js'
 import { WriteClient, writeContractAndWait } from '../viem'
 import { PROXY_DEPLOYER_ADDRESS } from '../constants'
 import { addressString } from '../bigint'
@@ -26,9 +28,11 @@ import {
 import { objectEntries } from '../typescript'
 import { getRepTokenAddress, getZoltarAddress } from './zoltar'
 
-const getSecurityPoolUtilsAddress = () => getCreate2Address({ bytecode: `0x${peripherals_SecurityPoolUtils_SecurityPoolUtils.evm.bytecode.object}`, from: addressString(PROXY_DEPLOYER_ADDRESS), salt: numberToBytes(0, { size: 32 }) })
+const ZERO_SALT = toHex(0, { size: 32 })
 
-const getScalarOutcomesAddress = () => getCreate2Address({ bytecode: `0x${ScalarOutcomes_ScalarOutcomes.evm.bytecode.object}`, from: addressString(PROXY_DEPLOYER_ADDRESS), salt: numberToBytes(0, { size: 32 }) })
+const getSecurityPoolUtilsAddress = () => getCreate2Address({ bytecode: `0x${peripherals_SecurityPoolUtils_SecurityPoolUtils.evm.bytecode.object}`, from: addressString(PROXY_DEPLOYER_ADDRESS), salt: ZERO_SALT })
+
+const getScalarOutcomesAddress = () => getCreate2Address({ bytecode: `0x${ScalarOutcomes_ScalarOutcomes.evm.bytecode.object}`, from: addressString(PROXY_DEPLOYER_ADDRESS), salt: ZERO_SALT })
 
 export function getDeploymentStepAddresses() {
 	return getDeploymentStatusOracleSteps().map(step => step.address)
@@ -42,19 +46,6 @@ function getDeploymentStatusOracleByteCode() {
 	})
 }
 
-export const applyLibraries = (bytecode: string): `0x${string}` => {
-	type LibraryReplacement = { hash: string; address: `0x${string}` }
-	const librariesToReplace: LibraryReplacement[] = [
-		{ hash: keccak256(toHex('contracts/ScalarOutcomes.sol:ScalarOutcomes')).slice(2, 36), address: getScalarOutcomesAddress() },
-		{ hash: keccak256(toHex('contracts/peripherals/SecurityPoolUtils.sol:SecurityPoolUtils')).slice(2, 36), address: getSecurityPoolUtilsAddress() },
-	]
-	let updatedBytecode = bytecode
-	for (const { hash, address } of librariesToReplace) {
-		updatedBytecode = updatedBytecode.replaceAll(`__$${hash}$__`, address.slice(2).toLowerCase())
-	}
-	return `0x${updatedBytecode}`
-}
-
 const getSecurityPoolForkerByteCode = (zoltar: `0x${string}`) =>
 	encodeDeployData({
 		abi: peripherals_SecurityPoolForker_SecurityPoolForker.abi,
@@ -62,36 +53,29 @@ const getSecurityPoolForkerByteCode = (zoltar: `0x${string}`) =>
 		args: [zoltar],
 	})
 
-const getSecurityPoolFactoryByteCode = (
-	securityPoolForker: `0x${string}`,
-	questionData: `0x${string}`,
-	escalationGameFactory: `0x${string}`,
-	openOracle: `0x${string}`,
-	zoltar: `0x${string}`,
-	shareTokenFactory: `0x${string}`,
-	uniformPriceDualCapBatchAuctionFactory: `0x${string}`,
-	priceOracleManagerAndOperatorQueuerFactory: `0x${string}`,
-) =>
+const getSecurityPoolFactoryByteCode = ({
+	escalationGameFactory,
+	openOracle,
+	priceOracleManagerAndOperatorQueuerFactory,
+	securityPoolForker,
+	shareTokenFactory,
+	uniformPriceDualCapBatchAuctionFactory,
+	zoltar,
+	zoltarQuestionData,
+}: {
+	escalationGameFactory: `0x${string}`
+	openOracle: `0x${string}`
+	priceOracleManagerAndOperatorQueuerFactory: `0x${string}`
+	securityPoolForker: `0x${string}`
+	shareTokenFactory: `0x${string}`
+	uniformPriceDualCapBatchAuctionFactory: `0x${string}`
+	zoltar: `0x${string}`
+	zoltarQuestionData: `0x${string}`
+}) =>
 	encodeDeployData({
 		abi: peripherals_factories_SecurityPoolFactory_SecurityPoolFactory.abi,
 		bytecode: applyLibraries(peripherals_factories_SecurityPoolFactory_SecurityPoolFactory.evm.bytecode.object),
-		args: [securityPoolForker, questionData, escalationGameFactory, openOracle, zoltar, shareTokenFactory, uniformPriceDualCapBatchAuctionFactory, priceOracleManagerAndOperatorQueuerFactory],
-	})
-
-const getSecurityPoolFactoryAddress = (
-	securityPoolForker: `0x${string}`,
-	questionData: `0x${string}`,
-	escalationGameFactory: `0x${string}`,
-	openOracle: `0x${string}`,
-	zoltar: `0x${string}`,
-	shareTokenFactory: `0x${string}`,
-	uniformPriceDualCapBatchAuctionFactory: `0x${string}`,
-	priceOracleManagerAndOperatorQueuerFactory: `0x${string}`,
-) =>
-	getCreate2Address({
-		from: addressString(PROXY_DEPLOYER_ADDRESS),
-		salt: numberToBytes(0, { size: 32 }),
-		bytecode: getSecurityPoolFactoryByteCode(securityPoolForker, questionData, escalationGameFactory, openOracle, zoltar, shareTokenFactory, uniformPriceDualCapBatchAuctionFactory, priceOracleManagerAndOperatorQueuerFactory),
+		args: [securityPoolForker, zoltarQuestionData, escalationGameFactory, openOracle, zoltar, shareTokenFactory, uniformPriceDualCapBatchAuctionFactory, priceOracleManagerAndOperatorQueuerFactory],
 	})
 
 const getShareTokenFactoryByteCode = (zoltar: `0x${string}`) =>
@@ -107,47 +91,79 @@ const getEscalationGameFactoryByteCode = () =>
 		bytecode: `0x${peripherals_factories_EscalationGameFactory_EscalationGameFactory.evm.bytecode.object}`,
 	})
 
+const getZoltarInitCode = (zoltarQuestionDataAddress: `0x${string}`) =>
+	encodeDeployData({
+		abi: Zoltar_Zoltar.abi,
+		bytecode: `0x${Zoltar_Zoltar.evm.bytecode.object}`,
+		args: [zoltarQuestionDataAddress],
+	})
+
 const getZoltarQuestionDataByteCode = () =>
 	encodeDeployData({
 		abi: ZoltarQuestionData_ZoltarQuestionData.abi,
 		bytecode: applyLibraries(ZoltarQuestionData_ZoltarQuestionData.evm.bytecode.object),
 	})
 
-export function getInfraContractAddresses() {
-	const getAddress = (bytecode: `0x${string}`) => getCreate2Address({ bytecode, from: addressString(PROXY_DEPLOYER_ADDRESS), salt: numberToBytes(0, { size: 32 }) })
+const deploymentAddressHelpers = createDeploymentAddressHelpers({
+	deploymentStatusOracleBytecode: getDeploymentStatusOracleByteCode,
+	getEscalationGameFactoryByteCode,
+	getSecurityPoolFactoryByteCode,
+	getSecurityPoolForkerByteCode,
+	getShareTokenFactoryByteCode,
+	getZoltarInitCode,
+	libraryReplacements: () => [
+		{ hash: keccak256(toHex('contracts/ScalarOutcomes.sol:ScalarOutcomes')).slice(2, 36), address: getScalarOutcomesAddress() },
+		{ hash: keccak256(toHex('contracts/peripherals/SecurityPoolUtils.sol:SecurityPoolUtils')).slice(2, 36), address: getSecurityPoolUtilsAddress() },
+	],
+	openOracleBytecode: `0x${peripherals_openOracle_OpenOracle_OpenOracle.evm.bytecode.object}`,
+	priceOracleManagerAndOperatorQueuerFactoryBytecode: `0x${peripherals_factories_PriceOracleManagerAndOperatorQueuerFactory_PriceOracleManagerAndOperatorQueuerFactory.evm.bytecode.object}`,
+	proxyDeployerAddress: addressString(PROXY_DEPLOYER_ADDRESS),
+	scalarOutcomesBytecode: `0x${ScalarOutcomes_ScalarOutcomes.evm.bytecode.object}`,
+	securityPoolUtilsBytecode: `0x${peripherals_SecurityPoolUtils_SecurityPoolUtils.evm.bytecode.object}`,
+	uniformPriceDualCapBatchAuctionFactoryBytecode: `0x${peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory.evm.bytecode.object}`,
+	zeroSalt: ZERO_SALT,
+	zoltarQuestionDataBytecode: getZoltarQuestionDataByteCode,
+})
 
-	const contracts = {
-		securityPoolUtils: getSecurityPoolUtilsAddress(),
-		openOracle: getAddress(`0x${peripherals_openOracle_OpenOracle_OpenOracle.evm.bytecode.object}`),
-		zoltar: getZoltarAddress(),
-		shareTokenFactory: getAddress(getShareTokenFactoryByteCode(getZoltarAddress())),
-		priceOracleManagerAndOperatorQueuerFactory: getAddress(`0x${peripherals_factories_PriceOracleManagerAndOperatorQueuerFactory_PriceOracleManagerAndOperatorQueuerFactory.evm.bytecode.object}`),
-		securityPoolForker: getAddress(getSecurityPoolForkerByteCode(getZoltarAddress())),
-		escalationGameFactory: getAddress(getEscalationGameFactoryByteCode()),
-		zoltarQuestionData: getAddress(getZoltarQuestionDataByteCode()),
-		scalarOutcomes: getScalarOutcomesAddress(),
-		uniformPriceDualCapBatchAuctionFactory: getAddress(`0x${peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory.evm.bytecode.object}`),
-	}
-	const securityPoolFactory = getSecurityPoolFactoryAddress(
-		contracts.securityPoolForker,
-		contracts.zoltarQuestionData,
-		contracts.escalationGameFactory,
-		contracts.openOracle,
-		contracts.zoltar,
-		contracts.shareTokenFactory,
-		contracts.uniformPriceDualCapBatchAuctionFactory,
-		contracts.priceOracleManagerAndOperatorQueuerFactory,
-	)
-	return { ...contracts, securityPoolFactory }
-}
+export const { applyLinkedLibraries: applyLibraries, getDeploymentStatusOracleAddress, getInfraContractAddresses } = deploymentAddressHelpers
 
-export function getDeploymentStatusOracleAddress() {
-	return getCreate2Address({
-		bytecode: getDeploymentStatusOracleByteCode(),
-		from: addressString(PROXY_DEPLOYER_ADDRESS),
-		salt: numberToBytes(0, { size: 32 }),
-	})
-}
+export const { getSecurityPoolAddresses } = createAddressDerivationHelpers({
+	customGetRepTokenAddress: universeId => getRepTokenAddress(universeId),
+	genesisRepTokenAddress: '0x0000000000000000000000000000000000000000',
+	getEscalationGameInitCode: securityPool =>
+		encodeDeployData({
+			abi: peripherals_EscalationGame_EscalationGame.abi,
+			bytecode: `0x${peripherals_EscalationGame_EscalationGame.evm.bytecode.object}`,
+			args: [securityPool],
+		}),
+	getInfraContracts: () => getInfraContractAddresses(),
+	getPriceOracleManagerAndOperatorQueuerInitCode: (openOracle, repToken) =>
+		encodeDeployData({
+			abi: peripherals_PriceOracleManagerAndOperatorQueuer_PriceOracleManagerAndOperatorQueuer.abi,
+			bytecode: `0x${peripherals_PriceOracleManagerAndOperatorQueuer_PriceOracleManagerAndOperatorQueuer.evm.bytecode.object}`,
+			args: [openOracle, repToken],
+		}),
+	getReputationTokenInitCode: () => '0x',
+	getSecurityPoolInitCode: ({ escalationGameFactory, openOracle, parent, priceOracleManagerAndOperatorQueuer, questionId, securityMultiplier, securityPoolFactory, securityPoolForker, shareToken, truthAuction, universeId, zoltar, zoltarQuestionData }) =>
+		encodeDeployData({
+			abi: peripherals_SecurityPool_SecurityPool.abi,
+			bytecode: applyLibraries(peripherals_SecurityPool_SecurityPool.evm.bytecode.object),
+			args: [securityPoolForker, securityPoolFactory, zoltarQuestionData, escalationGameFactory, priceOracleManagerAndOperatorQueuer, shareToken, openOracle, parent, zoltar, universeId, questionId, securityMultiplier, truthAuction],
+		}),
+	getShareTokenInitCode: (securityPoolFactory, zoltarAddress, questionId) =>
+		encodeDeployData({
+			abi: peripherals_tokens_ShareToken_ShareToken.abi,
+			bytecode: `0x${peripherals_tokens_ShareToken_ShareToken.evm.bytecode.object}`,
+			args: [securityPoolFactory, zoltarAddress, questionId],
+		}),
+	getTruthAuctionInitCode: securityPoolForker =>
+		encodeDeployData({
+			abi: peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.abi,
+			bytecode: `0x${peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.evm.bytecode.object}`,
+			args: [securityPoolForker],
+		}),
+	getZoltarAddress: () => getZoltarAddress(),
+})
 
 export async function loadDeploymentStatusOracleMask(client: Pick<WriteClient, 'readContract'>): Promise<bigint> {
 	return BigInt(
@@ -239,126 +255,22 @@ export async function ensureInfraDeployed(client: WriteClient): Promise<void> {
 	if (!existence.escalationGameFactory) await deployBytecode(getEscalationGameFactoryByteCode())
 	if (!existence.securityPoolFactory)
 		await deployBytecode(
-			getSecurityPoolFactoryByteCode(
-				contractAddresses.securityPoolForker,
-				contractAddresses.zoltarQuestionData,
-				contractAddresses.escalationGameFactory,
-				contractAddresses.openOracle,
-				contractAddresses.zoltar,
-				contractAddresses.shareTokenFactory,
-				contractAddresses.uniformPriceDualCapBatchAuctionFactory,
-				contractAddresses.priceOracleManagerAndOperatorQueuerFactory,
-			),
+			getSecurityPoolFactoryByteCode({
+				escalationGameFactory: contractAddresses.escalationGameFactory,
+				openOracle: contractAddresses.openOracle,
+				priceOracleManagerAndOperatorQueuerFactory: contractAddresses.priceOracleManagerAndOperatorQueuerFactory,
+				securityPoolForker: contractAddresses.securityPoolForker,
+				shareTokenFactory: contractAddresses.shareTokenFactory,
+				uniformPriceDualCapBatchAuctionFactory: contractAddresses.uniformPriceDualCapBatchAuctionFactory,
+				zoltar: contractAddresses.zoltar,
+				zoltarQuestionData: contractAddresses.zoltarQuestionData,
+			}),
 		)
 
 	for (const [name, contractAddress] of objectEntries(contractAddresses)) {
 		if (!(await contractExists(client, contractAddress))) throw new Error(`${name} does not exist even though we deployed it`)
 	}
 	if (!(await contractExists(client, getDeploymentStatusOracleAddress()))) throw new Error('deploymentStatusOracle does not exist even though we deployed it')
-}
-
-const computeSecurityPoolSalt = (parent: `0x${string}`, universeId: bigint, questionId: bigint, securityMultiplier: bigint) => {
-	const values: readonly [`0x${string}`, bigint, bigint, bigint] = [parent, universeId, questionId, securityMultiplier]
-	return keccak256(
-		encodeAbiParameters(
-			[
-				{ name: 'parent', type: 'address' },
-				{ name: 'universeId', type: 'uint248' },
-				{ name: 'questionId', type: 'uint256' },
-				{ name: 'securityMultiplier', type: 'uint256' },
-			],
-			values,
-		),
-	)
-}
-
-const computeShareTokenSalt = (securityMultiplier: bigint, questionId: bigint) => {
-	const values: readonly [bigint, bigint] = [securityMultiplier, questionId]
-	return keccak256(
-		encodeAbiParameters(
-			[
-				{ name: 'securityMultiplier', type: 'uint256' },
-				{ name: 'questionId', type: 'uint256' },
-			],
-			values,
-		),
-	)
-}
-
-export const getSecurityPoolAddresses = (parent: `0x${string}`, universeId: bigint, questionId: bigint, securityMultiplier: bigint) => {
-	const securityPoolSalt = computeSecurityPoolSalt(parent, universeId, questionId, securityMultiplier)
-	const infraContracts = getInfraContractAddresses()
-	const securityPoolTypes = [
-		{ name: 'securityPoolFactory', type: 'address' },
-		{ name: 'securityPoolSalt', type: 'bytes32' },
-	]
-	const securityPoolSaltWithMsgSender = keccak256(encodeAbiParameters(securityPoolTypes, [infraContracts.securityPoolFactory, securityPoolSalt]))
-
-	const contracts = {
-		priceOracleManagerAndOperatorQueuer: getCreate2Address({
-			bytecode: encodeDeployData({
-				abi: peripherals_PriceOracleManagerAndOperatorQueuer_PriceOracleManagerAndOperatorQueuer.abi,
-				bytecode: `0x${peripherals_PriceOracleManagerAndOperatorQueuer_PriceOracleManagerAndOperatorQueuer.evm.bytecode.object}`,
-				args: [infraContracts.openOracle, getRepTokenAddress(universeId)],
-			}),
-			from: infraContracts.priceOracleManagerAndOperatorQueuerFactory,
-			salt: securityPoolSaltWithMsgSender,
-		}),
-		shareToken: getCreate2Address({
-			bytecode: encodeDeployData({
-				abi: peripherals_tokens_ShareToken_ShareToken.abi,
-				bytecode: `0x${peripherals_tokens_ShareToken_ShareToken.evm.bytecode.object}`,
-				args: [infraContracts.securityPoolFactory, infraContracts.zoltar, questionId],
-			}),
-			from: infraContracts.shareTokenFactory,
-			salt: computeShareTokenSalt(securityMultiplier, questionId),
-		}),
-		truthAuction:
-			BigInt(parent) === 0n
-				? zeroAddress
-				: getCreate2Address({
-						bytecode: encodeDeployData({
-							abi: peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.abi,
-							bytecode: `0x${peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.evm.bytecode.object}`,
-							args: [infraContracts.securityPoolForker],
-						}),
-						from: infraContracts.uniformPriceDualCapBatchAuctionFactory,
-						salt: securityPoolSalt,
-					}),
-	}
-	const securityPool = getCreate2Address({
-		bytecode: encodeDeployData({
-			abi: peripherals_SecurityPool_SecurityPool.abi,
-			bytecode: applyLibraries(peripherals_SecurityPool_SecurityPool.evm.bytecode.object),
-			args: [
-				infraContracts.securityPoolForker,
-				infraContracts.securityPoolFactory,
-				infraContracts.zoltarQuestionData,
-				infraContracts.escalationGameFactory,
-				contracts.priceOracleManagerAndOperatorQueuer,
-				contracts.shareToken,
-				infraContracts.openOracle,
-				parent,
-				infraContracts.zoltar,
-				universeId,
-				questionId,
-				securityMultiplier,
-				contracts.truthAuction,
-			],
-		}),
-		from: infraContracts.securityPoolFactory,
-		salt: numberToBytes(0, { size: 32 }),
-	})
-	const escalationGame = getCreate2Address({
-		bytecode: encodeDeployData({
-			abi: peripherals_EscalationGame_EscalationGame.abi,
-			bytecode: `0x${peripherals_EscalationGame_EscalationGame.evm.bytecode.object}`,
-			args: [securityPool],
-		}),
-		from: infraContracts.escalationGameFactory,
-		salt: numberToBytes(0, { size: 32 }),
-	})
-	return { ...contracts, securityPool, escalationGame }
 }
 
 export const deployOriginSecurityPool = async (client: WriteClient, universeId: bigint, questionId: bigint, securityMultiplier: bigint, startingRetentionRate: bigint, startingRepEthPrice: bigint) => {

--- a/solidity/ts/testsuite/simulator/utils/contracts/peripherals.ts
+++ b/solidity/ts/testsuite/simulator/utils/contracts/peripherals.ts
@@ -1,5 +1,6 @@
 import 'viem/window'
 import { ReadContractReturnType } from 'viem'
+import type { Address, Hex } from 'viem'
 import { ReadClient, WriteClient, writeContractAndWait } from '../viem'
 import { WETH_ADDRESS } from '../constants'
 import {
@@ -20,7 +21,7 @@ export enum OperationType {
 	SetSecurityBondsAllowance = 2,
 }
 
-export const requestPriceIfNeededAndQueueOperation = async (client: WriteClient, priceOracleManagerAndOperatorQueuer: `0x${string}`, operation: OperationType, targetVault: `0x${string}`, amount: bigint) => {
+export const requestPriceIfNeededAndQueueOperation = async (client: WriteClient, priceOracleManagerAndOperatorQueuer: Address, operation: OperationType, targetVault: Address, amount: bigint) => {
 	const ethCost = await getRequestPriceEthCost(client, priceOracleManagerAndOperatorQueuer)
 	return await writeContractAndWait(client, () =>
 		client.writeContract({
@@ -33,7 +34,7 @@ export const requestPriceIfNeededAndQueueOperation = async (client: WriteClient,
 	)
 }
 
-export const requestPrice = async (client: WriteClient, priceOracleManagerAndOperatorQueuer: `0x${string}`) => {
+export const requestPrice = async (client: WriteClient, priceOracleManagerAndOperatorQueuer: Address) => {
 	const ethCost = await getRequestPriceEthCost(client, priceOracleManagerAndOperatorQueuer)
 	return await writeContractAndWait(client, () =>
 		client.writeContract({
@@ -46,7 +47,7 @@ export const requestPrice = async (client: WriteClient, priceOracleManagerAndOpe
 	)
 }
 
-export const getPendingReportId = async (client: ReadClient, priceOracleManagerAndOperatorQueuer: `0x${string}`) =>
+export const getPendingReportId = async (client: ReadClient, priceOracleManagerAndOperatorQueuer: Address) =>
 	await client.readContract({
 		abi: peripherals_PriceOracleManagerAndOperatorQueuer_PriceOracleManagerAndOperatorQueuer.abi,
 		functionName: 'pendingReportId',
@@ -55,18 +56,18 @@ export const getPendingReportId = async (client: ReadClient, priceOracleManagerA
 	})
 
 interface ExtraReportData {
-	stateHash: `0x${string}`
-	callbackContract: `0x${string}`
+	stateHash: Hex
+	callbackContract: Address
 	numReports: number
 	callbackGasLimit: number
-	callbackSelector: `0x${string}`
-	protocolFeeRecipient: `0x${string}`
+	callbackSelector: Hex
+	protocolFeeRecipient: Address
 	trackDisputes: boolean
 	keepFee: boolean
 	feeToken: boolean
 }
 
-function isOpenOracleExtraData(value: ReadContractReturnType): value is readonly [`0x${string}`, `0x${string}`, bigint, bigint, `0x${string}`, `0x${string}`, boolean, boolean, boolean] {
+function isOpenOracleExtraData(value: ReadContractReturnType): value is readonly [Hex, Address, bigint, bigint, Hex, Address, boolean, boolean, boolean] {
 	return Array.isArray(value) && value.length === 9
 }
 
@@ -97,7 +98,7 @@ export const getOpenOracleExtraData = async (client: ReadClient, extraDataId: bi
 	}
 }
 
-export const openOracleSubmitInitialReport = async (client: WriteClient, reportId: bigint, amount1: bigint, amount2: bigint, stateHash: `0x${string}`) =>
+export const openOracleSubmitInitialReport = async (client: WriteClient, reportId: bigint, amount1: bigint, amount2: bigint, stateHash: Hex) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_openOracle_OpenOracle_OpenOracle.abi,
@@ -118,7 +119,7 @@ export const openOracleSettle = async (client: WriteClient, reportId: bigint) =>
 		}),
 	)
 
-export const getRequestPriceEthCost = async (client: ReadClient, priceOracleManagerAndOperatorQueuer: `0x${string}`) =>
+export const getRequestPriceEthCost = async (client: ReadClient, priceOracleManagerAndOperatorQueuer: Address) =>
 	await client.readContract({
 		abi: peripherals_PriceOracleManagerAndOperatorQueuer_PriceOracleManagerAndOperatorQueuer.abi,
 		functionName: 'getRequestPriceEthCost',
@@ -151,9 +152,9 @@ interface ReportMeta {
 	escalationHalt: bigint
 	fee: bigint
 	settlerReward: bigint
-	token1: `0x${string}`
+	token1: Address
 	settlementTime: number
-	token2: `0x${string}`
+	token2: Address
 	timeType: boolean
 	feePercentage: number
 	protocolFee: number
@@ -187,7 +188,7 @@ export const getOpenOracleReportMeta = async (client: ReadClient, reportId: bigi
 	}
 }
 
-export const getLastPrice = async (client: ReadClient, priceOracleManagerAndOperatorQueuer: `0x${string}`) =>
+export const getLastPrice = async (client: ReadClient, priceOracleManagerAndOperatorQueuer: Address) =>
 	await client.readContract({
 		abi: peripherals_PriceOracleManagerAndOperatorQueuer_PriceOracleManagerAndOperatorQueuer.abi,
 		functionName: 'lastPrice',
@@ -195,7 +196,7 @@ export const getLastPrice = async (client: ReadClient, priceOracleManagerAndOper
 		args: [],
 	})
 
-export const participateAuction = async (client: WriteClient, auctionAddress: `0x${string}`, repToBuy: bigint, ethToInvest: bigint): Promise<bigint> => {
+export const participateAuction = async (client: WriteClient, auctionAddress: Address, repToBuy: bigint, ethToInvest: bigint): Promise<bigint> => {
 	if (repToBuy === 0n) {
 		throw new Error('repToBuy cannot be zero')
 	}
@@ -213,7 +214,7 @@ export const participateAuction = async (client: WriteClient, auctionAddress: `0
 	)
 	return tick
 }
-export const getEthRaiseCap = async (client: ReadClient, auctionAddress: `0x${string}`) =>
+export const getEthRaiseCap = async (client: ReadClient, auctionAddress: Address) =>
 	await client.readContract({
 		abi: peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.abi,
 		functionName: 'ethRaiseCap',
@@ -221,7 +222,7 @@ export const getEthRaiseCap = async (client: ReadClient, auctionAddress: `0x${st
 		args: [],
 	})
 
-export const balanceOfShares = async (client: ReadClient, shareTokenAddress: `0x${string}`, universeId: bigint, account: `0x${string}`) =>
+export const balanceOfShares = async (client: ReadClient, shareTokenAddress: Address, universeId: bigint, account: Address) =>
 	await client.readContract({
 		abi: peripherals_tokens_ShareToken_ShareToken.abi,
 		functionName: 'balanceOfShares',
@@ -229,7 +230,7 @@ export const balanceOfShares = async (client: ReadClient, shareTokenAddress: `0x
 		args: [universeId, account],
 	})
 
-export const balanceOfSharesInCash = async (client: ReadClient, securityPoolAddress: `0x${string}`, shareTokenAddress: `0x${string}`, universeId: bigint, account: `0x${string}`): Promise<[bigint, bigint, bigint]> => {
+export const balanceOfSharesInCash = async (client: ReadClient, securityPoolAddress: Address, shareTokenAddress: Address, universeId: bigint, account: Address): Promise<[bigint, bigint, bigint]> => {
 	const array: readonly [bigint, bigint, bigint] = await client.readContract({
 		abi: peripherals_tokens_ShareToken_ShareToken.abi,
 		functionName: 'balanceOfShares',
@@ -244,7 +245,7 @@ const getTokenId = (universeId: bigint, outcome: QuestionOutcome) => {
 	return ((universeId & universeMask) << 8n) | (BigInt(outcome) & 255n)
 }
 
-export const migrateShares = async (client: WriteClient, shareTokenAddress: `0x${string}`, fromUniverseId: bigint, outcome: QuestionOutcome) =>
+export const migrateShares = async (client: WriteClient, shareTokenAddress: Address, fromUniverseId: bigint, outcome: QuestionOutcome) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_tokens_ShareToken_ShareToken.abi,

--- a/solidity/ts/testsuite/simulator/utils/contracts/peripheralsTestUtils.ts
+++ b/solidity/ts/testsuite/simulator/utils/contracts/peripheralsTestUtils.ts
@@ -1,4 +1,5 @@
 import { zeroAddress } from 'viem'
+import type { Address } from 'viem'
 import { AnvilWindowEthereum } from '../../AnvilWindowEthereum'
 import { addressString } from '../bigint'
 import { DAY, GENESIS_REPUTATION_TOKEN, WETH_ADDRESS } from '../constants'
@@ -28,7 +29,7 @@ export const approveAndDepositRep = async (client: WriteClient, repDeposit: bigi
 	assert.strictEqual(newBalance, startBalance + repDeposit, 'Did not deposit rep')
 }
 
-export const triggerOwnGameFork = async (client: WriteClient, securityPoolAddress: `0x${string}`) => {
+export const triggerOwnGameFork = async (client: WriteClient, securityPoolAddress: Address) => {
 	const repToken = await getRepToken(client, securityPoolAddress)
 	const forkThreshold = (await getTotalTheoreticalSupply(client, repToken)) / 20n / securityMultiplier
 	const vault = await getSecurityVault(client, securityPoolAddress, client.account.address)
@@ -39,7 +40,7 @@ export const triggerOwnGameFork = async (client: WriteClient, securityPoolAddres
 	await forkZoltarWithOwnEscalationGame(client, securityPoolAddress)
 }
 
-export const handleOracleReporting = async (client: WriteClient, mockWindow: AnvilWindowEthereum, priceOracleManagerAndOperatorQueuer: `0x${string}`, forceRepEthPriceTo: bigint) => {
+export const handleOracleReporting = async (client: WriteClient, mockWindow: AnvilWindowEthereum, priceOracleManagerAndOperatorQueuer: Address, forceRepEthPriceTo: bigint) => {
 	const pendingReportId = await getPendingReportId(client, priceOracleManagerAndOperatorQueuer)
 	if (pendingReportId === 0n) {
 		// operation already executed
@@ -69,12 +70,12 @@ export const handleOracleReporting = async (client: WriteClient, mockWindow: Anv
 	await openOracleSettle(client, pendingReportId)
 }
 
-export const manipulatePriceOracleAndPerformOperation = async (client: WriteClient, mockWindow: AnvilWindowEthereum, priceOracleManagerAndOperatorQueuer: `0x${string}`, operation: OperationType, targetVault: `0x${string}`, amount: bigint, forceRepEthPriceTo: bigint = PRICE_PRECISION) => {
+export const manipulatePriceOracleAndPerformOperation = async (client: WriteClient, mockWindow: AnvilWindowEthereum, priceOracleManagerAndOperatorQueuer: Address, operation: OperationType, targetVault: Address, amount: bigint, forceRepEthPriceTo: bigint = PRICE_PRECISION) => {
 	await requestPriceIfNeededAndQueueOperation(client, priceOracleManagerAndOperatorQueuer, operation, targetVault, amount)
 	await handleOracleReporting(client, mockWindow, priceOracleManagerAndOperatorQueuer, forceRepEthPriceTo)
 }
 
-export const manipulatePriceOracle = async (client: WriteClient, mockWindow: AnvilWindowEthereum, priceOracleManagerAndOperatorQueuer: `0x${string}`, forceRepEthPriceTo: bigint = PRICE_PRECISION) => {
+export const manipulatePriceOracle = async (client: WriteClient, mockWindow: AnvilWindowEthereum, priceOracleManagerAndOperatorQueuer: Address, forceRepEthPriceTo: bigint = PRICE_PRECISION) => {
 	await requestPrice(client, priceOracleManagerAndOperatorQueuer)
 	await handleOracleReporting(client, mockWindow, priceOracleManagerAndOperatorQueuer, forceRepEthPriceTo)
 }

--- a/solidity/ts/testsuite/simulator/utils/contracts/securityPool.ts
+++ b/solidity/ts/testsuite/simulator/utils/contracts/securityPool.ts
@@ -1,9 +1,10 @@
 import { peripherals_SecurityPool_SecurityPool } from '../../../../types/contractArtifact'
+import type { Address } from 'viem'
 import { SystemState } from '../../types/peripheralTypes'
 import { QuestionOutcome } from '../../types/types'
 import { ReadClient, WriteClient, writeContractAndWait } from '../viem'
 
-export const depositToEscalationGame = async (client: WriteClient, securityPoolAddress: `0x${string}`, outcome: QuestionOutcome, amount: bigint) =>
+export const depositToEscalationGame = async (client: WriteClient, securityPoolAddress: Address, outcome: QuestionOutcome, amount: bigint) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_SecurityPool_SecurityPool.abi,
@@ -13,7 +14,7 @@ export const depositToEscalationGame = async (client: WriteClient, securityPoolA
 		}),
 	)
 
-export const withdrawFromEscalationGame = async (client: WriteClient, securityPoolAddress: `0x${string}`, outcome: QuestionOutcome, depositIndexes: bigint[]) => {
+export const withdrawFromEscalationGame = async (client: WriteClient, securityPoolAddress: Address, outcome: QuestionOutcome, depositIndexes: bigint[]) => {
 	const hash = await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_SecurityPool_SecurityPool.abi,
@@ -25,7 +26,7 @@ export const withdrawFromEscalationGame = async (client: WriteClient, securityPo
 	return hash
 }
 
-export const depositRep = async (client: WriteClient, securityPoolAddress: `0x${string}`, amount: bigint) =>
+export const depositRep = async (client: WriteClient, securityPoolAddress: Address, amount: bigint) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_SecurityPool_SecurityPool.abi,
@@ -35,7 +36,7 @@ export const depositRep = async (client: WriteClient, securityPoolAddress: `0x${
 		}),
 	)
 
-export const createCompleteSet = async (client: WriteClient, securityPoolAddress: `0x${string}`, completeSetsToCreate: bigint) =>
+export const createCompleteSet = async (client: WriteClient, securityPoolAddress: Address, completeSetsToCreate: bigint) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_SecurityPool_SecurityPool.abi,
@@ -46,7 +47,7 @@ export const createCompleteSet = async (client: WriteClient, securityPoolAddress
 		}),
 	)
 
-export const redeemCompleteSet = async (client: WriteClient, securityPoolAddress: `0x${string}`, completeSetsToRedeem: bigint) =>
+export const redeemCompleteSet = async (client: WriteClient, securityPoolAddress: Address, completeSetsToRedeem: bigint) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_SecurityPool_SecurityPool.abi,
@@ -56,7 +57,7 @@ export const redeemCompleteSet = async (client: WriteClient, securityPoolAddress
 		}),
 	)
 
-export const getTotalSecurityBondAllowance = async (client: ReadClient, securityPoolAddress: `0x${string}`) =>
+export const getTotalSecurityBondAllowance = async (client: ReadClient, securityPoolAddress: Address) =>
 	await client.readContract({
 		abi: peripherals_SecurityPool_SecurityPool.abi,
 		functionName: 'totalSecurityBondAllowance',
@@ -64,7 +65,7 @@ export const getTotalSecurityBondAllowance = async (client: ReadClient, security
 		args: [],
 	})
 
-export const getCompleteSetCollateralAmount = async (client: ReadClient, securityPoolAddress: `0x${string}`) =>
+export const getCompleteSetCollateralAmount = async (client: ReadClient, securityPoolAddress: Address) =>
 	await client.readContract({
 		abi: peripherals_SecurityPool_SecurityPool.abi,
 		functionName: 'completeSetCollateralAmount',
@@ -72,7 +73,7 @@ export const getCompleteSetCollateralAmount = async (client: ReadClient, securit
 		args: [],
 	})
 
-export const getSystemState = async (client: ReadClient, securityPoolAddress: `0x${string}`): Promise<SystemState> =>
+export const getSystemState = async (client: ReadClient, securityPoolAddress: Address): Promise<SystemState> =>
 	await client.readContract({
 		abi: peripherals_SecurityPool_SecurityPool.abi,
 		functionName: 'systemState',
@@ -80,7 +81,7 @@ export const getSystemState = async (client: ReadClient, securityPoolAddress: `0
 		args: [],
 	})
 
-export const getCurrentRetentionRate = async (client: ReadClient, securityPoolAddress: `0x${string}`) =>
+export const getCurrentRetentionRate = async (client: ReadClient, securityPoolAddress: Address) =>
 	await client.readContract({
 		abi: peripherals_SecurityPool_SecurityPool.abi,
 		functionName: 'currentRetentionRate',
@@ -88,7 +89,7 @@ export const getCurrentRetentionRate = async (client: ReadClient, securityPoolAd
 		args: [],
 	})
 
-export const getSecurityVault = async (client: ReadClient, securityPoolAddress: `0x${string}`, securityVault: `0x${string}`) => {
+export const getSecurityVault = async (client: ReadClient, securityPoolAddress: Address, securityVault: Address) => {
 	const [repDepositShare, securityBondAllowance, unpaidEthFees, feeIndex, lockedRepInEscalationGame] = await client.readContract({
 		abi: peripherals_SecurityPool_SecurityPool.abi,
 		functionName: 'securityVaults',
@@ -98,7 +99,7 @@ export const getSecurityVault = async (client: ReadClient, securityPoolAddress: 
 	return { repDepositShare, securityBondAllowance, unpaidEthFees, feeIndex, lockedRepInEscalationGame }
 }
 
-export const getVaultCount = async (client: ReadClient, securityPoolAddress: `0x${string}`) =>
+export const getVaultCount = async (client: ReadClient, securityPoolAddress: Address) =>
 	await client.readContract({
 		abi: peripherals_SecurityPool_SecurityPool.abi,
 		functionName: 'getVaultCount',
@@ -106,7 +107,7 @@ export const getVaultCount = async (client: ReadClient, securityPoolAddress: `0x
 		args: [],
 	})
 
-export const getVaults = async (client: ReadClient, securityPoolAddress: `0x${string}`, startIndex: bigint, count: bigint) =>
+export const getVaults = async (client: ReadClient, securityPoolAddress: Address, startIndex: bigint, count: bigint) =>
 	await client.readContract({
 		abi: peripherals_SecurityPool_SecurityPool.abi,
 		functionName: 'getVaults',
@@ -114,7 +115,7 @@ export const getVaults = async (client: ReadClient, securityPoolAddress: `0x${st
 		args: [startIndex, count],
 	})
 
-export const getSecurityPoolsEscalationGame = async (client: ReadClient, securityPoolAddress: `0x${string}`) =>
+export const getSecurityPoolsEscalationGame = async (client: ReadClient, securityPoolAddress: Address) =>
 	await client.readContract({
 		abi: peripherals_SecurityPool_SecurityPool.abi,
 		functionName: 'escalationGame',
@@ -122,7 +123,7 @@ export const getSecurityPoolsEscalationGame = async (client: ReadClient, securit
 		args: [],
 	})
 
-export const getPoolOwnershipDenominator = async (client: ReadClient, securityPoolAddress: `0x${string}`) =>
+export const getPoolOwnershipDenominator = async (client: ReadClient, securityPoolAddress: Address) =>
 	await client.readContract({
 		abi: peripherals_SecurityPool_SecurityPool.abi,
 		functionName: 'poolOwnershipDenominator',
@@ -130,7 +131,7 @@ export const getPoolOwnershipDenominator = async (client: ReadClient, securityPo
 		args: [],
 	})
 
-export const poolOwnershipToRep = async (client: ReadClient, securityPoolAddress: `0x${string}`, poolOwnership: bigint) =>
+export const poolOwnershipToRep = async (client: ReadClient, securityPoolAddress: Address, poolOwnership: bigint) =>
 	await client.readContract({
 		abi: peripherals_SecurityPool_SecurityPool.abi,
 		functionName: 'poolOwnershipToRep',
@@ -138,7 +139,7 @@ export const poolOwnershipToRep = async (client: ReadClient, securityPoolAddress
 		args: [poolOwnership],
 	})
 
-export const redeemShares = async (client: WriteClient, securityPoolAddress: `0x${string}`) =>
+export const redeemShares = async (client: WriteClient, securityPoolAddress: Address) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_SecurityPool_SecurityPool.abi,
@@ -148,7 +149,7 @@ export const redeemShares = async (client: WriteClient, securityPoolAddress: `0x
 		}),
 	)
 
-export const getTotalFeesOwedToVaults = async (client: ReadClient, securityPoolAddress: `0x${string}`) =>
+export const getTotalFeesOwedToVaults = async (client: ReadClient, securityPoolAddress: Address) =>
 	await client.readContract({
 		abi: peripherals_SecurityPool_SecurityPool.abi,
 		functionName: 'totalFeesOwedToVaults',
@@ -156,7 +157,7 @@ export const getTotalFeesOwedToVaults = async (client: ReadClient, securityPoolA
 		args: [],
 	})
 
-export const sharesToCash = async (client: ReadClient, securityPoolAddress: `0x${string}`, completeSetAmount: bigint) =>
+export const sharesToCash = async (client: ReadClient, securityPoolAddress: Address, completeSetAmount: bigint) =>
 	await client.readContract({
 		abi: peripherals_SecurityPool_SecurityPool.abi,
 		functionName: 'sharesToCash',
@@ -164,12 +165,12 @@ export const sharesToCash = async (client: ReadClient, securityPoolAddress: `0x$
 		args: [completeSetAmount],
 	})
 
-export const threeShareArrayToCash = async (client: ReadClient, securityPoolAddress: `0x${string}`, shares: readonly [bigint, bigint, bigint]): Promise<[bigint, bigint, bigint]> => {
+export const threeShareArrayToCash = async (client: ReadClient, securityPoolAddress: Address, shares: readonly [bigint, bigint, bigint]): Promise<[bigint, bigint, bigint]> => {
 	const [firstShare, secondShare, thirdShare] = shares
 	return await Promise.all([sharesToCash(client, securityPoolAddress, firstShare), sharesToCash(client, securityPoolAddress, secondShare), sharesToCash(client, securityPoolAddress, thirdShare)])
 }
 
-export const updateVaultFees = async (client: WriteClient, securityPoolAddress: `0x${string}`, vault: `0x${string}`) =>
+export const updateVaultFees = async (client: WriteClient, securityPoolAddress: Address, vault: Address) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_SecurityPool_SecurityPool.abi,
@@ -179,7 +180,7 @@ export const updateVaultFees = async (client: WriteClient, securityPoolAddress: 
 		}),
 	)
 
-export const redeemFees = async (client: WriteClient, securityPoolAddress: `0x${string}`, vault: `0x${string}`) =>
+export const redeemFees = async (client: WriteClient, securityPoolAddress: Address, vault: Address) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_SecurityPool_SecurityPool.abi,
@@ -189,7 +190,7 @@ export const redeemFees = async (client: WriteClient, securityPoolAddress: `0x${
 		}),
 	)
 
-export const redeemRep = async (client: WriteClient, securityPoolAddress: `0x${string}`, vault: `0x${string}`) =>
+export const redeemRep = async (client: WriteClient, securityPoolAddress: Address, vault: Address) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_SecurityPool_SecurityPool.abi,
@@ -199,7 +200,7 @@ export const redeemRep = async (client: WriteClient, securityPoolAddress: `0x${s
 		}),
 	)
 
-export const getRepToken = async (client: ReadClient, securityPoolAddress: `0x${string}`) =>
+export const getRepToken = async (client: ReadClient, securityPoolAddress: Address) =>
 	await client.readContract({
 		abi: peripherals_SecurityPool_SecurityPool.abi,
 		functionName: 'repToken',

--- a/solidity/ts/testsuite/simulator/utils/contracts/securityPoolForker.ts
+++ b/solidity/ts/testsuite/simulator/utils/contracts/securityPoolForker.ts
@@ -3,7 +3,7 @@ import { QuestionOutcome } from '../../types/types'
 import { getInfraContractAddresses } from './deployPeripherals'
 import { contractExists } from '../utilities'
 import { ReadClient, WriteClient, writeContractAndWait } from '../viem'
-import type { Abi } from 'viem'
+import type { Abi, Address } from 'viem'
 
 const getQuestionOutcomeAbi = [
 	{
@@ -27,7 +27,7 @@ const getQuestionOutcomeAbi = [
 	},
 ] satisfies Abi
 
-export const initiateSecurityPoolFork = async (client: WriteClient, securityPoolAddress: `0x${string}`) =>
+export const initiateSecurityPoolFork = async (client: WriteClient, securityPoolAddress: Address) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_SecurityPoolForker_SecurityPoolForker.abi,
@@ -37,7 +37,7 @@ export const initiateSecurityPoolFork = async (client: WriteClient, securityPool
 		}),
 	)
 
-export const migrateRepToZoltar = async (client: WriteClient, securityPoolAddress: `0x${string}`, outcomeIndices: (number | bigint)[]) =>
+export const migrateRepToZoltar = async (client: WriteClient, securityPoolAddress: Address, outcomeIndices: (number | bigint)[]) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_SecurityPoolForker_SecurityPoolForker.abi,
@@ -47,7 +47,7 @@ export const migrateRepToZoltar = async (client: WriteClient, securityPoolAddres
 		}),
 	)
 
-export const migrateVault = async (client: WriteClient, securityPoolAddress: `0x${string}`, outcome: bigint | QuestionOutcome) =>
+export const migrateVault = async (client: WriteClient, securityPoolAddress: Address, outcome: bigint | QuestionOutcome) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_SecurityPoolForker_SecurityPoolForker.abi,
@@ -57,7 +57,7 @@ export const migrateVault = async (client: WriteClient, securityPoolAddress: `0x
 		}),
 	)
 
-export const startTruthAuction = async (client: WriteClient, securityPoolAddress: `0x${string}`) =>
+export const startTruthAuction = async (client: WriteClient, securityPoolAddress: Address) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_SecurityPoolForker_SecurityPoolForker.abi,
@@ -67,7 +67,7 @@ export const startTruthAuction = async (client: WriteClient, securityPoolAddress
 		}),
 	)
 
-export const finalizeTruthAuction = async (client: WriteClient, securityPoolAddress: `0x${string}`) =>
+export const finalizeTruthAuction = async (client: WriteClient, securityPoolAddress: Address) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_SecurityPoolForker_SecurityPoolForker.abi,
@@ -77,7 +77,7 @@ export const finalizeTruthAuction = async (client: WriteClient, securityPoolAddr
 		}),
 	)
 
-export const claimAuctionProceeds = async (client: WriteClient, securityPoolAddress: `0x${string}`, vault: `0x${string}`, tickIndex: readonly { tick: bigint; bidIndex: bigint }[]) =>
+export const claimAuctionProceeds = async (client: WriteClient, securityPoolAddress: Address, vault: Address, tickIndex: readonly { tick: bigint; bidIndex: bigint }[]) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_SecurityPoolForker_SecurityPoolForker.abi,
@@ -87,7 +87,7 @@ export const claimAuctionProceeds = async (client: WriteClient, securityPoolAddr
 		}),
 	)
 
-export const forkZoltarWithOwnEscalationGame = async (client: WriteClient, securityPoolAddress: `0x${string}`) =>
+export const forkZoltarWithOwnEscalationGame = async (client: WriteClient, securityPoolAddress: Address) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_SecurityPoolForker_SecurityPoolForker.abi,
@@ -97,7 +97,7 @@ export const forkZoltarWithOwnEscalationGame = async (client: WriteClient, secur
 		}),
 	)
 
-export const getMigratedRep = async (client: ReadClient, securityPoolAddress: `0x${string}`) =>
+export const getMigratedRep = async (client: ReadClient, securityPoolAddress: Address) =>
 	await client.readContract({
 		abi: peripherals_SecurityPoolForker_SecurityPoolForker.abi,
 		functionName: 'getMigratedRep',
@@ -105,7 +105,7 @@ export const getMigratedRep = async (client: ReadClient, securityPoolAddress: `0
 		args: [securityPoolAddress],
 	})
 
-export const getQuestionOutcome = async (client: ReadClient, securityPoolAddress: `0x${string}`) => {
+export const getQuestionOutcome = async (client: ReadClient, securityPoolAddress: Address) => {
 	if (!(await contractExists(client, securityPoolAddress))) return QuestionOutcome.None
 	return await client.readContract({
 		abi: getQuestionOutcomeAbi,
@@ -115,7 +115,7 @@ export const getQuestionOutcome = async (client: ReadClient, securityPoolAddress
 	})
 }
 
-export const createChildUniverse = async (client: WriteClient, securityPoolAddress: `0x${string}`, outcome: QuestionOutcome) =>
+export const createChildUniverse = async (client: WriteClient, securityPoolAddress: Address, outcome: QuestionOutcome) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_SecurityPoolForker_SecurityPoolForker.abi,
@@ -125,7 +125,7 @@ export const createChildUniverse = async (client: WriteClient, securityPoolAddre
 		}),
 	)
 
-export const getSecurityPoolForkerForkData = async (client: ReadClient, securityPoolAddress: `0x${string}`) => {
+export const getSecurityPoolForkerForkData = async (client: ReadClient, securityPoolAddress: Address) => {
 	const data = await client.readContract({
 		abi: peripherals_SecurityPoolForker_SecurityPoolForker.abi,
 		functionName: 'forkData',
@@ -136,7 +136,7 @@ export const getSecurityPoolForkerForkData = async (client: ReadClient, security
 	return { repAtFork, truthAuction, truthAuctionStarted, migratedRep, auctionedSecurityBondAllowance, ownFork, outcomeIndex }
 }
 
-export const migrateFromEscalationGame = async (client: WriteClient, parentSecurityPool: `0x${string}`, vault: `0x${string}`, outcomeIndex: QuestionOutcome, depositIndexes: bigint[]) =>
+export const migrateFromEscalationGame = async (client: WriteClient, parentSecurityPool: Address, vault: Address, outcomeIndex: QuestionOutcome, depositIndexes: bigint[]) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_SecurityPoolForker_SecurityPoolForker.abi,

--- a/solidity/ts/testsuite/simulator/utils/contracts/zoltar.ts
+++ b/solidity/ts/testsuite/simulator/utils/contracts/zoltar.ts
@@ -1,15 +1,15 @@
 import { ReputationToken_ReputationToken, Zoltar_Zoltar, ZoltarQuestionData_ZoltarQuestionData } from '../../../../types/contractArtifact'
-import { createAddressDerivationHelpers } from '../../../../../../shared/js/addressDerivation.js'
-import { createDeploymentAddressHelpers } from '../../../../../../shared/js/deploymentAddresses.js'
+import { createRepTokenAddressHelper } from '../../../../../../shared/js/addressDerivation.js'
+import { createZoltarAddressHelpers } from '../../../../../../shared/js/deploymentAddresses.js'
 import { ReadClient, WriteClient, writeContractAndWait } from '../viem'
 import { GENESIS_REPUTATION_TOKEN, PROXY_DEPLOYER_ADDRESS } from '../constants'
-import { encodeDeployData, getAddress, toHex } from 'viem'
+import { encodeDeployData, getAddress, type Address, type Hex, toHex } from 'viem'
 import { addressString } from '../bigint'
 import { ensureProxyDeployerDeployed } from '../utilities'
 
-const ZERO_SALT = toHex(0, { size: 32 })
+const ZERO_SALT: Hex = toHex(0, { size: 32 })
 
-function getZoltarInitCode(zoltarQuestionDataAddress: `0x${string}`): `0x${string}` {
+function getZoltarInitCode(zoltarQuestionDataAddress: Address): Hex {
 	return encodeDeployData({
 		abi: Zoltar_Zoltar.abi,
 		bytecode: `0x${Zoltar_Zoltar.evm.bytecode.object}`,
@@ -17,74 +17,39 @@ function getZoltarInitCode(zoltarQuestionDataAddress: `0x${string}`): `0x${strin
 	})
 }
 
-const deploymentAddressHelpers = createDeploymentAddressHelpers({
-	deploymentStatusOracleBytecode: () => {
-		throw new Error('deploymentStatusOracleBytecode is not available in zoltar helper')
-	},
-	getEscalationGameFactoryByteCode: () => {
-		throw new Error('getEscalationGameFactoryByteCode is not available in zoltar helper')
-	},
-	getSecurityPoolFactoryByteCode: () => {
-		throw new Error('getSecurityPoolFactoryByteCode is not available in zoltar helper')
-	},
-	getSecurityPoolForkerByteCode: () => {
-		throw new Error('getSecurityPoolForkerByteCode is not available in zoltar helper')
-	},
-	getShareTokenFactoryByteCode: () => {
-		throw new Error('getShareTokenFactoryByteCode is not available in zoltar helper')
-	},
+export const { getZoltarAddress } = createZoltarAddressHelpers({
 	getZoltarInitCode,
-	libraryReplacements: () => [],
-	openOracleBytecode: '0x',
-	priceOracleManagerAndOperatorQueuerFactoryBytecode: '0x',
 	proxyDeployerAddress: addressString(PROXY_DEPLOYER_ADDRESS),
-	scalarOutcomesBytecode: '0x',
-	securityPoolUtilsBytecode: '0x',
-	uniformPriceDualCapBatchAuctionFactoryBytecode: '0x',
 	zeroSalt: ZERO_SALT,
 	zoltarQuestionDataBytecode: () => `0x${ZoltarQuestionData_ZoltarQuestionData.evm.bytecode.object}`,
 })
 
-export const { getZoltarAddress } = deploymentAddressHelpers
-const { getZoltarQuestionDataAddress } = deploymentAddressHelpers
+const { getZoltarQuestionDataAddress } = createZoltarAddressHelpers({
+	getZoltarInitCode,
+	proxyDeployerAddress: addressString(PROXY_DEPLOYER_ADDRESS),
+	zeroSalt: ZERO_SALT,
+	zoltarQuestionDataBytecode: () => `0x${ZoltarQuestionData_ZoltarQuestionData.evm.bytecode.object}`,
+})
 
-export const { getRepTokenAddress } = createAddressDerivationHelpers({
+export const { getRepTokenAddress } = createRepTokenAddressHelper({
 	genesisRepTokenAddress: getAddress(addressString(GENESIS_REPUTATION_TOKEN)),
-	getEscalationGameInitCode: () => {
-		throw new Error('getEscalationGameInitCode is not available in zoltar helper')
-	},
-	getInfraContracts: () => {
-		throw new Error('getInfraContracts is not available in zoltar helper')
-	},
-	getPriceOracleManagerAndOperatorQueuerInitCode: () => {
-		throw new Error('getPriceOracleManagerAndOperatorQueuerInitCode is not available in zoltar helper')
-	},
 	getReputationTokenInitCode: zoltarAddress =>
 		encodeDeployData({
 			abi: ReputationToken_ReputationToken.abi,
 			bytecode: `0x${ReputationToken_ReputationToken.evm.bytecode.object}`,
 			args: [zoltarAddress],
 		}),
-	getSecurityPoolInitCode: () => {
-		throw new Error('getSecurityPoolInitCode is not available in zoltar helper')
-	},
-	getShareTokenInitCode: () => {
-		throw new Error('getShareTokenInitCode is not available in zoltar helper')
-	},
-	getTruthAuctionInitCode: () => {
-		throw new Error('getTruthAuctionInitCode is not available in zoltar helper')
-	},
-	getZoltarAddress: () => getZoltarAddress(),
+	getZoltarAddress,
 })
 
 const isZoltarQuestionDataDeployed = async (client: ReadClient) => {
-	const expectedDeployedBytecode: `0x${string}` = `0x${ZoltarQuestionData_ZoltarQuestionData.evm.deployedBytecode.object}`
+	const expectedDeployedBytecode: Hex = `0x${ZoltarQuestionData_ZoltarQuestionData.evm.deployedBytecode.object}`
 	const address = getZoltarQuestionDataAddress()
 	const deployedBytecode = await client.getCode({ address })
 	return deployedBytecode === expectedDeployedBytecode
 }
 
-const deployZoltarQuestionDataTransaction = (): { data: `0x${string}`; to: `0x${string}` } => ({
+const deployZoltarQuestionDataTransaction = (): { data: Hex; to: Address } => ({
 	data: `0x${ZoltarQuestionData_ZoltarQuestionData.evm.bytecode.object}`,
 	to: addressString(PROXY_DEPLOYER_ADDRESS),
 })
@@ -97,7 +62,7 @@ const ensureZoltarQuestionDataDeployed = async (client: WriteClient) => {
 }
 
 export const isZoltarDeployed = async (client: ReadClient) => {
-	const expectedDeployedBytecode: `0x${string}` = `0x${Zoltar_Zoltar.evm.deployedBytecode.object}`
+	const expectedDeployedBytecode: Hex = `0x${Zoltar_Zoltar.evm.deployedBytecode.object}`
 	const address = getZoltarAddress()
 	const deployedBytecode = await client.getCode({ address })
 	return deployedBytecode === expectedDeployedBytecode
@@ -156,7 +121,7 @@ export const splitMigrationRep = async (client: WriteClient, universeId: bigint,
 	)
 }
 
-export async function getTotalTheoreticalSupply(client: ReadClient, repToken: `0x${string}`) {
+export async function getTotalTheoreticalSupply(client: ReadClient, repToken: Address) {
 	return await client.readContract({
 		abi: ReputationToken_ReputationToken.abi,
 		functionName: 'getTotalTheoreticalSupply',
@@ -183,7 +148,7 @@ export const deployChild = async (client: WriteClient, universeId: bigint, outco
 		}),
 	)
 
-export const getMigrationRepBalance = async (client: ReadClient, universeId: bigint, address: `0x${string}`) => {
+export const getMigrationRepBalance = async (client: ReadClient, universeId: bigint, address: Address) => {
 	const repBalance = await client.readContract({
 		abi: Zoltar_Zoltar.abi,
 		functionName: 'getMigrationRepBalance',

--- a/solidity/ts/testsuite/simulator/utils/contracts/zoltar.ts
+++ b/solidity/ts/testsuite/simulator/utils/contracts/zoltar.ts
@@ -1,9 +1,13 @@
 import { ReputationToken_ReputationToken, Zoltar_Zoltar, ZoltarQuestionData_ZoltarQuestionData } from '../../../../types/contractArtifact'
+import { createAddressDerivationHelpers } from '../../../../../../shared/js/addressDerivation.js'
+import { createDeploymentAddressHelpers } from '../../../../../../shared/js/deploymentAddresses.js'
 import { ReadClient, WriteClient, writeContractAndWait } from '../viem'
 import { GENESIS_REPUTATION_TOKEN, PROXY_DEPLOYER_ADDRESS } from '../constants'
-import { encodeDeployData, getAddress, getContractAddress, getCreate2Address, keccak256, numberToBytes } from 'viem'
-import { addressString, bytes32String } from '../bigint'
+import { encodeDeployData, getAddress, toHex } from 'viem'
+import { addressString } from '../bigint'
 import { ensureProxyDeployerDeployed } from '../utilities'
+
+const ZERO_SALT = toHex(0, { size: 32 })
 
 function getZoltarInitCode(zoltarQuestionDataAddress: `0x${string}`): `0x${string}` {
 	return encodeDeployData({
@@ -13,20 +17,65 @@ function getZoltarInitCode(zoltarQuestionDataAddress: `0x${string}`): `0x${strin
 	})
 }
 
-export function getZoltarAddress(): `0x${string}` {
-	const zoltarQuestionDataAddress = getZoltarQuestionDataAddress()
-	const initCode = getZoltarInitCode(zoltarQuestionDataAddress)
-	return getCreate2Address({
-		from: addressString(PROXY_DEPLOYER_ADDRESS),
-		salt: numberToBytes(0, { size: 32 }),
-		bytecode: initCode,
-	})
-}
+const deploymentAddressHelpers = createDeploymentAddressHelpers({
+	deploymentStatusOracleBytecode: () => {
+		throw new Error('deploymentStatusOracleBytecode is not available in zoltar helper')
+	},
+	getEscalationGameFactoryByteCode: () => {
+		throw new Error('getEscalationGameFactoryByteCode is not available in zoltar helper')
+	},
+	getSecurityPoolFactoryByteCode: () => {
+		throw new Error('getSecurityPoolFactoryByteCode is not available in zoltar helper')
+	},
+	getSecurityPoolForkerByteCode: () => {
+		throw new Error('getSecurityPoolForkerByteCode is not available in zoltar helper')
+	},
+	getShareTokenFactoryByteCode: () => {
+		throw new Error('getShareTokenFactoryByteCode is not available in zoltar helper')
+	},
+	getZoltarInitCode,
+	libraryReplacements: () => [],
+	openOracleBytecode: '0x',
+	priceOracleManagerAndOperatorQueuerFactoryBytecode: '0x',
+	proxyDeployerAddress: addressString(PROXY_DEPLOYER_ADDRESS),
+	scalarOutcomesBytecode: '0x',
+	securityPoolUtilsBytecode: '0x',
+	uniformPriceDualCapBatchAuctionFactoryBytecode: '0x',
+	zeroSalt: ZERO_SALT,
+	zoltarQuestionDataBytecode: () => `0x${ZoltarQuestionData_ZoltarQuestionData.evm.bytecode.object}`,
+})
 
-function getZoltarQuestionDataAddress(): `0x${string}` {
-	const bytecode: `0x${string}` = `0x${ZoltarQuestionData_ZoltarQuestionData.evm.bytecode.object}`
-	return getContractAddress({ bytecode, from: addressString(PROXY_DEPLOYER_ADDRESS), opcode: 'CREATE2', salt: numberToBytes(0, { size: 32 }) })
-}
+export const { getZoltarAddress } = deploymentAddressHelpers
+const { getZoltarQuestionDataAddress } = deploymentAddressHelpers
+
+export const { getRepTokenAddress } = createAddressDerivationHelpers({
+	genesisRepTokenAddress: getAddress(addressString(GENESIS_REPUTATION_TOKEN)),
+	getEscalationGameInitCode: () => {
+		throw new Error('getEscalationGameInitCode is not available in zoltar helper')
+	},
+	getInfraContracts: () => {
+		throw new Error('getInfraContracts is not available in zoltar helper')
+	},
+	getPriceOracleManagerAndOperatorQueuerInitCode: () => {
+		throw new Error('getPriceOracleManagerAndOperatorQueuerInitCode is not available in zoltar helper')
+	},
+	getReputationTokenInitCode: zoltarAddress =>
+		encodeDeployData({
+			abi: ReputationToken_ReputationToken.abi,
+			bytecode: `0x${ReputationToken_ReputationToken.evm.bytecode.object}`,
+			args: [zoltarAddress],
+		}),
+	getSecurityPoolInitCode: () => {
+		throw new Error('getSecurityPoolInitCode is not available in zoltar helper')
+	},
+	getShareTokenInitCode: () => {
+		throw new Error('getShareTokenInitCode is not available in zoltar helper')
+	},
+	getTruthAuctionInitCode: () => {
+		throw new Error('getTruthAuctionInitCode is not available in zoltar helper')
+	},
+	getZoltarAddress: () => getZoltarAddress(),
+})
 
 const isZoltarQuestionDataDeployed = async (client: ReadClient) => {
 	const expectedDeployedBytecode: `0x${string}` = `0x${ZoltarQuestionData_ZoltarQuestionData.evm.deployedBytecode.object}`
@@ -114,16 +163,6 @@ export async function getTotalTheoreticalSupply(client: ReadClient, repToken: `0
 		address: repToken,
 		args: [],
 	})
-}
-
-export function getRepTokenAddress(universeId: bigint): `0x${string}` {
-	if (universeId === 0n) return getAddress(addressString(GENESIS_REPUTATION_TOKEN))
-	const initCode = encodeDeployData({
-		abi: ReputationToken_ReputationToken.abi,
-		bytecode: `0x${ReputationToken_ReputationToken.evm.bytecode.object}`,
-		args: [getZoltarAddress()],
-	})
-	return getCreate2Address({ from: getZoltarAddress(), salt: bytes32String(universeId), bytecodeHash: keccak256(initCode) })
 }
 
 export const getZoltarForkThreshold = async (client: ReadClient, universeId: bigint) =>

--- a/solidity/ts/testsuite/simulator/utils/utilities.ts
+++ b/solidity/ts/testsuite/simulator/utils/utilities.ts
@@ -128,7 +128,7 @@ export async function ensureProxyDeployerDeployed(client: WriteClient): Promise<
 	await client.waitForTransactionReceipt({ hash: deployHash })
 }
 
-export const contractExists = async (client: ReadClient, contract: `0x${string}`) => (await client.getCode({ address: contract })) !== undefined
+export const contractExists = async (client: ReadClient, contract: Address) => (await client.getCode({ address: contract })) !== undefined
 
 const uint248BitMask = (1n << 248n) - 1n
 export function getChildUniverseId(parentUniverseId: bigint, outcome: bigint | QuestionOutcome): bigint {

--- a/solidity/ts/testsuite/simulator/utils/viem.ts
+++ b/solidity/ts/testsuite/simulator/utils/viem.ts
@@ -1,4 +1,5 @@
 import { createPublicClient, createWalletClient, custom, EIP1193Provider, http, publicActions } from 'viem'
+import type { Hash } from 'viem'
 import 'viem/window'
 import { addressString } from './bigint'
 import { mainnet } from 'viem/chains'
@@ -19,7 +20,7 @@ export const createWriteClient = (ethereum: EIP1193Provider | undefined | AnvilW
 export type WriteClient = ReturnType<typeof createWriteClient>
 export type ReadClient = ReturnType<typeof createReadClient> | ReturnType<typeof createWriteClient>
 
-export const writeContractAndWait = async (client: WriteClient, execute: () => Promise<`0x${string}`>) => {
+export const writeContractAndWait = async (client: WriteClient, execute: () => Promise<Hash>) => {
 	const hash = await execute()
 	await client.waitForTransactionReceipt({ hash })
 	return hash

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,7 @@
 		"noEmit": true
 	},
 	"include": [
+		"shared/ts/**/*.ts",
 		"ui/ts/**/*.ts",
 		"ui/ts/**/*.tsx",
 	],

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -30,6 +30,10 @@ COPY ./ui/tsconfig.vendor.json /source/ui/tsconfig.vendor.json
 COPY ./ui/build/ /source/ui/build/
 COPY ./ui/index.html /source/ui/index.html
 
+# Shared TypeScript source used by both UI and simulator helpers
+COPY ./shared/tsconfig.json /source/shared/tsconfig.json
+COPY ./shared/ts/ /source/shared/ts/
+
 # Solidity contracts and TypeScript source
 COPY ./solidity/tsconfig.json /source/solidity/tsconfig.json
 COPY ./solidity/tsconfig-compile.json /source/solidity/tsconfig-compile.json

--- a/ui/ts/components/SecurityPoolSection.tsx
+++ b/ui/ts/components/SecurityPoolSection.tsx
@@ -21,6 +21,7 @@ export function SecurityPoolSection({
 	marketDetails,
 	onCreateSecurityPool,
 	onLoadMarket,
+	onOpenCreatedPool,
 	onSecurityPoolFormChange,
 	onResetSecurityPoolCreation,
 	securityPools,
@@ -78,6 +79,9 @@ export function SecurityPoolSection({
 							badge={<span className='badge ok'>Deployed</span>}
 							actions={
 								<div className='actions'>
+									<button className='primary' onClick={() => onOpenCreatedPool?.(securityPoolResult.securityPoolAddress)}>
+										Open Pool
+									</button>
 									<button className='secondary' onClick={onResetSecurityPoolCreation}>
 										Create Another Pool
 									</button>
@@ -86,6 +90,12 @@ export function SecurityPoolSection({
 						>
 							<Question question={createdQuestionDetails} loading={createdQuestionDetails === undefined} />
 							<ul className='status-list hashes'>
+								<li>
+									<span>Pool address</span>
+									<strong>
+										<AddressValue address={securityPoolResult.securityPoolAddress} />
+									</strong>
+								</li>
 								<li>
 									<span>Security Multiplier</span>
 									<strong>{securityPoolResult.securityMultiplier.toString()}</strong>

--- a/ui/ts/components/SecurityPoolsSection.tsx
+++ b/ui/ts/components/SecurityPoolsSection.tsx
@@ -42,7 +42,16 @@ export function SecurityPoolsSection({ createPool, overview, workflow }: Securit
 				/>
 			) : undefined}
 
-			{view === 'create' ? <SecurityPoolSection {...createPool} showHeader={false} /> : undefined}
+			{view === 'create' ? (
+				<SecurityPoolSection
+					{...createPool}
+					showHeader={false}
+					onOpenCreatedPool={securityPoolAddress => {
+						workflow.onSecurityPoolAddressChange(securityPoolAddress)
+						setView('operate')
+					}}
+				/>
+			) : undefined}
 
 			{view === 'operate' ? <SecurityPoolWorkflowSection {...workflow} showHeader={false} /> : undefined}
 		</section>

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -1,7 +1,7 @@
 import { encodeAbiParameters, encodeDeployData, getAddress, getCreate2Address, keccak256, parseAbiItem, toHex, zeroAddress, RpcError, type Address, type Hash, type Hex } from 'viem'
 import { ABIS } from './abis.js'
-import { createAddressDerivationHelpers } from '../../shared/js/addressDerivation.js'
-import { createDeploymentAddressHelpers } from '../../shared/js/deploymentAddresses.js'
+import { createRepTokenAddressHelper, createSecurityPoolAddressHelper } from '../../shared/js/addressDerivation.js'
+import { createApplyLinkedLibrariesHelper, createDeploymentStatusOracleAddressHelper, createInfraContractAddressHelper, createZoltarAddressHelpers } from '../../shared/js/deploymentAddresses.js'
 import { assertNever } from './lib/assert.js'
 import { GENESIS_REPUTATION_TOKEN_ADDRESS } from './lib/universe.js'
 import {
@@ -250,23 +250,31 @@ function getDeploymentStatusSnapshot(deployedMask: bigint, deploymentStatusOracl
 	}
 }
 
-const deploymentAddressHelpers = createDeploymentAddressHelpers({
-	deploymentStatusOracleBytecode: getDeploymentStatusOracleByteCode,
+const { applyLibraries } = createApplyLinkedLibrariesHelper(() => [
+	{
+		hash: keccak256(toHex('contracts/ScalarOutcomes.sol:ScalarOutcomes')).slice(2, 36),
+		address: getScalarOutcomesAddress(),
+	},
+	{
+		hash: keccak256(toHex('contracts/peripherals/SecurityPoolUtils.sol:SecurityPoolUtils')).slice(2, 36),
+		address: getSecurityPoolUtilsAddress(),
+	},
+])
+
+export const { getZoltarAddress, getZoltarQuestionDataAddress } = createZoltarAddressHelpers({
+	getZoltarInitCode,
+	proxyDeployerAddress: PROXY_DEPLOYER_ADDRESS,
+	zeroSalt: ZERO_SALT,
+	zoltarQuestionDataBytecode: getZoltarQuestionDataByteCode,
+})
+
+const { getInfraContractAddresses } = createInfraContractAddressHelper({
 	getEscalationGameFactoryByteCode,
 	getSecurityPoolFactoryByteCode,
 	getSecurityPoolForkerByteCode,
 	getShareTokenFactoryByteCode,
-	getZoltarInitCode,
-	libraryReplacements: () => [
-		{
-			hash: keccak256(toHex('contracts/ScalarOutcomes.sol:ScalarOutcomes')).slice(2, 36),
-			address: getScalarOutcomesAddress(),
-		},
-		{
-			hash: keccak256(toHex('contracts/peripherals/SecurityPoolUtils.sol:SecurityPoolUtils')).slice(2, 36),
-			address: getSecurityPoolUtilsAddress(),
-		},
-	],
+	getZoltarAddress,
+	getZoltarQuestionDataAddress,
 	openOracleBytecode: `0x${peripherals_openOracle_OpenOracle_OpenOracle.evm.bytecode.object}`,
 	priceOracleManagerAndOperatorQueuerFactoryBytecode: `0x${peripherals_factories_PriceOracleManagerAndOperatorQueuerFactory_PriceOracleManagerAndOperatorQueuerFactory.evm.bytecode.object}`,
 	proxyDeployerAddress: PROXY_DEPLOYER_ADDRESS,
@@ -274,14 +282,26 @@ const deploymentAddressHelpers = createDeploymentAddressHelpers({
 	securityPoolUtilsBytecode: `0x${peripherals_SecurityPoolUtils_SecurityPoolUtils.evm.bytecode.object}`,
 	uniformPriceDualCapBatchAuctionFactoryBytecode: `0x${peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory.evm.bytecode.object}`,
 	zeroSalt: ZERO_SALT,
-	zoltarQuestionDataBytecode: getZoltarQuestionDataByteCode,
 })
 
-export const { getZoltarAddress } = deploymentAddressHelpers
-const { applyLinkedLibraries: applyLibraries, getDeploymentStatusOracleAddress, getInfraContractAddresses } = deploymentAddressHelpers
+const { getDeploymentStatusOracleAddress } = createDeploymentStatusOracleAddressHelper({
+	deploymentStatusOracleBytecode: getDeploymentStatusOracleByteCode,
+	proxyDeployerAddress: PROXY_DEPLOYER_ADDRESS,
+	zeroSalt: ZERO_SALT,
+})
 
-const { getSecurityPoolAddresses } = createAddressDerivationHelpers({
+const { getRepTokenAddress } = createRepTokenAddressHelper({
 	genesisRepTokenAddress: GENESIS_REPUTATION_TOKEN_ADDRESS,
+	getReputationTokenInitCode: zoltarAddress =>
+		encodeDeployData({
+			abi: ReputationToken_ReputationToken.abi,
+			bytecode: `0x${ReputationToken_ReputationToken.evm.bytecode.object}`,
+			args: [zoltarAddress],
+		}),
+	getZoltarAddress,
+})
+
+const { getSecurityPoolAddresses } = createSecurityPoolAddressHelper({
 	getEscalationGameInitCode: securityPool =>
 		encodeDeployData({
 			abi: peripherals_EscalationGame_EscalationGame.abi,
@@ -295,12 +315,7 @@ const { getSecurityPoolAddresses } = createAddressDerivationHelpers({
 			bytecode: `0x${peripherals_PriceOracleManagerAndOperatorQueuer_PriceOracleManagerAndOperatorQueuer.evm.bytecode.object}`,
 			args: [openOracle, repToken],
 		}),
-	getReputationTokenInitCode: zoltarAddress =>
-		encodeDeployData({
-			abi: ReputationToken_ReputationToken.abi,
-			bytecode: `0x${ReputationToken_ReputationToken.evm.bytecode.object}`,
-			args: [zoltarAddress],
-		}),
+	getRepTokenAddress,
 	getSecurityPoolInitCode: ({ escalationGameFactory, openOracle, parent, priceOracleManagerAndOperatorQueuer, questionId, securityMultiplier, securityPoolFactory, securityPoolForker, shareToken, truthAuction, universeId, zoltar, zoltarQuestionData }) =>
 		encodeDeployData({
 			abi: peripherals_SecurityPool_SecurityPool.abi,
@@ -319,7 +334,6 @@ const { getSecurityPoolAddresses } = createAddressDerivationHelpers({
 			bytecode: `0x${peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.evm.bytecode.object}`,
 			args: [securityPoolForker],
 		}),
-	getZoltarAddress: () => getZoltarAddress(),
 })
 
 async function deployViaProxy(client: WriteClient, bytecode: Hex) {

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -1,6 +1,9 @@
-import { encodeAbiParameters, encodeDeployData, getAddress, getContractAddress, getCreate2Address, keccak256, numberToBytes, parseAbiItem, toHex, zeroAddress, RpcError, type Address, type Hash, type Hex } from 'viem'
+import { encodeAbiParameters, encodeDeployData, getAddress, getCreate2Address, keccak256, parseAbiItem, toHex, zeroAddress, RpcError, type Address, type Hash, type Hex } from 'viem'
 import { ABIS } from './abis.js'
+import { createAddressDerivationHelpers } from '../../shared/js/addressDerivation.js'
+import { createDeploymentAddressHelpers } from '../../shared/js/deploymentAddresses.js'
 import { assertNever } from './lib/assert.js'
+import { GENESIS_REPUTATION_TOKEN_ADDRESS } from './lib/universe.js'
 import {
 	DeploymentStatusOracle_DeploymentStatusOracle,
 	ReputationToken_ReputationToken,
@@ -62,7 +65,7 @@ const PROXY_DEPLOYER_ADDRESS = bigintToAddress(0x7a0d94f55792c434d74a40883c6ed85
 const PROXY_DEPLOYER_SIGNER = getAddress('0x4c8d290a1b368ac4728d83a9e8321fc3af2b39b1')
 const PROXY_DEPLOYER_RAW_TRANSACTION = '0xf87e8085174876e800830186a08080ad601f80600e600039806000f350fe60003681823780368234f58015156014578182fd5b80825250506014600cf31ba02222222222222222222222222222222222222222222222222222222222222222a02222222222222222222222222222222222222222222222222222222222222222' satisfies Hex
 const ZERO_HASH = '0x0000000000000000000000000000000000000000000000000000000000000000' satisfies Hash
-const ZERO_SALT = numberToBytes(0, { size: 32 })
+const ZERO_SALT = toHex(0, { size: 32 })
 const FUND_PROXY_DEPLOYER_SIGNER_AMOUNT = 10000000000000000n
 const LIQUIDATION_OPERATION_TYPE = 0
 const ESCALATION_TIME_LENGTH = 4_233_600n
@@ -165,56 +168,37 @@ const getSecurityPoolForkerByteCode = (zoltarAddress: Address) =>
 		args: [zoltarAddress],
 	})
 
-const getZoltarQuestionDataAddress = () =>
-	getContractAddress({
-		bytecode: `0x${ZoltarQuestionData_ZoltarQuestionData.evm.bytecode.object}`,
-		from: PROXY_DEPLOYER_ADDRESS,
-		opcode: 'CREATE2',
-		salt: ZERO_SALT,
-	})
-
-const getZoltarInitCode = (zoltarQuestionDataAddress: Address) =>
+const getZoltarInitCode = (zoltarQuestionDataAddress: Address): Hex =>
 	encodeDeployData({
 		abi: Zoltar_Zoltar.abi,
 		bytecode: `0x${Zoltar_Zoltar.evm.bytecode.object}`,
 		args: [zoltarQuestionDataAddress],
 	})
 
-const getZoltarAddress = () => {
-	const zoltarQuestionDataAddress = getZoltarQuestionDataAddress()
-	return getCreate2Address({
-		from: PROXY_DEPLOYER_ADDRESS,
-		salt: ZERO_SALT,
-		bytecode: getZoltarInitCode(zoltarQuestionDataAddress),
-	})
-}
-
-const getSecurityPoolFactoryByteCode = (securityPoolForker: Address, questionData: Address, escalationGameFactory: Address, openOracle: Address, zoltar: Address, shareTokenFactory: Address, uniformPriceDualCapBatchAuctionFactory: Address, priceOracleManagerAndOperatorQueuerFactory: Address) =>
+const getSecurityPoolFactoryByteCode = ({
+	escalationGameFactory,
+	openOracle,
+	priceOracleManagerAndOperatorQueuerFactory,
+	securityPoolForker,
+	shareTokenFactory,
+	uniformPriceDualCapBatchAuctionFactory,
+	zoltar,
+	zoltarQuestionData,
+}: {
+	escalationGameFactory: Address
+	openOracle: Address
+	priceOracleManagerAndOperatorQueuerFactory: Address
+	securityPoolForker: Address
+	shareTokenFactory: Address
+	uniformPriceDualCapBatchAuctionFactory: Address
+	zoltar: Address
+	zoltarQuestionData: Address
+}) =>
 	encodeDeployData({
 		abi: peripherals_factories_SecurityPoolFactory_SecurityPoolFactory.abi,
 		bytecode: applyLibraries(peripherals_factories_SecurityPoolFactory_SecurityPoolFactory.evm.bytecode.object),
-		args: [securityPoolForker, questionData, escalationGameFactory, openOracle, zoltar, shareTokenFactory, uniformPriceDualCapBatchAuctionFactory, priceOracleManagerAndOperatorQueuerFactory],
+		args: [securityPoolForker, zoltarQuestionData, escalationGameFactory, openOracle, zoltar, shareTokenFactory, uniformPriceDualCapBatchAuctionFactory, priceOracleManagerAndOperatorQueuerFactory],
 	})
-
-function applyLibraries(bytecode: string): Hex {
-	const librariesToReplace = [
-		{
-			hash: keccak256(toHex('contracts/ScalarOutcomes.sol:ScalarOutcomes')).slice(2, 36),
-			address: getScalarOutcomesAddress(),
-		},
-		{
-			hash: keccak256(toHex('contracts/peripherals/SecurityPoolUtils.sol:SecurityPoolUtils')).slice(2, 36),
-			address: getSecurityPoolUtilsAddress(),
-		},
-	] as const
-
-	let updatedBytecode = bytecode
-	for (const { hash, address } of librariesToReplace) {
-		updatedBytecode = updatedBytecode.replaceAll(`__$${hash}$__`, address.slice(2).toLowerCase())
-	}
-
-	return `0x${updatedBytecode}`
-}
 
 function getDeploymentStatusOracleStepAddresses() {
 	const addresses = getInfraContractAddresses()
@@ -242,14 +226,6 @@ function getDeploymentStatusOracleByteCode() {
 	})
 }
 
-function getDeploymentStatusOracleAddress() {
-	return getCreate2Address({
-		bytecode: getDeploymentStatusOracleByteCode(),
-		from: PROXY_DEPLOYER_ADDRESS,
-		salt: ZERO_SALT,
-	})
-}
-
 function getDeploymentStatusSnapshot(deployedMask: bigint, deploymentStatusOracleDeployed: boolean): DeploymentStatusSnapshot {
 	const steps = getDeploymentSteps()
 	let maskIndex = 0n
@@ -274,36 +250,77 @@ function getDeploymentStatusSnapshot(deployedMask: bigint, deploymentStatusOracl
 	}
 }
 
-function getInfraContractAddresses() {
-	const getAddressForBytecode = (bytecode: Hex) =>
-		getCreate2Address({
-			bytecode,
-			from: PROXY_DEPLOYER_ADDRESS,
-			salt: ZERO_SALT,
-		})
+const deploymentAddressHelpers = createDeploymentAddressHelpers({
+	deploymentStatusOracleBytecode: getDeploymentStatusOracleByteCode,
+	getEscalationGameFactoryByteCode,
+	getSecurityPoolFactoryByteCode,
+	getSecurityPoolForkerByteCode,
+	getShareTokenFactoryByteCode,
+	getZoltarInitCode,
+	libraryReplacements: () => [
+		{
+			hash: keccak256(toHex('contracts/ScalarOutcomes.sol:ScalarOutcomes')).slice(2, 36),
+			address: getScalarOutcomesAddress(),
+		},
+		{
+			hash: keccak256(toHex('contracts/peripherals/SecurityPoolUtils.sol:SecurityPoolUtils')).slice(2, 36),
+			address: getSecurityPoolUtilsAddress(),
+		},
+	],
+	openOracleBytecode: `0x${peripherals_openOracle_OpenOracle_OpenOracle.evm.bytecode.object}`,
+	priceOracleManagerAndOperatorQueuerFactoryBytecode: `0x${peripherals_factories_PriceOracleManagerAndOperatorQueuerFactory_PriceOracleManagerAndOperatorQueuerFactory.evm.bytecode.object}`,
+	proxyDeployerAddress: PROXY_DEPLOYER_ADDRESS,
+	scalarOutcomesBytecode: `0x${ScalarOutcomes_ScalarOutcomes.evm.bytecode.object}`,
+	securityPoolUtilsBytecode: `0x${peripherals_SecurityPoolUtils_SecurityPoolUtils.evm.bytecode.object}`,
+	uniformPriceDualCapBatchAuctionFactoryBytecode: `0x${peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory.evm.bytecode.object}`,
+	zeroSalt: ZERO_SALT,
+	zoltarQuestionDataBytecode: getZoltarQuestionDataByteCode,
+})
 
-	const contracts = {
-		securityPoolUtils: getSecurityPoolUtilsAddress(),
-		openOracle: getAddressForBytecode(`0x${peripherals_openOracle_OpenOracle_OpenOracle.evm.bytecode.object}`),
-		zoltarQuestionData: getAddressForBytecode(getZoltarQuestionDataByteCode()),
-		zoltar: getZoltarAddress(),
-		shareTokenFactory: getAddressForBytecode(getShareTokenFactoryByteCode(getZoltarAddress())),
-		priceOracleManagerAndOperatorQueuerFactory: getAddressForBytecode(`0x${peripherals_factories_PriceOracleManagerAndOperatorQueuerFactory_PriceOracleManagerAndOperatorQueuerFactory.evm.bytecode.object}`),
-		securityPoolForker: getAddressForBytecode(getSecurityPoolForkerByteCode(getZoltarAddress())),
-		escalationGameFactory: getAddressForBytecode(getEscalationGameFactoryByteCode()),
-		scalarOutcomes: getScalarOutcomesAddress(),
-		uniformPriceDualCapBatchAuctionFactory: getAddressForBytecode(`0x${peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory.evm.bytecode.object}`),
-	}
+export const { getZoltarAddress } = deploymentAddressHelpers
+const { applyLinkedLibraries: applyLibraries, getDeploymentStatusOracleAddress, getInfraContractAddresses } = deploymentAddressHelpers
 
-	return {
-		...contracts,
-		securityPoolFactory: getCreate2Address({
-			from: PROXY_DEPLOYER_ADDRESS,
-			salt: ZERO_SALT,
-			bytecode: getSecurityPoolFactoryByteCode(contracts.securityPoolForker, contracts.zoltarQuestionData, contracts.escalationGameFactory, contracts.openOracle, contracts.zoltar, contracts.shareTokenFactory, contracts.uniformPriceDualCapBatchAuctionFactory, contracts.priceOracleManagerAndOperatorQueuerFactory),
+const { getSecurityPoolAddresses } = createAddressDerivationHelpers({
+	genesisRepTokenAddress: GENESIS_REPUTATION_TOKEN_ADDRESS,
+	getEscalationGameInitCode: securityPool =>
+		encodeDeployData({
+			abi: peripherals_EscalationGame_EscalationGame.abi,
+			bytecode: `0x${peripherals_EscalationGame_EscalationGame.evm.bytecode.object}`,
+			args: [securityPool],
 		}),
-	}
-}
+	getInfraContracts: () => getInfraContractAddresses(),
+	getPriceOracleManagerAndOperatorQueuerInitCode: (openOracle, repToken) =>
+		encodeDeployData({
+			abi: peripherals_PriceOracleManagerAndOperatorQueuer_PriceOracleManagerAndOperatorQueuer.abi,
+			bytecode: `0x${peripherals_PriceOracleManagerAndOperatorQueuer_PriceOracleManagerAndOperatorQueuer.evm.bytecode.object}`,
+			args: [openOracle, repToken],
+		}),
+	getReputationTokenInitCode: zoltarAddress =>
+		encodeDeployData({
+			abi: ReputationToken_ReputationToken.abi,
+			bytecode: `0x${ReputationToken_ReputationToken.evm.bytecode.object}`,
+			args: [zoltarAddress],
+		}),
+	getSecurityPoolInitCode: ({ escalationGameFactory, openOracle, parent, priceOracleManagerAndOperatorQueuer, questionId, securityMultiplier, securityPoolFactory, securityPoolForker, shareToken, truthAuction, universeId, zoltar, zoltarQuestionData }) =>
+		encodeDeployData({
+			abi: peripherals_SecurityPool_SecurityPool.abi,
+			bytecode: applyLibraries(peripherals_SecurityPool_SecurityPool.evm.bytecode.object),
+			args: [securityPoolForker, securityPoolFactory, zoltarQuestionData, escalationGameFactory, priceOracleManagerAndOperatorQueuer, shareToken, openOracle, parent, zoltar, universeId, questionId, securityMultiplier, truthAuction],
+		}),
+	getShareTokenInitCode: (securityPoolFactory, zoltarAddress, questionId) =>
+		encodeDeployData({
+			abi: peripherals_tokens_ShareToken_ShareToken.abi,
+			bytecode: `0x${peripherals_tokens_ShareToken_ShareToken.evm.bytecode.object}`,
+			args: [securityPoolFactory, zoltarAddress, questionId],
+		}),
+	getTruthAuctionInitCode: securityPoolForker =>
+		encodeDeployData({
+			abi: peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.abi,
+			bytecode: `0x${peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.evm.bytecode.object}`,
+			args: [securityPoolForker],
+		}),
+	getZoltarAddress: () => getZoltarAddress(),
+})
 
 async function deployViaProxy(client: WriteClient, bytecode: Hex) {
 	const hash = await client.sendTransaction({
@@ -467,7 +484,16 @@ export function getDeploymentSteps(): DeploymentStep[] {
 			deploy: async client =>
 				await deployViaProxy(
 					client,
-					getSecurityPoolFactoryByteCode(addresses.securityPoolForker, addresses.zoltarQuestionData, addresses.escalationGameFactory, addresses.openOracle, addresses.zoltar, addresses.shareTokenFactory, addresses.uniformPriceDualCapBatchAuctionFactory, addresses.priceOracleManagerAndOperatorQueuerFactory),
+					getSecurityPoolFactoryByteCode({
+						escalationGameFactory: addresses.escalationGameFactory,
+						openOracle: addresses.openOracle,
+						priceOracleManagerAndOperatorQueuerFactory: addresses.priceOracleManagerAndOperatorQueuerFactory,
+						securityPoolForker: addresses.securityPoolForker,
+						shareTokenFactory: addresses.shareTokenFactory,
+						uniformPriceDualCapBatchAuctionFactory: addresses.uniformPriceDualCapBatchAuctionFactory,
+						zoltar: addresses.zoltar,
+						zoltarQuestionData: addresses.zoltarQuestionData,
+					}),
 				),
 		},
 	]
@@ -1057,6 +1083,7 @@ export async function createSecurityPool(
 	return {
 		deployPoolHash,
 		questionId: getQuestionIdHex(parameters.questionId),
+		securityPoolAddress: getSecurityPoolAddresses(zeroAddress, 0n, parameters.questionId, parameters.securityMultiplier).securityPool,
 		securityMultiplier: parameters.securityMultiplier,
 		universeId: 0n,
 	} satisfies SecurityPoolCreationResult

--- a/ui/ts/hooks/useZoltarFork.ts
+++ b/ui/ts/hooks/useZoltarFork.ts
@@ -1,13 +1,12 @@
 import { useSignal } from '@preact/signals'
 import { useCallback, useEffect } from 'preact/hooks'
 import { zeroAddress, type Address, type Hash } from 'viem'
-import { approveErc20, forkZoltarUniverse, getDeploymentSteps, loadErc20Allowance, loadErc20Balance, loadRepTokensMigratedRepBalance } from '../contracts.js'
+import { approveErc20, forkZoltarUniverse, getZoltarAddress, loadErc20Allowance, loadErc20Balance, loadRepTokensMigratedRepBalance } from '../contracts.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
 import { requireWallet } from '../lib/walletGuard.js'
 import { getErrorMessage } from '../lib/errors.js'
 import { parseBigIntInput } from '../lib/marketForm.js'
 import { GENESIS_REPUTATION_TOKEN_ADDRESS } from '../lib/universe.js'
-import { requireDefined } from '../lib/required.js'
 import { useRequestGuard } from '../lib/requestGuard.js'
 import type { ZoltarForkActionResult, ZoltarUniverseSummary } from '../types/contracts.js'
 
@@ -26,14 +25,6 @@ type UseZoltarForkParameters = {
 
 function formatQuestionId(questionId: bigint) {
 	return `0x${questionId.toString(16)}`
-}
-
-function getZoltarAddress() {
-	const zoltarStep = requireDefined(
-		getDeploymentSteps().find(step => step.id === 'zoltar'),
-		'Zoltar deployment step not found',
-	)
-	return zoltarStep.address
 }
 
 export function useZoltarFork({ accountAddress, activeUniverseId, ensureZoltarUniverse, onTransaction, onTransactionFinished, onTransactionRequested, onTransactionSubmitted, refreshState, refreshZoltarUniverse, zoltarUniverse }: UseZoltarForkParameters) {

--- a/ui/ts/tests/securityPoolCreation.test.ts
+++ b/ui/ts/tests/securityPoolCreation.test.ts
@@ -1,0 +1,72 @@
+/// <reference types="bun-types" />
+
+import { beforeEach, describe, expect, setDefaultTimeout, test } from 'bun:test'
+import { zeroAddress } from 'viem'
+import { createSecurityPool } from '../contracts.js'
+import { createWalletWriteClient } from '../lib/clients.js'
+import type { InjectedEthereum } from '../injectedEthereum.js'
+import { DAY, TEST_ADDRESSES } from '../../../solidity/ts/testsuite/simulator/utils/constants'
+import { addressString } from '../../../solidity/ts/testsuite/simulator/utils/bigint'
+import { AnvilWindowEthereum } from '../../../solidity/ts/testsuite/simulator/AnvilWindowEthereum'
+import { TEST_TIMEOUT_MS, useIsolatedAnvilNode } from '../../../solidity/ts/testsuite/simulator/useIsolatedAnvilNode'
+import { createWriteClient, type WriteClient } from '../../../solidity/ts/testsuite/simulator/utils/viem'
+import { ensureInfraDeployed, getSecurityPoolAddresses } from '../../../solidity/ts/testsuite/simulator/utils/contracts/deployPeripherals'
+import { ensureZoltarDeployed } from '../../../solidity/ts/testsuite/simulator/utils/contracts/zoltar'
+import { createQuestion, getQuestionId } from '../../../solidity/ts/testsuite/simulator/utils/contracts/zoltarQuestionData'
+import { ensureProxyDeployerDeployed, setupTestAccounts } from '../../../solidity/ts/testsuite/simulator/utils/utilities'
+
+setDefaultTimeout(TEST_TIMEOUT_MS)
+
+function installInjectedEthereum(mockWindow: AnvilWindowEthereum) {
+	const globalWindow = globalThis as typeof globalThis & { window?: Window }
+	if (globalWindow.window === undefined) {
+		globalWindow.window = globalThis as unknown as Window & typeof globalThis
+	}
+	globalWindow.window.ethereum = mockWindow as unknown as InjectedEthereum
+}
+
+describe('security pool creation helper', () => {
+	const { getAnvilWindowEthereum } = useIsolatedAnvilNode()
+	let mockWindow: AnvilWindowEthereum
+	let client: WriteClient
+
+	beforeEach(async () => {
+		mockWindow = getAnvilWindowEthereum()
+		client = createWriteClient(mockWindow, TEST_ADDRESSES[0], 0)
+		installInjectedEthereum(mockWindow)
+		await setupTestAccounts(mockWindow)
+		await ensureProxyDeployerDeployed(client)
+		await ensureZoltarDeployed(client)
+		await ensureInfraDeployed(client)
+	})
+
+	test('returns the deployed security pool address from the deployment receipt', async () => {
+		const currentTimestamp = await mockWindow.getTime()
+		const questionData = {
+			title: 'Test question for security pool creation',
+			description: '',
+			startTime: 0n,
+			endTime: currentTimestamp + 365n * DAY,
+			numTicks: 0n,
+			displayValueMin: 0n,
+			displayValueMax: 0n,
+			answerUnit: '',
+		}
+		const outcomes = ['Yes', 'No']
+		const questionId = getQuestionId(questionData, outcomes)
+		await createQuestion(client, questionData, outcomes)
+
+		const result = await createSecurityPool(createWalletWriteClient(addressString(TEST_ADDRESSES[0])), {
+			currentRetentionRate: 999_999_996_848_000_000n,
+			questionId,
+			securityMultiplier: 2n,
+			startingRepEthPrice: 10n,
+		})
+
+		const expectedAddresses = getSecurityPoolAddresses(zeroAddress, 0n, questionId, 2n)
+
+		expect(result.questionId).toBe(`0x${questionId.toString(16).padStart(64, '0')}`)
+		expect(result.securityPoolAddress).toBe(expectedAddresses.securityPool)
+		expect(result.deployPoolHash.startsWith('0x')).toBe(true)
+	})
+})

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -131,6 +131,7 @@ export type SecurityPoolRouteContentProps = {
 	onCreateSecurityPool: () => void
 	onLoadMarket: () => void
 	onLoadMarketById: (marketId: string) => Promise<void>
+	onOpenCreatedPool?: (securityPoolAddress: Address) => void
 	loadingMarketDetails: boolean
 	marketDetails: MarketDetails | undefined
 	poolCreationMarketDetails: MarketDetails | undefined

--- a/ui/ts/types/contracts.ts
+++ b/ui/ts/types/contracts.ts
@@ -111,6 +111,7 @@ export type MarketDetails = QuestionData & {
 export type SecurityPoolCreationResult = {
 	deployPoolHash: Hash
 	questionId: string
+	securityPoolAddress: Address
 	securityMultiplier: bigint
 	universeId: bigint
 }


### PR DESCRIPTION
## Summary
- Extracted CREATE2 address derivation into shared TypeScript helpers under `shared/ts`.
- Updated simulator deployment utilities to consume the shared address/deployment helpers instead of duplicating logic.
- Replaced market-view loading text with spinner-style placeholders and added security pool creation UI coverage.
- Added shared build wiring so generated `shared/js` output is produced during setup and generation flows.

## Testing
- Not run (PR content prepared from the provided diff only).
- Suggested checks: `bun tsc`
- Suggested checks: `bun test`
- Suggested checks: `bun run format`
- Suggested checks: `bun run check`
- Suggested checks: `bun run knip`