### PR TITLE
Build UI before starting dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"ui:setup": "bun install --frozen-lockfile && cd solidity && bun install --frozen-lockfile && bun run setup && cd .. && bun run generate && cd ui && bun install --frozen-lockfile && bun run build && bun run build:tests",
 		"ui:build": "bun run generate && cd ui && bun install --frozen-lockfile && bun run build && bun run build:tests",
 		"ui:watch": "bun run ui:build && bun ./ui/build/watch.mts",
-		"ui:serve": "bun ./ui/dev-server.mjs",
+		"ui:serve": "bun run ui:build && bun ./ui/dev-server.mjs",
 		"ui:vendor": "cd ui && bun install --frozen-lockfile && bun ./build/vendor.mts",
 		"gas-costs": "cd solidity && bun run gas-costs",
 		"test": "bun run tsc && bun test --timeout 300000",


### PR DESCRIPTION
## Summary
- Updated `ui:serve` to run `ui:build` before launching the dev server.
- This ensures the UI assets are generated up front and reduces 404s for shared build output during local development.

## Testing
- Not run (change is limited to `package.json` script wiring).