### PR TITLE
Add editable vault input and unify loading spinners in market views

### DIFF
--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -131,6 +131,10 @@ export function SecurityVaultSection({
 					</MetricField>
 				</div>
 			)}
+			<label className='field'>
+				<span>Selected Vault Address</span>
+				<input value={normalizedSecurityVaultForm.selectedVaultAddress} onInput={event => onSecurityVaultFormChange({ selectedVaultAddress: event.currentTarget.value })} placeholder='0x...' />
+			</label>
 			{showSecurityPoolAddressInput ? (
 				<label className='field'>
 					<span>Security Pool Address</span>


### PR DESCRIPTION
## Summary
- Added a `Selected Vault Address` input to the security vault form so the selected vault can be edited directly.
- Replaced several loading text placeholders in market, oracle, and migration views with spinner-based loading states for a more consistent UI.
- Adjusted Zoltar migration guard messaging so loading states no longer surface redundant text while data is still being fetched.

## Testing
- Not run (PR summary only)
- Expected validation in repo: `bun tsc`
- Expected validation in repo: `bun test`
- Expected validation in repo: `bun run format`
- Expected validation in repo: `bun run check`
- Expected validation in repo: `bun run knip`