### PR TITLE
Rename UI dev server to TypeScript and tighten file serving

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"ui:setup": "bun install --frozen-lockfile && cd solidity && bun install --frozen-lockfile && bun run setup && cd .. && bun run generate && cd ui && bun install --frozen-lockfile && bun run build && bun run build:tests",
 		"ui:build": "bun run generate && cd ui && bun install --frozen-lockfile && bun run build && bun run build:tests",
 		"ui:watch": "bun run ui:build && bun ./ui/build/watch.mts",
-		"ui:serve": "bun run ui:build && bun ./ui/dev-server.mjs",
+		"ui:serve": "bun run ui:build && bun ./ui/dev-server.ts",
 		"ui:vendor": "cd ui && bun install --frozen-lockfile && bun ./build/vendor.mts",
 		"gas-costs": "cd solidity && bun run gas-costs",
 		"test": "bun run tsc && bun test --timeout 300000",

--- a/ui/build/watch.mts
+++ b/ui/build/watch.mts
@@ -7,7 +7,7 @@ import * as url from 'node:url'
 const directoryOfThisFile = path.dirname(url.fileURLToPath(import.meta.url))
 const UI_ROOT_PATH = path.join(directoryOfThisFile, '..')
 const REPOSITORY_ROOT_PATH = path.join(UI_ROOT_PATH, '..')
-const DEV_SERVER_PATH = path.join(UI_ROOT_PATH, 'dev-server.mjs')
+const DEV_SERVER_PATH = path.join(UI_ROOT_PATH, 'dev-server.ts')
 const INDEX_HTML_PATH = path.join(UI_ROOT_PATH, 'index.html')
 const TYPE_SCRIPT_OUTPUT_PATH = path.join(UI_ROOT_PATH, 'js')
 const TYPE_SCRIPT_SOURCE_PATH = path.join(UI_ROOT_PATH, 'ts')

--- a/ui/dev-server.ts
+++ b/ui/dev-server.ts
@@ -4,8 +4,20 @@ import * as path from 'node:path'
 import * as url from 'node:url'
 
 const directoryOfThisFile = path.dirname(url.fileURLToPath(import.meta.url))
-const rootDirectory = directoryOfThisFile
+const uiRootDirectory = directoryOfThisFile
+const repositoryRootDirectory = path.resolve(uiRootDirectory, '..')
 const liveReloadClients = new Set()
+
+const getServedFilePath = requestPath => {
+	const urlPath = requestPath.endsWith('/') ? `${ requestPath }index.html` : requestPath
+	const relativeFilePath = decodeURI(urlPath).replace(/^\/+/, '')
+	const baseDirectory = relativeFilePath.startsWith('shared/') ? repositoryRootDirectory : uiRootDirectory
+	const filePath = path.resolve(baseDirectory, relativeFilePath)
+	if (filePath !== baseDirectory && !filePath.startsWith(`${ baseDirectory }${ path.sep }`)) {
+		return undefined
+	}
+	return filePath
+}
 
 const sendLiveReloadEvent = reason => {
 	for (const client of liveReloadClients) {
@@ -47,10 +59,8 @@ server.on('request', async (request, response) => {
 			response.end()
 			return
 		}
-		const urlPath = requestPath.endsWith('/') ? `${ requestPath }index.html` : requestPath
-		const relativeFilePath = decodeURI(urlPath).replace(/^\/+/, '')
-		const filePath = path.resolve(rootDirectory, relativeFilePath)
-		if (!filePath.startsWith(rootDirectory)) {
+		const filePath = getServedFilePath(requestPath)
+		if (filePath === undefined) {
 			response.writeHead(403)
 			response.end()
 			return

--- a/ui/package.json
+++ b/ui/package.json
@@ -26,7 +26,7 @@
 		"build": "tsc",
 		"build:tests": "bun ./build/tests.mts",
 		"watch": "tsc --watch",
-		"serve": "bun x tsc --project tsconfig.json && bun ./dev-server.mjs",
+		"serve": "bun x tsc --project tsconfig.json && bun ./dev-server.ts",
 		"vendor": "bun install --frozen-lockfile && bun --tsconfig-override=tsconfig.vendor.json ./build/vendor.mts"
 	}
 }


### PR DESCRIPTION
## Summary
- Renamed the UI dev server entrypoint from `dev-server.mjs` to `dev-server.ts` and updated the root and UI package scripts to invoke the new file.
- Updated the UI watch workflow to point at the TypeScript dev server.
- Hardened static file serving so requests are resolved against either the UI root or repository root for `shared/` assets, with a stricter path escape check.

## Testing
- Not run (PR summary only).
- Concrete checks to run: `bun tsc`, `bun test`, `bun run format`, `bun run check`, `bun run knip`.