### PR TITLE
Improve open oracle quote errors and dev server file serving

### DIFF
--- a/ui/ts/components/OpenOracleSection.tsx
+++ b/ui/ts/components/OpenOracleSection.tsx
@@ -263,7 +263,11 @@ function renderReportDetailsCard(
 		defaultPrice: openOracleInitialReportState.defaultPrice,
 		defaultPriceSource: openOracleInitialReportState.defaultPriceSource,
 		priceInput: openOracleForm.price,
+		quoteAttemptedSources: openOracleInitialReportState.quoteAttemptedSources,
+		quoteFailureReason: openOracleInitialReportState.quoteFailureReason,
 		reportDetails: openOracleReportDetails,
+		token1AllowanceError: openOracleInitialReportState.token1AllowanceError,
+		token2AllowanceError: openOracleInitialReportState.token2AllowanceError,
 		token1Decimals: openOracleInitialReportState.token1Decimals ?? openOracleReportDetails.token1Decimals,
 		token2Decimals: openOracleInitialReportState.token2Decimals ?? openOracleReportDetails.token2Decimals,
 	})

--- a/ui/ts/hooks/useOpenOracleOperations.ts
+++ b/ui/ts/hooks/useOpenOracleOperations.ts
@@ -6,7 +6,7 @@ import type { Address } from 'viem'
 import { approveErc20, createOpenOracleReportInstance, disputeOracleReport, getOpenOracleAddress, loadErc20Allowance, loadOpenOracleReportDetails, settleOracleReport, submitInitialOracleReport } from '../contracts.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
 import { getErrorMessage } from '../lib/errors.js'
-import { deriveOpenOracleInitialReportSubmissionDetails, formatOpenOraclePriceInput, loadOpenOracleInitialReportPrice, OPEN_ORACLE_APPROVAL_AMOUNT } from '../lib/openOracle.js'
+import { deriveOpenOracleInitialReportSubmissionDetails, formatOpenOraclePriceInput, loadOpenOracleInitialReportPriceResult, OPEN_ORACLE_APPROVAL_AMOUNT } from '../lib/openOracle.js'
 import { requireDefined } from '../lib/required.js'
 import { buildWriteActionConfig, runWriteAction } from '../lib/writeAction.js'
 import { useRequestGuard } from '../lib/requestGuard.js'
@@ -29,8 +29,13 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 	const loadedOpenOracleReportId = useSignal<bigint | undefined>(undefined)
 	const openOracleInitialReportDefaultPrice = useSignal<string | undefined>(undefined)
 	const openOracleInitialReportDefaultPriceSource = useSignal<'Uniswap V4' | 'Uniswap V3 fallback' | undefined>(undefined)
+	const openOracleInitialReportQuoteAttemptedSources = useSignal<('Uniswap V4' | 'Uniswap V3 fallback')[] | undefined>(undefined)
+	const openOracleInitialReportQuoteFailureKind = useSignal<'unsupported-pair' | 'quote-failed' | undefined>(undefined)
+	const openOracleInitialReportQuoteFailureReason = useSignal<string | undefined>(undefined)
 	const openOracleInitialReportToken1Allowance = useSignal<bigint | undefined>(undefined)
+	const openOracleInitialReportToken1AllowanceError = useSignal<string | undefined>(undefined)
 	const openOracleInitialReportToken2Allowance = useSignal<bigint | undefined>(undefined)
+	const openOracleInitialReportToken2AllowanceError = useSignal<string | undefined>(undefined)
 	const nextOpenOracleInitialReportStateLoad = useRequestGuard()
 
 	const refreshOpenOracleInitialReportState = async (details: OpenOracleReportDetails | undefined) => {
@@ -39,32 +44,66 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 		if (currentDetails === undefined) {
 			openOracleInitialReportDefaultPrice.value = undefined
 			openOracleInitialReportDefaultPriceSource.value = undefined
+			openOracleInitialReportQuoteAttemptedSources.value = undefined
+			openOracleInitialReportQuoteFailureKind.value = undefined
+			openOracleInitialReportQuoteFailureReason.value = undefined
 			openOracleInitialReportToken1Allowance.value = undefined
+			openOracleInitialReportToken1AllowanceError.value = undefined
 			openOracleInitialReportToken2Allowance.value = undefined
+			openOracleInitialReportToken2AllowanceError.value = undefined
 			return
 		}
 
 		await openOracleInitialReportStateLoad.run({
 			isCurrent,
 			onStart: () => {
+				openOracleInitialReportDefaultPrice.value = undefined
+				openOracleInitialReportDefaultPriceSource.value = undefined
+				openOracleInitialReportQuoteAttemptedSources.value = undefined
+				openOracleInitialReportQuoteFailureKind.value = undefined
+				openOracleInitialReportQuoteFailureReason.value = undefined
 				openOracleInitialReportToken1Allowance.value = undefined
+				openOracleInitialReportToken1AllowanceError.value = undefined
 				openOracleInitialReportToken2Allowance.value = undefined
+				openOracleInitialReportToken2AllowanceError.value = undefined
 			},
 			load: async () => {
 				const readClient = createConnectedReadClient()
-				const [initialPrice, token1Allowance, token2Allowance] = await Promise.all([
-					loadOpenOracleInitialReportPrice(readClient, currentDetails.token1, currentDetails.token2, currentDetails.exactToken1Report).catch(() => undefined),
-					accountAddress === undefined ? Promise.resolve(undefined) : loadErc20Allowance(readClient, currentDetails.token1, accountAddress, getOpenOracleAddress()).catch(() => undefined),
-					accountAddress === undefined ? Promise.resolve(undefined) : loadErc20Allowance(readClient, currentDetails.token2, accountAddress, getOpenOracleAddress()).catch(() => undefined),
-				])
+				const loadAllowance = async (tokenAddress: Address) => {
+					if (accountAddress === undefined) {
+						return { allowance: undefined, error: undefined }
+					}
 
-				return { initialPrice, token1Allowance, token2Allowance }
+					try {
+						return {
+							allowance: await loadErc20Allowance(readClient, tokenAddress, accountAddress, getOpenOracleAddress()),
+							error: undefined,
+						}
+					} catch (error) {
+						return {
+							allowance: undefined,
+							error: getErrorMessage(error, 'Failed to load token approval'),
+						}
+					}
+				}
+
+				const [initialPriceResult, token1AllowanceResult, token2AllowanceResult] = await Promise.all([loadOpenOracleInitialReportPriceResult(readClient, currentDetails.token1, currentDetails.token2, currentDetails.exactToken1Report), loadAllowance(currentDetails.token1), loadAllowance(currentDetails.token2)])
+
+				return { initialPriceResult, token1AllowanceResult, token2AllowanceResult }
 			},
-			onSuccess: ({ initialPrice, token1Allowance, token2Allowance }) => {
+			onSuccess: ({ initialPriceResult, token1AllowanceResult, token2AllowanceResult }) => {
+				const initialPrice = initialPriceResult.status === 'success' ? initialPriceResult : undefined
+				const priceFailure = initialPriceResult.status === 'failure' ? initialPriceResult : undefined
+
 				openOracleInitialReportDefaultPrice.value = initialPrice === undefined ? undefined : formatOpenOraclePriceInput(initialPrice.price)
 				openOracleInitialReportDefaultPriceSource.value = initialPrice?.priceSource
-				openOracleInitialReportToken1Allowance.value = token1Allowance
-				openOracleInitialReportToken2Allowance.value = token2Allowance
+				openOracleInitialReportQuoteAttemptedSources.value = priceFailure?.attemptedSources
+				openOracleInitialReportQuoteFailureKind.value = priceFailure?.failureKind
+				openOracleInitialReportQuoteFailureReason.value = priceFailure?.reason
+				openOracleInitialReportToken1Allowance.value = token1AllowanceResult.allowance
+				openOracleInitialReportToken1AllowanceError.value = token1AllowanceResult.error
+				openOracleInitialReportToken2Allowance.value = token2AllowanceResult.allowance
+				openOracleInitialReportToken2AllowanceError.value = token2AllowanceResult.error
 
 				if (openOracleForm.value.price.trim() === '' || openOracleForm.value.reportId.trim() !== currentDetails.reportId.toString()) {
 					openOracleForm.value = {
@@ -110,8 +149,13 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 				loadedOpenOracleReportId.value = undefined
 				openOracleInitialReportDefaultPrice.value = undefined
 				openOracleInitialReportDefaultPriceSource.value = undefined
+				openOracleInitialReportQuoteAttemptedSources.value = undefined
+				openOracleInitialReportQuoteFailureKind.value = undefined
+				openOracleInitialReportQuoteFailureReason.value = undefined
 				openOracleInitialReportToken1Allowance.value = undefined
+				openOracleInitialReportToken1AllowanceError.value = undefined
 				openOracleInitialReportToken2Allowance.value = undefined
+				openOracleInitialReportToken2AllowanceError.value = undefined
 				openOracleError.value = getErrorMessage(error, 'Failed to load oracle report')
 			},
 		})
@@ -134,7 +178,10 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 
 	const runOracleAction = async (action: (walletAddress: Address) => Promise<OpenOracleActionResult>, errorFallback: string) =>
 		await runWriteAction(
-			buildWriteActionConfig({ accountAddress, onTransaction, onTransactionFinished, onTransactionRequested, refreshState }, openOracleError, 'Connect a wallet before operating open oracle'),
+			{
+				...buildWriteActionConfig({ accountAddress, onTransaction, onTransactionFinished, onTransactionRequested, refreshState }, openOracleError, 'Connect a wallet before operating open oracle'),
+				refreshErrorFallback: 'Oracle transaction succeeded, but refreshing the selected report failed',
+			},
 			async walletAddress => {
 				openOracleResult.value = undefined
 				return await action(walletAddress)
@@ -210,7 +257,11 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 				defaultPrice: openOracleInitialReportDefaultPrice.value,
 				defaultPriceSource: openOracleInitialReportDefaultPriceSource.value,
 				priceInput: openOracleForm.value.price,
+				quoteAttemptedSources: openOracleInitialReportQuoteAttemptedSources.value,
+				quoteFailureReason: openOracleInitialReportQuoteFailureReason.value,
 				reportDetails,
+				token1AllowanceError: openOracleInitialReportToken1AllowanceError.value,
+				token2AllowanceError: openOracleInitialReportToken2AllowanceError.value,
 				token1Decimals: reportDetails.token1Decimals,
 				token2Decimals: reportDetails.token2Decimals,
 			})
@@ -264,9 +315,14 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 			defaultPrice: openOracleInitialReportDefaultPrice.value,
 			defaultPriceSource: openOracleInitialReportDefaultPriceSource.value,
 			loading: openOracleInitialReportStateLoad.isLoading.value,
+			quoteAttemptedSources: openOracleInitialReportQuoteAttemptedSources.value,
+			quoteFailureKind: openOracleInitialReportQuoteFailureKind.value,
+			quoteFailureReason: openOracleInitialReportQuoteFailureReason.value,
 			token1Allowance: openOracleInitialReportToken1Allowance.value,
+			token1AllowanceError: openOracleInitialReportToken1AllowanceError.value,
 			token1Decimals: openOracleReportDetails.value?.token1Decimals,
 			token2Allowance: openOracleInitialReportToken2Allowance.value,
+			token2AllowanceError: openOracleInitialReportToken2AllowanceError.value,
 			token2Decimals: openOracleReportDetails.value?.token2Decimals,
 		},
 		openOracleReportDetails: openOracleReportDetails.value,

--- a/ui/ts/hooks/usePriceOracleManager.ts
+++ b/ui/ts/hooks/usePriceOracleManager.ts
@@ -45,6 +45,7 @@ export function usePriceOracleManager({ accountAddress, onTransaction, onTransac
 				onTransaction,
 				onTransactionFinished,
 				onTransactionRequested,
+				refreshErrorFallback: 'Price request succeeded, but refreshing price oracle details failed',
 				refreshState: async () => {
 					await loadPoolOracleManager(managerAddress)
 				},

--- a/ui/ts/hooks/useReportingOperations.ts
+++ b/ui/ts/hooks/useReportingOperations.ts
@@ -42,7 +42,10 @@ export function useReportingOperations({ accountAddress, onTransaction, onTransa
 	const runReportingAction = async (action: (walletAddress: Address, securityPoolAddress: Address, currentForm: ReportingFormState) => Promise<ReportingActionResult>, errorFallback: string) => {
 		const currentForm = reportingForm.value
 		await runWriteAction(
-			buildWriteActionConfig({ accountAddress, onTransaction, onTransactionFinished, onTransactionRequested, refreshState }, reportingError, 'Connect a wallet before reporting on a market'),
+			{
+				...buildWriteActionConfig({ accountAddress, onTransaction, onTransactionFinished, onTransactionRequested, refreshState }, reportingError, 'Connect a wallet before reporting on a market'),
+				refreshErrorFallback: 'Reporting transaction succeeded, but refreshing reporting details failed',
+			},
 			async walletAddress => {
 				reportingResult.value = undefined
 				const securityPoolAddress = parseAddressInput(currentForm.securityPoolAddress, 'Security pool address')

--- a/ui/ts/lib/openOracle.ts
+++ b/ui/ts/lib/openOracle.ts
@@ -11,6 +11,21 @@ export const OPEN_ORACLE_APPROVAL_AMOUNT = maxUint256
 type OpenOracleReportStatus = 'Awaiting Initial Report' | 'Pending' | 'Disputed' | 'Settled'
 export type OpenOracleSelectedReportActionMode = 'initial-report' | 'dispute' | 'read-only'
 export type OpenOracleInitialReportPriceSource = 'Uniswap V4' | 'Uniswap V3 fallback' | 'Manual override' | 'Unavailable'
+export type OpenOracleInitialReportQuoteSource = Exclude<OpenOracleInitialReportPriceSource, 'Manual override' | 'Unavailable'>
+export type OpenOracleInitialReportQuoteFailureKind = 'unsupported-pair' | 'quote-failed'
+type OpenOracleInitialReportPriceLoadResult =
+	| {
+			status: 'success'
+			price: bigint
+			priceSource: OpenOracleInitialReportQuoteSource
+			token2Amount: bigint
+	  }
+	| {
+			attemptedSources: OpenOracleInitialReportQuoteSource[]
+			failureKind: OpenOracleInitialReportQuoteFailureKind
+			reason: string | undefined
+			status: 'failure'
+	  }
 
 type OpenOracleInitialReportSubmissionDetails = {
 	amount1: bigint | undefined
@@ -87,37 +102,142 @@ export function formatOpenOraclePriceInput(price: bigint | undefined) {
 	return price === undefined ? '' : formatCurrencyInputBalance(price)
 }
 
-export async function loadOpenOracleInitialReportPrice(
-	client: Parameters<typeof quoteExactInput>[0],
-	token1: Parameters<typeof quoteExactInput>[1],
-	token2: Parameters<typeof quoteExactInput>[2],
-	token1Amount: bigint,
-): Promise<{ price: bigint; priceSource: Exclude<OpenOracleInitialReportPriceSource, 'Manual override' | 'Unavailable'>; token2Amount: bigint } | undefined> {
+function supportsOpenOracleV3Fallback(token1: Parameters<typeof quoteExactInput>[1], token2: Parameters<typeof quoteExactInput>[2]) {
+	return (token1 === REP_ADDRESS && token2 === ETH_ADDRESS) || (token1 === ETH_ADDRESS && token2 === REP_ADDRESS)
+}
+
+function extractOpenOracleQuoteFailureReason(error: unknown) {
+	if (error instanceof Error) return error.message
+	if (typeof error === 'string') return error
+	try {
+		return JSON.stringify(error)
+	} catch {
+		return undefined
+	}
+}
+
+function sanitizeOpenOracleFailureReason(reason: string | undefined) {
+	if (reason === undefined) return undefined
+
+	let sanitized = reason.trim().replace(/\s+/g, ' ')
+	if (sanitized === '' || ((sanitized.startsWith('{') || sanitized.startsWith('[')) && (sanitized.endsWith('}') || sanitized.endsWith(']')))) {
+		return undefined
+	}
+
+	sanitized = sanitized.replace(/^(failed to [^:]+:\s*)+/i, '')
+	sanitized = sanitized.replace(/\.$/, '')
+	if (sanitized === '') return undefined
+
+	const maxLength = 140
+	return sanitized.length > maxLength ? `${sanitized.slice(0, maxLength - 3).trimEnd()}...` : sanitized
+}
+
+function formatOpenOracleQuoteAttemptedSources(attemptedSources: OpenOracleInitialReportQuoteSource[]) {
+	if (attemptedSources.length === 0) return undefined
+	if (attemptedSources.length === 1) return attemptedSources[0]
+
+	const [firstSource, ...remainingSources] = attemptedSources
+	const lastSource = remainingSources.pop()
+	if (lastSource === undefined) return firstSource
+
+	if (remainingSources.length === 0) return `${firstSource}, then ${lastSource}`
+	return `${firstSource}, ${remainingSources.join(', ')}, then ${lastSource}`
+}
+
+export function formatOpenOracleInitialReportPriceUnavailableMessage({ attemptedSources, reason, token1Label, token2Label }: { attemptedSources: OpenOracleInitialReportQuoteSource[] | undefined; reason: string | undefined; token1Label: string | undefined; token2Label: string | undefined }) {
+	const resolvedToken1Label = token1Label?.trim() || 'Token1'
+	const resolvedToken2Label = token2Label?.trim() || 'Token2'
+	const segments = [`Automatic price quote unavailable for ${resolvedToken1Label} / ${resolvedToken2Label}.`]
+	const attemptedSourceText = attemptedSources === undefined ? undefined : formatOpenOracleQuoteAttemptedSources(attemptedSources)
+	const sanitizedReason = sanitizeOpenOracleFailureReason(reason)
+
+	if (attemptedSourceText !== undefined) {
+		segments.push(`Tried: ${attemptedSourceText}.`)
+	}
+	if (sanitizedReason !== undefined) {
+		segments.push(`Reason: ${sanitizedReason}.`)
+	}
+	segments.push('Enter a price manually to submit the initial report.')
+
+	return segments.join(' ')
+}
+
+export function formatOpenOracleInitialReportApprovalStatusUnavailableMessage({ reason, tokenLabel }: { reason: string | undefined; tokenLabel: string | undefined }) {
+	const resolvedTokenLabel = tokenLabel?.trim() || 'token'
+	const segments = [`Unable to verify ${resolvedTokenLabel} approval for this report.`]
+	const sanitizedReason = sanitizeOpenOracleFailureReason(reason)
+
+	if (sanitizedReason !== undefined) {
+		segments.push(`Reason: ${sanitizedReason}.`)
+	}
+	segments.push('Retry loading the report or approval status before submitting the initial report.')
+
+	return segments.join(' ')
+}
+
+export async function loadOpenOracleInitialReportPriceResult(client: Parameters<typeof quoteExactInput>[0], token1: Parameters<typeof quoteExactInput>[1], token2: Parameters<typeof quoteExactInput>[2], token1Amount: bigint): Promise<OpenOracleInitialReportPriceLoadResult> {
+	const attemptedSources: OpenOracleInitialReportQuoteSource[] = ['Uniswap V4']
+
 	try {
 		const token2Amount = await quoteExactInput(client, token1, token2, token1Amount)
 		const price = calculateOpenOraclePrice(token1Amount, token2Amount)
-		if (price === undefined) return undefined
-		return { price, priceSource: 'Uniswap V4', token2Amount }
-	} catch {
+		if (price !== undefined) {
+			return { price, priceSource: 'Uniswap V4', status: 'success', token2Amount }
+		}
+		return { attemptedSources, failureKind: 'quote-failed', reason: 'Uniswap V4 returned an unusable quote', status: 'failure' }
+	} catch (error) {
+		if (!supportsOpenOracleV3Fallback(token1, token2)) {
+			return {
+				attemptedSources,
+				failureKind: 'unsupported-pair',
+				reason: extractOpenOracleQuoteFailureReason(error),
+				status: 'failure',
+			}
+		}
+
+		attemptedSources.push('Uniswap V3 fallback')
 		try {
 			if (token1 === REP_ADDRESS && token2 === ETH_ADDRESS) {
 				const ethPerRep = await quoteRepForEthV3(client, ONE_REP)
 				const token2Amount = (token1Amount * ethPerRep) / ONE_REP
 				const price = calculateOpenOraclePrice(token1Amount, token2Amount)
-				if (price === undefined) return undefined
-				return { price, priceSource: 'Uniswap V3 fallback', token2Amount }
+				if (price !== undefined) {
+					return { price, priceSource: 'Uniswap V3 fallback', status: 'success', token2Amount }
+				}
 			}
 			if (token1 === ETH_ADDRESS && token2 === REP_ADDRESS) {
 				const ethPerRep = await quoteRepForEthV3(client, ONE_REP)
 				const token2Amount = (token1Amount * ONE_REP) / ethPerRep
 				const price = calculateOpenOraclePrice(token1Amount, token2Amount)
-				if (price === undefined) return undefined
-				return { price, priceSource: 'Uniswap V3 fallback', token2Amount }
+				if (price !== undefined) {
+					return { price, priceSource: 'Uniswap V3 fallback', status: 'success', token2Amount }
+				}
 			}
-		} catch {
-			return undefined
+			return { attemptedSources, failureKind: 'quote-failed', reason: 'Uniswap V3 fallback returned an unusable quote', status: 'failure' }
+		} catch (fallbackError) {
+			return {
+				attemptedSources,
+				failureKind: 'quote-failed',
+				reason: extractOpenOracleQuoteFailureReason(fallbackError),
+				status: 'failure',
+			}
 		}
-		return undefined
+	}
+}
+
+export async function loadOpenOracleInitialReportPrice(
+	client: Parameters<typeof quoteExactInput>[0],
+	token1: Parameters<typeof quoteExactInput>[1],
+	token2: Parameters<typeof quoteExactInput>[2],
+	token1Amount: bigint,
+): Promise<{ price: bigint; priceSource: OpenOracleInitialReportQuoteSource; token2Amount: bigint } | undefined> {
+	const result = await loadOpenOracleInitialReportPriceResult(client, token1, token2, token1Amount)
+	if (result.status === 'failure') return undefined
+
+	return {
+		price: result.price,
+		priceSource: result.priceSource,
+		token2Amount: result.token2Amount,
 	}
 }
 
@@ -127,7 +247,11 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 	defaultPrice,
 	defaultPriceSource,
 	priceInput,
+	quoteAttemptedSources,
+	quoteFailureReason,
 	reportDetails,
+	token1AllowanceError,
+	token2AllowanceError,
 	token1Decimals,
 	token2Decimals,
 }: {
@@ -136,11 +260,19 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 	defaultPrice: string | undefined
 	defaultPriceSource: OpenOracleInitialReportPriceSource | undefined
 	priceInput: string
+	quoteAttemptedSources: OpenOracleInitialReportQuoteSource[] | undefined
+	quoteFailureReason: string | undefined
 	reportDetails:
 		| {
 				exactToken1Report: bigint
+				token1?: string | undefined
+				token1Symbol?: string | undefined
+				token2?: string | undefined
+				token2Symbol?: string | undefined
 		  }
 		| undefined
+	token1AllowanceError: string | undefined
+	token2AllowanceError: string | undefined
 	token1Decimals: number | undefined
 	token2Decimals: number | undefined
 }): OpenOracleInitialReportSubmissionDetails {
@@ -160,9 +292,24 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 	if (reportDetails === undefined) {
 		blockReason = 'Load a report first'
 	} else if (resolvedPriceInput === '') {
-		blockReason = 'Price unavailable'
+		blockReason = formatOpenOracleInitialReportPriceUnavailableMessage({
+			attemptedSources: quoteAttemptedSources,
+			reason: quoteFailureReason,
+			token1Label: reportDetails.token1Symbol ?? reportDetails.token1,
+			token2Label: reportDetails.token2Symbol ?? reportDetails.token2,
+		})
 	} else if (price === undefined || price <= 0n || amount2 === undefined || amount2 <= 0n) {
 		blockReason = 'Invalid price'
+	} else if (approvedToken1Amount === undefined && token1AllowanceError !== undefined) {
+		blockReason = formatOpenOracleInitialReportApprovalStatusUnavailableMessage({
+			reason: token1AllowanceError,
+			tokenLabel: reportDetails.token1Symbol ?? reportDetails.token1,
+		})
+	} else if (approvedToken2Amount === undefined && token2AllowanceError !== undefined) {
+		blockReason = formatOpenOracleInitialReportApprovalStatusUnavailableMessage({
+			reason: token2AllowanceError,
+			tokenLabel: reportDetails.token2Symbol ?? reportDetails.token2,
+		})
 	} else if (amount1 === undefined || approvedToken1Amount === undefined || approvedToken1Amount < amount1) {
 		blockReason = 'Token1 approval required'
 	} else if (approvedToken2Amount === undefined || approvedToken2Amount < amount2) {

--- a/ui/ts/lib/writeAction.ts
+++ b/ui/ts/lib/writeAction.ts
@@ -8,6 +8,7 @@ type RunWriteActionParameters = {
 	onTransaction: (hash: Hash) => void
 	onTransactionFinished: () => void
 	onTransactionRequested: () => void
+	refreshErrorFallback?: string
 	refreshState: () => Promise<void>
 	setErrorMessage: (message: string | undefined) => void
 }
@@ -33,15 +34,24 @@ export async function runWriteAction<TResult extends { hash: Hash }>(parameters:
 	}
 
 	try {
-		parameters.onTransactionRequested()
-		parameters.setErrorMessage(undefined)
-		const result = await action(parameters.accountAddress)
-		if (result === undefined) return
-		await Promise.resolve(parameters.onTransaction(result.hash))
-		await onSuccess?.(result, parameters.accountAddress)
-		await parameters.refreshState()
-	} catch (error) {
-		parameters.setErrorMessage(getErrorMessage(error, errorFallback))
+		let result: TResult | undefined
+		try {
+			parameters.onTransactionRequested()
+			parameters.setErrorMessage(undefined)
+			result = await action(parameters.accountAddress)
+			if (result === undefined) return
+			await Promise.resolve(parameters.onTransaction(result.hash))
+		} catch (error) {
+			parameters.setErrorMessage(getErrorMessage(error, errorFallback))
+			return
+		}
+
+		try {
+			await onSuccess?.(result, parameters.accountAddress)
+			await parameters.refreshState()
+		} catch (error) {
+			parameters.setErrorMessage(getErrorMessage(error, parameters.refreshErrorFallback ?? 'Transaction succeeded, but refreshing the UI failed'))
+		}
 	} finally {
 		await Promise.resolve(parameters.onTransactionFinished())
 	}

--- a/ui/ts/tests/openOracle.test.ts
+++ b/ui/ts/tests/openOracle.test.ts
@@ -3,7 +3,18 @@
 import { beforeEach, describe, expect, setDefaultTimeout, test } from 'bun:test'
 import { getAddress, maxUint256, zeroAddress, type Address } from 'viem'
 import { createOpenOracleReportInstance, getOpenOracleAddress, loadOpenOracleReportDetails, loadOpenOracleReportSummaries, loadOracleManagerDetails, requestOraclePrice, settleOracleReport, submitInitialOracleReport } from '../contracts.js'
-import { deriveOpenOracleInitialReportSubmissionDetails, formatOpenOracleFeePercentage, formatOpenOracleMultiplier, loadOpenOracleInitialReportPrice, OPEN_ORACLE_APPROVAL_AMOUNT, getOpenOracleReportStatus, getOpenOracleSelectedReportActionMode } from '../lib/openOracle.js'
+import {
+	deriveOpenOracleInitialReportSubmissionDetails,
+	formatOpenOracleFeePercentage,
+	formatOpenOracleInitialReportApprovalStatusUnavailableMessage,
+	formatOpenOracleInitialReportPriceUnavailableMessage,
+	formatOpenOracleMultiplier,
+	getOpenOracleReportStatus,
+	getOpenOracleSelectedReportActionMode,
+	loadOpenOracleInitialReportPrice,
+	loadOpenOracleInitialReportPriceResult,
+	OPEN_ORACLE_APPROVAL_AMOUNT,
+} from '../lib/openOracle.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
 import type { InjectedEthereum } from '../injectedEthereum.js'
 import { DAY, GENESIS_REPUTATION_TOKEN, WETH_ADDRESS, TEST_ADDRESSES } from '../../../solidity/ts/testsuite/simulator/utils/constants'
@@ -36,6 +47,14 @@ const outcomes = ['Yes', 'No']
 function createQuoteClient(amountOut: bigint): Parameters<typeof loadOpenOracleInitialReportPrice>[0] {
 	return {
 		simulateContract: async () => ({ result: [amountOut, 100000n] }),
+	} as unknown as Parameters<typeof loadOpenOracleInitialReportPrice>[0]
+}
+
+function createFailingQuoteClient(message: string): Parameters<typeof loadOpenOracleInitialReportPrice>[0] {
+	return {
+		simulateContract: async () => {
+			throw new Error(message)
+		},
 	} as unknown as Parameters<typeof loadOpenOracleInitialReportPrice>[0]
 }
 
@@ -123,25 +142,22 @@ describe('Open Oracle helpers', () => {
 		expect(firstPage.reports.map(report => report.price)).toEqual([0n, 0n])
 	})
 
-	test('initial report price helpers derive a Uniswap default price and can fall back to manual input', async () => {
+	test('initial report price helpers derive a Uniswap default price and preserve quote failure metadata', async () => {
 		const quote = await loadOpenOracleInitialReportPrice(createQuoteClient(25n), getAddress('0x00000000000000000000000000000000000000a1'), getAddress('0x00000000000000000000000000000000000000a2'), 100n)
 		expect(quote).toEqual({
 			price: 4_000_000_000_000_000_000n,
 			priceSource: 'Uniswap V4',
 			token2Amount: 25n,
 		})
-		await expect(
-			loadOpenOracleInitialReportPrice(
-				{
-					simulateContract: async () => {
-						throw new Error('no pool')
-					},
-				} as unknown as Parameters<typeof loadOpenOracleInitialReportPrice>[0],
-				getAddress('0x00000000000000000000000000000000000000a1'),
-				getAddress('0x00000000000000000000000000000000000000a2'),
-				100n,
-			),
-		).resolves.toBeUndefined()
+
+		const failure = await loadOpenOracleInitialReportPriceResult(createFailingQuoteClient('no pool'), getAddress('0x00000000000000000000000000000000000000a1'), getAddress('0x00000000000000000000000000000000000000a2'), 100n)
+		expect(failure).toEqual({
+			attemptedSources: ['Uniswap V4'],
+			failureKind: 'unsupported-pair',
+			reason: 'no pool',
+			status: 'failure',
+		})
+		await expect(loadOpenOracleInitialReportPrice(createFailingQuoteClient('no pool'), getAddress('0x00000000000000000000000000000000000000a1'), getAddress('0x00000000000000000000000000000000000000a2'), 100n)).resolves.toBeUndefined()
 	})
 
 	test('initial report submission helper computes preview amounts and approval gating', () => {
@@ -154,7 +170,11 @@ describe('Open Oracle helpers', () => {
 			defaultPrice: '4.0',
 			defaultPriceSource: 'Uniswap V4',
 			priceInput: '',
+			quoteAttemptedSources: undefined,
+			quoteFailureReason: undefined,
 			reportDetails: details,
+			token1AllowanceError: undefined,
+			token2AllowanceError: undefined,
 			token1Decimals: 18,
 			token2Decimals: 18,
 		})
@@ -165,6 +185,123 @@ describe('Open Oracle helpers', () => {
 		expect(preview.amount2).toBe(25n)
 		expect(preview.canSubmit).toBe(false)
 		expect(preview.blockReason).toBe('Token2 approval required')
+	})
+
+	test('initial report submission helper explains unsupported quote paths for non-REP pairs', () => {
+		const preview = deriveOpenOracleInitialReportSubmissionDetails({
+			approvedToken1Amount: 100n,
+			approvedToken2Amount: 100n,
+			defaultPrice: undefined,
+			defaultPriceSource: undefined,
+			priceInput: '',
+			quoteAttemptedSources: ['Uniswap V4'],
+			quoteFailureReason: undefined,
+			reportDetails: {
+				exactToken1Report: 100n,
+				token1Symbol: 'ABC',
+				token2Symbol: 'XYZ',
+			},
+			token1AllowanceError: undefined,
+			token2AllowanceError: undefined,
+			token1Decimals: 18,
+			token2Decimals: 18,
+		})
+
+		expect(preview.canSubmit).toBe(false)
+		expect(preview.blockReason).toBe('Automatic price quote unavailable for ABC / XYZ. Tried: Uniswap V4. Enter a price manually to submit the initial report.')
+	})
+
+	test('initial report submission helper explains exhausted REP fallback paths with a short reason', () => {
+		const preview = deriveOpenOracleInitialReportSubmissionDetails({
+			approvedToken1Amount: 100n,
+			approvedToken2Amount: 100n,
+			defaultPrice: undefined,
+			defaultPriceSource: undefined,
+			priceInput: '',
+			quoteAttemptedSources: ['Uniswap V4', 'Uniswap V3 fallback'],
+			quoteFailureReason: 'Failed to load automatic price: execution reverted: pool not found',
+			reportDetails: {
+				exactToken1Report: 100n,
+				token1Symbol: 'REP',
+				token2Symbol: 'ETH',
+			},
+			token1AllowanceError: undefined,
+			token2AllowanceError: undefined,
+			token1Decimals: 18,
+			token2Decimals: 18,
+		})
+
+		expect(preview.canSubmit).toBe(false)
+		expect(preview.blockReason).toBe('Automatic price quote unavailable for REP / ETH. Tried: Uniswap V4, then Uniswap V3 fallback. Reason: execution reverted: pool not found. Enter a price manually to submit the initial report.')
+	})
+
+	test('manual price entry overrides automatic quote unavailability', () => {
+		const preview = deriveOpenOracleInitialReportSubmissionDetails({
+			approvedToken1Amount: 100n,
+			approvedToken2Amount: 24n,
+			defaultPrice: undefined,
+			defaultPriceSource: undefined,
+			priceInput: '4.0',
+			quoteAttemptedSources: ['Uniswap V4'],
+			quoteFailureReason: 'no pool',
+			reportDetails: {
+				exactToken1Report: 100n,
+				token1Symbol: 'ABC',
+				token2Symbol: 'XYZ',
+			},
+			token1AllowanceError: undefined,
+			token2AllowanceError: undefined,
+			token1Decimals: 18,
+			token2Decimals: 18,
+		})
+
+		expect(preview.priceSource).toBe('Manual override')
+		expect(preview.price).toBe(4_000_000_000_000_000_000n)
+		expect(preview.blockReason).toBe('Token2 approval required')
+	})
+
+	test('formats unavailable price messages with sanitized reasons and address fallback labels', () => {
+		expect(
+			formatOpenOracleInitialReportPriceUnavailableMessage({
+				attemptedSources: ['Uniswap V4'],
+				reason: 'Failed to load automatic price: execution reverted: pool not found',
+				token1Label: undefined,
+				token2Label: '0x00000000000000000000000000000000000000a2',
+			}),
+		).toBe('Automatic price quote unavailable for Token1 / 0x00000000000000000000000000000000000000a2. Tried: Uniswap V4. Reason: execution reverted: pool not found. Enter a price manually to submit the initial report.')
+	})
+
+	test('initial report submission helper surfaces allowance read failures separately from approval gating', () => {
+		const preview = deriveOpenOracleInitialReportSubmissionDetails({
+			approvedToken1Amount: undefined,
+			approvedToken2Amount: 25n,
+			defaultPrice: '4.0',
+			defaultPriceSource: 'Uniswap V4',
+			priceInput: '',
+			quoteAttemptedSources: undefined,
+			quoteFailureReason: undefined,
+			reportDetails: {
+				exactToken1Report: 100n,
+				token1Symbol: 'REP',
+				token2Symbol: 'ETH',
+			},
+			token1AllowanceError: 'Failed to load token approval: request timed out',
+			token2AllowanceError: undefined,
+			token1Decimals: 18,
+			token2Decimals: 18,
+		})
+
+		expect(preview.canSubmit).toBe(false)
+		expect(preview.blockReason).toBe('Unable to verify REP approval for this report. Reason: request timed out. Retry loading the report or approval status before submitting the initial report.')
+	})
+
+	test('formats unavailable approval status messages with sanitized reasons', () => {
+		expect(
+			formatOpenOracleInitialReportApprovalStatusUnavailableMessage({
+				reason: 'Failed to load token approval: execution reverted',
+				tokenLabel: 'WETH',
+			}),
+		).toBe('Unable to verify WETH approval for this report. Reason: execution reverted. Retry loading the report or approval status before submitting the initial report.')
 	})
 
 	test('open oracle fee and multiplier formatters render human values', () => {

--- a/ui/ts/tests/writeAction.test.ts
+++ b/ui/ts/tests/writeAction.test.ts
@@ -1,0 +1,64 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { getAddress } from 'viem'
+import { runWriteAction } from '../lib/writeAction.js'
+
+const walletAddress = getAddress('0x00000000000000000000000000000000000000a1')
+const transactionHash = '0x00000000000000000000000000000000000000000000000000000000000000a1'
+
+describe('runWriteAction', () => {
+	test('uses the action fallback when the write action fails', async () => {
+		let errorMessage: string | undefined
+
+		await runWriteAction(
+			{
+				accountAddress: walletAddress,
+				missingWalletMessage: 'Connect wallet',
+				onTransaction: () => undefined,
+				onTransactionFinished: () => undefined,
+				onTransactionRequested: () => undefined,
+				refreshState: async () => undefined,
+				setErrorMessage: message => {
+					errorMessage = message
+				},
+			},
+			async () => {
+				throw new Error('execution reverted')
+			},
+			'Failed to report on outcome',
+		)
+
+		expect(errorMessage).toBe('Failed to report on outcome: execution reverted')
+	})
+
+	test('uses the refresh fallback when post-transaction refresh fails', async () => {
+		let errorMessage: string | undefined
+		let onSuccessCalled = false
+
+		await runWriteAction(
+			{
+				accountAddress: walletAddress,
+				missingWalletMessage: 'Connect wallet',
+				onTransaction: () => undefined,
+				onTransactionFinished: () => undefined,
+				onTransactionRequested: () => undefined,
+				refreshErrorFallback: 'Reporting transaction succeeded, but refreshing reporting details failed',
+				refreshState: async () => {
+					throw new Error('RPC unavailable')
+				},
+				setErrorMessage: message => {
+					errorMessage = message
+				},
+			},
+			async () => ({ hash: transactionHash }),
+			'Failed to report on outcome',
+			async () => {
+				onSuccessCalled = true
+			},
+		)
+
+		expect(onSuccessCalled).toBe(true)
+		expect(errorMessage).toBe('Reporting transaction succeeded, but refreshing reporting details failed: RPC unavailable')
+	})
+})

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -22,7 +22,7 @@ import type {
 	ZoltarMigrationActionResult,
 	ZoltarUniverseSummary,
 } from './contracts.js'
-import type { OpenOracleInitialReportPriceSource } from '../lib/openOracle.js'
+import type { OpenOracleInitialReportPriceSource, OpenOracleInitialReportQuoteFailureKind, OpenOracleInitialReportQuoteSource } from '../lib/openOracle.js'
 
 export type DeploymentSectionProps = {
 	title: string
@@ -257,9 +257,14 @@ export type OpenOracleRouteContentProps = {
 		defaultPrice: string | undefined
 		defaultPriceSource: OpenOracleInitialReportPriceSource | undefined
 		loading: boolean
+		quoteAttemptedSources: OpenOracleInitialReportQuoteSource[] | undefined
+		quoteFailureKind: OpenOracleInitialReportQuoteFailureKind | undefined
+		quoteFailureReason: string | undefined
 		token1Allowance: bigint | undefined
+		token1AllowanceError: string | undefined
 		token1Decimals: number | undefined
 		token2Allowance: bigint | undefined
+		token2AllowanceError: string | undefined
 		token2Decimals: number | undefined
 	}
 	openOracleCreateForm: OpenOracleCreateFormState


### PR DESCRIPTION
## Summary
- Added richer open oracle quote handling with fallback metadata, clearer failure reasons, and better submission/approval blocking messages.
- Propagated quote and allowance error state through the open oracle UI so users can see why an initial report is blocked.
- Improved write-action refresh handling so post-transaction refresh failures surface dedicated fallback errors instead of masking the original success.
- Updated the dev server to serve static files from the repository root as well as `ui/`.

## Testing
- `bun tsc` — Not run
- `bun test` — Not run
- `bun run format` — Not run
- `bun run check` — Not run
- `bun run knip` — Not run