### PR TITLE
Refine security pool lookup and workflow states

### DIFF
--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -25,7 +25,7 @@ import { useSecurityVaultOperations } from './hooks/useSecurityVaultOperations.j
 import { useTradingOperations } from './hooks/useTradingOperations.js'
 import { useUrlState } from './hooks/useUrlState.js'
 import { getDeploymentSections } from './lib/deployment.js'
-import { resolveMissingAwareLoadableValueState } from './lib/loadState.js'
+import { resolveLoadableValueState } from './lib/loadState.js'
 import { isMainnetChain } from './lib/network.js'
 import { getUseQuestionForPoolState } from './lib/securityPoolNavigation.js'
 import { createInitialTransactionState, markTransactionFinished, markTransactionRequested, markTransactionSubmitted } from './lib/transactionState.js'
@@ -187,7 +187,7 @@ export function App() {
 	const augurPlaceHolderDeploymentMissing = augurPlaceHolderDeployed === false
 	const showDeployTab = augurPlaceHolderDeploymentMissing || (hasLoadedDeploymentStatuses && deploymentStatuses.some(step => !step.deployed))
 	const showAugurPlaceHolderDeploymentWarning = augurPlaceHolderDeploymentMissing
-	const zoltarUniverseState = resolveMissingAwareLoadableValueState({
+	const zoltarUniverseState = resolveLoadableValueState({
 		isLoading: loadingZoltarUniverse,
 		isMissing: zoltarUniverseMissing,
 		value: zoltarUniverse,

--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -25,8 +25,9 @@ import { useSecurityVaultOperations } from './hooks/useSecurityVaultOperations.j
 import { useTradingOperations } from './hooks/useTradingOperations.js'
 import { useUrlState } from './hooks/useUrlState.js'
 import { getDeploymentSections } from './lib/deployment.js'
-import { resolveRequestedLoadableValueState } from './lib/loadState.js'
+import { resolveMissingAwareLoadableValueState } from './lib/loadState.js'
 import { isMainnetChain } from './lib/network.js'
+import { getUseQuestionForPoolState } from './lib/securityPoolNavigation.js'
 import { createInitialTransactionState, markTransactionFinished, markTransactionRequested, markTransactionSubmitted } from './lib/transactionState.js'
 import type { TransactionState } from './lib/transactionState.js'
 import { DEPLOY_ROUTE, OPEN_ORACLE_ROUTE, SECURITY_POOLS_ROUTE, ZOLTAR_ROUTE } from './lib/routing.js'
@@ -103,7 +104,7 @@ export function App() {
 		zoltarQuestionCount,
 		zoltarQuestions,
 		zoltarUniverse,
-		zoltarUniverseResolvedId,
+		zoltarUniverseMissing,
 	} = useMarketCreation({ ...baseHookConfig, activeUniverseId, autoLoadInitialData: walletBootstrapComplete, deploymentStatuses })
 	const zoltarUniverseHasForked = zoltarUniverse?.hasForked === true
 	const { checkingDuplicateOriginPool, createPool, duplicateOriginPoolExists, loadMarket, loadMarketById, loadingMarketDetails, marketDetails, poolCreationMarketDetails, resetSecurityPoolCreation, securityPoolCreating, securityPoolError, securityPoolForm, securityPoolResult, setSecurityPoolForm } =
@@ -186,10 +187,9 @@ export function App() {
 	const augurPlaceHolderDeploymentMissing = augurPlaceHolderDeployed === false
 	const showDeployTab = augurPlaceHolderDeploymentMissing || (hasLoadedDeploymentStatuses && deploymentStatuses.some(step => !step.deployed))
 	const showAugurPlaceHolderDeploymentWarning = augurPlaceHolderDeploymentMissing
-	const zoltarUniverseState = resolveRequestedLoadableValueState({
-		currentKey: activeUniverseId.toString(),
+	const zoltarUniverseState = resolveMissingAwareLoadableValueState({
 		isLoading: loadingZoltarUniverse,
-		resolvedKey: zoltarUniverseResolvedId?.toString(),
+		isMissing: zoltarUniverseMissing,
 		value: zoltarUniverse,
 	})
 	const showZoltarUniverseWarning = zoltarUniverseState === 'missing'
@@ -490,10 +490,12 @@ export function App() {
 	}
 
 	const onUseQuestionForPool = (questionId: string) => {
+		const { marketId, securityPoolAddress } = getUseQuestionForPoolState(questionId)
 		setSecurityPoolForm(current => ({
 			...current,
-			marketId: questionId,
+			marketId,
 		}))
+		setSecurityPoolAddress(securityPoolAddress)
 		navigate('security-pools')
 	}
 

--- a/ui/ts/components/ForkZoltarSection.tsx
+++ b/ui/ts/components/ForkZoltarSection.tsx
@@ -56,13 +56,14 @@ export function ForkZoltarSection({
 	const hasEnoughRep = rootUniverse !== undefined && zoltarForkRepBalance !== undefined && zoltarForkRepBalance >= rootUniverse.forkThreshold
 	const hasEnoughApproval = rootUniverse !== undefined && zoltarForkAllowance !== undefined && zoltarForkAllowance >= rootUniverse.forkThreshold
 	const selectedQuestionId = zoltarForkQuestionId.trim()
+	const hasSelectedQuestionId = selectedQuestionId !== ''
 	const selectedQuestion = selectedQuestionId === '' ? undefined : zoltarQuestions.find(question => sameCaseInsensitiveText(question.questionId, selectedQuestionId))
 	const selectedQuestionLookupState = resolveLoadableValueState({
-		hasLoaded: hasLoadedZoltarQuestions,
 		isLoading: loadingZoltarQuestions,
+		isMissing: hasSelectedQuestionId && hasLoadedZoltarQuestions && selectedQuestion === undefined,
 		value: selectedQuestion,
 	})
-	const selectedQuestionPresentation = selectedQuestionId !== '' && selectedQuestionLookupState !== 'ready' ? getReportPresentation({ kind: 'question', state: selectedQuestionLookupState }) : undefined
+	const selectedQuestionPresentation = hasSelectedQuestionId && selectedQuestionLookupState !== 'ready' ? getReportPresentation({ kind: 'question', state: selectedQuestionLookupState }) : undefined
 	const canFork = accountAddress !== undefined && isMainnet && rootUniverse !== undefined && !hasForked && !zoltarForkPending && selectedQuestion !== undefined && hasEnoughRep && hasEnoughApproval
 
 	if (universeMissing) {

--- a/ui/ts/components/SecurityPoolSection.tsx
+++ b/ui/ts/components/SecurityPoolSection.tsx
@@ -20,7 +20,6 @@ export function SecurityPoolSection({
 	loadingMarketDetails,
 	marketDetails,
 	onCreateSecurityPool,
-	onLoadMarket,
 	onOpenCreatedPool,
 	onSecurityPoolFormChange,
 	onResetSecurityPoolCreation,
@@ -118,20 +117,10 @@ export function SecurityPoolSection({
 				) : (
 					<>
 						<div className='market-column'>
-							{marketDetails === undefined ? undefined : (
-								<EntityCard
-									title='Question'
-									badge={<span className='badge ok'>{marketDetails.marketType}</span>}
-									actions={
-										<div className='actions'>
-											<button className='secondary' onClick={onLoadMarket} disabled={loadingMarketDetails || isPoolActionPending}>
-												{loadingMarketDetails ? <LoadingText>Loading Question...</LoadingText> : 'Reload Question'}
-											</button>
-										</div>
-									}
-								>
-									<Question question={marketDetails} />
-									{marketDetails.marketType === 'scalar' ? undefined : (
+							{marketDetails === undefined && !loadingMarketDetails ? undefined : (
+								<EntityCard title='Question' badge={marketDetails === undefined ? undefined : <span className='badge ok'>{marketDetails.marketType}</span>}>
+									<Question question={marketDetails} loading={loadingMarketDetails && marketDetails === undefined} />
+									{marketDetails === undefined || marketDetails.marketType === 'scalar' ? undefined : (
 										<div className='question-chip-row'>
 											{marketDetails.outcomeLabels.map(label => (
 												<span key={label} className='status-chip muted'>
@@ -168,12 +157,11 @@ export function SecurityPoolSection({
 										<span>Question ID</span>
 										<input value={securityPoolForm.marketId} onInput={event => onSecurityPoolFormChange({ marketId: event.currentTarget.value })} placeholder='0x...' />
 									</label>
-
-									<div className='actions'>
-										<button className='secondary' onClick={onLoadMarket} disabled={loadingMarketDetails || isPoolActionPending}>
-											{loadingMarketDetails ? <LoadingText>Loading question...</LoadingText> : 'Open question'}
-										</button>
-									</div>
+									{loadingMarketDetails ? (
+										<p className='detail'>
+											<LoadingText>Loading question...</LoadingText>
+										</p>
+									) : undefined}
 
 									<label className='field'>
 										<span>Security Multiplier</span>

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -17,7 +17,7 @@ import { CurrencyValue } from './CurrencyValue.js'
 import { TimestampValue } from './TimestampValue.js'
 import { normalizeAddress, sameAddress } from '../lib/address.js'
 import { sameCaseInsensitiveText } from '../lib/caseInsensitive.js'
-import { resolveRequestedLoadableValueState } from '../lib/loadState.js'
+import { resolveRequestedLoadableValueState, type LoadableValueState } from '../lib/loadState.js'
 import { isMainnetChain } from '../lib/network.js'
 import { getSelectedVaultAddress, isSelectedVaultOwnedByAccount as isSelectedVaultOwnedByAccountHelper } from '../lib/securityVault.js'
 import { openInterestFeePerYearBigint } from '../lib/retentionRate.js'
@@ -29,6 +29,31 @@ import type { SecurityPoolWorkflowRouteContentProps } from '../types/components.
 
 type SelectedPoolView = 'vaults' | 'trading' | 'resolution'
 type SelectedVaultView = 'browse-vaults' | 'selected-vault'
+type SelectedPoolLookupDisplay = 'empty' | 'quiet' | 'loading' | 'missing' | 'ready'
+
+export function shouldShowSelectedPoolWorkflowDetails({ hasSelectedPoolAddress, selectedPoolExists, selectedPoolUniverseMismatch }: { hasSelectedPoolAddress: boolean; selectedPoolExists: boolean; selectedPoolUniverseMismatch: boolean }) {
+	return hasSelectedPoolAddress && selectedPoolExists && !selectedPoolUniverseMismatch
+}
+
+export function getSelectedPoolCardTitle({ hasSelectedPoolAddress, resolvedPoolTitle }: { hasSelectedPoolAddress: boolean; resolvedPoolTitle: string | undefined }) {
+	if (resolvedPoolTitle !== undefined) return resolvedPoolTitle
+	return hasSelectedPoolAddress ? 'Selected Pool' : 'Select a security pool'
+}
+
+export function getSelectedPoolLookupDisplay({ hasSelectedPoolAddress, selectedPoolExists, selectedPoolLookupState }: { hasSelectedPoolAddress: boolean; selectedPoolExists: boolean; selectedPoolLookupState: LoadableValueState }): SelectedPoolLookupDisplay {
+	if (!hasSelectedPoolAddress) return 'empty'
+	if (selectedPoolExists) return 'ready'
+	switch (selectedPoolLookupState) {
+		case 'loading':
+			return 'loading'
+		case 'missing':
+			return 'missing'
+		case 'ready':
+			return 'ready'
+		case 'unknown':
+			return 'quiet'
+	}
+}
 
 export function SecurityPoolWorkflowSection({
 	accountState,
@@ -78,18 +103,28 @@ export function SecurityPoolWorkflowSection({
 	const forkReady = selectedPoolState !== undefined && selectedPoolState !== 'operational'
 	const selectedPoolUniverseMismatch = selectedPool !== undefined && selectedPool.universeId !== activeUniverseId
 	const hasSelectedPoolAddress = securityPoolAddress.trim() !== ''
+	const showSelectedPoolWorkflowDetails = shouldShowSelectedPoolWorkflowDetails({
+		hasSelectedPoolAddress,
+		selectedPoolExists: selectedPool !== undefined,
+		selectedPoolUniverseMismatch,
+	})
 	const selectedPoolManagerAddress = selectedPool?.managerAddress
 	const selectedPoolManagerAddressKey = normalizeAddress(selectedPoolManagerAddress)
 	const selectedVaultAddress = getSelectedVaultAddress(securityVault.securityVaultForm.selectedVaultAddress, accountState.address) ?? ''
 	const selectedVaultIsOwnedByAccount = isSelectedVaultOwnedByAccountHelper(selectedVaultAddress, accountState.address)
-	const selectedPoolTitle = selectedPool !== undefined ? getQuestionTitle(selectedPool.marketDetails) : securityPoolAddress === '' ? 'Select a security pool' : <AddressValue address={securityPoolAddress} />
+	const resolvedSelectedPoolTitle = selectedPool === undefined ? undefined : getQuestionTitle(selectedPool.marketDetails)
+	const selectedPoolTitle = getSelectedPoolCardTitle({
+		hasSelectedPoolAddress,
+		resolvedPoolTitle: resolvedSelectedPoolTitle,
+	})
+	const selectedPoolLookupDisplay = getSelectedPoolLookupDisplay({
+		hasSelectedPoolAddress,
+		selectedPoolExists: selectedPool !== undefined,
+		selectedPoolLookupState,
+	})
 	const lastAutoLoadedManagerAddress = useRef<string | undefined>(undefined)
 	const lastSelectedPoolVaultDefaultKey = useRef<string | undefined>(undefined)
-	const selectedPoolPresentation = !hasSelectedPoolAddress
-		? { key: 'action_needed' as const, badgeLabel: 'Choose a pool', badgeTone: 'muted' as const, detail: 'Browse pools or paste an address.' }
-		: selectedPool === undefined
-			? getPoolRegistryPresentation({ mode: 'selection', state: selectedPoolLookupState })
-			: undefined
+	const selectedPoolBrowsePresentation = selectedPool === undefined ? getPoolRegistryPresentation({ mode: 'selection', state: selectedPoolLookupState }) : undefined
 	const loadedSelectedPool = selectedPool
 
 	useEffect(() => {
@@ -128,7 +163,7 @@ export function SecurityPoolWorkflowSection({
 			) : undefined}
 
 			<div className='workflow-stack'>
-				<EntityCard className='selected-pool-card' title={selectedPoolTitle} badge={selectedPoolState === undefined ? undefined : <span className='badge ok'>{selectedPoolState}</span>}>
+				<EntityCard className='selected-pool-card' title={selectedPoolTitle} badge={loadedSelectedPool?.systemState === undefined ? undefined : <span className='badge ok'>{loadedSelectedPool.systemState}</span>}>
 					<div className='form-grid'>
 						<label className='field'>
 							<span>Security Pool Address</span>
@@ -136,8 +171,18 @@ export function SecurityPoolWorkflowSection({
 						</label>
 					</div>
 
-					{selectedPoolPresentation !== undefined && loadedSelectedPool === undefined ? (
-						<StateHint presentation={selectedPoolPresentation} />
+					{selectedPoolLookupDisplay !== 'ready' ? (
+						selectedPoolLookupDisplay === 'empty' ? (
+							<p className='detail'>Paste a security pool address or browse pools.</p>
+						) : selectedPoolLookupDisplay === 'loading' ? (
+							<p className='detail'>
+								<LoadingText>Checking address...</LoadingText>
+							</p>
+						) : selectedPoolLookupDisplay === 'missing' ? (
+							<div className='notice error'>
+								<p>No security pool found at this address.</p>
+							</div>
+						) : undefined
 					) : (
 						<>
 							<div className='entity-card-subsection'>
@@ -238,7 +283,7 @@ export function SecurityPoolWorkflowSection({
 					</EntityCard>
 				)}
 
-				{!hasSelectedPoolAddress || selectedPoolUniverseMismatch ? undefined : (
+				{!showSelectedPoolWorkflowDetails ? undefined : (
 					<>
 						<div className='subtab-nav' role='tablist' aria-label='Selected pool views'>
 							<button className={`subtab-link ${view === 'vaults' ? 'active' : ''}`} type='button' onClick={() => setView('vaults')} aria-pressed={view === 'vaults'}>
@@ -266,8 +311,8 @@ export function SecurityPoolWorkflowSection({
 								{vaultView === 'browse-vaults' ? (
 									<EntityCard className='selected-pool-card' title='Browse Vaults' badge={<span className='badge muted'>{selectedPool?.vaultCount.toString() ?? '0'} vaults</span>}>
 										{selectedPool === undefined ? (
-											selectedPoolPresentation === undefined ? undefined : (
-												<StateHint presentation={selectedPoolPresentation} />
+											selectedPoolBrowsePresentation === undefined ? undefined : (
+												<StateHint presentation={selectedPoolBrowsePresentation} />
 											)
 										) : selectedPool.vaults.length === 0 ? (
 											<StateHint presentation={{ key: 'empty', badgeLabel: 'None yet', badgeTone: 'muted', detail: 'No vaults in this pool yet.' }} />

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -29,7 +29,7 @@ import type { SecurityPoolWorkflowRouteContentProps } from '../types/components.
 
 type SelectedPoolView = 'vaults' | 'trading' | 'resolution'
 type SelectedVaultView = 'browse-vaults' | 'selected-vault'
-type SelectedPoolLookupDisplay = 'empty' | 'quiet' | 'loading' | 'missing' | 'ready'
+type SelectedPoolLookupDisplay = 'empty' | LoadableValueState
 
 export function shouldShowSelectedPoolWorkflowDetails({ hasSelectedPoolAddress, selectedPoolExists, selectedPoolUniverseMismatch }: { hasSelectedPoolAddress: boolean; selectedPoolExists: boolean; selectedPoolUniverseMismatch: boolean }) {
 	return hasSelectedPoolAddress && selectedPoolExists && !selectedPoolUniverseMismatch
@@ -40,19 +40,9 @@ export function getSelectedPoolCardTitle({ hasSelectedPoolAddress, resolvedPoolT
 	return hasSelectedPoolAddress ? 'Selected Pool' : 'Select a security pool'
 }
 
-export function getSelectedPoolLookupDisplay({ hasSelectedPoolAddress, selectedPoolExists, selectedPoolLookupState }: { hasSelectedPoolAddress: boolean; selectedPoolExists: boolean; selectedPoolLookupState: LoadableValueState }): SelectedPoolLookupDisplay {
+export function getSelectedPoolLookupDisplay({ hasSelectedPoolAddress, selectedPoolLookupState }: { hasSelectedPoolAddress: boolean; selectedPoolLookupState: LoadableValueState }): SelectedPoolLookupDisplay {
 	if (!hasSelectedPoolAddress) return 'empty'
-	if (selectedPoolExists) return 'ready'
-	switch (selectedPoolLookupState) {
-		case 'loading':
-			return 'loading'
-		case 'missing':
-			return 'missing'
-		case 'ready':
-			return 'ready'
-		case 'unknown':
-			return 'quiet'
-	}
+	return selectedPoolLookupState
 }
 
 export function SecurityPoolWorkflowSection({
@@ -119,7 +109,6 @@ export function SecurityPoolWorkflowSection({
 	})
 	const selectedPoolLookupDisplay = getSelectedPoolLookupDisplay({
 		hasSelectedPoolAddress,
-		selectedPoolExists: selectedPool !== undefined,
 		selectedPoolLookupState,
 	})
 	const lastAutoLoadedManagerAddress = useRef<string | undefined>(undefined)

--- a/ui/ts/hooks/useSecurityPoolCreation.ts
+++ b/ui/ts/hooks/useSecurityPoolCreation.ts
@@ -23,6 +23,17 @@ type UseSecurityPoolCreationParameters = {
 	zoltarUniverseHasForked: boolean
 }
 
+export function resolveSecurityPoolQuestionLookupInput(marketIdInput: string) {
+	const marketId = marketIdInput.trim()
+	if (marketId === '') return undefined
+	try {
+		BigInt(marketId)
+		return marketId
+	} catch {
+		return undefined
+	}
+}
+
 export function useSecurityPoolCreation({ accountAddress, deploymentStatuses, onTransaction, onTransactionFinished, onTransactionRequested, onTransactionSubmitted, refreshState, zoltarUniverseHasForked }: UseSecurityPoolCreationParameters) {
 	const marketDetailsLoad = useLoadController()
 	const duplicateOriginPoolCheckLoad = useLoadController()
@@ -67,17 +78,20 @@ export function useSecurityPoolCreation({ accountAddress, deploymentStatuses, on
 		})
 	}
 
-	const loadMarketById = async (marketId: string) => {
+	const loadMarketById = async (marketId: string, options?: { clearExisting?: boolean; isCurrent?: () => boolean }) => {
 		if (!hasDeployedStep(deploymentStatuses, 'zoltarQuestionData')) {
 			securityPoolError.value = 'Deploy ZoltarQuestionData before loading a market'
 			return
 		}
 
-		const isCurrent = nextMarketDetailsLoad()
+		const isCurrent = options?.isCurrent ?? nextMarketDetailsLoad()
 		await marketDetailsLoad.run({
 			isCurrent,
 			onStart: () => {
 				securityPoolError.value = undefined
+				if (options?.clearExisting === true) {
+					marketDetails.value = undefined
+				}
 			},
 			load: async () => {
 				const { questionId } = createSecurityPoolParameters({
@@ -171,6 +185,19 @@ export function useSecurityPoolCreation({ accountAddress, deploymentStatuses, on
 	useEffect(() => {
 		void loadDuplicateOriginPoolState()
 	}, [securityPoolForm.value.marketId, securityPoolForm.value.securityMultiplier])
+
+	useEffect(() => {
+		const marketId = resolveSecurityPoolQuestionLookupInput(securityPoolForm.value.marketId)
+		const isCurrent = nextMarketDetailsLoad()
+
+		if (marketId === undefined) {
+			marketDetails.value = undefined
+			securityPoolError.value = undefined
+			return
+		}
+
+		void loadMarketById(marketId, { clearExisting: true, isCurrent })
+	}, [deploymentStatuses, securityPoolForm.value.marketId])
 
 	return {
 		checkingDuplicateOriginPool: duplicateOriginPoolCheckLoad.isLoading.value,

--- a/ui/ts/lib/loadState.ts
+++ b/ui/ts/lib/loadState.ts
@@ -19,25 +19,12 @@ export type LoadController = {
 }
 
 type ResolveLoadableValueStateOptions<TValue> = {
-	hasLoaded: boolean
-	isLoading: boolean
-	value: TValue | undefined
-}
-
-type ResolveMissingAwareLoadableValueStateOptions<TValue> = {
 	isLoading: boolean
 	isMissing: boolean
 	value: TValue | undefined
 }
 
-export function resolveLoadableValueState<TValue>({ hasLoaded, isLoading, value }: ResolveLoadableValueStateOptions<TValue>): LoadableValueState {
-	if (value !== undefined) return 'ready'
-	if (isLoading) return 'loading'
-	if (hasLoaded) return 'missing'
-	return 'unknown'
-}
-
-export function resolveMissingAwareLoadableValueState<TValue>({ isLoading, isMissing, value }: ResolveMissingAwareLoadableValueStateOptions<TValue>): LoadableValueState {
+export function resolveLoadableValueState<TValue>({ isLoading, isMissing, value }: ResolveLoadableValueStateOptions<TValue>): LoadableValueState {
 	if (value !== undefined) return 'ready'
 	if (isLoading) return 'loading'
 	if (isMissing) return 'missing'

--- a/ui/ts/lib/loadState.ts
+++ b/ui/ts/lib/loadState.ts
@@ -24,10 +24,23 @@ type ResolveLoadableValueStateOptions<TValue> = {
 	value: TValue | undefined
 }
 
+type ResolveMissingAwareLoadableValueStateOptions<TValue> = {
+	isLoading: boolean
+	isMissing: boolean
+	value: TValue | undefined
+}
+
 export function resolveLoadableValueState<TValue>({ hasLoaded, isLoading, value }: ResolveLoadableValueStateOptions<TValue>): LoadableValueState {
 	if (value !== undefined) return 'ready'
 	if (isLoading) return 'loading'
 	if (hasLoaded) return 'missing'
+	return 'unknown'
+}
+
+export function resolveMissingAwareLoadableValueState<TValue>({ isLoading, isMissing, value }: ResolveMissingAwareLoadableValueStateOptions<TValue>): LoadableValueState {
+	if (value !== undefined) return 'ready'
+	if (isLoading) return 'loading'
+	if (isMissing) return 'missing'
 	return 'unknown'
 }
 

--- a/ui/ts/lib/securityPoolNavigation.ts
+++ b/ui/ts/lib/securityPoolNavigation.ts
@@ -1,0 +1,6 @@
+export function getUseQuestionForPoolState(questionId: string) {
+	return {
+		marketId: questionId,
+		securityPoolAddress: '',
+	}
+}

--- a/ui/ts/lib/userCopy.ts
+++ b/ui/ts/lib/userCopy.ts
@@ -80,16 +80,13 @@ export function getPoolRegistryPresentation(
 			})
 		case 'unknown':
 			return createPresentation('not_checked', {
-				actionHint: 'Refresh pools',
 				badgeLabel: 'Not checked',
 				badgeTone: 'muted',
-				detail: 'Refresh pools to check this address.',
 			})
 		case 'missing':
 			return createPresentation('not_found', {
 				badgeLabel: 'Not found',
 				badgeTone: 'blocked',
-				detail: 'Refresh pools or try another address.',
 			})
 		case 'ready':
 			return undefined

--- a/ui/ts/tests/loadState.test.ts
+++ b/ui/ts/tests/loadState.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from 'bun:test'
-import { createLoadController, resolveLoadableValueState, resolveRequestedLoadableValueState, type LoadPhase } from '../lib/loadState.js'
+import { createLoadController, resolveLoadableValueState, resolveMissingAwareLoadableValueState, resolveRequestedLoadableValueState, type LoadPhase } from '../lib/loadState.js'
 
 function createDeferred<T>() {
 	let resolve: (value: T) => void = () => undefined
@@ -157,5 +157,12 @@ void describe('load state helpers', () => {
 		expect(resolveRequestedLoadableValueState({ currentKey: 'pool-a', isLoading: false, resolvedKey: 'pool-b', value: undefined })).toBe('unknown')
 		expect(resolveRequestedLoadableValueState({ currentKey: 'pool-a', isLoading: false, resolvedKey: 'pool-a', value: undefined })).toBe('missing')
 		expect(resolveRequestedLoadableValueState({ currentKey: 'pool-a', isLoading: false, resolvedKey: 'pool-a', value: 42 })).toBe('ready')
+	})
+
+	void test('resolves missing-aware value states from explicit missing truth', () => {
+		expect(resolveMissingAwareLoadableValueState({ isLoading: false, isMissing: false, value: undefined })).toBe('unknown')
+		expect(resolveMissingAwareLoadableValueState({ isLoading: true, isMissing: false, value: undefined })).toBe('loading')
+		expect(resolveMissingAwareLoadableValueState({ isLoading: false, isMissing: true, value: undefined })).toBe('missing')
+		expect(resolveMissingAwareLoadableValueState({ isLoading: false, isMissing: false, value: 42 })).toBe('ready')
 	})
 })

--- a/ui/ts/tests/loadState.test.ts
+++ b/ui/ts/tests/loadState.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from 'bun:test'
-import { createLoadController, resolveLoadableValueState, resolveMissingAwareLoadableValueState, resolveRequestedLoadableValueState, type LoadPhase } from '../lib/loadState.js'
+import { createLoadController, resolveLoadableValueState, resolveRequestedLoadableValueState, type LoadPhase } from '../lib/loadState.js'
 
 function createDeferred<T>() {
 	let resolve: (value: T) => void = () => undefined
@@ -144,11 +144,11 @@ void describe('load state helpers', () => {
 		expect(controller.isLoading.value).toBe(false)
 	})
 
-	void test('resolves loadable value states without conflating unknown and missing', () => {
-		expect(resolveLoadableValueState({ hasLoaded: false, isLoading: false, value: undefined })).toBe('unknown')
-		expect(resolveLoadableValueState({ hasLoaded: false, isLoading: true, value: undefined })).toBe('loading')
-		expect(resolveLoadableValueState({ hasLoaded: true, isLoading: false, value: undefined })).toBe('missing')
-		expect(resolveLoadableValueState({ hasLoaded: true, isLoading: false, value: 42 })).toBe('ready')
+	void test('resolves loadable value states from explicit missing truth', () => {
+		expect(resolveLoadableValueState({ isLoading: false, isMissing: false, value: undefined })).toBe('unknown')
+		expect(resolveLoadableValueState({ isLoading: true, isMissing: false, value: undefined })).toBe('loading')
+		expect(resolveLoadableValueState({ isLoading: false, isMissing: true, value: undefined })).toBe('missing')
+		expect(resolveLoadableValueState({ isLoading: false, isMissing: false, value: 42 })).toBe('ready')
 	})
 
 	void test('resolves requested loadable value states for the current key only', () => {
@@ -157,12 +157,5 @@ void describe('load state helpers', () => {
 		expect(resolveRequestedLoadableValueState({ currentKey: 'pool-a', isLoading: false, resolvedKey: 'pool-b', value: undefined })).toBe('unknown')
 		expect(resolveRequestedLoadableValueState({ currentKey: 'pool-a', isLoading: false, resolvedKey: 'pool-a', value: undefined })).toBe('missing')
 		expect(resolveRequestedLoadableValueState({ currentKey: 'pool-a', isLoading: false, resolvedKey: 'pool-a', value: 42 })).toBe('ready')
-	})
-
-	void test('resolves missing-aware value states from explicit missing truth', () => {
-		expect(resolveMissingAwareLoadableValueState({ isLoading: false, isMissing: false, value: undefined })).toBe('unknown')
-		expect(resolveMissingAwareLoadableValueState({ isLoading: true, isMissing: false, value: undefined })).toBe('loading')
-		expect(resolveMissingAwareLoadableValueState({ isLoading: false, isMissing: true, value: undefined })).toBe('missing')
-		expect(resolveMissingAwareLoadableValueState({ isLoading: false, isMissing: false, value: 42 })).toBe('ready')
 	})
 })

--- a/ui/ts/tests/securityPoolCreationState.test.ts
+++ b/ui/ts/tests/securityPoolCreationState.test.ts
@@ -1,0 +1,14 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { resolveSecurityPoolQuestionLookupInput } from '../hooks/useSecurityPoolCreation.js'
+
+void describe('security pool creation question lookup input', () => {
+	void test('returns a normalized question id only for loadable inputs', () => {
+		expect(resolveSecurityPoolQuestionLookupInput('')).toBeUndefined()
+		expect(resolveSecurityPoolQuestionLookupInput('   ')).toBeUndefined()
+		expect(resolveSecurityPoolQuestionLookupInput('not-a-question-id')).toBeUndefined()
+		expect(resolveSecurityPoolQuestionLookupInput(' 123 ')).toBe('123')
+		expect(resolveSecurityPoolQuestionLookupInput(' 0x123 ')).toBe('0x123')
+	})
+})

--- a/ui/ts/tests/securityPoolNavigation.test.ts
+++ b/ui/ts/tests/securityPoolNavigation.test.ts
@@ -1,0 +1,13 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { getUseQuestionForPoolState } from '../lib/securityPoolNavigation.js'
+
+void describe('security pool navigation', () => {
+	void test('clears the selected pool address when reusing a question for create pool', () => {
+		expect(getUseQuestionForPoolState('0x123')).toEqual({
+			marketId: '0x123',
+			securityPoolAddress: '',
+		})
+	})
+})

--- a/ui/ts/tests/securityPoolWorkflow.test.ts
+++ b/ui/ts/tests/securityPoolWorkflow.test.ts
@@ -1,0 +1,107 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { getSelectedPoolCardTitle, getSelectedPoolLookupDisplay, shouldShowSelectedPoolWorkflowDetails } from '../components/SecurityPoolWorkflowSection.js'
+
+void describe('selected pool workflow lookup state', () => {
+	void test('uses a stable card title until a pool resolves', () => {
+		expect(
+			getSelectedPoolCardTitle({
+				hasSelectedPoolAddress: false,
+				resolvedPoolTitle: undefined,
+			}),
+		).toBe('Select a security pool')
+
+		expect(
+			getSelectedPoolCardTitle({
+				hasSelectedPoolAddress: true,
+				resolvedPoolTitle: undefined,
+			}),
+		).toBe('Selected Pool')
+
+		expect(
+			getSelectedPoolCardTitle({
+				hasSelectedPoolAddress: true,
+				resolvedPoolTitle: 'Will REP exceed threshold?',
+			}),
+		).toBe('Will REP exceed threshold?')
+	})
+
+	void test('maps selected pool lookup states to the redesigned display modes', () => {
+		expect(
+			getSelectedPoolLookupDisplay({
+				hasSelectedPoolAddress: false,
+				selectedPoolExists: false,
+				selectedPoolLookupState: 'unknown',
+			}),
+		).toBe('empty')
+
+		expect(
+			getSelectedPoolLookupDisplay({
+				hasSelectedPoolAddress: true,
+				selectedPoolExists: false,
+				selectedPoolLookupState: 'unknown',
+			}),
+		).toBe('quiet')
+
+		expect(
+			getSelectedPoolLookupDisplay({
+				hasSelectedPoolAddress: true,
+				selectedPoolExists: false,
+				selectedPoolLookupState: 'loading',
+			}),
+		).toBe('loading')
+
+		expect(
+			getSelectedPoolLookupDisplay({
+				hasSelectedPoolAddress: true,
+				selectedPoolExists: false,
+				selectedPoolLookupState: 'missing',
+			}),
+		).toBe('missing')
+
+		expect(
+			getSelectedPoolLookupDisplay({
+				hasSelectedPoolAddress: true,
+				selectedPoolExists: true,
+				selectedPoolLookupState: 'ready',
+			}),
+		).toBe('ready')
+	})
+})
+
+void describe('selected pool workflow visibility', () => {
+	void test('shows workflow details only for a resolved pool in the active universe', () => {
+		expect(
+			shouldShowSelectedPoolWorkflowDetails({
+				hasSelectedPoolAddress: false,
+				selectedPoolExists: false,
+				selectedPoolUniverseMismatch: false,
+			}),
+		).toBe(false)
+
+		expect(
+			shouldShowSelectedPoolWorkflowDetails({
+				hasSelectedPoolAddress: true,
+				selectedPoolExists: false,
+				selectedPoolUniverseMismatch: false,
+			}),
+		).toBe(false)
+
+		expect(
+			shouldShowSelectedPoolWorkflowDetails({
+				hasSelectedPoolAddress: true,
+				selectedPoolExists: true,
+				selectedPoolUniverseMismatch: true,
+			}),
+		).toBe(false)
+
+		expect(
+			shouldShowSelectedPoolWorkflowDetails({
+				hasSelectedPoolAddress: true,
+				selectedPoolExists: true,
+				selectedPoolUniverseMismatch: false,
+			}),
+		).toBe(true)
+	})
+})

--- a/ui/ts/tests/securityPoolWorkflow.test.ts
+++ b/ui/ts/tests/securityPoolWorkflow.test.ts
@@ -27,11 +27,10 @@ void describe('selected pool workflow lookup state', () => {
 		).toBe('Will REP exceed threshold?')
 	})
 
-	void test('maps selected pool lookup states to the redesigned display modes', () => {
+	void test('adds only the empty selected-pool state on top of loadable lookup states', () => {
 		expect(
 			getSelectedPoolLookupDisplay({
 				hasSelectedPoolAddress: false,
-				selectedPoolExists: false,
 				selectedPoolLookupState: 'unknown',
 			}),
 		).toBe('empty')
@@ -39,15 +38,13 @@ void describe('selected pool workflow lookup state', () => {
 		expect(
 			getSelectedPoolLookupDisplay({
 				hasSelectedPoolAddress: true,
-				selectedPoolExists: false,
 				selectedPoolLookupState: 'unknown',
 			}),
-		).toBe('quiet')
+		).toBe('unknown')
 
 		expect(
 			getSelectedPoolLookupDisplay({
 				hasSelectedPoolAddress: true,
-				selectedPoolExists: false,
 				selectedPoolLookupState: 'loading',
 			}),
 		).toBe('loading')
@@ -55,7 +52,6 @@ void describe('selected pool workflow lookup state', () => {
 		expect(
 			getSelectedPoolLookupDisplay({
 				hasSelectedPoolAddress: true,
-				selectedPoolExists: false,
 				selectedPoolLookupState: 'missing',
 			}),
 		).toBe('missing')
@@ -63,7 +59,6 @@ void describe('selected pool workflow lookup state', () => {
 		expect(
 			getSelectedPoolLookupDisplay({
 				hasSelectedPoolAddress: true,
-				selectedPoolExists: true,
 				selectedPoolLookupState: 'ready',
 			}),
 		).toBe('ready')

--- a/ui/ts/tests/userCopy.test.ts
+++ b/ui/ts/tests/userCopy.test.ts
@@ -6,8 +6,11 @@ import { getMetricPlaceholderPresentation, getPoolRegistryPresentation, getRepor
 void describe('user copy helpers', () => {
 	void test('maps pool selection states semantically', () => {
 		expect(getPoolRegistryPresentation({ mode: 'selection', state: 'unknown' })?.key).toBe('not_checked')
+		expect(getPoolRegistryPresentation({ mode: 'selection', state: 'unknown' })?.detail).toBeUndefined()
+		expect(getPoolRegistryPresentation({ mode: 'selection', state: 'unknown' })?.actionHint).toBeUndefined()
 		expect(getPoolRegistryPresentation({ mode: 'selection', state: 'loading' })?.key).toBe('loading')
 		expect(getPoolRegistryPresentation({ mode: 'selection', state: 'missing' })?.key).toBe('not_found')
+		expect(getPoolRegistryPresentation({ mode: 'selection', state: 'missing' })?.detail).toBeUndefined()
 		expect(getPoolRegistryPresentation({ mode: 'selection', state: 'ready' })).toBeUndefined()
 	})
 


### PR DESCRIPTION
## Summary
- Tightened security pool lookup behavior so the create flow now loads market details automatically from typed question IDs and clears stale results when input changes.
- Simplified the selected-pool workflow by separating empty, loading, missing, and ready states, with clearer card titles and reduced UI noise.
- Updated navigation and copy helpers so “use question for pool” resets the pool address and lookup hints are more restrained.
- Added tests covering load-state resolution, question ID normalization, pool navigation, workflow visibility, and updated copy expectations.

## Testing
- Not run (PR content only)
- Existing test coverage was added for:
  - `ui/ts/tests/loadState.test.ts`
  - `ui/ts/tests/securityPoolCreationState.test.ts`
  - `ui/ts/tests/securityPoolNavigation.test.ts`
  - `ui/ts/tests/securityPoolWorkflow.test.ts`
  - `ui/ts/tests/userCopy.test.ts`