### PR TITLE
Block REP deposits that exceed wallet balance

### DIFF
--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -9,7 +9,7 @@ import { StateHint } from './StateHint.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { normalizeAddress, sameAddress } from '../lib/address.js'
 import { formatCurrencyBalance, formatCurrencyInputBalance } from '../lib/formatters.js'
-import { approvalShortage } from '../lib/inputs.js'
+import { approvalShortage, balanceShortage } from '../lib/inputs.js'
 import { isMainnetChain } from '../lib/network.js'
 import { parseRepAmountInput } from '../lib/marketForm.js'
 import { getSelectedVaultAddress, isSecurityVaultDepositBelowMinimum, isSelectedVaultOwnedByAccount as isSelectedVaultOwnedByAccountHelper, MIN_SECURITY_VAULT_REP_DEPOSIT } from '../lib/securityVault.js'
@@ -66,11 +66,13 @@ export function SecurityVaultSection({
 	const securityBondAllowance = securityVaultDetails?.securityBondAllowance ?? 0n
 	const approvedRep = securityVaultRepAllowance
 	const shortage = approvalShortage(depositAmount, approvedRep)
+	const repBalanceGap = balanceShortage(depositAmount, securityVaultRepBalance)
 	const withdrawableRepAmount = securityVaultDetails === undefined ? undefined : securityVaultDetails.repDepositShare > securityVaultDetails.lockedRepInEscalationGame ? securityVaultDetails.repDepositShare - securityVaultDetails.lockedRepInEscalationGame : 0n
 	const isDepositBelowMinimum = isSecurityVaultDepositBelowMinimum(securityVaultDetails?.repDepositShare, depositAmount)
 	const hasClaimableFees = securityVaultDetails !== undefined && securityVaultDetails.unpaidEthFees > 0n
 	const canClaimFees = selectedVaultIsOwnedByAccount && isMainnet && hasClaimableFees
 	const hasSufficientDepositAllowance = selectedVaultIsOwnedByAccount && approvedRep !== undefined && depositAmount !== undefined && depositAmount > 0n && approvedRep >= depositAmount
+	const hasInsufficientRepBalance = repBalanceGap !== undefined && repBalanceGap > 0n
 	const canApproveRep = selectedVaultIsOwnedByAccount && isMainnet && securityVaultDetails !== undefined && depositAmount !== undefined && depositAmount > 0n && shortage !== undefined && shortage > 0n
 	const canSetSecurityBondAllowance = selectedVaultIsOwnedByAccount && isMainnet && securityVaultDetails !== undefined && securityBondAllowanceAmount !== undefined && securityBondAllowanceAmount > 0n
 	const approveButtonLabel = depositAmount === undefined || depositAmount <= 0n || shortage === undefined ? 'Approve REP' : shortage === 0n ? 'Approval Satisfied' : `Approve ${formatCurrencyBalance(shortage)} REP`
@@ -81,7 +83,7 @@ export function SecurityVaultSection({
 		if (securityVaultMissing) return 'Choose a pool first.'
 		if (securityVaultDetails === undefined) return 'Refresh the vault first.'
 		if (depositAmount === undefined || depositAmount <= 0n) return 'Enter a deposit amount greater than zero.'
-		if (shortage === 0n) return 'No additional REP approval is needed for this deposit amount.'
+		if (shortage === 0n) return 'This deposit amount is already approved.'
 		return `Approve ${formatCurrencyBalance(shortage)} more REP before depositing.`
 	})()
 	const latestActionLabel =
@@ -231,19 +233,19 @@ export function SecurityVaultSection({
 				<button className='secondary' title={approveButtonTitle} onClick={() => onApproveRep(shortage)} disabled={!canApproveRep}>
 					{approveButtonLabel}
 				</button>
-				<button className='primary' onClick={onDepositRep} disabled={!selectedVaultIsOwnedByAccount || accountState.address === undefined || !isMainnet || !hasSufficientDepositAllowance || isDepositBelowMinimum}>
+				<button className='primary' onClick={onDepositRep} disabled={!selectedVaultIsOwnedByAccount || accountState.address === undefined || !isMainnet || !hasSufficientDepositAllowance || hasInsufficientRepBalance || isDepositBelowMinimum}>
 					Create / Deposit REP
 				</button>
 			</div>
-			{isDepositBelowMinimum ? (
+			{repBalanceGap !== undefined && repBalanceGap > 0n ? (
+				<ErrorNotice message={`Insufficient REP balance. Deposit amount exceeds your wallet balance by ${formatCurrencyBalance(repBalanceGap)} REP.`} />
+			) : isDepositBelowMinimum ? (
 				<p className='detail'>
 					New vaults require at least <CurrencyValue value={MIN_SECURITY_VAULT_REP_DEPOSIT} suffix='REP' copyable={false} /> in the first deposit.
 				</p>
 			) : depositAmount === undefined ? undefined : shortage === undefined ? undefined : shortage > 0n ? (
 				<p className='detail'>Need {<CurrencyValue value={shortage} suffix='REP' copyable={false} />} more REP approved before depositing.</p>
-			) : (
-				<p className='detail'>No additional REP approval is needed for this deposit amount.</p>
-			)}
+			) : undefined}
 		</div>
 	)
 

--- a/ui/ts/hooks/useSecurityVaultOperations.ts
+++ b/ui/ts/hooks/useSecurityVaultOperations.ts
@@ -4,8 +4,9 @@ import { useErc20AllowanceLoader, useErc20BalanceLoader } from './useErc20Loader
 import { useFormState } from './useFormState.js'
 import { useLoadController } from './useLoadController.js'
 import type { Address } from 'viem'
-import { approveErc20, depositRepToSecurityPool, loadOracleManagerDetails, loadSecurityVaultDetails, queueOracleManagerOperation, redeemSecurityVaultFees, updateSecurityVaultFees } from '../contracts.js'
+import { approveErc20, depositRepToSecurityPool, loadErc20Balance, loadOracleManagerDetails, loadSecurityVaultDetails, queueOracleManagerOperation, redeemSecurityVaultFees, updateSecurityVaultFees } from '../contracts.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
+import { formatCurrencyBalance } from '../lib/formatters.js'
 import { sameAddress } from '../lib/address.js'
 import { getErrorMessage } from '../lib/errors.js'
 import { parseAddressInput } from '../lib/inputs.js'
@@ -159,12 +160,23 @@ export function useSecurityVaultOperations({ accountAddress, onTransaction, onTr
 
 	const depositRep = async () =>
 		await runVaultAction(
-			async (vaultAddress, securityPoolAddress) => await depositRepToSecurityPool(createWalletWriteClient(vaultAddress, { onTransactionSubmitted }), securityPoolAddress, parseRepAmountInput(securityVaultForm.value.depositAmount, 'REP deposit amount')),
+			async (vaultAddress, securityPoolAddress) => {
+				const depositAmount = parseRepAmountInput(securityVaultForm.value.depositAmount, 'REP deposit amount')
+				const details = await loadExistingSecurityVaultDetails(securityPoolAddress, vaultAddress, 'Security pool does not exist')
+				if (details === undefined) return undefined
+				const currentRepBalance = await loadErc20Balance(createConnectedReadClient(), details.repToken, vaultAddress)
+				repBalanceLoader.signal.value = currentRepBalance
+				if (currentRepBalance < depositAmount) {
+					throw new Error(`Insufficient REP balance. Wallet balance is ${formatCurrencyBalance(currentRepBalance)} REP but the deposit amount is ${formatCurrencyBalance(depositAmount)} REP.`)
+				}
+				return await depositRepToSecurityPool(createWalletWriteClient(vaultAddress, { onTransactionSubmitted }), securityPoolAddress, depositAmount)
+			},
 			'Failed to deposit REP',
 			async (_result, securityPoolAddress, vaultAddress) => {
 				await reloadSecurityVaultDetails(securityPoolAddress, vaultAddress)
 				const details = securityVaultDetails.value
 				if (details === undefined) return
+				await reloadSecurityVaultRepBalance(details.repToken, vaultAddress)
 				await reloadSecurityVaultRepAllowance(details.repToken, vaultAddress, securityPoolAddress)
 			},
 		)

--- a/ui/ts/lib/inputs.ts
+++ b/ui/ts/lib/inputs.ts
@@ -87,6 +87,11 @@ export function approvalShortage(amount: bigint | undefined, allowance: bigint |
 	return amount > allowance ? amount - allowance : 0n
 }
 
+export function balanceShortage(amount: bigint | undefined, balance: bigint | undefined): bigint | undefined {
+	if (amount === undefined || balance === undefined) return undefined
+	return amount > balance ? amount - balance : 0n
+}
+
 export function parseReportingOutcomeListInput(value: string, label: string): ReportingOutcomeKey[] {
 	return parseListInput(value, label, entry => parseReportingOutcomeInput(entry.toLowerCase()))
 }

--- a/ui/ts/tests/inputs.test.ts
+++ b/ui/ts/tests/inputs.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, test } from 'bun:test'
 import { getAddress } from 'viem'
-import { parseOptionalBigIntInput, resolveOptionalAddressInput, resolveOptionalBigIntListInput } from '../lib/inputs.js'
+import { balanceShortage, parseOptionalBigIntInput, resolveOptionalAddressInput, resolveOptionalBigIntListInput } from '../lib/inputs.js'
 
 void describe('input helpers', () => {
 	void test('parseOptionalBigIntInput returns undefined for empty input', () => {
@@ -26,5 +26,12 @@ void describe('input helpers', () => {
 		expect(resolveOptionalBigIntListInput('', [1n, 2n], 'Outcome indexes')).toEqual([1n, 2n])
 		expect(resolveOptionalBigIntListInput('  ', [1n, 2n], 'Outcome indexes')).toEqual([1n, 2n])
 		expect(resolveOptionalBigIntListInput('3, 4', [1n, 2n], 'Outcome indexes')).toEqual([3n, 4n])
+	})
+
+	void test('balanceShortage reports how much REP is missing for a deposit', () => {
+		expect(balanceShortage(undefined, 5n)).toBe(undefined)
+		expect(balanceShortage(5n, undefined)).toBe(undefined)
+		expect(balanceShortage(5n, 5n)).toBe(0n)
+		expect(balanceShortage(6n, 5n)).toBe(1n)
 	})
 })


### PR DESCRIPTION
## Summary
- Added a wallet-balance check before REP deposits so users cannot submit deposits larger than their REP balance.
- Surfaced the shortage in the UI with a blocking error state and disabled the deposit button when the balance is insufficient.
- Added a shared `balanceShortage` helper plus test coverage for the new input logic.

## Testing
- Not run
- Existing unit coverage updated in `ui/ts/tests/inputs.test.ts` for `balanceShortage`