### PR TITLE
Remove obsolete overview refresh action

### DIFF
--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -534,7 +534,6 @@ export function App() {
 						isLoadingUniverseRepBalance={loadingZoltarForkAccess}
 						onConnect={() => void connectWallet()}
 						onGoToGenesisUniverse={() => setActiveUniverseId(0n)}
-						onRefresh={() => refreshState()}
 						repEthPrice={repEthPrice}
 						repEthSource={repEthSource}
 						repUsdcPrice={repUsdcPrice}

--- a/ui/ts/components/OverviewPanels.tsx
+++ b/ui/ts/components/OverviewPanels.tsx
@@ -15,7 +15,6 @@ export function OverviewPanels({
 	isLoadingUniverseRepBalance,
 	onConnect,
 	onGoToGenesisUniverse,
-	onRefresh,
 	repEthPrice,
 	repEthSource,
 	repUsdcPrice,
@@ -101,9 +100,6 @@ export function OverviewPanels({
 						</div>
 					</div>
 					<div className='actions overview-actions'>
-						<button className='secondary' onClick={onRefresh} disabled={isRefreshing}>
-							{isRefreshing ? 'Refreshing...' : 'Refresh'}
-						</button>
 						{accountState.address === undefined ? (
 							<button className='primary' onClick={onConnect} disabled={isConnectingWallet}>
 								{isWalletLoading ? 'Connecting...' : 'Connect wallet'}

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -53,7 +53,6 @@ export type OverviewPanelsProps = {
 	isLoadingRepPrices: boolean
 	onConnect: () => void
 	onGoToGenesisUniverse: () => void
-	onRefresh: () => void
 }
 
 export type TabNavigationProps = {


### PR DESCRIPTION
## Summary
- Removed the unused `Refresh` action from the overview panels UI.
- Cleaned up the corresponding `onRefresh` prop wiring in `App` and `OverviewPanels`.
- Removed the obsolete prop from the overview component type definition.

## Testing
- Not run (PR description only)