### PR TITLE
Rename REP deposit labels to "Rep Deposit"

### DIFF
--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -332,7 +332,7 @@ export function SecurityPoolWorkflowSection({
 														}
 													>
 														<div className='workflow-vault-grid'>
-															<MetricField label='REP Deposit Share'>
+															<MetricField label='Rep Deposit'>
 																<CurrencyValue value={vault.repDepositShare} suffix='REP' />
 															</MetricField>
 															<MetricField label='Pool Ownership'>{vault.poolOwnership.toString()}</MetricField>

--- a/ui/ts/components/SecurityPoolsOverviewSection.tsx
+++ b/ui/ts/components/SecurityPoolsOverviewSection.tsx
@@ -134,7 +134,7 @@ export function SecurityPoolsOverviewSection({
 													}
 												>
 													<div className='workflow-vault-grid'>
-														<MetricField label='REP Deposit Share'>
+														<MetricField label='Rep Deposit'>
 															<CurrencyValue value={vault.repDepositShare} suffix='REP' />
 														</MetricField>
 														<MetricField label='Pool Ownership'>{vault.poolOwnership.toString()}</MetricField>

--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -126,7 +126,7 @@ export function SecurityVaultSection({
 					<MetricField className='entity-metric' label='Selected Vault'>
 						<AddressValue address={securityVaultDetails.vaultAddress} />
 					</MetricField>
-					<MetricField className='entity-metric' label='REP Deposit Share'>
+					<MetricField className='entity-metric' label='Rep Deposit'>
 						<CurrencyValue value={securityVaultDetails.repDepositShare} suffix='REP' />
 					</MetricField>
 					<MetricField className='entity-metric' label='Approved REP'>


### PR DESCRIPTION
## Summary
- Updated the REP deposit metric label in the security vault, pool overview, and workflow sections.
- Kept the displayed REP value and surrounding UI behavior unchanged.

## Testing
- Not run (documentation/UI text change only).