### PR TITLE
Clarify REP approval targets in vault flows

### DIFF
--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -9,7 +9,7 @@ import { StateHint } from './StateHint.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { normalizeAddress, sameAddress } from '../lib/address.js'
 import { formatCurrencyBalance, formatCurrencyInputBalance } from '../lib/formatters.js'
-import { approvalShortage, balanceShortage } from '../lib/inputs.js'
+import { approvalShortage, approvalTargetAmount, balanceShortage } from '../lib/inputs.js'
 import { isMainnetChain } from '../lib/network.js'
 import { parseRepAmountInput } from '../lib/marketForm.js'
 import { getSelectedVaultAddress, isSecurityVaultDepositBelowMinimum, isSelectedVaultOwnedByAccount as isSelectedVaultOwnedByAccountHelper, MIN_SECURITY_VAULT_REP_DEPOSIT } from '../lib/securityVault.js'
@@ -66,6 +66,7 @@ export function SecurityVaultSection({
 	const securityBondAllowance = securityVaultDetails?.securityBondAllowance ?? 0n
 	const approvedRep = securityVaultRepAllowance
 	const shortage = approvalShortage(depositAmount, approvedRep)
+	const approvalTargetRep = approvalTargetAmount(depositAmount, approvedRep)
 	const repBalanceGap = balanceShortage(depositAmount, securityVaultRepBalance)
 	const withdrawableRepAmount = securityVaultDetails === undefined ? undefined : securityVaultDetails.repDepositShare > securityVaultDetails.lockedRepInEscalationGame ? securityVaultDetails.repDepositShare - securityVaultDetails.lockedRepInEscalationGame : 0n
 	const isDepositBelowMinimum = isSecurityVaultDepositBelowMinimum(securityVaultDetails?.repDepositShare, depositAmount)
@@ -73,9 +74,9 @@ export function SecurityVaultSection({
 	const canClaimFees = selectedVaultIsOwnedByAccount && isMainnet && hasClaimableFees
 	const hasSufficientDepositAllowance = selectedVaultIsOwnedByAccount && approvedRep !== undefined && depositAmount !== undefined && depositAmount > 0n && approvedRep >= depositAmount
 	const hasInsufficientRepBalance = repBalanceGap !== undefined && repBalanceGap > 0n
-	const canApproveRep = selectedVaultIsOwnedByAccount && isMainnet && securityVaultDetails !== undefined && depositAmount !== undefined && depositAmount > 0n && shortage !== undefined && shortage > 0n
+	const canApproveRep = selectedVaultIsOwnedByAccount && isMainnet && securityVaultDetails !== undefined && approvalTargetRep !== undefined
 	const canSetSecurityBondAllowance = selectedVaultIsOwnedByAccount && isMainnet && securityVaultDetails !== undefined && securityBondAllowanceAmount !== undefined && securityBondAllowanceAmount > 0n
-	const approveButtonLabel = depositAmount === undefined || depositAmount <= 0n || shortage === undefined ? 'Approve REP' : shortage === 0n ? 'Approval Satisfied' : `Approve ${formatCurrencyBalance(shortage)} REP`
+	const approveButtonLabel = depositAmount === undefined || depositAmount <= 0n || shortage === undefined ? 'Approve REP' : shortage === 0n ? 'Approval Satisfied' : `Approve ${formatCurrencyBalance(approvalTargetRep)} REP`
 	const approveButtonTitle = (() => {
 		const walletPresentation = getWalletPresentation({ accountAddress: accountState.address, isMainnet })
 		if (walletPresentation !== undefined) return walletPresentation.detail
@@ -83,8 +84,9 @@ export function SecurityVaultSection({
 		if (securityVaultMissing) return 'Choose a pool first.'
 		if (securityVaultDetails === undefined) return 'Refresh the vault first.'
 		if (depositAmount === undefined || depositAmount <= 0n) return 'Enter a deposit amount greater than zero.'
+		if (shortage === undefined) return 'Loading current REP approval.'
 		if (shortage === 0n) return 'This deposit amount is already approved.'
-		return `Approve ${formatCurrencyBalance(shortage)} more REP before depositing.`
+		return `Approve ${formatCurrencyBalance(approvalTargetRep)} REP to cover this deposit amount. Current allowance is short by ${formatCurrencyBalance(shortage)} REP.`
 	})()
 	const latestActionLabel =
 		securityVaultResult === undefined
@@ -230,7 +232,7 @@ export function SecurityVaultSection({
 				</div>
 			</label>
 			<div className='actions'>
-				<button className='secondary' title={approveButtonTitle} onClick={() => onApproveRep(shortage)} disabled={!canApproveRep}>
+				<button className='secondary' title={approveButtonTitle} onClick={() => onApproveRep(approvalTargetRep)} disabled={!canApproveRep}>
 					{approveButtonLabel}
 				</button>
 				<button className='primary' onClick={onDepositRep} disabled={!selectedVaultIsOwnedByAccount || accountState.address === undefined || !isMainnet || !hasSufficientDepositAllowance || hasInsufficientRepBalance || isDepositBelowMinimum}>
@@ -244,7 +246,9 @@ export function SecurityVaultSection({
 					New vaults require at least <CurrencyValue value={MIN_SECURITY_VAULT_REP_DEPOSIT} suffix='REP' copyable={false} /> in the first deposit.
 				</p>
 			) : depositAmount === undefined ? undefined : shortage === undefined ? undefined : shortage > 0n ? (
-				<p className='detail'>Need {<CurrencyValue value={shortage} suffix='REP' copyable={false} />} more REP approved before depositing.</p>
+				<p className='detail'>
+					Need <CurrencyValue value={shortage} suffix='REP' copyable={false} /> more REP approved before depositing. Approving will set the allowance to <CurrencyValue value={approvalTargetRep ?? depositAmount} suffix='REP' copyable={false} />.
+				</p>
 			) : undefined}
 		</div>
 	)

--- a/ui/ts/components/ZoltarMigrationSection.tsx
+++ b/ui/ts/components/ZoltarMigrationSection.tsx
@@ -12,7 +12,7 @@ import { UniverseLink } from './UniverseLink.js'
 import { getMigrationOutcomeSplitLimit, MigrationOutcomeUniversesSection } from './MigrationOutcomeUniversesSection.js'
 import type { LoadableValueState } from '../lib/loadState.js'
 import { formatCurrencyBalance, formatCurrencyInputBalance } from '../lib/formatters.js'
-import { parseBigIntListInput } from '../lib/inputs.js'
+import { approvalShortage, approvalTargetAmount, parseBigIntListInput } from '../lib/inputs.js'
 import { parseRepAmountInput as parseMigrationAmountInput } from '../lib/marketForm.js'
 import { getUniversePresentation, getWalletPresentation } from '../lib/userCopy.js'
 import type { ZoltarMigrationFormState } from '../types/app.js'
@@ -116,24 +116,25 @@ export function ZoltarMigrationSection({
 	const amountExceedsAvailableRep = hasValidAmount && migrationAmount !== undefined && migrationAmount > totalRepAvailable
 	const hasEnoughRep = hasValidAmount && zoltarForkRepBalance !== undefined && zoltarForkRepBalance >= missingPreparationAmount
 	const hasPreparedBalance = hasValidAmount && zoltarMigrationPreparedRepBalance !== undefined && zoltarMigrationPreparedRepBalance >= migrationAmount
-	const approvedRep = zoltarForkAllowance ?? 0n
-	const approvalShortage = missingPreparationAmount > approvedRep ? missingPreparationAmount - approvedRep : 0n
-	const hasSufficientAllowance = zoltarForkAllowance !== undefined && approvalShortage === 0n
+	const approvalGap = approvalShortage(missingPreparationAmount, zoltarForkAllowance)
+	const approvalTargetRep = approvalTargetAmount(missingPreparationAmount, zoltarForkAllowance)
+	const hasSufficientAllowance = approvalGap !== undefined && approvalGap === 0n
 	const hasValidOutcomeIndexes = selectedOutcomeIndexes.length > 0
 	const needsAdditionalPreparation = missingPreparationAmount > 0n
 	const splitLimit = useMemo(() => getMigrationOutcomeSplitLimit(rootUniverse?.childUniverses ?? [], zoltarMigrationChildRepBalances, zoltarMigrationPreparedRepBalance, selectedOutcomeIndexSet), [rootUniverse?.childUniverses, selectedOutcomeIndexSet, zoltarMigrationChildRepBalances, zoltarMigrationPreparedRepBalance])
 	const hasSufficientSplitLimit = migrationAmount !== undefined && splitLimit !== undefined && migrationAmount <= splitLimit
 	const canPrepare = accountAddress !== undefined && isMainnet && rootUniverse !== undefined && hasForked && !zoltarMigrationPending && hasValidAmount && needsAdditionalPreparation && hasEnoughRep && hasSufficientAllowance
-	const canApproveRep = accountAddress !== undefined && isMainnet && rootUniverse !== undefined && hasForked && !zoltarForkPending && hasValidAmount && approvalShortage > 0n
+	const canApproveRep = accountAddress !== undefined && isMainnet && rootUniverse !== undefined && hasForked && !zoltarForkPending && approvalTargetRep !== undefined
 	const canSplit = accountAddress !== undefined && isMainnet && rootUniverse !== undefined && hasForked && !zoltarMigrationPending && hasValidAmount && hasPreparedBalance && hasValidOutcomeIndexes && hasSufficientSplitLimit
 	const migrationAmountSource = getMigrationAmountSource(zoltarMigrationPreparedRepBalance, zoltarForkRepBalance)
-	const approveButtonLabel = !hasValidAmount || migrationAmount === undefined ? 'Approve REP' : approvalShortage > 0n ? `Approve ${formatCurrencyBalance(approvalShortage)} REP` : 'Approval Satisfied'
+	const approveButtonLabel = !hasValidAmount || migrationAmount === undefined || approvalGap === undefined ? 'Approve REP' : approvalGap > 0n ? `Approve ${formatCurrencyBalance(approvalTargetRep)} REP` : 'Approval Satisfied'
 	const approveButtonTitle = (() => {
 		const guard = getMigrationGuardMessage(accountAddress, isMainnet, rootUniverse, loadingZoltarForkAccess, hasForked, loadingZoltarUniverse, 'Fork Zoltar before preparing REP.')
 		if (guard !== undefined) return guard
 		if (!hasValidAmount || migrationAmount === undefined) return 'Enter an amount greater than zero.'
-		if (approvalShortage === 0n) return 'No additional REP approval is needed for this amount.'
-		return `Approve ${formatCurrencyBalance(approvalShortage)} more REP for Zoltar before preparing the selected amount.`
+		if (approvalGap === undefined) return 'Loading current REP approval.'
+		if (approvalGap === 0n) return 'No additional REP approval is needed for this amount.'
+		return `Approve ${formatCurrencyBalance(approvalTargetRep)} REP for Zoltar to cover the selected amount. Current allowance is short by ${formatCurrencyBalance(approvalGap)} REP.`
 	})()
 	const getAlreadyPreparedHint = () => {
 		if (hasValidOutcomeIndexes && splitLimit === 0n) {
@@ -149,8 +150,11 @@ export function ZoltarMigrationSection({
 		if (zoltarForkRepBalance === undefined || zoltarForkRepBalance < missingPreparationAmount) {
 			return `Need ${formatCurrencyBalance(missingPreparationAmount)} more REP in this universe to prepare the selected amount.`
 		}
-		if (approvalShortage > 0n) {
-			return `Approve ${formatCurrencyBalance(approvalShortage)} more REP for Zoltar before preparing the selected amount.`
+		if (approvalGap === undefined) {
+			return 'Loading current REP approval before preparing the selected amount.'
+		}
+		if (approvalGap > 0n) {
+			return `Approve ${formatCurrencyBalance(approvalTargetRep)} REP for Zoltar to cover the selected amount. Current allowance is short by ${formatCurrencyBalance(approvalGap)} REP.`
 		}
 		if (!hasSufficientAllowance) {
 			return 'Waiting for approved REP amount before preparing the selected amount.'
@@ -228,7 +232,11 @@ export function ZoltarMigrationSection({
 						<MetricField label='Approved REP'>
 							<CurrencyValue loading={loadingZoltarForkAccess && zoltarForkAllowance === undefined} value={zoltarForkAllowance} suffix='REP' />
 						</MetricField>
-						{approvalShortage > 0n ? <p className='detail'>Need {formatCurrencyBalance(approvalShortage)} more REP approved before preparing the current amount.</p> : undefined}
+						{approvalGap === undefined || approvalGap === 0n ? undefined : (
+							<p className='detail'>
+								Need {formatCurrencyBalance(approvalGap)} more REP approved before preparing the current amount. Approving will set the allowance to {formatCurrencyBalance(approvalTargetRep ?? missingPreparationAmount)} REP.
+							</p>
+						)}
 					</div>
 					<MetricField label='Universe'>
 						{rootUniverse === undefined ? (
@@ -266,7 +274,7 @@ export function ZoltarMigrationSection({
 					)}
 
 					<div className='actions'>
-						<button className='secondary' title={approveButtonTitle} onClick={() => onApproveZoltarForkRep(approvalShortage)} disabled={!canApproveRep || zoltarForkActiveAction === 'approve'}>
+						<button className='secondary' title={approveButtonTitle} onClick={() => onApproveZoltarForkRep(approvalTargetRep)} disabled={!canApproveRep || zoltarForkActiveAction === 'approve'}>
 							{zoltarForkActiveAction === 'approve' ? <LoadingText>Approving REP...</LoadingText> : approveButtonLabel}
 						</button>
 						<button className='secondary' title={prepareHintMessage} onClick={onPrepareRepForMigration} disabled={!canPrepare}>

--- a/ui/ts/lib/inputs.ts
+++ b/ui/ts/lib/inputs.ts
@@ -87,6 +87,11 @@ export function approvalShortage(amount: bigint | undefined, allowance: bigint |
 	return amount > allowance ? amount - allowance : 0n
 }
 
+export function approvalTargetAmount(amount: bigint | undefined, allowance: bigint | undefined): bigint | undefined {
+	if (amount === undefined || amount <= 0n || allowance === undefined) return undefined
+	return amount > allowance ? amount : undefined
+}
+
 export function balanceShortage(amount: bigint | undefined, balance: bigint | undefined): bigint | undefined {
 	if (amount === undefined || balance === undefined) return undefined
 	return amount > balance ? amount - balance : 0n

--- a/ui/ts/tests/inputs.test.ts
+++ b/ui/ts/tests/inputs.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, test } from 'bun:test'
 import { getAddress } from 'viem'
-import { balanceShortage, parseOptionalBigIntInput, resolveOptionalAddressInput, resolveOptionalBigIntListInput } from '../lib/inputs.js'
+import { approvalShortage, approvalTargetAmount, balanceShortage, parseOptionalBigIntInput, resolveOptionalAddressInput, resolveOptionalBigIntListInput } from '../lib/inputs.js'
 
 void describe('input helpers', () => {
 	void test('parseOptionalBigIntInput returns undefined for empty input', () => {
@@ -33,5 +33,13 @@ void describe('input helpers', () => {
 		expect(balanceShortage(5n, undefined)).toBe(undefined)
 		expect(balanceShortage(5n, 5n)).toBe(0n)
 		expect(balanceShortage(6n, 5n)).toBe(1n)
+	})
+
+	void test('approvalTargetAmount returns the full target approval when allowance is short', () => {
+		expect(approvalShortage(11n, 10n)).toBe(1n)
+		expect(approvalTargetAmount(11n, 10n)).toBe(11n)
+		expect(approvalTargetAmount(10n, 10n)).toBe(undefined)
+		expect(approvalTargetAmount(10n, undefined)).toBe(undefined)
+		expect(approvalTargetAmount(0n, 0n)).toBe(undefined)
 	})
 })


### PR DESCRIPTION
## Summary
- Updated Security Vault approval copy and actions to approve the full deposit target instead of only the shortage.
- Applied the same approval-target behavior and clearer user messaging to Zoltar migration preparation.
- Added a shared helper for computing approval targets and covered it with input helper tests.

## Testing
- Not run (PR content only).
- Existing test coverage added for `approvalTargetAmount` in `ui/ts/tests/inputs.test.ts`.