### PR TITLE
Buffer oracle funding and clarify REP approvals

### DIFF
--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -3,6 +3,7 @@ import { ABIS } from './abis.js'
 import { createRepTokenAddressHelper, createSecurityPoolAddressHelper } from '../../shared/js/addressDerivation.js'
 import { createApplyLinkedLibrariesHelper, createDeploymentStatusOracleAddressHelper, createInfraContractAddressHelper, createZoltarAddressHelpers } from '../../shared/js/deploymentAddresses.js'
 import { assertNever } from './lib/assert.js'
+import { addOpenOracleBountyBuffer } from './lib/openOracle.js'
 import { GENESIS_REPUTATION_TOKEN_ADDRESS } from './lib/universe.js'
 import {
 	DeploymentStatusOracle_DeploymentStatusOracle,
@@ -1588,13 +1589,24 @@ export async function createOpenOracleReportInstance(
 	} satisfies OpenOracleActionResult
 }
 
-export async function requestOraclePrice(client: WriteClient, managerAddress: Address, ethCost: bigint) {
+async function loadBufferedOracleRequestEthCost(client: WriteClient, managerAddress: Address) {
+	const requestPriceEthCost = await client.readContract({
+		address: managerAddress,
+		abi: peripherals_PriceOracleManagerAndOperatorQueuer_PriceOracleManagerAndOperatorQueuer.abi,
+		functionName: 'getRequestPriceEthCost',
+		args: [],
+	})
+
+	return addOpenOracleBountyBuffer(requestPriceEthCost)
+}
+
+export async function requestOraclePrice(client: WriteClient, managerAddress: Address) {
 	const callParams = {
 		address: managerAddress,
 		abi: peripherals_PriceOracleManagerAndOperatorQueuer_PriceOracleManagerAndOperatorQueuer.abi,
 		functionName: 'requestPrice',
 		args: [],
-		value: ethCost,
+		value: await loadBufferedOracleRequestEthCost(client, managerAddress),
 	}
 	const hash = await writeContractAndWait(client, () => callParams)
 	return {
@@ -2119,13 +2131,13 @@ export async function loadAllSecurityPools(client: ReadClient): Promise<ListedSe
 	)
 }
 
-export async function queueSecurityPoolLiquidation(client: WriteClient, managerAddress: Address, targetVault: Address, amount: bigint, ethCost: bigint) {
+export async function queueSecurityPoolLiquidation(client: WriteClient, managerAddress: Address, targetVault: Address, amount: bigint) {
 	const callParams = {
 		address: managerAddress,
 		abi: peripherals_PriceOracleManagerAndOperatorQueuer_PriceOracleManagerAndOperatorQueuer.abi,
 		functionName: 'requestPriceIfNeededAndQueueOperation',
 		args: [LIQUIDATION_OPERATION_TYPE, targetVault, amount],
-		value: ethCost,
+		value: await loadBufferedOracleRequestEthCost(client, managerAddress),
 	}
 	const hash = await writeContractAndWait(client, () => callParams)
 	return hash
@@ -2162,13 +2174,13 @@ function getShareTokenId(universeId: bigint, outcome: ReportingOutcomeKey) {
 	return ((universeId & universeMask) << 8n) | (getShareMigrationOutcomeValue(outcome) & 255n)
 }
 
-export async function queueOracleManagerOperation(client: WriteClient, managerAddress: Address, operation: OracleQueueOperation, targetVault: Address, amount: bigint, ethCost: bigint) {
+export async function queueOracleManagerOperation(client: WriteClient, managerAddress: Address, operation: OracleQueueOperation, targetVault: Address, amount: bigint) {
 	const callParams = {
 		address: managerAddress,
 		abi: peripherals_PriceOracleManagerAndOperatorQueuer_PriceOracleManagerAndOperatorQueuer.abi,
 		functionName: 'requestPriceIfNeededAndQueueOperation',
 		args: [getOracleOperationType(operation), targetVault, amount],
-		value: ethCost,
+		value: await loadBufferedOracleRequestEthCost(client, managerAddress),
 	}
 	const hash = await writeContractAndWait(client, () => callParams)
 	return {

--- a/ui/ts/hooks/usePriceOracleManager.ts
+++ b/ui/ts/hooks/usePriceOracleManager.ts
@@ -54,8 +54,8 @@ export function usePriceOracleManager({ accountAddress, onTransaction, onTransac
 				},
 			},
 			async walletAddress => {
-				const details = poolOracleManagerDetails.value ?? (await loadOracleManagerDetails(createConnectedReadClient(), managerAddress))
-				return await requestOraclePrice(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), managerAddress, details.requestPriceEthCost)
+				poolOracleManagerDetails.value ??= await loadOracleManagerDetails(createConnectedReadClient(), managerAddress)
+				return await requestOraclePrice(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), managerAddress)
 			},
 			'Failed to request price',
 			result => {

--- a/ui/ts/hooks/useSecurityPoolsOverview.ts
+++ b/ui/ts/hooks/useSecurityPoolsOverview.ts
@@ -1,6 +1,6 @@
 import { useSignal } from '@preact/signals'
 import type { Address, Hash } from 'viem'
-import { loadAllSecurityPools, loadOracleManagerDetails, queueSecurityPoolLiquidation } from '../contracts.js'
+import { loadAllSecurityPools, queueSecurityPoolLiquidation } from '../contracts.js'
 import { useLoadController } from './useLoadController.js'
 import { normalizeAddress } from '../lib/address.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
@@ -68,8 +68,7 @@ export function useSecurityPoolsOverview({ accountAddress, onTransaction, onTran
 			async walletAddress => {
 				const targetVault = parseAddressInput(liquidationTargetVault.value, 'Target vault')
 				const amount = parseBigIntInput(liquidationAmount.value, 'Liquidation amount')
-				const oracleDetails = await loadOracleManagerDetails(createConnectedReadClient(), managerAddress)
-				const hash = await queueSecurityPoolLiquidation(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), managerAddress, targetVault, amount, oracleDetails.requestPriceEthCost)
+				const hash = await queueSecurityPoolLiquidation(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), managerAddress, targetVault, amount)
 				return { hash }
 			},
 			'Failed to queue liquidation',

--- a/ui/ts/hooks/useSecurityVaultOperations.ts
+++ b/ui/ts/hooks/useSecurityVaultOperations.ts
@@ -4,7 +4,7 @@ import { useErc20AllowanceLoader, useErc20BalanceLoader } from './useErc20Loader
 import { useFormState } from './useFormState.js'
 import { useLoadController } from './useLoadController.js'
 import type { Address } from 'viem'
-import { approveErc20, depositRepToSecurityPool, loadErc20Balance, loadOracleManagerDetails, loadSecurityVaultDetails, queueOracleManagerOperation, redeemSecurityVaultFees, updateSecurityVaultFees } from '../contracts.js'
+import { approveErc20, depositRepToSecurityPool, loadErc20Balance, loadSecurityVaultDetails, queueOracleManagerOperation, redeemSecurityVaultFees, updateSecurityVaultFees } from '../contracts.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
 import { formatCurrencyBalance } from '../lib/formatters.js'
 import { sameAddress } from '../lib/address.js'
@@ -188,8 +188,7 @@ export function useSecurityVaultOperations({ accountAddress, onTransaction, onTr
 				if (amount <= 0n) throw new Error('Security bond allowance must be greater than zero')
 				const details = await loadExistingSecurityVaultDetails(securityPoolAddress, vaultAddress, 'Security pool does not exist')
 				if (details === undefined) return undefined
-				const managerDetails = await loadOracleManagerDetails(createConnectedReadClient(), details.managerAddress)
-				const result = await queueOracleManagerOperation(createWalletWriteClient(vaultAddress, { onTransactionSubmitted }), details.managerAddress, 'setSecurityBondsAllowance', vaultAddress, amount, managerDetails.requestPriceEthCost)
+				const result = await queueOracleManagerOperation(createWalletWriteClient(vaultAddress, { onTransactionSubmitted }), details.managerAddress, 'setSecurityBondsAllowance', vaultAddress, amount)
 				return {
 					action: 'queueSetSecurityBondAllowance',
 					hash: result.hash,
@@ -221,8 +220,7 @@ export function useSecurityVaultOperations({ accountAddress, onTransaction, onTr
 
 				const details = await loadExistingSecurityVaultDetails(securityPoolAddress, vaultAddress, 'Security pool does not exist')
 				if (details === undefined) return undefined
-				const managerDetails = await loadOracleManagerDetails(createConnectedReadClient(), details.managerAddress)
-				const result = await queueOracleManagerOperation(createWalletWriteClient(vaultAddress, { onTransactionSubmitted }), details.managerAddress, 'withdrawRep', vaultAddress, amount, managerDetails.requestPriceEthCost)
+				const result = await queueOracleManagerOperation(createWalletWriteClient(vaultAddress, { onTransactionSubmitted }), details.managerAddress, 'withdrawRep', vaultAddress, amount)
 				return {
 					action: 'queueWithdrawRep',
 					hash: result.hash,

--- a/ui/ts/lib/openOracle.ts
+++ b/ui/ts/lib/openOracle.ts
@@ -7,6 +7,8 @@ import { quoteBestExactInput, quoteBestV3ExactInput, quoteExactInput } from './u
 
 const OPEN_ORACLE_PRICE_PRECISION = 10n ** 18n
 export const OPEN_ORACLE_APPROVAL_AMOUNT = maxUint256
+const OPEN_ORACLE_BOUNTY_BUFFER_NUMERATOR = 12n
+const OPEN_ORACLE_BOUNTY_BUFFER_DENOMINATOR = 10n
 
 type OpenOracleReportStatus = 'Awaiting Initial Report' | 'Pending' | 'Disputed' | 'Settled'
 export type OpenOracleSelectedReportActionMode = 'initial-report' | 'dispute' | 'read-only'
@@ -96,6 +98,11 @@ export function formatOpenOracleFeePercentage(feePercentage: bigint | undefined)
 export function formatOpenOracleMultiplier(multiplier: bigint | undefined) {
 	if (multiplier === undefined) return '—'
 	return `${(Number(multiplier) / 100).toFixed(2)}x`
+}
+
+export function addOpenOracleBountyBuffer(requiredBounty: bigint) {
+	if (requiredBounty <= 0n) return requiredBounty
+	return (requiredBounty * OPEN_ORACLE_BOUNTY_BUFFER_NUMERATOR + OPEN_ORACLE_BOUNTY_BUFFER_DENOMINATOR - 1n) / OPEN_ORACLE_BOUNTY_BUFFER_DENOMINATOR
 }
 
 function calculateOpenOraclePrice(token1Amount: bigint, token2Amount: bigint) {

--- a/ui/ts/tests/openOracle.test.ts
+++ b/ui/ts/tests/openOracle.test.ts
@@ -5,6 +5,7 @@ import { getAddress, maxUint256, zeroAddress, type Address } from 'viem'
 import { createOpenOracleReportInstance, getOpenOracleAddress, loadOpenOracleReportDetails, loadOpenOracleReportSummaries, loadOracleManagerDetails, requestOraclePrice, settleOracleReport, submitInitialOracleReport } from '../contracts.js'
 import {
 	deriveOpenOracleInitialReportSubmissionDetails,
+	addOpenOracleBountyBuffer,
 	formatOpenOracleFeePercentage,
 	formatOpenOracleInitialReportApprovalStatusUnavailableMessage,
 	formatOpenOracleInitialReportPriceUnavailableMessage,
@@ -366,6 +367,11 @@ describe('Open Oracle helpers', () => {
 		expect(OPEN_ORACLE_APPROVAL_AMOUNT).toBe(maxUint256)
 	})
 
+	test('oracle bounty buffer adds a 20% headroom and rounds up', () => {
+		expect(addOpenOracleBountyBuffer(101n)).toBe(122n)
+		expect(addOpenOracleBountyBuffer(1_000n)).toBe(1_200n)
+	})
+
 	test('selected report action mode follows the report lifecycle', () => {
 		expect(getOpenOracleSelectedReportActionMode({ currentReporter: zeroAddress, disputeOccurred: false, isDistributed: false, reportTimestamp: 0n })).toBe('initial-report')
 		const reporter = getAddress(addressString(TEST_ADDRESSES[1]))
@@ -386,9 +392,7 @@ describe('Open Oracle helpers', () => {
 	})
 
 	test('requestOraclePrice creates a pending report visible via loadOpenOracleReportDetails', async () => {
-		const { requestPriceEthCost } = await loadOracleManagerDetails(uiReadClient, managerAddress)
-
-		await requestOraclePrice(uiWriteClient, managerAddress, requestPriceEthCost)
+		await requestOraclePrice(uiWriteClient, managerAddress)
 
 		const details = await loadOracleManagerDetails(uiReadClient, managerAddress)
 		const reportId = details.pendingReportId
@@ -407,8 +411,7 @@ describe('Open Oracle helpers', () => {
 	})
 
 	test('submitted and settled reports are tracked in loadOpenOracleReportDetails', async () => {
-		const { requestPriceEthCost } = await loadOracleManagerDetails(uiReadClient, managerAddress)
-		await requestOraclePrice(uiWriteClient, managerAddress, requestPriceEthCost)
+		await requestOraclePrice(uiWriteClient, managerAddress)
 
 		const reportId = (await loadOracleManagerDetails(uiReadClient, managerAddress)).pendingReportId
 		const { exactToken1Report } = await loadOpenOracleReportDetails(uiReadClient, getOpenOracleAddress(), reportId)


### PR DESCRIPTION
## Summary
- Removed the manual overview refresh action and cleaned up related props wiring.
- Renamed REP deposit labels from "REP Deposit Share" to "Rep Deposit" across security pool and vault views.
- Updated REP approval flows to approve the full target amount, with clearer UI copy for current allowance gaps.
- Added a 20% buffered ETH value for open oracle requests so price requests and queued oracle operations fund the bounty with headroom.
- Updated hooks and tests to match the new oracle funding and approval behavior.

## Testing
- Not run (PR summary only)
- Existing tests updated for buffered oracle requests and approval target calculations
- TypeScript and full test suite not run in this context