### PR TITLE
Remove REP price bootstrap from security pool setup

### DIFF
--- a/solidity/contracts/peripherals/PriceOracleManagerAndOperatorQueuer.sol
+++ b/solidity/contracts/peripherals/PriceOracleManagerAndOperatorQueuer.sol
@@ -118,7 +118,7 @@ contract PriceOracleManagerAndOperatorQueuer {
 	}
 
 	function isPriceValid() public view returns (bool) {
-		return lastSettlementTimestamp + PRICE_VALID_FOR_SECONDS > block.timestamp;
+		return lastSettlementTimestamp != 0 && lastSettlementTimestamp + PRICE_VALID_FOR_SECONDS > block.timestamp;
 	}
 
 	function requestPriceIfNeededAndQueueOperation(OperationType operation, address targetVault, uint256 amount) public payable {

--- a/solidity/contracts/peripherals/SecurityPool.sol
+++ b/solidity/contracts/peripherals/SecurityPool.sol
@@ -119,12 +119,13 @@ contract SecurityPool is ISecurityPool {
 		}
 	}
 
-	function setStartingParams(uint256 _currentRetentionRate, uint256 _repEthPrice, uint256 _completeSetCollateralAmount) external {
+	function setStartingParams(uint256 _currentRetentionRate, uint256 _completeSetCollateralAmount) external {
 		require(msg.sender == address(securityPoolFactory), 'only callable by securityPoolFactory');
 		lastUpdatedFeeAccumulator = block.timestamp;
 		currentRetentionRate = _currentRetentionRate;
 		completeSetCollateralAmount = _completeSetCollateralAmount;
-		priceOracleManagerAndOperatorQueuer.setRepEthPrice(_repEthPrice);
+		uint256 initialOraclePrice = address(parent) == address(0x0) ? 0 : parent.priceOracleManagerAndOperatorQueuer().lastPrice();
+		priceOracleManagerAndOperatorQueuer.setRepEthPrice(initialOraclePrice);
 	}
 
 	function updateCollateralAmount() public {

--- a/solidity/contracts/peripherals/SecurityPoolForker.sol
+++ b/solidity/contracts/peripherals/SecurityPoolForker.sol
@@ -105,7 +105,7 @@ contract SecurityPoolForker is ISecurityPoolForker {
 		// first vault migrater creates new pool and transfers all REP to it
 		uint248 childUniverseId = uint248(uint256(keccak256(abi.encode(parent.universeId(), outcomeIndex))));
 		uint256 retentionRate = SecurityPoolUtils.calculateRetentionRate(parent.completeSetCollateralAmount(), parent.totalSecurityBondAllowance());
-		(ISecurityPool child, UniformPriceDualCapBatchAuction truthAuction) = parent.securityPoolFactory().deployChildSecurityPool(parent, parent.shareToken(), childUniverseId, parent.questionId(), parent.securityMultiplier(), retentionRate, parent.priceOracleManagerAndOperatorQueuer().lastPrice(), 0);
+		(ISecurityPool child, UniformPriceDualCapBatchAuction truthAuction) = parent.securityPoolFactory().deployChildSecurityPool(parent, parent.shareToken(), childUniverseId, parent.questionId(), parent.securityMultiplier(), retentionRate, 0);
 		forkDataByPool[child].outcomeIndex = outcomeIndex;
 		forkDataByPool[child].truthAuction = truthAuction;
 		trustedAuctionAddresses[address(truthAuction)] = true;

--- a/solidity/contracts/peripherals/factories/SecurityPoolFactory.sol
+++ b/solidity/contracts/peripherals/factories/SecurityPoolFactory.sol
@@ -26,7 +26,7 @@ contract SecurityPoolFactory is ISecurityPoolFactory {
 	ISecurityPoolForker securityPoolForker;
 	SecurityPoolDeployment[] private securityPoolDeployments;
 
-	event DeploySecurityPool(ISecurityPool securityPool, UniformPriceDualCapBatchAuction truthAuction, PriceOracleManagerAndOperatorQueuer priceOracleManagerAndOperatorQueuer, IShareToken shareToken, ISecurityPool parent, uint248 universeId, uint256 questionId, uint256 securityMultiplier, uint256 currentRetentionRate, uint256 startingRepEthPrice, uint256 completeSetCollateralAmount);
+	event DeploySecurityPool(ISecurityPool securityPool, UniformPriceDualCapBatchAuction truthAuction, PriceOracleManagerAndOperatorQueuer priceOracleManagerAndOperatorQueuer, IShareToken shareToken, ISecurityPool parent, uint248 universeId, uint256 questionId, uint256 securityMultiplier, uint256 currentRetentionRate, uint256 completeSetCollateralAmount);
 
 	constructor(ISecurityPoolForker _securityPoolForker, ZoltarQuestionData _questionData, EscalationGameFactory _escalationGameFactory, OpenOracle _openOracle, Zoltar _zoltar, ShareTokenFactory _shareTokenFactory, UniformPriceDualCapBatchAuctionFactory _uniformPriceDualCapBatchAuctionFactory, PriceOracleManagerAndOperatorQueuerFactory _priceOracleManagerAndOperatorQueuerFactory) {
 		securityPoolForker = _securityPoolForker;
@@ -52,7 +52,7 @@ contract SecurityPoolFactory is ISecurityPoolFactory {
 		}
 	}
 
-	function deployChildSecurityPool(ISecurityPool parent, IShareToken shareToken, uint248 universeId, uint256 questionId, uint256 securityMultiplier, uint256 currentRetentionRate, uint256 startingRepEthPrice, uint256 completeSetCollateralAmount) external returns (ISecurityPool securityPool, UniformPriceDualCapBatchAuction truthAuction) {
+	function deployChildSecurityPool(ISecurityPool parent, IShareToken shareToken, uint248 universeId, uint256 questionId, uint256 securityMultiplier, uint256 currentRetentionRate, uint256 completeSetCollateralAmount) external returns (ISecurityPool securityPool, UniformPriceDualCapBatchAuction truthAuction) {
 		require(msg.sender == address(securityPoolForker), 'only securityPoolForker');
 		bytes32 securityPoolSalt = keccak256(abi.encode(parent, universeId, questionId, securityMultiplier));
 		ReputationToken reputationToken = zoltar.getRepToken(universeId);
@@ -63,13 +63,13 @@ contract SecurityPoolFactory is ISecurityPoolFactory {
 		securityPool = new SecurityPool{ salt: bytes32(uint256(0x0)) }(address(securityPoolForker), this, questionData, escalationGameFactory, priceOracleManagerAndOperatorQueuer, shareToken, openOracle, parent, zoltar, universeId, questionId, securityMultiplier, address(truthAuction));
 
 		priceOracleManagerAndOperatorQueuer.setSecurityPool(securityPool);
-		securityPool.setStartingParams(currentRetentionRate, startingRepEthPrice, completeSetCollateralAmount);
-		securityPoolDeployments.push(SecurityPoolDeployment(securityPool, truthAuction, priceOracleManagerAndOperatorQueuer, shareToken, parent, universeId, questionId, securityMultiplier, currentRetentionRate, startingRepEthPrice, completeSetCollateralAmount));
+		securityPool.setStartingParams(currentRetentionRate, completeSetCollateralAmount);
+		securityPoolDeployments.push(SecurityPoolDeployment(securityPool, truthAuction, priceOracleManagerAndOperatorQueuer, shareToken, parent, universeId, questionId, securityMultiplier, currentRetentionRate, completeSetCollateralAmount));
 
-		emit DeploySecurityPool(securityPool, truthAuction, priceOracleManagerAndOperatorQueuer, shareToken, parent, universeId, questionId, securityMultiplier, currentRetentionRate, startingRepEthPrice, completeSetCollateralAmount);
+		emit DeploySecurityPool(securityPool, truthAuction, priceOracleManagerAndOperatorQueuer, shareToken, parent, universeId, questionId, securityMultiplier, currentRetentionRate, completeSetCollateralAmount);
 	}
 
-	function deployOriginSecurityPool(uint248 universeId, uint256 questionId, uint256 securityMultiplier, uint256 currentRetentionRate, uint256 startingRepEthPrice) external returns (ISecurityPool securityPool) {
+	function deployOriginSecurityPool(uint248 universeId, uint256 questionId, uint256 securityMultiplier, uint256 currentRetentionRate) external returns (ISecurityPool securityPool) {
 		// Validate that the question exists
 		require(questionData.questionCreatedTimestamp(questionId) > 0, 'Question does not exist');
 
@@ -91,11 +91,11 @@ contract SecurityPoolFactory is ISecurityPoolFactory {
 		securityPool = new SecurityPool{ salt: bytes32(uint256(0x0)) }(address(securityPoolForker), this, questionData, escalationGameFactory, priceOracleManagerAndOperatorQueuer, shareToken, openOracle, ISecurityPool(payable(0x0)), zoltar, universeId, questionId, securityMultiplier, address(0));
 
 		priceOracleManagerAndOperatorQueuer.setSecurityPool(securityPool);
-		securityPool.setStartingParams(currentRetentionRate, startingRepEthPrice, 0);
+		securityPool.setStartingParams(currentRetentionRate, 0);
 
 		shareToken.authorize(securityPool);
-		securityPoolDeployments.push(SecurityPoolDeployment(securityPool, UniformPriceDualCapBatchAuction(address(0x0)), priceOracleManagerAndOperatorQueuer, shareToken, ISecurityPool(payable(0x0)), universeId, questionId, securityMultiplier, currentRetentionRate, startingRepEthPrice, 0));
+		securityPoolDeployments.push(SecurityPoolDeployment(securityPool, UniformPriceDualCapBatchAuction(address(0x0)), priceOracleManagerAndOperatorQueuer, shareToken, ISecurityPool(payable(0x0)), universeId, questionId, securityMultiplier, currentRetentionRate, 0));
 
-		emit DeploySecurityPool(securityPool, UniformPriceDualCapBatchAuction(address(0x0)), priceOracleManagerAndOperatorQueuer, shareToken, ISecurityPool(payable(0x0)), universeId, questionId, securityMultiplier, currentRetentionRate, startingRepEthPrice, 0);
+		emit DeploySecurityPool(securityPool, UniformPriceDualCapBatchAuction(address(0x0)), priceOracleManagerAndOperatorQueuer, shareToken, ISecurityPool(payable(0x0)), universeId, questionId, securityMultiplier, currentRetentionRate, 0);
 	}
 }

--- a/solidity/contracts/peripherals/interfaces/ISecurityPool.sol
+++ b/solidity/contracts/peripherals/interfaces/ISecurityPool.sol
@@ -62,7 +62,7 @@ interface ISecurityPool {
 	function repToPoolOwnership(uint256 repAmount) external view returns (uint256);
 	function poolOwnershipToRep(uint256 poolOwnership) external view returns (uint256);
 
-	function setStartingParams(uint256 currentRetentionRate, uint256 repEthPrice, uint256 completeSetCollateralAmount) external;
+	function setStartingParams(uint256 currentRetentionRate, uint256 completeSetCollateralAmount) external;
 
 	function updateCollateralAmount() external;
 	function updateRetentionRate() external;
@@ -107,12 +107,11 @@ interface ISecurityPoolFactory {
 		uint256 questionId;
 		uint256 securityMultiplier;
 		uint256 currentRetentionRate;
-		uint256 startingRepEthPrice;
 		uint256 completeSetCollateralAmount;
 	}
 
-	function deployChildSecurityPool(ISecurityPool parent, IShareToken shareToken, uint248 universeId, uint256 questionId, uint256 securityMultiplier, uint256 currentRetentionRate, uint256 startingRepEthPrice, uint256 completeSetCollateralAmount) external returns (ISecurityPool securityPool, UniformPriceDualCapBatchAuction truthAuction);
-	function deployOriginSecurityPool(uint248 universeId, uint256 questionId, uint256 securityMultiplier, uint256 currentRetentionRate, uint256 startingRepEthPrice) external returns (ISecurityPool securityPool);
+	function deployChildSecurityPool(ISecurityPool parent, IShareToken shareToken, uint248 universeId, uint256 questionId, uint256 securityMultiplier, uint256 currentRetentionRate, uint256 completeSetCollateralAmount) external returns (ISecurityPool securityPool, UniformPriceDualCapBatchAuction truthAuction);
+	function deployOriginSecurityPool(uint248 universeId, uint256 questionId, uint256 securityMultiplier, uint256 currentRetentionRate) external returns (ISecurityPool securityPool);
 	function securityPoolDeploymentCount() external view returns (uint256);
 	function securityPoolDeploymentsRange(uint256 startIndex, uint256 count) external view returns (SecurityPoolDeployment[] memory deployments);
 }

--- a/solidity/ts/gas-costs.ts
+++ b/solidity/ts/gas-costs.ts
@@ -19,7 +19,6 @@ import { createWriteClient, WriteClient, writeContractAndWait } from './testsuit
 const genesisUniverse = 0n
 const securityMultiplier = 2n
 const maxRetentionRate = 999_999_996_848_000_000n
-const startingRepEthPrice = 10n
 const repDepositAmount = 1_000n * 10n ** 18n
 const securityBondAllowance = repDepositAmount / 4n
 const openInterestAmount = 100n * 10n ** 18n
@@ -151,7 +150,7 @@ const setupPool = async (title: string): Promise<PoolContext> => {
 	const questionData = await buildQuestionData(title)
 	const questionId = getQuestionId(questionData, questionOutcomes)
 	await confirmTx(alice, createQuestion(alice, questionData, [...questionOutcomes]))
-	await confirmTx(alice, deployOriginSecurityPool(alice, genesisUniverse, questionId, securityMultiplier, maxRetentionRate, startingRepEthPrice))
+	await confirmTx(alice, deployOriginSecurityPool(alice, genesisUniverse, questionId, securityMultiplier, maxRetentionRate))
 	const addresses = getSecurityPoolAddresses(zeroAddress, genesisUniverse, questionId, securityMultiplier)
 	return { questionData, questionId, addresses }
 }
@@ -299,7 +298,7 @@ const scenarios: Scenario[] = [
 			const questionData = await buildQuestionData('Gas deploy pool')
 			const questionId = getQuestionId(questionData, questionOutcomes)
 			await confirmTx(alice, createQuestion(alice, questionData, [...questionOutcomes]))
-			return await waitForGas(alice, deployOriginSecurityPool(alice, genesisUniverse, questionId, securityMultiplier, maxRetentionRate, startingRepEthPrice))
+			return await waitForGas(alice, deployOriginSecurityPool(alice, genesisUniverse, questionId, securityMultiplier, maxRetentionRate))
 		},
 	},
 	{

--- a/solidity/ts/tests/escalationGame_forkThreshold.test.ts
+++ b/solidity/ts/tests/escalationGame_forkThreshold.test.ts
@@ -36,7 +36,6 @@ describe('Escalation Game Fork Threshold Test', () => {
 	let client: WriteClient
 	const genesisUniverse = 0n
 	const securityMultiplier = 2n
-	const startingRepEthPrice = 10n
 	const currentTimestamp = BigInt(Math.floor(Date.now() / 1000))
 	const questionEndDate = currentTimestamp + 365n * DAY
 	let securityPoolAddresses: {
@@ -66,7 +65,7 @@ describe('Escalation Game Fork Threshold Test', () => {
 		questionId = getQuestionId(questionData, outcomes)
 		await createQuestion(client, questionData, outcomes)
 
-		await deployOriginSecurityPool(client, genesisUniverse, questionId, securityMultiplier, MAX_RETENTION_RATE, startingRepEthPrice)
+		await deployOriginSecurityPool(client, genesisUniverse, questionId, securityMultiplier, MAX_RETENTION_RATE)
 		await approveAndDepositRep(client, 1000n * 10n ** 18n, questionId)
 
 		securityPoolAddresses = getSecurityPoolAddresses(addressString(0x0n), genesisUniverse, questionId, securityMultiplier)

--- a/solidity/ts/tests/peripherals.test.ts
+++ b/solidity/ts/tests/peripherals.test.ts
@@ -73,7 +73,7 @@ describe('Peripherals Contract Test Suite', () => {
 	}
 	const genesisUniverse = 0n
 	const securityMultiplier = 2n
-	const startingRepEthPrice = 10n
+	const reportedRepEthPrice = 10n
 	const testInternalSenderBalance = 10n ** 18n
 	const MAX_RETENTION_RATE = 999_999_996_848_000_000n // ≈90% yearly
 	const EXTRA_INFO = 'test question!'
@@ -115,14 +115,14 @@ describe('Peripherals Contract Test Suite', () => {
 		}
 		questionId = getQuestionId(questionData, outcomes)
 		await createQuestion(client, questionData, outcomes)
-		await deployOriginSecurityPool(client, genesisUniverse, questionId, securityMultiplier, MAX_RETENTION_RATE, startingRepEthPrice)
+		await deployOriginSecurityPool(client, genesisUniverse, questionId, securityMultiplier, MAX_RETENTION_RATE)
 		await approveAndDepositRep(client, repDeposit, questionId)
 		securityPoolAddresses = getSecurityPoolAddresses(addressString(0x0n), genesisUniverse, questionId, securityMultiplier)
 	})
 
 	test('can deposit rep and withdraw it', async () => {
-		await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.WithdrawRep, client.account.address, repDeposit, startingRepEthPrice)
-		strictEqualTypeSafe(await getLastPrice(client, securityPoolAddresses.priceOracleManagerAndOperatorQueuer), startingRepEthPrice, 'Price was not set!')
+		await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.WithdrawRep, client.account.address, repDeposit, reportedRepEthPrice)
+		strictEqualTypeSafe(await getLastPrice(client, securityPoolAddresses.priceOracleManagerAndOperatorQueuer), reportedRepEthPrice, 'Price was not set!')
 		approximatelyEqual(await getERC20Balance(client, addressString(GENESIS_REPUTATION_TOKEN), securityPoolAddresses.securityPool), 0n, 100n, 'Did not empty security pool of rep')
 		const startBalance = await getERC20Balance(client, addressString(GENESIS_REPUTATION_TOKEN), client.account.address)
 		approximatelyEqual(await getERC20Balance(client, addressString(GENESIS_REPUTATION_TOKEN), client.account.address), startBalance, 100n, 'Did not get rep back')
@@ -170,7 +170,6 @@ describe('Peripherals Contract Test Suite', () => {
 			securityMultiplier: storedSecurityMultiplier,
 			securityPool: securityPoolAddress,
 			shareToken: shareTokenAddress,
-			startingRepEthPrice: storedStartingRepEthPrice,
 			truthAuction: truthAuctionAddress,
 			universeId,
 		} = deployment
@@ -186,8 +185,8 @@ describe('Peripherals Contract Test Suite', () => {
 		strictEqualTypeSafe(storedQuestionId, questionId, 'stored question id should match')
 		strictEqualTypeSafe(storedSecurityMultiplier, securityMultiplier, 'stored security multiplier should match')
 		strictEqualTypeSafe(storedCurrentRetentionRate, MAX_RETENTION_RATE, 'stored retention rate should match')
-		strictEqualTypeSafe(storedStartingRepEthPrice, startingRepEthPrice, 'stored starting price should match')
 		strictEqualTypeSafe(completeSetCollateralAmount, 0n, 'origin deployments should not have complete set collateral')
+		strictEqualTypeSafe(await getLastPrice(client, managerAddress), 0n, 'origin manager should start with a zero price')
 	})
 
 	test('deployment status oracle returns the deployment bitmask in one read', async () => {
@@ -451,7 +450,6 @@ describe('Peripherals Contract Test Suite', () => {
 			securityMultiplier: childStoredSecurityMultiplier,
 			securityPool: childSecurityPoolAddress,
 			shareToken: childShareTokenAddress,
-			startingRepEthPrice: childStartingRepEthPrice,
 			truthAuction: childTruthAuctionAddress,
 			universeId: childStoredUniverseId,
 		} = matchingChildDeployment
@@ -466,8 +464,8 @@ describe('Peripherals Contract Test Suite', () => {
 		strictEqualTypeSafe(childStoredQuestionId, questionId, 'child question id should match')
 		strictEqualTypeSafe(childStoredSecurityMultiplier, securityMultiplier, 'child multiplier should match')
 		strictEqualTypeSafe(childCurrentRetentionRate, MAX_RETENTION_RATE, 'child retention rate should match')
-		strictEqualTypeSafe(childStartingRepEthPrice > 0n, true, 'child starting price should be recorded')
 		strictEqualTypeSafe(childCompleteSetCollateralAmount, 0n, 'child complete set collateral should default to zero during fork')
+		strictEqualTypeSafe(await getLastPrice(client, childManagerAddress), await getLastPrice(client, securityPoolAddresses.priceOracleManagerAndOperatorQueuer), 'child manager should inherit the parent price')
 	})
 
 	test('Can Liquidate', async () => {
@@ -1085,7 +1083,7 @@ describe('Peripherals Contract Test Suite', () => {
 
 		// Attempt to deploy security pool with non-binary question should fail
 		// The first outcome must be "Yes", so it will fail with that message
-		await assert.rejects(deployOriginSecurityPool(client, genesisUniverse, multiOutcomeQuestionId, securityMultiplier, MAX_RETENTION_RATE, startingRepEthPrice), /First outcome must be "Yes"/)
+		await assert.rejects(deployOriginSecurityPool(client, genesisUniverse, multiOutcomeQuestionId, securityMultiplier, MAX_RETENTION_RATE), /First outcome must be "Yes"/)
 	})
 
 	test('cannot deploy security pool with scalar question', async () => {
@@ -1106,7 +1104,7 @@ describe('Peripherals Contract Test Suite', () => {
 
 		// Attempt to deploy security pool with scalar question should fail
 		// For scalar questions, getOutcomeLabels returns an empty array, first outcome will be empty string, not "Yes"
-		await assert.rejects(deployOriginSecurityPool(client, genesisUniverse, scalarQuestionId, securityMultiplier, MAX_RETENTION_RATE, startingRepEthPrice), /First outcome must be "Yes"/)
+		await assert.rejects(deployOriginSecurityPool(client, genesisUniverse, scalarQuestionId, securityMultiplier, MAX_RETENTION_RATE), /First outcome must be "Yes"/)
 	})
 
 	test('cannot deploy security pool with non-existent question', async () => {
@@ -1114,7 +1112,7 @@ describe('Peripherals Contract Test Suite', () => {
 		const nonExistentQuestionId = 999999999999n
 
 		// Attempt to deploy security pool with non-existent question should fail
-		await assert.rejects(deployOriginSecurityPool(client, genesisUniverse, nonExistentQuestionId, securityMultiplier, MAX_RETENTION_RATE, startingRepEthPrice), /Question does not exist/)
+		await assert.rejects(deployOriginSecurityPool(client, genesisUniverse, nonExistentQuestionId, securityMultiplier, MAX_RETENTION_RATE), /Question does not exist/)
 	})
 
 	test('can fork security pool using separate initiate and migrate calls with multiple migrations', async () => {

--- a/solidity/ts/tests/priceOracleSecurity.test.ts
+++ b/solidity/ts/tests/priceOracleSecurity.test.ts
@@ -26,7 +26,6 @@ describe('Price Oracle Refund Security Tests', () => {
 	let priceOracle: Address
 	const genesisUniverse = 0n
 	const securityMultiplier = 2n
-	const startingRepEthPrice = 10n
 	const MAX_RETENTION_RATE = 999_999_996_848_000_000n
 	const EXTRA_INFO = 'test question!'
 
@@ -50,7 +49,7 @@ describe('Price Oracle Refund Security Tests', () => {
 		const outcomes = ['Yes', 'No']
 		await createQuestion(client, questionData, outcomes)
 		const questionId = getQuestionId(questionData, outcomes)
-		await deployOriginSecurityPool(client, genesisUniverse, questionId, securityMultiplier, MAX_RETENTION_RATE, startingRepEthPrice)
+		await deployOriginSecurityPool(client, genesisUniverse, questionId, securityMultiplier, MAX_RETENTION_RATE)
 		await approveAndDepositRep(client, repDeposit, questionId)
 		const addresses = getSecurityPoolAddresses(addressString(0x0n), genesisUniverse, questionId, securityMultiplier)
 		priceOracle = addresses.priceOracleManagerAndOperatorQueuer

--- a/solidity/ts/testsuite/simulator/utils/contracts/deployPeripherals.ts
+++ b/solidity/ts/testsuite/simulator/utils/contracts/deployPeripherals.ts
@@ -281,14 +281,14 @@ export async function ensureInfraDeployed(client: WriteClient): Promise<void> {
 	if (!(await contractExists(client, getDeploymentStatusOracleAddress()))) throw new Error('deploymentStatusOracle does not exist even though we deployed it')
 }
 
-export const deployOriginSecurityPool = async (client: WriteClient, universeId: bigint, questionId: bigint, securityMultiplier: bigint, startingRetentionRate: bigint, startingRepEthPrice: bigint) => {
+export const deployOriginSecurityPool = async (client: WriteClient, universeId: bigint, questionId: bigint, securityMultiplier: bigint, startingRetentionRate: bigint) => {
 	const infraAddresses = getInfraContractAddresses()
 	return await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_factories_SecurityPoolFactory_SecurityPoolFactory.abi,
 			functionName: 'deployOriginSecurityPool',
 			address: infraAddresses.securityPoolFactory,
-			args: [universeId, questionId, securityMultiplier, startingRetentionRate, startingRepEthPrice],
+			args: [universeId, questionId, securityMultiplier, startingRetentionRate],
 		}),
 	)
 }

--- a/ui/ts/components/SecurityPoolSection.tsx
+++ b/ui/ts/components/SecurityPoolSection.tsx
@@ -173,11 +173,6 @@ export function SecurityPoolSection({
 										<input value={securityPoolForm.currentRetentionRate} onInput={event => onSecurityPoolFormChange({ currentRetentionRate: event.currentTarget.value })} placeholder={formatOpenInterestFeePerYearPercent(999999996848000000n)} />
 									</label>
 
-									<label className='field'>
-										<span>Starting REP / ETH Price</span>
-										<input value={securityPoolForm.startingRepEthPrice} onInput={event => onSecurityPoolFormChange({ startingRepEthPrice: event.currentTarget.value })} />
-									</label>
-
 									<div className='actions'>
 										<button className='primary' onClick={onCreateSecurityPool} disabled={isCreateDisabled}>
 											{createButtonLabel}

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -123,7 +123,6 @@ type SecurityPoolDeploymentQueryResult = {
 	securityMultiplier: bigint
 	securityPool: Address
 	shareToken: Address
-	startingRepEthPrice: bigint
 	truthAuction: Address
 	universeId: bigint
 }
@@ -1129,14 +1128,13 @@ export async function createSecurityPool(
 		currentRetentionRate: bigint
 		questionId: bigint
 		securityMultiplier: bigint
-		startingRepEthPrice: bigint
 	},
 ) {
 	const deployPoolHash = await writeContractAndWait(client, () => ({
 		address: getDeploymentStep('securityPoolFactory').address,
 		abi: peripherals_factories_SecurityPoolFactory_SecurityPoolFactory.abi,
 		functionName: 'deployOriginSecurityPool',
-		args: [0n, parameters.questionId, parameters.securityMultiplier, parameters.currentRetentionRate, parameters.startingRepEthPrice],
+		args: [0n, parameters.questionId, parameters.securityMultiplier, parameters.currentRetentionRate],
 	}))
 
 	return {
@@ -2076,7 +2074,7 @@ export async function loadAllSecurityPools(client: ReadClient): Promise<ListedSe
 
 	return await Promise.all(
 		deployments.map(async deployment => {
-			const { currentRetentionRate, parent, priceOracleManagerAndOperatorQueuer: managerAddress, questionId, securityMultiplier, securityPool: securityPoolAddress, startingRepEthPrice, truthAuction: truthAuctionAddress, universeId } = deployment
+			const { currentRetentionRate, parent, priceOracleManagerAndOperatorQueuer: managerAddress, questionId, securityMultiplier, securityPool: securityPoolAddress, truthAuction: truthAuctionAddress, universeId } = deployment
 			const [systemState, forkData, marketDetails] = await Promise.all([
 				client.readContract({
 					abi: peripherals_SecurityPool_SecurityPool.abi,
@@ -2107,7 +2105,6 @@ export async function loadAllSecurityPools(client: ReadClient): Promise<ListedSe
 				questionId: getQuestionIdHex(questionId),
 				securityMultiplier,
 				securityPoolAddress,
-				startingRepEthPrice,
 				systemState: getSecurityPoolSystemState(systemState),
 				truthAuctionAddress,
 				truthAuctionStartedAt,

--- a/ui/ts/lib/marketCreation.ts
+++ b/ui/ts/lib/marketCreation.ts
@@ -234,6 +234,5 @@ export function createSecurityPoolParameters(form: SecurityPoolFormState) {
 		currentRetentionRate: parseOpenInterestFeePerYearPercentInput(form.currentRetentionRate, 'Open interest fee per year'),
 		questionId: parseQuestionIdInput(form.marketId),
 		securityMultiplier: parseBigIntInput(form.securityMultiplier, 'Security multiplier'),
-		startingRepEthPrice: parseBigIntInput(form.startingRepEthPrice, 'Starting REP/ETH price'),
 	}
 }

--- a/ui/ts/lib/marketForm.ts
+++ b/ui/ts/lib/marketForm.ts
@@ -23,7 +23,6 @@ export function getDefaultSecurityPoolFormState(): SecurityPoolFormState {
 		currentRetentionRate: DEFAULT_CURRENT_RETENTION_RATE,
 		marketId: '',
 		securityMultiplier: '2',
-		startingRepEthPrice: '10',
 	}
 }
 

--- a/ui/ts/tests/openOracle.test.ts
+++ b/ui/ts/tests/openOracle.test.ts
@@ -42,7 +42,7 @@ function installInjectedEthereum(mockWindow: AnvilWindowEthereum) {
 const genesisUniverse = 0n
 const securityMultiplier = 2n
 const MAX_RETENTION_RATE = 999_999_996_848_000_000n
-const startingRepEthPrice = 10n
+const reportedRepEthPrice = 10n
 const outcomes = ['Yes', 'No']
 
 function createQuoteClient(amountOut: bigint): Parameters<typeof loadOpenOracleInitialReportPrice>[0] {
@@ -91,7 +91,7 @@ describe('Open Oracle helpers', () => {
 		}
 		const questionId = getQuestionId(questionData, outcomes)
 		await createQuestion(client, questionData, outcomes)
-		await deployOriginSecurityPool(client, genesisUniverse, questionId, securityMultiplier, MAX_RETENTION_RATE, startingRepEthPrice)
+		await deployOriginSecurityPool(client, genesisUniverse, questionId, securityMultiplier, MAX_RETENTION_RATE)
 		managerAddress = getSecurityPoolAddresses(zeroAddress, genesisUniverse, questionId, securityMultiplier).priceOracleManagerAndOperatorQueuer
 	})
 
@@ -380,7 +380,7 @@ describe('Open Oracle helpers', () => {
 		expect(details.managerAddress).toBe(managerAddress)
 		expect(details.openOracleAddress).toBe(getOpenOracleAddress())
 		expect(details.pendingReportId).toBe(0n)
-		expect(details.lastPrice).toBe(startingRepEthPrice)
+		expect(details.lastPrice).toBe(0n)
 		expect(details.lastSettlementTimestamp).toBe(0n)
 		expect(details.isPriceValid).toBe(false)
 	})
@@ -414,7 +414,7 @@ describe('Open Oracle helpers', () => {
 		const { exactToken1Report } = await loadOpenOracleReportDetails(uiReadClient, getOpenOracleAddress(), reportId)
 		const PRICE_PRECISION = 10n ** 18n
 		const amount1 = exactToken1Report
-		const amount2 = (amount1 * PRICE_PRECISION) / startingRepEthPrice
+		const amount2 = (amount1 * PRICE_PRECISION) / reportedRepEthPrice
 
 		const openOracleAddress = getOpenOracleAddress()
 		await approveToken(client, addressString(GENESIS_REPUTATION_TOKEN), openOracleAddress)

--- a/ui/ts/tests/securityPoolCreation.test.ts
+++ b/ui/ts/tests/securityPoolCreation.test.ts
@@ -60,7 +60,6 @@ describe('security pool creation helper', () => {
 			currentRetentionRate: 999_999_996_848_000_000n,
 			questionId,
 			securityMultiplier: 2n,
-			startingRepEthPrice: 10n,
 		})
 
 		const expectedAddresses = getSecurityPoolAddresses(zeroAddress, 0n, questionId, 2n)

--- a/ui/ts/tests/securityVault.integration.test.ts
+++ b/ui/ts/tests/securityVault.integration.test.ts
@@ -28,7 +28,6 @@ function installInjectedEthereum(mockWindow: AnvilWindowEthereum) {
 const genesisUniverse = 0n
 const securityMultiplier = 2n
 const MAX_RETENTION_RATE = 999_999_996_848_000_000n
-const startingRepEthPrice = 10n
 const outcomes = ['Yes', 'No']
 const depositAmount = 10_000n * 10n ** 18n
 const belowMinimumDepositAmount = 9n * 10n ** 18n
@@ -67,7 +66,7 @@ describe('Security vault integration', () => {
 		}
 		const questionId = getQuestionId(questionData, outcomes)
 		await createQuestion(client, questionData, outcomes)
-		await deployOriginSecurityPool(client, genesisUniverse, questionId, securityMultiplier, MAX_RETENTION_RATE, startingRepEthPrice)
+		await deployOriginSecurityPool(client, genesisUniverse, questionId, securityMultiplier, MAX_RETENTION_RATE)
 		securityPoolAddress = getSecurityPoolAddresses(zeroAddress, genesisUniverse, questionId, securityMultiplier).securityPool
 	})
 

--- a/ui/ts/types/app.ts
+++ b/ui/ts/types/app.ts
@@ -35,7 +35,6 @@ export type SecurityPoolFormState = {
 	currentRetentionRate: string
 	marketId: string
 	securityMultiplier: string
-	startingRepEthPrice: string
 }
 
 export type SecurityVaultFormState = {

--- a/ui/ts/types/contracts.ts
+++ b/ui/ts/types/contracts.ts
@@ -235,7 +235,6 @@ export type ListedSecurityPool = {
 	questionId: string
 	securityMultiplier: bigint
 	securityPoolAddress: Address
-	startingRepEthPrice: bigint
 	systemState: SecurityPoolSystemState
 	truthAuctionAddress: Address
 	truthAuctionStartedAt: bigint


### PR DESCRIPTION
## Summary
- Remove the need to pass a starting REP/ETH price into security pool deployment and fork setup.
- Initialize security pool oracle state from the parent pool when applicable, and leave origin pools with a zero starting price.
- Tighten price validity checks so an unset oracle timestamp is not treated as valid.
- Update UI copy and approval flows to use clearer `Rep Deposit` labels and approve-to-target messaging.
- Remove the obsolete overview refresh action and align related tests and type definitions with the new deployment flow.

## Testing
- Not run (PR content only).
- Relevant checks in the repository: `bun tsc`, `bun test`, `bun run format`, `bun run check`, `bun run knip`.