### PR TITLE
Require valid oracle pricing before vault actions

### DIFF
--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -354,7 +354,7 @@ export function SecurityPoolWorkflowSection({
 									</EntityCard>
 								) : (
 									<EntityCard className='selected-pool-card' title='Selected Vault' badge={<span className={`badge ${selectedVaultIsOwnedByAccount ? 'ok' : 'muted'}`}>{selectedVaultIsOwnedByAccount ? 'Owned' : 'Read only'}</span>}>
-										<SecurityVaultSection {...securityVault} autoLoadVault compactLayout showHeader={false} showSecurityPoolAddressInput={false} />
+										<SecurityVaultSection {...securityVault} autoLoadVault compactLayout oracleManagerDetails={sameAddress(poolOracleManagerDetails?.managerAddress, selectedPoolManagerAddress) ? poolOracleManagerDetails : undefined} showHeader={false} showSecurityPoolAddressInput={false} />
 									</EntityCard>
 								)}
 							</div>

--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -6,13 +6,14 @@ import { ErrorNotice } from './ErrorNotice.js'
 import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
 import { StateHint } from './StateHint.js'
+import { TimestampValue } from './TimestampValue.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { normalizeAddress, sameAddress } from '../lib/address.js'
 import { formatCurrencyBalance, formatCurrencyInputBalance } from '../lib/formatters.js'
 import { approvalShortage, balanceShortage } from '../lib/inputs.js'
 import { isMainnetChain } from '../lib/network.js'
 import { parseRepAmountInput } from '../lib/marketForm.js'
-import { getSelectedVaultAddress, isSecurityVaultDepositBelowMinimum, isSelectedVaultOwnedByAccount as isSelectedVaultOwnedByAccountHelper, MIN_SECURITY_VAULT_REP_DEPOSIT } from '../lib/securityVault.js'
+import { getSelectedVaultAddress, hasValidSecurityVaultOraclePrice, isSecurityVaultDepositBelowMinimum, isSelectedVaultOwnedByAccount as isSelectedVaultOwnedByAccountHelper, MIN_SECURITY_VAULT_REP_DEPOSIT } from '../lib/securityVault.js'
 import { getWalletPresentation } from '../lib/userCopy.js'
 import type { SecurityVaultSectionProps } from '../types/components.js'
 
@@ -27,6 +28,7 @@ export function SecurityVaultSection({
 	onRedeemFees,
 	onSetSecurityBondAllowance,
 	onSecurityVaultFormChange,
+	oracleManagerDetails,
 	onWithdrawRep,
 	securityVaultDetails,
 	securityVaultError,
@@ -64,6 +66,8 @@ export function SecurityVaultSection({
 		}
 	})()
 	const securityBondAllowance = securityVaultDetails?.securityBondAllowance ?? 0n
+	const hasValidOraclePrice = hasValidSecurityVaultOraclePrice(securityVaultDetails?.managerAddress, oracleManagerDetails)
+	const oraclePriceValidUntilTimestamp = hasValidOraclePrice ? oracleManagerDetails?.priceValidUntilTimestamp : undefined
 	const approvedRep = securityVaultRepAllowance
 	const shortage = approvalShortage(depositAmount, approvedRep)
 	const repBalanceGap = balanceShortage(depositAmount, securityVaultRepBalance)
@@ -74,7 +78,8 @@ export function SecurityVaultSection({
 	const hasSufficientDepositAllowance = selectedVaultIsOwnedByAccount && approvedRep !== undefined && depositAmount !== undefined && depositAmount > 0n && approvedRep >= depositAmount
 	const hasInsufficientRepBalance = repBalanceGap !== undefined && repBalanceGap > 0n
 	const canApproveRep = selectedVaultIsOwnedByAccount && isMainnet && securityVaultDetails !== undefined && depositAmount !== undefined && depositAmount > 0n && shortage !== undefined && shortage > 0n
-	const canSetSecurityBondAllowance = selectedVaultIsOwnedByAccount && isMainnet && securityVaultDetails !== undefined && securityBondAllowanceAmount !== undefined && securityBondAllowanceAmount > 0n
+	const canSetSecurityBondAllowance = selectedVaultIsOwnedByAccount && isMainnet && securityVaultDetails !== undefined && hasValidOraclePrice && securityBondAllowanceAmount !== undefined && securityBondAllowanceAmount > 0n
+	const canWithdrawRep = selectedVaultIsOwnedByAccount && accountState.address !== undefined && isMainnet && hasValidOraclePrice && hasWithdrawAmount && withdrawableRepAmount !== undefined && withdrawableRepAmount > 0n
 	const approveButtonLabel = depositAmount === undefined || depositAmount <= 0n || shortage === undefined ? 'Approve REP' : shortage === 0n ? 'Approval Satisfied' : `Approve ${formatCurrencyBalance(shortage)} REP`
 	const approveButtonTitle = (() => {
 		const walletPresentation = getWalletPresentation({ accountAddress: accountState.address, isMainnet })
@@ -180,6 +185,11 @@ export function SecurityVaultSection({
 					<MetricField className='entity-metric' label='Current Security Bond Allowance'>
 						<CurrencyValue value={securityBondAllowance} suffix='REP' />
 					</MetricField>
+					{oraclePriceValidUntilTimestamp === undefined ? undefined : (
+						<MetricField className='entity-metric' label='Price Valid Until'>
+							<TimestampValue timestamp={oraclePriceValidUntilTimestamp} />
+						</MetricField>
+					)}
 				</div>
 				<label className='field'>
 					<span>Security Bond Allowance Amount</span>
@@ -190,6 +200,7 @@ export function SecurityVaultSection({
 						Set Security Bond Allowance
 					</button>
 				</div>
+				{hasValidOraclePrice ? undefined : <p className='detail'>A valid oracle price is required before setting the security bond allowance.</p>}
 			</div>
 		)
 
@@ -261,9 +272,13 @@ export function SecurityVaultSection({
 					<MetricField className='entity-metric' label='Withdrawable REP'>
 						<CurrencyValue value={withdrawableRepAmount} suffix='REP' />
 					</MetricField>
+					{oraclePriceValidUntilTimestamp === undefined ? undefined : (
+						<MetricField className='entity-metric' label='Price Valid Until'>
+							<TimestampValue timestamp={oraclePriceValidUntilTimestamp} />
+						</MetricField>
+					)}
 				</div>
 			)}
-			<p className='detail'>Withdrawals are queued through the oracle manager.</p>
 			<label className='field'>
 				<span>REP Withdraw Amount</span>
 				<div className='field-inline'>
@@ -282,10 +297,11 @@ export function SecurityVaultSection({
 				</div>
 			</label>
 			<div className='actions'>
-				<button className='secondary' onClick={onWithdrawRep} disabled={!selectedVaultIsOwnedByAccount || accountState.address === undefined || !isMainnet || !hasWithdrawAmount || withdrawableRepAmount === 0n}>
+				<button className='secondary' onClick={onWithdrawRep} disabled={!canWithdrawRep}>
 					Withdraw REP
 				</button>
 			</div>
+			{hasValidOraclePrice ? undefined : <p className='detail'>A valid oracle price is required before withdrawing REP.</p>}
 		</div>
 	)
 

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -3,6 +3,7 @@ import { ABIS } from './abis.js'
 import { createRepTokenAddressHelper, createSecurityPoolAddressHelper } from '../../shared/js/addressDerivation.js'
 import { createApplyLinkedLibrariesHelper, createDeploymentStatusOracleAddressHelper, createInfraContractAddressHelper, createZoltarAddressHelpers } from '../../shared/js/deploymentAddresses.js'
 import { assertNever } from './lib/assert.js'
+import { getOracleManagerPriceValidUntilTimestamp } from './lib/securityVault.js'
 import { GENESIS_REPUTATION_TOKEN_ADDRESS } from './lib/universe.js'
 import {
 	DeploymentStatusOracle_DeploymentStatusOracle,
@@ -1400,12 +1401,13 @@ export async function loadOracleManagerDetails(client: ReadClient, managerAddres
 	return {
 		callbackStateHash,
 		exactToken1Report,
-		isPriceValid: pendingReportId === 0n ? false : rawIsPriceValid,
+		isPriceValid: lastSettlementTimestamp > 0n && rawIsPriceValid,
 		lastPrice,
 		lastSettlementTimestamp,
 		managerAddress,
 		openOracleAddress: resolvedOracleAddress,
 		pendingReportId,
+		priceValidUntilTimestamp: getOracleManagerPriceValidUntilTimestamp(lastSettlementTimestamp),
 		requestPriceEthCost,
 		token1,
 		token2,

--- a/ui/ts/hooks/useSecurityVaultOperations.ts
+++ b/ui/ts/hooks/useSecurityVaultOperations.ts
@@ -189,6 +189,7 @@ export function useSecurityVaultOperations({ accountAddress, onTransaction, onTr
 				const details = await loadExistingSecurityVaultDetails(securityPoolAddress, vaultAddress, 'Security pool does not exist')
 				if (details === undefined) return undefined
 				const managerDetails = await loadOracleManagerDetails(createConnectedReadClient(), details.managerAddress)
+				if (!managerDetails.isPriceValid) throw new Error('A valid oracle price is required before setting the security bond allowance')
 				const result = await queueOracleManagerOperation(createWalletWriteClient(vaultAddress, { onTransactionSubmitted }), details.managerAddress, 'setSecurityBondsAllowance', vaultAddress, amount, managerDetails.requestPriceEthCost)
 				return {
 					action: 'queueSetSecurityBondAllowance',
@@ -222,6 +223,7 @@ export function useSecurityVaultOperations({ accountAddress, onTransaction, onTr
 				const details = await loadExistingSecurityVaultDetails(securityPoolAddress, vaultAddress, 'Security pool does not exist')
 				if (details === undefined) return undefined
 				const managerDetails = await loadOracleManagerDetails(createConnectedReadClient(), details.managerAddress)
+				if (!managerDetails.isPriceValid) throw new Error('A valid oracle price is required before withdrawing REP')
 				const result = await queueOracleManagerOperation(createWalletWriteClient(vaultAddress, { onTransactionSubmitted }), details.managerAddress, 'withdrawRep', vaultAddress, amount, managerDetails.requestPriceEthCost)
 				return {
 					action: 'queueWithdrawRep',

--- a/ui/ts/lib/securityVault.ts
+++ b/ui/ts/lib/securityVault.ts
@@ -1,7 +1,9 @@
 import type { Address } from 'viem'
+import type { OracleManagerDetails } from '../types/contracts.js'
 import { sameAddress } from './address.js'
 
 export const MIN_SECURITY_VAULT_REP_DEPOSIT = 10n * 10n ** 18n
+export const ORACLE_MANAGER_PRICE_VALID_FOR_SECONDS = 60n * 60n
 
 export function getSelectedVaultAddress(selectedVaultAddress: string | undefined, accountAddress: Address | undefined) {
 	const trimmedSelectedVaultAddress = selectedVaultAddress?.trim() ?? ''
@@ -18,4 +20,15 @@ export function isSelectedVaultOwnedByAccount(selectedVaultAddress: string | und
 export function isSecurityVaultDepositBelowMinimum(currentRepDeposit: bigint | undefined, depositAmount: bigint | undefined) {
 	if (depositAmount === undefined || depositAmount <= 0n) return false
 	return (currentRepDeposit ?? 0n) === 0n && depositAmount < MIN_SECURITY_VAULT_REP_DEPOSIT
+}
+
+export function getOracleManagerPriceValidUntilTimestamp(lastSettlementTimestamp: bigint | undefined) {
+	if (lastSettlementTimestamp === undefined || lastSettlementTimestamp === 0n) return undefined
+	return lastSettlementTimestamp + ORACLE_MANAGER_PRICE_VALID_FOR_SECONDS
+}
+
+export function hasValidSecurityVaultOraclePrice(managerAddress: Address | undefined, oracleManagerDetails: Pick<OracleManagerDetails, 'isPriceValid' | 'managerAddress'> | undefined) {
+	if (managerAddress === undefined || oracleManagerDetails === undefined) return false
+	if (!sameAddress(managerAddress, oracleManagerDetails.managerAddress)) return false
+	return oracleManagerDetails.isPriceValid
 }

--- a/ui/ts/tests/openOracle.test.ts
+++ b/ui/ts/tests/openOracle.test.ts
@@ -15,6 +15,7 @@ import {
 	loadOpenOracleInitialReportPriceResult,
 	OPEN_ORACLE_APPROVAL_AMOUNT,
 } from '../lib/openOracle.js'
+import { ORACLE_MANAGER_PRICE_VALID_FOR_SECONDS } from '../lib/securityVault.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
 import { ETH_ADDRESS, REP_ADDRESS, USDC_ADDRESS } from '../lib/uniswapQuoter.js'
 import type { InjectedEthereum } from '../injectedEthereum.js'
@@ -383,6 +384,7 @@ describe('Open Oracle helpers', () => {
 		expect(details.lastPrice).toBe(startingRepEthPrice)
 		expect(details.lastSettlementTimestamp).toBe(0n)
 		expect(details.isPriceValid).toBe(false)
+		expect(details.priceValidUntilTimestamp).toBe(undefined)
 	})
 
 	test('requestOraclePrice creates a pending report visible via loadOpenOracleReportDetails', async () => {
@@ -436,5 +438,11 @@ describe('Open Oracle helpers', () => {
 		reportDetails = await loadOpenOracleReportDetails(uiReadClient, openOracleAddress, reportId)
 		expect(reportDetails.settlementTimestamp).toBeGreaterThan(0n)
 		expect(getOpenOracleReportStatus(reportDetails)).toBe('Settled')
+
+		const managerDetails = await loadOracleManagerDetails(uiReadClient, managerAddress)
+		expect(managerDetails.pendingReportId).toBe(0n)
+		expect(managerDetails.lastSettlementTimestamp).toBeGreaterThan(0n)
+		expect(managerDetails.isPriceValid).toBe(true)
+		expect(managerDetails.priceValidUntilTimestamp).toBe(managerDetails.lastSettlementTimestamp + ORACLE_MANAGER_PRICE_VALID_FOR_SECONDS)
 	})
 })

--- a/ui/ts/tests/securityVault.test.ts
+++ b/ui/ts/tests/securityVault.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from 'bun:test'
 import { getAddress, zeroAddress } from 'viem'
 import { formatCurrencyInputBalance } from '../lib/formatters.js'
 import { parseRepAmountInput } from '../lib/marketForm.js'
-import { getSelectedVaultAddress, isSecurityVaultDepositBelowMinimum, isSelectedVaultOwnedByAccount, MIN_SECURITY_VAULT_REP_DEPOSIT } from '../lib/securityVault.js'
+import { getOracleManagerPriceValidUntilTimestamp, getSelectedVaultAddress, hasValidSecurityVaultOraclePrice, isSecurityVaultDepositBelowMinimum, isSelectedVaultOwnedByAccount, MIN_SECURITY_VAULT_REP_DEPOSIT, ORACLE_MANAGER_PRICE_VALID_FOR_SECONDS } from '../lib/securityVault.js'
 import { loadSecurityVaultDetails } from '../contracts.js'
 
 void describe('security vault helpers', () => {
@@ -43,6 +43,27 @@ void describe('security vault helpers', () => {
 		expect(isSecurityVaultDepositBelowMinimum(0n, MIN_SECURITY_VAULT_REP_DEPOSIT)).toBe(false)
 		expect(isSecurityVaultDepositBelowMinimum(1n, 1n)).toBe(false)
 		expect(isSecurityVaultDepositBelowMinimum(MIN_SECURITY_VAULT_REP_DEPOSIT, 5n * 10n ** 17n)).toBe(false)
+	})
+
+	void test('requires matching valid oracle manager details for queued vault actions', () => {
+		const managerAddress = getAddress('0x00000000000000000000000000000000000000d1')
+		const otherManagerAddress = getAddress('0x00000000000000000000000000000000000000d2')
+		const validOracleManagerDetails = {
+			isPriceValid: true,
+			managerAddress,
+		}
+
+		expect(hasValidSecurityVaultOraclePrice(managerAddress, validOracleManagerDetails)).toBe(true)
+		expect(hasValidSecurityVaultOraclePrice(managerAddress, { ...validOracleManagerDetails, isPriceValid: false })).toBe(false)
+		expect(hasValidSecurityVaultOraclePrice(managerAddress, { ...validOracleManagerDetails, managerAddress: otherManagerAddress })).toBe(false)
+		expect(hasValidSecurityVaultOraclePrice(undefined, validOracleManagerDetails)).toBe(false)
+		expect(hasValidSecurityVaultOraclePrice(managerAddress, undefined)).toBe(false)
+	})
+
+	void test('derives the oracle price expiry timestamp from the last settlement time', () => {
+		expect(getOracleManagerPriceValidUntilTimestamp(undefined)).toBe(undefined)
+		expect(getOracleManagerPriceValidUntilTimestamp(0n)).toBe(undefined)
+		expect(getOracleManagerPriceValidUntilTimestamp(15n)).toBe(15n + ORACLE_MANAGER_PRICE_VALID_FOR_SECONDS)
 	})
 
 	void test('returns undefined for a missing security pool without reading contract state', async () => {

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -239,6 +239,7 @@ export type SecurityVaultRouteContentProps = {
 
 export type SecurityVaultSectionProps = SecurityVaultRouteContentProps & {
 	compactLayout?: boolean
+	oracleManagerDetails?: OracleManagerDetails | undefined
 	autoLoadVault?: boolean
 	showSecurityPoolAddressInput?: boolean
 	showHeader?: boolean

--- a/ui/ts/types/contracts.ts
+++ b/ui/ts/types/contracts.ts
@@ -144,6 +144,7 @@ export type OracleManagerDetails = {
 	managerAddress: Address
 	openOracleAddress: Address
 	pendingReportId: bigint
+	priceValidUntilTimestamp: bigint | undefined
 	requestPriceEthCost: bigint
 	token1: Address | undefined
 	token2: Address | undefined


### PR DESCRIPTION
## Summary
- Block security bond allowance and REP withdrawal actions unless the linked oracle manager has a currently valid price.
- Surface oracle validity in the vault UI, including a price expiry timestamp when available and inline guidance when pricing is stale.
- Tighten oracle manager loading so validity is based on settlement age and add helper coverage for the new validation logic.

## Testing
- Added/updated unit coverage in `ui/ts/tests/openOracle.test.ts` for oracle settlement validity and expiry timestamp calculation.
- Added/updated unit coverage in `ui/ts/tests/securityVault.test.ts` for vault oracle validation helpers and expiry timestamp derivation.
- Not run: `bun tsc`
- Not run: `bun test`
- Not run: `bun run format`
- Not run: `bun run check`
- Not run: `bun run knip`