### PR TITLE
Remove redundant market outcome chips from security pool question card

### DIFF
--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -1697,12 +1697,6 @@ button.currency-value.copyable:hover:not(:disabled) {
 	overflow-wrap: anywhere;
 }
 
-.question-chip-row {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 0.75rem;
-}
-
 .entity-card {
 	position: relative;
 	display: grid;

--- a/ui/ts/components/SecurityPoolSection.tsx
+++ b/ui/ts/components/SecurityPoolSection.tsx
@@ -120,15 +120,6 @@ export function SecurityPoolSection({
 							{marketDetails === undefined && !loadingMarketDetails ? undefined : (
 								<EntityCard title='Question' badge={marketDetails === undefined ? undefined : <span className='badge ok'>{marketDetails.marketType}</span>}>
 									<Question question={marketDetails} loading={loadingMarketDetails && marketDetails === undefined} />
-									{marketDetails === undefined || marketDetails.marketType === 'scalar' ? undefined : (
-										<div className='question-chip-row'>
-											{marketDetails.outcomeLabels.map(label => (
-												<span key={label} className='status-chip muted'>
-													{label}
-												</span>
-											))}
-										</div>
-									)}
 								</EntityCard>
 							)}
 


### PR DESCRIPTION
## Summary
- Removed the extra outcome chip row from the Security Pool question card.
- Deleted the now-unused `.question-chip-row` CSS rule.
- Kept the existing question and market type badge rendering unchanged.

## Testing
- Not run (PR description only)
- Verified the diff only removes the redundant UI markup and associated styling