### PR TITLE
Refresh selected pool data when opening Selected Pool

### DIFF
--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -200,6 +200,13 @@ export function App() {
 	const universePresentation = showZoltarUniverseWarning ? getUniversePresentation(zoltarUniverseState) : undefined
 	const walletPresentation = getWalletPresentation({ accountAddress: accountState.address, hasInjectedWallet, isMainnet })
 	const selectedPool = securityPools.find(pool => pool.securityPoolAddress.toLowerCase() === securityPoolAddress.toLowerCase())
+	const refreshSelectedPoolData = () => {
+		if (!walletBootstrapComplete) return
+		if (!securityPoolAddress.startsWith('0x') || securityPoolAddress.length !== 42) return
+		void loadSecurityPools(securityPoolAddress)
+		void loadReporting()
+		void loadForkAuction()
+	}
 	const renderRouteContent = () => {
 		if (wrongNetworkMessage !== undefined) {
 			return <MainnetGateSection message={wrongNetworkMessage} />
@@ -349,6 +356,7 @@ export function App() {
 							loadingSecurityPools,
 							onLoadPoolOracleManager: managerAddress => void loadPoolOracleManager(managerAddress),
 							onRequestPoolPrice: managerAddress => void requestPoolPrice(managerAddress),
+							onRefreshSelectedPoolData: refreshSelectedPoolData,
 							onViewPendingReport: reportId => {
 								setOpenOracleForm(current => ({ ...current, reportId: reportId.toString() }))
 								navigate('open-oracle')
@@ -461,11 +469,7 @@ export function App() {
 		setTradingForm(current => (current.securityPoolAddress === securityPoolAddress ? current : { ...current, securityPoolAddress }))
 		setForkAuctionForm(current => (current.securityPoolAddress === securityPoolAddress ? current : { ...current, securityPoolAddress }))
 		setReportingForm(current => (current.securityPoolAddress === securityPoolAddress ? current : { ...current, securityPoolAddress }))
-		if (!walletBootstrapComplete) return
-		if (!securityPoolAddress.startsWith('0x') || securityPoolAddress.length !== 42) return
-		void loadSecurityPools(securityPoolAddress)
-		void loadReporting()
-		void loadForkAuction()
+		refreshSelectedPoolData()
 	}, [securityPoolAddress, walletBootstrapComplete])
 
 	useEffect(() => {

--- a/ui/ts/components/SecurityPoolsSection.tsx
+++ b/ui/ts/components/SecurityPoolsSection.tsx
@@ -7,6 +7,10 @@ import type { SecurityPoolsSectionProps } from '../types/components.js'
 
 type SecurityPoolsView = 'browse' | 'create' | 'operate'
 
+export function shouldRefreshSelectedPoolDataOnViewOpen({ nextView, securityPoolAddress }: { nextView: SecurityPoolsView; securityPoolAddress: string }) {
+	return nextView === 'operate' && securityPoolAddress.trim() !== ''
+}
+
 export function SecurityPoolsSection({ createPool, overview, workflow }: SecurityPoolsSectionProps) {
 	const [view, setView] = useState<SecurityPoolsView>(() =>
 		resolveFirstMatchingValue<SecurityPoolsView>(
@@ -17,17 +21,22 @@ export function SecurityPoolsSection({ createPool, overview, workflow }: Securit
 			'browse',
 		),
 	)
+	const openView = (nextView: SecurityPoolsView) => {
+		setView(nextView)
+		if (!shouldRefreshSelectedPoolDataOnViewOpen({ nextView, securityPoolAddress: workflow.securityPoolAddress })) return
+		workflow.onRefreshSelectedPoolData()
+	}
 
 	return (
 		<section className='panel market-panel'>
 			<div className='subtab-nav' role='tablist' aria-label='Security Pools views'>
-				<button className={`subtab-link ${view === 'browse' ? 'active' : ''}`} type='button' onClick={() => setView('browse')} aria-pressed={view === 'browse'}>
+				<button className={`subtab-link ${view === 'browse' ? 'active' : ''}`} type='button' onClick={() => openView('browse')} aria-pressed={view === 'browse'}>
 					Browse Pools
 				</button>
-				<button className={`subtab-link ${view === 'create' ? 'active' : ''}`} type='button' onClick={() => setView('create')} aria-pressed={view === 'create'}>
+				<button className={`subtab-link ${view === 'create' ? 'active' : ''}`} type='button' onClick={() => openView('create')} aria-pressed={view === 'create'}>
 					Create Pool
 				</button>
-				<button className={`subtab-link ${view === 'operate' ? 'active' : ''}`} type='button' onClick={() => setView('operate')} aria-pressed={view === 'operate'}>
+				<button className={`subtab-link ${view === 'operate' ? 'active' : ''}`} type='button' onClick={() => openView('operate')} aria-pressed={view === 'operate'}>
 					Selected Pool
 				</button>
 			</div>

--- a/ui/ts/tests/securityPoolsSection.test.ts
+++ b/ui/ts/tests/securityPoolsSection.test.ts
@@ -1,0 +1,38 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { shouldRefreshSelectedPoolDataOnViewOpen } from '../components/SecurityPoolsSection.js'
+
+void describe('security pools selected tab refresh', () => {
+	const securityPoolAddress = '0x1234567890123456789012345678901234567890'
+
+	void test('refreshes selected pool data only when opening the selected pool view with a filled address', () => {
+		expect(
+			shouldRefreshSelectedPoolDataOnViewOpen({
+				nextView: 'browse',
+				securityPoolAddress,
+			}),
+		).toBe(false)
+
+		expect(
+			shouldRefreshSelectedPoolDataOnViewOpen({
+				nextView: 'create',
+				securityPoolAddress,
+			}),
+		).toBe(false)
+
+		expect(
+			shouldRefreshSelectedPoolDataOnViewOpen({
+				nextView: 'operate',
+				securityPoolAddress: '',
+			}),
+		).toBe(false)
+
+		expect(
+			shouldRefreshSelectedPoolDataOnViewOpen({
+				nextView: 'operate',
+				securityPoolAddress,
+			}),
+		).toBe(true)
+	})
+})

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -197,6 +197,7 @@ export type SecurityPoolWorkflowRouteContentProps = {
 	onLoadPoolOracleManager: (managerAddress: Address) => void
 	onOpenLiquidationModal: (managerAddress: Address, securityPoolAddress: Address, vaultAddress: Address) => void
 	onQueueLiquidation: (managerAddress: Address, securityPoolAddress: Address) => void
+	onRefreshSelectedPoolData: () => void
 	onRequestPoolPrice: (managerAddress: Address) => void
 	onViewPendingReport: (reportId: bigint) => void
 	poolOracleManagerDetails: OracleManagerDetails | undefined


### PR DESCRIPTION
## Summary
- Refreshes the selected pool’s data when the Security Pools view is opened on the `Selected Pool` tab.
- Moves the refresh trigger into `SecurityPoolsSection` so it runs only for the operate view with a non-empty pool address.
- Adds a unit test covering the refresh condition for browse, create, empty address, and operate states.

## Testing
- Not run