### PR TITLE
Refine trading and reporting pool views

### DIFF
--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -408,6 +408,7 @@ export function App() {
 								onRedeemCompleteSet: () => void redeemCompleteSet(),
 								onRedeemShares: () => void redeemShares(),
 								onTradingFormChange: update => setTradingForm(current => ({ ...current, ...update })),
+								selectedPool,
 								tradingError,
 								tradingForm,
 								tradingResult,
@@ -476,6 +477,11 @@ export function App() {
 		if (securityPoolResult === undefined) return
 		void loadSecurityPools()
 	}, [securityPoolResult?.deployPoolHash])
+
+	useEffect(() => {
+		if (tradingResult === undefined) return
+		refreshSelectedPoolData()
+	}, [tradingResult?.hash])
 
 	useEffect(() => {
 		if (!augurPlaceHolderDeploymentMissing) return

--- a/ui/ts/components/OpenInterestCapacityMetrics.tsx
+++ b/ui/ts/components/OpenInterestCapacityMetrics.tsx
@@ -1,0 +1,21 @@
+import { CurrencyValue } from './CurrencyValue.js'
+import { MetricField } from './MetricField.js'
+import { getRemainingMintCapacity } from '../lib/trading.js'
+
+type OpenInterestCapacityMetricsProps = {
+	completeSetCollateralAmount: bigint | undefined
+	totalSecurityBondAllowance: bigint | undefined
+}
+
+export function OpenInterestCapacityMetrics({ completeSetCollateralAmount, totalSecurityBondAllowance }: OpenInterestCapacityMetricsProps) {
+	return (
+		<>
+			<MetricField label='Open Interest Minted / Max'>
+				<CurrencyValue value={completeSetCollateralAmount} suffix='ETH' /> / <CurrencyValue value={totalSecurityBondAllowance} suffix='ETH' />
+			</MetricField>
+			<MetricField label='Remaining Mint Capacity'>
+				<CurrencyValue value={getRemainingMintCapacity(totalSecurityBondAllowance, completeSetCollateralAmount)} suffix='ETH' />
+			</MetricField>
+		</>
+	)
+}

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -3,21 +3,35 @@ import { CurrencyValue } from './CurrencyValue.js'
 import { EnumDropdown } from './EnumDropdown.js'
 import { EntityCard } from './EntityCard.js'
 import { ErrorNotice } from './ErrorNotice.js'
-import { LoadingText } from './LoadingText.js'
 import { EscalationSide } from './EscalationSide.js'
+import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
 import { Question } from './Question.js'
+import { TimestampValue } from './TimestampValue.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { UniverseLink } from './UniverseLink.js'
 import { formatDuration } from '../lib/formatters.js'
+import { parseOptionalBigIntInput } from '../lib/inputs.js'
 import { isMainnetChain } from '../lib/network.js'
 import { REPORTING_OUTCOME_DROPDOWN_OPTIONS, getReportingOutcomeLabel } from '../lib/reporting.js'
 import { calculateEstimatedEscalationReturn, getEscalationPhase, getEscalationTimeRemaining, getLeadingEscalationOutcome } from '../lib/reportingDomain.js'
-import { TimestampValue } from './TimestampValue.js'
-import { parseOptionalBigIntInput } from '../lib/inputs.js'
 import type { ReportingSectionProps } from '../types/components.js'
 
-export function ReportingSection({ accountState, loadingReportingDetails, onLoadReporting, onReportOutcome, onReportingFormChange, onWithdrawEscalation, reportingDetails, reportingError, reportingForm, reportingResult, showHeader = true, showSecurityPoolAddressInput = true }: ReportingSectionProps) {
+export function ReportingSection({
+	accountState,
+	embedInCard = false,
+	loadingReportingDetails,
+	onLoadReporting,
+	onReportOutcome,
+	onReportingFormChange,
+	onWithdrawEscalation,
+	reportingDetails,
+	reportingError,
+	reportingForm,
+	reportingResult,
+	showHeader = true,
+	showSecurityPoolAddressInput = true,
+}: ReportingSectionProps) {
 	const isMainnet = isMainnetChain(accountState.chainId)
 	const selectedAmount = parseOptionalBigIntInput(reportingForm.reportAmount)
 	const totalBalance = reportingDetails === undefined ? 0n : reportingDetails.sides.reduce((sum, side) => sum + side.balance, 0n)
@@ -25,6 +39,261 @@ export function ReportingSection({ accountState, loadingReportingDetails, onLoad
 	const selectedSide = reportingDetails?.sides.find(side => side.key === reportingForm.selectedOutcome)
 	const selectedEstimate = selectedSide === undefined || selectedAmount === undefined ? undefined : calculateEstimatedEscalationReturn(selectedSide.balance, totalBalance, selectedAmount)
 	const reportAmountError = selectedAmount === undefined && reportingForm.reportAmount.trim() !== '' ? 'Enter a valid report amount to preview profit.' : undefined
+	const loadedEscalationGame =
+		reportingDetails === undefined ? undefined : embedInCard ? (
+			<div className='entity-card-subsection'>
+				<div className='entity-card-subsection-header'>
+					<h4>Loaded Escalation Game</h4>
+					<span className='badge ok'>{getEscalationPhase(reportingDetails)}</span>
+				</div>
+				<ul className='status-list hashes'>
+					<li>
+						<span>Security Pool</span>
+						<strong>
+							<AddressValue address={reportingDetails.securityPoolAddress} />
+						</strong>
+					</li>
+					<li>
+						<span>Escalation Game</span>
+						<strong>
+							<AddressValue address={reportingDetails.escalationGameAddress} />
+						</strong>
+					</li>
+					<li>
+						<span>Universe</span>
+						<strong>
+							<UniverseLink universeId={reportingDetails.universeId} />
+						</strong>
+					</li>
+					<li>
+						<span>Market End</span>
+						<strong>
+							<TimestampValue timestamp={reportingDetails.marketDetails.endTime} />
+						</strong>
+					</li>
+					<li>
+						<span>Resolution</span>
+						<strong>{getReportingOutcomeLabel(reportingDetails.resolution)}</strong>
+					</li>
+				</ul>
+				<div className='entity-card-subsection'>
+					<div className='entity-card-subsection-header'>
+						<h4>Question</h4>
+						<span className='badge muted'>{reportingDetails.marketDetails.marketType}</span>
+					</div>
+					<Question question={reportingDetails.marketDetails} />
+				</div>
+			</div>
+		) : (
+			<EntityCard title='Loaded Escalation Game' badge={<span className='badge ok'>{getEscalationPhase(reportingDetails)}</span>}>
+				<ul className='status-list hashes'>
+					<li>
+						<span>Security Pool</span>
+						<strong>
+							<AddressValue address={reportingDetails.securityPoolAddress} />
+						</strong>
+					</li>
+					<li>
+						<span>Escalation Game</span>
+						<strong>
+							<AddressValue address={reportingDetails.escalationGameAddress} />
+						</strong>
+					</li>
+					<li>
+						<span>Universe</span>
+						<strong>
+							<UniverseLink universeId={reportingDetails.universeId} />
+						</strong>
+					</li>
+					<li>
+						<span>Market End</span>
+						<strong>
+							<TimestampValue timestamp={reportingDetails.marketDetails.endTime} />
+						</strong>
+					</li>
+					<li>
+						<span>Resolution</span>
+						<strong>{getReportingOutcomeLabel(reportingDetails.resolution)}</strong>
+					</li>
+				</ul>
+				<div className='entity-card-subsection'>
+					<div className='entity-card-subsection-header'>
+						<h4>Question</h4>
+						<span className='badge muted'>{reportingDetails.marketDetails.marketType}</span>
+					</div>
+					<Question question={reportingDetails.marketDetails} />
+				</div>
+			</EntityCard>
+		)
+	const escalationMetrics =
+		reportingDetails === undefined ? undefined : embedInCard ? (
+			<div className='entity-card-subsection'>
+				<div className='entity-card-subsection-header'>
+					<h4>Escalation Metrics</h4>
+					<span className='badge muted'>status</span>
+				</div>
+				<div className='escalation-metrics'>
+					<MetricField label='Current Bond'>
+						<CurrencyValue value={reportingDetails.currentRequiredBond} suffix='REP' />
+					</MetricField>
+					<MetricField label='Binding Capital'>
+						<CurrencyValue value={reportingDetails.bindingCapital} suffix='REP' />
+					</MetricField>
+					<MetricField label='Threshold'>
+						<CurrencyValue value={reportingDetails.nonDecisionThreshold} suffix='REP' />
+					</MetricField>
+					<MetricField label='Time Left'>{formatDuration(getEscalationTimeRemaining(reportingDetails))}</MetricField>
+				</div>
+				<p className='detail'>
+					Game starts at <TimestampValue timestamp={reportingDetails.startingTime} /> and currently uses a start bond of <CurrencyValue value={reportingDetails.startBond} suffix='REP' />.
+				</p>
+			</div>
+		) : (
+			<EntityCard title='Escalation Metrics' badge={<span className='badge muted'>status</span>}>
+				<div className='escalation-metrics'>
+					<MetricField label='Current Bond'>
+						<CurrencyValue value={reportingDetails.currentRequiredBond} suffix='REP' />
+					</MetricField>
+					<MetricField label='Binding Capital'>
+						<CurrencyValue value={reportingDetails.bindingCapital} suffix='REP' />
+					</MetricField>
+					<MetricField label='Threshold'>
+						<CurrencyValue value={reportingDetails.nonDecisionThreshold} suffix='REP' />
+					</MetricField>
+					<MetricField label='Time Left'>{formatDuration(getEscalationTimeRemaining(reportingDetails))}</MetricField>
+				</div>
+				<p className='detail'>
+					Game starts at <TimestampValue timestamp={reportingDetails.startingTime} /> and currently uses a start bond of <CurrencyValue value={reportingDetails.startBond} suffix='REP' />.
+				</p>
+			</EntityCard>
+		)
+	const escalationSides =
+		reportingDetails === undefined ? undefined : embedInCard ? (
+			<div className='entity-card-subsection'>
+				<div className='entity-card-subsection-header'>
+					<h4>Outcome Sides</h4>
+				</div>
+				<div className='escalation-sides'>
+					{reportingDetails.sides.map(side => {
+						const estimate = selectedAmount === undefined ? undefined : calculateEstimatedEscalationReturn(side.balance, totalBalance, selectedAmount)
+						const userStake = side.userDeposits.reduce((sum, deposit) => sum + deposit.amount, 0n)
+						return <EscalationSide key={side.key} estimate={estimate} isLeading={leadingOutcome === side.key} isSelected={reportingForm.selectedOutcome === side.key} side={side} userStake={userStake} />
+					})}
+				</div>
+			</div>
+		) : (
+			<div className='escalation-sides'>
+				{reportingDetails.sides.map(side => {
+					const estimate = selectedAmount === undefined ? undefined : calculateEstimatedEscalationReturn(side.balance, totalBalance, selectedAmount)
+					const userStake = side.userDeposits.reduce((sum, deposit) => sum + deposit.amount, 0n)
+					return <EscalationSide key={side.key} estimate={estimate} isLeading={leadingOutcome === side.key} isSelected={reportingForm.selectedOutcome === side.key} side={side} userStake={userStake} />
+				})}
+			</div>
+		)
+	const latestReportingAction =
+		reportingResult === undefined ? undefined : embedInCard ? (
+			<div className='entity-card-subsection'>
+				<div className='entity-card-subsection-header'>
+					<h4>Latest Reporting Action</h4>
+					<span className='badge ok'>{getReportingOutcomeLabel(reportingResult.outcome)}</span>
+				</div>
+				<p className='detail'>Action: {reportingResult.action}</p>
+				<p className='detail'>Outcome: {getReportingOutcomeLabel(reportingResult.outcome)}</p>
+				<p className='detail'>
+					Pool: <AddressValue address={reportingResult.securityPoolAddress} />
+				</p>
+				<p className='detail'>
+					Universe: <UniverseLink universeId={reportingResult.universeId} />
+				</p>
+				<p className='detail'>
+					Transaction: <TransactionHashLink hash={reportingResult.hash} />
+				</p>
+			</div>
+		) : (
+			<EntityCard title='Latest Reporting Action' badge={<span className='badge ok'>{getReportingOutcomeLabel(reportingResult.outcome)}</span>}>
+				<p className='detail'>Action: {reportingResult.action}</p>
+				<p className='detail'>Outcome: {getReportingOutcomeLabel(reportingResult.outcome)}</p>
+				<p className='detail'>
+					Pool: <AddressValue address={reportingResult.securityPoolAddress} />
+				</p>
+				<p className='detail'>
+					Universe: <UniverseLink universeId={reportingResult.universeId} />
+				</p>
+				<p className='detail'>
+					Transaction: <TransactionHashLink hash={reportingResult.hash} />
+				</p>
+			</EntityCard>
+		)
+	const actionsSection = (
+		<div className='form-grid'>
+			{showSecurityPoolAddressInput ? (
+				<label className='field'>
+					<span>Security Pool Address</span>
+					<input value={reportingForm.securityPoolAddress} onInput={event => onReportingFormChange({ securityPoolAddress: event.currentTarget.value })} placeholder='0x...' />
+				</label>
+			) : undefined}
+
+			<div className='actions'>
+				<button className='secondary' onClick={onLoadReporting} disabled={loadingReportingDetails}>
+					{loadingReportingDetails ? <LoadingText>Loading escalation...</LoadingText> : 'Refresh reporting'}
+				</button>
+			</div>
+
+			<label className='field'>
+				<span>Outcome Side</span>
+				<EnumDropdown options={REPORTING_OUTCOME_DROPDOWN_OPTIONS} value={reportingForm.selectedOutcome} onChange={selectedOutcome => onReportingFormChange({ selectedOutcome })} />
+			</label>
+
+			<label className='field'>
+				<span>Report / Contribution Amount</span>
+				<input value={reportingForm.reportAmount} onInput={event => onReportingFormChange({ reportAmount: event.currentTarget.value })} />
+			</label>
+
+			{reportAmountError === undefined ? undefined : <p className='detail'>{reportAmountError}</p>}
+
+			{selectedEstimate === undefined ? undefined : (
+				<p className='detail'>
+					If {getReportingOutcomeLabel(reportingForm.selectedOutcome)} wins and no one else contributes afterward, the current amount projects roughly <CurrencyValue value={selectedEstimate.profit} suffix='REP' /> of profit.
+				</p>
+			)}
+
+			<div className='actions'>
+				<button className='primary' onClick={onReportOutcome} disabled={accountState.address === undefined || !isMainnet}>
+					Report / Contribute On Selected Side
+				</button>
+			</div>
+
+			<label className='field'>
+				<span>Withdraw Deposit Indexes</span>
+				<input value={reportingForm.withdrawDepositIndexes} onInput={event => onReportingFormChange({ withdrawDepositIndexes: event.currentTarget.value })} placeholder='Leave empty to withdraw all your deposits on the selected side' />
+			</label>
+
+			<div className='actions'>
+				<button className='secondary' onClick={onWithdrawEscalation} disabled={accountState.address === undefined || !isMainnet}>
+					Withdraw Escalation Deposits
+				</button>
+			</div>
+		</div>
+	)
+
+	if (embedInCard) {
+		return (
+			<>
+				{loadedEscalationGame}
+				{escalationMetrics}
+				{escalationSides}
+				{latestReportingAction}
+				<div className='entity-card-subsection'>
+					<div className='entity-card-subsection-header'>
+						<h4>Actions</h4>
+						<span className='badge muted'>manage</span>
+					</div>
+					{actionsSection}
+				</div>
+				<ErrorNotice message={reportingError} />
+			</>
+		)
+	}
 
 	return (
 		<section className='panel market-panel'>
@@ -39,144 +308,15 @@ export function ReportingSection({ accountState, loadingReportingDetails, onLoad
 
 			<div className='market-grid'>
 				<div className='market-column'>
-					{reportingDetails === undefined ? undefined : (
-						<>
-							<EntityCard title='Loaded Escalation Game' badge={<span className='badge ok'>{getEscalationPhase(reportingDetails)}</span>}>
-								<ul className='status-list hashes'>
-									<li>
-										<span>Security Pool</span>
-										<strong>
-											<AddressValue address={reportingDetails.securityPoolAddress} />
-										</strong>
-									</li>
-									<li>
-										<span>Escalation Game</span>
-										<strong>
-											<AddressValue address={reportingDetails.escalationGameAddress} />
-										</strong>
-									</li>
-									<li>
-										<span>Universe</span>
-										<strong>
-											<UniverseLink universeId={reportingDetails.universeId} />
-										</strong>
-									</li>
-									<li>
-										<span>Market End</span>
-										<strong>
-											<TimestampValue timestamp={reportingDetails.marketDetails.endTime} />
-										</strong>
-									</li>
-									<li>
-										<span>Resolution</span>
-										<strong>{getReportingOutcomeLabel(reportingDetails.resolution)}</strong>
-									</li>
-								</ul>
-								<div className='entity-card-subsection'>
-									<div className='entity-card-subsection-header'>
-										<h4>Question</h4>
-										<span className='badge muted'>{reportingDetails.marketDetails.marketType}</span>
-									</div>
-									<Question question={reportingDetails.marketDetails} />
-								</div>
-							</EntityCard>
-
-							<EntityCard title='Escalation Metrics' badge={<span className='badge muted'>status</span>}>
-								<div className='escalation-metrics'>
-									<MetricField label='Current Bond'>
-										<CurrencyValue value={reportingDetails.currentRequiredBond} suffix='REP' />
-									</MetricField>
-									<MetricField label='Binding Capital'>
-										<CurrencyValue value={reportingDetails.bindingCapital} suffix='REP' />
-									</MetricField>
-									<MetricField label='Threshold'>
-										<CurrencyValue value={reportingDetails.nonDecisionThreshold} suffix='REP' />
-									</MetricField>
-									<MetricField label='Time Left'>{formatDuration(getEscalationTimeRemaining(reportingDetails))}</MetricField>
-								</div>
-								<p className='detail'>
-									Game starts at <TimestampValue timestamp={reportingDetails.startingTime} /> and currently uses a start bond of <CurrencyValue value={reportingDetails.startBond} suffix='REP' />.
-								</p>
-							</EntityCard>
-
-							<div className='escalation-sides'>
-								{reportingDetails.sides.map(side => {
-									const estimate = selectedAmount === undefined ? undefined : calculateEstimatedEscalationReturn(side.balance, totalBalance, selectedAmount)
-									const userStake = side.userDeposits.reduce((sum, deposit) => sum + deposit.amount, 0n)
-									return <EscalationSide key={side.key} estimate={estimate} isLeading={leadingOutcome === side.key} isSelected={reportingForm.selectedOutcome === side.key} side={side} userStake={userStake} />
-								})}
-							</div>
-						</>
-					)}
-
-					{reportingResult === undefined ? undefined : (
-						<EntityCard title='Latest Reporting Action' badge={<span className='badge ok'>{getReportingOutcomeLabel(reportingResult.outcome)}</span>}>
-							<p className='detail'>Action: {reportingResult.action}</p>
-							<p className='detail'>Outcome: {getReportingOutcomeLabel(reportingResult.outcome)}</p>
-							<p className='detail'>
-								Pool: <AddressValue address={reportingResult.securityPoolAddress} />
-							</p>
-							<p className='detail'>
-								Universe: <UniverseLink universeId={reportingResult.universeId} />
-							</p>
-							<p className='detail'>
-								Transaction: <TransactionHashLink hash={reportingResult.hash} />
-							</p>
-						</EntityCard>
-					)}
+					{loadedEscalationGame}
+					{escalationMetrics}
+					{escalationSides}
+					{latestReportingAction}
 				</div>
 
 				<div className='market-column'>
 					<EntityCard title='Resolution Actions' badge={<span className='badge muted'>manage</span>}>
-						<div className='form-grid'>
-							{showSecurityPoolAddressInput ? (
-								<label className='field'>
-									<span>Security Pool Address</span>
-									<input value={reportingForm.securityPoolAddress} onInput={event => onReportingFormChange({ securityPoolAddress: event.currentTarget.value })} placeholder='0x...' />
-								</label>
-							) : undefined}
-
-							<div className='actions'>
-								<button className='secondary' onClick={onLoadReporting} disabled={loadingReportingDetails}>
-									{loadingReportingDetails ? <LoadingText>Loading escalation...</LoadingText> : 'Refresh reporting'}
-								</button>
-							</div>
-
-							<label className='field'>
-								<span>Outcome Side</span>
-								<EnumDropdown options={REPORTING_OUTCOME_DROPDOWN_OPTIONS} value={reportingForm.selectedOutcome} onChange={selectedOutcome => onReportingFormChange({ selectedOutcome })} />
-							</label>
-
-							<label className='field'>
-								<span>Report / Contribution Amount</span>
-								<input value={reportingForm.reportAmount} onInput={event => onReportingFormChange({ reportAmount: event.currentTarget.value })} />
-							</label>
-
-							{reportAmountError === undefined ? undefined : <p className='detail'>{reportAmountError}</p>}
-
-							{selectedEstimate === undefined ? undefined : (
-								<p className='detail'>
-									If {getReportingOutcomeLabel(reportingForm.selectedOutcome)} wins and no one else contributes afterward, the current amount projects roughly <CurrencyValue value={selectedEstimate.profit} suffix='REP' /> of profit.
-								</p>
-							)}
-
-							<div className='actions'>
-								<button className='primary' onClick={onReportOutcome} disabled={accountState.address === undefined || !isMainnet}>
-									Report / Contribute On Selected Side
-								</button>
-							</div>
-
-							<label className='field'>
-								<span>Withdraw Deposit Indexes</span>
-								<input value={reportingForm.withdrawDepositIndexes} onInput={event => onReportingFormChange({ withdrawDepositIndexes: event.currentTarget.value })} placeholder='Leave empty to withdraw all your deposits on the selected side' />
-							</label>
-
-							<div className='actions'>
-								<button className='secondary' onClick={onWithdrawEscalation} disabled={accountState.address === undefined || !isMainnet}>
-									Withdraw Escalation Deposits
-								</button>
-							</div>
-						</div>
+						{actionsSection}
 					</EntityCard>
 
 					<ErrorNotice message={reportingError} />

--- a/ui/ts/components/SecurityPoolSection.tsx
+++ b/ui/ts/components/SecurityPoolSection.tsx
@@ -4,6 +4,7 @@ import { EntityCard } from './EntityCard.js'
 import { ErrorNotice } from './ErrorNotice.js'
 import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
+import { OpenInterestCapacityMetrics } from './OpenInterestCapacityMetrics.js'
 import { Question } from './Question.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { UniverseLink } from './UniverseLink.js'
@@ -133,6 +134,7 @@ export function SecurityPoolSection({
 													<MetricField label='Open Interest Fee / Year'>
 														<CurrencyValue value={openInterestFeePerYearBigint(pool.currentRetentionRate)} suffix='%' />
 													</MetricField>
+													<OpenInterestCapacityMetrics completeSetCollateralAmount={pool.completeSetCollateralAmount} totalSecurityBondAllowance={pool.totalSecurityBondAllowance} />
 												</div>
 											</EntityCard>
 										))}

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -6,6 +6,7 @@ import { ForkAuctionSection } from './ForkAuctionSection.js'
 import { LiquidationModal } from './LiquidationModal.js'
 import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
+import { OpenInterestCapacityMetrics } from './OpenInterestCapacityMetrics.js'
 import { Question, getQuestionTitle } from './Question.js'
 import { ReportingSection } from './ReportingSection.js'
 import { SecurityVaultSection } from './SecurityVaultSection.js'
@@ -184,6 +185,7 @@ export function SecurityPoolWorkflowSection({
 									<MetricField label='Open Interest Fee / Year'>
 										<CurrencyValue value={openInterestFeePerYearBigint(loadedSelectedPool?.currentRetentionRate)} suffix='%' />
 									</MetricField>
+									<OpenInterestCapacityMetrics completeSetCollateralAmount={loadedSelectedPool?.completeSetCollateralAmount} totalSecurityBondAllowance={loadedSelectedPool?.totalSecurityBondAllowance} />
 									{reportingReady ? <MetricField label='Reporting'>Unlocked</MetricField> : undefined}
 									<MetricField label='Manager'>
 										<AddressValue address={loadedSelectedPool?.managerAddress} />
@@ -363,7 +365,7 @@ export function SecurityPoolWorkflowSection({
 						{view === 'trading' ? (
 							<div className='workflow-stack'>
 								<EntityCard className='selected-pool-card' title='Trading' badge={<span className='badge muted'>manage</span>}>
-									<TradingSection {...trading} showHeader={false} showSecurityPoolAddressInput={false} />
+									<TradingSection {...trading} embedInCard showHeader={false} showSecurityPoolAddressInput={false} />
 								</EntityCard>
 							</div>
 						) : undefined}
@@ -372,7 +374,7 @@ export function SecurityPoolWorkflowSection({
 							<div className='workflow-stack'>
 								{reportingReady ? (
 									<EntityCard className='selected-pool-card' title='Reporting' badge={<span className='badge ok'>Unlocked</span>}>
-										<ReportingSection {...reporting} showHeader={false} showSecurityPoolAddressInput={false} />
+										<ReportingSection {...reporting} embedInCard showHeader={false} showSecurityPoolAddressInput={false} />
 									</EntityCard>
 								) : undefined}
 

--- a/ui/ts/components/SecurityPoolsOverviewSection.tsx
+++ b/ui/ts/components/SecurityPoolsOverviewSection.tsx
@@ -5,6 +5,7 @@ import { ErrorNotice } from './ErrorNotice.js'
 import { LiquidationModal } from './LiquidationModal.js'
 import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
+import { OpenInterestCapacityMetrics } from './OpenInterestCapacityMetrics.js'
 import { Question, getQuestionTitle } from './Question.js'
 import { StateHint } from './StateHint.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
@@ -105,6 +106,7 @@ export function SecurityPoolsOverviewSection({
 										<MetricField label='Open Interest Fee / Year'>
 											<CurrencyValue value={openInterestFeePerYearBigint(pool.currentRetentionRate)} suffix='%' />
 										</MetricField>
+										<OpenInterestCapacityMetrics completeSetCollateralAmount={pool.completeSetCollateralAmount} totalSecurityBondAllowance={pool.totalSecurityBondAllowance} />
 										<MetricField label='Manager'>
 											<AddressValue address={pool.managerAddress} />
 										</MetricField>

--- a/ui/ts/components/TradingSection.tsx
+++ b/ui/ts/components/TradingSection.tsx
@@ -1,15 +1,219 @@
+import { AddressValue } from './AddressValue.js'
 import { EnumDropdown } from './EnumDropdown.js'
 import { EntityCard } from './EntityCard.js'
 import { ErrorNotice } from './ErrorNotice.js'
+import { MetricField } from './MetricField.js'
+import { OpenInterestCapacityMetrics } from './OpenInterestCapacityMetrics.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { UniverseLink } from './UniverseLink.js'
 import { isMainnetChain } from '../lib/network.js'
 import { REPORTING_OUTCOME_DROPDOWN_OPTIONS } from '../lib/reporting.js'
+import { getRemainingMintCapacity, getTradingMintGuardMessage } from '../lib/trading.js'
 import type { TradingSectionProps } from '../types/components.js'
 
-export function TradingSection({ accountState, onCreateCompleteSet, onMigrateShares, onRedeemCompleteSet, onRedeemShares, onTradingFormChange, tradingError, tradingForm, tradingResult, showHeader = true, showSecurityPoolAddressInput = true }: TradingSectionProps) {
+export function TradingSection({ accountState, embedInCard = false, onCreateCompleteSet, onMigrateShares, onRedeemCompleteSet, onRedeemShares, onTradingFormChange, selectedPool, tradingError, tradingForm, tradingResult, showHeader = true, showSecurityPoolAddressInput = true }: TradingSectionProps) {
 	const isMainnet = isMainnetChain(accountState.chainId)
-	const isTradingDisabled = accountState.address === undefined || !isMainnet
+	const currentTimestamp = BigInt(Math.floor(Date.now() / 1000))
+	const remainingMintCapacity = getRemainingMintCapacity(selectedPool?.totalSecurityBondAllowance, selectedPool?.completeSetCollateralAmount)
+	const marketHasEnded = selectedPool?.marketDetails.endTime === undefined ? undefined : selectedPool.marketDetails.endTime <= currentTimestamp
+	const mintGuardMessage = getTradingMintGuardMessage({
+		accountAddress: accountState.address,
+		completeSetCollateralAmount: selectedPool?.completeSetCollateralAmount,
+		ethBalance: accountState.ethBalance,
+		isMainnet,
+		mintAmountInput: tradingForm.completeSetAmount,
+		systemState: selectedPool?.systemState,
+		totalSecurityBondAllowance: selectedPool?.totalSecurityBondAllowance,
+	})
+	const redeemCompleteSetGuardMessage = (() => {
+		if (accountState.address === undefined) return 'Connect a wallet before redeeming complete sets.'
+		if (!isMainnet) return 'Switch to Ethereum mainnet before redeeming complete sets.'
+		if (selectedPool !== undefined && selectedPool.systemState !== 'operational') return 'Redeeming complete sets is only available while the pool is operational.'
+
+		const trimmedAmount = tradingForm.redeemAmount.trim()
+		if (trimmedAmount === '') return 'Enter a redeem amount greater than zero.'
+
+		try {
+			if (BigInt(trimmedAmount) <= 0n) return 'Enter a redeem amount greater than zero.'
+		} catch {
+			return 'Enter a valid whole-number redeem amount.'
+		}
+
+		return undefined
+	})()
+	const migrateSharesGuardMessage = (() => {
+		if (accountState.address === undefined) return 'Connect a wallet before migrating shares.'
+		if (!isMainnet) return 'Switch to Ethereum mainnet before migrating shares.'
+
+		const trimmedUniverseId = tradingForm.fromUniverseId.trim()
+		if (trimmedUniverseId === '') return 'Enter a source universe ID to migrate shares from.'
+
+		try {
+			if (BigInt(trimmedUniverseId) < 0n) return 'Enter a valid non-negative universe ID.'
+		} catch {
+			return 'Enter a valid whole-number universe ID.'
+		}
+
+		return undefined
+	})()
+	const redeemSharesGuardMessage = (() => {
+		if (accountState.address === undefined) return 'Connect a wallet before redeeming shares.'
+		if (!isMainnet) return 'Switch to Ethereum mainnet before redeeming shares.'
+		if (selectedPool !== undefined && selectedPool.systemState !== 'operational') return 'Redeeming shares is only available while the pool is operational.'
+		if (marketHasEnded === false) return 'Wait until the market end time before redeeming resolved shares.'
+		return undefined
+	})()
+	const latestTradingAction =
+		tradingResult === undefined ? undefined : embedInCard ? (
+			<div className='entity-card-subsection'>
+				<div className='entity-card-subsection-header'>
+					<h4>Latest Trading Action</h4>
+					<span className='badge ok'>{tradingResult.action}</span>
+				</div>
+				<p className='detail'>Action: {tradingResult.action}</p>
+				<p className='detail'>Pool: {tradingResult.securityPoolAddress}</p>
+				<p className='detail'>
+					Universe: <UniverseLink universeId={tradingResult.universeId} />
+				</p>
+				<p className='detail'>
+					Transaction: <TransactionHashLink hash={tradingResult.hash} />
+				</p>
+			</div>
+		) : (
+			<EntityCard title='Latest Trading Action' badge={<span className='badge ok'>{tradingResult.action}</span>}>
+				<p className='detail'>Action: {tradingResult.action}</p>
+				<p className='detail'>Pool: {tradingResult.securityPoolAddress}</p>
+				<p className='detail'>
+					Universe: <UniverseLink universeId={tradingResult.universeId} />
+				</p>
+				<p className='detail'>
+					Transaction: <TransactionHashLink hash={tradingResult.hash} />
+				</p>
+			</EntityCard>
+		)
+	const poolSection =
+		!showSecurityPoolAddressInput && selectedPool === undefined ? undefined : (
+			<div className='entity-card-subsection'>
+				<div className='entity-card-subsection-header'>
+					<h4>Pool</h4>
+					{selectedPool === undefined ? undefined : <span className={`badge ${selectedPool.systemState === 'operational' ? 'ok' : 'blocked'}`}>{selectedPool.systemState}</span>}
+				</div>
+				{showSecurityPoolAddressInput ? (
+					<label className='field'>
+						<span>Security Pool Address</span>
+						<input value={tradingForm.securityPoolAddress} onInput={event => onTradingFormChange({ securityPoolAddress: event.currentTarget.value })} placeholder='0x...' />
+					</label>
+				) : undefined}
+				{selectedPool === undefined ? (
+					<p className='detail'>Load a pool to inspect live mint capacity and trading status.</p>
+				) : (
+					<div className='workflow-metric-grid'>
+						<MetricField label='Pool'>
+							<AddressValue address={selectedPool.securityPoolAddress} />
+						</MetricField>
+						<MetricField label='Universe'>
+							<UniverseLink universeId={selectedPool.universeId} />
+						</MetricField>
+						<OpenInterestCapacityMetrics completeSetCollateralAmount={selectedPool.completeSetCollateralAmount} totalSecurityBondAllowance={selectedPool.totalSecurityBondAllowance} />
+					</div>
+				)}
+			</div>
+		)
+	const mintSection = (
+		<div className='entity-card-subsection'>
+			<div className='entity-card-subsection-header'>
+				<h4>Mint Complete Sets</h4>
+				{remainingMintCapacity === undefined ? undefined : <span className={`badge ${remainingMintCapacity > 0n ? 'ok' : 'blocked'}`}>{remainingMintCapacity > 0n ? 'Capacity available' : 'Capacity full'}</span>}
+			</div>
+			<label className='field'>
+				<span>Mint Complete Sets Amount</span>
+				<input value={tradingForm.completeSetAmount} onInput={event => onTradingFormChange({ completeSetAmount: event.currentTarget.value })} />
+			</label>
+			<p className='detail'>Minting sends ETH directly to the pool. No token approval step is required.</p>
+			<p className='detail'>{mintGuardMessage ?? 'This amount will mint complete sets against the pool&apos;s remaining bond-backed capacity.'}</p>
+			<div className='actions'>
+				<button className='primary' title={mintGuardMessage} onClick={onCreateCompleteSet} disabled={mintGuardMessage !== undefined}>
+					Mint Complete Sets
+				</button>
+			</div>
+		</div>
+	)
+	const redeemCompleteSetSection = (
+		<div className='entity-card-subsection'>
+			<div className='entity-card-subsection-header'>
+				<h4>Redeem Complete Sets</h4>
+			</div>
+			<label className='field'>
+				<span>Redeem Complete Sets Amount</span>
+				<input value={tradingForm.redeemAmount} onInput={event => onTradingFormChange({ redeemAmount: event.currentTarget.value })} />
+			</label>
+			<p className='detail'>Burn complete sets from this universe to withdraw the matching ETH collateral.</p>
+			<div className='actions'>
+				<button className='secondary' title={redeemCompleteSetGuardMessage} onClick={onRedeemCompleteSet} disabled={redeemCompleteSetGuardMessage !== undefined}>
+					Redeem Complete Sets
+				</button>
+			</div>
+			{redeemCompleteSetGuardMessage === undefined ? undefined : <p className='detail'>{redeemCompleteSetGuardMessage}</p>}
+		</div>
+	)
+	const migrateSharesSection = (
+		<div className='entity-card-subsection'>
+			<div className='entity-card-subsection-header'>
+				<h4>Migrate Forked Shares</h4>
+			</div>
+			<div className='field-row'>
+				<label className='field'>
+					<span>From Universe ID</span>
+					<input value={tradingForm.fromUniverseId} onInput={event => onTradingFormChange({ fromUniverseId: event.currentTarget.value })} />
+				</label>
+				<label className='field'>
+					<span>Outcome To Migrate</span>
+					<EnumDropdown options={REPORTING_OUTCOME_DROPDOWN_OPTIONS} value={tradingForm.selectedOutcome} onChange={selectedOutcome => onTradingFormChange({ selectedOutcome })} />
+				</label>
+			</div>
+			<p className='detail'>Use this after a fork to move shares from an older universe into the current pool universe.</p>
+			<div className='actions'>
+				<button className='secondary' title={migrateSharesGuardMessage} onClick={onMigrateShares} disabled={migrateSharesGuardMessage !== undefined}>
+					Migrate Shares
+				</button>
+			</div>
+			{migrateSharesGuardMessage === undefined ? undefined : <p className='detail'>{migrateSharesGuardMessage}</p>}
+		</div>
+	)
+	const redeemSharesSection = (
+		<div className='entity-card-subsection'>
+			<div className='entity-card-subsection-header'>
+				<h4>Redeem Resolved Shares</h4>
+			</div>
+			<p className='detail'>Redeem the finalized winning shares you hold once the question has fully resolved.</p>
+			<div className='actions'>
+				<button className='secondary' title={redeemSharesGuardMessage} onClick={onRedeemShares} disabled={redeemSharesGuardMessage !== undefined}>
+					Redeem Shares
+				</button>
+			</div>
+			{redeemSharesGuardMessage === undefined ? undefined : <p className='detail'>{redeemSharesGuardMessage}</p>}
+		</div>
+	)
+	const tradingSections = (
+		<>
+			{poolSection}
+			{latestTradingAction}
+			{mintSection}
+			{redeemCompleteSetSection}
+			{migrateSharesSection}
+			{redeemSharesSection}
+		</>
+	)
+
+	if (embedInCard) {
+		return (
+			<>
+				{tradingSections}
+				<ErrorNotice message={tradingError} />
+			</>
+		)
+	}
+
 	return (
 		<section className='panel market-panel'>
 			{showHeader ? (
@@ -23,67 +227,8 @@ export function TradingSection({ accountState, onCreateCompleteSet, onMigrateSha
 
 			<div className='market-grid'>
 				<div className='market-column'>
-					{tradingResult === undefined ? undefined : (
-						<EntityCard title='Latest Trading Action' badge={<span className='badge ok'>{tradingResult.action}</span>}>
-							<p className='detail'>Action: {tradingResult.action}</p>
-							<p className='detail'>Pool: {tradingResult.securityPoolAddress}</p>
-							<p className='detail'>
-								Universe: <UniverseLink universeId={tradingResult.universeId} />
-							</p>
-							<p className='detail'>
-								Transaction: <TransactionHashLink hash={tradingResult.hash} />
-							</p>
-						</EntityCard>
-					)}
-				</div>
-
-				<div className='market-column'>
 					<EntityCard title='Trading Actions' badge={<span className='badge muted'>manage</span>}>
-						<div className='form-grid'>
-							{showSecurityPoolAddressInput ? (
-								<label className='field'>
-									<span>Security Pool Address</span>
-									<input value={tradingForm.securityPoolAddress} onInput={event => onTradingFormChange({ securityPoolAddress: event.currentTarget.value })} placeholder='0x...' />
-								</label>
-							) : undefined}
-
-							<div className='field-row'>
-								<label className='field'>
-									<span>Mint Complete Sets Amount</span>
-									<input value={tradingForm.completeSetAmount} onInput={event => onTradingFormChange({ completeSetAmount: event.currentTarget.value })} />
-								</label>
-								<label className='field'>
-									<span>Redeem Complete Sets Amount</span>
-									<input value={tradingForm.redeemAmount} onInput={event => onTradingFormChange({ redeemAmount: event.currentTarget.value })} />
-								</label>
-							</div>
-
-							<div className='field-row'>
-								<label className='field'>
-									<span>From Universe ID</span>
-									<input value={tradingForm.fromUniverseId} onInput={event => onTradingFormChange({ fromUniverseId: event.currentTarget.value })} />
-								</label>
-								<label className='field'>
-									<span>Outcome To Migrate</span>
-									<EnumDropdown options={REPORTING_OUTCOME_DROPDOWN_OPTIONS} value={tradingForm.selectedOutcome} onChange={selectedOutcome => onTradingFormChange({ selectedOutcome })} />
-								</label>
-							</div>
-
-							<div className='actions'>
-								<button className='primary' onClick={onCreateCompleteSet} disabled={isTradingDisabled}>
-									Mint Complete Sets
-								</button>
-								<button className='secondary' onClick={onRedeemCompleteSet} disabled={isTradingDisabled}>
-									Redeem Complete Sets
-								</button>
-								<button className='secondary' onClick={onMigrateShares} disabled={isTradingDisabled}>
-									Migrate Shares
-								</button>
-								<button className='secondary' onClick={onRedeemShares} disabled={isTradingDisabled}>
-									Redeem Shares
-								</button>
-							</div>
-						</div>
+						{tradingSections}
 					</EntityCard>
 
 					<ErrorNotice message={tradingError} />

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -2088,11 +2088,17 @@ export async function loadAllSecurityPools(client: ReadClient): Promise<ListedSe
 
 	return await Promise.all(
 		deployments.map(async deployment => {
-			const { currentRetentionRate, parent, priceOracleManagerAndOperatorQueuer: managerAddress, questionId, securityMultiplier, securityPool: securityPoolAddress, truthAuction: truthAuctionAddress, universeId } = deployment
-			const [systemState, forkData, marketDetails] = await Promise.all([
+			const { parent, priceOracleManagerAndOperatorQueuer: managerAddress, questionId, securityMultiplier, securityPool: securityPoolAddress, truthAuction: truthAuctionAddress, universeId } = deployment
+			const [completeSetCollateralAmount, currentRetentionRate, forkData, marketDetails, systemState, totalSecurityBondAllowance] = await Promise.all([
 				client.readContract({
 					abi: peripherals_SecurityPool_SecurityPool.abi,
-					functionName: 'systemState',
+					functionName: 'completeSetCollateralAmount',
+					address: securityPoolAddress,
+					args: [],
+				}),
+				client.readContract({
+					abi: peripherals_SecurityPool_SecurityPool.abi,
+					functionName: 'currentRetentionRate',
 					address: securityPoolAddress,
 					args: [],
 				}),
@@ -2103,12 +2109,25 @@ export async function loadAllSecurityPools(client: ReadClient): Promise<ListedSe
 					args: [securityPoolAddress],
 				}),
 				loadMarketDetails(client, questionId),
+				client.readContract({
+					abi: peripherals_SecurityPool_SecurityPool.abi,
+					functionName: 'systemState',
+					address: securityPoolAddress,
+					args: [],
+				}),
+				client.readContract({
+					abi: peripherals_SecurityPool_SecurityPool.abi,
+					functionName: 'totalSecurityBondAllowance',
+					address: securityPoolAddress,
+					args: [],
+				}),
 			])
 			const forkDataTuple: ForkDataTuple = forkData
 			const [, , truthAuctionStartedAt, migratedRep, , forkOwnSecurityPool, forkOutcomeIndex] = forkDataTuple
 
 			const { vaultCount, vaults } = await loadSecurityPoolVaultSummaries(client, securityPoolAddress)
 			return {
+				completeSetCollateralAmount,
 				currentRetentionRate,
 				forkOutcome: getReportingOutcomeKey(forkOutcomeIndex),
 				forkOwnSecurityPool,
@@ -2120,6 +2139,7 @@ export async function loadAllSecurityPools(client: ReadClient): Promise<ListedSe
 				securityMultiplier,
 				securityPoolAddress,
 				systemState: getSecurityPoolSystemState(systemState),
+				totalSecurityBondAllowance,
 				truthAuctionAddress,
 				truthAuctionStartedAt,
 				universeId,

--- a/ui/ts/lib/trading.ts
+++ b/ui/ts/lib/trading.ts
@@ -1,0 +1,50 @@
+import type { Address } from 'viem'
+import { formatCurrencyBalance } from './formatters.js'
+import type { SecurityPoolSystemState } from '../types/contracts.js'
+
+export function getRemainingMintCapacity(totalSecurityBondAllowance: bigint | undefined, completeSetCollateralAmount: bigint | undefined) {
+	if (totalSecurityBondAllowance === undefined || completeSetCollateralAmount === undefined) return undefined
+	return totalSecurityBondAllowance > completeSetCollateralAmount ? totalSecurityBondAllowance - completeSetCollateralAmount : 0n
+}
+
+export function getTradingMintGuardMessage({
+	accountAddress,
+	completeSetCollateralAmount,
+	ethBalance,
+	isMainnet,
+	mintAmountInput,
+	systemState,
+	totalSecurityBondAllowance,
+}: {
+	accountAddress: Address | undefined
+	completeSetCollateralAmount: bigint | undefined
+	ethBalance: bigint | undefined
+	isMainnet: boolean
+	mintAmountInput: string
+	systemState: SecurityPoolSystemState | undefined
+	totalSecurityBondAllowance: bigint | undefined
+}) {
+	if (accountAddress === undefined) return 'Connect a wallet before minting complete sets.'
+	if (!isMainnet) return 'Switch to Ethereum mainnet before minting complete sets.'
+	if (systemState !== undefined && systemState !== 'operational') return 'Minting is only available while the pool is operational.'
+
+	const remainingCapacity = getRemainingMintCapacity(totalSecurityBondAllowance, completeSetCollateralAmount)
+	if (remainingCapacity === undefined) return 'Loading pool mint capacity.'
+	if (remainingCapacity === 0n) return 'This pool has no remaining mint capacity.'
+
+	const trimmedAmount = mintAmountInput.trim()
+	if (trimmedAmount === '') return 'Enter a mint amount greater than zero.'
+
+	let mintAmount: bigint
+	try {
+		mintAmount = BigInt(trimmedAmount)
+	} catch {
+		return 'Enter a valid whole-number mint amount.'
+	}
+
+	if (mintAmount <= 0n) return 'Enter a mint amount greater than zero.'
+	if (mintAmount > remainingCapacity) return `This pool only has ${formatCurrencyBalance(remainingCapacity)} ETH of mint capacity remaining.`
+	if (ethBalance === undefined) return 'Loading wallet ETH balance.'
+	if (mintAmount > ethBalance) return `Need ${formatCurrencyBalance(mintAmount - ethBalance)} more ETH in this wallet to mint the selected amount.`
+	return undefined
+}

--- a/ui/ts/tests/trading.test.ts
+++ b/ui/ts/tests/trading.test.ts
@@ -1,0 +1,139 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { getRemainingMintCapacity, getTradingMintGuardMessage } from '../lib/trading.js'
+
+void describe('trading helpers', () => {
+	void test('computes remaining mint capacity from total bond allowance and minted open interest', () => {
+		expect(getRemainingMintCapacity(10n, 4n)).toBe(6n)
+		expect(getRemainingMintCapacity(10n, 10n)).toBe(0n)
+		expect(getRemainingMintCapacity(10n, 12n)).toBe(0n)
+		expect(getRemainingMintCapacity(undefined, 12n)).toBeUndefined()
+	})
+
+	void test('blocks minting until the wallet is connected on mainnet', () => {
+		expect(
+			getTradingMintGuardMessage({
+				accountAddress: undefined,
+				completeSetCollateralAmount: 0n,
+				ethBalance: 10n,
+				isMainnet: true,
+				mintAmountInput: '1',
+				systemState: 'operational',
+				totalSecurityBondAllowance: 10n,
+			}),
+		).toBe('Connect a wallet before minting complete sets.')
+
+		expect(
+			getTradingMintGuardMessage({
+				accountAddress: '0x1234567890123456789012345678901234567890',
+				completeSetCollateralAmount: 0n,
+				ethBalance: 10n,
+				isMainnet: false,
+				mintAmountInput: '1',
+				systemState: 'operational',
+				totalSecurityBondAllowance: 10n,
+			}),
+		).toBe('Switch to Ethereum mainnet before minting complete sets.')
+	})
+
+	void test('surfaces the main mint block reasons before the transaction is sent', () => {
+		expect(
+			getTradingMintGuardMessage({
+				accountAddress: '0x1234567890123456789012345678901234567890',
+				completeSetCollateralAmount: 1n,
+				ethBalance: 10n ** 18n,
+				isMainnet: true,
+				mintAmountInput: '100',
+				systemState: 'forkMigration',
+				totalSecurityBondAllowance: 10n,
+			}),
+		).toBe('Minting is only available while the pool is operational.')
+
+		expect(
+			getTradingMintGuardMessage({
+				accountAddress: '0x1234567890123456789012345678901234567890',
+				completeSetCollateralAmount: undefined,
+				ethBalance: 10n ** 18n,
+				isMainnet: true,
+				mintAmountInput: '100',
+				systemState: 'operational',
+				totalSecurityBondAllowance: 10n,
+			}),
+		).toBe('Loading pool mint capacity.')
+
+		expect(
+			getTradingMintGuardMessage({
+				accountAddress: '0x1234567890123456789012345678901234567890',
+				completeSetCollateralAmount: 10n,
+				ethBalance: 10n ** 18n,
+				isMainnet: true,
+				mintAmountInput: '100',
+				systemState: 'operational',
+				totalSecurityBondAllowance: 10n,
+			}),
+		).toBe('This pool has no remaining mint capacity.')
+
+		expect(
+			getTradingMintGuardMessage({
+				accountAddress: '0x1234567890123456789012345678901234567890',
+				completeSetCollateralAmount: 0n,
+				ethBalance: 10n ** 18n,
+				isMainnet: true,
+				mintAmountInput: 'abc',
+				systemState: 'operational',
+				totalSecurityBondAllowance: 10n ** 18n,
+			}),
+		).toBe('Enter a valid whole-number mint amount.')
+
+		expect(
+			getTradingMintGuardMessage({
+				accountAddress: '0x1234567890123456789012345678901234567890',
+				completeSetCollateralAmount: 0n,
+				ethBalance: 10n ** 18n,
+				isMainnet: true,
+				mintAmountInput: '0',
+				systemState: 'operational',
+				totalSecurityBondAllowance: 10n ** 18n,
+			}),
+		).toBe('Enter a mint amount greater than zero.')
+
+		expect(
+			getTradingMintGuardMessage({
+				accountAddress: '0x1234567890123456789012345678901234567890',
+				completeSetCollateralAmount: 8n * 10n ** 17n,
+				ethBalance: 10n ** 18n,
+				isMainnet: true,
+				mintAmountInput: '300000000000000000',
+				systemState: 'operational',
+				totalSecurityBondAllowance: 10n ** 18n,
+			}),
+		).toBe('This pool only has 0.2 ETH of mint capacity remaining.')
+
+		expect(
+			getTradingMintGuardMessage({
+				accountAddress: '0x1234567890123456789012345678901234567890',
+				completeSetCollateralAmount: 0n,
+				ethBalance: 5n * 10n ** 17n,
+				isMainnet: true,
+				mintAmountInput: '1000000000000000000',
+				systemState: 'operational',
+				totalSecurityBondAllowance: 2n * 10n ** 18n,
+			}),
+		).toBe('Need 0.5 more ETH in this wallet to mint the selected amount.')
+	})
+
+	void test('allows minting when the pool has capacity and the wallet has enough ETH', () => {
+		expect(
+			getTradingMintGuardMessage({
+				accountAddress: '0x1234567890123456789012345678901234567890',
+				completeSetCollateralAmount: 4n * 10n ** 17n,
+				ethBalance: 2n * 10n ** 18n,
+				isMainnet: true,
+				mintAmountInput: '500000000000000000',
+				systemState: 'operational',
+				totalSecurityBondAllowance: 2n * 10n ** 18n,
+			}),
+		).toBeUndefined()
+	})
+})

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -299,6 +299,7 @@ export type ReportingRouteContentProps = {
 }
 
 export type ReportingSectionProps = ReportingRouteContentProps & {
+	embedInCard?: boolean
 	showHeader?: boolean
 	showSecurityPoolAddressInput?: boolean
 }
@@ -310,12 +311,14 @@ export type TradingRouteContentProps = {
 	onRedeemCompleteSet: () => void
 	onRedeemShares: () => void
 	onTradingFormChange: (update: Partial<TradingFormState>) => void
+	selectedPool: ListedSecurityPool | undefined
 	tradingError: string | undefined
 	tradingForm: TradingFormState
 	tradingResult: TradingActionResult | undefined
 }
 
 export type TradingSectionProps = TradingRouteContentProps & {
+	embedInCard?: boolean
 	showSecurityPoolAddressInput?: boolean
 	showHeader?: boolean
 }

--- a/ui/ts/types/contracts.ts
+++ b/ui/ts/types/contracts.ts
@@ -226,6 +226,7 @@ export type OpenOracleReportDetails = {
 }
 
 export type ListedSecurityPool = {
+	completeSetCollateralAmount: bigint
 	currentRetentionRate: bigint
 	forkOutcome: ReportingOutcomeKey | 'none'
 	forkOwnSecurityPool: boolean
@@ -237,6 +238,7 @@ export type ListedSecurityPool = {
 	securityMultiplier: bigint
 	securityPoolAddress: Address
 	systemState: SecurityPoolSystemState
+	totalSecurityBondAllowance: bigint
 	truthAuctionAddress: Address
 	truthAuctionStartedAt: bigint
 	universeId: bigint


### PR DESCRIPTION
## Summary
- Reworked the trading and reporting screens to support embedded card mode and cleaner section layout.
- Added live pool-capacity metrics so users can see minted open interest versus allowance and remaining mint capacity across pool views.
- Expanded trading guards and action messaging for minting, redeeming, and share migration based on pool state and wallet/network conditions.
- Refreshed reporting and trading flows to reload selected pool data after successful trading actions.
- Added targeted trading tests for the new guard and capacity logic.

## Testing
- Not run (not requested).