### PR TITLE
Refactor token approvals into shared UI control

### DIFF
--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -88,7 +88,7 @@ export function App() {
 		setZoltarForkQuestionId,
 		setZoltarMigrationForm,
 		zoltarChildUniverseError,
-		zoltarForkAllowance,
+		zoltarForkApproval,
 		zoltarForkActiveAction,
 		zoltarForkError,
 		zoltarForkPending,
@@ -113,8 +113,24 @@ export function App() {
 			deploymentStatuses,
 			zoltarUniverseHasForked,
 		})
-	const { approveRep, depositRep, loadSecurityVault, loadingSecurityVault, redeemFees, securityVaultDetails, securityVaultError, securityVaultForm, securityVaultMissing, securityVaultRepAllowance, securityVaultRepBalance, securityVaultResult, setSecurityBondAllowance, setSecurityVaultForm, withdrawRep } =
-		useSecurityVaultOperations(baseHookConfig)
+	const {
+		approveRep,
+		depositRep,
+		loadSecurityVault,
+		loadingSecurityVault,
+		redeemFees,
+		securityVaultActiveAction,
+		securityVaultDetails,
+		securityVaultError,
+		securityVaultForm,
+		securityVaultMissing,
+		securityVaultRepApproval,
+		securityVaultRepBalance,
+		securityVaultResult,
+		setSecurityBondAllowance,
+		setSecurityVaultForm,
+		withdrawRep,
+	} = useSecurityVaultOperations(baseHookConfig)
 	const {
 		approveToken1,
 		approveToken2,
@@ -123,6 +139,7 @@ export function App() {
 		loadOracleReport,
 		loadingOpenOracleCreate,
 		loadingOracleReport,
+		openOracleActiveAction,
 		openOracleError,
 		openOracleCreateForm,
 		openOracleForm,
@@ -255,7 +272,7 @@ export function App() {
 						onUseQuestionForPool={onUseQuestionForPool}
 						onZoltarMigrationFormChange={update => setZoltarMigrationForm(current => ({ ...current, ...update }))}
 						zoltarQuestionCount={zoltarQuestionCount}
-						zoltarForkAllowance={zoltarForkAllowance}
+						zoltarForkApproval={zoltarForkApproval}
 						zoltarForkError={zoltarForkError}
 						zoltarChildUniverseError={zoltarChildUniverseError}
 						zoltarForkPending={zoltarForkPending}
@@ -392,11 +409,12 @@ export function App() {
 								onSetSecurityBondAllowance: () => void setSecurityBondAllowance(),
 								onSecurityVaultFormChange: update => setSecurityVaultForm(current => ({ ...current, ...update })),
 								onWithdrawRep: () => void withdrawRep(),
+								securityVaultActiveAction,
 								securityVaultDetails,
 								securityVaultError,
 								securityVaultForm,
 								securityVaultMissing,
-								securityVaultRepAllowance,
+								securityVaultRepApproval,
 								securityVaultRepBalance,
 								securityVaultResult,
 								securityPoolVaults: selectedPool?.vaults,
@@ -421,8 +439,8 @@ export function App() {
 						accountState={accountState}
 						initialView={urlOpenOracleReportId === '' && openOracleForm.reportId === '' ? 'browse' : 'selected-report'}
 						loadingOracleReport={loadingOracleReport}
-						onApproveToken1={() => void approveToken1()}
-						onApproveToken2={() => void approveToken2()}
+						onApproveToken1={amount => void approveToken1(amount)}
+						onApproveToken2={amount => void approveToken2(amount)}
 						onCreateOpenOracleGame={() => void createOpenOracleGame()}
 						onDisputeReport={() => void disputeReport()}
 						onLoadOracleReport={reportId => void loadOracleReport(reportId)}
@@ -432,6 +450,7 @@ export function App() {
 						onSettleReport={() => void settleReport()}
 						onSubmitInitialReport={() => void submitInitialReport()}
 						loadingOpenOracleCreate={loadingOpenOracleCreate}
+						openOracleActiveAction={openOracleActiveAction}
 						openOracleError={openOracleError}
 						openOracleCreateForm={openOracleCreateForm}
 						openOracleForm={openOracleForm}

--- a/ui/ts/components/ForkZoltarSection.tsx
+++ b/ui/ts/components/ForkZoltarSection.tsx
@@ -6,9 +6,11 @@ import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
 import { Question } from './Question.js'
 import { StateHint } from './StateHint.js'
+import { TokenApprovalControl } from './TokenApprovalControl.js'
 import { sameCaseInsensitiveText } from '../lib/caseInsensitive.js'
 import { resolveLoadableValueState, type LoadableValueState } from '../lib/loadState.js'
-import { getReportPresentation, getUniversePresentation } from '../lib/userCopy.js'
+import { deriveTokenApprovalRequirement, type TokenApprovalState } from '../lib/tokenApproval.js'
+import { getReportPresentation, getUniversePresentation, getWalletPresentation } from '../lib/userCopy.js'
 import type { MarketDetails, ZoltarUniverseSummary } from '../types/contracts.js'
 
 type ForkZoltarSectionProps = {
@@ -21,7 +23,7 @@ type ForkZoltarSectionProps = {
 	onForkZoltar: () => void
 	onZoltarForkQuestionIdChange: (questionId: string) => void
 	zoltarForkActiveAction: 'approve' | 'fork' | undefined
-	zoltarForkAllowance: bigint | undefined
+	zoltarForkApproval: TokenApprovalState
 	zoltarForkError: string | undefined
 	zoltarForkPending: boolean
 	zoltarForkQuestionId: string
@@ -41,7 +43,7 @@ export function ForkZoltarSection({
 	onForkZoltar,
 	onZoltarForkQuestionIdChange,
 	zoltarForkActiveAction,
-	zoltarForkAllowance,
+	zoltarForkApproval,
 	zoltarForkError,
 	zoltarForkPending,
 	zoltarForkQuestionId,
@@ -54,7 +56,8 @@ export function ForkZoltarSection({
 	const universeMissing = zoltarUniverseState === 'missing'
 	const hasForked = rootUniverse?.hasForked === true
 	const hasEnoughRep = rootUniverse !== undefined && zoltarForkRepBalance !== undefined && zoltarForkRepBalance >= rootUniverse.forkThreshold
-	const hasEnoughApproval = rootUniverse !== undefined && zoltarForkAllowance !== undefined && zoltarForkAllowance >= rootUniverse.forkThreshold
+	const approvalRequirement = deriveTokenApprovalRequirement(rootUniverse?.forkThreshold, zoltarForkApproval.value)
+	const hasEnoughApproval = rootUniverse !== undefined && approvalRequirement.hasSufficientApproval
 	const selectedQuestionId = zoltarForkQuestionId.trim()
 	const hasSelectedQuestionId = selectedQuestionId !== ''
 	const selectedQuestion = selectedQuestionId === '' ? undefined : zoltarQuestions.find(question => sameCaseInsensitiveText(question.questionId, selectedQuestionId))
@@ -65,6 +68,13 @@ export function ForkZoltarSection({
 	})
 	const selectedQuestionPresentation = hasSelectedQuestionId && selectedQuestionLookupState !== 'ready' ? getReportPresentation({ kind: 'question', state: selectedQuestionLookupState }) : undefined
 	const canFork = accountAddress !== undefined && isMainnet && rootUniverse !== undefined && !hasForked && !zoltarForkPending && selectedQuestion !== undefined && hasEnoughRep && hasEnoughApproval
+	const approvalGuardMessage = (() => {
+		const walletPresentation = getWalletPresentation({ accountAddress, isMainnet })
+		if (walletPresentation !== undefined) return walletPresentation.detail
+		if (rootUniverse === undefined) return undefined
+		if (hasForked) return 'Zoltar is already forked.'
+		return undefined
+	})()
 
 	if (universeMissing) {
 		const presentation = getUniversePresentation(zoltarUniverseState)
@@ -83,12 +93,26 @@ export function ForkZoltarSection({
 					<MetricField label='Fork Threshold'>
 						<CurrencyValue loading={loadingZoltarForkAccess || rootUniverse === undefined} value={rootUniverse?.forkThreshold} suffix='REP' />
 					</MetricField>
-					<MetricField label='REP Approved To Zoltar'>
-						<CurrencyValue loading={loadingZoltarForkAccess} value={zoltarForkAllowance} suffix='REP' />
-					</MetricField>
 				</div>
 
 				<div className='form-grid'>
+					{hasForked ? undefined : (
+						<TokenApprovalControl
+							actionLabel='forking Zoltar'
+							allowanceError={zoltarForkApproval.error}
+							allowanceLoading={zoltarForkApproval.loading}
+							approvedAmount={zoltarForkApproval.value}
+							guardMessage={approvalGuardMessage}
+							onApprove={amount => onApproveZoltarForkRep(amount)}
+							pending={zoltarForkActiveAction === 'approve'}
+							pendingLabel='Approving REP Threshold...'
+							requiredAmount={rootUniverse?.forkThreshold}
+							resetKey={`${rootUniverse?.reputationToken ?? ''}:${rootUniverse?.universeId.toString() ?? ''}:${rootUniverse?.forkThreshold.toString() ?? ''}`}
+							tokenSymbol='REP'
+							tokenUnits={18}
+						/>
+					)}
+
 					<label className='field'>
 						<span>Fork Question ID</span>
 						<input value={zoltarForkQuestionId} onInput={event => onZoltarForkQuestionIdChange(event.currentTarget.value)} placeholder='0x...' disabled={hasForked || zoltarForkPending} />
@@ -106,11 +130,6 @@ export function ForkZoltarSection({
 					{selectedQuestionPresentation === undefined ? undefined : <StateHint presentation={selectedQuestionPresentation} />}
 
 					<div className='actions'>
-						{hasForked ? undefined : (
-							<button className='secondary' onClick={() => onApproveZoltarForkRep()} disabled={accountAddress === undefined || !isMainnet || rootUniverse === undefined || zoltarForkPending || hasEnoughApproval}>
-								{zoltarForkActiveAction === 'approve' ? <LoadingText>Approving REP Threshold...</LoadingText> : hasEnoughApproval ? 'Threshold Approved' : 'Approve REP Threshold'}
-							</button>
-						)}
 						<button
 							className='primary'
 							onClick={() => {

--- a/ui/ts/components/MarketSection.tsx
+++ b/ui/ts/components/MarketSection.tsx
@@ -37,7 +37,7 @@ export function MarketSection({
 	onZoltarForkQuestionIdChange,
 	onZoltarMigrationFormChange,
 	zoltarChildUniverseError,
-	zoltarForkAllowance,
+	zoltarForkApproval,
 	zoltarForkError,
 	zoltarForkPending,
 	zoltarForkQuestionId,
@@ -146,7 +146,7 @@ export function MarketSection({
 						onForkZoltar={onForkZoltar}
 						onZoltarForkQuestionIdChange={onZoltarForkQuestionIdChange}
 						zoltarForkActiveAction={zoltarForkActiveAction}
-						zoltarForkAllowance={zoltarForkAllowance}
+						zoltarForkApproval={zoltarForkApproval}
 						zoltarForkError={zoltarForkError}
 						zoltarForkPending={zoltarForkPending}
 						zoltarForkQuestionId={zoltarForkQuestionId}
@@ -167,9 +167,8 @@ export function MarketSection({
 						onPrepareRepForMigration={onPrepareRepForMigration}
 						onZoltarMigrationFormChange={onZoltarMigrationFormChange}
 						zoltarForkRepBalance={zoltarForkRepBalance}
-						zoltarForkAllowance={zoltarForkAllowance}
+						zoltarForkApproval={zoltarForkApproval}
 						zoltarForkActiveAction={zoltarForkActiveAction}
-						zoltarForkPending={zoltarForkPending}
 						zoltarMigrationChildRepBalances={zoltarMigrationChildRepBalances}
 						zoltarMigrationActiveAction={zoltarMigrationActiveAction}
 						zoltarMigrationError={zoltarMigrationError}

--- a/ui/ts/components/OpenOracleSection.tsx
+++ b/ui/ts/components/OpenOracleSection.tsx
@@ -9,6 +9,7 @@ import { ErrorNotice } from './ErrorNotice.js'
 import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
 import { StateHint } from './StateHint.js'
+import { TokenApprovalControl } from './TokenApprovalControl.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { TimestampValue } from './TimestampValue.js'
 import { useLoadController } from '../hooks/useLoadController.js'
@@ -80,13 +81,14 @@ function renderReportSummaryCard(report: OpenOracleReportSummary, onSelectReport
 function renderSelectedReportActionSection(
 	actionMode: OpenOracleSelectedReportActionMode,
 	isConnected: boolean,
+	openOracleActiveAction: OpenOracleSectionProps['openOracleActiveAction'],
 	openOracleForm: OpenOracleFormState,
 	initialReportSubmission: ReturnType<typeof deriveOpenOracleInitialReportSubmissionDetails>,
 	openOracleInitialReportState: OpenOracleSectionProps['openOracleInitialReportState'],
 	token1Symbol: string,
 	token2Symbol: string,
-	onApproveToken1: () => void,
-	onApproveToken2: () => void,
+	onApproveToken1: (amount?: bigint) => void,
+	onApproveToken2: (amount?: bigint) => void,
 	onDisputeReport: () => void,
 	onOpenOracleFormChange: (update: Partial<OpenOracleFormState>) => void,
 	onRefreshPrice: () => void,
@@ -119,41 +121,44 @@ function renderSelectedReportActionSection(
 						<p className='detail'>
 							Price source: <strong>{openOracleInitialReportState.loading ? 'Loading...' : initialReportSubmission.priceSource}</strong>
 						</p>
-						<div className='question-summary-grid'>
-							<MetricField label={`Required ${token1Symbol}`}>
-								<CurrencyValue value={initialReportSubmission.amount1} units={initialReportSubmission.token1Decimals ?? 18} suffix={token1Symbol} copyable={false} />
-							</MetricField>
-							<MetricField label={`Required ${token2Symbol}`}>
-								<CurrencyValue value={initialReportSubmission.amount2} units={initialReportSubmission.token2Decimals ?? 18} suffix={token2Symbol} copyable={false} />
-							</MetricField>
-							<MetricField label={`Approved ${token1Symbol}`}>
-								<CurrencyValue value={initialReportSubmission.approvedToken1Amount} units={initialReportSubmission.token1Decimals ?? 18} suffix={token1Symbol} copyable={false} />
-							</MetricField>
-							<MetricField label={`Approved ${token2Symbol}`}>
-								<CurrencyValue value={initialReportSubmission.approvedToken2Amount} units={initialReportSubmission.token2Decimals ?? 18} suffix={token2Symbol} copyable={false} />
-							</MetricField>
-						</div>
-						<div className='field-row'>
-							<label className='field'>
-								<span>{`${token1Symbol} Approve Amount (leave empty for max)`}</span>
-								<input value={openOracleForm.approveAmount1} onInput={event => onOpenOracleFormChange({ approveAmount1: event.currentTarget.value })} placeholder='Max' />
-							</label>
-							<div className='actions'>
-								<button className='secondary' onClick={onApproveToken1} disabled={!isConnected || openOracleInitialReportState.loading}>
-									{`Approve ${token1Symbol}`}
-								</button>
+						<div className='entity-card-subsection'>
+							<div className='entity-card-subsection-header'>
+								<h4>{`${token1Symbol} Approval`}</h4>
 							</div>
+							<TokenApprovalControl
+								actionLabel='submitting the initial report'
+								allowanceError={openOracleInitialReportState.token1Approval.error}
+								allowanceLoading={openOracleInitialReportState.token1Approval.loading}
+								approvedAmount={openOracleInitialReportState.token1Approval.value}
+								guardMessage={!isConnected ? 'Connect a wallet before approving tokens.' : undefined}
+								onApprove={amount => onApproveToken1(amount)}
+								pending={openOracleActiveAction === 'approveToken1'}
+								pendingLabel={`Approving ${token1Symbol}...`}
+								requiredAmount={initialReportSubmission.amount1}
+								resetKey={`token1:${token1Symbol}:${initialReportSubmission.amount1?.toString() ?? ''}:${openOracleForm.reportId}`}
+								tokenSymbol={token1Symbol}
+								tokenUnits={initialReportSubmission.token1Decimals ?? 18}
+							/>
 						</div>
-						<div className='field-row'>
-							<label className='field'>
-								<span>{`${token2Symbol} Approve Amount (leave empty for max)`}</span>
-								<input value={openOracleForm.approveAmount2} onInput={event => onOpenOracleFormChange({ approveAmount2: event.currentTarget.value })} placeholder='Max' />
-							</label>
-							<div className='actions'>
-								<button className='secondary' onClick={onApproveToken2} disabled={!isConnected || openOracleInitialReportState.loading}>
-									{`Approve ${token2Symbol}`}
-								</button>
+
+						<div className='entity-card-subsection'>
+							<div className='entity-card-subsection-header'>
+								<h4>{`${token2Symbol} Approval`}</h4>
 							</div>
+							<TokenApprovalControl
+								actionLabel='submitting the initial report'
+								allowanceError={openOracleInitialReportState.token2Approval.error}
+								allowanceLoading={openOracleInitialReportState.token2Approval.loading}
+								approvedAmount={openOracleInitialReportState.token2Approval.value}
+								guardMessage={!isConnected ? 'Connect a wallet before approving tokens.' : initialReportSubmission.amount2 === undefined ? `Enter a valid ${token1Symbol} / ${token2Symbol} price before approving ${token2Symbol}.` : undefined}
+								onApprove={amount => onApproveToken2(amount)}
+								pending={openOracleActiveAction === 'approveToken2'}
+								pendingLabel={`Approving ${token2Symbol}...`}
+								requiredAmount={initialReportSubmission.amount2}
+								resetKey={`token2:${token2Symbol}:${initialReportSubmission.amount2?.toString() ?? ''}:${openOracleForm.reportId}`}
+								tokenSymbol={token2Symbol}
+								tokenUnits={initialReportSubmission.token2Decimals ?? 18}
+							/>
 						</div>
 						<ErrorNotice message={initialReportSubmission.blockReason} />
 						<div className='actions'>
@@ -214,10 +219,11 @@ function renderReportDetailsCard(
 	openOracleReportDetails: OpenOracleReportDetails | undefined,
 	openOracleForm: OpenOracleFormState,
 	openOracleInitialReportState: OpenOracleSectionProps['openOracleInitialReportState'],
+	openOracleActiveAction: OpenOracleSectionProps['openOracleActiveAction'],
 	loadingOracleReport: boolean,
 	isConnected: boolean,
-	onApproveToken1: () => void,
-	onApproveToken2: () => void,
+	onApproveToken1: (amount?: bigint) => void,
+	onApproveToken2: (amount?: bigint) => void,
 	onDisputeReport: () => void,
 	onLoadOracleReport: (reportId?: string) => void,
 	onOpenOracleFormChange: (update: Partial<OpenOracleFormState>) => void,
@@ -264,8 +270,8 @@ function renderReportDetailsCard(
 	const statusTone = getOpenOracleReportStatusTone(status)
 	const actionMode = getOpenOracleSelectedReportActionMode(openOracleReportDetails)
 	const initialReportSubmission = deriveOpenOracleInitialReportSubmissionDetails({
-		approvedToken1Amount: openOracleInitialReportState.token1Allowance,
-		approvedToken2Amount: openOracleInitialReportState.token2Allowance,
+		approvedToken1Amount: openOracleInitialReportState.token1Approval.value,
+		approvedToken2Amount: openOracleInitialReportState.token2Approval.value,
 		defaultPrice: openOracleInitialReportState.defaultPrice,
 		defaultPriceError: openOracleInitialReportState.defaultPriceError,
 		defaultPriceSource: openOracleInitialReportState.defaultPriceSource,
@@ -273,8 +279,8 @@ function renderReportDetailsCard(
 		quoteAttemptedSources: openOracleInitialReportState.quoteAttemptedSources,
 		quoteFailureReason: openOracleInitialReportState.quoteFailureReason,
 		reportDetails: openOracleReportDetails,
-		token1AllowanceError: openOracleInitialReportState.token1AllowanceError,
-		token2AllowanceError: openOracleInitialReportState.token2AllowanceError,
+		token1AllowanceError: openOracleInitialReportState.token1Approval.error,
+		token2AllowanceError: openOracleInitialReportState.token2Approval.error,
 		token1Decimals: openOracleInitialReportState.token1Decimals ?? openOracleReportDetails.token1Decimals,
 		token2Decimals: openOracleInitialReportState.token2Decimals ?? openOracleReportDetails.token2Decimals,
 	})
@@ -442,6 +448,7 @@ function renderReportDetailsCard(
 			{renderSelectedReportActionSection(
 				actionMode,
 				isConnected,
+				openOracleActiveAction,
 				openOracleForm,
 				initialReportSubmission,
 				openOracleInitialReportState,
@@ -486,6 +493,7 @@ export function OpenOracleSection({
 	onSettleReport,
 	onSubmitInitialReport,
 	loadingOpenOracleCreate,
+	openOracleActiveAction,
 	openOracleCreateForm,
 	openOracleError,
 	openOracleForm,
@@ -687,7 +695,7 @@ export function OpenOracleSection({
 			{view === 'selected-report' ? (
 				<div className='market-grid'>
 					<div className='market-column'>
-						{renderReportDetailsCard(openOracleReportDetails, openOracleForm, openOracleInitialReportState, loadingOracleReport, isConnected, onApproveToken1, onApproveToken2, onDisputeReport, onLoadOracleReport, onOpenOracleFormChange, onRefreshPrice, onSettleReport, onSubmitInitialReport)}
+						{renderReportDetailsCard(openOracleReportDetails, openOracleForm, openOracleInitialReportState, openOracleActiveAction, loadingOracleReport, isConnected, onApproveToken1, onApproveToken2, onDisputeReport, onLoadOracleReport, onOpenOracleFormChange, onRefreshPrice, onSettleReport, onSubmitInitialReport)}
 						{renderLatestActionCard(openOracleResult)}
 					</div>
 				</div>

--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -7,13 +7,15 @@ import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
 import { StateHint } from './StateHint.js'
 import { TimestampValue } from './TimestampValue.js'
+import { TokenApprovalControl } from './TokenApprovalControl.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { normalizeAddress, sameAddress } from '../lib/address.js'
 import { formatCurrencyBalance, formatCurrencyInputBalance } from '../lib/formatters.js'
-import { approvalShortage, approvalTargetAmount, balanceShortage } from '../lib/inputs.js'
+import { balanceShortage } from '../lib/inputs.js'
 import { isMainnetChain } from '../lib/network.js'
 import { parseRepAmountInput } from '../lib/marketForm.js'
 import { getSelectedVaultAddress, hasValidSecurityVaultOraclePrice, isSecurityVaultDepositBelowMinimum, isSelectedVaultOwnedByAccount as isSelectedVaultOwnedByAccountHelper, MIN_SECURITY_VAULT_REP_DEPOSIT } from '../lib/securityVault.js'
+import { deriveTokenApprovalRequirement } from '../lib/tokenApproval.js'
 import { getWalletPresentation } from '../lib/userCopy.js'
 import type { SecurityVaultSectionProps } from '../types/components.js'
 
@@ -34,7 +36,8 @@ export function SecurityVaultSection({
 	securityVaultError,
 	securityVaultForm,
 	securityVaultMissing,
-	securityVaultRepAllowance,
+	securityVaultActiveAction,
+	securityVaultRepApproval,
 	securityVaultRepBalance,
 	securityVaultResult,
 	showHeader = true,
@@ -68,30 +71,24 @@ export function SecurityVaultSection({
 	const securityBondAllowance = securityVaultDetails?.securityBondAllowance ?? 0n
 	const hasValidOraclePrice = hasValidSecurityVaultOraclePrice(securityVaultDetails?.managerAddress, oracleManagerDetails)
 	const oraclePriceValidUntilTimestamp = hasValidOraclePrice ? oracleManagerDetails?.priceValidUntilTimestamp : undefined
-	const approvedRep = securityVaultRepAllowance
-	const shortage = approvalShortage(depositAmount, approvedRep)
-	const approvalTargetRep = approvalTargetAmount(depositAmount, approvedRep)
+	const approvalRequirement = deriveTokenApprovalRequirement(depositAmount, securityVaultRepApproval.value)
 	const repBalanceGap = balanceShortage(depositAmount, securityVaultRepBalance)
 	const withdrawableRepAmount = securityVaultDetails === undefined ? undefined : securityVaultDetails.repDepositShare > securityVaultDetails.lockedRepInEscalationGame ? securityVaultDetails.repDepositShare - securityVaultDetails.lockedRepInEscalationGame : 0n
 	const isDepositBelowMinimum = isSecurityVaultDepositBelowMinimum(securityVaultDetails?.repDepositShare, depositAmount)
 	const hasClaimableFees = securityVaultDetails !== undefined && securityVaultDetails.unpaidEthFees > 0n
 	const canClaimFees = selectedVaultIsOwnedByAccount && isMainnet && hasClaimableFees
-	const hasSufficientDepositAllowance = selectedVaultIsOwnedByAccount && approvedRep !== undefined && depositAmount !== undefined && depositAmount > 0n && approvedRep >= depositAmount
+	const hasSufficientDepositAllowance = selectedVaultIsOwnedByAccount && depositAmount !== undefined && depositAmount > 0n && approvalRequirement.hasSufficientApproval
 	const hasInsufficientRepBalance = repBalanceGap !== undefined && repBalanceGap > 0n
-	const canApproveRep = selectedVaultIsOwnedByAccount && isMainnet && securityVaultDetails !== undefined && approvalTargetRep !== undefined
 	const canSetSecurityBondAllowance = selectedVaultIsOwnedByAccount && isMainnet && securityVaultDetails !== undefined && hasValidOraclePrice && securityBondAllowanceAmount !== undefined && securityBondAllowanceAmount > 0n
 	const canWithdrawRep = selectedVaultIsOwnedByAccount && accountState.address !== undefined && isMainnet && hasValidOraclePrice && hasWithdrawAmount && withdrawableRepAmount !== undefined && withdrawableRepAmount > 0n
-	const approveButtonLabel = depositAmount === undefined || depositAmount <= 0n || shortage === undefined ? 'Approve REP' : shortage === 0n ? 'Approval Satisfied' : `Approve ${formatCurrencyBalance(approvalTargetRep)} REP`
-	const approveButtonTitle = (() => {
+	const approvalGuardMessage = (() => {
 		const walletPresentation = getWalletPresentation({ accountAddress: accountState.address, isMainnet })
 		if (walletPresentation !== undefined) return walletPresentation.detail
 		if (!selectedVaultIsOwnedByAccount) return 'Select your own vault to approve REP.'
 		if (securityVaultMissing) return 'Choose a pool first.'
 		if (securityVaultDetails === undefined) return 'Refresh the vault first.'
 		if (depositAmount === undefined || depositAmount <= 0n) return 'Enter a deposit amount greater than zero.'
-		if (shortage === undefined) return 'Loading current REP approval.'
-		if (shortage === 0n) return 'This deposit amount is already approved.'
-		return `Approve ${formatCurrencyBalance(approvalTargetRep)} REP to cover this deposit amount. Current allowance is short by ${formatCurrencyBalance(shortage)} REP.`
+		return undefined
 	})()
 	const latestActionLabel =
 		securityVaultResult === undefined
@@ -137,7 +134,7 @@ export function SecurityVaultSection({
 						<CurrencyValue value={securityVaultDetails.repDepositShare} suffix='REP' />
 					</MetricField>
 					<MetricField className='entity-metric' label='Approved REP'>
-						{approvedRep === undefined ? <LoadingText>Loading...</LoadingText> : <CurrencyValue value={approvedRep} suffix='REP' />}
+						<CurrencyValue loading={securityVaultRepApproval.loading} value={securityVaultRepApproval.value} suffix='REP' />
 					</MetricField>
 					<MetricField className='entity-metric' label='Security Bond Allowance'>
 						<CurrencyValue value={securityBondAllowance} suffix='REP' />
@@ -242,10 +239,21 @@ export function SecurityVaultSection({
 					</button>
 				</div>
 			</label>
+			<TokenApprovalControl
+				actionLabel='depositing REP'
+				allowanceError={securityVaultRepApproval.error}
+				allowanceLoading={securityVaultRepApproval.loading}
+				approvedAmount={securityVaultRepApproval.value}
+				guardMessage={approvalGuardMessage}
+				onApprove={amount => onApproveRep(amount)}
+				pending={securityVaultActiveAction === 'approveRep'}
+				pendingLabel='Approving REP...'
+				requiredAmount={depositAmount}
+				resetKey={`${securityVaultDetails?.repToken ?? ''}:${securityVaultDetails?.securityPoolAddress ?? ''}:${depositAmount?.toString() ?? ''}`}
+				tokenSymbol='REP'
+				tokenUnits={18}
+			/>
 			<div className='actions'>
-				<button className='secondary' title={approveButtonTitle} onClick={() => onApproveRep(approvalTargetRep)} disabled={!canApproveRep}>
-					{approveButtonLabel}
-				</button>
 				<button className='primary' onClick={onDepositRep} disabled={!selectedVaultIsOwnedByAccount || accountState.address === undefined || !isMainnet || !hasSufficientDepositAllowance || hasInsufficientRepBalance || isDepositBelowMinimum}>
 					Create / Deposit REP
 				</button>
@@ -255,10 +263,6 @@ export function SecurityVaultSection({
 			) : isDepositBelowMinimum ? (
 				<p className='detail'>
 					New vaults require at least <CurrencyValue value={MIN_SECURITY_VAULT_REP_DEPOSIT} suffix='REP' copyable={false} /> in the first deposit.
-				</p>
-			) : depositAmount === undefined ? undefined : shortage === undefined ? undefined : shortage > 0n ? (
-				<p className='detail'>
-					Need <CurrencyValue value={shortage} suffix='REP' copyable={false} /> more REP approved before depositing. Approving will set the allowance to <CurrencyValue value={approvalTargetRep ?? depositAmount} suffix='REP' copyable={false} />.
 				</p>
 			) : undefined}
 		</div>

--- a/ui/ts/components/TokenApprovalControl.tsx
+++ b/ui/ts/components/TokenApprovalControl.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useMemo, useState } from 'preact/hooks'
+import { CurrencyValue } from './CurrencyValue.js'
+import { ErrorNotice } from './ErrorNotice.js'
+import { FormInput } from './FormInput.js'
+import { LoadingText } from './LoadingText.js'
+import { MetricField } from './MetricField.js'
+import { formatCurrencyBalance } from '../lib/formatters.js'
+import { deriveTokenApprovalRequirement, formatTokenApprovalNeededMessage, formatTokenApprovalPartialMessage, formatTokenApprovalUnavailableMessage, parseTokenApprovalAmountInput } from '../lib/tokenApproval.js'
+
+type TokenApprovalControlProps = {
+	actionLabel: string
+	allowanceError: string | undefined
+	allowanceLoading: boolean
+	approvedAmount: bigint | undefined
+	guardMessage: string | undefined
+	onApprove: (amount?: bigint) => void
+	pending: boolean
+	pendingLabel: string
+	requiredAmount: bigint | undefined
+	resetKey: string
+	tokenSymbol: string
+	tokenUnits: number
+}
+
+function resolveApprovalButtonLabel({
+	guardMessage,
+	isCustomAmount,
+	isMaxAmount,
+	nextApprovalAmount,
+	pending,
+	pendingLabel,
+	requirementSatisfied,
+	tokenSymbol,
+	tokenUnits,
+}: {
+	guardMessage: string | undefined
+	isCustomAmount: boolean
+	isMaxAmount: boolean
+	nextApprovalAmount: bigint | undefined
+	pending: boolean
+	pendingLabel: string
+	requirementSatisfied: boolean
+	tokenSymbol: string
+	tokenUnits: number
+}) {
+	if (pending) return <LoadingText>{pendingLabel}</LoadingText>
+	if (guardMessage !== undefined || nextApprovalAmount === undefined) return `Approve ${tokenSymbol}`
+	if (requirementSatisfied && !isCustomAmount && !isMaxAmount) return 'Approval Satisfied'
+	if (isMaxAmount) return `Approve Max ${tokenSymbol}`
+	return `Approve ${formatCurrencyBalance(nextApprovalAmount, tokenUnits)} ${tokenSymbol}`
+}
+
+export function TokenApprovalControl({ actionLabel, allowanceError, allowanceLoading, approvedAmount, guardMessage, onApprove, pending, pendingLabel, requiredAmount, resetKey, tokenSymbol, tokenUnits }: TokenApprovalControlProps) {
+	const [draftAmount, setDraftAmount] = useState('')
+	const requirement = useMemo(() => deriveTokenApprovalRequirement(requiredAmount, approvedAmount), [approvedAmount, requiredAmount])
+
+	useEffect(() => {
+		setDraftAmount('')
+	}, [resetKey])
+
+	const parsedAmount = useMemo(() => {
+		try {
+			return parseTokenApprovalAmountInput(draftAmount, 'Approval amount', tokenUnits)
+		} catch (error) {
+			return {
+				error: error instanceof Error ? error.message : 'Approval amount must be a decimal number',
+				kind: 'invalid' as const,
+			}
+		}
+	}, [draftAmount, tokenUnits])
+
+	const nextApprovalAmount = parsedAmount.kind === 'default' ? requirement.targetAmount : parsedAmount.kind === 'invalid' ? undefined : parsedAmount.amount
+
+	const amountValidationMessage = parsedAmount.kind === 'invalid' ? parsedAmount.error : parsedAmount.kind === 'default' || approvedAmount === undefined || parsedAmount.amount > approvedAmount ? undefined : `Approval amount must be greater than the current approved ${tokenSymbol} amount.`
+
+	const partialApprovalMessage =
+		nextApprovalAmount === undefined || requiredAmount === undefined || draftAmount.trim() === '' || amountValidationMessage !== undefined
+			? undefined
+			: formatTokenApprovalPartialMessage({
+					actionLabel,
+					nextApprovedAmount: nextApprovalAmount,
+					requiredAmount,
+					tokenLabel: tokenSymbol,
+					tokenUnits,
+				})
+
+	const statusMessage =
+		guardMessage ??
+		amountValidationMessage ??
+		(amountValidationMessage === undefined && draftAmount.trim() === '' ? formatTokenApprovalNeededMessage({ actionLabel, requirement, tokenLabel: tokenSymbol, tokenUnits }) : undefined) ??
+		partialApprovalMessage ??
+		(allowanceLoading ? `Loading current ${tokenSymbol} approval.` : undefined)
+
+	const allowanceMessage = allowanceError === undefined ? undefined : formatTokenApprovalUnavailableMessage({ actionLabel, reason: allowanceError, tokenLabel: tokenSymbol })
+	const canApprove = !pending && guardMessage === undefined && allowanceMessage === undefined && !allowanceLoading && requiredAmount !== undefined && amountValidationMessage === undefined && nextApprovalAmount !== undefined && (parsedAmount.kind !== 'default' || !requirement.hasSufficientApproval)
+	const buttonLabel = resolveApprovalButtonLabel({
+		guardMessage,
+		isCustomAmount: parsedAmount.kind === 'custom',
+		isMaxAmount: parsedAmount.kind === 'max',
+		nextApprovalAmount,
+		pending,
+		pendingLabel,
+		requirementSatisfied: requirement.hasSufficientApproval,
+		tokenSymbol,
+		tokenUnits,
+	})
+
+	return (
+		<div className='form-grid'>
+			<div className='workflow-metric-grid'>
+				<MetricField label={`Required ${tokenSymbol}`}>
+					<CurrencyValue value={requiredAmount} units={tokenUnits} suffix={tokenSymbol} copyable={false} />
+				</MetricField>
+				<MetricField label={`Approved ${tokenSymbol}`}>
+					<CurrencyValue loading={allowanceLoading} value={approvedAmount} units={tokenUnits} suffix={tokenSymbol} copyable={false} />
+				</MetricField>
+				<MetricField label={`Need More ${tokenSymbol} Approved`}>
+					<CurrencyValue value={requirement.neededAmount} units={tokenUnits} suffix={tokenSymbol} copyable={false} />
+				</MetricField>
+			</div>
+
+			<label className='field'>
+				<span>{`${tokenSymbol} Approval Amount`}</span>
+				<div className='field-inline'>
+					<FormInput className='field-inline-input' value={draftAmount} onInput={event => setDraftAmount(event.currentTarget.value)} placeholder='Leave blank for required total' invalid={amountValidationMessage !== undefined} disabled={pending} />
+					<button className='quiet field-inline-action' type='button' onClick={() => setDraftAmount('max')} disabled={pending}>
+						Max
+					</button>
+				</div>
+			</label>
+
+			<div className='actions'>
+				<button className='secondary' type='button' onClick={() => onApprove(nextApprovalAmount)} disabled={!canApprove}>
+					{buttonLabel}
+				</button>
+			</div>
+
+			{allowanceMessage === undefined ? undefined : <ErrorNotice message={allowanceMessage} />}
+			{allowanceMessage !== undefined || statusMessage === undefined ? undefined : <p className='detail'>{statusMessage}</p>}
+		</div>
+	)
+}

--- a/ui/ts/components/ZoltarMigrationSection.tsx
+++ b/ui/ts/components/ZoltarMigrationSection.tsx
@@ -7,13 +7,15 @@ import { FormInput } from './FormInput.js'
 import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
 import { StateHint } from './StateHint.js'
+import { TokenApprovalControl } from './TokenApprovalControl.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { UniverseLink } from './UniverseLink.js'
 import { getMigrationOutcomeSplitLimit, MigrationOutcomeUniversesSection } from './MigrationOutcomeUniversesSection.js'
 import type { LoadableValueState } from '../lib/loadState.js'
 import { formatCurrencyBalance, formatCurrencyInputBalance } from '../lib/formatters.js'
-import { approvalShortage, approvalTargetAmount, parseBigIntListInput } from '../lib/inputs.js'
+import { parseBigIntListInput } from '../lib/inputs.js'
 import { parseRepAmountInput as parseMigrationAmountInput } from '../lib/marketForm.js'
+import { deriveTokenApprovalRequirement, type TokenApprovalState } from '../lib/tokenApproval.js'
 import { getUniversePresentation, getWalletPresentation } from '../lib/userCopy.js'
 import type { ZoltarMigrationFormState } from '../types/app.js'
 import type { ZoltarMigrationActionResult, ZoltarUniverseSummary } from '../types/contracts.js'
@@ -27,9 +29,8 @@ type ZoltarMigrationSectionProps = {
 	onPrepareRepForMigration: () => void
 	onZoltarMigrationFormChange: (update: Partial<ZoltarMigrationFormState>) => void
 	zoltarForkRepBalance: bigint | undefined
-	zoltarForkAllowance: bigint | undefined
+	zoltarForkApproval: TokenApprovalState
 	zoltarForkActiveAction: 'approve' | 'fork' | undefined
-	zoltarForkPending: boolean
 	zoltarMigrationChildRepBalances: Record<string, bigint | undefined>
 	zoltarMigrationActiveAction: 'prepare' | 'split' | undefined
 	zoltarMigrationError: string | undefined
@@ -77,9 +78,8 @@ export function ZoltarMigrationSection({
 	onPrepareRepForMigration,
 	onZoltarMigrationFormChange,
 	zoltarForkRepBalance,
-	zoltarForkAllowance,
+	zoltarForkApproval,
 	zoltarForkActiveAction,
-	zoltarForkPending,
 	zoltarMigrationChildRepBalances,
 	zoltarMigrationActiveAction,
 	zoltarMigrationError,
@@ -116,25 +116,20 @@ export function ZoltarMigrationSection({
 	const amountExceedsAvailableRep = hasValidAmount && migrationAmount !== undefined && migrationAmount > totalRepAvailable
 	const hasEnoughRep = hasValidAmount && zoltarForkRepBalance !== undefined && zoltarForkRepBalance >= missingPreparationAmount
 	const hasPreparedBalance = hasValidAmount && zoltarMigrationPreparedRepBalance !== undefined && zoltarMigrationPreparedRepBalance >= migrationAmount
-	const approvalGap = approvalShortage(missingPreparationAmount, zoltarForkAllowance)
-	const approvalTargetRep = approvalTargetAmount(missingPreparationAmount, zoltarForkAllowance)
-	const hasSufficientAllowance = approvalGap !== undefined && approvalGap === 0n
+	const approvalRequirement = deriveTokenApprovalRequirement(missingPreparationAmount, zoltarForkApproval.value)
+	const hasSufficientAllowance = approvalRequirement.hasSufficientApproval
 	const hasValidOutcomeIndexes = selectedOutcomeIndexes.length > 0
 	const needsAdditionalPreparation = missingPreparationAmount > 0n
 	const splitLimit = useMemo(() => getMigrationOutcomeSplitLimit(rootUniverse?.childUniverses ?? [], zoltarMigrationChildRepBalances, zoltarMigrationPreparedRepBalance, selectedOutcomeIndexSet), [rootUniverse?.childUniverses, selectedOutcomeIndexSet, zoltarMigrationChildRepBalances, zoltarMigrationPreparedRepBalance])
 	const hasSufficientSplitLimit = migrationAmount !== undefined && splitLimit !== undefined && migrationAmount <= splitLimit
 	const canPrepare = accountAddress !== undefined && isMainnet && rootUniverse !== undefined && hasForked && !zoltarMigrationPending && hasValidAmount && needsAdditionalPreparation && hasEnoughRep && hasSufficientAllowance
-	const canApproveRep = accountAddress !== undefined && isMainnet && rootUniverse !== undefined && hasForked && !zoltarForkPending && approvalTargetRep !== undefined
 	const canSplit = accountAddress !== undefined && isMainnet && rootUniverse !== undefined && hasForked && !zoltarMigrationPending && hasValidAmount && hasPreparedBalance && hasValidOutcomeIndexes && hasSufficientSplitLimit
 	const migrationAmountSource = getMigrationAmountSource(zoltarMigrationPreparedRepBalance, zoltarForkRepBalance)
-	const approveButtonLabel = !hasValidAmount || migrationAmount === undefined || approvalGap === undefined ? 'Approve REP' : approvalGap > 0n ? `Approve ${formatCurrencyBalance(approvalTargetRep)} REP` : 'Approval Satisfied'
-	const approveButtonTitle = (() => {
+	const approvalGuardMessage = (() => {
 		const guard = getMigrationGuardMessage(accountAddress, isMainnet, rootUniverse, loadingZoltarForkAccess, hasForked, loadingZoltarUniverse, 'Fork Zoltar before preparing REP.')
 		if (guard !== undefined) return guard
 		if (!hasValidAmount || migrationAmount === undefined) return 'Enter an amount greater than zero.'
-		if (approvalGap === undefined) return 'Loading current REP approval.'
-		if (approvalGap === 0n) return 'No additional REP approval is needed for this amount.'
-		return `Approve ${formatCurrencyBalance(approvalTargetRep)} REP for Zoltar to cover the selected amount. Current allowance is short by ${formatCurrencyBalance(approvalGap)} REP.`
+		return undefined
 	})()
 	const getAlreadyPreparedHint = () => {
 		if (hasValidOutcomeIndexes && splitLimit === 0n) {
@@ -149,12 +144,6 @@ export function ZoltarMigrationSection({
 		if (missingPreparationAmount === 0n) return getAlreadyPreparedHint()
 		if (zoltarForkRepBalance === undefined || zoltarForkRepBalance < missingPreparationAmount) {
 			return `Need ${formatCurrencyBalance(missingPreparationAmount)} more REP in this universe to prepare the selected amount.`
-		}
-		if (approvalGap === undefined) {
-			return 'Loading current REP approval before preparing the selected amount.'
-		}
-		if (approvalGap > 0n) {
-			return `Approve ${formatCurrencyBalance(approvalTargetRep)} REP for Zoltar to cover the selected amount. Current allowance is short by ${formatCurrencyBalance(approvalGap)} REP.`
 		}
 		if (!hasSufficientAllowance) {
 			return 'Waiting for approved REP amount before preparing the selected amount.'
@@ -228,16 +217,6 @@ export function ZoltarMigrationSection({
 					<MetricField label='Migration REP Balance'>
 						<CurrencyValue loading={loadingZoltarForkAccess && zoltarMigrationPreparedRepBalance === undefined} value={zoltarMigrationPreparedRepBalance} suffix='REP' />
 					</MetricField>
-					<div>
-						<MetricField label='Approved REP'>
-							<CurrencyValue loading={loadingZoltarForkAccess && zoltarForkAllowance === undefined} value={zoltarForkAllowance} suffix='REP' />
-						</MetricField>
-						{approvalGap === undefined || approvalGap === 0n ? undefined : (
-							<p className='detail'>
-								Need {formatCurrencyBalance(approvalGap)} more REP approved before preparing the current amount. Approving will set the allowance to {formatCurrencyBalance(approvalTargetRep ?? missingPreparationAmount)} REP.
-							</p>
-						)}
-					</div>
 					<MetricField label='Universe'>
 						{rootUniverse === undefined ? (
 							<span className='loading-value' role='status' aria-label='Loading universe data'>
@@ -260,6 +239,21 @@ export function ZoltarMigrationSection({
 						{migrationAmountHintMessage === undefined ? undefined : <p className='detail'>{migrationAmountHintMessage}</p>}
 					</div>
 
+					<TokenApprovalControl
+						actionLabel='preparing the current amount'
+						allowanceError={zoltarForkApproval.error}
+						allowanceLoading={zoltarForkApproval.loading}
+						approvedAmount={zoltarForkApproval.value}
+						guardMessage={approvalGuardMessage}
+						onApprove={amount => onApproveZoltarForkRep(amount)}
+						pending={zoltarForkActiveAction === 'approve'}
+						pendingLabel='Approving REP...'
+						requiredAmount={missingPreparationAmount}
+						resetKey={`${rootUniverse?.reputationToken ?? ''}:${rootUniverse?.universeId.toString() ?? ''}:${missingPreparationAmount.toString()}`}
+						tokenSymbol='REP'
+						tokenUnits={18}
+					/>
+
 					{rootUniverse === undefined ? undefined : (
 						<MigrationOutcomeUniversesSection
 							childUniverseRepBalances={zoltarMigrationChildRepBalances}
@@ -274,9 +268,6 @@ export function ZoltarMigrationSection({
 					)}
 
 					<div className='actions'>
-						<button className='secondary' title={approveButtonTitle} onClick={() => onApproveZoltarForkRep(approvalTargetRep)} disabled={!canApproveRep || zoltarForkActiveAction === 'approve'}>
-							{zoltarForkActiveAction === 'approve' ? <LoadingText>Approving REP...</LoadingText> : approveButtonLabel}
-						</button>
 						<button className='secondary' title={prepareHintMessage} onClick={onPrepareRepForMigration} disabled={!canPrepare}>
 							{zoltarMigrationActiveAction === 'prepare' ? <LoadingText>Preparing REP...</LoadingText> : 'Prepare REP'}
 						</button>

--- a/ui/ts/hooks/useErc20Loader.ts
+++ b/ui/ts/hooks/useErc20Loader.ts
@@ -1,7 +1,9 @@
 import { useSignal } from '@preact/signals'
 import { loadErc20Allowance, loadErc20Balance } from '../contracts.js'
 import { createConnectedReadClient } from '../lib/clients.js'
+import { getErrorDetail } from '../lib/errors.js'
 import { useRequestGuard } from '../lib/requestGuard.js'
+import type { TokenApprovalState } from '../lib/tokenApproval.js'
 import type { ReadClient } from '../types/contracts.js'
 
 function useErc20Loader<TArgs extends unknown[]>(loadFn: (client: ReadClient, ...args: TArgs) => Promise<bigint>) {
@@ -26,5 +28,37 @@ export function useErc20BalanceLoader() {
 }
 
 export function useErc20AllowanceLoader() {
-	return useErc20Loader(loadErc20Allowance)
+	const signal = useSignal<TokenApprovalState>({
+		error: undefined,
+		loading: false,
+		value: undefined,
+	})
+	const nextLoad = useRequestGuard()
+	const reload = async (...args: Parameters<typeof loadErc20Allowance> extends [ReadClient, ...infer TArgs] ? TArgs : never) => {
+		const isCurrent = nextLoad()
+		signal.value = {
+			...signal.value,
+			error: undefined,
+			loading: true,
+		}
+		try {
+			const value = await loadErc20Allowance(createConnectedReadClient(), ...args)
+			if (!isCurrent()) return
+			signal.value = {
+				error: undefined,
+				loading: false,
+				value,
+			}
+		} catch (error) {
+			if (!isCurrent()) return
+			const errorDetail = getErrorDetail(error)
+			signal.value = {
+				error: errorDetail === undefined ? 'Failed to load token approval' : `Failed to load token approval: ${errorDetail}`,
+				loading: false,
+				value: undefined,
+			}
+		}
+	}
+
+	return { signal, reload }
 }

--- a/ui/ts/hooks/useOpenOracleOperations.ts
+++ b/ui/ts/hooks/useOpenOracleOperations.ts
@@ -6,8 +6,9 @@ import type { Address } from 'viem'
 import { approveErc20, createOpenOracleReportInstance, disputeOracleReport, getOpenOracleAddress, loadErc20Allowance, loadOpenOracleReportDetails, settleOracleReport, submitInitialOracleReport } from '../contracts.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
 import { getErrorDetail, getErrorMessage } from '../lib/errors.js'
-import { deriveOpenOracleInitialReportSubmissionDetails, formatOpenOraclePriceInput, loadOpenOracleInitialReportPriceResult, OPEN_ORACLE_APPROVAL_AMOUNT } from '../lib/openOracle.js'
+import { deriveOpenOracleInitialReportSubmissionDetails, formatOpenOraclePriceInput, loadOpenOracleInitialReportPriceResult } from '../lib/openOracle.js'
 import { requireDefined } from '../lib/required.js'
+import type { TokenApprovalState } from '../lib/tokenApproval.js'
 import { buildWriteActionConfig, runWriteAction } from '../lib/writeAction.js'
 import { useRequestGuard } from '../lib/requestGuard.js'
 import { parseAddressInput, parseBytes32Input, parseReportIdInput } from '../lib/inputs.js'
@@ -23,6 +24,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 	const openOracleInitialReportStateLoad = useLoadController()
 	const { state: openOracleCreateForm, setState: setOpenOracleCreateForm } = useFormState<OpenOracleCreateFormState>(getDefaultOpenOracleCreateFormState())
 	const openOracleError = useSignal<string | undefined>(undefined)
+	const openOracleActiveAction = useSignal<OpenOracleActionResult['action'] | undefined>(undefined)
 	const { state: openOracleForm, setState: setOpenOracleForm } = useFormState<OpenOracleFormState>(getDefaultOpenOracleFormState())
 	const openOracleResult = useSignal<OpenOracleActionResult | undefined>(undefined)
 	const openOracleReportDetails = useSignal<OpenOracleReportDetails | undefined>(undefined)
@@ -33,11 +35,35 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 	const openOracleInitialReportQuoteAttemptedSources = useSignal<('Uniswap V4' | 'Uniswap V3 fallback')[] | undefined>(undefined)
 	const openOracleInitialReportQuoteFailureKind = useSignal<'unsupported-pair' | 'quote-failed' | undefined>(undefined)
 	const openOracleInitialReportQuoteFailureReason = useSignal<string | undefined>(undefined)
-	const openOracleInitialReportToken1Allowance = useSignal<bigint | undefined>(undefined)
-	const openOracleInitialReportToken1AllowanceError = useSignal<string | undefined>(undefined)
-	const openOracleInitialReportToken2Allowance = useSignal<bigint | undefined>(undefined)
-	const openOracleInitialReportToken2AllowanceError = useSignal<string | undefined>(undefined)
+	const openOracleInitialReportToken1Approval = useSignal<TokenApprovalState>({
+		error: undefined,
+		loading: false,
+		value: undefined,
+	})
+	const openOracleInitialReportToken2Approval = useSignal<TokenApprovalState>({
+		error: undefined,
+		loading: false,
+		value: undefined,
+	})
 	const nextOpenOracleInitialReportStateLoad = useRequestGuard()
+	type OpenOracleInitialReportStateResult = {
+		initialPriceResult: Awaited<ReturnType<typeof loadOpenOracleInitialReportPriceResult>>
+		token1ApprovalResult: TokenApprovalState
+		token2ApprovalResult: TokenApprovalState
+	}
+
+	const resetOpenOracleTokenApprovalState = (loading: boolean) => {
+		openOracleInitialReportToken1Approval.value = {
+			error: undefined,
+			loading,
+			value: undefined,
+		}
+		openOracleInitialReportToken2Approval.value = {
+			error: undefined,
+			loading,
+			value: undefined,
+		}
+	}
 
 	const refreshOpenOracleInitialReportState = async (details: OpenOracleReportDetails | undefined) => {
 		const currentDetails = details
@@ -49,10 +75,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 			openOracleInitialReportQuoteAttemptedSources.value = undefined
 			openOracleInitialReportQuoteFailureKind.value = undefined
 			openOracleInitialReportQuoteFailureReason.value = undefined
-			openOracleInitialReportToken1Allowance.value = undefined
-			openOracleInitialReportToken1AllowanceError.value = undefined
-			openOracleInitialReportToken2Allowance.value = undefined
-			openOracleInitialReportToken2AllowanceError.value = undefined
+			resetOpenOracleTokenApprovalState(false)
 			return
 		}
 
@@ -65,37 +88,40 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 				openOracleInitialReportQuoteAttemptedSources.value = undefined
 				openOracleInitialReportQuoteFailureKind.value = undefined
 				openOracleInitialReportQuoteFailureReason.value = undefined
-				openOracleInitialReportToken1Allowance.value = undefined
-				openOracleInitialReportToken1AllowanceError.value = undefined
-				openOracleInitialReportToken2Allowance.value = undefined
-				openOracleInitialReportToken2AllowanceError.value = undefined
+				resetOpenOracleTokenApprovalState(accountAddress !== undefined)
 			},
 			load: async () => {
 				const readClient = createConnectedReadClient()
 				const loadAllowance = async (tokenAddress: Address) => {
 					if (accountAddress === undefined) {
-						return { allowance: undefined, error: undefined }
+						return {
+							error: undefined,
+							loading: false,
+							value: undefined,
+						} satisfies TokenApprovalState
 					}
 
 					try {
 						return {
-							allowance: await loadErc20Allowance(readClient, tokenAddress, accountAddress, getOpenOracleAddress()),
 							error: undefined,
-						}
+							loading: false,
+							value: await loadErc20Allowance(readClient, tokenAddress, accountAddress, getOpenOracleAddress()),
+						} satisfies TokenApprovalState
 					} catch (error) {
 						const errorDetail = getErrorDetail(error)
 						return {
-							allowance: undefined,
 							error: errorDetail === undefined ? 'Failed to load token approval' : `Failed to load token approval: ${errorDetail}`,
-						}
+							loading: false,
+							value: undefined,
+						} satisfies TokenApprovalState
 					}
 				}
 
-				const [initialPriceResult, token1AllowanceResult, token2AllowanceResult] = await Promise.all([loadOpenOracleInitialReportPriceResult(readClient, currentDetails.token1, currentDetails.token2, currentDetails.exactToken1Report), loadAllowance(currentDetails.token1), loadAllowance(currentDetails.token2)])
+				const [initialPriceResult, token1ApprovalResult, token2ApprovalResult] = await Promise.all([loadOpenOracleInitialReportPriceResult(readClient, currentDetails.token1, currentDetails.token2, currentDetails.exactToken1Report), loadAllowance(currentDetails.token1), loadAllowance(currentDetails.token2)])
 
-				return { initialPriceResult, token1AllowanceResult, token2AllowanceResult }
+				return { initialPriceResult, token1ApprovalResult, token2ApprovalResult }
 			},
-			onSuccess: ({ initialPriceResult, token1AllowanceResult, token2AllowanceResult }) => {
+			onSuccess: ({ initialPriceResult, token1ApprovalResult, token2ApprovalResult }: OpenOracleInitialReportStateResult) => {
 				const initialPrice = initialPriceResult.status === 'success' ? initialPriceResult : undefined
 				const priceFailure = initialPriceResult.status === 'failure' ? initialPriceResult : undefined
 
@@ -105,10 +131,8 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 				openOracleInitialReportQuoteAttemptedSources.value = priceFailure?.attemptedSources
 				openOracleInitialReportQuoteFailureKind.value = priceFailure?.failureKind
 				openOracleInitialReportQuoteFailureReason.value = priceFailure?.reason
-				openOracleInitialReportToken1Allowance.value = token1AllowanceResult.allowance
-				openOracleInitialReportToken1AllowanceError.value = token1AllowanceResult.error
-				openOracleInitialReportToken2Allowance.value = token2AllowanceResult.allowance
-				openOracleInitialReportToken2AllowanceError.value = token2AllowanceResult.error
+				openOracleInitialReportToken1Approval.value = token1ApprovalResult
+				openOracleInitialReportToken2Approval.value = token2ApprovalResult
 
 				if (openOracleForm.value.price.trim() === '' || openOracleForm.value.reportId.trim() !== currentDetails.reportId.toString()) {
 					openOracleForm.value = {
@@ -140,7 +164,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 				const details = await loadOpenOracleReportDetails(createConnectedReadClient(), getOpenOracleAddress(), reportId)
 				return { details, reportId }
 			},
-			onSuccess: ({ details, reportId }) => {
+			onSuccess: ({ details, reportId }: { details: OpenOracleReportDetails; reportId: bigint }) => {
 				openOracleReportDetails.value = details
 				loadedOpenOracleReportId.value = reportId
 				openOracleForm.value = {
@@ -149,7 +173,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 					stateHash: details.stateHash,
 				}
 			},
-			onError: error => {
+			onError: (error: unknown) => {
 				openOracleReportDetails.value = undefined
 				loadedOpenOracleReportId.value = undefined
 				openOracleInitialReportDefaultPrice.value = undefined
@@ -158,10 +182,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 				openOracleInitialReportQuoteAttemptedSources.value = undefined
 				openOracleInitialReportQuoteFailureKind.value = undefined
 				openOracleInitialReportQuoteFailureReason.value = undefined
-				openOracleInitialReportToken1Allowance.value = undefined
-				openOracleInitialReportToken1AllowanceError.value = undefined
-				openOracleInitialReportToken2Allowance.value = undefined
-				openOracleInitialReportToken2AllowanceError.value = undefined
+				resetOpenOracleTokenApprovalState(false)
 				openOracleError.value = getErrorMessage(error, 'Failed to load oracle report')
 			},
 		})
@@ -182,57 +203,89 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 		}
 	}
 
-	const runOracleAction = async (action: (walletAddress: Address) => Promise<OpenOracleActionResult>, errorFallback: string) =>
-		await runWriteAction(
-			{
-				...buildWriteActionConfig({ accountAddress, onTransaction, onTransactionFinished, onTransactionRequested, refreshState }, openOracleError, 'Connect a wallet before operating open oracle'),
-				refreshErrorFallback: 'Oracle transaction succeeded, but refreshing the selected report failed',
-			},
-			async walletAddress => {
-				openOracleResult.value = undefined
-				return await action(walletAddress)
-			},
-			errorFallback,
-			async result => {
-				openOracleResult.value = result
-				if (result.action === 'createReportInstance') {
-					openOracleCreateForm.value = getDefaultOpenOracleCreateFormState()
-				}
-				if (result.action !== 'createReportInstance' && openOracleForm.value.reportId.trim() !== '') {
-					await ensureLoadedSelectedReport()
-				}
-				if (result.action === 'approveToken1' || result.action === 'approveToken2') {
-					await refreshOpenOracleInitialReportState(openOracleReportDetails.value)
-				}
-			},
-		)
-
-	const parseApproveAmount = (raw: string) => {
-		const trimmed = raw.trim()
-		if (trimmed === '') return OPEN_ORACLE_APPROVAL_AMOUNT
+	const runOracleAction = async (actionName: OpenOracleActionResult['action'], action: (walletAddress: Address) => Promise<OpenOracleActionResult>, errorFallback: string) => {
 		try {
-			return parseBigIntInput(trimmed, 'Approve amount')
-		} catch {
-			return OPEN_ORACLE_APPROVAL_AMOUNT
+			await runWriteAction(
+				{
+					...buildWriteActionConfig({ accountAddress, onTransaction, onTransactionFinished, onTransactionRequested, refreshState }, openOracleError, 'Connect a wallet before operating open oracle'),
+					refreshErrorFallback: 'Oracle transaction succeeded, but refreshing the selected report failed',
+				},
+				async walletAddress => {
+					openOracleActiveAction.value = actionName
+					openOracleResult.value = undefined
+					return await action(walletAddress)
+				},
+				errorFallback,
+				async result => {
+					openOracleResult.value = result
+					if (result.action === 'createReportInstance') {
+						openOracleCreateForm.value = getDefaultOpenOracleCreateFormState()
+					}
+					if (result.action !== 'createReportInstance' && openOracleForm.value.reportId.trim() !== '') {
+						await ensureLoadedSelectedReport()
+					}
+					if (result.action === 'approveToken1' || result.action === 'approveToken2') {
+						await refreshOpenOracleInitialReportState(openOracleReportDetails.value)
+					}
+				},
+			)
+		} finally {
+			openOracleActiveAction.value = undefined
 		}
 	}
 
-	const approveToken1 = async () =>
-		await runOracleAction(async walletAddress => {
-			const reportDetails = requireDefined(openOracleReportDetails.value, 'Load an oracle report first')
-			return await approveErc20(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), reportDetails.token1, getOpenOracleAddress(), parseApproveAmount(openOracleForm.value.approveAmount1), 'approveToken1')
-		}, 'Failed to approve token1')
+	const getInitialReportSubmission = (reportDetails: OpenOracleReportDetails) =>
+		deriveOpenOracleInitialReportSubmissionDetails({
+			approvedToken1Amount: openOracleInitialReportToken1Approval.value.value,
+			approvedToken2Amount: openOracleInitialReportToken2Approval.value.value,
+			defaultPrice: openOracleInitialReportDefaultPrice.value,
+			defaultPriceError: openOracleInitialReportDefaultPriceError.value,
+			defaultPriceSource: openOracleInitialReportDefaultPriceSource.value,
+			priceInput: openOracleForm.value.price,
+			quoteAttemptedSources: openOracleInitialReportQuoteAttemptedSources.value,
+			quoteFailureReason: openOracleInitialReportQuoteFailureReason.value,
+			reportDetails,
+			token1AllowanceError: openOracleInitialReportToken1Approval.value.error,
+			token2AllowanceError: openOracleInitialReportToken2Approval.value.error,
+			token1Decimals: reportDetails.token1Decimals,
+			token2Decimals: reportDetails.token2Decimals,
+		})
 
-	const approveToken2 = async () =>
-		await runOracleAction(async walletAddress => {
-			const reportDetails = requireDefined(openOracleReportDetails.value, 'Load an oracle report first')
-			return await approveErc20(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), reportDetails.token2, getOpenOracleAddress(), parseApproveAmount(openOracleForm.value.approveAmount2), 'approveToken2')
-		}, 'Failed to approve token2')
+	const approveToken1 = async (amount?: bigint) =>
+		await runOracleAction(
+			'approveToken1',
+			async walletAddress => {
+				const reportDetails = requireDefined(openOracleReportDetails.value, 'Load an oracle report first')
+				const submission = getInitialReportSubmission(reportDetails)
+				const approvalAmount = amount ?? submission.token1Approval.targetAmount ?? submission.amount1
+				if (approvalAmount === undefined) {
+					throw new Error('No token1 approval amount is required for the selected report')
+				}
+				return await approveErc20(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), reportDetails.token1, getOpenOracleAddress(), approvalAmount, 'approveToken1')
+			},
+			'Failed to approve token1',
+		)
+
+	const approveToken2 = async (amount?: bigint) =>
+		await runOracleAction(
+			'approveToken2',
+			async walletAddress => {
+				const reportDetails = requireDefined(openOracleReportDetails.value, 'Load an oracle report first')
+				const submission = getInitialReportSubmission(reportDetails)
+				const approvalAmount = amount ?? submission.token2Approval.targetAmount ?? submission.amount2
+				if (approvalAmount === undefined) {
+					throw new Error('No token2 approval amount is required for the selected report')
+				}
+				return await approveErc20(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), reportDetails.token2, getOpenOracleAddress(), approvalAmount, 'approveToken2')
+			},
+			'Failed to approve token2',
+		)
 
 	const createOpenOracleGame = async () => {
 		loadingOpenOracleCreate.value = true
 		try {
 			await runOracleAction(
+				'createReportInstance',
 				async walletAddress =>
 					await createOpenOracleReportInstance(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), {
 						disputeDelay: Number(parseBigIntInput(openOracleCreateForm.value.disputeDelay, 'Dispute delay')),
@@ -255,48 +308,42 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 	}
 
 	const submitInitialReport = async () =>
-		await runOracleAction(async walletAddress => {
-			const reportDetails = requireDefined(openOracleReportDetails.value, 'Load an oracle report first')
-			const submission = deriveOpenOracleInitialReportSubmissionDetails({
-				approvedToken1Amount: openOracleInitialReportToken1Allowance.value,
-				approvedToken2Amount: openOracleInitialReportToken2Allowance.value,
-				defaultPrice: openOracleInitialReportDefaultPrice.value,
-				defaultPriceError: openOracleInitialReportDefaultPriceError.value,
-				defaultPriceSource: openOracleInitialReportDefaultPriceSource.value,
-				priceInput: openOracleForm.value.price,
-				quoteAttemptedSources: openOracleInitialReportQuoteAttemptedSources.value,
-				quoteFailureReason: openOracleInitialReportQuoteFailureReason.value,
-				reportDetails,
-				token1AllowanceError: openOracleInitialReportToken1AllowanceError.value,
-				token2AllowanceError: openOracleInitialReportToken2AllowanceError.value,
-				token1Decimals: reportDetails.token1Decimals,
-				token2Decimals: reportDetails.token2Decimals,
-			})
-			if (!submission.canSubmit || submission.amount1 === undefined || submission.amount2 === undefined) {
-				throw new Error(submission.blockReason ?? 'Invalid price')
-			}
+		await runOracleAction(
+			'submitInitialReport',
+			async walletAddress => {
+				const reportDetails = requireDefined(openOracleReportDetails.value, 'Load an oracle report first')
+				const submission = getInitialReportSubmission(reportDetails)
+				if (!submission.canSubmit || submission.amount1 === undefined || submission.amount2 === undefined) {
+					throw new Error(submission.blockReason ?? 'Invalid price')
+				}
 
-			return await submitInitialOracleReport(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), getOpenOracleAddress(), reportDetails.reportId, submission.amount1, submission.amount2, parseBytes32Input(openOracleForm.value.stateHash, 'State hash'))
-		}, 'Failed to submit initial report')
+				return await submitInitialOracleReport(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), getOpenOracleAddress(), reportDetails.reportId, submission.amount1, submission.amount2, parseBytes32Input(openOracleForm.value.stateHash, 'State hash'))
+			},
+			'Failed to submit initial report',
+		)
 
-	const settleReport = async () => await runOracleAction(async walletAddress => await settleOracleReport(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), getOpenOracleAddress(), parseReportIdInput(openOracleForm.value.reportId)), 'Failed to settle report')
+	const settleReport = async () => await runOracleAction('settle', async walletAddress => await settleOracleReport(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), getOpenOracleAddress(), parseReportIdInput(openOracleForm.value.reportId)), 'Failed to settle report')
 
 	const disputeReport = async () =>
-		await runOracleAction(async walletAddress => {
-			const { details } = await ensureLoadedSelectedReport()
-			const form = openOracleForm.value
-			const tokenToSwap = form.disputeTokenToSwap === 'token1' ? details.token1 : details.token2
-			return await disputeOracleReport(
-				createWalletWriteClient(walletAddress, { onTransactionSubmitted }),
-				getOpenOracleAddress(),
-				details.reportId,
-				tokenToSwap,
-				parseBigIntInput(form.disputeNewAmount1, 'New token1 amount'),
-				parseBigIntInput(form.disputeNewAmount2, 'New token2 amount'),
-				details.currentAmount2,
-				parseBytes32Input(form.stateHash, 'State hash'),
-			)
-		}, 'Failed to dispute report')
+		await runOracleAction(
+			'dispute',
+			async walletAddress => {
+				const { details } = await ensureLoadedSelectedReport()
+				const form = openOracleForm.value
+				const tokenToSwap = form.disputeTokenToSwap === 'token1' ? details.token1 : details.token2
+				return await disputeOracleReport(
+					createWalletWriteClient(walletAddress, { onTransactionSubmitted }),
+					getOpenOracleAddress(),
+					details.reportId,
+					tokenToSwap,
+					parseBigIntInput(form.disputeNewAmount1, 'New token1 amount'),
+					parseBigIntInput(form.disputeNewAmount2, 'New token2 amount'),
+					details.currentAmount2,
+					parseBytes32Input(form.stateHash, 'State hash'),
+				)
+			},
+			'Failed to dispute report',
+		)
 
 	useEffect(() => {
 		if (openOracleReportDetails.value === undefined) {
@@ -312,6 +359,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 		createOpenOracleGame,
 		disputeReport,
 		loadOracleReport,
+		openOracleActiveAction: openOracleActiveAction.value,
 		refreshPrice: () => void refreshOpenOracleInitialReportState(openOracleReportDetails.value),
 		loadingOpenOracleCreate: loadingOpenOracleCreate.value,
 		loadingOracleReport: oracleReportLoad.isLoading.value,
@@ -326,11 +374,9 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 			quoteAttemptedSources: openOracleInitialReportQuoteAttemptedSources.value,
 			quoteFailureKind: openOracleInitialReportQuoteFailureKind.value,
 			quoteFailureReason: openOracleInitialReportQuoteFailureReason.value,
-			token1Allowance: openOracleInitialReportToken1Allowance.value,
-			token1AllowanceError: openOracleInitialReportToken1AllowanceError.value,
+			token1Approval: openOracleInitialReportToken1Approval.value,
 			token1Decimals: openOracleReportDetails.value?.token1Decimals,
-			token2Allowance: openOracleInitialReportToken2Allowance.value,
-			token2AllowanceError: openOracleInitialReportToken2AllowanceError.value,
+			token2Approval: openOracleInitialReportToken2Approval.value,
 			token2Decimals: openOracleReportDetails.value?.token2Decimals,
 		},
 		openOracleReportDetails: openOracleReportDetails.value,

--- a/ui/ts/hooks/useSecurityVaultOperations.ts
+++ b/ui/ts/hooks/useSecurityVaultOperations.ts
@@ -27,6 +27,7 @@ export function useSecurityVaultOperations({ accountAddress, onTransaction, onTr
 	const { state: securityVaultForm, setState: updateSecurityVaultForm } = useFormState<SecurityVaultFormState>(getDefaultSecurityVaultFormState())
 	const repBalanceLoader = useErc20BalanceLoader()
 	const repAllowanceLoader = useErc20AllowanceLoader()
+	const securityVaultActiveAction = useSignal<SecurityVaultActionResult['action'] | undefined>(undefined)
 	const securityVaultResult = useSignal<SecurityVaultActionResult | undefined>(undefined)
 
 	const resolveSelectedVaultAddress = () => {
@@ -65,7 +66,11 @@ export function useSecurityVaultOperations({ accountAddress, onTransaction, onTr
 		securityVaultDetails.value = undefined
 		securityVaultMissing.value = true
 		repBalanceLoader.signal.value = undefined
-		repAllowanceLoader.signal.value = undefined
+		repAllowanceLoader.signal.value = {
+			error: undefined,
+			loading: false,
+			value: undefined,
+		}
 		securityVaultError.value = missingPoolMessage
 		return undefined
 	}
@@ -90,7 +95,11 @@ export function useSecurityVaultOperations({ accountAddress, onTransaction, onTr
 				securityVaultMissing.value = details === undefined
 				if (details === undefined) {
 					repBalanceLoader.signal.value = undefined
-					repAllowanceLoader.signal.value = undefined
+					repAllowanceLoader.signal.value = {
+						error: undefined,
+						loading: false,
+						value: undefined,
+					}
 					return undefined
 				}
 				if (sameAddress(vaultAddress, accountAddress)) {
@@ -98,51 +107,70 @@ export function useSecurityVaultOperations({ accountAddress, onTransaction, onTr
 					await reloadSecurityVaultRepAllowance(details.repToken, vaultAddress, securityPoolAddress)
 				} else {
 					repBalanceLoader.signal.value = undefined
-					repAllowanceLoader.signal.value = undefined
+					repAllowanceLoader.signal.value = {
+						error: undefined,
+						loading: false,
+						value: undefined,
+					}
 				}
 				return details
 			},
 			onSuccess: () => undefined,
-			onError: error => {
+			onError: (error: unknown) => {
 				securityVaultDetails.value = undefined
 				securityVaultMissing.value = false
 				repBalanceLoader.signal.value = undefined
-				repAllowanceLoader.signal.value = undefined
+				repAllowanceLoader.signal.value = {
+					error: undefined,
+					loading: false,
+					value: undefined,
+				}
 				securityVaultError.value = getErrorMessage(error, 'Failed to load security vault')
 			},
 		})
 	}
 
-	const runVaultAction = async (action: (ethereumAddress: Address, securityPoolAddress: Address) => Promise<SecurityVaultActionResult | undefined>, errorFallback: string, onSuccess?: (result: SecurityVaultActionResult, securityPoolAddress: Address, walletAddress: Address) => Promise<void> | void) => {
+	const runVaultAction = async (
+		actionName: SecurityVaultActionResult['action'],
+		action: (ethereumAddress: Address, securityPoolAddress: Address) => Promise<SecurityVaultActionResult | undefined>,
+		errorFallback: string,
+		onSuccess?: (result: SecurityVaultActionResult, securityPoolAddress: Address, walletAddress: Address) => Promise<void> | void,
+	) => {
 		let securityPoolAddress: Address | undefined
-		await runWriteAction(
-			buildWriteActionConfig({ accountAddress, onTransaction, onTransactionFinished, onTransactionRequested, refreshState }, securityVaultError, 'Connect a wallet before operating a security vault'),
-			async walletAddress => {
-				const currentForm = securityVaultForm.value
-				securityPoolAddress = parseAddressInput(currentForm.securityPoolAddress, 'Security pool address')
-				if (securityVaultMissing.value) {
-					securityVaultError.value = 'Security pool does not exist'
-					return undefined
-				}
-				const selectedVaultAddress = resolveSelectedVaultAddress()
-				if (!sameAddress(selectedVaultAddress, walletAddress)) {
-					throw new Error('Selected vault is read-only')
-				}
-				securityVaultError.value = undefined
-				securityVaultResult.value = undefined
-				return await action(selectedVaultAddress, securityPoolAddress)
-			},
-			errorFallback,
-			async (result, walletAddress) => {
-				const resolvedSecurityPoolAddress = requireDefined(securityPoolAddress, 'Security pool address is required')
-				securityVaultResult.value = result
-				await onSuccess?.(result, resolvedSecurityPoolAddress, walletAddress)
-			},
-		)
+		try {
+			await runWriteAction(
+				buildWriteActionConfig({ accountAddress, onTransaction, onTransactionFinished, onTransactionRequested, refreshState }, securityVaultError, 'Connect a wallet before operating a security vault'),
+				async walletAddress => {
+					const currentForm = securityVaultForm.value
+					securityPoolAddress = parseAddressInput(currentForm.securityPoolAddress, 'Security pool address')
+					if (securityVaultMissing.value) {
+						securityVaultError.value = 'Security pool does not exist'
+						return undefined
+					}
+					const selectedVaultAddress = resolveSelectedVaultAddress()
+					if (!sameAddress(selectedVaultAddress, walletAddress)) {
+						throw new Error('Selected vault is read-only')
+					}
+					securityVaultError.value = undefined
+					securityVaultResult.value = undefined
+					securityVaultActiveAction.value = actionName
+					return await action(selectedVaultAddress, securityPoolAddress)
+				},
+				errorFallback,
+				async (result, walletAddress) => {
+					const resolvedSecurityPoolAddress = requireDefined(securityPoolAddress, 'Security pool address is required')
+					securityVaultResult.value = result
+					await onSuccess?.(result, resolvedSecurityPoolAddress, walletAddress)
+				},
+			)
+		} finally {
+			securityVaultActiveAction.value = undefined
+		}
 	}
 
 	const approveRep = async (amount?: bigint) =>
 		await runVaultAction(
+			'approveRep',
 			async (vaultAddress, securityPoolAddress) => {
 				const details = await loadExistingSecurityVaultDetails(securityPoolAddress, vaultAddress, 'Security pool does not exist')
 				if (details === undefined) return undefined
@@ -160,6 +188,7 @@ export function useSecurityVaultOperations({ accountAddress, onTransaction, onTr
 
 	const depositRep = async () =>
 		await runVaultAction(
+			'depositRep',
 			async (vaultAddress, securityPoolAddress) => {
 				const depositAmount = parseRepAmountInput(securityVaultForm.value.depositAmount, 'REP deposit amount')
 				const details = await loadExistingSecurityVaultDetails(securityPoolAddress, vaultAddress, 'Security pool does not exist')
@@ -183,6 +212,7 @@ export function useSecurityVaultOperations({ accountAddress, onTransaction, onTr
 
 	const setSecurityBondAllowance = async () =>
 		await runVaultAction(
+			'queueSetSecurityBondAllowance',
 			async (vaultAddress, securityPoolAddress) => {
 				const amount = parseRepAmountInput(securityVaultForm.value.securityBondAllowanceAmount, 'Security bond allowance')
 				if (amount <= 0n) throw new Error('Security bond allowance must be greater than zero')
@@ -204,6 +234,7 @@ export function useSecurityVaultOperations({ accountAddress, onTransaction, onTr
 
 	const redeemFees = async () =>
 		await runVaultAction(
+			'redeemFees',
 			async (vaultAddress, securityPoolAddress) => {
 				await refreshVaultFees(vaultAddress, securityPoolAddress)
 				return await redeemSecurityVaultFees(createWalletWriteClient(vaultAddress, { onTransactionSubmitted }), securityPoolAddress, vaultAddress)
@@ -216,6 +247,7 @@ export function useSecurityVaultOperations({ accountAddress, onTransaction, onTr
 
 	const withdrawRep = async () =>
 		await runVaultAction(
+			'queueWithdrawRep',
 			async (vaultAddress, securityPoolAddress) => {
 				const amount = parseRepAmountInput(securityVaultForm.value.repWithdrawAmount, 'REP withdraw amount')
 				if (amount <= 0n) throw new Error('REP withdraw amount must be greater than zero')
@@ -240,13 +272,21 @@ export function useSecurityVaultOperations({ accountAddress, onTransaction, onTr
 		const selectedVaultAddress = securityVaultForm.value.selectedVaultAddress.trim()
 		if (accountAddress === undefined || securityVaultDetails.value === undefined || selectedVaultAddress === '') {
 			repBalanceLoader.signal.value = undefined
-			repAllowanceLoader.signal.value = undefined
+			repAllowanceLoader.signal.value = {
+				error: undefined,
+				loading: false,
+				value: undefined,
+			}
 			return
 		}
 
 		if (!sameAddress(securityVaultDetails.value.vaultAddress, selectedVaultAddress) || !sameAddress(selectedVaultAddress, accountAddress)) {
 			repBalanceLoader.signal.value = undefined
-			repAllowanceLoader.signal.value = undefined
+			repAllowanceLoader.signal.value = {
+				error: undefined,
+				loading: false,
+				value: undefined,
+			}
 			return
 		}
 
@@ -260,9 +300,10 @@ export function useSecurityVaultOperations({ accountAddress, onTransaction, onTr
 		loadSecurityVault,
 		loadingSecurityVault: securityVaultLoad.isLoading.value,
 		redeemFees,
+		securityVaultActiveAction: securityVaultActiveAction.value,
 		setSecurityBondAllowance,
 		withdrawRep,
-		securityVaultRepAllowance: repAllowanceLoader.signal.value,
+		securityVaultRepApproval: repAllowanceLoader.signal.value,
 		securityVaultDetails: securityVaultDetails.value,
 		securityVaultError: securityVaultError.value,
 		securityVaultForm: securityVaultForm.value,

--- a/ui/ts/hooks/useZoltarFork.ts
+++ b/ui/ts/hooks/useZoltarFork.ts
@@ -5,8 +5,9 @@ import { approveErc20, forkZoltarUniverse, getZoltarAddress, loadErc20Allowance,
 import { useLoadController } from './useLoadController.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
 import { requireWallet } from '../lib/walletGuard.js'
-import { getErrorMessage } from '../lib/errors.js'
+import { getErrorDetail, getErrorMessage } from '../lib/errors.js'
 import { parseBigIntInput } from '../lib/marketForm.js'
+import type { TokenApprovalState } from '../lib/tokenApproval.js'
 import { GENESIS_REPUTATION_TOKEN_ADDRESS } from '../lib/universe.js'
 import { useRequestGuard } from '../lib/requestGuard.js'
 import type { ZoltarForkActionResult, ZoltarUniverseSummary } from '../types/contracts.js'
@@ -34,7 +35,11 @@ export function useZoltarFork({ accountAddress, activeUniverseId, ensureZoltarUn
 	const zoltarForkPending = useSignal(false)
 	const zoltarForkQuestionId = useSignal('')
 	const zoltarForkResult = useSignal<ZoltarForkActionResult | undefined>(undefined)
-	const zoltarForkAllowance = useSignal<bigint | undefined>(undefined)
+	const zoltarForkApproval = useSignal<TokenApprovalState>({
+		error: undefined,
+		loading: false,
+		value: undefined,
+	})
 	const zoltarForkRepBalance = useSignal<bigint | undefined>(undefined)
 	const zoltarForkActiveAction = useSignal<'approve' | 'fork' | undefined>(undefined)
 	const zoltarMigrationPreparedRepBalance = useSignal<bigint | undefined>(undefined)
@@ -44,7 +49,11 @@ export function useZoltarFork({ accountAddress, activeUniverseId, ensureZoltarUn
 	const loadZoltarForkAccess = async () => {
 		const reputationToken = zoltarUniverse?.reputationToken ?? (activeUniverseId === 0n ? GENESIS_REPUTATION_TOKEN_ADDRESS : undefined)
 		if (accountAddress === undefined || reputationToken === undefined || reputationToken === zeroAddress) {
-			zoltarForkAllowance.value = undefined
+			zoltarForkApproval.value = {
+				error: undefined,
+				loading: false,
+				value: undefined,
+			}
 			zoltarForkRepBalance.value = undefined
 			zoltarMigrationPreparedRepBalance.value = undefined
 			zoltarMigrationChildRepBalances.value = {}
@@ -65,11 +74,31 @@ export function useZoltarFork({ accountAddress, activeUniverseId, ensureZoltarUn
 				}
 			}),
 			forkAccessLoad.track(async () => {
+				if (isCurrent()) {
+					zoltarForkApproval.value = {
+						...zoltarForkApproval.value,
+						error: undefined,
+						loading: true,
+					}
+				}
 				try {
 					const allowance = await loadErc20Allowance(readClient, reputationToken, accountAddress, getZoltarAddress())
-					if (isCurrent()) zoltarForkAllowance.value = allowance
-				} catch {
-					if (isCurrent()) zoltarForkAllowance.value = undefined
+					if (isCurrent()) {
+						zoltarForkApproval.value = {
+							error: undefined,
+							loading: false,
+							value: allowance,
+						}
+					}
+				} catch (error) {
+					if (isCurrent()) {
+						const errorDetail = getErrorDetail(error)
+						zoltarForkApproval.value = {
+							error: errorDetail === undefined ? 'Failed to load token approval' : `Failed to load token approval: ${errorDetail}`,
+							loading: false,
+							value: undefined,
+						}
+					}
 				}
 			}),
 			forkAccessLoad.track(async () => {
@@ -187,7 +216,7 @@ export function useZoltarFork({ accountAddress, activeUniverseId, ensureZoltarUn
 		loadZoltarForkAccess,
 		loadingZoltarForkAccess: forkAccessLoad.isLoading.value,
 		zoltarForkActiveAction: zoltarForkActiveAction.value,
-		zoltarForkAllowance: zoltarForkAllowance.value,
+		zoltarForkApproval: zoltarForkApproval.value,
 		zoltarForkError: zoltarForkError.value,
 		zoltarForkPending: zoltarForkPending.value,
 		zoltarForkQuestionId: zoltarForkQuestionId.value,

--- a/ui/ts/lib/inputs.ts
+++ b/ui/ts/lib/inputs.ts
@@ -1,6 +1,7 @@
 import type { ReportingOutcomeKey } from '../types/contracts.js'
 import { getAddress, isHex, type Address, type Hex } from 'viem'
 import { parseBigIntInput } from './marketForm.js'
+import { deriveTokenApprovalRequirement } from './tokenApproval.js'
 
 export function parseAddressInput(value: string, label: string): Address {
 	const trimmed = value.trim()
@@ -83,13 +84,11 @@ export function getReportingOutcomeKey(outcome: ReportingOutcomeKey | bigint): R
 }
 
 export function approvalShortage(amount: bigint | undefined, allowance: bigint | undefined): bigint | undefined {
-	if (amount === undefined || allowance === undefined) return undefined
-	return amount > allowance ? amount - allowance : 0n
+	return deriveTokenApprovalRequirement(amount, allowance).neededAmount
 }
 
 export function approvalTargetAmount(amount: bigint | undefined, allowance: bigint | undefined): bigint | undefined {
-	if (amount === undefined || amount <= 0n || allowance === undefined) return undefined
-	return amount > allowance ? amount : undefined
+	return deriveTokenApprovalRequirement(amount, allowance).targetAmount
 }
 
 export function balanceShortage(amount: bigint | undefined, balance: bigint | undefined): bigint | undefined {

--- a/ui/ts/lib/marketForm.ts
+++ b/ui/ts/lib/marketForm.ts
@@ -40,8 +40,6 @@ export function getDefaultOpenOracleFormState(): OpenOracleFormState {
 	return {
 		amount1: '0',
 		amount2: '0',
-		approveAmount1: '',
-		approveAmount2: '',
 		disputeNewAmount1: '0',
 		disputeNewAmount2: '0',
 		disputeTokenToSwap: 'token1',

--- a/ui/ts/lib/openOracle.ts
+++ b/ui/ts/lib/openOracle.ts
@@ -1,12 +1,12 @@
-import { maxUint256, zeroAddress } from 'viem'
+import { zeroAddress } from 'viem'
 import type { OpenOracleReportSummary } from '../types/contracts.js'
 import { parseDecimalInput } from './decimal.js'
 import { getErrorDetail } from './errors.js'
 import { formatCurrencyInputBalance } from './formatters.js'
+import { deriveTokenApprovalRequirement, formatTokenApprovalNeededMessage, formatTokenApprovalUnavailableMessage, type TokenApprovalRequirement } from './tokenApproval.js'
 import { quoteBestExactInput, quoteBestV3ExactInput, quoteExactInput } from './uniswapQuoter.js'
 
 const OPEN_ORACLE_PRICE_PRECISION = 10n ** 18n
-export const OPEN_ORACLE_APPROVAL_AMOUNT = maxUint256
 const OPEN_ORACLE_BOUNTY_BUFFER_NUMERATOR = 12n
 const OPEN_ORACLE_BOUNTY_BUFFER_DENOMINATOR = 10n
 
@@ -33,14 +33,14 @@ type OpenOracleInitialReportPriceLoadResult =
 type OpenOracleInitialReportSubmissionDetails = {
 	amount1: bigint | undefined
 	amount2: bigint | undefined
-	approvedToken1Amount: bigint | undefined
-	approvedToken2Amount: bigint | undefined
 	blockReason: string | undefined
 	canSubmit: boolean
 	price: bigint | undefined
 	priceInput: string
 	priceSource: OpenOracleInitialReportPriceSource
+	token1Approval: TokenApprovalRequirement
 	token1Decimals: number | undefined
+	token2Approval: TokenApprovalRequirement
 	token2Decimals: number | undefined
 }
 
@@ -170,16 +170,11 @@ export function formatOpenOracleInitialReportPriceUnavailableMessage({ attempted
 }
 
 export function formatOpenOracleInitialReportApprovalStatusUnavailableMessage({ reason, tokenLabel }: { reason: string | undefined; tokenLabel: string | undefined }) {
-	const resolvedTokenLabel = tokenLabel?.trim() || 'token'
-	const segments = [`Unable to verify ${resolvedTokenLabel} approval for this report.`]
-	const sanitizedReason = sanitizeOpenOracleFailureReason(reason)
-
-	if (sanitizedReason !== undefined) {
-		segments.push(`Reason: ${sanitizedReason}.`)
-	}
-	segments.push('Retry loading the report or approval status before submitting the initial report.')
-
-	return segments.join(' ')
+	return formatTokenApprovalUnavailableMessage({
+		actionLabel: 'submitting the initial report',
+		reason,
+		tokenLabel,
+	})
 }
 
 export async function loadOpenOracleInitialReportPriceResult(client: Parameters<typeof quoteExactInput>[0], token1: Parameters<typeof quoteExactInput>[1], token2: Parameters<typeof quoteExactInput>[2], token1Amount: bigint): Promise<OpenOracleInitialReportPriceLoadResult> {
@@ -281,6 +276,8 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 	const amount1 = reportDetails?.exactToken1Report
 	const amount2 = amount1 === undefined || price === undefined ? undefined : calculateOpenOracleToken2Amount(amount1, price)
 	const priceSource = trimmedPriceInput === '' ? (defaultPrice === undefined ? 'Unavailable' : (defaultPriceSource ?? 'Manual override')) : defaultPrice !== undefined && trimmedPriceInput === defaultPrice ? (defaultPriceSource ?? 'Manual override') : 'Manual override'
+	const token1Approval = deriveTokenApprovalRequirement(amount1, approvedToken1Amount)
+	const token2Approval = deriveTokenApprovalRequirement(amount2, approvedToken2Amount)
 
 	let blockReason: string | undefined
 	if (reportDetails === undefined) {
@@ -301,28 +298,44 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 			reason: token1AllowanceError,
 			tokenLabel: reportDetails.token1Symbol ?? reportDetails.token1,
 		})
+	} else if (approvedToken1Amount === undefined) {
+		blockReason = `Loading current ${reportDetails.token1Symbol ?? reportDetails.token1 ?? 'Token1'} approval.`
 	} else if (approvedToken2Amount === undefined && token2AllowanceError !== undefined) {
 		blockReason = formatOpenOracleInitialReportApprovalStatusUnavailableMessage({
 			reason: token2AllowanceError,
 			tokenLabel: reportDetails.token2Symbol ?? reportDetails.token2,
 		})
-	} else if (amount1 === undefined || approvedToken1Amount === undefined || approvedToken1Amount < amount1) {
-		blockReason = 'Token1 approval required'
-	} else if (approvedToken2Amount === undefined || approvedToken2Amount < amount2) {
-		blockReason = 'Token2 approval required'
+	} else if (approvedToken2Amount === undefined) {
+		blockReason = `Loading current ${reportDetails.token2Symbol ?? reportDetails.token2 ?? 'Token2'} approval.`
+	} else if (!token1Approval.hasSufficientApproval) {
+		blockReason =
+			formatTokenApprovalNeededMessage({
+				actionLabel: 'submitting the initial report',
+				requirement: token1Approval,
+				tokenLabel: reportDetails.token1Symbol ?? reportDetails.token1 ?? 'Token1',
+				tokenUnits: token1Decimals ?? 18,
+			}) ?? 'Token1 approval required'
+	} else if (!token2Approval.hasSufficientApproval) {
+		blockReason =
+			formatTokenApprovalNeededMessage({
+				actionLabel: 'submitting the initial report',
+				requirement: token2Approval,
+				tokenLabel: reportDetails.token2Symbol ?? reportDetails.token2 ?? 'Token2',
+				tokenUnits: token2Decimals ?? 18,
+			}) ?? 'Token2 approval required'
 	}
 
 	return {
 		amount1,
 		amount2,
-		approvedToken1Amount,
-		approvedToken2Amount,
 		blockReason,
 		canSubmit: blockReason === undefined,
 		price,
 		priceInput: resolvedPriceInput,
 		priceSource,
+		token1Approval,
 		token1Decimals,
+		token2Approval,
 		token2Decimals,
 	}
 }

--- a/ui/ts/lib/tokenApproval.ts
+++ b/ui/ts/lib/tokenApproval.ts
@@ -1,0 +1,98 @@
+import { maxUint256 } from 'viem'
+import { parseDecimalInput } from './decimal.js'
+import { formatCurrencyBalance } from './formatters.js'
+
+export type TokenApprovalState = {
+	error: string | undefined
+	loading: boolean
+	value: bigint | undefined
+}
+
+export type TokenApprovalRequirement = {
+	approvedAmount: bigint | undefined
+	hasSufficientApproval: boolean
+	neededAmount: bigint | undefined
+	requiredAmount: bigint | undefined
+	targetAmount: bigint | undefined
+}
+
+type ParsedTokenApprovalAmount = { kind: 'custom'; amount: bigint } | { kind: 'default' } | { kind: 'max'; amount: typeof maxUint256 }
+
+function sanitizeApprovalFailureReason(reason: string | undefined) {
+	if (reason === undefined) return undefined
+
+	let sanitized = reason.trim().replace(/\s+/g, ' ')
+	if (sanitized === '') return undefined
+
+	sanitized = sanitized.replace(/^(failed to [^:.]+[:.]\s*)+/i, '')
+	sanitized = sanitized.replace(/\.$/, '')
+	return sanitized === '' ? undefined : sanitized
+}
+
+export function deriveTokenApprovalRequirement(requiredAmount: bigint | undefined, approvedAmount: bigint | undefined): TokenApprovalRequirement {
+	if (requiredAmount === undefined) {
+		return {
+			approvedAmount,
+			hasSufficientApproval: false,
+			neededAmount: undefined,
+			requiredAmount,
+			targetAmount: undefined,
+		}
+	}
+
+	if (requiredAmount <= 0n) {
+		return {
+			approvedAmount,
+			hasSufficientApproval: true,
+			neededAmount: 0n,
+			requiredAmount,
+			targetAmount: undefined,
+		}
+	}
+
+	const hasSufficientApproval = approvedAmount !== undefined && approvedAmount >= requiredAmount
+	const neededAmount = approvedAmount === undefined ? undefined : approvedAmount >= requiredAmount ? 0n : requiredAmount - approvedAmount
+
+	return {
+		approvedAmount,
+		hasSufficientApproval,
+		neededAmount,
+		requiredAmount,
+		targetAmount: hasSufficientApproval ? undefined : requiredAmount,
+	}
+}
+
+export function parseTokenApprovalAmountInput(value: string, label: string, units: number): ParsedTokenApprovalAmount {
+	const trimmed = value.trim()
+	if (trimmed === '') return { kind: 'default' }
+	if (trimmed.toLowerCase() === 'max') return { kind: 'max', amount: maxUint256 }
+	return {
+		kind: 'custom',
+		amount: parseDecimalInput(trimmed, label, units),
+	}
+}
+
+export function formatTokenApprovalUnavailableMessage({ actionLabel, reason, tokenLabel }: { actionLabel?: string | undefined; reason: string | undefined; tokenLabel: string | undefined }) {
+	const resolvedTokenLabel = tokenLabel?.trim() || 'token'
+	const sanitizedReason = sanitizeApprovalFailureReason(reason)
+	const segments = [`Unable to verify ${resolvedTokenLabel} approval${actionLabel === undefined ? '' : ` before ${actionLabel}`}.`]
+
+	if (sanitizedReason !== undefined) {
+		segments.push(`Reason: ${sanitizedReason}.`)
+	}
+	segments.push('Retry loading the approval status before continuing.')
+
+	return segments.join(' ')
+}
+
+export function formatTokenApprovalNeededMessage({ actionLabel, requirement, tokenLabel, tokenUnits }: { actionLabel: string; requirement: TokenApprovalRequirement; tokenLabel: string; tokenUnits: number }) {
+	if (requirement.neededAmount === undefined || requirement.neededAmount <= 0n) return undefined
+	const targetAmount = requirement.targetAmount ?? requirement.requiredAmount
+	if (targetAmount === undefined) return undefined
+	return `Need ${formatCurrencyBalance(requirement.neededAmount, tokenUnits)} more ${tokenLabel} approved before ${actionLabel}. Approving will set the allowance to ${formatCurrencyBalance(targetAmount, tokenUnits)} ${tokenLabel}.`
+}
+
+export function formatTokenApprovalPartialMessage({ actionLabel, nextApprovedAmount, requiredAmount, tokenLabel, tokenUnits }: { actionLabel: string; nextApprovedAmount: bigint; requiredAmount: bigint; tokenLabel: string; tokenUnits: number }) {
+	if (nextApprovedAmount >= requiredAmount) return undefined
+	return `Approving ${formatCurrencyBalance(nextApprovedAmount, tokenUnits)} ${tokenLabel} will still leave ${formatCurrencyBalance(requiredAmount - nextApprovedAmount, tokenUnits)} more ${tokenLabel} needed before ${actionLabel}.`
+}

--- a/ui/ts/tests/inputs.test.ts
+++ b/ui/ts/tests/inputs.test.ts
@@ -35,11 +35,11 @@ void describe('input helpers', () => {
 		expect(balanceShortage(6n, 5n)).toBe(1n)
 	})
 
-	void test('approvalTargetAmount returns the full target approval when allowance is short', () => {
+	void test('approvalTargetAmount returns the next total allowance target for the shared approval flow', () => {
 		expect(approvalShortage(11n, 10n)).toBe(1n)
 		expect(approvalTargetAmount(11n, 10n)).toBe(11n)
 		expect(approvalTargetAmount(10n, 10n)).toBe(undefined)
-		expect(approvalTargetAmount(10n, undefined)).toBe(undefined)
+		expect(approvalTargetAmount(10n, undefined)).toBe(10n)
 		expect(approvalTargetAmount(0n, 0n)).toBe(undefined)
 	})
 })

--- a/ui/ts/tests/openOracle.test.ts
+++ b/ui/ts/tests/openOracle.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 
 import { beforeEach, describe, expect, setDefaultTimeout, test } from 'bun:test'
-import { getAddress, maxUint256, zeroAddress, type Address } from 'viem'
+import { getAddress, zeroAddress, type Address } from 'viem'
 import { createOpenOracleReportInstance, getOpenOracleAddress, loadOpenOracleReportDetails, loadOpenOracleReportSummaries, loadOracleManagerDetails, requestOraclePrice, settleOracleReport, submitInitialOracleReport } from '../contracts.js'
 import {
 	deriveOpenOracleInitialReportSubmissionDetails,
@@ -14,7 +14,6 @@ import {
 	getOpenOracleSelectedReportActionMode,
 	loadOpenOracleInitialReportPrice,
 	loadOpenOracleInitialReportPriceResult,
-	OPEN_ORACLE_APPROVAL_AMOUNT,
 } from '../lib/openOracle.js'
 import { ORACLE_MANAGER_PRICE_VALID_FOR_SECONDS } from '../lib/securityVault.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
@@ -46,6 +45,7 @@ const securityMultiplier = 2n
 const MAX_RETENTION_RATE = 999_999_996_848_000_000n
 const reportedRepEthPrice = 10n
 const outcomes = ['Yes', 'No']
+const ONE = 10n ** 18n
 
 function createQuoteClient(amountOut: bigint): Parameters<typeof loadOpenOracleInitialReportPrice>[0] {
 	return {
@@ -217,11 +217,13 @@ describe('Open Oracle helpers', () => {
 
 	test('initial report submission helper computes preview amounts and approval gating', () => {
 		const details = {
-			exactToken1Report: 100n,
+			exactToken1Report: 100n * ONE,
+			token1Symbol: 'REP',
+			token2Symbol: 'ETH',
 		}
 		const preview = deriveOpenOracleInitialReportSubmissionDetails({
-			approvedToken1Amount: 100n,
-			approvedToken2Amount: 24n,
+			approvedToken1Amount: 100n * ONE,
+			approvedToken2Amount: 24n * ONE,
 			defaultPrice: '4.0',
 			defaultPriceError: undefined,
 			defaultPriceSource: 'Uniswap V4',
@@ -237,16 +239,17 @@ describe('Open Oracle helpers', () => {
 
 		expect(preview.priceSource).toBe('Uniswap V4')
 		expect(preview.price).toBe(4_000_000_000_000_000_000n)
-		expect(preview.amount1).toBe(100n)
-		expect(preview.amount2).toBe(25n)
+		expect(preview.amount1).toBe(100n * ONE)
+		expect(preview.amount2).toBe(25n * ONE)
+		expect(preview.token2Approval.neededAmount).toBe(ONE)
 		expect(preview.canSubmit).toBe(false)
-		expect(preview.blockReason).toBeDefined()
+		expect(preview.blockReason).toBe('Need 1 more ETH approved before submitting the initial report. Approving will set the allowance to 25 ETH.')
 	})
 
 	test('initial report submission helper explains exhausted quote paths with a short reason', () => {
 		const preview = deriveOpenOracleInitialReportSubmissionDetails({
-			approvedToken1Amount: 100n,
-			approvedToken2Amount: 100n,
+			approvedToken1Amount: 100n * ONE,
+			approvedToken2Amount: 100n * ONE,
 			defaultPrice: undefined,
 			defaultPriceError: undefined,
 			defaultPriceSource: undefined,
@@ -254,7 +257,7 @@ describe('Open Oracle helpers', () => {
 			quoteAttemptedSources: ['Uniswap V4', 'Uniswap V3 fallback'],
 			quoteFailureReason: 'Failed to fetch price from Uniswap. Uniswap V4 quote failed: execution reverted for an unknown reason. Uniswap V3 fallback failed: no pool',
 			reportDetails: {
-				exactToken1Report: 100n,
+				exactToken1Report: 100n * ONE,
 				token1Symbol: 'REP',
 				token2Symbol: 'ETH',
 			},
@@ -270,8 +273,8 @@ describe('Open Oracle helpers', () => {
 
 	test('manual price entry overrides automatic quote unavailability', () => {
 		const preview = deriveOpenOracleInitialReportSubmissionDetails({
-			approvedToken1Amount: 100n,
-			approvedToken2Amount: 24n,
+			approvedToken1Amount: 100n * ONE,
+			approvedToken2Amount: 24n * ONE,
 			defaultPrice: undefined,
 			defaultPriceError: undefined,
 			defaultPriceSource: undefined,
@@ -279,7 +282,7 @@ describe('Open Oracle helpers', () => {
 			quoteAttemptedSources: ['Uniswap V4'],
 			quoteFailureReason: 'no pool',
 			reportDetails: {
-				exactToken1Report: 100n,
+				exactToken1Report: 100n * ONE,
 				token1Symbol: 'ABC',
 				token2Symbol: 'XYZ',
 			},
@@ -291,13 +294,13 @@ describe('Open Oracle helpers', () => {
 
 		expect(preview.priceSource).toBe('Manual override')
 		expect(preview.price).toBe(4_000_000_000_000_000_000n)
-		expect(preview.blockReason).toBe('Token2 approval required')
+		expect(preview.blockReason).toBe('Need 1 more XYZ approved before submitting the initial report. Approving will set the allowance to 25 XYZ.')
 	})
 
 	test('initial report submission helper surfaces the fetch price failure reason when no default price is available', () => {
 		const preview = deriveOpenOracleInitialReportSubmissionDetails({
-			approvedToken1Amount: 100n,
-			approvedToken2Amount: 100n,
+			approvedToken1Amount: 100n * ONE,
+			approvedToken2Amount: 100n * ONE,
 			defaultPrice: undefined,
 			defaultPriceError: 'Failed to fetch price from Uniswap. Uniswap V4 quote failed: no v3 pool. Uniswap V3 fallback failed: no v3 pool',
 			defaultPriceSource: undefined,
@@ -305,7 +308,7 @@ describe('Open Oracle helpers', () => {
 			quoteAttemptedSources: ['Uniswap V4', 'Uniswap V3 fallback'],
 			quoteFailureReason: 'Failed to fetch price from Uniswap. Uniswap V4 quote failed: no v3 pool. Uniswap V3 fallback failed: no v3 pool',
 			reportDetails: {
-				exactToken1Report: 100n,
+				exactToken1Report: 100n * ONE,
 			},
 			token1AllowanceError: undefined,
 			token2AllowanceError: undefined,
@@ -331,7 +334,7 @@ describe('Open Oracle helpers', () => {
 	test('initial report submission helper surfaces allowance read failures separately from approval gating', () => {
 		const preview = deriveOpenOracleInitialReportSubmissionDetails({
 			approvedToken1Amount: undefined,
-			approvedToken2Amount: 25n,
+			approvedToken2Amount: 25n * ONE,
 			defaultPrice: '4.0',
 			defaultPriceError: undefined,
 			defaultPriceSource: 'Uniswap V4',
@@ -339,7 +342,7 @@ describe('Open Oracle helpers', () => {
 			quoteAttemptedSources: undefined,
 			quoteFailureReason: undefined,
 			reportDetails: {
-				exactToken1Report: 100n,
+				exactToken1Report: 100n * ONE,
 				token1Symbol: 'REP',
 				token2Symbol: 'ETH',
 			},
@@ -350,7 +353,7 @@ describe('Open Oracle helpers', () => {
 		})
 
 		expect(preview.canSubmit).toBe(false)
-		expect(preview.blockReason).toBe('Unable to verify REP approval for this report. Reason: request timed out. Retry loading the report or approval status before submitting the initial report.')
+		expect(preview.blockReason).toBe('Unable to verify REP approval before submitting the initial report. Reason: request timed out. Retry loading the approval status before continuing.')
 	})
 
 	test('formats unavailable approval status messages with sanitized reasons', () => {
@@ -359,13 +362,12 @@ describe('Open Oracle helpers', () => {
 				reason: 'Failed to load token approval: execution reverted',
 				tokenLabel: 'WETH',
 			}),
-		).toBe('Unable to verify WETH approval for this report. Reason: execution reverted. Retry loading the report or approval status before submitting the initial report.')
+		).toBe('Unable to verify WETH approval before submitting the initial report. Reason: execution reverted. Retry loading the approval status before continuing.')
 	})
 
 	test('open oracle fee and multiplier formatters render human values', () => {
 		expect(formatOpenOracleFeePercentage(10_000n)).toBe('0.1%')
 		expect(formatOpenOracleMultiplier(140n)).toBe('1.40x')
-		expect(OPEN_ORACLE_APPROVAL_AMOUNT).toBe(maxUint256)
 	})
 
 	test('oracle bounty buffer adds a 20% headroom and rounds up', () => {

--- a/ui/ts/tests/tokenApproval.test.ts
+++ b/ui/ts/tests/tokenApproval.test.ts
@@ -1,0 +1,90 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { maxUint256 } from 'viem'
+import { deriveTokenApprovalRequirement, formatTokenApprovalNeededMessage, formatTokenApprovalPartialMessage, formatTokenApprovalUnavailableMessage, parseTokenApprovalAmountInput } from '../lib/tokenApproval.js'
+
+const ONE = 10n ** 18n
+
+describe('token approval helpers', () => {
+	test('derives the approval requirement and exact default target from required and approved amounts', () => {
+		const requirement = deriveTokenApprovalRequirement(25n * ONE, 24n * ONE)
+
+		expect(requirement.requiredAmount).toBe(25n * ONE)
+		expect(requirement.approvedAmount).toBe(24n * ONE)
+		expect(requirement.neededAmount).toBe(ONE)
+		expect(requirement.targetAmount).toBe(25n * ONE)
+		expect(requirement.hasSufficientApproval).toBe(false)
+	})
+
+	test('marks zero or fully covered requirements as satisfied', () => {
+		expect(deriveTokenApprovalRequirement(0n, undefined)).toEqual({
+			approvedAmount: undefined,
+			hasSufficientApproval: true,
+			neededAmount: 0n,
+			requiredAmount: 0n,
+			targetAmount: undefined,
+		})
+		expect(deriveTokenApprovalRequirement(25n * ONE, 25n * ONE).hasSufficientApproval).toBe(true)
+	})
+
+	test('parses blank approval input as the default exact-target mode', () => {
+		expect(parseTokenApprovalAmountInput('', 'Approval amount', 18)).toEqual({ kind: 'default' })
+		expect(parseTokenApprovalAmountInput('   ', 'Approval amount', 18)).toEqual({ kind: 'default' })
+	})
+
+	test('parses max approval input as unlimited allowance', () => {
+		expect(parseTokenApprovalAmountInput('max', 'Approval amount', 18)).toEqual({
+			amount: maxUint256,
+			kind: 'max',
+		})
+		expect(parseTokenApprovalAmountInput('MAX', 'Approval amount', 18)).toEqual({
+			amount: maxUint256,
+			kind: 'max',
+		})
+	})
+
+	test('parses custom approval input using token decimals', () => {
+		expect(parseTokenApprovalAmountInput('1.25', 'Approval amount', 18)).toEqual({
+			amount: 125n * 10n ** 16n,
+			kind: 'custom',
+		})
+		expect(parseTokenApprovalAmountInput('12.5', 'Approval amount', 6)).toEqual({
+			amount: 12_500_000n,
+			kind: 'custom',
+		})
+	})
+
+	test('formats shared shortage and partial-approval messages in token units', () => {
+		const requirement = deriveTokenApprovalRequirement(25n * ONE, 24n * ONE)
+
+		expect(
+			formatTokenApprovalNeededMessage({
+				actionLabel: 'submitting the initial report',
+				requirement,
+				tokenLabel: 'ETH',
+				tokenUnits: 18,
+			}),
+		).toBe('Need 1 more ETH approved before submitting the initial report. Approving will set the allowance to 25 ETH.')
+
+		expect(
+			formatTokenApprovalPartialMessage({
+				actionLabel: 'submitting the initial report',
+				nextApprovedAmount: 24_500_000_000_000_000_000n,
+				requiredAmount: 25n * ONE,
+				tokenLabel: 'ETH',
+				tokenUnits: 18,
+			}),
+		).toBe('Approving 24.5 ETH will still leave 0.5 more ETH needed before submitting the initial report.')
+	})
+
+	test('formats unavailable approval status messages with sanitized reasons', () => {
+		expect(
+			formatTokenApprovalUnavailableMessage({
+				actionLabel: 'depositing REP',
+				reason: 'Failed to load token approval: execution reverted',
+				tokenLabel: 'REP',
+			}),
+		).toBe('Unable to verify REP approval before depositing REP. Reason: execution reverted. Retry loading the approval status before continuing.')
+	})
+})

--- a/ui/ts/types/app.ts
+++ b/ui/ts/types/app.ts
@@ -48,8 +48,6 @@ export type SecurityVaultFormState = {
 export type OpenOracleFormState = {
 	amount1: string
 	amount2: string
-	approveAmount1: string
-	approveAmount2: string
 	disputeNewAmount1: string
 	disputeNewAmount2: string
 	disputeTokenToSwap: 'token1' | 'token2'

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -24,6 +24,7 @@ import type {
 } from './contracts.js'
 import type { OpenOracleInitialReportPriceSource } from '../lib/openOracle.js'
 import type { LoadableValueState } from '../lib/loadState.js'
+import type { TokenApprovalState } from '../lib/tokenApproval.js'
 import type { UserMessagePresentation } from '../lib/userCopy.js'
 import type { OpenOracleInitialReportQuoteFailureKind, OpenOracleInitialReportQuoteSource } from '../lib/openOracle.js'
 
@@ -107,7 +108,7 @@ export type MarketRouteContentProps = {
 	onUseQuestionForPool: (questionId: string) => void
 	onZoltarMigrationFormChange: (update: Partial<ZoltarMigrationFormState>) => void
 	zoltarQuestionCount: bigint | undefined
-	zoltarForkAllowance: bigint | undefined
+	zoltarForkApproval: TokenApprovalState
 	zoltarForkError: string | undefined
 	loadingZoltarForkAccess: boolean
 	zoltarChildUniverseError: string | undefined
@@ -227,11 +228,12 @@ export type SecurityVaultRouteContentProps = {
 	onSetSecurityBondAllowance: () => void
 	onSecurityVaultFormChange: (update: Partial<SecurityVaultFormState>) => void
 	onWithdrawRep: () => void
+	securityVaultActiveAction: SecurityVaultActionResult['action'] | undefined
 	securityVaultDetails: SecurityVaultDetails | undefined
 	securityVaultError: string | undefined
 	securityVaultForm: SecurityVaultFormState
 	securityVaultMissing: boolean
-	securityVaultRepAllowance: bigint | undefined
+	securityVaultRepApproval: TokenApprovalState
 	securityVaultRepBalance: bigint | undefined
 	securityVaultResult: SecurityVaultActionResult | undefined
 	securityPoolVaults?: SecurityPoolVaultSummary[] | undefined
@@ -248,8 +250,8 @@ export type SecurityVaultSectionProps = SecurityVaultRouteContentProps & {
 export type OpenOracleRouteContentProps = {
 	accountState: AccountState
 	loadingOracleReport: boolean
-	onApproveToken1: () => void
-	onApproveToken2: () => void
+	onApproveToken1: (amount?: bigint) => void
+	onApproveToken2: (amount?: bigint) => void
 	onCreateOpenOracleGame: () => void
 	onDisputeReport: () => void
 	onLoadOracleReport: (reportId?: string) => void
@@ -259,6 +261,7 @@ export type OpenOracleRouteContentProps = {
 	onSettleReport: () => void
 	onSubmitInitialReport: () => void
 	loadingOpenOracleCreate: boolean
+	openOracleActiveAction: OpenOracleActionResult['action'] | undefined
 	openOracleError: string | undefined
 	openOracleInitialReportState: {
 		defaultPrice: string | undefined
@@ -268,11 +271,9 @@ export type OpenOracleRouteContentProps = {
 		quoteAttemptedSources: OpenOracleInitialReportQuoteSource[] | undefined
 		quoteFailureKind: OpenOracleInitialReportQuoteFailureKind | undefined
 		quoteFailureReason: string | undefined
-		token1Allowance: bigint | undefined
-		token1AllowanceError: string | undefined
+		token1Approval: TokenApprovalState
 		token1Decimals: number | undefined
-		token2Allowance: bigint | undefined
-		token2AllowanceError: string | undefined
+		token2Approval: TokenApprovalState
 		token2Decimals: number | undefined
 	}
 	openOracleCreateForm: OpenOracleCreateFormState


### PR DESCRIPTION
## Summary
- Introduce a reusable `TokenApprovalControl` for ERC20 approval flows across Zoltar fork, migration, security vault, and Open Oracle.
- Replace ad hoc allowance logic with shared token approval state and requirement helpers, including clearer guard/status messaging and max/custom approval amounts.
- Update hooks and component props to track active approval actions and expose normalized approval data.
- Add and update tests for token approval behavior and related Open Oracle/input parsing changes.

## Testing
- Not run
- Expected follow-up checks per repo instructions: `bun tsc`, `bun test`, `bun run format`, `bun run check`, `bun run knip`