### PR TITLE
Add ETH-to-WETH wrapping for open oracle reports

### DIFF
--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -151,6 +151,7 @@ export function App() {
 		setOpenOracleForm,
 		settleReport,
 		submitInitialReport,
+		wrapRequiredEthToWeth,
 	} = useOpenOracleOperations(baseHookConfig)
 	const { loadingReportingDetails, loadReporting, onReportOutcome, reportingDetails, reportingError, reportingForm, reportingResult, setReportingForm, withdrawEscalation } = useReportingOperations(baseHookConfig)
 	const { loadingPoolOracleManager, loadPoolOracleManager, poolOracleManagerDetails, poolOracleManagerError, poolPriceOracleResult, requestPoolPrice } = usePriceOracleManager(baseHookConfig)
@@ -450,6 +451,7 @@ export function App() {
 						onOpenOracleFormChange={update => setOpenOracleForm(current => ({ ...current, ...update }))}
 						onSettleReport={() => void settleReport()}
 						onSubmitInitialReport={() => void submitInitialReport()}
+						onWrapEthToWeth={() => void wrapRequiredEthToWeth()}
 						loadingOpenOracleCreate={loadingOpenOracleCreate}
 						openOracleActiveAction={openOracleActiveAction}
 						openOracleError={openOracleError}

--- a/ui/ts/components/OpenOracleSection.tsx
+++ b/ui/ts/components/OpenOracleSection.tsx
@@ -16,6 +16,7 @@ import { useLoadController } from '../hooks/useLoadController.js'
 import { createConnectedReadClient } from '../lib/clients.js'
 import { deriveOpenOracleInitialReportSubmissionDetails, formatOpenOracleFeePercentage, formatOpenOracleMultiplier, getOpenOracleReportStatus, getOpenOracleReportStatusTone, getOpenOracleSelectedReportActionMode, type OpenOracleSelectedReportActionMode } from '../lib/openOracle.js'
 import { loadOpenOracleReportSummaries } from '../contracts.js'
+import { formatCurrencyBalance } from '../lib/formatters.js'
 import { getReportPresentation } from '../lib/userCopy.js'
 import { resolveFirstMatchingValue } from '../lib/viewState.js'
 import type { OpenOracleFormState } from '../types/app.js'
@@ -94,11 +95,13 @@ function renderSelectedReportActionSection(
 	onRefreshPrice: () => void,
 	onSettleReport: () => void,
 	onSubmitInitialReport: () => void,
+	onWrapEthToWeth: () => void,
 ) {
 	const disputeTokenOptions: EnumDropdownOption<OpenOracleFormState['disputeTokenToSwap']>[] = [
 		{ value: 'token1', label: token1Symbol },
 		{ value: 'token2', label: token2Symbol },
 	]
+	const wrapPending = openOracleActiveAction === 'wrapEthToWeth'
 	switch (actionMode) {
 		case 'initial-report':
 			return (
@@ -121,6 +124,25 @@ function renderSelectedReportActionSection(
 						<p className='detail'>
 							Price source: <strong>{openOracleInitialReportState.loading ? 'Loading...' : initialReportSubmission.priceSource}</strong>
 						</p>
+						<div className='question-summary-grid'>
+							<MetricField label={`Required ${token1Symbol}`}>
+								<CurrencyValue value={initialReportSubmission.amount1} units={initialReportSubmission.token1Decimals ?? 18} suffix={token1Symbol} copyable={false} />
+							</MetricField>
+							<MetricField label={`Required ${token2Symbol}`}>
+								<CurrencyValue value={initialReportSubmission.amount2} units={initialReportSubmission.token2Decimals ?? 18} suffix={token2Symbol} copyable={false} />
+							</MetricField>
+							<MetricField label={`Wallet ${token1Symbol}`}>
+								<CurrencyValue value={initialReportSubmission.token1Balance} units={initialReportSubmission.token1Decimals ?? 18} suffix={token1Symbol} copyable={false} />
+							</MetricField>
+							<MetricField label={`Wallet ${token2Symbol}`}>
+								<CurrencyValue value={initialReportSubmission.token2Balance} units={initialReportSubmission.token2Decimals ?? 18} suffix={token2Symbol} copyable={false} />
+							</MetricField>
+							{initialReportSubmission.requiredWrapEthAmount !== undefined || initialReportSubmission.ethBalance !== undefined ? (
+								<MetricField label='Wallet ETH'>
+									<CurrencyValue value={initialReportSubmission.ethBalance} suffix='ETH' copyable={false} />
+								</MetricField>
+							) : undefined}
+						</div>
 						<div className='entity-card-subsection'>
 							<div className='entity-card-subsection-header'>
 								<h4>{`${token1Symbol} Approval`}</h4>
@@ -161,6 +183,13 @@ function renderSelectedReportActionSection(
 							/>
 						</div>
 						<ErrorNotice message={initialReportSubmission.blockReason} />
+						{initialReportSubmission.requiredWrapEthAmount === undefined ? undefined : (
+							<div className='actions'>
+								<button className='secondary' onClick={onWrapEthToWeth} disabled={!isConnected || !initialReportSubmission.canWrapEthToWeth || openOracleInitialReportState.loading || wrapPending}>
+									{wrapPending ? 'Wrapping ETH...' : `Wrap ${formatCurrencyBalance(initialReportSubmission.requiredWrapEthAmount)} ETH to WETH`}
+								</button>
+							</div>
+						)}
 						<div className='actions'>
 							<button className='primary' onClick={onSubmitInitialReport} disabled={!isConnected || !initialReportSubmission.canSubmit || openOracleInitialReportState.loading}>
 								Submit Initial Report
@@ -230,6 +259,7 @@ function renderReportDetailsCard(
 	onRefreshPrice: () => void,
 	onSettleReport: () => void,
 	onSubmitInitialReport: () => void,
+	onWrapEthToWeth: () => void,
 ) {
 	if (openOracleReportDetails === undefined) {
 		const reportPresentation = getReportPresentation({
@@ -275,12 +305,19 @@ function renderReportDetailsCard(
 		defaultPrice: openOracleInitialReportState.defaultPrice,
 		defaultPriceError: openOracleInitialReportState.defaultPriceError,
 		defaultPriceSource: openOracleInitialReportState.defaultPriceSource,
+		ethBalance: openOracleInitialReportState.ethBalance,
+		ethBalanceError: openOracleInitialReportState.ethBalanceError,
+		hasConnectedWallet: isConnected,
 		priceInput: openOracleForm.price,
 		quoteAttemptedSources: openOracleInitialReportState.quoteAttemptedSources,
 		quoteFailureReason: openOracleInitialReportState.quoteFailureReason,
 		reportDetails: openOracleReportDetails,
 		token1AllowanceError: openOracleInitialReportState.token1Approval.error,
+		token1Balance: openOracleInitialReportState.token1Balance,
+		token1BalanceError: openOracleInitialReportState.token1BalanceError,
 		token2AllowanceError: openOracleInitialReportState.token2Approval.error,
+		token2Balance: openOracleInitialReportState.token2Balance,
+		token2BalanceError: openOracleInitialReportState.token2BalanceError,
 		token1Decimals: openOracleInitialReportState.token1Decimals ?? openOracleReportDetails.token1Decimals,
 		token2Decimals: openOracleInitialReportState.token2Decimals ?? openOracleReportDetails.token2Decimals,
 	})
@@ -461,6 +498,7 @@ function renderReportDetailsCard(
 				onRefreshPrice,
 				onSettleReport,
 				onSubmitInitialReport,
+				onWrapEthToWeth,
 			)}
 		</EntityCard>
 	)
@@ -492,6 +530,7 @@ export function OpenOracleSection({
 	onRefreshPrice,
 	onSettleReport,
 	onSubmitInitialReport,
+	onWrapEthToWeth,
 	loadingOpenOracleCreate,
 	openOracleActiveAction,
 	openOracleCreateForm,
@@ -695,7 +734,23 @@ export function OpenOracleSection({
 			{view === 'selected-report' ? (
 				<div className='market-grid'>
 					<div className='market-column'>
-						{renderReportDetailsCard(openOracleReportDetails, openOracleForm, openOracleInitialReportState, openOracleActiveAction, loadingOracleReport, isConnected, onApproveToken1, onApproveToken2, onDisputeReport, onLoadOracleReport, onOpenOracleFormChange, onRefreshPrice, onSettleReport, onSubmitInitialReport)}
+						{renderReportDetailsCard(
+							openOracleReportDetails,
+							openOracleForm,
+							openOracleInitialReportState,
+							openOracleActiveAction,
+							loadingOracleReport,
+							isConnected,
+							onApproveToken1,
+							onApproveToken2,
+							onDisputeReport,
+							onLoadOracleReport,
+							onOpenOracleFormChange,
+							onRefreshPrice,
+							onSettleReport,
+							onSubmitInitialReport,
+							onWrapEthToWeth,
+						)}
 						{renderLatestActionCard(openOracleResult)}
 					</div>
 				</div>

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -5,6 +5,7 @@ import { createApplyLinkedLibrariesHelper, createDeploymentStatusOracleAddressHe
 import { assertNever } from './lib/assert.js'
 import { getOracleManagerPriceValidUntilTimestamp } from './lib/securityVault.js'
 import { addOpenOracleBountyBuffer } from './lib/openOracle.js'
+import { WETH_ADDRESS } from './lib/uniswapQuoter.js'
 import { GENESIS_REPUTATION_TOKEN_ADDRESS } from './lib/universe.js'
 import {
 	DeploymentStatusOracle_DeploymentStatusOracle,
@@ -1611,6 +1612,20 @@ export async function requestOraclePrice(client: WriteClient, managerAddress: Ad
 	const hash = await writeContractAndWait(client, () => callParams)
 	return {
 		action: 'requestPrice',
+		hash,
+	} satisfies OpenOracleActionResult
+}
+
+export async function wrapEthToWeth(client: WriteClient, amount: bigint) {
+	const hash = await writeContractAndWait(client, () => ({
+		address: WETH_ADDRESS,
+		abi: [parseAbiItem('function deposit() payable')],
+		functionName: 'deposit',
+		args: [],
+		value: amount,
+	}))
+	return {
+		action: 'wrapEthToWeth',
 		hash,
 	} satisfies OpenOracleActionResult
 }

--- a/ui/ts/hooks/useOpenOracleOperations.ts
+++ b/ui/ts/hooks/useOpenOracleOperations.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'preact/hooks'
 import { useFormState } from './useFormState.js'
 import { useLoadController } from './useLoadController.js'
 import type { Address } from 'viem'
-import { approveErc20, createOpenOracleReportInstance, disputeOracleReport, getOpenOracleAddress, loadErc20Allowance, loadOpenOracleReportDetails, settleOracleReport, submitInitialOracleReport } from '../contracts.js'
+import { approveErc20, createOpenOracleReportInstance, disputeOracleReport, getOpenOracleAddress, loadErc20Allowance, loadErc20Balance, loadOpenOracleReportDetails, settleOracleReport, submitInitialOracleReport, wrapEthToWeth } from '../contracts.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
 import { getErrorDetail, getErrorMessage } from '../lib/errors.js'
 import { deriveOpenOracleInitialReportSubmissionDetails, formatOpenOraclePriceInput, loadOpenOracleInitialReportPriceResult } from '../lib/openOracle.js'
@@ -35,20 +35,33 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 	const openOracleInitialReportQuoteAttemptedSources = useSignal<('Uniswap V4' | 'Uniswap V3 fallback')[] | undefined>(undefined)
 	const openOracleInitialReportQuoteFailureKind = useSignal<'unsupported-pair' | 'quote-failed' | undefined>(undefined)
 	const openOracleInitialReportQuoteFailureReason = useSignal<string | undefined>(undefined)
+	const openOracleInitialReportEthBalance = useSignal<bigint | undefined>(undefined)
+	const openOracleInitialReportEthBalanceError = useSignal<string | undefined>(undefined)
 	const openOracleInitialReportToken1Approval = useSignal<TokenApprovalState>({
 		error: undefined,
 		loading: false,
 		value: undefined,
 	})
+	const openOracleInitialReportToken1Balance = useSignal<bigint | undefined>(undefined)
+	const openOracleInitialReportToken1BalanceError = useSignal<string | undefined>(undefined)
 	const openOracleInitialReportToken2Approval = useSignal<TokenApprovalState>({
 		error: undefined,
 		loading: false,
 		value: undefined,
 	})
+	const openOracleInitialReportToken2Balance = useSignal<bigint | undefined>(undefined)
+	const openOracleInitialReportToken2BalanceError = useSignal<string | undefined>(undefined)
 	const nextOpenOracleInitialReportStateLoad = useRequestGuard()
+	type BalanceState = {
+		error: string | undefined
+		value: bigint | undefined
+	}
 	type OpenOracleInitialReportStateResult = {
+		ethBalanceResult: BalanceState
 		initialPriceResult: Awaited<ReturnType<typeof loadOpenOracleInitialReportPriceResult>>
+		token1BalanceResult: BalanceState
 		token1ApprovalResult: TokenApprovalState
+		token2BalanceResult: BalanceState
 		token2ApprovalResult: TokenApprovalState
 	}
 
@@ -65,6 +78,15 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 		}
 	}
 
+	const resetOpenOracleTokenBalanceState = () => {
+		openOracleInitialReportEthBalance.value = undefined
+		openOracleInitialReportEthBalanceError.value = undefined
+		openOracleInitialReportToken1Balance.value = undefined
+		openOracleInitialReportToken1BalanceError.value = undefined
+		openOracleInitialReportToken2Balance.value = undefined
+		openOracleInitialReportToken2BalanceError.value = undefined
+	}
+
 	const refreshOpenOracleInitialReportState = async (details: OpenOracleReportDetails | undefined) => {
 		const currentDetails = details
 		const isCurrent = nextOpenOracleInitialReportStateLoad()
@@ -76,6 +98,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 			openOracleInitialReportQuoteFailureKind.value = undefined
 			openOracleInitialReportQuoteFailureReason.value = undefined
 			resetOpenOracleTokenApprovalState(false)
+			resetOpenOracleTokenBalanceState()
 			return
 		}
 
@@ -89,6 +112,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 				openOracleInitialReportQuoteFailureKind.value = undefined
 				openOracleInitialReportQuoteFailureReason.value = undefined
 				resetOpenOracleTokenApprovalState(accountAddress !== undefined)
+				resetOpenOracleTokenBalanceState()
 			},
 			load: async () => {
 				const readClient = createConnectedReadClient()
@@ -117,11 +141,62 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 					}
 				}
 
-				const [initialPriceResult, token1ApprovalResult, token2ApprovalResult] = await Promise.all([loadOpenOracleInitialReportPriceResult(readClient, currentDetails.token1, currentDetails.token2, currentDetails.exactToken1Report), loadAllowance(currentDetails.token1), loadAllowance(currentDetails.token2)])
+				const loadBalance = async (tokenAddress: Address) => {
+					if (accountAddress === undefined) {
+						return {
+							error: undefined,
+							value: undefined,
+						} satisfies BalanceState
+					}
 
-				return { initialPriceResult, token1ApprovalResult, token2ApprovalResult }
+					try {
+						return {
+							error: undefined,
+							value: await loadErc20Balance(readClient, tokenAddress, accountAddress),
+						} satisfies BalanceState
+					} catch (error) {
+						const errorDetail = getErrorDetail(error)
+						return {
+							error: errorDetail === undefined ? 'Failed to load wallet balance' : `Failed to load wallet balance: ${errorDetail}`,
+							value: undefined,
+						} satisfies BalanceState
+					}
+				}
+
+				const loadEthBalance = async () => {
+					if (accountAddress === undefined) {
+						return {
+							error: undefined,
+							value: undefined,
+						} satisfies BalanceState
+					}
+
+					try {
+						return {
+							error: undefined,
+							value: await readClient.getBalance({ address: accountAddress }),
+						} satisfies BalanceState
+					} catch (error) {
+						const errorDetail = getErrorDetail(error)
+						return {
+							error: errorDetail === undefined ? 'Failed to load wallet balance' : `Failed to load wallet balance: ${errorDetail}`,
+							value: undefined,
+						} satisfies BalanceState
+					}
+				}
+
+				const [ethBalanceResult, initialPriceResult, token1ApprovalResult, token1BalanceResult, token2ApprovalResult, token2BalanceResult] = await Promise.all([
+					loadEthBalance(),
+					loadOpenOracleInitialReportPriceResult(readClient, currentDetails.token1, currentDetails.token2, currentDetails.exactToken1Report),
+					loadAllowance(currentDetails.token1),
+					loadBalance(currentDetails.token1),
+					loadAllowance(currentDetails.token2),
+					loadBalance(currentDetails.token2),
+				])
+
+				return { ethBalanceResult, initialPriceResult, token1ApprovalResult, token1BalanceResult, token2ApprovalResult, token2BalanceResult }
 			},
-			onSuccess: ({ initialPriceResult, token1ApprovalResult, token2ApprovalResult }: OpenOracleInitialReportStateResult) => {
+			onSuccess: ({ ethBalanceResult, initialPriceResult, token1ApprovalResult, token1BalanceResult, token2ApprovalResult, token2BalanceResult }: OpenOracleInitialReportStateResult) => {
 				const initialPrice = initialPriceResult.status === 'success' ? initialPriceResult : undefined
 				const priceFailure = initialPriceResult.status === 'failure' ? initialPriceResult : undefined
 
@@ -131,8 +206,14 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 				openOracleInitialReportQuoteAttemptedSources.value = priceFailure?.attemptedSources
 				openOracleInitialReportQuoteFailureKind.value = priceFailure?.failureKind
 				openOracleInitialReportQuoteFailureReason.value = priceFailure?.reason
+				openOracleInitialReportEthBalance.value = ethBalanceResult.value
+				openOracleInitialReportEthBalanceError.value = ethBalanceResult.error
 				openOracleInitialReportToken1Approval.value = token1ApprovalResult
+				openOracleInitialReportToken1Balance.value = token1BalanceResult.value
+				openOracleInitialReportToken1BalanceError.value = token1BalanceResult.error
 				openOracleInitialReportToken2Approval.value = token2ApprovalResult
+				openOracleInitialReportToken2Balance.value = token2BalanceResult.value
+				openOracleInitialReportToken2BalanceError.value = token2BalanceResult.error
 
 				if (openOracleForm.value.price.trim() === '' || openOracleForm.value.reportId.trim() !== currentDetails.reportId.toString()) {
 					openOracleForm.value = {
@@ -183,6 +264,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 				openOracleInitialReportQuoteFailureKind.value = undefined
 				openOracleInitialReportQuoteFailureReason.value = undefined
 				resetOpenOracleTokenApprovalState(false)
+				resetOpenOracleTokenBalanceState()
 				openOracleError.value = getErrorMessage(error, 'Failed to load oracle report')
 			},
 		})
@@ -224,7 +306,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 					if (result.action !== 'createReportInstance' && openOracleForm.value.reportId.trim() !== '') {
 						await ensureLoadedSelectedReport()
 					}
-					if (result.action === 'approveToken1' || result.action === 'approveToken2') {
+					if (result.action === 'approveToken1' || result.action === 'approveToken2' || result.action === 'wrapEthToWeth') {
 						await refreshOpenOracleInitialReportState(openOracleReportDetails.value)
 					}
 				},
@@ -241,12 +323,19 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 			defaultPrice: openOracleInitialReportDefaultPrice.value,
 			defaultPriceError: openOracleInitialReportDefaultPriceError.value,
 			defaultPriceSource: openOracleInitialReportDefaultPriceSource.value,
+			ethBalance: openOracleInitialReportEthBalance.value,
+			ethBalanceError: openOracleInitialReportEthBalanceError.value,
+			hasConnectedWallet: accountAddress !== undefined,
 			priceInput: openOracleForm.value.price,
 			quoteAttemptedSources: openOracleInitialReportQuoteAttemptedSources.value,
 			quoteFailureReason: openOracleInitialReportQuoteFailureReason.value,
 			reportDetails,
 			token1AllowanceError: openOracleInitialReportToken1Approval.value.error,
+			token1Balance: openOracleInitialReportToken1Balance.value,
+			token1BalanceError: openOracleInitialReportToken1BalanceError.value,
 			token2AllowanceError: openOracleInitialReportToken2Approval.value.error,
+			token2Balance: openOracleInitialReportToken2Balance.value,
+			token2BalanceError: openOracleInitialReportToken2BalanceError.value,
 			token1Decimals: reportDetails.token1Decimals,
 			token2Decimals: reportDetails.token2Decimals,
 		})
@@ -312,6 +401,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 			'submitInitialReport',
 			async walletAddress => {
 				const reportDetails = requireDefined(openOracleReportDetails.value, 'Load an oracle report first')
+				await refreshOpenOracleInitialReportState(reportDetails)
 				const submission = getInitialReportSubmission(reportDetails)
 				if (!submission.canSubmit || submission.amount1 === undefined || submission.amount2 === undefined) {
 					throw new Error(submission.blockReason ?? 'Invalid price')
@@ -320,6 +410,22 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 				return await submitInitialOracleReport(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), getOpenOracleAddress(), reportDetails.reportId, submission.amount1, submission.amount2, parseBytes32Input(openOracleForm.value.stateHash, 'State hash'))
 			},
 			'Failed to submit initial report',
+		)
+
+	const wrapRequiredEthToWeth = async () =>
+		await runOracleAction(
+			'wrapEthToWeth',
+			async walletAddress => {
+				const reportDetails = requireDefined(openOracleReportDetails.value, 'Load an oracle report first')
+				await refreshOpenOracleInitialReportState(reportDetails)
+				const submission = getInitialReportSubmission(reportDetails)
+				if (submission.requiredWrapEthAmount === undefined || !submission.canWrapEthToWeth) {
+					throw new Error(submission.blockReason ?? 'No WETH wrapping is required for the selected report')
+				}
+
+				return await wrapEthToWeth(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), submission.requiredWrapEthAmount)
+			},
+			'Failed to wrap ETH to WETH',
 		)
 
 	const settleReport = async () => await runOracleAction('settle', async walletAddress => await settleOracleReport(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), getOpenOracleAddress(), parseReportIdInput(openOracleForm.value.reportId)), 'Failed to settle report')
@@ -370,13 +476,19 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 			defaultPrice: openOracleInitialReportDefaultPrice.value,
 			defaultPriceError: openOracleInitialReportDefaultPriceError.value,
 			defaultPriceSource: openOracleInitialReportDefaultPriceSource.value,
+			ethBalance: openOracleInitialReportEthBalance.value,
+			ethBalanceError: openOracleInitialReportEthBalanceError.value,
 			loading: openOracleInitialReportStateLoad.isLoading.value,
 			quoteAttemptedSources: openOracleInitialReportQuoteAttemptedSources.value,
 			quoteFailureKind: openOracleInitialReportQuoteFailureKind.value,
 			quoteFailureReason: openOracleInitialReportQuoteFailureReason.value,
 			token1Approval: openOracleInitialReportToken1Approval.value,
+			token1Balance: openOracleInitialReportToken1Balance.value,
+			token1BalanceError: openOracleInitialReportToken1BalanceError.value,
 			token1Decimals: openOracleReportDetails.value?.token1Decimals,
 			token2Approval: openOracleInitialReportToken2Approval.value,
+			token2Balance: openOracleInitialReportToken2Balance.value,
+			token2BalanceError: openOracleInitialReportToken2BalanceError.value,
 			token2Decimals: openOracleReportDetails.value?.token2Decimals,
 		},
 		openOracleReportDetails: openOracleReportDetails.value,
@@ -388,5 +500,6 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 		setOpenOracleForm,
 		settleReport,
 		submitInitialReport,
+		wrapRequiredEthToWeth,
 	}
 }

--- a/ui/ts/lib/openOracle.ts
+++ b/ui/ts/lib/openOracle.ts
@@ -2,9 +2,9 @@ import { zeroAddress } from 'viem'
 import type { OpenOracleReportSummary } from '../types/contracts.js'
 import { parseDecimalInput } from './decimal.js'
 import { getErrorDetail } from './errors.js'
-import { formatCurrencyInputBalance } from './formatters.js'
+import { formatCurrencyBalance, formatCurrencyInputBalance } from './formatters.js'
 import { deriveTokenApprovalRequirement, formatTokenApprovalNeededMessage, formatTokenApprovalUnavailableMessage, type TokenApprovalRequirement } from './tokenApproval.js'
-import { quoteBestExactInput, quoteBestV3ExactInput, quoteExactInput } from './uniswapQuoter.js'
+import { quoteBestExactInput, quoteBestV3ExactInput, quoteExactInput, WETH_ADDRESS } from './uniswapQuoter.js'
 
 const OPEN_ORACLE_PRICE_PRECISION = 10n ** 18n
 const OPEN_ORACLE_BOUNTY_BUFFER_NUMERATOR = 12n
@@ -35,12 +35,17 @@ type OpenOracleInitialReportSubmissionDetails = {
 	amount2: bigint | undefined
 	blockReason: string | undefined
 	canSubmit: boolean
+	canWrapEthToWeth: boolean
+	ethBalance: bigint | undefined
 	price: bigint | undefined
 	priceInput: string
 	priceSource: OpenOracleInitialReportPriceSource
+	requiredWrapEthAmount: bigint | undefined
 	token1Approval: TokenApprovalRequirement
+	token1Balance: bigint | undefined
 	token1Decimals: number | undefined
 	token2Approval: TokenApprovalRequirement
+	token2Balance: bigint | undefined
 	token2Decimals: number | undefined
 }
 
@@ -177,6 +182,45 @@ export function formatOpenOracleInitialReportApprovalStatusUnavailableMessage({ 
 	})
 }
 
+export function formatOpenOracleInitialReportBalanceStatusUnavailableMessage({ reason, tokenLabel }: { reason: string | undefined; tokenLabel: string | undefined }) {
+	const resolvedTokenLabel = tokenLabel?.trim() || 'token'
+	const segments = [`Unable to verify ${resolvedTokenLabel} wallet balance for this report.`]
+	const sanitizedReason = sanitizeOpenOracleFailureReason(reason)
+
+	if (sanitizedReason !== undefined) {
+		segments.push(`Reason: ${sanitizedReason}.`)
+	}
+	segments.push('Retry loading the report or wallet balance before submitting the initial report.')
+
+	return segments.join(' ')
+}
+
+function isWethToken(tokenAddress: string | undefined) {
+	return tokenAddress?.toLowerCase() === WETH_ADDRESS.toLowerCase()
+}
+
+function getOpenOracleTokenUnits(tokenAddress: string | undefined, tokenDecimals: number | undefined) {
+	if (isWethToken(tokenAddress)) return 18
+	return tokenDecimals ?? 18
+}
+
+function formatOpenOracleTokenAmount(amount: bigint, tokenAddress: string | undefined, tokenDecimals: number | undefined) {
+	return formatCurrencyBalance(amount, getOpenOracleTokenUnits(tokenAddress, tokenDecimals))
+}
+
+function formatOpenOracleInitialReportInsufficientBalanceMessage({ availableAmount, requiredAmount, tokenAddress, tokenDecimals, tokenLabel }: { availableAmount: bigint; requiredAmount: bigint; tokenAddress: string | undefined; tokenDecimals: number | undefined; tokenLabel: string | undefined }) {
+	const resolvedTokenLabel = tokenLabel?.trim() || 'token'
+	return `Insufficient ${resolvedTokenLabel} balance. Need ${formatOpenOracleTokenAmount(requiredAmount, tokenAddress, tokenDecimals)} ${resolvedTokenLabel} for the initial report and only ${formatOpenOracleTokenAmount(availableAmount, tokenAddress, tokenDecimals)} ${resolvedTokenLabel} is available in the connected wallet.`
+}
+
+function formatOpenOracleInitialReportWrapRequiredMessage(shortfallAmount: bigint) {
+	return `Need ${formatOpenOracleTokenAmount(shortfallAmount, WETH_ADDRESS, 18)} more WETH for this initial report. Wrap ${formatOpenOracleTokenAmount(shortfallAmount, WETH_ADDRESS, 18)} ETH to WETH, then submit the initial report.`
+}
+
+function formatOpenOracleInitialReportInsufficientEthToWrapMessage(shortfallAmount: bigint, ethBalance: bigint) {
+	return `Need ${formatOpenOracleTokenAmount(shortfallAmount, WETH_ADDRESS, 18)} more WETH for this initial report, but only ${formatOpenOracleTokenAmount(ethBalance, WETH_ADDRESS, 18)} ETH is available to wrap.`
+}
+
 export async function loadOpenOracleInitialReportPriceResult(client: Parameters<typeof quoteExactInput>[0], token1: Parameters<typeof quoteExactInput>[1], token2: Parameters<typeof quoteExactInput>[2], token1Amount: bigint): Promise<OpenOracleInitialReportPriceLoadResult> {
 	let v4Failure: unknown = 'Uniswap V4 returned an unusable quote'
 
@@ -233,12 +277,19 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 	defaultPrice,
 	defaultPriceError,
 	defaultPriceSource,
+	ethBalance,
+	ethBalanceError,
+	hasConnectedWallet = false,
 	priceInput,
 	quoteAttemptedSources,
 	quoteFailureReason,
 	reportDetails,
 	token1AllowanceError,
+	token1Balance,
+	token1BalanceError,
 	token2AllowanceError,
+	token2Balance,
+	token2BalanceError,
 	token1Decimals,
 	token2Decimals,
 }: {
@@ -247,6 +298,9 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 	defaultPrice: string | undefined
 	defaultPriceError: string | undefined
 	defaultPriceSource: OpenOracleInitialReportPriceSource | undefined
+	ethBalance?: bigint | undefined
+	ethBalanceError?: string | undefined
+	hasConnectedWallet?: boolean
 	priceInput: string
 	quoteAttemptedSources: OpenOracleInitialReportQuoteSource[] | undefined
 	quoteFailureReason: string | undefined
@@ -260,7 +314,11 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 		  }
 		| undefined
 	token1AllowanceError: string | undefined
+	token1Balance?: bigint | undefined
+	token1BalanceError?: string | undefined
 	token2AllowanceError: string | undefined
+	token2Balance?: bigint | undefined
+	token2BalanceError?: string | undefined
 	token1Decimals: number | undefined
 	token2Decimals: number | undefined
 }): OpenOracleInitialReportSubmissionDetails {
@@ -276,8 +334,15 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 	const amount1 = reportDetails?.exactToken1Report
 	const amount2 = amount1 === undefined || price === undefined ? undefined : calculateOpenOracleToken2Amount(amount1, price)
 	const priceSource = trimmedPriceInput === '' ? (defaultPrice === undefined ? 'Unavailable' : (defaultPriceSource ?? 'Manual override')) : defaultPrice !== undefined && trimmedPriceInput === defaultPrice ? (defaultPriceSource ?? 'Manual override') : 'Manual override'
+	const token1IsWeth = isWethToken(reportDetails?.token1)
+	const token2IsWeth = isWethToken(reportDetails?.token2)
+	const resolvedToken1Decimals = getOpenOracleTokenUnits(reportDetails?.token1, token1Decimals)
+	const resolvedToken2Decimals = getOpenOracleTokenUnits(reportDetails?.token2, token2Decimals)
 	const token1Approval = deriveTokenApprovalRequirement(amount1, approvedToken1Amount)
 	const token2Approval = deriveTokenApprovalRequirement(amount2, approvedToken2Amount)
+	const requiredWethAmount = (token1IsWeth ? (amount1 ?? 0n) : 0n) + (token2IsWeth ? (amount2 ?? 0n) : 0n)
+	const currentWethBalance = token1IsWeth ? token1Balance : token2IsWeth ? token2Balance : undefined
+	const requiredWrapEthAmount = requiredWethAmount <= 0n || currentWethBalance === undefined || currentWethBalance >= requiredWethAmount ? undefined : requiredWethAmount - currentWethBalance
 
 	let blockReason: string | undefined
 	if (reportDetails === undefined) {
@@ -307,13 +372,54 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 		})
 	} else if (approvedToken2Amount === undefined) {
 		blockReason = `Loading current ${reportDetails.token2Symbol ?? reportDetails.token2 ?? 'Token2'} approval.`
+	} else if (hasConnectedWallet && token1Balance === undefined && token1BalanceError !== undefined) {
+		blockReason = formatOpenOracleInitialReportBalanceStatusUnavailableMessage({
+			reason: token1BalanceError,
+			tokenLabel: reportDetails.token1Symbol ?? reportDetails.token1,
+		})
+	} else if (hasConnectedWallet && token1Balance === undefined) {
+		blockReason = `Loading current ${reportDetails.token1Symbol ?? reportDetails.token1 ?? 'Token1'} balance.`
+	} else if (hasConnectedWallet && token2Balance === undefined && token2BalanceError !== undefined) {
+		blockReason = formatOpenOracleInitialReportBalanceStatusUnavailableMessage({
+			reason: token2BalanceError,
+			tokenLabel: reportDetails.token2Symbol ?? reportDetails.token2,
+		})
+	} else if (hasConnectedWallet && token2Balance === undefined) {
+		blockReason = `Loading current ${reportDetails.token2Symbol ?? reportDetails.token2 ?? 'Token2'} balance.`
+	} else if (hasConnectedWallet && !token1IsWeth && amount1 !== undefined && token1Balance !== undefined && token1Balance < amount1) {
+		blockReason = formatOpenOracleInitialReportInsufficientBalanceMessage({
+			availableAmount: token1Balance,
+			requiredAmount: amount1,
+			tokenAddress: reportDetails.token1,
+			tokenDecimals: resolvedToken1Decimals,
+			tokenLabel: reportDetails.token1Symbol ?? reportDetails.token1,
+		})
+	} else if (hasConnectedWallet && !token2IsWeth && amount2 !== undefined && token2Balance !== undefined && token2Balance < amount2) {
+		blockReason = formatOpenOracleInitialReportInsufficientBalanceMessage({
+			availableAmount: token2Balance,
+			requiredAmount: amount2,
+			tokenAddress: reportDetails.token2,
+			tokenDecimals: resolvedToken2Decimals,
+			tokenLabel: reportDetails.token2Symbol ?? reportDetails.token2,
+		})
+	} else if (hasConnectedWallet && requiredWrapEthAmount !== undefined && ethBalance === undefined && ethBalanceError !== undefined) {
+		blockReason = formatOpenOracleInitialReportBalanceStatusUnavailableMessage({
+			reason: ethBalanceError,
+			tokenLabel: 'ETH',
+		})
+	} else if (hasConnectedWallet && requiredWrapEthAmount !== undefined && ethBalance === undefined) {
+		blockReason = 'Loading current ETH balance.'
+	} else if (hasConnectedWallet && requiredWrapEthAmount !== undefined && ethBalance !== undefined && ethBalance >= requiredWrapEthAmount) {
+		blockReason = formatOpenOracleInitialReportWrapRequiredMessage(requiredWrapEthAmount)
+	} else if (hasConnectedWallet && requiredWrapEthAmount !== undefined) {
+		blockReason = formatOpenOracleInitialReportInsufficientEthToWrapMessage(requiredWrapEthAmount, ethBalance ?? 0n)
 	} else if (!token1Approval.hasSufficientApproval) {
 		blockReason =
 			formatTokenApprovalNeededMessage({
 				actionLabel: 'submitting the initial report',
 				requirement: token1Approval,
 				tokenLabel: reportDetails.token1Symbol ?? reportDetails.token1 ?? 'Token1',
-				tokenUnits: token1Decimals ?? 18,
+				tokenUnits: resolvedToken1Decimals,
 			}) ?? 'Token1 approval required'
 	} else if (!token2Approval.hasSufficientApproval) {
 		blockReason =
@@ -321,7 +427,7 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 				actionLabel: 'submitting the initial report',
 				requirement: token2Approval,
 				tokenLabel: reportDetails.token2Symbol ?? reportDetails.token2 ?? 'Token2',
-				tokenUnits: token2Decimals ?? 18,
+				tokenUnits: resolvedToken2Decimals,
 			}) ?? 'Token2 approval required'
 	}
 
@@ -330,12 +436,17 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 		amount2,
 		blockReason,
 		canSubmit: blockReason === undefined,
+		canWrapEthToWeth: requiredWrapEthAmount !== undefined && ethBalance !== undefined && ethBalance >= requiredWrapEthAmount,
+		ethBalance,
 		price,
 		priceInput: resolvedPriceInput,
 		priceSource,
+		requiredWrapEthAmount,
 		token1Approval,
-		token1Decimals,
+		token1Balance,
+		token1Decimals: resolvedToken1Decimals,
 		token2Approval,
-		token2Decimals,
+		token2Balance,
+		token2Decimals: resolvedToken2Decimals,
 	}
 }

--- a/ui/ts/tests/openOracle.test.ts
+++ b/ui/ts/tests/openOracle.test.ts
@@ -2,12 +2,13 @@
 
 import { beforeEach, describe, expect, setDefaultTimeout, test } from 'bun:test'
 import { getAddress, zeroAddress, type Address } from 'viem'
-import { createOpenOracleReportInstance, getOpenOracleAddress, loadOpenOracleReportDetails, loadOpenOracleReportSummaries, loadOracleManagerDetails, requestOraclePrice, settleOracleReport, submitInitialOracleReport } from '../contracts.js'
+import { createOpenOracleReportInstance, getOpenOracleAddress, loadErc20Balance, loadOpenOracleReportDetails, loadOpenOracleReportSummaries, loadOracleManagerDetails, requestOraclePrice, settleOracleReport, submitInitialOracleReport, wrapEthToWeth } from '../contracts.js'
 import {
 	deriveOpenOracleInitialReportSubmissionDetails,
 	addOpenOracleBountyBuffer,
 	formatOpenOracleFeePercentage,
 	formatOpenOracleInitialReportApprovalStatusUnavailableMessage,
+	formatOpenOracleInitialReportBalanceStatusUnavailableMessage,
 	formatOpenOracleInitialReportPriceUnavailableMessage,
 	formatOpenOracleMultiplier,
 	getOpenOracleReportStatus,
@@ -28,7 +29,7 @@ import { createWriteClient, type WriteClient } from '../../../solidity/ts/testsu
 import { deployOriginSecurityPool, ensureInfraDeployed, getSecurityPoolAddresses } from '../../../solidity/ts/testsuite/simulator/utils/contracts/deployPeripherals'
 import { ensureZoltarDeployed } from '../../../solidity/ts/testsuite/simulator/utils/contracts/zoltar'
 import { createQuestion, getQuestionId } from '../../../solidity/ts/testsuite/simulator/utils/contracts/zoltarQuestionData'
-import { getOpenOracleExtraData, wrapWeth } from '../../../solidity/ts/testsuite/simulator/utils/contracts/peripherals'
+import { getOpenOracleExtraData } from '../../../solidity/ts/testsuite/simulator/utils/contracts/peripherals'
 
 setDefaultTimeout(TEST_TIMEOUT_MS)
 
@@ -246,6 +247,74 @@ describe('Open Oracle helpers', () => {
 		expect(preview.blockReason).toBe('Need 1 more ETH approved before submitting the initial report. Approving will set the allowance to 25 ETH.')
 	})
 
+	test('initial report submission helper blocks when the connected wallet is short on token1 balance', () => {
+		const preview = deriveOpenOracleInitialReportSubmissionDetails({
+			approvedToken1Amount: 100n * ONE,
+			approvedToken2Amount: 25n * ONE,
+			defaultPrice: '4.0',
+			defaultPriceError: undefined,
+			defaultPriceSource: 'Uniswap V4',
+			ethBalance: 0n,
+			ethBalanceError: undefined,
+			hasConnectedWallet: true,
+			priceInput: '',
+			quoteAttemptedSources: undefined,
+			quoteFailureReason: undefined,
+			reportDetails: {
+				exactToken1Report: 100n * ONE,
+				token1Symbol: 'REP',
+				token2: WETH_ADDRESS,
+				token2Symbol: 'WETH',
+			},
+			token1AllowanceError: undefined,
+			token1Balance: 40n * ONE,
+			token1BalanceError: undefined,
+			token2AllowanceError: undefined,
+			token2Balance: 25n * ONE,
+			token2BalanceError: undefined,
+			token1Decimals: 18,
+			token2Decimals: 18,
+		})
+
+		expect(preview.canSubmit).toBe(false)
+		expect(preview.blockReason).toBe('Insufficient REP balance. Need 100 REP for the initial report and only 40 REP is available in the connected wallet.')
+	})
+
+	test('initial report submission helper can require wrapping ETH to WETH before submit', () => {
+		const preview = deriveOpenOracleInitialReportSubmissionDetails({
+			approvedToken1Amount: 100n * ONE,
+			approvedToken2Amount: 25n * ONE,
+			defaultPrice: '4.0',
+			defaultPriceError: undefined,
+			defaultPriceSource: 'Uniswap V4',
+			ethBalance: 20n * ONE,
+			ethBalanceError: undefined,
+			hasConnectedWallet: true,
+			priceInput: '',
+			quoteAttemptedSources: undefined,
+			quoteFailureReason: undefined,
+			reportDetails: {
+				exactToken1Report: 100n * ONE,
+				token1Symbol: 'REP',
+				token2: WETH_ADDRESS,
+				token2Symbol: 'WETH',
+			},
+			token1AllowanceError: undefined,
+			token1Balance: 100n * ONE,
+			token1BalanceError: undefined,
+			token2AllowanceError: undefined,
+			token2Balance: 10n * ONE,
+			token2BalanceError: undefined,
+			token1Decimals: 18,
+			token2Decimals: 18,
+		})
+
+		expect(preview.canSubmit).toBe(false)
+		expect(preview.canWrapEthToWeth).toBe(true)
+		expect(preview.requiredWrapEthAmount).toBe(15n * ONE)
+		expect(preview.blockReason).toBe('Need 15 more WETH for this initial report. Wrap 15 ETH to WETH, then submit the initial report.')
+	})
+
 	test('initial report submission helper explains exhausted quote paths with a short reason', () => {
 		const preview = deriveOpenOracleInitialReportSubmissionDetails({
 			approvedToken1Amount: 100n * ONE,
@@ -365,6 +434,15 @@ describe('Open Oracle helpers', () => {
 		).toBe('Unable to verify WETH approval before submitting the initial report. Reason: execution reverted. Retry loading the approval status before continuing.')
 	})
 
+	test('formats unavailable balance status messages with sanitized reasons', () => {
+		expect(
+			formatOpenOracleInitialReportBalanceStatusUnavailableMessage({
+				reason: 'Failed to load wallet balance: execution reverted',
+				tokenLabel: 'ETH',
+			}),
+		).toBe('Unable to verify ETH wallet balance for this report. Reason: execution reverted. Retry loading the report or wallet balance before submitting the initial report.')
+	})
+
 	test('open oracle fee and multiplier formatters render human values', () => {
 		expect(formatOpenOracleFeePercentage(10_000n)).toBe('0.1%')
 		expect(formatOpenOracleMultiplier(140n)).toBe('1.40x')
@@ -426,7 +504,12 @@ describe('Open Oracle helpers', () => {
 		const openOracleAddress = getOpenOracleAddress()
 		await approveToken(client, addressString(GENESIS_REPUTATION_TOKEN), openOracleAddress)
 		await approveToken(client, WETH_ADDRESS, openOracleAddress)
-		await wrapWeth(client, amount2)
+		const walletAddress = addressString(TEST_ADDRESSES[0])
+		const wethBalanceBefore = await loadErc20Balance(uiReadClient, WETH_ADDRESS, walletAddress)
+		const wrapResult = await wrapEthToWeth(uiWriteClient, amount2)
+		expect(wrapResult.action).toBe('wrapEthToWeth')
+		const wethBalanceAfter = await loadErc20Balance(uiReadClient, WETH_ADDRESS, walletAddress)
+		expect(wethBalanceAfter - wethBalanceBefore).toBe(amount2)
 
 		const stateHash = (await getOpenOracleExtraData(client, reportId)).stateHash
 		await submitInitialOracleReport(uiWriteClient, openOracleAddress, reportId, amount1, amount2, stateHash)

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -260,6 +260,7 @@ export type OpenOracleRouteContentProps = {
 	onOpenOracleCreateFormChange: (update: Partial<OpenOracleCreateFormState>) => void
 	onSettleReport: () => void
 	onSubmitInitialReport: () => void
+	onWrapEthToWeth: () => void
 	loadingOpenOracleCreate: boolean
 	openOracleActiveAction: OpenOracleActionResult['action'] | undefined
 	openOracleError: string | undefined
@@ -267,13 +268,19 @@ export type OpenOracleRouteContentProps = {
 		defaultPrice: string | undefined
 		defaultPriceError: string | undefined
 		defaultPriceSource: OpenOracleInitialReportPriceSource | undefined
+		ethBalance: bigint | undefined
+		ethBalanceError: string | undefined
 		loading: boolean
 		quoteAttemptedSources: OpenOracleInitialReportQuoteSource[] | undefined
 		quoteFailureKind: OpenOracleInitialReportQuoteFailureKind | undefined
 		quoteFailureReason: string | undefined
 		token1Approval: TokenApprovalState
+		token1Balance: bigint | undefined
+		token1BalanceError: string | undefined
 		token1Decimals: number | undefined
 		token2Approval: TokenApprovalState
+		token2Balance: bigint | undefined
+		token2BalanceError: string | undefined
 		token2Decimals: number | undefined
 	}
 	openOracleCreateForm: OpenOracleCreateFormState

--- a/ui/ts/types/contracts.ts
+++ b/ui/ts/types/contracts.ts
@@ -151,7 +151,7 @@ export type OracleManagerDetails = {
 }
 
 export type OpenOracleActionResult = ActionResult & {
-	action: 'approveToken1' | 'approveToken2' | 'createReportInstance' | 'dispute' | 'queueOperation' | 'requestPrice' | 'settle' | 'submitInitialReport'
+	action: 'approveToken1' | 'approveToken2' | 'createReportInstance' | 'dispute' | 'queueOperation' | 'requestPrice' | 'settle' | 'submitInitialReport' | 'wrapEthToWeth'
 }
 
 export type OpenOracleReportSummary = {


### PR DESCRIPTION
## Summary
- Adds wallet balance loading for the selected report’s required tokens plus ETH so initial-report readiness can account for available funds.
- Updates initial report derivation to detect WETH shortfalls, block submission with clearer messages, and surface a dedicated wrap-ETH action.
- Wires a new `wrapEthToWeth` contract operation into the UI and refresh flow, and expands tests for balance and wrapping cases.

## Testing
- `bun test`
- `bun x tsc` or `bun tsc` not run
- `bun run format` not run
- `bun run check` not run
- `bun run knip` not run