### PR TITLE
Show loading state in report hints

### DIFF
--- a/ui/ts/components/StateHint.tsx
+++ b/ui/ts/components/StateHint.tsx
@@ -1,3 +1,4 @@
+import { LoadingText } from './LoadingText.js'
 import type { UserMessagePresentation } from '../lib/userCopy.js'
 
 type StateHintProps = {
@@ -13,7 +14,7 @@ export function StateHint({ className = '', presentation }: StateHintProps) {
 					<span className={`badge ${presentation.badgeTone ?? 'muted'}`}>{presentation.badgeLabel}</span>
 				</p>
 			)}
-			{presentation.detail === undefined ? undefined : <p className='detail'>{presentation.detail}</p>}
+			{presentation.detail === undefined ? undefined : <p className='detail'>{presentation.detailIsLoading ? <LoadingText>{presentation.detail}</LoadingText> : presentation.detail}</p>}
 			{presentation.actionHint === undefined ? undefined : <p className='detail'>{presentation.actionHint}</p>}
 		</div>
 	)

--- a/ui/ts/lib/userCopy.ts
+++ b/ui/ts/lib/userCopy.ts
@@ -10,6 +10,7 @@ export type UserMessagePresentation = {
 	badgeLabel?: string
 	badgeTone?: UserMessageTone
 	detail?: string
+	detailIsLoading?: boolean
 	key: UserMessageKey
 	placeholder?: string
 }
@@ -149,9 +150,8 @@ export function getReportPresentation({ kind, state }: { kind: 'question' | 'rep
 	switch (state) {
 		case 'loading':
 			return createPresentation('loading', {
-				badgeLabel: 'Loading',
-				badgeTone: 'pending',
-				detail: 'Checking this ID.',
+				detail: 'retrieving...',
+				detailIsLoading: true,
 			})
 		case 'unknown':
 			return createPresentation('not_checked', {

--- a/ui/ts/tests/userCopy.test.ts
+++ b/ui/ts/tests/userCopy.test.ts
@@ -22,6 +22,11 @@ void describe('user copy helpers', () => {
 	void test('maps universe and report lookup states semantically', () => {
 		expect(getUniversePresentation('missing')?.key).toBe('not_found')
 		expect(getReportPresentation({ kind: 'question', state: 'unknown' })?.actionHint).toBe('Refresh questions')
+		expect(getReportPresentation({ kind: 'question', state: 'loading' })).toEqual({
+			detail: 'retrieving...',
+			detailIsLoading: true,
+			key: 'loading',
+		})
 	})
 
 	void test('maps wallet and placeholder states semantically', () => {


### PR DESCRIPTION
## Summary
- Update report state hints to render loading detail text with the loading text treatment.
- Simplify the loading report presentation to use a loading-only detail instead of a badge plus static message.
- Add a test covering the loading report presentation shape.

## Testing
- Not run (PR description only)