### PR TITLE
Show max for oversized token approvals

### DIFF
--- a/ui/ts/components/TokenApprovalControl.tsx
+++ b/ui/ts/components/TokenApprovalControl.tsx
@@ -5,7 +5,7 @@ import { FormInput } from './FormInput.js'
 import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
 import { formatCurrencyBalance } from '../lib/formatters.js'
-import { deriveTokenApprovalRequirement, formatTokenApprovalNeededMessage, formatTokenApprovalPartialMessage, formatTokenApprovalUnavailableMessage, parseTokenApprovalAmountInput } from '../lib/tokenApproval.js'
+import { deriveTokenApprovalRequirement, formatTokenApprovalNeededMessage, formatTokenApprovalPartialMessage, formatTokenApprovalUnavailableMessage, parseTokenApprovalAmountInput, shouldDisplayMaxTokenApprovalAmount } from '../lib/tokenApproval.js'
 
 type TokenApprovalControlProps = {
 	actionLabel: string
@@ -53,6 +53,7 @@ function resolveApprovalButtonLabel({
 export function TokenApprovalControl({ actionLabel, allowanceError, allowanceLoading, approvedAmount, guardMessage, onApprove, pending, pendingLabel, requiredAmount, resetKey, tokenSymbol, tokenUnits }: TokenApprovalControlProps) {
 	const [draftAmount, setDraftAmount] = useState('')
 	const requirement = useMemo(() => deriveTokenApprovalRequirement(requiredAmount, approvedAmount), [approvedAmount, requiredAmount])
+	const displayApprovedAmountAsMax = shouldDisplayMaxTokenApprovalAmount(approvedAmount)
 
 	useEffect(() => {
 		setDraftAmount('')
@@ -112,7 +113,13 @@ export function TokenApprovalControl({ actionLabel, allowanceError, allowanceLoa
 					<CurrencyValue value={requiredAmount} units={tokenUnits} suffix={tokenSymbol} copyable={false} />
 				</MetricField>
 				<MetricField label={`Approved ${tokenSymbol}`}>
-					<CurrencyValue loading={allowanceLoading} value={approvedAmount} units={tokenUnits} suffix={tokenSymbol} copyable={false} />
+					{displayApprovedAmountAsMax && !allowanceLoading ? (
+						<span className='currency-value' title='Approval exceeds max(uint200)'>
+							max
+						</span>
+					) : (
+						<CurrencyValue loading={allowanceLoading} value={approvedAmount} units={tokenUnits} suffix={tokenSymbol} copyable={false} />
+					)}
 				</MetricField>
 				<MetricField label={`Need More ${tokenSymbol} Approved`}>
 					<CurrencyValue value={requirement.neededAmount} units={tokenUnits} suffix={tokenSymbol} copyable={false} />

--- a/ui/ts/lib/tokenApproval.ts
+++ b/ui/ts/lib/tokenApproval.ts
@@ -2,6 +2,8 @@ import { maxUint256 } from 'viem'
 import { parseDecimalInput } from './decimal.js'
 import { formatCurrencyBalance } from './formatters.js'
 
+export const maxUint200 = 2n ** 200n - 1n
+
 export type TokenApprovalState = {
 	error: string | undefined
 	loading: boolean
@@ -70,6 +72,10 @@ export function parseTokenApprovalAmountInput(value: string, label: string, unit
 		kind: 'custom',
 		amount: parseDecimalInput(trimmed, label, units),
 	}
+}
+
+export function shouldDisplayMaxTokenApprovalAmount(amount: bigint | undefined) {
+	return amount !== undefined && amount > maxUint200
 }
 
 export function formatTokenApprovalUnavailableMessage({ actionLabel, reason, tokenLabel }: { actionLabel?: string | undefined; reason: string | undefined; tokenLabel: string | undefined }) {

--- a/ui/ts/tests/tokenApproval.test.ts
+++ b/ui/ts/tests/tokenApproval.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, test } from 'bun:test'
 import { maxUint256 } from 'viem'
-import { deriveTokenApprovalRequirement, formatTokenApprovalNeededMessage, formatTokenApprovalPartialMessage, formatTokenApprovalUnavailableMessage, parseTokenApprovalAmountInput } from '../lib/tokenApproval.js'
+import { deriveTokenApprovalRequirement, formatTokenApprovalNeededMessage, formatTokenApprovalPartialMessage, formatTokenApprovalUnavailableMessage, maxUint200, parseTokenApprovalAmountInput, shouldDisplayMaxTokenApprovalAmount } from '../lib/tokenApproval.js'
 
 const ONE = 10n ** 18n
 
@@ -42,6 +42,12 @@ describe('token approval helpers', () => {
 			amount: maxUint256,
 			kind: 'max',
 		})
+	})
+
+	test('flags approvals above uint200 max for compact max display', () => {
+		expect(shouldDisplayMaxTokenApprovalAmount(maxUint200)).toBe(false)
+		expect(shouldDisplayMaxTokenApprovalAmount(maxUint200 + 1n)).toBe(true)
+		expect(shouldDisplayMaxTokenApprovalAmount(undefined)).toBe(false)
 	})
 
 	test('parses custom approval input using token decimals', () => {


### PR DESCRIPTION
## Summary
- Add a helper to detect approvals above the `uint200` display threshold.
- Render `max` in the approved amount field when the approval exceeds that threshold.
- Add unit coverage for the new compact-display behavior.

## Testing
- Not run