### PR TITLE
Show REP-backed pool capacity and add ETH wrapping for open reports

### DIFF
--- a/ui/ts/components/OpenInterestCapacityMetrics.tsx
+++ b/ui/ts/components/OpenInterestCapacityMetrics.tsx
@@ -1,23 +1,25 @@
 import { CurrencyValue } from './CurrencyValue.js'
 import { MetricField } from './MetricField.js'
-import { hasRepBackedPoolWithNoActiveAllowance } from '../lib/trading.js'
+import { getAllowanceBackedRep } from '../lib/trading.js'
 
 type OpenInterestCapacityMetricsProps = {
 	completeSetCollateralAmount: bigint | undefined
+	lastOraclePrice: bigint | undefined
 	totalRepDeposit: bigint | undefined
 	totalSecurityBondAllowance: bigint | undefined
 }
 
-export function OpenInterestCapacityMetrics({ completeSetCollateralAmount, totalRepDeposit, totalSecurityBondAllowance }: OpenInterestCapacityMetricsProps) {
-	const maxCapacityBadge = hasRepBackedPoolWithNoActiveAllowance(totalRepDeposit, totalSecurityBondAllowance) ? (
-		<span className='badge muted' title='REP is deposited in the pool, but the vaults have not set any active security bond allowance.'>
-			No active allowances
-		</span>
-	) : undefined
+export function OpenInterestCapacityMetrics({ completeSetCollateralAmount, lastOraclePrice, totalRepDeposit, totalSecurityBondAllowance }: OpenInterestCapacityMetricsProps) {
+	const allowanceBackedRep = getAllowanceBackedRep(totalSecurityBondAllowance, lastOraclePrice)
 
 	return (
-		<MetricField label='Open Interest Minted / Max'>
-			<CurrencyValue value={completeSetCollateralAmount} suffix='ETH' /> / <CurrencyValue value={totalSecurityBondAllowance} suffix='ETH' /> {maxCapacityBadge}
-		</MetricField>
+		<>
+			<MetricField label='Open Interest Minted / Max'>
+				<CurrencyValue value={completeSetCollateralAmount} suffix='ETH' /> / <CurrencyValue value={totalSecurityBondAllowance} suffix='ETH' />
+			</MetricField>
+			<MetricField label={<span title='Uses the most recent settled oracle price.'>Allowance * Last Oracle / REP Deposit</span>}>
+				<CurrencyValue value={allowanceBackedRep} suffix='REP' /> / <CurrencyValue value={totalRepDeposit} suffix='REP' />
+			</MetricField>
+		</>
 	)
 }

--- a/ui/ts/components/OpenInterestCapacityMetrics.tsx
+++ b/ui/ts/components/OpenInterestCapacityMetrics.tsx
@@ -1,21 +1,23 @@
 import { CurrencyValue } from './CurrencyValue.js'
 import { MetricField } from './MetricField.js'
-import { getRemainingMintCapacity } from '../lib/trading.js'
+import { hasRepBackedPoolWithNoActiveAllowance } from '../lib/trading.js'
 
 type OpenInterestCapacityMetricsProps = {
 	completeSetCollateralAmount: bigint | undefined
+	totalRepDeposit: bigint | undefined
 	totalSecurityBondAllowance: bigint | undefined
 }
 
-export function OpenInterestCapacityMetrics({ completeSetCollateralAmount, totalSecurityBondAllowance }: OpenInterestCapacityMetricsProps) {
+export function OpenInterestCapacityMetrics({ completeSetCollateralAmount, totalRepDeposit, totalSecurityBondAllowance }: OpenInterestCapacityMetricsProps) {
+	const maxCapacityBadge = hasRepBackedPoolWithNoActiveAllowance(totalRepDeposit, totalSecurityBondAllowance) ? (
+		<span className='badge muted' title='REP is deposited in the pool, but the vaults have not set any active security bond allowance.'>
+			No active allowances
+		</span>
+	) : undefined
+
 	return (
-		<>
-			<MetricField label='Open Interest Minted / Max'>
-				<CurrencyValue value={completeSetCollateralAmount} suffix='ETH' /> / <CurrencyValue value={totalSecurityBondAllowance} suffix='ETH' />
-			</MetricField>
-			<MetricField label='Remaining Mint Capacity'>
-				<CurrencyValue value={getRemainingMintCapacity(totalSecurityBondAllowance, completeSetCollateralAmount)} suffix='ETH' />
-			</MetricField>
-		</>
+		<MetricField label='Open Interest Minted / Max'>
+			<CurrencyValue value={completeSetCollateralAmount} suffix='ETH' /> / <CurrencyValue value={totalSecurityBondAllowance} suffix='ETH' /> {maxCapacityBadge}
+		</MetricField>
 	)
 }

--- a/ui/ts/components/SecurityPoolSection.tsx
+++ b/ui/ts/components/SecurityPoolSection.tsx
@@ -134,7 +134,7 @@ export function SecurityPoolSection({
 													<MetricField label='Open Interest Fee / Year'>
 														<CurrencyValue value={openInterestFeePerYearBigint(pool.currentRetentionRate)} suffix='%' />
 													</MetricField>
-													<OpenInterestCapacityMetrics completeSetCollateralAmount={pool.completeSetCollateralAmount} totalSecurityBondAllowance={pool.totalSecurityBondAllowance} />
+													<OpenInterestCapacityMetrics completeSetCollateralAmount={pool.completeSetCollateralAmount} totalRepDeposit={pool.totalRepDeposit} totalSecurityBondAllowance={pool.totalSecurityBondAllowance} />
 												</div>
 											</EntityCard>
 										))}

--- a/ui/ts/components/SecurityPoolSection.tsx
+++ b/ui/ts/components/SecurityPoolSection.tsx
@@ -134,7 +134,7 @@ export function SecurityPoolSection({
 													<MetricField label='Open Interest Fee / Year'>
 														<CurrencyValue value={openInterestFeePerYearBigint(pool.currentRetentionRate)} suffix='%' />
 													</MetricField>
-													<OpenInterestCapacityMetrics completeSetCollateralAmount={pool.completeSetCollateralAmount} totalRepDeposit={pool.totalRepDeposit} totalSecurityBondAllowance={pool.totalSecurityBondAllowance} />
+													<OpenInterestCapacityMetrics completeSetCollateralAmount={pool.completeSetCollateralAmount} lastOraclePrice={pool.lastOraclePrice} totalRepDeposit={pool.totalRepDeposit} totalSecurityBondAllowance={pool.totalSecurityBondAllowance} />
 												</div>
 											</EntityCard>
 										))}

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -185,7 +185,7 @@ export function SecurityPoolWorkflowSection({
 									<MetricField label='Open Interest Fee / Year'>
 										<CurrencyValue value={openInterestFeePerYearBigint(loadedSelectedPool?.currentRetentionRate)} suffix='%' />
 									</MetricField>
-									<OpenInterestCapacityMetrics completeSetCollateralAmount={loadedSelectedPool?.completeSetCollateralAmount} totalSecurityBondAllowance={loadedSelectedPool?.totalSecurityBondAllowance} />
+									<OpenInterestCapacityMetrics completeSetCollateralAmount={loadedSelectedPool?.completeSetCollateralAmount} totalRepDeposit={loadedSelectedPool?.totalRepDeposit} totalSecurityBondAllowance={loadedSelectedPool?.totalSecurityBondAllowance} />
 									{reportingReady ? <MetricField label='Reporting'>Unlocked</MetricField> : undefined}
 									<MetricField label='Manager'>
 										<AddressValue address={loadedSelectedPool?.managerAddress} />

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -185,7 +185,7 @@ export function SecurityPoolWorkflowSection({
 									<MetricField label='Open Interest Fee / Year'>
 										<CurrencyValue value={openInterestFeePerYearBigint(loadedSelectedPool?.currentRetentionRate)} suffix='%' />
 									</MetricField>
-									<OpenInterestCapacityMetrics completeSetCollateralAmount={loadedSelectedPool?.completeSetCollateralAmount} totalRepDeposit={loadedSelectedPool?.totalRepDeposit} totalSecurityBondAllowance={loadedSelectedPool?.totalSecurityBondAllowance} />
+									<OpenInterestCapacityMetrics completeSetCollateralAmount={loadedSelectedPool?.completeSetCollateralAmount} lastOraclePrice={loadedSelectedPool?.lastOraclePrice} totalRepDeposit={loadedSelectedPool?.totalRepDeposit} totalSecurityBondAllowance={loadedSelectedPool?.totalSecurityBondAllowance} />
 									{reportingReady ? <MetricField label='Reporting'>Unlocked</MetricField> : undefined}
 									<MetricField label='Manager'>
 										<AddressValue address={loadedSelectedPool?.managerAddress} />

--- a/ui/ts/components/SecurityPoolsOverviewSection.tsx
+++ b/ui/ts/components/SecurityPoolsOverviewSection.tsx
@@ -106,7 +106,7 @@ export function SecurityPoolsOverviewSection({
 										<MetricField label='Open Interest Fee / Year'>
 											<CurrencyValue value={openInterestFeePerYearBigint(pool.currentRetentionRate)} suffix='%' />
 										</MetricField>
-										<OpenInterestCapacityMetrics completeSetCollateralAmount={pool.completeSetCollateralAmount} totalSecurityBondAllowance={pool.totalSecurityBondAllowance} />
+										<OpenInterestCapacityMetrics completeSetCollateralAmount={pool.completeSetCollateralAmount} totalRepDeposit={pool.totalRepDeposit} totalSecurityBondAllowance={pool.totalSecurityBondAllowance} />
 										<MetricField label='Manager'>
 											<AddressValue address={pool.managerAddress} />
 										</MetricField>

--- a/ui/ts/components/SecurityPoolsOverviewSection.tsx
+++ b/ui/ts/components/SecurityPoolsOverviewSection.tsx
@@ -106,7 +106,7 @@ export function SecurityPoolsOverviewSection({
 										<MetricField label='Open Interest Fee / Year'>
 											<CurrencyValue value={openInterestFeePerYearBigint(pool.currentRetentionRate)} suffix='%' />
 										</MetricField>
-										<OpenInterestCapacityMetrics completeSetCollateralAmount={pool.completeSetCollateralAmount} totalRepDeposit={pool.totalRepDeposit} totalSecurityBondAllowance={pool.totalSecurityBondAllowance} />
+										<OpenInterestCapacityMetrics completeSetCollateralAmount={pool.completeSetCollateralAmount} lastOraclePrice={pool.lastOraclePrice} totalRepDeposit={pool.totalRepDeposit} totalSecurityBondAllowance={pool.totalSecurityBondAllowance} />
 										<MetricField label='Manager'>
 											<AddressValue address={pool.managerAddress} />
 										</MetricField>

--- a/ui/ts/components/TradingSection.tsx
+++ b/ui/ts/components/TradingSection.tsx
@@ -8,14 +8,13 @@ import { TransactionHashLink } from './TransactionHashLink.js'
 import { UniverseLink } from './UniverseLink.js'
 import { isMainnetChain } from '../lib/network.js'
 import { REPORTING_OUTCOME_DROPDOWN_OPTIONS } from '../lib/reporting.js'
-import { getRemainingMintCapacity, getTradingMintGuardMessage, hasRepBackedPoolWithNoActiveAllowance } from '../lib/trading.js'
+import { getRemainingMintCapacity, getTradingMintGuardMessage } from '../lib/trading.js'
 import type { TradingSectionProps } from '../types/components.js'
 
 export function TradingSection({ accountState, embedInCard = false, onCreateCompleteSet, onMigrateShares, onRedeemCompleteSet, onRedeemShares, onTradingFormChange, selectedPool, tradingError, tradingForm, tradingResult, showHeader = true, showSecurityPoolAddressInput = true }: TradingSectionProps) {
 	const isMainnet = isMainnetChain(accountState.chainId)
 	const currentTimestamp = BigInt(Math.floor(Date.now() / 1000))
 	const remainingMintCapacity = getRemainingMintCapacity(selectedPool?.totalSecurityBondAllowance, selectedPool?.completeSetCollateralAmount)
-	const hasRepWithoutActiveAllowance = hasRepBackedPoolWithNoActiveAllowance(selectedPool?.totalRepDeposit, selectedPool?.totalSecurityBondAllowance)
 	const marketHasEnded = selectedPool?.marketDetails.endTime === undefined ? undefined : selectedPool.marketDetails.endTime <= currentTimestamp
 	const mintGuardMessage = getTradingMintGuardMessage({
 		accountAddress: accountState.address,
@@ -116,7 +115,7 @@ export function TradingSection({ accountState, embedInCard = false, onCreateComp
 						<MetricField label='Universe'>
 							<UniverseLink universeId={selectedPool.universeId} />
 						</MetricField>
-						<OpenInterestCapacityMetrics completeSetCollateralAmount={selectedPool.completeSetCollateralAmount} totalRepDeposit={selectedPool.totalRepDeposit} totalSecurityBondAllowance={selectedPool.totalSecurityBondAllowance} />
+						<OpenInterestCapacityMetrics completeSetCollateralAmount={selectedPool.completeSetCollateralAmount} lastOraclePrice={selectedPool.lastOraclePrice} totalRepDeposit={selectedPool.totalRepDeposit} totalSecurityBondAllowance={selectedPool.totalSecurityBondAllowance} />
 					</div>
 				)}
 			</div>
@@ -125,7 +124,7 @@ export function TradingSection({ accountState, embedInCard = false, onCreateComp
 		<div className='entity-card-subsection'>
 			<div className='entity-card-subsection-header'>
 				<h4>Mint Complete Sets</h4>
-				{remainingMintCapacity === undefined ? undefined : hasRepWithoutActiveAllowance ? <span className='badge muted'>No active allowances</span> : <span className={`badge ${remainingMintCapacity > 0n ? 'ok' : 'blocked'}`}>{remainingMintCapacity > 0n ? 'Capacity available' : 'Capacity full'}</span>}
+				{remainingMintCapacity === undefined ? undefined : <span className={`badge ${remainingMintCapacity > 0n ? 'ok' : 'blocked'}`}>{remainingMintCapacity > 0n ? 'Capacity available' : 'Capacity full'}</span>}
 			</div>
 			<label className='field'>
 				<span>Mint Complete Sets Amount</span>

--- a/ui/ts/components/TradingSection.tsx
+++ b/ui/ts/components/TradingSection.tsx
@@ -8,13 +8,14 @@ import { TransactionHashLink } from './TransactionHashLink.js'
 import { UniverseLink } from './UniverseLink.js'
 import { isMainnetChain } from '../lib/network.js'
 import { REPORTING_OUTCOME_DROPDOWN_OPTIONS } from '../lib/reporting.js'
-import { getRemainingMintCapacity, getTradingMintGuardMessage } from '../lib/trading.js'
+import { getRemainingMintCapacity, getTradingMintGuardMessage, hasRepBackedPoolWithNoActiveAllowance } from '../lib/trading.js'
 import type { TradingSectionProps } from '../types/components.js'
 
 export function TradingSection({ accountState, embedInCard = false, onCreateCompleteSet, onMigrateShares, onRedeemCompleteSet, onRedeemShares, onTradingFormChange, selectedPool, tradingError, tradingForm, tradingResult, showHeader = true, showSecurityPoolAddressInput = true }: TradingSectionProps) {
 	const isMainnet = isMainnetChain(accountState.chainId)
 	const currentTimestamp = BigInt(Math.floor(Date.now() / 1000))
 	const remainingMintCapacity = getRemainingMintCapacity(selectedPool?.totalSecurityBondAllowance, selectedPool?.completeSetCollateralAmount)
+	const hasRepWithoutActiveAllowance = hasRepBackedPoolWithNoActiveAllowance(selectedPool?.totalRepDeposit, selectedPool?.totalSecurityBondAllowance)
 	const marketHasEnded = selectedPool?.marketDetails.endTime === undefined ? undefined : selectedPool.marketDetails.endTime <= currentTimestamp
 	const mintGuardMessage = getTradingMintGuardMessage({
 		accountAddress: accountState.address,
@@ -23,6 +24,7 @@ export function TradingSection({ accountState, embedInCard = false, onCreateComp
 		isMainnet,
 		mintAmountInput: tradingForm.completeSetAmount,
 		systemState: selectedPool?.systemState,
+		totalRepDeposit: selectedPool?.totalRepDeposit,
 		totalSecurityBondAllowance: selectedPool?.totalSecurityBondAllowance,
 	})
 	const redeemCompleteSetGuardMessage = (() => {
@@ -114,7 +116,7 @@ export function TradingSection({ accountState, embedInCard = false, onCreateComp
 						<MetricField label='Universe'>
 							<UniverseLink universeId={selectedPool.universeId} />
 						</MetricField>
-						<OpenInterestCapacityMetrics completeSetCollateralAmount={selectedPool.completeSetCollateralAmount} totalSecurityBondAllowance={selectedPool.totalSecurityBondAllowance} />
+						<OpenInterestCapacityMetrics completeSetCollateralAmount={selectedPool.completeSetCollateralAmount} totalRepDeposit={selectedPool.totalRepDeposit} totalSecurityBondAllowance={selectedPool.totalSecurityBondAllowance} />
 					</div>
 				)}
 			</div>
@@ -123,7 +125,7 @@ export function TradingSection({ accountState, embedInCard = false, onCreateComp
 		<div className='entity-card-subsection'>
 			<div className='entity-card-subsection-header'>
 				<h4>Mint Complete Sets</h4>
-				{remainingMintCapacity === undefined ? undefined : <span className={`badge ${remainingMintCapacity > 0n ? 'ok' : 'blocked'}`}>{remainingMintCapacity > 0n ? 'Capacity available' : 'Capacity full'}</span>}
+				{remainingMintCapacity === undefined ? undefined : hasRepWithoutActiveAllowance ? <span className='badge muted'>No active allowances</span> : <span className={`badge ${remainingMintCapacity > 0n ? 'ok' : 'blocked'}`}>{remainingMintCapacity > 0n ? 'Capacity available' : 'Capacity full'}</span>}
 			</div>
 			<label className='field'>
 				<span>Mint Complete Sets Amount</span>

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -2111,7 +2111,7 @@ export async function loadAllSecurityPools(client: ReadClient): Promise<ListedSe
 	return await Promise.all(
 		deployments.map(async deployment => {
 			const { parent, priceOracleManagerAndOperatorQueuer: managerAddress, questionId, securityMultiplier, securityPool: securityPoolAddress, truthAuction: truthAuctionAddress, universeId } = deployment
-			const [completeSetCollateralAmount, currentRetentionRate, forkData, marketDetails, systemState, totalSecurityBondAllowance] = await Promise.all([
+			const [completeSetCollateralAmount, currentRetentionRate, forkData, lastOraclePrice, lastSettlementTimestamp, marketDetails, systemState, totalSecurityBondAllowance] = await Promise.all([
 				client.readContract({
 					abi: peripherals_SecurityPool_SecurityPool.abi,
 					functionName: 'completeSetCollateralAmount',
@@ -2129,6 +2129,18 @@ export async function loadAllSecurityPools(client: ReadClient): Promise<ListedSe
 					functionName: 'forkData',
 					address: getInfraContractAddresses().securityPoolForker,
 					args: [securityPoolAddress],
+				}),
+				client.readContract({
+					abi: peripherals_PriceOracleManagerAndOperatorQueuer_PriceOracleManagerAndOperatorQueuer.abi,
+					functionName: 'lastPrice',
+					address: managerAddress,
+					args: [],
+				}),
+				client.readContract({
+					abi: peripherals_PriceOracleManagerAndOperatorQueuer_PriceOracleManagerAndOperatorQueuer.abi,
+					functionName: 'lastSettlementTimestamp',
+					address: managerAddress,
+					args: [],
 				}),
 				loadMarketDetails(client, questionId),
 				client.readContract({
@@ -2154,6 +2166,7 @@ export async function loadAllSecurityPools(client: ReadClient): Promise<ListedSe
 				currentRetentionRate,
 				forkOutcome: getReportingOutcomeKey(forkOutcomeIndex),
 				forkOwnSecurityPool,
+				lastOraclePrice: lastSettlementTimestamp > 0n ? lastOraclePrice : undefined,
 				managerAddress,
 				marketDetails,
 				migratedRep,

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -2141,6 +2141,7 @@ export async function loadAllSecurityPools(client: ReadClient): Promise<ListedSe
 			const [, , truthAuctionStartedAt, migratedRep, , forkOwnSecurityPool, forkOutcomeIndex] = forkDataTuple
 
 			const { vaultCount, vaults } = await loadSecurityPoolVaultSummaries(client, securityPoolAddress)
+			const totalRepDeposit = vaults.reduce((sum, vault) => sum + vault.repDepositShare, 0n)
 			return {
 				completeSetCollateralAmount,
 				currentRetentionRate,
@@ -2154,6 +2155,7 @@ export async function loadAllSecurityPools(client: ReadClient): Promise<ListedSe
 				securityMultiplier,
 				securityPoolAddress,
 				systemState: getSecurityPoolSystemState(systemState),
+				totalRepDeposit,
 				totalSecurityBondAllowance,
 				truthAuctionAddress,
 				truthAuctionStartedAt,

--- a/ui/ts/lib/trading.ts
+++ b/ui/ts/lib/trading.ts
@@ -2,9 +2,16 @@ import type { Address } from 'viem'
 import { formatCurrencyBalance } from './formatters.js'
 import type { SecurityPoolSystemState } from '../types/contracts.js'
 
+const PRICE_PRECISION = 10n ** 18n
+
 export function getRemainingMintCapacity(totalSecurityBondAllowance: bigint | undefined, completeSetCollateralAmount: bigint | undefined) {
 	if (totalSecurityBondAllowance === undefined || completeSetCollateralAmount === undefined) return undefined
 	return totalSecurityBondAllowance > completeSetCollateralAmount ? totalSecurityBondAllowance - completeSetCollateralAmount : 0n
+}
+
+export function getAllowanceBackedRep(totalSecurityBondAllowance: bigint | undefined, lastOraclePrice: bigint | undefined) {
+	if (totalSecurityBondAllowance === undefined || lastOraclePrice === undefined) return undefined
+	return (totalSecurityBondAllowance * lastOraclePrice) / PRICE_PRECISION
 }
 
 export function hasRepBackedPoolWithNoActiveAllowance(totalRepDeposit: bigint | undefined, totalSecurityBondAllowance: bigint | undefined) {

--- a/ui/ts/lib/trading.ts
+++ b/ui/ts/lib/trading.ts
@@ -7,6 +7,10 @@ export function getRemainingMintCapacity(totalSecurityBondAllowance: bigint | un
 	return totalSecurityBondAllowance > completeSetCollateralAmount ? totalSecurityBondAllowance - completeSetCollateralAmount : 0n
 }
 
+export function hasRepBackedPoolWithNoActiveAllowance(totalRepDeposit: bigint | undefined, totalSecurityBondAllowance: bigint | undefined) {
+	return (totalRepDeposit ?? 0n) > 0n && (totalSecurityBondAllowance ?? 0n) === 0n
+}
+
 export function getTradingMintGuardMessage({
 	accountAddress,
 	completeSetCollateralAmount,
@@ -14,6 +18,7 @@ export function getTradingMintGuardMessage({
 	isMainnet,
 	mintAmountInput,
 	systemState,
+	totalRepDeposit,
 	totalSecurityBondAllowance,
 }: {
 	accountAddress: Address | undefined
@@ -22,6 +27,7 @@ export function getTradingMintGuardMessage({
 	isMainnet: boolean
 	mintAmountInput: string
 	systemState: SecurityPoolSystemState | undefined
+	totalRepDeposit: bigint | undefined
 	totalSecurityBondAllowance: bigint | undefined
 }) {
 	if (accountAddress === undefined) return 'Connect a wallet before minting complete sets.'
@@ -30,7 +36,13 @@ export function getTradingMintGuardMessage({
 
 	const remainingCapacity = getRemainingMintCapacity(totalSecurityBondAllowance, completeSetCollateralAmount)
 	if (remainingCapacity === undefined) return 'Loading pool mint capacity.'
-	if (remainingCapacity === 0n) return 'This pool has no remaining mint capacity.'
+	if (remainingCapacity === 0n) {
+		if (hasRepBackedPoolWithNoActiveAllowance(totalRepDeposit, totalSecurityBondAllowance)) {
+			return 'This pool has no remaining mint capacity because its vaults currently have no active security bond allowance. Deposited REP alone does not create mint capacity.'
+		}
+
+		return 'This pool has no remaining mint capacity.'
+	}
 
 	const trimmedAmount = mintAmountInput.trim()
 	if (trimmedAmount === '') return 'Enter a mint amount greater than zero.'

--- a/ui/ts/tests/trading.test.ts
+++ b/ui/ts/tests/trading.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from 'bun:test'
-import { getRemainingMintCapacity, getTradingMintGuardMessage } from '../lib/trading.js'
+import { getRemainingMintCapacity, getTradingMintGuardMessage, hasRepBackedPoolWithNoActiveAllowance } from '../lib/trading.js'
 
 void describe('trading helpers', () => {
 	void test('computes remaining mint capacity from total bond allowance and minted open interest', () => {
@@ -9,6 +9,12 @@ void describe('trading helpers', () => {
 		expect(getRemainingMintCapacity(10n, 10n)).toBe(0n)
 		expect(getRemainingMintCapacity(10n, 12n)).toBe(0n)
 		expect(getRemainingMintCapacity(undefined, 12n)).toBeUndefined()
+	})
+
+	void test('detects pools that have REP backing but no active allowance', () => {
+		expect(hasRepBackedPoolWithNoActiveAllowance(20n * 10n ** 18n, 0n)).toBe(true)
+		expect(hasRepBackedPoolWithNoActiveAllowance(20n * 10n ** 18n, 1n)).toBe(false)
+		expect(hasRepBackedPoolWithNoActiveAllowance(0n, 0n)).toBe(false)
 	})
 
 	void test('blocks minting until the wallet is connected on mainnet', () => {
@@ -20,6 +26,7 @@ void describe('trading helpers', () => {
 				isMainnet: true,
 				mintAmountInput: '1',
 				systemState: 'operational',
+				totalRepDeposit: 0n,
 				totalSecurityBondAllowance: 10n,
 			}),
 		).toBe('Connect a wallet before minting complete sets.')
@@ -32,6 +39,7 @@ void describe('trading helpers', () => {
 				isMainnet: false,
 				mintAmountInput: '1',
 				systemState: 'operational',
+				totalRepDeposit: 0n,
 				totalSecurityBondAllowance: 10n,
 			}),
 		).toBe('Switch to Ethereum mainnet before minting complete sets.')
@@ -46,6 +54,7 @@ void describe('trading helpers', () => {
 				isMainnet: true,
 				mintAmountInput: '100',
 				systemState: 'forkMigration',
+				totalRepDeposit: 0n,
 				totalSecurityBondAllowance: 10n,
 			}),
 		).toBe('Minting is only available while the pool is operational.')
@@ -58,6 +67,7 @@ void describe('trading helpers', () => {
 				isMainnet: true,
 				mintAmountInput: '100',
 				systemState: 'operational',
+				totalRepDeposit: 0n,
 				totalSecurityBondAllowance: 10n,
 			}),
 		).toBe('Loading pool mint capacity.')
@@ -70,6 +80,7 @@ void describe('trading helpers', () => {
 				isMainnet: true,
 				mintAmountInput: '100',
 				systemState: 'operational',
+				totalRepDeposit: 0n,
 				totalSecurityBondAllowance: 10n,
 			}),
 		).toBe('This pool has no remaining mint capacity.')
@@ -80,8 +91,22 @@ void describe('trading helpers', () => {
 				completeSetCollateralAmount: 0n,
 				ethBalance: 10n ** 18n,
 				isMainnet: true,
+				mintAmountInput: '100',
+				systemState: 'operational',
+				totalRepDeposit: 20n * 10n ** 18n,
+				totalSecurityBondAllowance: 0n,
+			}),
+		).toBe('This pool has no remaining mint capacity because its vaults currently have no active security bond allowance. Deposited REP alone does not create mint capacity.')
+
+		expect(
+			getTradingMintGuardMessage({
+				accountAddress: '0x1234567890123456789012345678901234567890',
+				completeSetCollateralAmount: 0n,
+				ethBalance: 10n ** 18n,
+				isMainnet: true,
 				mintAmountInput: 'abc',
 				systemState: 'operational',
+				totalRepDeposit: 0n,
 				totalSecurityBondAllowance: 10n ** 18n,
 			}),
 		).toBe('Enter a valid whole-number mint amount.')
@@ -94,6 +119,7 @@ void describe('trading helpers', () => {
 				isMainnet: true,
 				mintAmountInput: '0',
 				systemState: 'operational',
+				totalRepDeposit: 0n,
 				totalSecurityBondAllowance: 10n ** 18n,
 			}),
 		).toBe('Enter a mint amount greater than zero.')
@@ -106,6 +132,7 @@ void describe('trading helpers', () => {
 				isMainnet: true,
 				mintAmountInput: '300000000000000000',
 				systemState: 'operational',
+				totalRepDeposit: 0n,
 				totalSecurityBondAllowance: 10n ** 18n,
 			}),
 		).toBe('This pool only has 0.2 ETH of mint capacity remaining.')
@@ -118,6 +145,7 @@ void describe('trading helpers', () => {
 				isMainnet: true,
 				mintAmountInput: '1000000000000000000',
 				systemState: 'operational',
+				totalRepDeposit: 0n,
 				totalSecurityBondAllowance: 2n * 10n ** 18n,
 			}),
 		).toBe('Need 0.5 more ETH in this wallet to mint the selected amount.')
@@ -132,6 +160,7 @@ void describe('trading helpers', () => {
 				isMainnet: true,
 				mintAmountInput: '500000000000000000',
 				systemState: 'operational',
+				totalRepDeposit: 0n,
 				totalSecurityBondAllowance: 2n * 10n ** 18n,
 			}),
 		).toBeUndefined()

--- a/ui/ts/tests/trading.test.ts
+++ b/ui/ts/tests/trading.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from 'bun:test'
-import { getRemainingMintCapacity, getTradingMintGuardMessage, hasRepBackedPoolWithNoActiveAllowance } from '../lib/trading.js'
+import { getAllowanceBackedRep, getRemainingMintCapacity, getTradingMintGuardMessage, hasRepBackedPoolWithNoActiveAllowance } from '../lib/trading.js'
 
 void describe('trading helpers', () => {
 	void test('computes remaining mint capacity from total bond allowance and minted open interest', () => {
@@ -9,6 +9,12 @@ void describe('trading helpers', () => {
 		expect(getRemainingMintCapacity(10n, 10n)).toBe(0n)
 		expect(getRemainingMintCapacity(10n, 12n)).toBe(0n)
 		expect(getRemainingMintCapacity(undefined, 12n)).toBeUndefined()
+	})
+
+	void test('converts allowance to REP using the latest oracle price', () => {
+		expect(getAllowanceBackedRep(2n * 10n ** 18n, 2_500n * 10n ** 18n)).toBe(5_000n * 10n ** 18n)
+		expect(getAllowanceBackedRep(undefined, 2_500n * 10n ** 18n)).toBeUndefined()
+		expect(getAllowanceBackedRep(2n * 10n ** 18n, undefined)).toBeUndefined()
 	})
 
 	void test('detects pools that have REP backing but no active allowance', () => {

--- a/ui/ts/types/contracts.ts
+++ b/ui/ts/types/contracts.ts
@@ -230,6 +230,7 @@ export type ListedSecurityPool = {
 	currentRetentionRate: bigint
 	forkOutcome: ReportingOutcomeKey | 'none'
 	forkOwnSecurityPool: boolean
+	lastOraclePrice: bigint | undefined
 	managerAddress: Address
 	marketDetails: MarketDetails
 	migratedRep: bigint

--- a/ui/ts/types/contracts.ts
+++ b/ui/ts/types/contracts.ts
@@ -238,6 +238,7 @@ export type ListedSecurityPool = {
 	securityMultiplier: bigint
 	securityPoolAddress: Address
 	systemState: SecurityPoolSystemState
+	totalRepDeposit: bigint
 	totalSecurityBondAllowance: bigint
 	truthAuctionAddress: Address
 	truthAuctionStartedAt: bigint


### PR DESCRIPTION
## Summary
- Show REP-backed security pools even when no active security bond allowance is set, with clearer capacity status in trading and pool views.
- Add wallet balance checks to open-oracle initial report flow so the UI can surface required token balances, ETH shortfalls, and WETH wrap requirements.
- Add an explicit ETH-to-WETH wrapping action for initial oracle reports that need wrapped ETH before submission.
- Update tests to cover the new open-oracle and trading balance / wrapping behavior.

## Testing
- `bun tsc`
- `bun test`
- `bun run format`
- `bun run check`
- `bun run knip`