### PR TITLE
Add WETH wrap flow and clearer approval/status display

### DIFF
--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -134,6 +134,7 @@ export function App() {
 		setOpenOracleForm,
 		settleReport,
 		submitInitialReport,
+		wrapWethForInitialReport,
 	} = useOpenOracleOperations(baseHookConfig)
 	const { loadingReportingDetails, loadReporting, onReportOutcome, reportingDetails, reportingError, reportingForm, reportingResult, setReportingForm, withdrawEscalation } = useReportingOperations(baseHookConfig)
 	const { loadingPoolOracleManager, loadPoolOracleManager, poolOracleManagerDetails, poolOracleManagerError, poolPriceOracleResult, requestPoolPrice } = usePriceOracleManager(baseHookConfig)
@@ -179,7 +180,7 @@ export function App() {
 		submitBid,
 		withdrawBids,
 	} = useForkAuctionOperations(baseHookConfig)
-	const { repEthPrice, repEthSource, repUsdcPrice, repUsdcSource, isLoadingRepPrices } = useRepPrices()
+	const { repEthPrice, repEthSource, repEthSourceUrl, repUsdcPrice, repUsdcSource, repUsdcSourceUrl, isLoadingRepPrices } = useRepPrices()
 	const deploymentSections = getDeploymentSections(deploymentStatuses)
 	const errorMessage = deploymentErrorMessage ?? walletErrorMessage
 	const isMainnet = isMainnetChain(accountState.chainId)
@@ -431,6 +432,7 @@ export function App() {
 						onOpenOracleFormChange={update => setOpenOracleForm(current => ({ ...current, ...update }))}
 						onSettleReport={() => void settleReport()}
 						onSubmitInitialReport={() => void submitInitialReport()}
+						onWrapWethForInitialReport={() => void wrapWethForInitialReport()}
 						loadingOpenOracleCreate={loadingOpenOracleCreate}
 						openOracleError={openOracleError}
 						openOracleCreateForm={openOracleCreateForm}
@@ -540,8 +542,10 @@ export function App() {
 						onGoToGenesisUniverse={() => setActiveUniverseId(0n)}
 						repEthPrice={repEthPrice}
 						repEthSource={repEthSource}
+						repEthSourceUrl={repEthSourceUrl}
 						repUsdcPrice={repUsdcPrice}
 						repUsdcSource={repUsdcSource}
+						repUsdcSourceUrl={repUsdcSourceUrl}
 						universePresentation={universePresentation}
 						universeLabel={universeLabel}
 						universeRepBalance={zoltarForkRepBalance}

--- a/ui/ts/components/ApprovedAmountValue.tsx
+++ b/ui/ts/components/ApprovedAmountValue.tsx
@@ -1,0 +1,29 @@
+import { CurrencyValue } from './CurrencyValue.js'
+
+export const APPROVAL_MAX_DISPLAY_THRESHOLD = (1n << 200n) - 1n
+
+type ApprovedAmountValueProps = {
+	className?: string
+	copyable?: boolean
+	decimals?: number
+	loading?: boolean
+	suffix?: string
+	units?: number
+	value: bigint | undefined
+}
+
+export function isApprovalAmountMaxDisplay(value: bigint | undefined) {
+	return value !== undefined && value > APPROVAL_MAX_DISPLAY_THRESHOLD
+}
+
+export function ApprovedAmountValue({ className = '', copyable = true, decimals = 2, loading = false, suffix = '', units = 18, value }: ApprovedAmountValueProps) {
+	if (isApprovalAmountMaxDisplay(value)) {
+		return (
+			<span className={`currency-value approval-max ${className}`.trim()} title='Unlimited approval'>
+				max
+			</span>
+		)
+	}
+
+	return <CurrencyValue className={className} copyable={copyable} decimals={decimals} loading={loading} suffix={suffix} units={units} value={value} />
+}

--- a/ui/ts/components/ForkZoltarSection.tsx
+++ b/ui/ts/components/ForkZoltarSection.tsx
@@ -1,4 +1,5 @@
 import type { Address } from 'viem'
+import { ApprovedAmountValue } from './ApprovedAmountValue.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { EntityCard } from './EntityCard.js'
 import { ErrorNotice } from './ErrorNotice.js'
@@ -84,7 +85,7 @@ export function ForkZoltarSection({
 						<CurrencyValue loading={loadingZoltarForkAccess || rootUniverse === undefined} value={rootUniverse?.forkThreshold} suffix='REP' />
 					</MetricField>
 					<MetricField label='REP Approved To Zoltar'>
-						<CurrencyValue loading={loadingZoltarForkAccess} value={zoltarForkAllowance} suffix='REP' />
+						<ApprovedAmountValue loading={loadingZoltarForkAccess} value={zoltarForkAllowance} suffix='REP' />
 					</MetricField>
 				</div>
 

--- a/ui/ts/components/OpenOracleSection.tsx
+++ b/ui/ts/components/OpenOracleSection.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'preact/hooks'
 import type { ComponentChildren } from 'preact'
 import { zeroAddress } from 'viem'
 import { AddressValue } from './AddressValue.js'
+import { ApprovedAmountValue } from './ApprovedAmountValue.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { EntityCard } from './EntityCard.js'
 import { EnumDropdown, type EnumDropdownOption } from './EnumDropdown.js'
@@ -39,6 +40,20 @@ function renderReportSection(title: string, fields: Array<{ label: string; value
 			</div>
 			<div className='question-summary-grid'>{fields.map(field => renderReportField(field.label, field.value))}</div>
 		</div>
+	)
+}
+
+function renderInitialPriceSourceLabel(priceSource: string, priceSourceUrl: string | undefined) {
+	if (priceSourceUrl === undefined) {
+		return <strong>{priceSource}</strong>
+	}
+
+	return (
+		<strong>
+			<a href={priceSourceUrl} target='_blank' rel='noreferrer'>
+				{priceSource}
+			</a>
+		</strong>
 	)
 }
 
@@ -92,6 +107,7 @@ function renderSelectedReportActionSection(
 	onRefreshPrice: () => void,
 	onSettleReport: () => void,
 	onSubmitInitialReport: () => void,
+	onWrapWethForInitialReport: () => void,
 ) {
 	const disputeTokenOptions: EnumDropdownOption<OpenOracleFormState['disputeTokenToSwap']>[] = [
 		{ value: 'token1', label: token1Symbol },
@@ -112,13 +128,11 @@ function renderSelectedReportActionSection(
 							</label>
 							<div className='actions'>
 								<button className='secondary' onClick={onRefreshPrice} disabled={openOracleInitialReportState.loading}>
-									{openOracleInitialReportState.loading ? 'Fetching...' : 'Fetch Price'}
+									{openOracleInitialReportState.loading ? 'Fetching...' : 'Fetch price from Uniswap'}
 								</button>
 							</div>
 						</div>
-						<p className='detail'>
-							Price source: <strong>{openOracleInitialReportState.loading ? 'Loading...' : initialReportSubmission.priceSource}</strong>
-						</p>
+						<p className='detail'>Price source: {openOracleInitialReportState.loading ? <strong>Loading...</strong> : renderInitialPriceSourceLabel(initialReportSubmission.priceSource, initialReportSubmission.priceSourceUrl)}</p>
 						<div className='question-summary-grid'>
 							<MetricField label={`Required ${token1Symbol}`}>
 								<CurrencyValue value={initialReportSubmission.amount1} units={initialReportSubmission.token1Decimals ?? 18} suffix={token1Symbol} copyable={false} />
@@ -127,12 +141,25 @@ function renderSelectedReportActionSection(
 								<CurrencyValue value={initialReportSubmission.amount2} units={initialReportSubmission.token2Decimals ?? 18} suffix={token2Symbol} copyable={false} />
 							</MetricField>
 							<MetricField label={`Approved ${token1Symbol}`}>
-								<CurrencyValue value={initialReportSubmission.approvedToken1Amount} units={initialReportSubmission.token1Decimals ?? 18} suffix={token1Symbol} copyable={false} />
+								<ApprovedAmountValue value={initialReportSubmission.approvedToken1Amount} units={initialReportSubmission.token1Decimals ?? 18} suffix={token1Symbol} copyable={false} />
 							</MetricField>
 							<MetricField label={`Approved ${token2Symbol}`}>
-								<CurrencyValue value={initialReportSubmission.approvedToken2Amount} units={initialReportSubmission.token2Decimals ?? 18} suffix={token2Symbol} copyable={false} />
+								<ApprovedAmountValue value={initialReportSubmission.approvedToken2Amount} units={initialReportSubmission.token2Decimals ?? 18} suffix={token2Symbol} copyable={false} />
 							</MetricField>
 						</div>
+						{initialReportSubmission.requiredWethWrapAmount === undefined || initialReportSubmission.requiredWethWrapAmount <= 0n ? undefined : (
+							<div className='entity-card-subsection'>
+								<p className='detail'>
+									Need <CurrencyValue value={initialReportSubmission.requiredWethWrapAmount} suffix='WETH' copyable={false} /> more WETH for this report.
+								</p>
+								{initialReportSubmission.wrapRequiredWethDisabledReason === undefined ? undefined : <p className='detail'>{initialReportSubmission.wrapRequiredWethDisabledReason}</p>}
+								<div className='actions'>
+									<button className='secondary' onClick={onWrapWethForInitialReport} disabled={!isConnected || !initialReportSubmission.canWrapRequiredWeth || openOracleInitialReportState.loading} title={initialReportSubmission.wrapRequiredWethDisabledReason}>
+										Wrap needed ETH to WETH
+									</button>
+								</div>
+							</div>
+						)}
 						<div className='field-row'>
 							<label className='field'>
 								<span>{`${token1Symbol} Approve Amount (leave empty for max)`}</span>
@@ -211,6 +238,7 @@ function renderSelectedReportActionSection(
 }
 
 function renderReportDetailsCard(
+	accountEthBalance: bigint | undefined,
 	openOracleReportDetails: OpenOracleReportDetails | undefined,
 	openOracleForm: OpenOracleFormState,
 	openOracleInitialReportState: OpenOracleSectionProps['openOracleInitialReportState'],
@@ -224,6 +252,7 @@ function renderReportDetailsCard(
 	onRefreshPrice: () => void,
 	onSettleReport: () => void,
 	onSubmitInitialReport: () => void,
+	onWrapWethForInitialReport: () => void,
 ) {
 	if (openOracleReportDetails === undefined) {
 		const reportPresentation = getReportPresentation({
@@ -269,14 +298,20 @@ function renderReportDetailsCard(
 		defaultPrice: openOracleInitialReportState.defaultPrice,
 		defaultPriceError: openOracleInitialReportState.defaultPriceError,
 		defaultPriceSource: openOracleInitialReportState.defaultPriceSource,
+		defaultPriceSourceUrl: openOracleInitialReportState.defaultPriceSourceUrl,
 		priceInput: openOracleForm.price,
 		quoteAttemptedSources: openOracleInitialReportState.quoteAttemptedSources,
 		quoteFailureReason: openOracleInitialReportState.quoteFailureReason,
 		reportDetails: openOracleReportDetails,
+		token1Balance: openOracleInitialReportState.token1Balance,
+		token1BalanceError: openOracleInitialReportState.token1BalanceError,
 		token1AllowanceError: openOracleInitialReportState.token1AllowanceError,
 		token2AllowanceError: openOracleInitialReportState.token2AllowanceError,
+		token2Balance: openOracleInitialReportState.token2Balance,
+		token2BalanceError: openOracleInitialReportState.token2BalanceError,
 		token1Decimals: openOracleInitialReportState.token1Decimals ?? openOracleReportDetails.token1Decimals,
 		token2Decimals: openOracleInitialReportState.token2Decimals ?? openOracleReportDetails.token2Decimals,
+		walletEthBalance: accountEthBalance,
 	})
 
 	return (
@@ -454,6 +489,7 @@ function renderReportDetailsCard(
 				onRefreshPrice,
 				onSettleReport,
 				onSubmitInitialReport,
+				onWrapWethForInitialReport,
 			)}
 		</EntityCard>
 	)
@@ -485,6 +521,7 @@ export function OpenOracleSection({
 	onRefreshPrice,
 	onSettleReport,
 	onSubmitInitialReport,
+	onWrapWethForInitialReport,
 	loadingOpenOracleCreate,
 	openOracleCreateForm,
 	openOracleError,
@@ -687,7 +724,23 @@ export function OpenOracleSection({
 			{view === 'selected-report' ? (
 				<div className='market-grid'>
 					<div className='market-column'>
-						{renderReportDetailsCard(openOracleReportDetails, openOracleForm, openOracleInitialReportState, loadingOracleReport, isConnected, onApproveToken1, onApproveToken2, onDisputeReport, onLoadOracleReport, onOpenOracleFormChange, onRefreshPrice, onSettleReport, onSubmitInitialReport)}
+						{renderReportDetailsCard(
+							accountState.ethBalance,
+							openOracleReportDetails,
+							openOracleForm,
+							openOracleInitialReportState,
+							loadingOracleReport,
+							isConnected,
+							onApproveToken1,
+							onApproveToken2,
+							onDisputeReport,
+							onLoadOracleReport,
+							onOpenOracleFormChange,
+							onRefreshPrice,
+							onSettleReport,
+							onSubmitInitialReport,
+							onWrapWethForInitialReport,
+						)}
 						{renderLatestActionCard(openOracleResult)}
 					</div>
 				</div>

--- a/ui/ts/components/OverviewPanels.tsx
+++ b/ui/ts/components/OverviewPanels.tsx
@@ -4,10 +4,6 @@ import { MetricField } from './MetricField.js'
 import { StateHint } from './StateHint.js'
 import type { OverviewPanelsProps } from '../types/components.js'
 
-const UNISWAP_EXPLORE = 'https://app.uniswap.org/explore/pools/ethereum'
-const REP_ETH_V3_POOL_URL = `${UNISWAP_EXPLORE}/0xb055103b7633b61518CD806D95beeB2d4Cd217E7`
-const REP_USDC_V4_POOL_URL = `${UNISWAP_EXPLORE}/0x75d479eb83b7c9008ab854e74625a01841e5b3e06af40a89c10998ad2664f356`
-
 export function OverviewPanels({
 	accountState,
 	isConnectingWallet,
@@ -17,8 +13,10 @@ export function OverviewPanels({
 	onGoToGenesisUniverse,
 	repEthPrice,
 	repEthSource,
+	repEthSourceUrl,
 	repUsdcPrice,
 	repUsdcSource,
+	repUsdcSourceUrl,
 	universePresentation,
 	universeLabel,
 	universeRepBalance,
@@ -27,6 +25,15 @@ export function OverviewPanels({
 }: OverviewPanelsProps) {
 	const isWalletLoading = isConnectingWallet || (!walletBootstrapComplete && accountState.address === undefined)
 	const showAccountBalances = walletBootstrapComplete && accountState.address !== undefined
+	const renderSourceLink = (source: 'v3' | 'v4', sourceUrl: string | undefined) => {
+		const label = `u${source === 'v4' ? '4' : '3'}`
+		if (sourceUrl === undefined) return `(${label})`
+		return (
+			<a href={sourceUrl} title={source === 'v4' ? 'Price from Uniswap V4' : 'Price from Uniswap V3'} target='_blank' rel='noreferrer'>
+				{`(${label})`}
+			</a>
+		)
+	}
 
 	return (
 		<section className='overview-shell'>
@@ -59,32 +66,10 @@ export function OverviewPanels({
 									</MetricField>
 								</>
 							) : undefined}
-							<MetricField
-								label={
-									<>
-										REP/ETH{' '}
-										{repEthSource === undefined ? undefined : (
-											<a href={repEthSource === 'v4' ? undefined : REP_ETH_V3_POOL_URL} title={repEthSource === 'v4' ? 'Price from Uniswap V4' : 'Price from Uniswap V3 (REP/WETH pool)'} target='_blank' rel='noreferrer'>
-												{`(u${repEthSource === 'v4' ? '4' : '3'})`}
-											</a>
-										)}
-									</>
-								}
-							>
+							<MetricField label={<>REP/ETH {repEthSource === undefined ? undefined : renderSourceLink(repEthSource, repEthSourceUrl)}</>}>
 								<CurrencyValue value={repEthPrice} loading={isLoadingRepPrices} suffix='ETH' />
 							</MetricField>
-							<MetricField
-								label={
-									<>
-										REP/USDC{' '}
-										{repUsdcSource === undefined ? undefined : (
-											<a href={repUsdcSource === 'v4' ? REP_USDC_V4_POOL_URL : undefined} title={repUsdcSource === 'v4' ? 'Price from Uniswap V4 (REP/USDC pool)' : 'Price from Uniswap V3 (REP/USDC pool)'} target='_blank' rel='noreferrer'>
-												{`(u${repUsdcSource === 'v4' ? '4' : '3'})`}
-											</a>
-										)}
-									</>
-								}
-							>
+							<MetricField label={<>REP/USDC {repUsdcSource === undefined ? undefined : renderSourceLink(repUsdcSource, repUsdcSourceUrl)}</>}>
 								<CurrencyValue value={repUsdcPrice} loading={isLoadingRepPrices} suffix='USDC' units={6} />
 							</MetricField>
 							<MetricField label='Universe' valueClassName={universePresentation === undefined ? undefined : 'overview-universe-error'}>

--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'preact/hooks'
 import { AddressValue } from './AddressValue.js'
+import { ApprovedAmountValue } from './ApprovedAmountValue.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { EntityCard } from './EntityCard.js'
 import { ErrorNotice } from './ErrorNotice.js'
@@ -137,7 +138,7 @@ export function SecurityVaultSection({
 						<CurrencyValue value={securityVaultDetails.repDepositShare} suffix='REP' />
 					</MetricField>
 					<MetricField className='entity-metric' label='Approved REP'>
-						{approvedRep === undefined ? <LoadingText>Loading...</LoadingText> : <CurrencyValue value={approvedRep} suffix='REP' />}
+						{approvedRep === undefined ? <LoadingText>Loading...</LoadingText> : <ApprovedAmountValue value={approvedRep} suffix='REP' />}
 					</MetricField>
 					<MetricField className='entity-metric' label='Security Bond Allowance'>
 						<CurrencyValue value={securityBondAllowance} suffix='REP' />

--- a/ui/ts/components/ZoltarMigrationSection.tsx
+++ b/ui/ts/components/ZoltarMigrationSection.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'preact/hooks'
 import type { Address } from 'viem'
+import { ApprovedAmountValue } from './ApprovedAmountValue.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { EntityCard } from './EntityCard.js'
 import { ErrorNotice } from './ErrorNotice.js'
@@ -230,7 +231,7 @@ export function ZoltarMigrationSection({
 					</MetricField>
 					<div>
 						<MetricField label='Approved REP'>
-							<CurrencyValue loading={loadingZoltarForkAccess && zoltarForkAllowance === undefined} value={zoltarForkAllowance} suffix='REP' />
+							<ApprovedAmountValue loading={loadingZoltarForkAccess && zoltarForkAllowance === undefined} value={zoltarForkAllowance} suffix='REP' />
 						</MetricField>
 						{approvalGap === undefined || approvalGap === 0n ? undefined : (
 							<p className='detail'>

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -5,6 +5,7 @@ import { createApplyLinkedLibrariesHelper, createDeploymentStatusOracleAddressHe
 import { assertNever } from './lib/assert.js'
 import { getOracleManagerPriceValidUntilTimestamp } from './lib/securityVault.js'
 import { addOpenOracleBountyBuffer } from './lib/openOracle.js'
+import { WETH_ADDRESS } from './lib/uniswapQuoter.js'
 import { GENESIS_REPUTATION_TOKEN_ADDRESS } from './lib/universe.js'
 import {
 	DeploymentStatusOracle_DeploymentStatusOracle,
@@ -1611,6 +1612,27 @@ export async function requestOraclePrice(client: WriteClient, managerAddress: Ad
 	const hash = await writeContractAndWait(client, () => callParams)
 	return {
 		action: 'requestPrice',
+		hash,
+	} satisfies OpenOracleActionResult
+}
+
+export async function wrapWeth(client: WriteClient, amount: bigint) {
+	const hash = await writeContractAndWait(client, () => ({
+		address: WETH_ADDRESS,
+		abi: [
+			{
+				type: 'function',
+				name: 'deposit',
+				stateMutability: 'payable',
+				inputs: [],
+				outputs: [],
+			},
+		],
+		functionName: 'deposit',
+		value: amount,
+	}))
+	return {
+		action: 'wrapWeth',
 		hash,
 	} satisfies OpenOracleActionResult
 }

--- a/ui/ts/hooks/useOpenOracleOperations.ts
+++ b/ui/ts/hooks/useOpenOracleOperations.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'preact/hooks'
 import { useFormState } from './useFormState.js'
 import { useLoadController } from './useLoadController.js'
 import type { Address } from 'viem'
-import { approveErc20, createOpenOracleReportInstance, disputeOracleReport, getOpenOracleAddress, loadErc20Allowance, loadOpenOracleReportDetails, settleOracleReport, submitInitialOracleReport } from '../contracts.js'
+import { approveErc20, createOpenOracleReportInstance, disputeOracleReport, getOpenOracleAddress, loadErc20Allowance, loadErc20Balance, loadOpenOracleReportDetails, settleOracleReport, submitInitialOracleReport, wrapWeth } from '../contracts.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
 import { getErrorDetail, getErrorMessage } from '../lib/errors.js'
 import { deriveOpenOracleInitialReportSubmissionDetails, formatOpenOraclePriceInput, loadOpenOracleInitialReportPriceResult, OPEN_ORACLE_APPROVAL_AMOUNT } from '../lib/openOracle.js'
@@ -16,6 +16,23 @@ import type { OpenOracleCreateFormState, OpenOracleFormState, WriteOperationsPar
 import type { OpenOracleActionResult, OpenOracleReportDetails } from '../types/contracts.js'
 
 type UseOpenOracleOperationsParameters = WriteOperationsParameters
+type TokenAccessLoadResult = {
+	amount: bigint | undefined
+	error: string | undefined
+}
+
+type OpenOracleInitialReportStateLoadResult = {
+	initialPriceResult: Awaited<ReturnType<typeof loadOpenOracleInitialReportPriceResult>>
+	token1AllowanceResult: TokenAccessLoadResult
+	token2AllowanceResult: TokenAccessLoadResult
+	token1BalanceResult: TokenAccessLoadResult
+	token2BalanceResult: TokenAccessLoadResult
+}
+
+type LoadedOracleReportResult = {
+	details: OpenOracleReportDetails
+	reportId: bigint
+}
 
 export function useOpenOracleOperations({ accountAddress, onTransaction, onTransactionFinished, onTransactionRequested, onTransactionSubmitted, refreshState }: UseOpenOracleOperationsParameters) {
 	const loadingOpenOracleCreate = useSignal(false)
@@ -29,86 +46,100 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 	const loadedOpenOracleReportId = useSignal<bigint | undefined>(undefined)
 	const openOracleInitialReportDefaultPrice = useSignal<string | undefined>(undefined)
 	const openOracleInitialReportDefaultPriceError = useSignal<string | undefined>(undefined)
-	const openOracleInitialReportDefaultPriceSource = useSignal<'Uniswap V4' | 'Uniswap V3 fallback' | undefined>(undefined)
-	const openOracleInitialReportQuoteAttemptedSources = useSignal<('Uniswap V4' | 'Uniswap V3 fallback')[] | undefined>(undefined)
+	const openOracleInitialReportDefaultPriceSource = useSignal<'Uniswap V4' | 'Uniswap V3' | undefined>(undefined)
+	const openOracleInitialReportDefaultPriceSourceUrl = useSignal<string | undefined>(undefined)
+	const openOracleInitialReportQuoteAttemptedSources = useSignal<('Uniswap V4' | 'Uniswap V3')[] | undefined>(undefined)
 	const openOracleInitialReportQuoteFailureKind = useSignal<'unsupported-pair' | 'quote-failed' | undefined>(undefined)
 	const openOracleInitialReportQuoteFailureReason = useSignal<string | undefined>(undefined)
 	const openOracleInitialReportToken1Allowance = useSignal<bigint | undefined>(undefined)
 	const openOracleInitialReportToken1AllowanceError = useSignal<string | undefined>(undefined)
 	const openOracleInitialReportToken2Allowance = useSignal<bigint | undefined>(undefined)
 	const openOracleInitialReportToken2AllowanceError = useSignal<string | undefined>(undefined)
+	const openOracleInitialReportToken1Balance = useSignal<bigint | undefined>(undefined)
+	const openOracleInitialReportToken1BalanceError = useSignal<string | undefined>(undefined)
+	const openOracleInitialReportToken2Balance = useSignal<bigint | undefined>(undefined)
+	const openOracleInitialReportToken2BalanceError = useSignal<string | undefined>(undefined)
 	const nextOpenOracleInitialReportStateLoad = useRequestGuard()
+
+	const resetOpenOracleInitialReportState = () => {
+		openOracleInitialReportDefaultPrice.value = undefined
+		openOracleInitialReportDefaultPriceError.value = undefined
+		openOracleInitialReportDefaultPriceSource.value = undefined
+		openOracleInitialReportDefaultPriceSourceUrl.value = undefined
+		openOracleInitialReportQuoteAttemptedSources.value = undefined
+		openOracleInitialReportQuoteFailureKind.value = undefined
+		openOracleInitialReportQuoteFailureReason.value = undefined
+		openOracleInitialReportToken1Allowance.value = undefined
+		openOracleInitialReportToken1AllowanceError.value = undefined
+		openOracleInitialReportToken2Allowance.value = undefined
+		openOracleInitialReportToken2AllowanceError.value = undefined
+		openOracleInitialReportToken1Balance.value = undefined
+		openOracleInitialReportToken1BalanceError.value = undefined
+		openOracleInitialReportToken2Balance.value = undefined
+		openOracleInitialReportToken2BalanceError.value = undefined
+	}
 
 	const refreshOpenOracleInitialReportState = async (details: OpenOracleReportDetails | undefined) => {
 		const currentDetails = details
 		const isCurrent = nextOpenOracleInitialReportStateLoad()
 		if (currentDetails === undefined) {
-			openOracleInitialReportDefaultPrice.value = undefined
-			openOracleInitialReportDefaultPriceError.value = undefined
-			openOracleInitialReportDefaultPriceSource.value = undefined
-			openOracleInitialReportQuoteAttemptedSources.value = undefined
-			openOracleInitialReportQuoteFailureKind.value = undefined
-			openOracleInitialReportQuoteFailureReason.value = undefined
-			openOracleInitialReportToken1Allowance.value = undefined
-			openOracleInitialReportToken1AllowanceError.value = undefined
-			openOracleInitialReportToken2Allowance.value = undefined
-			openOracleInitialReportToken2AllowanceError.value = undefined
+			resetOpenOracleInitialReportState()
 			return
 		}
 
 		await openOracleInitialReportStateLoad.run({
 			isCurrent,
-			onStart: () => {
-				openOracleInitialReportDefaultPrice.value = undefined
-				openOracleInitialReportDefaultPriceError.value = undefined
-				openOracleInitialReportDefaultPriceSource.value = undefined
-				openOracleInitialReportQuoteAttemptedSources.value = undefined
-				openOracleInitialReportQuoteFailureKind.value = undefined
-				openOracleInitialReportQuoteFailureReason.value = undefined
-				openOracleInitialReportToken1Allowance.value = undefined
-				openOracleInitialReportToken1AllowanceError.value = undefined
-				openOracleInitialReportToken2Allowance.value = undefined
-				openOracleInitialReportToken2AllowanceError.value = undefined
-			},
+			onStart: resetOpenOracleInitialReportState,
 			load: async () => {
 				const readClient = createConnectedReadClient()
-				const loadAllowance = async (tokenAddress: Address) => {
+				const loadTokenAccess = async (tokenAddress: Address, type: 'allowance' | 'balance'): Promise<TokenAccessLoadResult> => {
 					if (accountAddress === undefined) {
-						return { allowance: undefined, error: undefined }
+						return { amount: undefined, error: undefined }
 					}
 
 					try {
 						return {
-							allowance: await loadErc20Allowance(readClient, tokenAddress, accountAddress, getOpenOracleAddress()),
+							amount: type === 'allowance' ? await loadErc20Allowance(readClient, tokenAddress, accountAddress, getOpenOracleAddress()) : await loadErc20Balance(readClient, tokenAddress, accountAddress),
 							error: undefined,
 						}
 					} catch (error) {
 						const errorDetail = getErrorDetail(error)
 						return {
-							allowance: undefined,
-							error: errorDetail === undefined ? 'Failed to load token approval' : `Failed to load token approval: ${errorDetail}`,
+							amount: undefined,
+							error: errorDetail === undefined ? `Failed to load token ${type}` : `Failed to load token ${type}: ${errorDetail}`,
 						}
 					}
 				}
 
-				const [initialPriceResult, token1AllowanceResult, token2AllowanceResult] = await Promise.all([loadOpenOracleInitialReportPriceResult(readClient, currentDetails.token1, currentDetails.token2, currentDetails.exactToken1Report), loadAllowance(currentDetails.token1), loadAllowance(currentDetails.token2)])
+				const [initialPriceResult, token1AllowanceResult, token2AllowanceResult, token1BalanceResult, token2BalanceResult] = await Promise.all([
+					loadOpenOracleInitialReportPriceResult(readClient, currentDetails.token1, currentDetails.token2, currentDetails.exactToken1Report),
+					loadTokenAccess(currentDetails.token1, 'allowance'),
+					loadTokenAccess(currentDetails.token2, 'allowance'),
+					loadTokenAccess(currentDetails.token1, 'balance'),
+					loadTokenAccess(currentDetails.token2, 'balance'),
+				])
 
-				return { initialPriceResult, token1AllowanceResult, token2AllowanceResult }
+				return { initialPriceResult, token1AllowanceResult, token2AllowanceResult, token1BalanceResult, token2BalanceResult }
 			},
-			onSuccess: ({ initialPriceResult, token1AllowanceResult, token2AllowanceResult }) => {
+			onSuccess: ({ initialPriceResult, token1AllowanceResult, token2AllowanceResult, token1BalanceResult, token2BalanceResult }: OpenOracleInitialReportStateLoadResult) => {
 				const initialPrice = initialPriceResult.status === 'success' ? initialPriceResult : undefined
 				const priceFailure = initialPriceResult.status === 'failure' ? initialPriceResult : undefined
 
 				openOracleInitialReportDefaultPrice.value = initialPrice === undefined ? undefined : formatOpenOraclePriceInput(initialPrice.price)
 				openOracleInitialReportDefaultPriceError.value = priceFailure?.reason
 				openOracleInitialReportDefaultPriceSource.value = initialPrice?.priceSource
+				openOracleInitialReportDefaultPriceSourceUrl.value = initialPrice?.priceSourceUrl
 				openOracleInitialReportQuoteAttemptedSources.value = priceFailure?.attemptedSources
 				openOracleInitialReportQuoteFailureKind.value = priceFailure?.failureKind
 				openOracleInitialReportQuoteFailureReason.value = priceFailure?.reason
-				openOracleInitialReportToken1Allowance.value = token1AllowanceResult.allowance
+				openOracleInitialReportToken1Allowance.value = token1AllowanceResult.amount
 				openOracleInitialReportToken1AllowanceError.value = token1AllowanceResult.error
-				openOracleInitialReportToken2Allowance.value = token2AllowanceResult.allowance
+				openOracleInitialReportToken2Allowance.value = token2AllowanceResult.amount
 				openOracleInitialReportToken2AllowanceError.value = token2AllowanceResult.error
+				openOracleInitialReportToken1Balance.value = token1BalanceResult.amount
+				openOracleInitialReportToken1BalanceError.value = token1BalanceResult.error
+				openOracleInitialReportToken2Balance.value = token2BalanceResult.amount
+				openOracleInitialReportToken2BalanceError.value = token2BalanceResult.error
 
 				if (openOracleForm.value.price.trim() === '' || openOracleForm.value.reportId.trim() !== currentDetails.reportId.toString()) {
 					openOracleForm.value = {
@@ -140,7 +171,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 				const details = await loadOpenOracleReportDetails(createConnectedReadClient(), getOpenOracleAddress(), reportId)
 				return { details, reportId }
 			},
-			onSuccess: ({ details, reportId }) => {
+			onSuccess: ({ details, reportId }: LoadedOracleReportResult) => {
 				openOracleReportDetails.value = details
 				loadedOpenOracleReportId.value = reportId
 				openOracleForm.value = {
@@ -152,16 +183,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 			onError: error => {
 				openOracleReportDetails.value = undefined
 				loadedOpenOracleReportId.value = undefined
-				openOracleInitialReportDefaultPrice.value = undefined
-				openOracleInitialReportDefaultPriceError.value = undefined
-				openOracleInitialReportDefaultPriceSource.value = undefined
-				openOracleInitialReportQuoteAttemptedSources.value = undefined
-				openOracleInitialReportQuoteFailureKind.value = undefined
-				openOracleInitialReportQuoteFailureReason.value = undefined
-				openOracleInitialReportToken1Allowance.value = undefined
-				openOracleInitialReportToken1AllowanceError.value = undefined
-				openOracleInitialReportToken2Allowance.value = undefined
-				openOracleInitialReportToken2AllowanceError.value = undefined
+				resetOpenOracleInitialReportState()
 				openOracleError.value = getErrorMessage(error, 'Failed to load oracle report')
 			},
 		})
@@ -201,7 +223,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 				if (result.action !== 'createReportInstance' && openOracleForm.value.reportId.trim() !== '') {
 					await ensureLoadedSelectedReport()
 				}
-				if (result.action === 'approveToken1' || result.action === 'approveToken2') {
+				if (result.action === 'approveToken1' || result.action === 'approveToken2' || result.action === 'wrapWeth') {
 					await refreshOpenOracleInitialReportState(openOracleReportDetails.value)
 				}
 			},
@@ -263,14 +285,20 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 				defaultPrice: openOracleInitialReportDefaultPrice.value,
 				defaultPriceError: openOracleInitialReportDefaultPriceError.value,
 				defaultPriceSource: openOracleInitialReportDefaultPriceSource.value,
+				defaultPriceSourceUrl: openOracleInitialReportDefaultPriceSourceUrl.value,
 				priceInput: openOracleForm.value.price,
 				quoteAttemptedSources: openOracleInitialReportQuoteAttemptedSources.value,
 				quoteFailureReason: openOracleInitialReportQuoteFailureReason.value,
 				reportDetails,
+				token1Balance: openOracleInitialReportToken1Balance.value,
+				token1BalanceError: openOracleInitialReportToken1BalanceError.value,
 				token1AllowanceError: openOracleInitialReportToken1AllowanceError.value,
 				token2AllowanceError: openOracleInitialReportToken2AllowanceError.value,
+				token2Balance: openOracleInitialReportToken2Balance.value,
+				token2BalanceError: openOracleInitialReportToken2BalanceError.value,
 				token1Decimals: reportDetails.token1Decimals,
 				token2Decimals: reportDetails.token2Decimals,
+				walletEthBalance: undefined,
 			})
 			if (!submission.canSubmit || submission.amount1 === undefined || submission.amount2 === undefined) {
 				throw new Error(submission.blockReason ?? 'Invalid price')
@@ -278,6 +306,38 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 
 			return await submitInitialOracleReport(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), getOpenOracleAddress(), reportDetails.reportId, submission.amount1, submission.amount2, parseBytes32Input(openOracleForm.value.stateHash, 'State hash'))
 		}, 'Failed to submit initial report')
+
+	const wrapWethForInitialReport = async () =>
+		await runOracleAction(async walletAddress => {
+			const reportDetails = requireDefined(openOracleReportDetails.value, 'Load an oracle report first')
+			const submission = deriveOpenOracleInitialReportSubmissionDetails({
+				approvedToken1Amount: openOracleInitialReportToken1Allowance.value,
+				approvedToken2Amount: openOracleInitialReportToken2Allowance.value,
+				defaultPrice: openOracleInitialReportDefaultPrice.value,
+				defaultPriceError: openOracleInitialReportDefaultPriceError.value,
+				defaultPriceSource: openOracleInitialReportDefaultPriceSource.value,
+				defaultPriceSourceUrl: openOracleInitialReportDefaultPriceSourceUrl.value,
+				priceInput: openOracleForm.value.price,
+				quoteAttemptedSources: openOracleInitialReportQuoteAttemptedSources.value,
+				quoteFailureReason: openOracleInitialReportQuoteFailureReason.value,
+				reportDetails,
+				token1Balance: openOracleInitialReportToken1Balance.value,
+				token1BalanceError: openOracleInitialReportToken1BalanceError.value,
+				token1AllowanceError: openOracleInitialReportToken1AllowanceError.value,
+				token2AllowanceError: openOracleInitialReportToken2AllowanceError.value,
+				token2Balance: openOracleInitialReportToken2Balance.value,
+				token2BalanceError: openOracleInitialReportToken2BalanceError.value,
+				token1Decimals: reportDetails.token1Decimals,
+				token2Decimals: reportDetails.token2Decimals,
+				walletEthBalance: undefined,
+			})
+			const wrapAmount = submission.requiredWethWrapAmount
+			if (wrapAmount === undefined || wrapAmount <= 0n) {
+				throw new Error(submission.wrapRequiredWethDisabledReason ?? 'No WETH wrap is required for this report')
+			}
+
+			return await wrapWeth(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), wrapAmount)
+		}, 'Failed to wrap ETH to WETH')
 
 	const settleReport = async () => await runOracleAction(async walletAddress => await settleOracleReport(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), getOpenOracleAddress(), parseReportIdInput(openOracleForm.value.reportId)), 'Failed to settle report')
 
@@ -322,15 +382,20 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 			defaultPrice: openOracleInitialReportDefaultPrice.value,
 			defaultPriceError: openOracleInitialReportDefaultPriceError.value,
 			defaultPriceSource: openOracleInitialReportDefaultPriceSource.value,
+			defaultPriceSourceUrl: openOracleInitialReportDefaultPriceSourceUrl.value,
 			loading: openOracleInitialReportStateLoad.isLoading.value,
 			quoteAttemptedSources: openOracleInitialReportQuoteAttemptedSources.value,
 			quoteFailureKind: openOracleInitialReportQuoteFailureKind.value,
 			quoteFailureReason: openOracleInitialReportQuoteFailureReason.value,
 			token1Allowance: openOracleInitialReportToken1Allowance.value,
 			token1AllowanceError: openOracleInitialReportToken1AllowanceError.value,
+			token1Balance: openOracleInitialReportToken1Balance.value,
+			token1BalanceError: openOracleInitialReportToken1BalanceError.value,
 			token1Decimals: openOracleReportDetails.value?.token1Decimals,
 			token2Allowance: openOracleInitialReportToken2Allowance.value,
 			token2AllowanceError: openOracleInitialReportToken2AllowanceError.value,
+			token2Balance: openOracleInitialReportToken2Balance.value,
+			token2BalanceError: openOracleInitialReportToken2BalanceError.value,
 			token2Decimals: openOracleReportDetails.value?.token2Decimals,
 		},
 		openOracleReportDetails: openOracleReportDetails.value,
@@ -342,5 +407,6 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 		setOpenOracleForm,
 		settleReport,
 		submitInitialReport,
+		wrapWethForInitialReport,
 	}
 }

--- a/ui/ts/hooks/useRepPrices.ts
+++ b/ui/ts/hooks/useRepPrices.ts
@@ -2,7 +2,7 @@ import { useSignal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { useLoadController } from './useLoadController.js'
 import { createConnectedReadClient } from '../lib/clients.js'
-import { quoteRepForEth, quoteRepForEthV3, quoteRepForUsdcV4 } from '../lib/uniswapQuoter.js'
+import { quoteBestExactInputWithSource, quoteBestV3ExactInputWithSource, quoteRepForUsdcV4WithSource, ETH_ADDRESS, REP_ADDRESS } from '../lib/uniswapQuoter.js'
 
 const ONE_REP = 10n ** 18n
 
@@ -11,27 +11,31 @@ type PriceSource = 'v4' | 'v3'
 type RepPrices = {
 	repEthPrice: bigint | undefined // ETH in wei received for 1 REP
 	repEthSource: PriceSource | undefined
+	repEthSourceUrl: string | undefined
 	repUsdcPrice: bigint | undefined // USDC in 1e6 units received for 1 REP
 	repUsdcSource: PriceSource | undefined
+	repUsdcSourceUrl: string | undefined
 	isLoadingRepPrices: boolean
 }
 
-async function fetchRepEthPrice(client: ReturnType<typeof createConnectedReadClient>): Promise<{ price: bigint; source: PriceSource }> {
+async function fetchRepEthPrice(client: ReturnType<typeof createConnectedReadClient>): Promise<{ price: bigint; source: PriceSource; sourceUrl: string | undefined }> {
 	try {
-		const price = await quoteRepForEth(client, ONE_REP)
-		return { price, source: 'v4' }
+		const { amountOut, source } = await quoteBestExactInputWithSource(client, REP_ADDRESS, ETH_ADDRESS, ONE_REP)
+		return { price: amountOut, source: 'v4', sourceUrl: source.poolUrl }
 	} catch {
 		// V4 REP/ETH pool doesn't exist yet — fall back to V3 REP/WETH (1% pool)
-		const price = await quoteRepForEthV3(client, ONE_REP)
-		return { price, source: 'v3' }
+		const { amountOut, source } = await quoteBestV3ExactInputWithSource(client, REP_ADDRESS, ETH_ADDRESS, ONE_REP)
+		return { price: amountOut, source: 'v3', sourceUrl: source.poolUrl }
 	}
 }
 
 export function useRepPrices(): RepPrices {
 	const repEthPrice = useSignal<bigint | undefined>(undefined)
 	const repEthSource = useSignal<PriceSource | undefined>(undefined)
+	const repEthSourceUrl = useSignal<string | undefined>(undefined)
 	const repUsdcPrice = useSignal<bigint | undefined>(undefined)
 	const repUsdcSource = useSignal<PriceSource | undefined>(undefined)
+	const repUsdcSourceUrl = useSignal<string | undefined>(undefined)
 	const repPricesLoad = useLoadController()
 
 	useEffect(() => {
@@ -40,12 +44,14 @@ export function useRepPrices(): RepPrices {
 
 		void repPricesLoad
 			.track(async () => {
-				const [{ price: ethPrice, source: ethSource }, usdcPrice] = await Promise.all([fetchRepEthPrice(client), quoteRepForUsdcV4(client, ONE_REP)])
+				const [{ price: ethPrice, source: ethSource, sourceUrl: ethSourceUrl }, usdcQuote] = await Promise.all([fetchRepEthPrice(client), quoteRepForUsdcV4WithSource(client, ONE_REP)])
 				if (cancelled) return
 				repEthPrice.value = ethPrice
 				repEthSource.value = ethSource
-				repUsdcPrice.value = usdcPrice
+				repEthSourceUrl.value = ethSourceUrl
+				repUsdcPrice.value = usdcQuote.amountOut
 				repUsdcSource.value = 'v4'
+				repUsdcSourceUrl.value = usdcQuote.source.poolUrl
 			})
 			.catch(() => {
 				// prices unavailable — leave as undefined
@@ -59,8 +65,10 @@ export function useRepPrices(): RepPrices {
 	return {
 		repEthPrice: repEthPrice.value,
 		repEthSource: repEthSource.value,
+		repEthSourceUrl: repEthSourceUrl.value,
 		repUsdcPrice: repUsdcPrice.value,
 		repUsdcSource: repUsdcSource.value,
+		repUsdcSourceUrl: repUsdcSourceUrl.value,
 		isLoadingRepPrices: repPricesLoad.isLoading.value,
 	}
 }

--- a/ui/ts/lib/openOracle.ts
+++ b/ui/ts/lib/openOracle.ts
@@ -2,8 +2,8 @@ import { maxUint256, zeroAddress } from 'viem'
 import type { OpenOracleReportSummary } from '../types/contracts.js'
 import { parseDecimalInput } from './decimal.js'
 import { getErrorDetail } from './errors.js'
-import { formatCurrencyInputBalance } from './formatters.js'
-import { quoteBestExactInput, quoteBestV3ExactInput, quoteExactInput } from './uniswapQuoter.js'
+import { formatCurrencyBalance, formatCurrencyInputBalance } from './formatters.js'
+import { quoteBestExactInputWithSource, quoteBestV3ExactInputWithSource, quoteExactInput, WETH_ADDRESS } from './uniswapQuoter.js'
 
 const OPEN_ORACLE_PRICE_PRECISION = 10n ** 18n
 export const OPEN_ORACLE_APPROVAL_AMOUNT = maxUint256
@@ -12,7 +12,7 @@ const OPEN_ORACLE_BOUNTY_BUFFER_DENOMINATOR = 10n
 
 type OpenOracleReportStatus = 'Awaiting Initial Report' | 'Pending' | 'Disputed' | 'Settled'
 export type OpenOracleSelectedReportActionMode = 'initial-report' | 'dispute' | 'read-only'
-export type OpenOracleInitialReportPriceSource = 'Uniswap V4' | 'Uniswap V3 fallback' | 'Manual override' | 'Unavailable'
+export type OpenOracleInitialReportPriceSource = 'Uniswap V4' | 'Uniswap V3' | 'Manual override' | 'Unavailable'
 export type OpenOracleInitialReportQuoteSource = Exclude<OpenOracleInitialReportPriceSource, 'Manual override' | 'Unavailable'>
 export type OpenOracleInitialReportQuoteFailureKind = 'unsupported-pair' | 'quote-failed'
 
@@ -21,6 +21,7 @@ type OpenOracleInitialReportPriceLoadResult =
 			status: 'success'
 			price: bigint
 			priceSource: OpenOracleInitialReportQuoteSource
+			priceSourceUrl: string | undefined
 			token2Amount: bigint
 	  }
 	| {
@@ -40,8 +41,12 @@ type OpenOracleInitialReportSubmissionDetails = {
 	price: bigint | undefined
 	priceInput: string
 	priceSource: OpenOracleInitialReportPriceSource
+	priceSourceUrl: string | undefined
+	requiredWethWrapAmount: bigint | undefined
 	token1Decimals: number | undefined
 	token2Decimals: number | undefined
+	canWrapRequiredWeth: boolean
+	wrapRequiredWethDisabledReason: string | undefined
 }
 
 function formatOpenOraclePriceLoadError(v4Error: unknown, v3Error?: unknown) {
@@ -50,11 +55,11 @@ function formatOpenOraclePriceLoadError(v4Error: unknown, v3Error?: unknown) {
 	const v4Message = v4Detail === undefined ? 'Uniswap V4 quote failed.' : `Uniswap V4 quote failed: ${v4Detail}.`
 
 	if (v3Error !== undefined) {
-		const v3Message = v3Detail === undefined ? 'Uniswap V3 fallback failed.' : `Uniswap V3 fallback failed: ${v3Detail}`
+		const v3Message = v3Detail === undefined ? 'Uniswap V3 quote failed.' : `Uniswap V3 quote failed: ${v3Detail}`
 		return `Failed to fetch price from Uniswap. ${v4Message} ${v3Message}`
 	}
 
-	return `Failed to fetch price from Uniswap. ${v4Message} Uniswap V3 fallback did not run.`
+	return `Failed to fetch price from Uniswap. ${v4Message} Uniswap V3 did not run.`
 }
 
 export function getOpenOracleReportStatus(report: Pick<OpenOracleReportSummary, 'currentReporter' | 'disputeOccurred' | 'isDistributed' | 'reportTimestamp'>): OpenOracleReportStatus {
@@ -123,6 +128,20 @@ export function formatOpenOraclePriceInput(price: bigint | undefined) {
 	return price === undefined ? '' : formatCurrencyInputBalance(price)
 }
 
+function resolveOpenOracleTokenLabel({ fallbackLabel, tokenAddress, tokenSymbol }: { fallbackLabel: string; tokenAddress: string | undefined; tokenSymbol: string | undefined }) {
+	const resolvedSymbol = tokenSymbol?.trim()
+	if (resolvedSymbol !== undefined && resolvedSymbol !== '') return resolvedSymbol
+
+	const resolvedAddress = tokenAddress?.trim()
+	if (resolvedAddress !== undefined && resolvedAddress !== '') return resolvedAddress
+
+	return fallbackLabel
+}
+
+function isCanonicalMainnetWeth(tokenAddress: string | undefined) {
+	return tokenAddress?.toLowerCase() === WETH_ADDRESS.toLowerCase()
+}
+
 function sanitizeOpenOracleFailureReason(reason: string | undefined) {
 	if (reason === undefined) return undefined
 
@@ -182,31 +201,55 @@ export function formatOpenOracleInitialReportApprovalStatusUnavailableMessage({ 
 	return segments.join(' ')
 }
 
+export function formatOpenOracleInitialReportBalanceStatusUnavailableMessage({ reason, tokenLabel }: { reason: string | undefined; tokenLabel: string | undefined }) {
+	const resolvedTokenLabel = tokenLabel?.trim() || 'token'
+	const segments = [`Unable to verify ${resolvedTokenLabel} balance for this report.`]
+	const sanitizedReason = sanitizeOpenOracleFailureReason(reason)
+
+	if (sanitizedReason !== undefined) {
+		segments.push(`Reason: ${sanitizedReason}.`)
+	}
+	segments.push('Retry loading the report or balance status before submitting the initial report.')
+
+	return segments.join(' ')
+}
+
+function formatOpenOracleInitialReportInsufficientBalanceMessage({ available, required, tokenAddress, tokenDecimals, tokenLabel }: { available: bigint; required: bigint; tokenAddress: string | undefined; tokenDecimals: number | undefined; tokenLabel: string }) {
+	const resolvedDecimals = tokenDecimals ?? 18
+	const segments = [`Insufficient ${tokenLabel} balance for this report. Need ${formatCurrencyBalance(required, resolvedDecimals)}, wallet has ${formatCurrencyBalance(available, resolvedDecimals)}.`]
+
+	if (isCanonicalMainnetWeth(tokenAddress)) {
+		segments.push('Wrap ETH into WETH first.')
+	}
+
+	return segments.join(' ')
+}
+
 export async function loadOpenOracleInitialReportPriceResult(client: Parameters<typeof quoteExactInput>[0], token1: Parameters<typeof quoteExactInput>[1], token2: Parameters<typeof quoteExactInput>[2], token1Amount: bigint): Promise<OpenOracleInitialReportPriceLoadResult> {
 	let v4Failure: unknown = 'Uniswap V4 returned an unusable quote'
 
 	try {
-		const token2Amount = await quoteBestExactInput(client, token1, token2, token1Amount)
+		const { amountOut: token2Amount, source } = await quoteBestExactInputWithSource(client, token1, token2, token1Amount)
 		const price = calculateOpenOraclePrice(token1Amount, token2Amount)
 		if (price !== undefined) {
-			return { price, priceSource: 'Uniswap V4', status: 'success', token2Amount }
+			return { price, priceSource: 'Uniswap V4', priceSourceUrl: source.poolUrl, status: 'success', token2Amount }
 		}
 	} catch (error) {
 		v4Failure = error
 	}
 
-	const attemptedSources: OpenOracleInitialReportQuoteSource[] = ['Uniswap V4', 'Uniswap V3 fallback']
+	const attemptedSources: OpenOracleInitialReportQuoteSource[] = ['Uniswap V4', 'Uniswap V3']
 	try {
-		const token2Amount = await quoteBestV3ExactInput(client, token1, token2, token1Amount)
+		const { amountOut: token2Amount, source } = await quoteBestV3ExactInputWithSource(client, token1, token2, token1Amount)
 		const price = calculateOpenOraclePrice(token1Amount, token2Amount)
 		if (price !== undefined) {
-			return { price, priceSource: 'Uniswap V3 fallback', status: 'success', token2Amount }
+			return { price, priceSource: 'Uniswap V3', priceSourceUrl: source.poolUrl, status: 'success', token2Amount }
 		}
 
 		return {
 			attemptedSources,
 			failureKind: 'quote-failed',
-			reason: formatOpenOraclePriceLoadError(v4Failure, 'Uniswap V3 fallback returned an unusable quote'),
+			reason: formatOpenOraclePriceLoadError(v4Failure, 'Uniswap V3 returned an unusable quote'),
 			status: 'failure',
 		}
 	} catch (v3Error) {
@@ -238,20 +281,27 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 	defaultPrice,
 	defaultPriceError,
 	defaultPriceSource,
+	defaultPriceSourceUrl,
 	priceInput,
 	quoteAttemptedSources,
 	quoteFailureReason,
 	reportDetails,
+	token1Balance,
+	token1BalanceError,
 	token1AllowanceError,
 	token2AllowanceError,
+	token2Balance,
+	token2BalanceError,
 	token1Decimals,
 	token2Decimals,
+	walletEthBalance,
 }: {
 	approvedToken1Amount: bigint | undefined
 	approvedToken2Amount: bigint | undefined
 	defaultPrice: string | undefined
 	defaultPriceError: string | undefined
 	defaultPriceSource: OpenOracleInitialReportPriceSource | undefined
+	defaultPriceSourceUrl: string | undefined
 	priceInput: string
 	quoteAttemptedSources: OpenOracleInitialReportQuoteSource[] | undefined
 	quoteFailureReason: string | undefined
@@ -264,10 +314,15 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 				token2Symbol?: string | undefined
 		  }
 		| undefined
+	token1Balance: bigint | undefined
+	token1BalanceError: string | undefined
 	token1AllowanceError: string | undefined
 	token2AllowanceError: string | undefined
+	token2Balance: bigint | undefined
+	token2BalanceError: string | undefined
 	token1Decimals: number | undefined
 	token2Decimals: number | undefined
+	walletEthBalance: bigint | undefined
 }): OpenOracleInitialReportSubmissionDetails {
 	const trimmedPriceInput = priceInput.trim()
 	const resolvedPriceInput = trimmedPriceInput === '' ? (defaultPrice ?? '') : trimmedPriceInput
@@ -281,6 +336,36 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 	const amount1 = reportDetails?.exactToken1Report
 	const amount2 = amount1 === undefined || price === undefined ? undefined : calculateOpenOracleToken2Amount(amount1, price)
 	const priceSource = trimmedPriceInput === '' ? (defaultPrice === undefined ? 'Unavailable' : (defaultPriceSource ?? 'Manual override')) : defaultPrice !== undefined && trimmedPriceInput === defaultPrice ? (defaultPriceSource ?? 'Manual override') : 'Manual override'
+	const priceSourceUrl = priceSource === 'Uniswap V4' || priceSource === 'Uniswap V3' ? defaultPriceSourceUrl : undefined
+	const token1Label = resolveOpenOracleTokenLabel({
+		fallbackLabel: 'Token1',
+		tokenAddress: reportDetails?.token1,
+		tokenSymbol: reportDetails?.token1Symbol,
+	})
+	const token2Label = resolveOpenOracleTokenLabel({
+		fallbackLabel: 'Token2',
+		tokenAddress: reportDetails?.token2,
+		tokenSymbol: reportDetails?.token2Symbol,
+	})
+	const token1BalanceShortage = amount1 === undefined || token1Balance === undefined || token1Balance >= amount1 ? undefined : amount1 - token1Balance
+	const token2BalanceShortage = amount2 === undefined || token2Balance === undefined || token2Balance >= amount2 ? undefined : amount2 - token2Balance
+	const requiredWethWrapAmount =
+		reportDetails === undefined
+			? undefined
+			: isCanonicalMainnetWeth(reportDetails.token1) && token1BalanceShortage !== undefined && token1BalanceShortage > 0n
+				? token1BalanceShortage
+				: isCanonicalMainnetWeth(reportDetails.token2) && token2BalanceShortage !== undefined && token2BalanceShortage > 0n
+					? token2BalanceShortage
+					: undefined
+	const canWrapRequiredWeth = requiredWethWrapAmount !== undefined && requiredWethWrapAmount > 0n && walletEthBalance !== undefined && walletEthBalance >= requiredWethWrapAmount
+	const wrapRequiredWethDisabledReason =
+		requiredWethWrapAmount === undefined || requiredWethWrapAmount <= 0n
+			? undefined
+			: walletEthBalance === undefined
+				? 'Loading wallet ETH balance.'
+				: walletEthBalance < requiredWethWrapAmount
+					? `Wallet has ${formatCurrencyBalance(walletEthBalance)} ETH, need ${formatCurrencyBalance(requiredWethWrapAmount)} ETH to wrap the required WETH.`
+					: undefined
 
 	let blockReason: string | undefined
 	if (reportDetails === undefined) {
@@ -291,25 +376,51 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 			formatOpenOracleInitialReportPriceUnavailableMessage({
 				attemptedSources: quoteAttemptedSources,
 				reason: quoteFailureReason,
-				token1Label: reportDetails.token1Symbol ?? reportDetails.token1,
-				token2Label: reportDetails.token2Symbol ?? reportDetails.token2,
+				token1Label,
+				token2Label,
 			})
 	} else if (price === undefined || price <= 0n || amount2 === undefined || amount2 <= 0n) {
 		blockReason = 'Invalid price'
 	} else if (approvedToken1Amount === undefined && token1AllowanceError !== undefined) {
 		blockReason = formatOpenOracleInitialReportApprovalStatusUnavailableMessage({
 			reason: token1AllowanceError,
-			tokenLabel: reportDetails.token1Symbol ?? reportDetails.token1,
+			tokenLabel: token1Label,
 		})
 	} else if (approvedToken2Amount === undefined && token2AllowanceError !== undefined) {
 		blockReason = formatOpenOracleInitialReportApprovalStatusUnavailableMessage({
 			reason: token2AllowanceError,
-			tokenLabel: reportDetails.token2Symbol ?? reportDetails.token2,
+			tokenLabel: token2Label,
+		})
+	} else if (token1Balance === undefined && token1BalanceError !== undefined) {
+		blockReason = formatOpenOracleInitialReportBalanceStatusUnavailableMessage({
+			reason: token1BalanceError,
+			tokenLabel: token1Label,
+		})
+	} else if (token2Balance === undefined && token2BalanceError !== undefined) {
+		blockReason = formatOpenOracleInitialReportBalanceStatusUnavailableMessage({
+			reason: token2BalanceError,
+			tokenLabel: token2Label,
+		})
+	} else if (amount1 !== undefined && token1Balance !== undefined && token1Balance < amount1) {
+		blockReason = formatOpenOracleInitialReportInsufficientBalanceMessage({
+			available: token1Balance,
+			required: amount1,
+			tokenAddress: reportDetails.token1,
+			tokenDecimals: token1Decimals,
+			tokenLabel: token1Label,
+		})
+	} else if (amount2 !== undefined && token2Balance !== undefined && token2Balance < amount2) {
+		blockReason = formatOpenOracleInitialReportInsufficientBalanceMessage({
+			available: token2Balance,
+			required: amount2,
+			tokenAddress: reportDetails.token2,
+			tokenDecimals: token2Decimals,
+			tokenLabel: token2Label,
 		})
 	} else if (amount1 === undefined || approvedToken1Amount === undefined || approvedToken1Amount < amount1) {
-		blockReason = 'Token1 approval required'
+		blockReason = `${token1Label} approval required`
 	} else if (approvedToken2Amount === undefined || approvedToken2Amount < amount2) {
-		blockReason = 'Token2 approval required'
+		blockReason = `${token2Label} approval required`
 	}
 
 	return {
@@ -322,7 +433,11 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 		price,
 		priceInput: resolvedPriceInput,
 		priceSource,
+		priceSourceUrl,
+		requiredWethWrapAmount,
 		token1Decimals,
 		token2Decimals,
+		canWrapRequiredWeth,
+		wrapRequiredWethDisabledReason,
 	}
 }

--- a/ui/ts/lib/uniswapQuoter.ts
+++ b/ui/ts/lib/uniswapQuoter.ts
@@ -1,9 +1,11 @@
-import { type Address, zeroAddress } from 'viem'
+import { encodeAbiParameters, getAddress, keccak256, type Address, type Hex, zeroAddress } from 'viem'
 import type { ReadClient } from './clients.js'
 
 export const UNISWAP_V4_QUOTER_ADDRESS: Address = '0x52f0e24d1c21c8a0cb1e5a5dd6198556bd9e1203'
 // Uniswap V3 QuoterV2 — used as fallback when a V4 pool doesn't exist
 const UNISWAP_V3_QUOTER_ADDRESS: Address = '0x61fFE014bA17989E743c5F6cB21bF9697530B21e'
+const UNISWAP_V3_FACTORY_ADDRESS: Address = '0x1F98431c8aD98523631AE4a59f267346ea31F984'
+const UNISWAP_POOL_EXPLORER_BASE_URL = 'https://app.uniswap.org/explore/pools/ethereum'
 
 // Known token addresses (mainnet)
 export const REP_ADDRESS: Address = '0x221657776846890989a759BA2973e427DfF5C9bB'
@@ -17,6 +19,20 @@ type PoolConfig = {
 	fee: number
 	tickSpacing: number
 	hooks?: Address
+}
+
+type UniswapV4QuoteSource = {
+	poolConfig: PoolConfig
+	poolId: Hex
+	poolUrl: string
+	protocol: 'v4'
+}
+
+type UniswapV3QuoteSource = {
+	fee: number
+	poolAddress: Address | undefined
+	poolUrl: string | undefined
+	protocol: 'v3'
 }
 
 // Default pool config (0.3% fee, standard tick spacing, no hooks)
@@ -33,6 +49,20 @@ const COMMON_V4_POOL_CONFIGS: readonly PoolConfig[] = [
 ]
 
 const COMMON_V3_FEES = [100, 500, 3000, 10000] as const
+
+const V3_FACTORY_ABI = [
+	{
+		name: 'getPool',
+		type: 'function',
+		stateMutability: 'view',
+		inputs: [
+			{ name: 'tokenA', type: 'address' },
+			{ name: 'tokenB', type: 'address' },
+			{ name: 'fee', type: 'uint24' },
+		],
+		outputs: [{ name: 'pool', type: 'address' }],
+	},
+] as const
 
 const QUOTER_ABI = [
 	{
@@ -68,6 +98,27 @@ const QUOTER_ABI = [
 	},
 ] as const
 
+function sortTokenPair(tokenA: Address, tokenB: Address): [Address, Address] {
+	return BigInt(tokenA) < BigInt(tokenB) ? [tokenA, tokenB] : [tokenB, tokenA]
+}
+
+function buildUniswapPoolExplorerUrl(poolIdentifier: string) {
+	return `${UNISWAP_POOL_EXPLORER_BASE_URL}/${poolIdentifier}`
+}
+
+export function buildUniswapV4PoolId(tokenA: Address, tokenB: Address, poolConfig: PoolConfig): Hex {
+	const [currency0, currency1] = sortTokenPair(tokenA, tokenB)
+	return keccak256(encodeAbiParameters([{ type: 'address' }, { type: 'address' }, { type: 'uint24' }, { type: 'int24' }, { type: 'address' }], [currency0, currency1, poolConfig.fee, poolConfig.tickSpacing, poolConfig.hooks ?? zeroAddress]))
+}
+
+export function buildUniswapV4PoolUrl(tokenA: Address, tokenB: Address, poolConfig: PoolConfig) {
+	return buildUniswapPoolExplorerUrl(buildUniswapV4PoolId(tokenA, tokenB, poolConfig))
+}
+
+export function buildUniswapV3PoolUrl(poolAddress: Address) {
+	return buildUniswapPoolExplorerUrl(poolAddress)
+}
+
 // Returns how much tokenOut you receive for swapping `amountIn` of tokenIn.
 // Use ETH_ADDRESS (zeroAddress) for ETH. Tokens can be in any order — currency0/1
 // ordering and zeroForOne direction are derived from the addresses automatically.
@@ -99,8 +150,9 @@ export async function quoteExactInput(client: ReadClient, tokenIn: Address, toke
 	return result[0]
 }
 
-export async function quoteBestExactInput(client: ReadClient, tokenIn: Address, tokenOut: Address, amountIn: bigint, poolConfigs: readonly PoolConfig[] = COMMON_V4_POOL_CONFIGS): Promise<bigint> {
+export async function quoteBestExactInputWithSource(client: ReadClient, tokenIn: Address, tokenOut: Address, amountIn: bigint, poolConfigs: readonly PoolConfig[] = COMMON_V4_POOL_CONFIGS): Promise<{ amountOut: bigint; source: UniswapV4QuoteSource }> {
 	let bestAmountOut: bigint | undefined
+	let bestPoolConfig: PoolConfig | undefined
 	let lastError: unknown
 
 	for (const poolConfig of poolConfigs) {
@@ -108,15 +160,33 @@ export async function quoteBestExactInput(client: ReadClient, tokenIn: Address, 
 			const amountOut = await quoteExactInput(client, tokenIn, tokenOut, amountIn, poolConfig)
 			if (bestAmountOut === undefined || amountOut > bestAmountOut) {
 				bestAmountOut = amountOut
+				bestPoolConfig = poolConfig
 			}
 		} catch (error) {
 			lastError = error
 		}
 	}
 
-	if (bestAmountOut !== undefined) return bestAmountOut
-	if (lastError !== undefined) throw lastError
-	throw new Error('No Uniswap V4 quote was available for the tested pool configurations')
+	if (bestAmountOut === undefined || bestPoolConfig === undefined) {
+		if (lastError !== undefined) throw lastError
+		throw new Error('No Uniswap V4 quote was available for the tested pool configurations')
+	}
+
+	const poolId = buildUniswapV4PoolId(tokenIn, tokenOut, bestPoolConfig)
+	return {
+		amountOut: bestAmountOut,
+		source: {
+			poolConfig: bestPoolConfig,
+			poolId,
+			poolUrl: buildUniswapV4PoolUrl(tokenIn, tokenOut, bestPoolConfig),
+			protocol: 'v4',
+		},
+	}
+}
+
+export async function quoteBestExactInput(client: ReadClient, tokenIn: Address, tokenOut: Address, amountIn: bigint, poolConfigs: readonly PoolConfig[] = COMMON_V4_POOL_CONFIGS): Promise<bigint> {
+	const result = await quoteBestExactInputWithSource(client, tokenIn, tokenOut, amountIn, poolConfigs)
+	return result.amountOut
 }
 
 // Returns how much ETH (in wei) you receive for swapping `amountIn` of `token`
@@ -184,11 +254,29 @@ function normalizeV3Token(token: Address) {
 	return token === ETH_ADDRESS ? WETH_ADDRESS : token
 }
 
-export async function quoteBestV3ExactInput(client: ReadClient, tokenIn: Address, tokenOut: Address, amountIn: bigint, fees: readonly number[] = COMMON_V3_FEES): Promise<bigint> {
+async function loadUniswapV3PoolAddress(client: ReadClient, tokenIn: Address, tokenOut: Address, fee: number): Promise<Address | undefined> {
+	const [token0, token1] = sortTokenPair(normalizeV3Token(tokenIn), normalizeV3Token(tokenOut))
+
+	try {
+		const poolAddress = await client.readContract({
+			address: UNISWAP_V3_FACTORY_ADDRESS,
+			abi: V3_FACTORY_ABI,
+			functionName: 'getPool',
+			args: [token0, token1, fee],
+		})
+		if (poolAddress === zeroAddress) return undefined
+		return getAddress(poolAddress)
+	} catch {
+		return undefined
+	}
+}
+
+export async function quoteBestV3ExactInputWithSource(client: ReadClient, tokenIn: Address, tokenOut: Address, amountIn: bigint, fees: readonly number[] = COMMON_V3_FEES): Promise<{ amountOut: bigint; source: UniswapV3QuoteSource }> {
 	const normalizedTokenIn = normalizeV3Token(tokenIn)
 	const normalizedTokenOut = normalizeV3Token(tokenOut)
 
 	let bestAmountOut: bigint | undefined
+	let bestFee: number | undefined
 	let lastError: unknown
 
 	for (const fee of fees) {
@@ -196,15 +284,33 @@ export async function quoteBestV3ExactInput(client: ReadClient, tokenIn: Address
 			const amountOut = await quoteV3ExactInput(client, normalizedTokenIn, normalizedTokenOut, amountIn, fee)
 			if (bestAmountOut === undefined || amountOut > bestAmountOut) {
 				bestAmountOut = amountOut
+				bestFee = fee
 			}
 		} catch (error) {
 			lastError = error
 		}
 	}
 
-	if (bestAmountOut !== undefined) return bestAmountOut
-	if (lastError !== undefined) throw lastError
-	throw new Error('No Uniswap V3 quote was available for the tested fee tiers')
+	if (bestAmountOut === undefined || bestFee === undefined) {
+		if (lastError !== undefined) throw lastError
+		throw new Error('No Uniswap V3 quote was available for the tested fee tiers')
+	}
+
+	const poolAddress = await loadUniswapV3PoolAddress(client, tokenIn, tokenOut, bestFee)
+	return {
+		amountOut: bestAmountOut,
+		source: {
+			fee: bestFee,
+			poolAddress,
+			poolUrl: poolAddress === undefined ? undefined : buildUniswapV3PoolUrl(poolAddress),
+			protocol: 'v3',
+		},
+	}
+}
+
+export async function quoteBestV3ExactInput(client: ReadClient, tokenIn: Address, tokenOut: Address, amountIn: bigint, fees: readonly number[] = COMMON_V3_FEES): Promise<bigint> {
+	const result = await quoteBestV3ExactInputWithSource(client, tokenIn, tokenOut, amountIn, fees)
+	return result.amountOut
 }
 
 // Returns how much WETH (= ETH) you receive for `repAmount` REP via Uniswap V3 (1% pool).
@@ -217,7 +323,6 @@ export async function quoteRepForEthV3(client: ReadClient, repAmount: bigint): P
 // Pool ID: 0x75d479eb83b7c9008ab854e74625a01841e5b3e06af40a89c10998ad2664f356
 const REP_USDC_V4_POOL: PoolConfig = { fee: 10001, tickSpacing: 200 }
 
-// Returns how much USDC (6 decimals) you receive for `repAmount` REP via the V4 REP/USDC pool.
-export async function quoteRepForUsdcV4(client: ReadClient, repAmount: bigint): Promise<bigint> {
-	return quoteExactInput(client, REP_ADDRESS, USDC_ADDRESS, repAmount, REP_USDC_V4_POOL)
+export async function quoteRepForUsdcV4WithSource(client: ReadClient, repAmount: bigint) {
+	return await quoteBestExactInputWithSource(client, REP_ADDRESS, USDC_ADDRESS, repAmount, [REP_USDC_V4_POOL])
 }

--- a/ui/ts/tests/approvedAmountValue.test.ts
+++ b/ui/ts/tests/approvedAmountValue.test.ts
@@ -1,0 +1,19 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { maxUint256 } from 'viem'
+import { APPROVAL_MAX_DISPLAY_THRESHOLD, isApprovalAmountMaxDisplay } from '../components/ApprovedAmountValue.js'
+
+void describe('ApprovedAmountValue helpers', () => {
+	void test('treats maxUint256 as max display', () => {
+		expect(isApprovalAmountMaxDisplay(maxUint256)).toBe(true)
+	})
+
+	void test('treats values above maxUint200 as max display', () => {
+		expect(isApprovalAmountMaxDisplay(APPROVAL_MAX_DISPLAY_THRESHOLD + 1n)).toBe(true)
+	})
+
+	void test('keeps maxUint200 itself numeric', () => {
+		expect(isApprovalAmountMaxDisplay(APPROVAL_MAX_DISPLAY_THRESHOLD)).toBe(false)
+	})
+})

--- a/ui/ts/tests/openOracle.test.ts
+++ b/ui/ts/tests/openOracle.test.ts
@@ -2,12 +2,13 @@
 
 import { beforeEach, describe, expect, setDefaultTimeout, test } from 'bun:test'
 import { getAddress, maxUint256, zeroAddress, type Address } from 'viem'
-import { createOpenOracleReportInstance, getOpenOracleAddress, loadOpenOracleReportDetails, loadOpenOracleReportSummaries, loadOracleManagerDetails, requestOraclePrice, settleOracleReport, submitInitialOracleReport } from '../contracts.js'
+import { createOpenOracleReportInstance, getOpenOracleAddress, loadErc20Balance, loadOpenOracleReportDetails, loadOpenOracleReportSummaries, loadOracleManagerDetails, requestOraclePrice, settleOracleReport, submitInitialOracleReport, wrapWeth as wrapUiWeth } from '../contracts.js'
 import {
-	deriveOpenOracleInitialReportSubmissionDetails,
 	addOpenOracleBountyBuffer,
+	deriveOpenOracleInitialReportSubmissionDetails,
 	formatOpenOracleFeePercentage,
 	formatOpenOracleInitialReportApprovalStatusUnavailableMessage,
+	formatOpenOracleInitialReportBalanceStatusUnavailableMessage,
 	formatOpenOracleInitialReportPriceUnavailableMessage,
 	formatOpenOracleMultiplier,
 	getOpenOracleReportStatus,
@@ -29,7 +30,7 @@ import { createWriteClient, type WriteClient } from '../../../solidity/ts/testsu
 import { deployOriginSecurityPool, ensureInfraDeployed, getSecurityPoolAddresses } from '../../../solidity/ts/testsuite/simulator/utils/contracts/deployPeripherals'
 import { ensureZoltarDeployed } from '../../../solidity/ts/testsuite/simulator/utils/contracts/zoltar'
 import { createQuestion, getQuestionId } from '../../../solidity/ts/testsuite/simulator/utils/contracts/zoltarQuestionData'
-import { getOpenOracleExtraData, wrapWeth } from '../../../solidity/ts/testsuite/simulator/utils/contracts/peripherals'
+import { getOpenOracleExtraData, wrapWeth as wrapWethTestHelper } from '../../../solidity/ts/testsuite/simulator/utils/contracts/peripherals'
 
 setDefaultTimeout(TEST_TIMEOUT_MS)
 
@@ -59,6 +60,37 @@ function createFailingQuoteClient(message: string): Parameters<typeof loadOpenOr
 			throw new Error(message)
 		},
 	} as unknown as Parameters<typeof loadOpenOracleInitialReportPrice>[0]
+}
+
+function createInitialReportSubmissionPreview(overrides: Partial<Parameters<typeof deriveOpenOracleInitialReportSubmissionDetails>[0]> = {}) {
+	return deriveOpenOracleInitialReportSubmissionDetails({
+		approvedToken1Amount: 100n,
+		approvedToken2Amount: 25n,
+		defaultPrice: '4.0',
+		defaultPriceError: undefined,
+		defaultPriceSource: 'Uniswap V4',
+		defaultPriceSourceUrl: 'https://app.uniswap.org/explore/pools/ethereum/0xpool',
+		priceInput: '',
+		quoteAttemptedSources: undefined,
+		quoteFailureReason: undefined,
+		reportDetails: {
+			exactToken1Report: 100n,
+			token1: REP_ADDRESS,
+			token1Symbol: 'REP',
+			token2: WETH_ADDRESS,
+			token2Symbol: 'WETH',
+		},
+		token1AllowanceError: undefined,
+		token1Balance: 100n,
+		token1BalanceError: undefined,
+		token1Decimals: 0,
+		token2AllowanceError: undefined,
+		token2Balance: 25n,
+		token2BalanceError: undefined,
+		token2Decimals: 0,
+		walletEthBalance: 10n,
+		...overrides,
+	})
 }
 
 describe('Open Oracle helpers', () => {
@@ -155,13 +187,13 @@ describe('Open Oracle helpers', () => {
 
 		const failure = await loadOpenOracleInitialReportPriceResult(createFailingQuoteClient('no pool'), getAddress('0x00000000000000000000000000000000000000a1'), getAddress('0x00000000000000000000000000000000000000a2'), 100n)
 		expect(failure).toEqual({
-			attemptedSources: ['Uniswap V4', 'Uniswap V3 fallback'],
+			attemptedSources: ['Uniswap V4', 'Uniswap V3'],
 			failureKind: 'quote-failed',
-			reason: 'Failed to fetch price from Uniswap. Uniswap V4 quote failed: no pool. Uniswap V3 fallback failed: no pool',
+			reason: 'Failed to fetch price from Uniswap. Uniswap V4 quote failed: no pool. Uniswap V3 quote failed: no pool',
 			status: 'failure',
 		})
 		await expect(loadOpenOracleInitialReportPrice(createFailingQuoteClient('no pool'), getAddress('0x00000000000000000000000000000000000000a1'), getAddress('0x00000000000000000000000000000000000000a2'), 100n)).rejects.toThrow(
-			'Failed to fetch price from Uniswap. Uniswap V4 quote failed: no pool. Uniswap V3 fallback failed: no pool',
+			'Failed to fetch price from Uniswap. Uniswap V4 quote failed: no pool. Uniswap V3 quote failed: no pool',
 		)
 	})
 
@@ -174,10 +206,10 @@ describe('Open Oracle helpers', () => {
 			},
 		} as unknown as Parameters<typeof loadOpenOracleInitialReportPrice>[0]
 
-		await expect(loadOpenOracleInitialReportPrice(failingClient, REP_ADDRESS, ETH_ADDRESS, 100n)).rejects.toThrow('Failed to fetch price from Uniswap. Uniswap V4 quote failed: no v4 pool. Uniswap V3 fallback failed: v3 quote reverted')
+		await expect(loadOpenOracleInitialReportPrice(failingClient, REP_ADDRESS, ETH_ADDRESS, 100n)).rejects.toThrow('Failed to fetch price from Uniswap. Uniswap V4 quote failed: no v4 pool. Uniswap V3 quote failed: v3 quote reverted')
 	})
 
-	test('initial report price helpers use the V3 fallback for REP/WETH pairs', async () => {
+	test('initial report price helpers use Uniswap V3 for REP/WETH pairs when V4 is unavailable', async () => {
 		let callCount = 0
 		const fallbackClient = {
 			simulateContract: async () => {
@@ -191,12 +223,12 @@ describe('Open Oracle helpers', () => {
 
 		await expect(loadOpenOracleInitialReportPrice(fallbackClient, REP_ADDRESS, WETH_ADDRESS, 100n * 10n ** 18n)).resolves.toEqual({
 			price: 500_000_000_000_000_000_000n,
-			priceSource: 'Uniswap V3 fallback',
+			priceSource: 'Uniswap V3',
 			token2Amount: 200_000_000_000_000_000n,
 		})
 	})
 
-	test('initial report price helpers use the V3 fallback for non-REP pairs too', async () => {
+	test('initial report price helpers use Uniswap V3 for non-REP pairs when V4 is unavailable', async () => {
 		let callCount = 0
 		const fallbackClient = {
 			simulateContract: async () => {
@@ -210,111 +242,86 @@ describe('Open Oracle helpers', () => {
 
 		await expect(loadOpenOracleInitialReportPrice(fallbackClient, USDC_ADDRESS, WETH_ADDRESS, 100n)).resolves.toEqual({
 			price: 2_000_000_000_000_000_000n,
-			priceSource: 'Uniswap V3 fallback',
+			priceSource: 'Uniswap V3',
 			token2Amount: 50n,
 		})
 	})
 
 	test('initial report submission helper computes preview amounts and approval gating', () => {
-		const details = {
-			exactToken1Report: 100n,
-		}
-		const preview = deriveOpenOracleInitialReportSubmissionDetails({
-			approvedToken1Amount: 100n,
+		const preview = createInitialReportSubmissionPreview({
 			approvedToken2Amount: 24n,
-			defaultPrice: '4.0',
-			defaultPriceError: undefined,
-			defaultPriceSource: 'Uniswap V4',
-			priceInput: '',
-			quoteAttemptedSources: undefined,
-			quoteFailureReason: undefined,
-			reportDetails: details,
-			token1AllowanceError: undefined,
-			token2AllowanceError: undefined,
-			token1Decimals: 18,
-			token2Decimals: 18,
 		})
 
 		expect(preview.priceSource).toBe('Uniswap V4')
+		expect(preview.priceSourceUrl).toBe('https://app.uniswap.org/explore/pools/ethereum/0xpool')
 		expect(preview.price).toBe(4_000_000_000_000_000_000n)
 		expect(preview.amount1).toBe(100n)
 		expect(preview.amount2).toBe(25n)
 		expect(preview.canSubmit).toBe(false)
-		expect(preview.blockReason).toBeDefined()
+		expect(preview.blockReason).toBe('WETH approval required')
 	})
 
 	test('initial report submission helper explains exhausted quote paths with a short reason', () => {
-		const preview = deriveOpenOracleInitialReportSubmissionDetails({
-			approvedToken1Amount: 100n,
+		const preview = createInitialReportSubmissionPreview({
 			approvedToken2Amount: 100n,
 			defaultPrice: undefined,
 			defaultPriceError: undefined,
 			defaultPriceSource: undefined,
+			defaultPriceSourceUrl: undefined,
 			priceInput: '',
-			quoteAttemptedSources: ['Uniswap V4', 'Uniswap V3 fallback'],
-			quoteFailureReason: 'Failed to fetch price from Uniswap. Uniswap V4 quote failed: execution reverted for an unknown reason. Uniswap V3 fallback failed: no pool',
+			quoteAttemptedSources: ['Uniswap V4', 'Uniswap V3'],
+			quoteFailureReason: 'Failed to fetch price from Uniswap. Uniswap V4 quote failed: execution reverted for an unknown reason. Uniswap V3 quote failed: no pool',
 			reportDetails: {
 				exactToken1Report: 100n,
+				token1: REP_ADDRESS,
 				token1Symbol: 'REP',
+				token2: ETH_ADDRESS,
 				token2Symbol: 'ETH',
 			},
-			token1AllowanceError: undefined,
-			token2AllowanceError: undefined,
-			token1Decimals: 18,
-			token2Decimals: 18,
 		})
 
 		expect(preview.canSubmit).toBe(false)
-		expect(preview.blockReason).toBe('Automatic price quote unavailable for REP / ETH. Tried: Uniswap V4, then Uniswap V3 fallback. Reason: Uniswap V4 quote failed: execution reverted for an unknown reason. Uniswap V3 fallback failed: no pool. Enter a price manually to submit the initial report.')
+		expect(preview.blockReason).toBe('Automatic price quote unavailable for REP / ETH. Tried: Uniswap V4, then Uniswap V3. Reason: Uniswap V4 quote failed: execution reverted for an unknown reason. Uniswap V3 quote failed: no pool. Enter a price manually to submit the initial report.')
 	})
 
 	test('manual price entry overrides automatic quote unavailability', () => {
-		const preview = deriveOpenOracleInitialReportSubmissionDetails({
-			approvedToken1Amount: 100n,
+		const preview = createInitialReportSubmissionPreview({
 			approvedToken2Amount: 24n,
 			defaultPrice: undefined,
 			defaultPriceError: undefined,
 			defaultPriceSource: undefined,
+			defaultPriceSourceUrl: undefined,
 			priceInput: '4.0',
 			quoteAttemptedSources: ['Uniswap V4'],
 			quoteFailureReason: 'no pool',
 			reportDetails: {
 				exactToken1Report: 100n,
+				token1: getAddress('0x00000000000000000000000000000000000000a1'),
 				token1Symbol: 'ABC',
+				token2: getAddress('0x00000000000000000000000000000000000000a2'),
 				token2Symbol: 'XYZ',
 			},
-			token1AllowanceError: undefined,
-			token2AllowanceError: undefined,
-			token1Decimals: 18,
-			token2Decimals: 18,
 		})
 
 		expect(preview.priceSource).toBe('Manual override')
 		expect(preview.price).toBe(4_000_000_000_000_000_000n)
-		expect(preview.blockReason).toBe('Token2 approval required')
+		expect(preview.blockReason).toBe('XYZ approval required')
 	})
 
 	test('initial report submission helper surfaces the fetch price failure reason when no default price is available', () => {
-		const preview = deriveOpenOracleInitialReportSubmissionDetails({
-			approvedToken1Amount: 100n,
+		const preview = createInitialReportSubmissionPreview({
 			approvedToken2Amount: 100n,
 			defaultPrice: undefined,
-			defaultPriceError: 'Failed to fetch price from Uniswap. Uniswap V4 quote failed: no v3 pool. Uniswap V3 fallback failed: no v3 pool',
+			defaultPriceError: 'Failed to fetch price from Uniswap. Uniswap V4 quote failed: no v3 pool. Uniswap V3 quote failed: no v3 pool',
 			defaultPriceSource: undefined,
+			defaultPriceSourceUrl: undefined,
 			priceInput: '',
-			quoteAttemptedSources: ['Uniswap V4', 'Uniswap V3 fallback'],
-			quoteFailureReason: 'Failed to fetch price from Uniswap. Uniswap V4 quote failed: no v3 pool. Uniswap V3 fallback failed: no v3 pool',
-			reportDetails: {
-				exactToken1Report: 100n,
-			},
-			token1AllowanceError: undefined,
-			token2AllowanceError: undefined,
-			token1Decimals: 18,
-			token2Decimals: 18,
+			quoteAttemptedSources: ['Uniswap V4', 'Uniswap V3'],
+			quoteFailureReason: 'Failed to fetch price from Uniswap. Uniswap V4 quote failed: no v3 pool. Uniswap V3 quote failed: no v3 pool',
 		})
 
 		expect(preview.canSubmit).toBe(false)
-		expect(preview.blockReason).toBe('Failed to fetch price from Uniswap. Uniswap V4 quote failed: no v3 pool. Uniswap V3 fallback failed: no v3 pool')
+		expect(preview.blockReason).toBe('Failed to fetch price from Uniswap. Uniswap V4 quote failed: no v3 pool. Uniswap V3 quote failed: no v3 pool')
 	})
 
 	test('formats unavailable price messages with sanitized reasons and address fallback labels', () => {
@@ -329,28 +336,74 @@ describe('Open Oracle helpers', () => {
 	})
 
 	test('initial report submission helper surfaces allowance read failures separately from approval gating', () => {
-		const preview = deriveOpenOracleInitialReportSubmissionDetails({
+		const preview = createInitialReportSubmissionPreview({
 			approvedToken1Amount: undefined,
-			approvedToken2Amount: 25n,
-			defaultPrice: '4.0',
-			defaultPriceError: undefined,
-			defaultPriceSource: 'Uniswap V4',
-			priceInput: '',
-			quoteAttemptedSources: undefined,
-			quoteFailureReason: undefined,
-			reportDetails: {
-				exactToken1Report: 100n,
-				token1Symbol: 'REP',
-				token2Symbol: 'ETH',
-			},
 			token1AllowanceError: 'Failed to load token approval: request timed out',
-			token2AllowanceError: undefined,
-			token1Decimals: 18,
-			token2Decimals: 18,
 		})
 
 		expect(preview.canSubmit).toBe(false)
 		expect(preview.blockReason).toBe('Unable to verify REP approval for this report. Reason: request timed out. Retry loading the report or approval status before submitting the initial report.')
+	})
+
+	test('initial report submission helper surfaces balance read failures separately from approval gating', () => {
+		const preview = createInitialReportSubmissionPreview({
+			token2Balance: undefined,
+			token2BalanceError: 'Failed to load token balance: request timed out',
+		})
+
+		expect(preview.canSubmit).toBe(false)
+		expect(preview.blockReason).toBe('Unable to verify WETH balance for this report. Reason: request timed out. Retry loading the report or balance status before submitting the initial report.')
+	})
+
+	test('initial report submission helper surfaces token-specific insufficient token1 balances', () => {
+		const preview = createInitialReportSubmissionPreview({
+			token1Balance: 99n,
+		})
+
+		expect(preview.canSubmit).toBe(false)
+		expect(preview.blockReason).toBe('Insufficient REP balance for this report. Need 100, wallet has 99.')
+	})
+
+	test('initial report submission helper surfaces insufficient WETH balances and exposes wrap details', () => {
+		const preview = createInitialReportSubmissionPreview({
+			token2Balance: 24n,
+			walletEthBalance: 10n,
+		})
+
+		expect(preview.canSubmit).toBe(false)
+		expect(preview.blockReason).toBe('Insufficient WETH balance for this report. Need 25, wallet has 24. Wrap ETH into WETH first.')
+		expect(preview.requiredWethWrapAmount).toBe(1n)
+		expect(preview.canWrapRequiredWeth).toBe(true)
+		expect(preview.wrapRequiredWethDisabledReason).toBeUndefined()
+	})
+
+	test('initial report submission helper reports when wallet ETH is insufficient to wrap the required WETH', () => {
+		const preview = createInitialReportSubmissionPreview({
+			token2Balance: 24n,
+			walletEthBalance: 0n,
+		})
+
+		expect(preview.requiredWethWrapAmount).toBe(1n)
+		expect(preview.canWrapRequiredWeth).toBe(false)
+		expect(preview.wrapRequiredWethDisabledReason).toBe('Wallet has 0 ETH, need 0.000000000000000001 ETH to wrap the required WETH.')
+	})
+
+	test('initial report submission helper reports when wallet ETH balance is still loading for WETH wrap', () => {
+		const preview = createInitialReportSubmissionPreview({
+			token2Balance: 24n,
+			walletEthBalance: undefined,
+		})
+
+		expect(preview.requiredWethWrapAmount).toBe(1n)
+		expect(preview.canWrapRequiredWeth).toBe(false)
+		expect(preview.wrapRequiredWethDisabledReason).toBe('Loading wallet ETH balance.')
+	})
+
+	test('initial report submission helper allows submit when balances and approvals are sufficient', () => {
+		const preview = createInitialReportSubmissionPreview()
+
+		expect(preview.canSubmit).toBe(true)
+		expect(preview.blockReason).toBeUndefined()
 	})
 
 	test('formats unavailable approval status messages with sanitized reasons', () => {
@@ -360,6 +413,15 @@ describe('Open Oracle helpers', () => {
 				tokenLabel: 'WETH',
 			}),
 		).toBe('Unable to verify WETH approval for this report. Reason: execution reverted. Retry loading the report or approval status before submitting the initial report.')
+	})
+
+	test('formats unavailable balance status messages with sanitized reasons', () => {
+		expect(
+			formatOpenOracleInitialReportBalanceStatusUnavailableMessage({
+				reason: 'Failed to load token balance: execution reverted',
+				tokenLabel: 'WETH',
+			}),
+		).toBe('Unable to verify WETH balance for this report. Reason: execution reverted. Retry loading the report or balance status before submitting the initial report.')
 	})
 
 	test('open oracle fee and multiplier formatters render human values', () => {
@@ -424,7 +486,7 @@ describe('Open Oracle helpers', () => {
 		const openOracleAddress = getOpenOracleAddress()
 		await approveToken(client, addressString(GENESIS_REPUTATION_TOKEN), openOracleAddress)
 		await approveToken(client, WETH_ADDRESS, openOracleAddress)
-		await wrapWeth(client, amount2)
+		await wrapWethTestHelper(client, amount2)
 
 		const stateHash = (await getOpenOracleExtraData(client, reportId)).stateHash
 		await submitInitialOracleReport(uiWriteClient, openOracleAddress, reportId, amount1, amount2, stateHash)
@@ -447,5 +509,17 @@ describe('Open Oracle helpers', () => {
 		expect(managerDetails.lastSettlementTimestamp).toBeGreaterThan(0n)
 		expect(managerDetails.isPriceValid).toBe(true)
 		expect(managerDetails.priceValidUntilTimestamp).toBe(managerDetails.lastSettlementTimestamp + ORACLE_MANAGER_PRICE_VALID_FOR_SECONDS)
+	})
+
+	test('ui wrapWeth helper deposits ETH into WETH and reports the wrap action', async () => {
+		const walletAddress = addressString(TEST_ADDRESSES[0])
+		const startBalance = await loadErc20Balance(uiReadClient, WETH_ADDRESS, walletAddress)
+		const wrapAmount = 123n
+
+		const result = await wrapUiWeth(uiWriteClient, wrapAmount)
+		expect(result.action).toBe('wrapWeth')
+
+		const endBalance = await loadErc20Balance(uiReadClient, WETH_ADDRESS, walletAddress)
+		expect(endBalance - startBalance).toBe(wrapAmount)
 	})
 })

--- a/ui/ts/tests/uniswapQuoter.integration.test.ts
+++ b/ui/ts/tests/uniswapQuoter.integration.test.ts
@@ -81,7 +81,7 @@ void describe('Uniswap V4 Quoter — integration', () => {
 	})
 
 	// REP/WETH V3 1% pool is the live source used as fallback when V4 is unavailable
-	void describe('REP/ETH — Uniswap V3 fallback (1% pool)', () => {
+	void describe('REP/ETH — Uniswap V3 (1% pool)', () => {
 		void test('quoteRepForEthV3 returns a plausible REP price in ETH', async () => {
 			const ethOut = await quoteRepForEthV3(client, ONE_REP)
 			// At time of writing REP is roughly $0.40 and ETH ~$2 191 → ~0.00018 ETH per REP

--- a/ui/ts/tests/uniswapQuoter.test.ts
+++ b/ui/ts/tests/uniswapQuoter.test.ts
@@ -1,8 +1,26 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from 'bun:test'
-import { zeroAddress } from 'viem'
-import { DEFAULT_POOL_CONFIG, ETH_ADDRESS, REP_ADDRESS, UNISWAP_V4_QUOTER_ADDRESS, WETH_ADDRESS, quoteBestExactInput, quoteBestV3ExactInput, quoteEthForRep, quoteEthForToken, quoteExactInput, quoteRepForEth, quoteTokenForEth } from '../lib/uniswapQuoter.js'
+import { getAddress, zeroAddress, type Address } from 'viem'
+import {
+	DEFAULT_POOL_CONFIG,
+	ETH_ADDRESS,
+	REP_ADDRESS,
+	UNISWAP_V4_QUOTER_ADDRESS,
+	WETH_ADDRESS,
+	buildUniswapV3PoolUrl,
+	buildUniswapV4PoolId,
+	buildUniswapV4PoolUrl,
+	quoteBestExactInput,
+	quoteBestExactInputWithSource,
+	quoteBestV3ExactInput,
+	quoteBestV3ExactInputWithSource,
+	quoteEthForRep,
+	quoteEthForToken,
+	quoteExactInput,
+	quoteRepForEth,
+	quoteTokenForEth,
+} from '../lib/uniswapQuoter.js'
 import type { ReadClient } from '../lib/clients.js'
 
 type SimulateArgs = Parameters<ReadClient['simulateContract']>[0]
@@ -160,6 +178,33 @@ void describe('quoteBestExactInput', () => {
 	})
 })
 
+void describe('quoteBestExactInputWithSource', () => {
+	void test('returns the best successful quote together with exact V4 pool metadata', async () => {
+		const poolConfigs = [
+			{ fee: 100, tickSpacing: 1 },
+			{ fee: 500, tickSpacing: 10 },
+			{ fee: 3000, tickSpacing: 60 },
+		] as const
+		const client = createPoolAwareClient({
+			100: 9n,
+			500: 12n,
+			3000: 7n,
+		})
+
+		const result = await quoteBestExactInputWithSource(client, ETH_ADDRESS, REP_ADDRESS, 1n, poolConfigs)
+
+		expect(result).toEqual({
+			amountOut: 12n,
+			source: {
+				poolConfig: poolConfigs[1],
+				poolId: buildUniswapV4PoolId(ETH_ADDRESS, REP_ADDRESS, poolConfigs[1]),
+				poolUrl: buildUniswapV4PoolUrl(ETH_ADDRESS, REP_ADDRESS, poolConfigs[1]),
+				protocol: 'v4',
+			},
+		})
+	})
+})
+
 void describe('quoteBestV3ExactInput', () => {
 	void test('returns the best successful quote across tested V3 fee tiers', async () => {
 		const client = createV3FeeAwareClient({
@@ -191,6 +236,47 @@ void describe('quoteBestV3ExactInput', () => {
 	void test('throws when every tested V3 fee tier fails', async () => {
 		const client = createV3FeeAwareClient({})
 		await expect(quoteBestV3ExactInput(client, ETH_ADDRESS, REP_ADDRESS, 1n)).rejects.toThrow('no v3 pool for fee 10000')
+	})
+})
+
+void describe('quoteBestV3ExactInputWithSource', () => {
+	void test('returns the best successful quote together with exact V3 pool metadata from the factory', async () => {
+		const poolAddress = getAddress('0x0000000000000000000000000000000000000abc')
+		const factoryCalls: Array<{ fee: number; tokenA: Address; tokenB: Address }> = []
+		const client = {
+			simulateContract: async (args: SimulateArgs) => {
+				const [param] = args.args as unknown as [{ tokenIn: string; tokenOut: string; amountIn: bigint; fee: number; sqrtPriceLimitX96: bigint }]
+				const amountOut = param.fee === 500 ? 9n : param.fee === 3000 ? 12n : undefined
+				if (amountOut === undefined) {
+					throw new Error(`no v3 pool for fee ${param.fee}`)
+				}
+				return { result: [amountOut, 0n, 0, 0n] }
+			},
+			readContract: async (args: { args?: unknown[] }) => {
+				const [tokenA, tokenB, fee] = args.args as [Address, Address, number]
+				factoryCalls.push({ fee, tokenA, tokenB })
+				return poolAddress
+			},
+		} as unknown as ReadClient
+
+		const result = await quoteBestV3ExactInputWithSource(client, ETH_ADDRESS, REP_ADDRESS, 1n, [500, 3000])
+
+		expect(result).toEqual({
+			amountOut: 12n,
+			source: {
+				fee: 3000,
+				poolAddress,
+				poolUrl: buildUniswapV3PoolUrl(poolAddress),
+				protocol: 'v3',
+			},
+		})
+		expect(factoryCalls).toEqual([
+			{
+				fee: 3000,
+				tokenA: REP_ADDRESS,
+				tokenB: WETH_ADDRESS,
+			},
+		])
 	})
 })
 

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -48,8 +48,10 @@ export type OverviewPanelsProps = {
 	isRefreshing: boolean
 	repEthPrice: bigint | undefined
 	repEthSource: 'v4' | 'v3' | undefined
+	repEthSourceUrl: string | undefined
 	repUsdcPrice: bigint | undefined
 	repUsdcSource: 'v4' | 'v3' | undefined
+	repUsdcSourceUrl: string | undefined
 	isLoadingRepPrices: boolean
 	onConnect: () => void
 	onGoToGenesisUniverse: () => void
@@ -258,21 +260,27 @@ export type OpenOracleRouteContentProps = {
 	onOpenOracleCreateFormChange: (update: Partial<OpenOracleCreateFormState>) => void
 	onSettleReport: () => void
 	onSubmitInitialReport: () => void
+	onWrapWethForInitialReport: () => void
 	loadingOpenOracleCreate: boolean
 	openOracleError: string | undefined
 	openOracleInitialReportState: {
 		defaultPrice: string | undefined
 		defaultPriceError: string | undefined
 		defaultPriceSource: OpenOracleInitialReportPriceSource | undefined
+		defaultPriceSourceUrl: string | undefined
 		loading: boolean
 		quoteAttemptedSources: OpenOracleInitialReportQuoteSource[] | undefined
 		quoteFailureKind: OpenOracleInitialReportQuoteFailureKind | undefined
 		quoteFailureReason: string | undefined
 		token1Allowance: bigint | undefined
 		token1AllowanceError: string | undefined
+		token1Balance: bigint | undefined
+		token1BalanceError: string | undefined
 		token1Decimals: number | undefined
 		token2Allowance: bigint | undefined
 		token2AllowanceError: string | undefined
+		token2Balance: bigint | undefined
+		token2BalanceError: string | undefined
 		token2Decimals: number | undefined
 	}
 	openOracleCreateForm: OpenOracleCreateFormState

--- a/ui/ts/types/contracts.ts
+++ b/ui/ts/types/contracts.ts
@@ -151,7 +151,7 @@ export type OracleManagerDetails = {
 }
 
 export type OpenOracleActionResult = ActionResult & {
-	action: 'approveToken1' | 'approveToken2' | 'createReportInstance' | 'dispute' | 'queueOperation' | 'requestPrice' | 'settle' | 'submitInitialReport'
+	action: 'approveToken1' | 'approveToken2' | 'createReportInstance' | 'dispute' | 'queueOperation' | 'requestPrice' | 'settle' | 'submitInitialReport' | 'wrapWeth'
 }
 
 export type OpenOracleReportSummary = {


### PR DESCRIPTION
## Summary
- Added an ETH-to-WETH wrapping flow for open oracle initial reports when the wallet needs more WETH to submit.
- Improved price source labeling with clickable Uniswap links and richer source metadata.
- Added explicit approval and balance display states, including a `max` display for oversized token approvals.
- Show loading indicators in report hints and submission actions for clearer transaction feedback.

## Testing
- Not run