### PR TITLE
Align field row actions to the bottom

### DIFF
--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -1915,6 +1915,10 @@ button.currency-value.copyable:hover:not(:disabled) {
 	gap: 1rem;
 }
 
+.field-row > .actions {
+	align-self: end;
+}
+
 .field {
 	display: grid;
 	gap: 0.5rem;


### PR DESCRIPTION
## Summary
- Align `.field-row` action buttons to the bottom of the row for better vertical alignment.
- Update the UI stylesheet only; no functional behavior changed.

## Testing
- Not run (not requested).