### PR TITLE
Highlight approval sufficiency in token approval UI

### DIFF
--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -649,6 +649,14 @@ button.currency-value.copyable:hover:not(:disabled) {
 	outline-offset: 2px;
 }
 
+.currency-value.approval-sufficient {
+	color: var(--success);
+}
+
+.currency-value.approval-insufficient {
+	color: var(--danger);
+}
+
 .timestamp-value {
 	font: inherit;
 	color: inherit;
@@ -1933,6 +1941,27 @@ button.currency-value.copyable:hover:not(:disabled) {
 
 .field-inline > .field-inline-action {
 	flex: 0 0 auto;
+}
+
+.approval-amount-field {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.75rem 1rem;
+}
+
+.approval-amount-field > .approval-amount-label {
+	flex: 0 1 auto;
+	min-width: 0;
+}
+
+.approval-amount-field > .approval-amount-controls {
+	flex: 1 1 18rem;
+	min-width: min(100%, 18rem);
+}
+
+.approval-amount-controls > .field-inline-input {
+	min-width: 0;
 }
 
 .field span {

--- a/ui/ts/components/ApprovedAmountValue.tsx
+++ b/ui/ts/components/ApprovedAmountValue.tsx
@@ -1,12 +1,14 @@
 import { CurrencyValue } from './CurrencyValue.js'
 
 export const APPROVAL_MAX_DISPLAY_THRESHOLD = (1n << 200n) - 1n
+export const APPROVAL_MAX_LABEL = 'Max'
 
 type ApprovedAmountValueProps = {
 	className?: string
 	copyable?: boolean
 	decimals?: number
 	loading?: boolean
+	requiredAmount?: bigint | undefined
 	suffix?: string
 	units?: number
 	value: bigint | undefined
@@ -16,14 +18,21 @@ export function isApprovalAmountMaxDisplay(value: bigint | undefined) {
 	return value !== undefined && value > APPROVAL_MAX_DISPLAY_THRESHOLD
 }
 
-export function ApprovedAmountValue({ className = '', copyable = true, decimals = 2, loading = false, suffix = '', units = 18, value }: ApprovedAmountValueProps) {
+export function getApprovedAmountTone(value: bigint | undefined, requiredAmount: bigint | undefined) {
+	if (value === undefined || requiredAmount === undefined) return undefined
+	return value >= requiredAmount ? 'sufficient' : 'insufficient'
+}
+
+export function ApprovedAmountValue({ className = '', copyable = true, decimals = 2, loading = false, requiredAmount, suffix = '', units = 18, value }: ApprovedAmountValueProps) {
+	const toneClassName = getApprovedAmountTone(value, requiredAmount)
+
 	if (isApprovalAmountMaxDisplay(value)) {
 		return (
-			<span className={`currency-value approval-max ${className}`.trim()} title='Unlimited approval'>
-				max
+			<span className={['currency-value', 'approval-max', toneClassName === undefined ? '' : `approval-${toneClassName}`, className].filter(Boolean).join(' ')} title='Unlimited approval'>
+				{APPROVAL_MAX_LABEL}
 			</span>
 		)
 	}
 
-	return <CurrencyValue className={className} copyable={copyable} decimals={decimals} loading={loading} suffix={suffix} units={units} value={value} />
+	return <CurrencyValue className={[toneClassName === undefined ? '' : `approval-${toneClassName}`, className].filter(Boolean).join(' ')} copyable={copyable} decimals={decimals} loading={loading} suffix={suffix} units={units} value={value} />
 }

--- a/ui/ts/components/TokenApprovalControl.tsx
+++ b/ui/ts/components/TokenApprovalControl.tsx
@@ -113,16 +113,13 @@ export function TokenApprovalControl({ actionLabel, allowanceError, allowanceLoa
 					<CurrencyValue value={requiredAmount} units={tokenUnits} suffix={tokenSymbol} copyable={false} />
 				</MetricField>
 				<MetricField label={`Approved ${tokenSymbol}`}>
-					<ApprovedAmountValue loading={allowanceLoading} value={approvedAmount} units={tokenUnits} suffix={tokenSymbol} copyable={false} />
-				</MetricField>
-				<MetricField label={`Need More ${tokenSymbol} Approved`}>
-					<CurrencyValue value={requirement.neededAmount} units={tokenUnits} suffix={tokenSymbol} copyable={false} />
+					<ApprovedAmountValue loading={allowanceLoading} value={approvedAmount} requiredAmount={requiredAmount} units={tokenUnits} suffix={tokenSymbol} copyable={false} />
 				</MetricField>
 			</div>
 
-			<label className='field'>
-				<span>{`${tokenSymbol} Approval Amount`}</span>
-				<div className='field-inline'>
+			<label className='field approval-amount-field'>
+				<span className='approval-amount-label'>{`${tokenSymbol} Approval Amount`}</span>
+				<div className='field-inline approval-amount-controls'>
 					<FormInput className='field-inline-input' value={draftAmount} onInput={event => setDraftAmount(event.currentTarget.value)} placeholder='Leave blank for required total' invalid={amountValidationMessage !== undefined} disabled={pending} />
 					<button className='quiet field-inline-action' type='button' onClick={() => setDraftAmount('max')} disabled={pending}>
 						Max

--- a/ui/ts/tests/approvedAmountValue.test.ts
+++ b/ui/ts/tests/approvedAmountValue.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, test } from 'bun:test'
 import { maxUint256 } from 'viem'
-import { APPROVAL_MAX_DISPLAY_THRESHOLD, isApprovalAmountMaxDisplay } from '../components/ApprovedAmountValue.js'
+import { APPROVAL_MAX_DISPLAY_THRESHOLD, APPROVAL_MAX_LABEL, getApprovedAmountTone, isApprovalAmountMaxDisplay } from '../components/ApprovedAmountValue.js'
 
 void describe('ApprovedAmountValue helpers', () => {
 	void test('treats maxUint256 as max display', () => {
@@ -15,5 +15,17 @@ void describe('ApprovedAmountValue helpers', () => {
 
 	void test('keeps maxUint200 itself numeric', () => {
 		expect(isApprovalAmountMaxDisplay(APPROVAL_MAX_DISPLAY_THRESHOLD)).toBe(false)
+	})
+
+	void test('uses a capitalized Max label for unlimited approval display', () => {
+		expect(APPROVAL_MAX_LABEL).toBe('Max')
+	})
+
+	void test('reports whether the approved amount satisfies the required amount', () => {
+		expect(getApprovedAmountTone(25n, 25n)).toBe('sufficient')
+		expect(getApprovedAmountTone(26n, 25n)).toBe('sufficient')
+		expect(getApprovedAmountTone(24n, 25n)).toBe('insufficient')
+		expect(getApprovedAmountTone(undefined, 25n)).toBe(undefined)
+		expect(getApprovedAmountTone(25n, undefined)).toBe(undefined)
 	})
 })


### PR DESCRIPTION
## Summary
- Color the approved amount to indicate whether it meets the required token allowance.
- Simplify the approval control layout by folding the extra "Need More" metric into the approved amount display.
- Update the unlimited-approval label to `Max` and add tests for the new tone helper and label.

## Testing
- Not run (PR description only).