### PR TITLE
Show WETH wrap status in open oracle reports

### DIFF
--- a/ui/ts/components/OpenOracleSection.tsx
+++ b/ui/ts/components/OpenOracleSection.tsx
@@ -142,6 +142,24 @@ function renderSelectedReportActionSection(
 							<MetricField label={`Required ${token2Symbol}`}>
 								<CurrencyValue value={initialReportSubmission.amount2} units={initialReportSubmission.token2Decimals ?? 18} suffix={token2Symbol} copyable={false} />
 							</MetricField>
+							<MetricField label={`Wallet ${token1Symbol}`}>
+								<CurrencyValue
+									loading={openOracleInitialReportState.loading && openOracleInitialReportState.token1Balance === undefined && openOracleInitialReportState.token1BalanceError === undefined}
+									value={openOracleInitialReportState.token1Balance}
+									units={initialReportSubmission.token1Decimals ?? 18}
+									suffix={token1Symbol}
+									copyable={false}
+								/>
+							</MetricField>
+							<MetricField label={`Wallet ${token2Symbol}`}>
+								<CurrencyValue
+									loading={openOracleInitialReportState.loading && openOracleInitialReportState.token2Balance === undefined && openOracleInitialReportState.token2BalanceError === undefined}
+									value={openOracleInitialReportState.token2Balance}
+									units={initialReportSubmission.token2Decimals ?? 18}
+									suffix={token2Symbol}
+									copyable={false}
+								/>
+							</MetricField>
 							<MetricField label={`Approved ${token1Symbol}`}>
 								<ApprovedAmountValue loading={openOracleInitialReportState.token1Approval.loading} value={initialReportSubmission.token1Approval.approvedAmount} units={initialReportSubmission.token1Decimals ?? 18} suffix={token1Symbol} copyable={false} />
 							</MetricField>
@@ -149,11 +167,15 @@ function renderSelectedReportActionSection(
 								<ApprovedAmountValue loading={openOracleInitialReportState.token2Approval.loading} value={initialReportSubmission.token2Approval.approvedAmount} units={initialReportSubmission.token2Decimals ?? 18} suffix={token2Symbol} copyable={false} />
 							</MetricField>
 						</div>
-						{initialReportSubmission.requiredWethWrapAmount === undefined || initialReportSubmission.requiredWethWrapAmount <= 0n ? undefined : (
+						{!initialReportSubmission.hasWethWrapAction ? undefined : (
 							<div className='entity-card-subsection'>
-								<p className='detail'>
-									Need <CurrencyValue value={initialReportSubmission.requiredWethWrapAmount} suffix='WETH' copyable={false} /> more WETH for this report.
-								</p>
+								{initialReportSubmission.requiredWethWrapAmount === undefined || initialReportSubmission.requiredWethWrapAmount <= 0n ? (
+									<p className='detail'>This report uses WETH for the initial report deposit.</p>
+								) : (
+									<p className='detail'>
+										Need <CurrencyValue value={initialReportSubmission.requiredWethWrapAmount} suffix='WETH' copyable={false} /> more WETH for this report.
+									</p>
+								)}
 								{initialReportSubmission.wrapRequiredWethDisabledReason === undefined ? undefined : <p className='detail'>{initialReportSubmission.wrapRequiredWethDisabledReason}</p>}
 								<div className='actions'>
 									<button className='secondary' type='button' onClick={onWrapWethForInitialReport} disabled={!isConnected || !initialReportSubmission.canWrapRequiredWeth || openOracleInitialReportState.loading || openOracleActiveAction === 'wrapWeth'} title={initialReportSubmission.wrapRequiredWethDisabledReason}>

--- a/ui/ts/lib/openOracle.ts
+++ b/ui/ts/lib/openOracle.ts
@@ -37,6 +37,7 @@ type OpenOracleInitialReportSubmissionDetails = {
 	blockReason: string | undefined
 	canSubmit: boolean
 	canWrapRequiredWeth: boolean
+	hasWethWrapAction: boolean
 	price: bigint | undefined
 	priceInput: string
 	priceSource: OpenOracleInitialReportPriceSource
@@ -346,6 +347,7 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 	const token2Approval = deriveTokenApprovalRequirement(amount2, approvedToken2Amount)
 	const token1BalanceShortage = amount1 === undefined || token1Balance === undefined || token1Balance >= amount1 ? undefined : amount1 - token1Balance
 	const token2BalanceShortage = amount2 === undefined || token2Balance === undefined || token2Balance >= amount2 ? undefined : amount2 - token2Balance
+	const hasWethWrapAction = reportDetails !== undefined && (isCanonicalMainnetWeth(reportDetails.token1) || isCanonicalMainnetWeth(reportDetails.token2))
 	const requiredWethWrapAmount =
 		reportDetails === undefined
 			? undefined
@@ -355,14 +357,19 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 					? token2BalanceShortage
 					: undefined
 	const canWrapRequiredWeth = requiredWethWrapAmount !== undefined && requiredWethWrapAmount > 0n && walletEthBalance !== undefined && walletEthBalance >= requiredWethWrapAmount
-	const wrapRequiredWethDisabledReason =
-		requiredWethWrapAmount === undefined || requiredWethWrapAmount <= 0n
-			? undefined
-			: walletEthBalance === undefined
+	const wrapRequiredWethDisabledReason = !hasWethWrapAction
+		? undefined
+		: requiredWethWrapAmount !== undefined && requiredWethWrapAmount > 0n
+			? walletEthBalance === undefined
 				? 'Loading wallet ETH balance.'
 				: walletEthBalance < requiredWethWrapAmount
 					? `Wallet has ${formatCurrencyBalance(walletEthBalance)} ETH, need ${formatCurrencyBalance(requiredWethWrapAmount)} ETH to wrap the required WETH.`
 					: undefined
+			: amount1 === undefined || amount2 === undefined
+				? `Enter a valid ${token1Label} / ${token2Label} price to determine whether this report needs more WETH.`
+				: (isCanonicalMainnetWeth(reportDetails?.token1) && token1Balance === undefined) || (isCanonicalMainnetWeth(reportDetails?.token2) && token2Balance === undefined)
+					? 'Loading current WETH balance.'
+					: 'No additional WETH is required for this report.'
 
 	let blockReason: string | undefined
 	if (reportDetails === undefined) {
@@ -434,6 +441,7 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 		blockReason,
 		canSubmit: blockReason === undefined,
 		canWrapRequiredWeth,
+		hasWethWrapAction,
 		price,
 		priceInput: resolvedPriceInput,
 		priceSource,

--- a/ui/ts/tests/openOracle.test.ts
+++ b/ui/ts/tests/openOracle.test.ts
@@ -364,6 +364,30 @@ describe('Open Oracle helpers', () => {
 		expect(preview.blockReason).toBe('Insufficient REP balance for this report. Need 100, wallet has 99.')
 	})
 
+	test('initial report submission helper disables submit for tiny insufficient REP balances', () => {
+		const preview = createInitialReportSubmissionPreview({
+			approvedToken1Amount: 11_000_000n,
+			approvedToken2Amount: 11_000_000n,
+			defaultPrice: '1',
+			reportDetails: {
+				exactToken1Report: 11_000_000n,
+				token1: REP_ADDRESS,
+				token1Symbol: 'REP',
+				token2: WETH_ADDRESS,
+				token2Symbol: 'WETH',
+			},
+			token1Balance: 10_000_000n,
+			token1Decimals: 18,
+			token2Balance: 11_000_000n,
+			token2Decimals: 18,
+			walletEthBalance: 0n,
+		})
+
+		expect(preview.amount1).toBe(11_000_000n)
+		expect(preview.canSubmit).toBe(false)
+		expect(preview.blockReason).toBe('Insufficient REP balance for this report. Need 0.000000000011, wallet has 0.00000000001.')
+	})
+
 	test('initial report submission helper surfaces insufficient WETH balances and exposes wrap details', () => {
 		const preview = createInitialReportSubmissionPreview({
 			token2Balance: 24n,
@@ -371,10 +395,37 @@ describe('Open Oracle helpers', () => {
 		})
 
 		expect(preview.canSubmit).toBe(false)
+		expect(preview.hasWethWrapAction).toBe(true)
 		expect(preview.blockReason).toBe('Insufficient WETH balance for this report. Need 25, wallet has 24. Wrap ETH into WETH first.')
 		expect(preview.requiredWethWrapAmount).toBe(1n)
 		expect(preview.canWrapRequiredWeth).toBe(true)
 		expect(preview.wrapRequiredWethDisabledReason).toBeUndefined()
+	})
+
+	test('initial report submission helper disables submit for tiny insufficient WETH balances', () => {
+		const preview = createInitialReportSubmissionPreview({
+			approvedToken1Amount: 11_000_000n,
+			approvedToken2Amount: 11_000_000n,
+			defaultPrice: '1',
+			reportDetails: {
+				exactToken1Report: 11_000_000n,
+				token1: REP_ADDRESS,
+				token1Symbol: 'REP',
+				token2: WETH_ADDRESS,
+				token2Symbol: 'WETH',
+			},
+			token1Balance: 11_000_000n,
+			token1Decimals: 18,
+			token2Balance: 10_000_000n,
+			token2Decimals: 18,
+			walletEthBalance: 1_000_000n,
+		})
+
+		expect(preview.amount2).toBe(11_000_000n)
+		expect(preview.canSubmit).toBe(false)
+		expect(preview.blockReason).toBe('Insufficient WETH balance for this report. Need 0.000000000011, wallet has 0.00000000001. Wrap ETH into WETH first.')
+		expect(preview.requiredWethWrapAmount).toBe(1_000_000n)
+		expect(preview.canWrapRequiredWeth).toBe(true)
 	})
 
 	test('initial report submission helper reports when wallet ETH is insufficient to wrap the required WETH', () => {
@@ -397,6 +448,32 @@ describe('Open Oracle helpers', () => {
 		expect(preview.requiredWethWrapAmount).toBe(1n)
 		expect(preview.canWrapRequiredWeth).toBe(false)
 		expect(preview.wrapRequiredWethDisabledReason).toBe('Loading wallet ETH balance.')
+	})
+
+	test('initial report submission helper keeps the WETH wrap action visible when no top-up is needed', () => {
+		const preview = createInitialReportSubmissionPreview()
+
+		expect(preview.hasWethWrapAction).toBe(true)
+		expect(preview.requiredWethWrapAmount).toBeUndefined()
+		expect(preview.canWrapRequiredWeth).toBe(false)
+		expect(preview.wrapRequiredWethDisabledReason).toBe('No additional WETH is required for this report.')
+	})
+
+	test('initial report submission helper explains that a price is needed before determining a WETH wrap amount', () => {
+		const preview = createInitialReportSubmissionPreview({
+			defaultPrice: undefined,
+			defaultPriceError: undefined,
+			defaultPriceSource: undefined,
+			defaultPriceSourceUrl: undefined,
+			priceInput: '',
+			quoteAttemptedSources: ['Uniswap V4'],
+			quoteFailureReason: 'no pool',
+		})
+
+		expect(preview.hasWethWrapAction).toBe(true)
+		expect(preview.requiredWethWrapAmount).toBeUndefined()
+		expect(preview.canWrapRequiredWeth).toBe(false)
+		expect(preview.wrapRequiredWethDisabledReason).toBe('Enter a valid REP / WETH price to determine whether this report needs more WETH.')
 	})
 
 	test('initial report submission helper allows submit when balances and approvals are sufficient', () => {


### PR DESCRIPTION
## Summary
- Adds wallet balance fields for the two report tokens in the open oracle initial report UI.
- Keeps the WETH wrap action visible when the report involves WETH, and explains whether wrapping is actually needed.
- Extends the open oracle helper logic and tests to cover wrap visibility, missing-price messaging, and tiny-balance edge cases.

## Testing
- Not run (PR content only).