### PR TITLE
Hide loading-only open oracle and approval gate messages

### DIFF
--- a/ui/ts/components/OpenOracleSection.tsx
+++ b/ui/ts/components/OpenOracleSection.tsx
@@ -154,9 +154,15 @@ function renderSelectedReportActionSection(
 								<p className='detail'>
 									Need <CurrencyValue value={initialReportSubmission.requiredWethWrapAmount} suffix='WETH' copyable={false} /> more WETH for this report.
 								</p>
-								{initialReportSubmission.wrapRequiredWethDisabledReason === undefined ? undefined : <p className='detail'>{initialReportSubmission.wrapRequiredWethDisabledReason}</p>}
+								{initialReportSubmission.wrapRequiredWethMessage?.kind !== 'visible' ? undefined : <p className='detail'>{initialReportSubmission.wrapRequiredWethMessage.message}</p>}
 								<div className='actions'>
-									<button className='secondary' type='button' onClick={onWrapWethForInitialReport} disabled={!isConnected || !initialReportSubmission.canWrapRequiredWeth || openOracleInitialReportState.loading || openOracleActiveAction === 'wrapWeth'} title={initialReportSubmission.wrapRequiredWethDisabledReason}>
+									<button
+										className='secondary'
+										type='button'
+										onClick={onWrapWethForInitialReport}
+										disabled={!isConnected || !initialReportSubmission.canWrapRequiredWeth || openOracleInitialReportState.loading || openOracleActiveAction === 'wrapWeth'}
+										title={initialReportSubmission.wrapRequiredWethMessage?.kind === 'visible' ? initialReportSubmission.wrapRequiredWethMessage.message : undefined}
+									>
 										{openOracleActiveAction === 'wrapWeth' ? <LoadingText>Wrapping ETH...</LoadingText> : 'Wrap needed ETH to WETH'}
 									</button>
 								</div>
@@ -201,7 +207,7 @@ function renderSelectedReportActionSection(
 								tokenUnits={initialReportSubmission.token2Decimals ?? 18}
 							/>
 						</div>
-						<ErrorNotice message={initialReportSubmission.blockReason} />
+						<ErrorNotice message={initialReportSubmission.blockMessage?.kind === 'visible' ? initialReportSubmission.blockMessage.message : undefined} />
 						<div className='actions'>
 							<button className='primary' onClick={onSubmitInitialReport} disabled={!isConnected || !initialReportSubmission.canSubmit || openOracleInitialReportState.loading || openOracleActiveAction === 'submitInitialReport'}>
 								{openOracleActiveAction === 'submitInitialReport' ? <LoadingText>Submitting...</LoadingText> : 'Submit Initial Report'}

--- a/ui/ts/components/TokenApprovalControl.tsx
+++ b/ui/ts/components/TokenApprovalControl.tsx
@@ -6,7 +6,7 @@ import { FormInput } from './FormInput.js'
 import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
 import { formatCurrencyBalance } from '../lib/formatters.js'
-import { deriveTokenApprovalRequirement, formatTokenApprovalNeededMessage, formatTokenApprovalPartialMessage, formatTokenApprovalUnavailableMessage, parseTokenApprovalAmountInput } from '../lib/tokenApproval.js'
+import { deriveTokenApprovalRequirement, formatTokenApprovalUnavailableMessage, parseTokenApprovalAmountInput, resolveTokenApprovalStatusMessage } from '../lib/tokenApproval.js'
 
 type TokenApprovalControlProps = {
 	actionLabel: string
@@ -73,24 +73,17 @@ export function TokenApprovalControl({ actionLabel, allowanceError, allowanceLoa
 	const nextApprovalAmount = parsedAmount.kind === 'default' ? requirement.targetAmount : parsedAmount.kind === 'invalid' ? undefined : parsedAmount.amount
 
 	const amountValidationMessage = parsedAmount.kind === 'invalid' ? parsedAmount.error : parsedAmount.kind === 'default' || approvedAmount === undefined || parsedAmount.amount > approvedAmount ? undefined : `Approval amount must be greater than the current approved ${tokenSymbol} amount.`
-
-	const partialApprovalMessage =
-		nextApprovalAmount === undefined || requiredAmount === undefined || draftAmount.trim() === '' || amountValidationMessage !== undefined
-			? undefined
-			: formatTokenApprovalPartialMessage({
-					actionLabel,
-					nextApprovedAmount: nextApprovalAmount,
-					requiredAmount,
-					tokenLabel: tokenSymbol,
-					tokenUnits,
-				})
-
-	const statusMessage =
-		guardMessage ??
-		amountValidationMessage ??
-		(amountValidationMessage === undefined && draftAmount.trim() === '' ? formatTokenApprovalNeededMessage({ actionLabel, requirement, tokenLabel: tokenSymbol, tokenUnits }) : undefined) ??
-		partialApprovalMessage ??
-		(allowanceLoading ? `Loading current ${tokenSymbol} approval.` : undefined)
+	const statusMessage = resolveTokenApprovalStatusMessage({
+		actionLabel,
+		amountValidationMessage,
+		draftAmount,
+		guardMessage,
+		nextApprovalAmount,
+		requiredAmount,
+		requirement,
+		tokenLabel: tokenSymbol,
+		tokenUnits,
+	})
 
 	const allowanceMessage = allowanceError === undefined ? undefined : formatTokenApprovalUnavailableMessage({ actionLabel, reason: allowanceError, tokenLabel: tokenSymbol })
 	const canApprove = !pending && guardMessage === undefined && allowanceMessage === undefined && !allowanceLoading && requiredAmount !== undefined && amountValidationMessage === undefined && nextApprovalAmount !== undefined && (parsedAmount.kind !== 'default' || !requirement.hasSufficientApproval)

--- a/ui/ts/hooks/useOpenOracleOperations.ts
+++ b/ui/ts/hooks/useOpenOracleOperations.ts
@@ -405,7 +405,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 				await refreshOpenOracleInitialReportState(reportDetails)
 				const submission = getInitialReportSubmission(reportDetails)
 				if (!submission.canSubmit || submission.amount1 === undefined || submission.amount2 === undefined) {
-					throw new Error(submission.blockReason ?? 'Invalid price')
+					throw new Error(submission.blockMessage?.message ?? 'Invalid price')
 				}
 
 				return await submitInitialOracleReport(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), getOpenOracleAddress(), reportDetails.reportId, submission.amount1, submission.amount2, parseBytes32Input(openOracleForm.value.stateHash, 'State hash'))
@@ -422,7 +422,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 				const submission = getInitialReportSubmission(reportDetails)
 				const wrapAmount = submission.requiredWethWrapAmount
 				if (wrapAmount === undefined || wrapAmount <= 0n || !submission.canWrapRequiredWeth) {
-					throw new Error(submission.wrapRequiredWethDisabledReason ?? 'No WETH wrap is required for this report')
+					throw new Error(submission.wrapRequiredWethMessage?.message ?? 'No WETH wrap is required for this report')
 				}
 
 				return await wrapWeth(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), wrapAmount)

--- a/ui/ts/lib/openOracle.ts
+++ b/ui/ts/lib/openOracle.ts
@@ -15,6 +15,10 @@ export type OpenOracleSelectedReportActionMode = 'initial-report' | 'dispute' | 
 export type OpenOracleInitialReportPriceSource = 'Uniswap V4' | 'Uniswap V3' | 'Manual override' | 'Unavailable'
 export type OpenOracleInitialReportQuoteSource = Exclude<OpenOracleInitialReportPriceSource, 'Manual override' | 'Unavailable'>
 export type OpenOracleInitialReportQuoteFailureKind = 'unsupported-pair' | 'quote-failed'
+type OpenOracleGateMessage = {
+	kind: 'hidden-loading' | 'visible'
+	message: string
+}
 
 type OpenOracleInitialReportPriceLoadResult =
 	| {
@@ -34,7 +38,7 @@ type OpenOracleInitialReportPriceLoadResult =
 type OpenOracleInitialReportSubmissionDetails = {
 	amount1: bigint | undefined
 	amount2: bigint | undefined
-	blockReason: string | undefined
+	blockMessage: OpenOracleGateMessage | undefined
 	canSubmit: boolean
 	canWrapRequiredWeth: boolean
 	price: bigint | undefined
@@ -46,7 +50,15 @@ type OpenOracleInitialReportSubmissionDetails = {
 	token1Decimals: number | undefined
 	token2Approval: TokenApprovalRequirement
 	token2Decimals: number | undefined
-	wrapRequiredWethDisabledReason: string | undefined
+	wrapRequiredWethMessage: OpenOracleGateMessage | undefined
+}
+
+function createHiddenLoadingGateMessage(message: string): OpenOracleGateMessage {
+	return { kind: 'hidden-loading', message }
+}
+
+function createVisibleGateMessage(message: string): OpenOracleGateMessage {
+	return { kind: 'visible', message }
 }
 
 function formatOpenOraclePriceLoadError(v4Error: unknown, v3Error?: unknown) {
@@ -355,84 +367,101 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 					? token2BalanceShortage
 					: undefined
 	const canWrapRequiredWeth = requiredWethWrapAmount !== undefined && requiredWethWrapAmount > 0n && walletEthBalance !== undefined && walletEthBalance >= requiredWethWrapAmount
-	const wrapRequiredWethDisabledReason =
+	const wrapRequiredWethMessage =
 		requiredWethWrapAmount === undefined || requiredWethWrapAmount <= 0n
 			? undefined
 			: walletEthBalance === undefined
-				? 'Loading wallet ETH balance.'
+				? createHiddenLoadingGateMessage('Loading wallet ETH balance.')
 				: walletEthBalance < requiredWethWrapAmount
-					? `Wallet has ${formatCurrencyBalance(walletEthBalance)} ETH, need ${formatCurrencyBalance(requiredWethWrapAmount)} ETH to wrap the required WETH.`
+					? createVisibleGateMessage(`Wallet has ${formatCurrencyBalance(walletEthBalance)} ETH, need ${formatCurrencyBalance(requiredWethWrapAmount)} ETH to wrap the required WETH.`)
 					: undefined
 
-	let blockReason: string | undefined
+	let blockMessage: OpenOracleGateMessage | undefined
 	if (reportDetails === undefined) {
-		blockReason = 'Load a report first'
+		blockMessage = createVisibleGateMessage('Load a report first')
 	} else if (resolvedPriceInput === '') {
-		blockReason =
-			defaultPriceError ??
-			formatOpenOracleInitialReportPriceUnavailableMessage({
-				attemptedSources: quoteAttemptedSources,
-				reason: quoteFailureReason,
-				token1Label,
-				token2Label,
-			})
+		blockMessage =
+			defaultPriceError !== undefined
+				? createVisibleGateMessage(defaultPriceError)
+				: quoteAttemptedSources === undefined && quoteFailureReason === undefined
+					? createHiddenLoadingGateMessage('Loading automatic price quote.')
+					: createVisibleGateMessage(
+							formatOpenOracleInitialReportPriceUnavailableMessage({
+								attemptedSources: quoteAttemptedSources,
+								reason: quoteFailureReason,
+								token1Label,
+								token2Label,
+							}),
+						)
 	} else if (price === undefined || price <= 0n || amount2 === undefined || amount2 <= 0n) {
-		blockReason = 'Invalid price'
+		blockMessage = createVisibleGateMessage('Invalid price')
 	} else if (approvedToken1Amount === undefined && token1AllowanceError !== undefined) {
-		blockReason = formatOpenOracleInitialReportApprovalStatusUnavailableMessage({
-			reason: token1AllowanceError,
-			tokenLabel: token1Label,
-		})
+		blockMessage = createVisibleGateMessage(
+			formatOpenOracleInitialReportApprovalStatusUnavailableMessage({
+				reason: token1AllowanceError,
+				tokenLabel: token1Label,
+			}),
+		)
 	} else if (approvedToken2Amount === undefined && token2AllowanceError !== undefined) {
-		blockReason = formatOpenOracleInitialReportApprovalStatusUnavailableMessage({
-			reason: token2AllowanceError,
-			tokenLabel: token2Label,
-		})
+		blockMessage = createVisibleGateMessage(
+			formatOpenOracleInitialReportApprovalStatusUnavailableMessage({
+				reason: token2AllowanceError,
+				tokenLabel: token2Label,
+			}),
+		)
 	} else if (token1Balance === undefined && token1BalanceError !== undefined) {
-		blockReason = formatOpenOracleInitialReportBalanceStatusUnavailableMessage({
-			reason: token1BalanceError,
-			tokenLabel: token1Label,
-		})
+		blockMessage = createVisibleGateMessage(
+			formatOpenOracleInitialReportBalanceStatusUnavailableMessage({
+				reason: token1BalanceError,
+				tokenLabel: token1Label,
+			}),
+		)
 	} else if (token2Balance === undefined && token2BalanceError !== undefined) {
-		blockReason = formatOpenOracleInitialReportBalanceStatusUnavailableMessage({
-			reason: token2BalanceError,
-			tokenLabel: token2Label,
-		})
+		blockMessage = createVisibleGateMessage(
+			formatOpenOracleInitialReportBalanceStatusUnavailableMessage({
+				reason: token2BalanceError,
+				tokenLabel: token2Label,
+			}),
+		)
 	} else if (token1Balance === undefined) {
-		blockReason = `Loading current ${token1Label} balance.`
+		blockMessage = createHiddenLoadingGateMessage(`Loading current ${token1Label} balance.`)
 	} else if (token2Balance === undefined) {
-		blockReason = `Loading current ${token2Label} balance.`
+		blockMessage = createHiddenLoadingGateMessage(`Loading current ${token2Label} balance.`)
 	} else if (amount1 !== undefined && token1Balance < amount1) {
-		blockReason = formatOpenOracleInitialReportInsufficientBalanceMessage({
-			available: token1Balance,
-			required: amount1,
-			tokenAddress: reportDetails.token1,
-			tokenDecimals: token1Decimals,
-			tokenLabel: token1Label,
-		})
+		blockMessage = createVisibleGateMessage(
+			formatOpenOracleInitialReportInsufficientBalanceMessage({
+				available: token1Balance,
+				required: amount1,
+				tokenAddress: reportDetails.token1,
+				tokenDecimals: token1Decimals,
+				tokenLabel: token1Label,
+			}),
+		)
 	} else if (amount2 !== undefined && token2Balance < amount2) {
-		blockReason = formatOpenOracleInitialReportInsufficientBalanceMessage({
-			available: token2Balance,
-			required: amount2,
-			tokenAddress: reportDetails.token2,
-			tokenDecimals: token2Decimals,
-			tokenLabel: token2Label,
-		})
+		blockMessage = createVisibleGateMessage(
+			formatOpenOracleInitialReportInsufficientBalanceMessage({
+				available: token2Balance,
+				required: amount2,
+				tokenAddress: reportDetails.token2,
+				tokenDecimals: token2Decimals,
+				tokenLabel: token2Label,
+			}),
+		)
 	} else if (approvedToken1Amount === undefined) {
-		blockReason = `Loading current ${token1Label} approval.`
+		blockMessage = createHiddenLoadingGateMessage(`Loading current ${token1Label} approval.`)
 	} else if (approvedToken2Amount === undefined) {
-		blockReason = `Loading current ${token2Label} approval.`
+		blockMessage = createHiddenLoadingGateMessage(`Loading current ${token2Label} approval.`)
 	} else if (!token1Approval.hasSufficientApproval) {
-		blockReason = `${token1Label} approval required`
+		blockMessage = createVisibleGateMessage(`${token1Label} approval required`)
 	} else if (!token2Approval.hasSufficientApproval) {
-		blockReason = `${token2Label} approval required`
+		blockMessage = createVisibleGateMessage(`${token2Label} approval required`)
 	}
 
 	return {
 		amount1,
 		amount2,
-		blockReason,
-		canSubmit: blockReason === undefined,
+		blockMessage,
+		canSubmit: blockMessage === undefined,
 		canWrapRequiredWeth,
 		price,
 		priceInput: resolvedPriceInput,
@@ -443,6 +472,6 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 		token1Decimals,
 		token2Approval,
 		token2Decimals,
-		wrapRequiredWethDisabledReason,
+		wrapRequiredWethMessage,
 	}
 }

--- a/ui/ts/lib/tokenApproval.ts
+++ b/ui/ts/lib/tokenApproval.ts
@@ -91,6 +91,48 @@ export function formatTokenApprovalUnavailableMessage({ actionLabel, reason, tok
 	return segments.join(' ')
 }
 
+export function resolveTokenApprovalStatusMessage({
+	actionLabel,
+	amountValidationMessage,
+	draftAmount,
+	guardMessage,
+	nextApprovalAmount,
+	requiredAmount,
+	requirement,
+	tokenLabel,
+	tokenUnits,
+}: {
+	actionLabel: string
+	amountValidationMessage: string | undefined
+	draftAmount: string
+	guardMessage: string | undefined
+	nextApprovalAmount: bigint | undefined
+	requiredAmount: bigint | undefined
+	requirement: TokenApprovalRequirement
+	tokenLabel: string
+	tokenUnits: number
+}) {
+	if (guardMessage !== undefined) return guardMessage
+	if (amountValidationMessage !== undefined) return amountValidationMessage
+	if (draftAmount.trim() === '') {
+		return formatTokenApprovalNeededMessage({
+			actionLabel,
+			requirement,
+			tokenLabel,
+			tokenUnits,
+		})
+	}
+	if (nextApprovalAmount === undefined || requiredAmount === undefined) return undefined
+
+	return formatTokenApprovalPartialMessage({
+		actionLabel,
+		nextApprovedAmount: nextApprovalAmount,
+		requiredAmount,
+		tokenLabel,
+		tokenUnits,
+	})
+}
+
 export function formatTokenApprovalNeededMessage({ actionLabel, requirement, tokenLabel, tokenUnits }: { actionLabel: string; requirement: TokenApprovalRequirement; tokenLabel: string; tokenUnits: number }) {
 	if (requirement.neededAmount === undefined || requirement.neededAmount <= 0n) return undefined
 	const targetAmount = requirement.targetAmount ?? requirement.requiredAmount

--- a/ui/ts/tests/openOracle.test.ts
+++ b/ui/ts/tests/openOracle.test.ts
@@ -258,7 +258,28 @@ describe('Open Oracle helpers', () => {
 		expect(preview.amount2).toBe(25n)
 		expect(preview.token2Approval.neededAmount).toBe(1n)
 		expect(preview.canSubmit).toBe(false)
-		expect(preview.blockReason).toBe('WETH approval required')
+		expect(preview.blockMessage).toEqual({
+			kind: 'visible',
+			message: 'WETH approval required',
+		})
+	})
+
+	test('initial report submission helper hides the automatic quote loading state', () => {
+		const preview = createInitialReportSubmissionPreview({
+			defaultPrice: undefined,
+			defaultPriceError: undefined,
+			defaultPriceSource: undefined,
+			defaultPriceSourceUrl: undefined,
+			priceInput: '',
+			quoteAttemptedSources: undefined,
+			quoteFailureReason: undefined,
+		})
+
+		expect(preview.canSubmit).toBe(false)
+		expect(preview.blockMessage).toEqual({
+			kind: 'hidden-loading',
+			message: 'Loading automatic price quote.',
+		})
 	})
 
 	test('initial report submission helper explains exhausted quote paths with a short reason', () => {
@@ -281,7 +302,10 @@ describe('Open Oracle helpers', () => {
 		})
 
 		expect(preview.canSubmit).toBe(false)
-		expect(preview.blockReason).toBe('Automatic price quote unavailable for REP / ETH. Tried: Uniswap V4, then Uniswap V3. Reason: Uniswap V4 quote failed: execution reverted for an unknown reason. Uniswap V3 quote failed: no pool. Enter a price manually to submit the initial report.')
+		expect(preview.blockMessage).toEqual({
+			kind: 'visible',
+			message: 'Automatic price quote unavailable for REP / ETH. Tried: Uniswap V4, then Uniswap V3. Reason: Uniswap V4 quote failed: execution reverted for an unknown reason. Uniswap V3 quote failed: no pool. Enter a price manually to submit the initial report.',
+		})
 	})
 
 	test('manual price entry overrides automatic quote unavailability', () => {
@@ -305,7 +329,10 @@ describe('Open Oracle helpers', () => {
 
 		expect(preview.priceSource).toBe('Manual override')
 		expect(preview.price).toBe(4_000_000_000_000_000_000n)
-		expect(preview.blockReason).toBe('XYZ approval required')
+		expect(preview.blockMessage).toEqual({
+			kind: 'visible',
+			message: 'XYZ approval required',
+		})
 	})
 
 	test('initial report submission helper surfaces the fetch price failure reason when no default price is available', () => {
@@ -321,7 +348,10 @@ describe('Open Oracle helpers', () => {
 		})
 
 		expect(preview.canSubmit).toBe(false)
-		expect(preview.blockReason).toBe('Failed to fetch price from Uniswap. Uniswap V4 quote failed: no v3 pool. Uniswap V3 quote failed: no v3 pool')
+		expect(preview.blockMessage).toEqual({
+			kind: 'visible',
+			message: 'Failed to fetch price from Uniswap. Uniswap V4 quote failed: no v3 pool. Uniswap V3 quote failed: no v3 pool',
+		})
 	})
 
 	test('formats unavailable price messages with sanitized reasons and address fallback labels', () => {
@@ -342,7 +372,10 @@ describe('Open Oracle helpers', () => {
 		})
 
 		expect(preview.canSubmit).toBe(false)
-		expect(preview.blockReason).toBe('Unable to verify REP approval before submitting the initial report. Reason: request timed out. Retry loading the approval status before continuing.')
+		expect(preview.blockMessage).toEqual({
+			kind: 'visible',
+			message: 'Unable to verify REP approval before submitting the initial report. Reason: request timed out. Retry loading the approval status before continuing.',
+		})
 	})
 
 	test('initial report submission helper surfaces balance read failures separately from approval gating', () => {
@@ -352,7 +385,42 @@ describe('Open Oracle helpers', () => {
 		})
 
 		expect(preview.canSubmit).toBe(false)
-		expect(preview.blockReason).toBe('Unable to verify WETH balance for this report. Reason: request timed out. Retry loading the report or balance status before submitting the initial report.')
+		expect(preview.blockMessage).toEqual({
+			kind: 'visible',
+			message: 'Unable to verify WETH balance for this report. Reason: request timed out. Retry loading the report or balance status before submitting the initial report.',
+		})
+	})
+
+	test('initial report submission helper hides token balance loading states such as REPv2 balance refresh', () => {
+		const preview = createInitialReportSubmissionPreview({
+			reportDetails: {
+				exactToken1Report: 100n,
+				token1: REP_ADDRESS,
+				token1Symbol: 'REPv2',
+				token2: WETH_ADDRESS,
+				token2Symbol: 'WETH',
+			},
+			token1Balance: undefined,
+		})
+
+		expect(preview.canSubmit).toBe(false)
+		expect(preview.blockMessage).toEqual({
+			kind: 'hidden-loading',
+			message: 'Loading current REPv2 balance.',
+		})
+	})
+
+	test('initial report submission helper hides token approval loading states', () => {
+		const preview = createInitialReportSubmissionPreview({
+			approvedToken1Amount: undefined,
+			token1AllowanceError: undefined,
+		})
+
+		expect(preview.canSubmit).toBe(false)
+		expect(preview.blockMessage).toEqual({
+			kind: 'hidden-loading',
+			message: 'Loading current REP approval.',
+		})
 	})
 
 	test('initial report submission helper surfaces token-specific insufficient token1 balances', () => {
@@ -361,7 +429,10 @@ describe('Open Oracle helpers', () => {
 		})
 
 		expect(preview.canSubmit).toBe(false)
-		expect(preview.blockReason).toBe('Insufficient REP balance for this report. Need 100, wallet has 99.')
+		expect(preview.blockMessage).toEqual({
+			kind: 'visible',
+			message: 'Insufficient REP balance for this report. Need 100, wallet has 99.',
+		})
 	})
 
 	test('initial report submission helper surfaces insufficient WETH balances and exposes wrap details', () => {
@@ -371,10 +442,13 @@ describe('Open Oracle helpers', () => {
 		})
 
 		expect(preview.canSubmit).toBe(false)
-		expect(preview.blockReason).toBe('Insufficient WETH balance for this report. Need 25, wallet has 24. Wrap ETH into WETH first.')
+		expect(preview.blockMessage).toEqual({
+			kind: 'visible',
+			message: 'Insufficient WETH balance for this report. Need 25, wallet has 24. Wrap ETH into WETH first.',
+		})
 		expect(preview.requiredWethWrapAmount).toBe(1n)
 		expect(preview.canWrapRequiredWeth).toBe(true)
-		expect(preview.wrapRequiredWethDisabledReason).toBeUndefined()
+		expect(preview.wrapRequiredWethMessage).toBeUndefined()
 	})
 
 	test('initial report submission helper reports when wallet ETH is insufficient to wrap the required WETH', () => {
@@ -385,7 +459,10 @@ describe('Open Oracle helpers', () => {
 
 		expect(preview.requiredWethWrapAmount).toBe(1n)
 		expect(preview.canWrapRequiredWeth).toBe(false)
-		expect(preview.wrapRequiredWethDisabledReason).toBe('Wallet has 0 ETH, need 0.000000000000000001 ETH to wrap the required WETH.')
+		expect(preview.wrapRequiredWethMessage).toEqual({
+			kind: 'visible',
+			message: 'Wallet has 0 ETH, need 0.000000000000000001 ETH to wrap the required WETH.',
+		})
 	})
 
 	test('initial report submission helper reports when wallet ETH balance is still loading for WETH wrap', () => {
@@ -396,14 +473,17 @@ describe('Open Oracle helpers', () => {
 
 		expect(preview.requiredWethWrapAmount).toBe(1n)
 		expect(preview.canWrapRequiredWeth).toBe(false)
-		expect(preview.wrapRequiredWethDisabledReason).toBe('Loading wallet ETH balance.')
+		expect(preview.wrapRequiredWethMessage).toEqual({
+			kind: 'hidden-loading',
+			message: 'Loading wallet ETH balance.',
+		})
 	})
 
 	test('initial report submission helper allows submit when balances and approvals are sufficient', () => {
 		const preview = createInitialReportSubmissionPreview()
 
 		expect(preview.canSubmit).toBe(true)
-		expect(preview.blockReason).toBeUndefined()
+		expect(preview.blockMessage).toBeUndefined()
 	})
 
 	test('formats unavailable approval status messages with sanitized reasons', () => {

--- a/ui/ts/tests/tokenApproval.test.ts
+++ b/ui/ts/tests/tokenApproval.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, test } from 'bun:test'
 import { maxUint256 } from 'viem'
-import { deriveTokenApprovalRequirement, formatTokenApprovalNeededMessage, formatTokenApprovalPartialMessage, formatTokenApprovalUnavailableMessage, maxUint200, parseTokenApprovalAmountInput, shouldDisplayMaxTokenApprovalAmount } from '../lib/tokenApproval.js'
+import { deriveTokenApprovalRequirement, formatTokenApprovalNeededMessage, formatTokenApprovalPartialMessage, formatTokenApprovalUnavailableMessage, maxUint200, parseTokenApprovalAmountInput, resolveTokenApprovalStatusMessage, shouldDisplayMaxTokenApprovalAmount } from '../lib/tokenApproval.js'
 
 const ONE = 10n ** 18n
 
@@ -78,6 +78,88 @@ describe('token approval helpers', () => {
 				actionLabel: 'submitting the initial report',
 				nextApprovedAmount: 24_500_000_000_000_000_000n,
 				requiredAmount: 25n * ONE,
+				tokenLabel: 'ETH',
+				tokenUnits: 18,
+			}),
+		).toBe('Approving 24.5 ETH will still leave 0.5 more ETH needed before submitting the initial report.')
+	})
+
+	test('resolveTokenApprovalStatusMessage hides loading-only approval states', () => {
+		const requirement = deriveTokenApprovalRequirement(25n * ONE, undefined)
+
+		expect(
+			resolveTokenApprovalStatusMessage({
+				actionLabel: 'submitting the initial report',
+				amountValidationMessage: undefined,
+				draftAmount: '',
+				guardMessage: undefined,
+				nextApprovalAmount: requirement.targetAmount,
+				requiredAmount: requirement.requiredAmount,
+				requirement,
+				tokenLabel: 'ETH',
+				tokenUnits: 18,
+			}),
+		).toBeUndefined()
+	})
+
+	test('resolveTokenApprovalStatusMessage prioritizes guard and validation messages', () => {
+		const requirement = deriveTokenApprovalRequirement(25n * ONE, 24n * ONE)
+
+		expect(
+			resolveTokenApprovalStatusMessage({
+				actionLabel: 'submitting the initial report',
+				amountValidationMessage: undefined,
+				draftAmount: '',
+				guardMessage: 'Connect a wallet before approving tokens.',
+				nextApprovalAmount: requirement.targetAmount,
+				requiredAmount: requirement.requiredAmount,
+				requirement,
+				tokenLabel: 'ETH',
+				tokenUnits: 18,
+			}),
+		).toBe('Connect a wallet before approving tokens.')
+
+		expect(
+			resolveTokenApprovalStatusMessage({
+				actionLabel: 'submitting the initial report',
+				amountValidationMessage: 'Approval amount must be greater than the current approved ETH amount.',
+				draftAmount: '24',
+				guardMessage: undefined,
+				nextApprovalAmount: 24n * ONE,
+				requiredAmount: requirement.requiredAmount,
+				requirement,
+				tokenLabel: 'ETH',
+				tokenUnits: 18,
+			}),
+		).toBe('Approval amount must be greater than the current approved ETH amount.')
+	})
+
+	test('resolveTokenApprovalStatusMessage preserves needed and partial approval copy', () => {
+		const requirement = deriveTokenApprovalRequirement(25n * ONE, 24n * ONE)
+
+		expect(
+			resolveTokenApprovalStatusMessage({
+				actionLabel: 'submitting the initial report',
+				amountValidationMessage: undefined,
+				draftAmount: '',
+				guardMessage: undefined,
+				nextApprovalAmount: requirement.targetAmount,
+				requiredAmount: requirement.requiredAmount,
+				requirement,
+				tokenLabel: 'ETH',
+				tokenUnits: 18,
+			}),
+		).toBe('Need 1 more ETH approved before submitting the initial report. Approving will set the allowance to 25 ETH.')
+
+		expect(
+			resolveTokenApprovalStatusMessage({
+				actionLabel: 'submitting the initial report',
+				amountValidationMessage: undefined,
+				draftAmount: '24.5',
+				guardMessage: undefined,
+				nextApprovalAmount: 24_500_000_000_000_000_000n,
+				requiredAmount: 25n * ONE,
+				requirement,
 				tokenLabel: 'ETH',
 				tokenUnits: 18,
 			}),


### PR DESCRIPTION
## Summary
- Hide loading-only gating text in the open oracle initial report flow so users no longer see transient balance, approval, quote, or WETH wrap loading messages.
- Split open oracle gate state into visible vs hidden-loading messages, while preserving explanatory copy for actual blocking errors.
- Consolidate token approval status message selection into a shared helper and add coverage for the new message priority behavior.

## Testing
- Not run (PR description only).