### PR TITLE
Preview fork auction and WETH state in the UI

### DIFF
--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -1835,6 +1835,18 @@ button.currency-value.copyable:hover:not(:disabled) {
 	line-height: 1.45;
 }
 
+.fork-auction-controls {
+	display: grid;
+	gap: 0.85rem;
+	margin: 0;
+	padding: 0;
+	border: 0;
+}
+
+.fork-auction-controls:disabled {
+	opacity: 0.72;
+}
+
 .workflow-create-section {
 	border-top-color: var(--border-strong);
 	padding-top: 1.25rem;

--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'preact'
 import { AddressValue } from './AddressValue.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { EnumDropdown } from './EnumDropdown.js'
@@ -9,21 +10,59 @@ import { TransactionHashLink } from './TransactionHashLink.js'
 import { UniverseLink } from './UniverseLink.js'
 import { TimestampValue } from './TimestampValue.js'
 import { formatDuration } from '../lib/formatters.js'
-import { AUCTION_TIME_SECONDS, estimateRepPurchased, getForkStageDescription, getOutcomeActionLabel, getSystemStateLabel, getTimeRemaining, MIGRATION_TIME_SECONDS } from '../lib/forkAuction.js'
+import { AUCTION_TIME_SECONDS, estimateRepPurchased, getForkStageDescription, getForkStageDescriptionForState, getOutcomeActionLabel, getSystemStateLabel, getTimeRemaining, hasForkActivity, MIGRATION_TIME_SECONDS } from '../lib/forkAuction.js'
 import { isMainnetChain } from '../lib/network.js'
 import { REPORTING_OUTCOME_DROPDOWN_OPTIONS, getReportingOutcomeLabel } from '../lib/reporting.js'
+import type { ListedSecurityPool } from '../types/contracts.js'
 import type { ForkAuctionSectionProps } from '../types/components.js'
 
-function getTruthAuctionWindow(details: ForkAuctionSectionProps['forkAuctionDetails']) {
-	if (details === undefined || details.truthAuctionStartedAt === 0n) return undefined
+const UNKNOWN_VALUE = '—'
+const UNAVAILABLE_UNTIL_FORK = 'Unavailable until fork'
+
+function getTruthAuctionWindow(startedAt: bigint | undefined) {
+	if (startedAt === undefined || startedAt === 0n) return undefined
 	return {
-		startedAt: details.truthAuctionStartedAt,
-		endsAt: details.truthAuctionStartedAt + AUCTION_TIME_SECONDS,
+		startedAt,
+		endsAt: startedAt + AUCTION_TIME_SECONDS,
 	}
+}
+
+function renderMetricValue(value: bigint | undefined, suffix: string, fallbackText: string) {
+	if (value === undefined) return fallbackText
+	return <CurrencyValue value={value} suffix={suffix} />
+}
+
+function renderAddress(address: string | undefined) {
+	if (address === undefined) return UNKNOWN_VALUE
+	return <AddressValue address={address} />
+}
+
+function renderTimestamp(timestamp: bigint | undefined, fallbackText: string) {
+	if (timestamp === undefined) return fallbackText
+	return <TimestampValue timestamp={timestamp} />
+}
+
+function getForkOnlyFallbackText(hasPreviewForkActivity: boolean) {
+	return hasPreviewForkActivity ? UNKNOWN_VALUE : UNAVAILABLE_UNTIL_FORK
+}
+
+function getPreviewForkType(previewPool: ListedSecurityPool | undefined, hasPreviewForkActivity: boolean) {
+	if (previewPool === undefined) return UNKNOWN_VALUE
+	if (!hasPreviewForkActivity) return UNAVAILABLE_UNTIL_FORK
+	return previewPool.forkOwnSecurityPool ? 'Own escalation fork' : 'Parent/Zoltar fork'
+}
+
+function getPreviewMigrationSummary(previewPool: ListedSecurityPool | undefined, hasPreviewForkActivity: boolean) {
+	if (previewPool === undefined) return UNKNOWN_VALUE
+	if (!hasPreviewForkActivity) return UNAVAILABLE_UNTIL_FORK
+	if (previewPool.truthAuctionStartedAt > 0n) return 'Started/finished'
+	return UNKNOWN_VALUE
 }
 
 export function ForkAuctionSection({
 	accountState,
+	disabled = false,
+	disabledMessage,
 	forkAuctionDetails,
 	forkAuctionError,
 	forkAuctionForm,
@@ -44,6 +83,7 @@ export function ForkAuctionSection({
 	onStartTruthAuction,
 	onSubmitBid,
 	onWithdrawBids,
+	previewPool,
 	showHeader = true,
 	showSecurityPoolAddressInput = true,
 }: ForkAuctionSectionProps) {
@@ -51,7 +91,20 @@ export function ForkAuctionSection({
 	const selectedAuctionPrice = forkAuctionDetails?.truthAuction?.clearingPrice
 	const estimatedRep = selectedAuctionPrice === undefined ? undefined : estimateRepPurchased(BigInt(forkAuctionForm.bidAmount || '0'), selectedAuctionPrice)
 	const migrationTimeRemaining = forkAuctionDetails === undefined ? undefined : getTimeRemaining(forkAuctionDetails.migrationEndsAt, forkAuctionDetails.currentTime)
-	const auctionWindow = getTruthAuctionWindow(forkAuctionDetails)
+	const previewAuctionWindow = getTruthAuctionWindow(previewPool?.truthAuctionStartedAt)
+	const auctionWindow = forkAuctionDetails === undefined ? previewAuctionWindow : getTruthAuctionWindow(forkAuctionDetails.truthAuctionStartedAt)
+	const previewQuestion = previewPool?.marketDetails
+	const question = forkAuctionDetails?.marketDetails ?? previewQuestion
+	const securityPoolAddress = forkAuctionDetails?.securityPoolAddress ?? previewPool?.securityPoolAddress
+	const universeId = forkAuctionDetails?.universeId ?? previewPool?.universeId
+	const parentSecurityPoolAddress = forkAuctionDetails?.parentSecurityPoolAddress ?? previewPool?.parent
+	const systemState = forkAuctionDetails?.systemState ?? previewPool?.systemState
+	const forkOutcome = forkAuctionDetails?.forkOutcome ?? previewPool?.forkOutcome
+	const truthAuctionAddress = forkAuctionDetails?.truthAuctionAddress ?? previewPool?.truthAuctionAddress
+	const hasPreviewForkActivity = previewPool === undefined ? false : hasForkActivity(previewPool)
+	const forkOnlyFallbackText = getForkOnlyFallbackText(hasPreviewForkActivity)
+	const forkStageDescription = forkAuctionDetails === undefined ? (systemState === undefined ? undefined : getForkStageDescriptionForState(systemState)) : getForkStageDescription(forkAuctionDetails)
+	const migrationSummaryText = forkAuctionDetails === undefined ? getPreviewMigrationSummary(previewPool, hasPreviewForkActivity) : undefined
 
 	return (
 		<section className='panel market-panel'>
@@ -66,98 +119,92 @@ export function ForkAuctionSection({
 
 			<div className='market-grid'>
 				<div className='market-column'>
-					{forkAuctionDetails === undefined ? undefined : (
+					{securityPoolAddress === undefined ? undefined : (
 						<>
 							<div className='status-card'>
 								<p className='panel-label'>Loaded Pool</p>
 								<ul className='status-list hashes'>
 									<li>
 										<span>Security Pool</span>
-										<strong>
-											<AddressValue address={forkAuctionDetails.securityPoolAddress} />
-										</strong>
+										<strong>{renderAddress(securityPoolAddress)}</strong>
 									</li>
 									<li>
 										<span>Universe</span>
-										<strong>
-											<UniverseLink universeId={forkAuctionDetails.universeId} />
-										</strong>
+										<strong>{universeId === undefined ? UNKNOWN_VALUE : <UniverseLink universeId={universeId} />}</strong>
 									</li>
 									<li>
 										<span>Parent Pool</span>
-										<strong>
-											<AddressValue address={forkAuctionDetails.parentSecurityPoolAddress} />
-										</strong>
+										<strong>{renderAddress(parentSecurityPoolAddress)}</strong>
 									</li>
 									<li>
 										<span>System State</span>
-										<strong>{getSystemStateLabel(forkAuctionDetails.systemState)}</strong>
+										<strong>{systemState === undefined ? UNKNOWN_VALUE : getSystemStateLabel(systemState)}</strong>
 									</li>
 									<li>
 										<span>Final Question Outcome</span>
-										<strong>{getReportingOutcomeLabel(forkAuctionDetails.questionOutcome)}</strong>
+										<strong>{forkAuctionDetails === undefined ? UNKNOWN_VALUE : getReportingOutcomeLabel(forkAuctionDetails.questionOutcome)}</strong>
 									</li>
 									<li>
 										<span>Fork Outcome</span>
-										<strong>{getReportingOutcomeLabel(forkAuctionDetails.forkOutcome)}</strong>
+										<strong>{forkOutcome === undefined ? UNKNOWN_VALUE : getReportingOutcomeLabel(forkOutcome)}</strong>
 									</li>
 								</ul>
-								<div className='entity-card-subsection'>
-									<div className='entity-card-subsection-header'>
-										<h4>Question</h4>
-										<span className='badge muted'>{forkAuctionDetails.marketDetails.marketType}</span>
+								{question === undefined ? undefined : (
+									<div className='entity-card-subsection'>
+										<div className='entity-card-subsection-header'>
+											<h4>Question</h4>
+											<span className='badge muted'>{question.marketType}</span>
+										</div>
+										<Question question={question} />
 									</div>
-									<Question question={forkAuctionDetails.marketDetails} />
-								</div>
-								<p className='detail'>{getForkStageDescription(forkAuctionDetails)}</p>
+								)}
+								{forkStageDescription === undefined ? undefined : <p className='detail'>{forkStageDescription}</p>}
 							</div>
 
 							<div className='status-card'>
 								<p className='panel-label'>Fork Metrics</p>
 								<div className='escalation-metrics'>
-									<MetricField label='REP At Fork'>
-										<CurrencyValue value={forkAuctionDetails.repAtFork} suffix='REP' />
-									</MetricField>
-									<MetricField label='Migrated REP'>
-										<CurrencyValue value={forkAuctionDetails.migratedRep} suffix='REP' />
-									</MetricField>
-									<MetricField label='Collateral'>
-										<CurrencyValue value={forkAuctionDetails.completeSetCollateralAmount} suffix='REP' />
-									</MetricField>
-									<MetricField label='Fork Type'>{forkAuctionDetails.forkOwnSecurityPool ? 'Own escalation fork' : 'Parent/Zoltar fork'}</MetricField>
-									<MetricField label='Migration Ends'>{forkAuctionDetails.migrationEndsAt === undefined ? 'Started/finished' : <TimestampValue timestamp={forkAuctionDetails.migrationEndsAt} />}</MetricField>
-									<MetricField label='Migration Time Left'>{migrationTimeRemaining === undefined ? formatDuration(MIGRATION_TIME_SECONDS) : formatDuration(migrationTimeRemaining)}</MetricField>
+									<MetricField label='REP At Fork'>{forkAuctionDetails === undefined ? forkOnlyFallbackText : <CurrencyValue value={forkAuctionDetails.repAtFork} suffix='REP' />}</MetricField>
+									<MetricField label='Migrated REP'>{renderMetricValue(forkAuctionDetails?.migratedRep ?? previewPool?.migratedRep, 'REP', UNKNOWN_VALUE)}</MetricField>
+									<MetricField label='Collateral'>{renderMetricValue(forkAuctionDetails?.completeSetCollateralAmount ?? previewPool?.completeSetCollateralAmount, 'REP', UNKNOWN_VALUE)}</MetricField>
+									<MetricField label='Fork Type'>{forkAuctionDetails === undefined ? getPreviewForkType(previewPool, hasPreviewForkActivity) : forkAuctionDetails.forkOwnSecurityPool ? 'Own escalation fork' : 'Parent/Zoltar fork'}</MetricField>
+									<MetricField label='Migration Ends'>{forkAuctionDetails === undefined ? migrationSummaryText : forkAuctionDetails.migrationEndsAt === undefined ? 'Started/finished' : <TimestampValue timestamp={forkAuctionDetails.migrationEndsAt} />}</MetricField>
+									<MetricField label='Migration Time Left'>{forkAuctionDetails === undefined ? forkOnlyFallbackText : migrationTimeRemaining === undefined ? formatDuration(MIGRATION_TIME_SECONDS) : formatDuration(migrationTimeRemaining)}</MetricField>
 								</div>
 							</div>
 
-							{forkAuctionDetails.truthAuction === undefined ? undefined : (
-								<div className='status-card'>
-									<p className='panel-label'>Truth Auction</p>
-									<div className='escalation-metrics'>
-										<MetricField label='Auction Address'>
-											<AddressValue address={forkAuctionDetails.truthAuctionAddress} />
-										</MetricField>
-										<MetricField label='Started'>
-											<TimestampValue timestamp={forkAuctionDetails.truthAuctionStartedAt} />
-										</MetricField>
-										<MetricField label='Ends'>{auctionWindow === undefined ? 'Not started' : <TimestampValue timestamp={auctionWindow.endsAt} />}</MetricField>
-										<MetricField label='Time Left'>{forkAuctionDetails.truthAuction.timeRemaining === undefined ? formatDuration(AUCTION_TIME_SECONDS) : formatDuration(forkAuctionDetails.truthAuction.timeRemaining)}</MetricField>
-										<MetricField label='ETH Raised / Cap'>
-											<CurrencyValue value={forkAuctionDetails.truthAuction.ethRaised} suffix='ETH' /> / <CurrencyValue value={forkAuctionDetails.truthAuction.ethRaiseCap} suffix='ETH' />
-										</MetricField>
-										<MetricField label='REP Purchased'>
-											<CurrencyValue value={forkAuctionDetails.truthAuction.totalRepPurchased} suffix='REP' />
-										</MetricField>
-										<MetricField label='Clearing Tick'>{forkAuctionDetails.truthAuction.clearingTick?.toString() ?? '—'}</MetricField>
-										<MetricField label='Clearing Price'>
-											<CurrencyValue value={forkAuctionDetails.truthAuction.clearingPrice} suffix='REP' />
-										</MetricField>
-										<MetricField label='Underfunded'>{forkAuctionDetails.truthAuction.underfunded ? 'Yes' : 'No'}</MetricField>
-										<MetricField label='Finalized'>{forkAuctionDetails.truthAuction.finalized ? 'Yes' : 'No'}</MetricField>
-									</div>
-									<p className='detail'>At the current clearing price, this bid would buy roughly {estimatedRep === undefined ? '—' : <CurrencyValue value={estimatedRep} suffix='REP' />} if it clears.</p>
+							<div className='status-card'>
+								<p className='panel-label'>Truth Auction</p>
+								<div className='escalation-metrics'>
+									<MetricField label='Auction Address'>{renderAddress(truthAuctionAddress)}</MetricField>
+									<MetricField label='Started'>
+										{forkAuctionDetails === undefined
+											? previewPool?.truthAuctionStartedAt === undefined || previewPool.truthAuctionStartedAt === 0n
+												? 'Not started'
+												: renderTimestamp(previewPool.truthAuctionStartedAt, 'Not started')
+											: forkAuctionDetails.truthAuctionStartedAt === 0n
+												? 'Not started'
+												: renderTimestamp(forkAuctionDetails.truthAuctionStartedAt, 'Not started')}
+									</MetricField>
+									<MetricField label='Ends'>{auctionWindow === undefined ? 'Not started' : <TimestampValue timestamp={auctionWindow.endsAt} />}</MetricField>
+									<MetricField label='Time Left'>{forkAuctionDetails?.truthAuction?.timeRemaining === undefined ? (forkAuctionDetails?.truthAuction === undefined ? forkOnlyFallbackText : formatDuration(AUCTION_TIME_SECONDS)) : formatDuration(forkAuctionDetails.truthAuction.timeRemaining)}</MetricField>
+									<MetricField label='ETH Raised / Cap'>
+										{forkAuctionDetails?.truthAuction === undefined ? (
+											forkOnlyFallbackText
+										) : (
+											<Fragment>
+												<CurrencyValue value={forkAuctionDetails.truthAuction.ethRaised} suffix='ETH' /> / <CurrencyValue value={forkAuctionDetails.truthAuction.ethRaiseCap} suffix='ETH' />
+											</Fragment>
+										)}
+									</MetricField>
+									<MetricField label='REP Purchased'>{forkAuctionDetails?.truthAuction === undefined ? forkOnlyFallbackText : <CurrencyValue value={forkAuctionDetails.truthAuction.totalRepPurchased} suffix='REP' />}</MetricField>
+									<MetricField label='Clearing Tick'>{forkAuctionDetails?.truthAuction?.clearingTick?.toString() ?? (forkAuctionDetails?.truthAuction === undefined ? forkOnlyFallbackText : UNKNOWN_VALUE)}</MetricField>
+									<MetricField label='Clearing Price'>{forkAuctionDetails?.truthAuction === undefined ? forkOnlyFallbackText : renderMetricValue(forkAuctionDetails.truthAuction.clearingPrice, 'REP', UNKNOWN_VALUE)}</MetricField>
+									<MetricField label='Underfunded'>{forkAuctionDetails?.truthAuction === undefined ? forkOnlyFallbackText : forkAuctionDetails.truthAuction.underfunded ? 'Yes' : 'No'}</MetricField>
+									<MetricField label='Finalized'>{forkAuctionDetails?.truthAuction === undefined ? forkOnlyFallbackText : forkAuctionDetails.truthAuction.finalized ? 'Yes' : 'No'}</MetricField>
 								</div>
-							)}
+								<p className='detail'>At the current clearing price, this bid would buy roughly {estimatedRep === undefined ? UNKNOWN_VALUE : <CurrencyValue value={estimatedRep} suffix='REP' />} if it clears.</p>
+							</div>
 
 							{forkAuctionResult === undefined ? undefined : (
 								<div className='status-card'>
@@ -193,133 +240,137 @@ export function ForkAuctionSection({
 							</button>
 						</div>
 
-						<label className='field'>
-							<span>Outcome</span>
-							<EnumDropdown options={REPORTING_OUTCOME_DROPDOWN_OPTIONS} value={forkAuctionForm.selectedOutcome} onChange={selectedOutcome => onForkAuctionFormChange({ selectedOutcome })} />
-						</label>
+						{disabledMessage === undefined ? undefined : <p className='detail'>{disabledMessage}</p>}
 
-						<label className='field'>
-							<span>REP Migration Outcomes</span>
-							<input value={forkAuctionForm.repMigrationOutcomes} onInput={event => onForkAuctionFormChange({ repMigrationOutcomes: event.currentTarget.value })} placeholder='yes,no,invalid' />
-						</label>
-
-						<label className='field'>
-							<span>Vault Address</span>
-							<input value={forkAuctionForm.claimVaultAddress} onInput={event => onForkAuctionFormChange({ claimVaultAddress: event.currentTarget.value })} placeholder='Leave empty to use connected wallet' />
-						</label>
-
-						<label className='field'>
-							<span>Escalation Deposit Indexes</span>
-							<input value={forkAuctionForm.depositIndexes} onInput={event => onForkAuctionFormChange({ depositIndexes: event.currentTarget.value })} placeholder='0,1,2' />
-						</label>
-
-						<div className='actions'>
-							<button className='primary' onClick={onForkWithOwnEscalation} disabled={accountState.address === undefined || !isMainnet}>
-								Fork With Own Escalation
-							</button>
-							<button className='secondary' onClick={onInitiateFork} disabled={accountState.address === undefined || !isMainnet}>
-								Initiate Pool Fork
-							</button>
-						</div>
-
-						<div className='field-row'>
+						<fieldset className='fork-auction-controls' disabled={disabled}>
 							<label className='field'>
-								<span>Direct Fork Universe ID</span>
-								<input value={forkAuctionForm.directForkUniverseId} onInput={event => onForkAuctionFormChange({ directForkUniverseId: event.currentTarget.value })} />
+								<span>Outcome</span>
+								<EnumDropdown options={REPORTING_OUTCOME_DROPDOWN_OPTIONS} value={forkAuctionForm.selectedOutcome} onChange={selectedOutcome => onForkAuctionFormChange({ selectedOutcome })} />
+							</label>
+
+							<label className='field'>
+								<span>REP Migration Outcomes</span>
+								<input value={forkAuctionForm.repMigrationOutcomes} onInput={event => onForkAuctionFormChange({ repMigrationOutcomes: event.currentTarget.value })} placeholder='yes,no,invalid' />
+							</label>
+
+							<label className='field'>
+								<span>Vault Address</span>
+								<input value={forkAuctionForm.claimVaultAddress} onInput={event => onForkAuctionFormChange({ claimVaultAddress: event.currentTarget.value })} placeholder='Leave empty to use connected wallet' />
+							</label>
+
+							<label className='field'>
+								<span>Escalation Deposit Indexes</span>
+								<input value={forkAuctionForm.depositIndexes} onInput={event => onForkAuctionFormChange({ depositIndexes: event.currentTarget.value })} placeholder='0,1,2' />
+							</label>
+
+							<div className='actions'>
+								<button className='primary' onClick={onForkWithOwnEscalation} disabled={disabled || accountState.address === undefined || !isMainnet}>
+									Fork With Own Escalation
+								</button>
+								<button className='secondary' onClick={onInitiateFork} disabled={disabled || accountState.address === undefined || !isMainnet}>
+									Initiate Pool Fork
+								</button>
+							</div>
+
+							<div className='field-row'>
+								<label className='field'>
+									<span>Direct Fork Universe ID</span>
+									<input value={forkAuctionForm.directForkUniverseId} onInput={event => onForkAuctionFormChange({ directForkUniverseId: event.currentTarget.value })} />
+								</label>
+								<label className='field'>
+									<span>Direct Fork Question ID</span>
+									<input value={forkAuctionForm.directForkQuestionId} onInput={event => onForkAuctionFormChange({ directForkQuestionId: event.currentTarget.value })} placeholder='0x...' />
+								</label>
+							</div>
+
+							<div className='actions'>
+								<button className='secondary' onClick={onForkUniverse} disabled={disabled || accountState.address === undefined || !isMainnet}>
+									Fork Universe Directly
+								</button>
+							</div>
+
+							<div className='actions'>
+								<button className='primary' onClick={onCreateChildUniverse} disabled={disabled || accountState.address === undefined || !isMainnet}>
+									Create {getOutcomeActionLabel(forkAuctionForm.selectedOutcome)} Child Universe
+								</button>
+								<button className='secondary' onClick={onMigrateRepToZoltar} disabled={disabled || accountState.address === undefined || !isMainnet}>
+									Migrate REP To Zoltar
+								</button>
+							</div>
+
+							<div className='actions'>
+								<button className='primary' onClick={onMigrateVault} disabled={disabled || accountState.address === undefined || !isMainnet}>
+									Migrate Vault
+								</button>
+								<button className='secondary' onClick={onMigrateEscalationDeposits} disabled={disabled || accountState.address === undefined || !isMainnet}>
+									Migrate Escalation Deposits
+								</button>
+							</div>
+
+							<label className='field'>
+								<span>Bid Tick</span>
+								<input value={forkAuctionForm.bidTick} onInput={event => onForkAuctionFormChange({ bidTick: event.currentTarget.value })} />
 							</label>
 							<label className='field'>
-								<span>Direct Fork Question ID</span>
-								<input value={forkAuctionForm.directForkQuestionId} onInput={event => onForkAuctionFormChange({ directForkQuestionId: event.currentTarget.value })} placeholder='0x...' />
+								<span>Bid Amount (ETH)</span>
+								<input value={forkAuctionForm.bidAmount} onInput={event => onForkAuctionFormChange({ bidAmount: event.currentTarget.value })} />
 							</label>
-						</div>
+							<div className='actions'>
+								<button className='primary' onClick={onStartTruthAuction} disabled={disabled || accountState.address === undefined || !isMainnet}>
+									Start Truth Auction
+								</button>
+								<button className='secondary' onClick={onSubmitBid} disabled={disabled || accountState.address === undefined || !isMainnet}>
+									Submit Bid
+								</button>
+							</div>
 
-						<div className='actions'>
-							<button className='secondary' onClick={onForkUniverse} disabled={accountState.address === undefined || !isMainnet}>
-								Fork Universe Directly
-							</button>
-						</div>
-
-						<div className='actions'>
-							<button className='primary' onClick={onCreateChildUniverse} disabled={accountState.address === undefined || !isMainnet}>
-								Create {getOutcomeActionLabel(forkAuctionForm.selectedOutcome)} Child Universe
-							</button>
-							<button className='secondary' onClick={onMigrateRepToZoltar} disabled={accountState.address === undefined || !isMainnet}>
-								Migrate REP To Zoltar
-							</button>
-						</div>
-
-						<div className='actions'>
-							<button className='primary' onClick={onMigrateVault} disabled={accountState.address === undefined || !isMainnet}>
-								Migrate Vault
-							</button>
-							<button className='secondary' onClick={onMigrateEscalationDeposits} disabled={accountState.address === undefined || !isMainnet}>
-								Migrate Escalation Deposits
-							</button>
-						</div>
-
-						<label className='field'>
-							<span>Bid Tick</span>
-							<input value={forkAuctionForm.bidTick} onInput={event => onForkAuctionFormChange({ bidTick: event.currentTarget.value })} />
-						</label>
-						<label className='field'>
-							<span>Bid Amount (ETH)</span>
-							<input value={forkAuctionForm.bidAmount} onInput={event => onForkAuctionFormChange({ bidAmount: event.currentTarget.value })} />
-						</label>
-						<div className='actions'>
-							<button className='primary' onClick={onStartTruthAuction} disabled={accountState.address === undefined || !isMainnet}>
-								Start Truth Auction
-							</button>
-							<button className='secondary' onClick={onSubmitBid} disabled={accountState.address === undefined || !isMainnet}>
-								Submit Bid
-							</button>
-						</div>
-
-						<label className='field'>
-							<span>Refund Tick</span>
-							<input value={forkAuctionForm.refundTick} onInput={event => onForkAuctionFormChange({ refundTick: event.currentTarget.value })} />
-						</label>
-						<label className='field'>
-							<span>Refund Bid Index</span>
-							<input value={forkAuctionForm.refundBidIndex} onInput={event => onForkAuctionFormChange({ refundBidIndex: event.currentTarget.value })} />
-						</label>
-						<div className='actions'>
-							<button className='primary' onClick={onRefundLosingBids} disabled={accountState.address === undefined || !isMainnet}>
-								Refund Losing Bid
-							</button>
-							<button className='secondary' onClick={onFinalizeTruthAuction} disabled={accountState.address === undefined || !isMainnet}>
-								Finalize Truth Auction
-							</button>
-						</div>
-
-						<label className='field'>
-							<span>Claim Bid Index</span>
-							<input value={forkAuctionForm.bidIndex} onInput={event => onForkAuctionFormChange({ bidIndex: event.currentTarget.value })} />
-						</label>
-						<div className='actions'>
-							<button className='primary' onClick={onClaimAuctionProceeds} disabled={accountState.address === undefined || !isMainnet}>
-								Claim Auction Proceeds
-							</button>
-						</div>
-
-						<div className='field-row'>
 							<label className='field'>
-								<span>Withdraw For Address</span>
-								<input value={forkAuctionForm.withdrawForAddress} onInput={event => onForkAuctionFormChange({ withdrawForAddress: event.currentTarget.value })} placeholder='Leave empty to use connected wallet' />
+								<span>Refund Tick</span>
+								<input value={forkAuctionForm.refundTick} onInput={event => onForkAuctionFormChange({ refundTick: event.currentTarget.value })} />
 							</label>
 							<label className='field'>
-								<span>Withdraw Tick</span>
-								<input value={forkAuctionForm.withdrawTick} onInput={event => onForkAuctionFormChange({ withdrawTick: event.currentTarget.value })} />
+								<span>Refund Bid Index</span>
+								<input value={forkAuctionForm.refundBidIndex} onInput={event => onForkAuctionFormChange({ refundBidIndex: event.currentTarget.value })} />
 							</label>
-						</div>
-						<label className='field'>
-							<span>Withdraw Bid Index</span>
-							<input value={forkAuctionForm.withdrawBidIndex} onInput={event => onForkAuctionFormChange({ withdrawBidIndex: event.currentTarget.value })} />
-						</label>
-						<div className='actions'>
-							<button className='secondary' onClick={onWithdrawBids} disabled={accountState.address === undefined || !isMainnet}>
-								Withdraw Bids
-							</button>
-						</div>
+							<div className='actions'>
+								<button className='primary' onClick={onRefundLosingBids} disabled={disabled || accountState.address === undefined || !isMainnet}>
+									Refund Losing Bid
+								</button>
+								<button className='secondary' onClick={onFinalizeTruthAuction} disabled={disabled || accountState.address === undefined || !isMainnet}>
+									Finalize Truth Auction
+								</button>
+							</div>
+
+							<label className='field'>
+								<span>Claim Bid Index</span>
+								<input value={forkAuctionForm.bidIndex} onInput={event => onForkAuctionFormChange({ bidIndex: event.currentTarget.value })} />
+							</label>
+							<div className='actions'>
+								<button className='primary' onClick={onClaimAuctionProceeds} disabled={disabled || accountState.address === undefined || !isMainnet}>
+									Claim Auction Proceeds
+								</button>
+							</div>
+
+							<div className='field-row'>
+								<label className='field'>
+									<span>Withdraw For Address</span>
+									<input value={forkAuctionForm.withdrawForAddress} onInput={event => onForkAuctionFormChange({ withdrawForAddress: event.currentTarget.value })} placeholder='Leave empty to use connected wallet' />
+								</label>
+								<label className='field'>
+									<span>Withdraw Tick</span>
+									<input value={forkAuctionForm.withdrawTick} onInput={event => onForkAuctionFormChange({ withdrawTick: event.currentTarget.value })} />
+								</label>
+							</div>
+							<label className='field'>
+								<span>Withdraw Bid Index</span>
+								<input value={forkAuctionForm.withdrawBidIndex} onInput={event => onForkAuctionFormChange({ withdrawBidIndex: event.currentTarget.value })} />
+							</label>
+							<div className='actions'>
+								<button className='secondary' onClick={onWithdrawBids} disabled={disabled || accountState.address === undefined || !isMainnet}>
+									Withdraw Bids
+								</button>
+							</div>
+						</fieldset>
 					</div>
 
 					<ErrorNotice message={forkAuctionError} />

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -26,6 +26,7 @@ import { getPoolRegistryPresentation } from '../lib/userCopy.js'
 import { formatUniverseLabel } from '../lib/universe.js'
 import { readSelectedPoolViewQueryParam, writeSelectedPoolViewQueryParam } from '../lib/urlParams.js'
 import { resolveEnumValue } from '../lib/viewState.js'
+import type { SecurityPoolSystemState } from '../types/contracts.js'
 import type { SecurityPoolWorkflowRouteContentProps } from '../types/components.js'
 
 type SelectedPoolView = 'vaults' | 'trading' | 'resolution'
@@ -44,6 +45,10 @@ export function getSelectedPoolCardTitle({ hasSelectedPoolAddress, resolvedPoolT
 export function getSelectedPoolLookupDisplay({ hasSelectedPoolAddress, selectedPoolLookupState }: { hasSelectedPoolAddress: boolean; selectedPoolLookupState: LoadableValueState }): SelectedPoolLookupDisplay {
 	if (!hasSelectedPoolAddress) return 'empty'
 	return selectedPoolLookupState
+}
+
+export function isForkWorkflowDisabled(selectedPoolState: SecurityPoolSystemState | undefined) {
+	return selectedPoolState === undefined || selectedPoolState === 'operational'
 }
 
 export function SecurityPoolWorkflowSection({
@@ -91,7 +96,7 @@ export function SecurityPoolWorkflowSection({
 	const selectedPoolState = selectedPool?.systemState ?? forkAuction.forkAuctionDetails?.systemState
 	const currentTimestamp = reporting.reportingDetails?.currentTime ?? BigInt(Math.floor(Date.now() / 1000))
 	const reportingReady = marketDetails !== undefined && marketDetails.endTime <= currentTimestamp
-	const forkReady = selectedPoolState !== undefined && selectedPoolState !== 'operational'
+	const forkWorkflowDisabled = isForkWorkflowDisabled(selectedPoolState)
 	const selectedPoolUniverseMismatch = selectedPool !== undefined && selectedPool.universeId !== activeUniverseId
 	const hasSelectedPoolAddress = securityPoolAddress.trim() !== ''
 	const showSelectedPoolWorkflowDetails = shouldShowSelectedPoolWorkflowDetails({
@@ -190,7 +195,7 @@ export function SecurityPoolWorkflowSection({
 									<MetricField label='Manager'>
 										<AddressValue address={loadedSelectedPool?.managerAddress} />
 									</MetricField>
-									{forkReady ? (
+									{!forkWorkflowDisabled ? (
 										<>
 											<MetricField label='Fork Flow'>Forked / active</MetricField>
 											<MetricField label='Truth Auction'>
@@ -378,14 +383,8 @@ export function SecurityPoolWorkflowSection({
 									</EntityCard>
 								) : undefined}
 
-								<EntityCard className='selected-pool-card' title='Fork & Truth Auction' badge={<span className={`badge ${forkReady ? 'ok' : 'blocked'}`}>{forkReady ? 'Available' : 'Locked until fork'}</span>}>
-									{forkReady ? (
-										<ForkAuctionSection {...forkAuction} showHeader={false} showSecurityPoolAddressInput={false} />
-									) : (
-										<EntityCard title='Fork flow is locked' badge={<span className='badge blocked'>Operational</span>}>
-											<p className='detail'>The pool must enter a non-operational state (forked or in escalation) before the fork & auction flow becomes available.</p>
-										</EntityCard>
-									)}
+								<EntityCard className='selected-pool-card' title='Fork & Truth Auction' badge={<span className={`badge ${forkWorkflowDisabled ? 'blocked' : 'ok'}`}>{forkWorkflowDisabled ? 'Locked until fork' : 'Available'}</span>}>
+									<ForkAuctionSection {...forkAuction} disabled={forkWorkflowDisabled} disabledMessage={forkWorkflowDisabled ? 'This pool is currently operational, so fork and truth auction actions are read only.' : undefined} previewPool={selectedPool} showHeader={false} showSecurityPoolAddressInput={false} />
 								</EntityCard>
 							</div>
 						) : undefined}

--- a/ui/ts/lib/forkAuction.ts
+++ b/ui/ts/lib/forkAuction.ts
@@ -1,4 +1,4 @@
-import type { ForkAuctionDetails, ReportingOutcomeKey, SecurityPoolSystemState } from '../types/contracts.js'
+import type { ForkAuctionDetails, ListedSecurityPool, ReportingOutcomeKey, SecurityPoolSystemState } from '../types/contracts.js'
 import { assertNever } from './assert.js'
 import { getTimeRemaining as getSharedTimeRemaining } from './time.js'
 import { getReportingOutcomeLabel } from './reporting.js'
@@ -28,8 +28,8 @@ export function getOutcomeActionLabel(outcome: ReportingOutcomeKey) {
 	return getReportingOutcomeLabel(outcome)
 }
 
-export function getForkStageDescription(details: ForkAuctionDetails) {
-	switch (details.systemState) {
+export function getForkStageDescriptionForState(state: SecurityPoolSystemState) {
+	switch (state) {
 		case 'operational':
 			return 'This pool is operational. If it is a child universe, the fork and auction path has completed.'
 		case 'poolForked':
@@ -39,8 +39,16 @@ export function getForkStageDescription(details: ForkAuctionDetails) {
 		case 'forkTruthAuction':
 			return 'Truth auction is active. Bidders compete to buy REP exposure for the unresolved collateral.'
 		default:
-			return assertNever(details.systemState)
+			return assertNever(state)
 	}
+}
+
+export function getForkStageDescription(details: ForkAuctionDetails) {
+	return getForkStageDescriptionForState(details.systemState)
+}
+
+export function hasForkActivity(pool: Pick<ListedSecurityPool, 'forkOutcome' | 'migratedRep' | 'systemState' | 'truthAuctionStartedAt'>) {
+	return pool.systemState !== 'operational' || pool.truthAuctionStartedAt > 0n || pool.migratedRep > 0n || pool.forkOutcome !== 'none'
 }
 
 export function getTimeRemaining(targetTime: bigint | undefined, currentTime: bigint) {

--- a/ui/ts/tests/forkAuction.test.ts
+++ b/ui/ts/tests/forkAuction.test.ts
@@ -1,12 +1,48 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from 'bun:test'
-import { getOutcomeActionLabel } from '../lib/forkAuction.js'
+import { getForkStageDescriptionForState, getOutcomeActionLabel, hasForkActivity } from '../lib/forkAuction.js'
 
 void describe('fork auction helpers', () => {
 	void test('getOutcomeActionLabel reuses reporting labels', () => {
 		expect(getOutcomeActionLabel('invalid')).toBe('Invalid')
 		expect(getOutcomeActionLabel('yes')).toBe('Yes')
 		expect(getOutcomeActionLabel('no')).toBe('No')
+	})
+
+	void test('describes each fork stage from system state', () => {
+		expect(getForkStageDescriptionForState('operational')).toContain('operational')
+		expect(getForkStageDescriptionForState('poolForked')).toContain('Child universes')
+		expect(getForkStageDescriptionForState('forkMigration')).toContain('Migration is active')
+		expect(getForkStageDescriptionForState('forkTruthAuction')).toContain('Truth auction is active')
+	})
+
+	void test('detects whether preview pool data reflects actual fork activity', () => {
+		expect(
+			hasForkActivity({
+				forkOutcome: 'none',
+				migratedRep: 0n,
+				systemState: 'operational',
+				truthAuctionStartedAt: 0n,
+			}),
+		).toBe(false)
+
+		expect(
+			hasForkActivity({
+				forkOutcome: 'yes',
+				migratedRep: 0n,
+				systemState: 'operational',
+				truthAuctionStartedAt: 0n,
+			}),
+		).toBe(true)
+
+		expect(
+			hasForkActivity({
+				forkOutcome: 'none',
+				migratedRep: 0n,
+				systemState: 'forkMigration',
+				truthAuctionStartedAt: 0n,
+			}),
+		).toBe(true)
 	})
 })

--- a/ui/ts/tests/securityPoolWorkflow.test.ts
+++ b/ui/ts/tests/securityPoolWorkflow.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from 'bun:test'
-import { getSelectedPoolCardTitle, getSelectedPoolLookupDisplay, shouldShowSelectedPoolWorkflowDetails } from '../components/SecurityPoolWorkflowSection.js'
+import { getSelectedPoolCardTitle, getSelectedPoolLookupDisplay, isForkWorkflowDisabled, shouldShowSelectedPoolWorkflowDetails } from '../components/SecurityPoolWorkflowSection.js'
 
 void describe('selected pool workflow lookup state', () => {
 	void test('uses a stable card title until a pool resolves', () => {
@@ -98,5 +98,13 @@ void describe('selected pool workflow visibility', () => {
 				selectedPoolUniverseMismatch: false,
 			}),
 		).toBe(true)
+	})
+
+	void test('disables the fork workflow only while the selected pool remains operational', () => {
+		expect(isForkWorkflowDisabled(undefined)).toBe(true)
+		expect(isForkWorkflowDisabled('operational')).toBe(true)
+		expect(isForkWorkflowDisabled('poolForked')).toBe(false)
+		expect(isForkWorkflowDisabled('forkMigration')).toBe(false)
+		expect(isForkWorkflowDisabled('forkTruthAuction')).toBe(false)
 	})
 })

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -359,6 +359,9 @@ export type ForkAuctionRouteContentProps = {
 }
 
 export type ForkAuctionSectionProps = ForkAuctionRouteContentProps & {
+	disabled?: boolean
+	disabledMessage?: string | undefined
+	previewPool?: ListedSecurityPool | undefined
 	showSecurityPoolAddressInput?: boolean
 	showHeader?: boolean
 }


### PR DESCRIPTION
## Summary
- Added preview-mode support to the fork auction workflow so locked views can show read-only pool, auction, and migration details when live onchain data is unavailable.
- Surfaced WETH wallet balance in the account overview and added WETH wrap context to open oracle initial report actions.
- Highlighted approval sufficiency in token approval UI and adjusted the approval amount display to show sufficiency/insufficiency states.
- Tightened layout for field-row actions and updated fork workflow controls to group disabled inputs cleanly.
- Expanded and updated UI tests for fork auction, open oracle, approval amounts, security pool workflow, and onchain state hooks.

## Testing
- Not run (PR summary only).
- Existing and updated test coverage added for `approvedAmountValue`, `forkAuction`, `openOracle`, `securityPoolWorkflow`, and `useOnchainState`.
- UI type/layout changes were made across `ui/` components and styles; run the repository checks before merging.