### PR TITLE
Track WETH balances and improve approval state UI

### DIFF
--- a/ui/ts/hooks/useOnchainState.ts
+++ b/ui/ts/hooks/useOnchainState.ts
@@ -25,38 +25,44 @@ type LoadWalletStateParameters = {
 	isCurrent: () => boolean
 	setAccountState: (state: AccountState) => void
 	setErrorMessage: (message: string | undefined) => void
+	trackLoad: <TResult>(work: () => Promise<TResult>) => Promise<TResult>
 }
 
-export async function loadWalletState({ chainIdPromise, connectedAddress, ethBalancePromise, getAccountState, isCurrent, setAccountState, setErrorMessage, wethBalancePromise }: LoadWalletStateParameters) {
+export async function loadWalletState({ chainIdPromise, connectedAddress, ethBalancePromise, getAccountState, isCurrent, setAccountState, setErrorMessage, trackLoad, wethBalancePromise }: LoadWalletStateParameters) {
 	if (connectedAddress === undefined || chainIdPromise === undefined || ethBalancePromise === undefined || wethBalancePromise === undefined) return
-	const chainIdTask = chainIdPromise
-		.then(chainId => {
+
+	void trackLoad(async () => {
+		try {
+			const chainId = await chainIdPromise
 			if (!isCurrent()) return
 			setAccountState({ ...getAccountState(), chainId })
-		})
-		.catch(() => {
+		} catch {
 			if (!isCurrent()) return
 			setAccountState({ ...getAccountState(), chainId: MAINNET_CHAIN_ID })
-		})
-	const ethBalanceTask = ethBalancePromise
-		.then(ethBalance => {
+		}
+	})
+
+	void trackLoad(async () => {
+		try {
+			const ethBalance = await ethBalancePromise
 			if (!isCurrent()) return
 			setAccountState({ ...getAccountState(), ethBalance })
-		})
-		.catch(error => {
+		} catch (error) {
 			if (!isCurrent()) return
 			setErrorMessage(getErrorMessage(error, 'Failed to refresh wallet balances'))
-		})
-	const wethBalanceTask = wethBalancePromise
-		.then(wethBalance => {
+		}
+	})
+
+	void trackLoad(async () => {
+		try {
+			const wethBalance = await wethBalancePromise
 			if (!isCurrent()) return
 			setAccountState({ ...getAccountState(), wethBalance })
-		})
-		.catch(error => {
+		} catch (error) {
 			if (!isCurrent()) return
 			setErrorMessage(getErrorMessage(error, 'Failed to refresh wallet balances'))
-		})
-	await Promise.all([chainIdTask, ethBalanceTask, wethBalanceTask])
+		}
+	})
 }
 
 export function useOnchainState() {
@@ -132,7 +138,7 @@ export function useOnchainState() {
 					const readClient = createConnectedReadClient()
 					const ethBalancePromise = readClient.getBalance({ address: connectedAddress })
 					const wethBalancePromise = loadErc20Balance(readClient, WETH_ADDRESS, connectedAddress)
-					await loadWalletState({
+					void loadWalletState({
 						connectedAddress,
 						chainIdPromise,
 						ethBalancePromise,
@@ -144,6 +150,7 @@ export function useOnchainState() {
 						setErrorMessage: message => {
 							errorMessage.value = message
 						},
+						trackLoad: walletStateLoad.track,
 						wethBalancePromise,
 					})
 				} else {

--- a/ui/ts/tests/useOnchainState.test.ts
+++ b/ui/ts/tests/useOnchainState.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, test } from 'bun:test'
 import { zeroAddress } from 'viem'
 import { loadWalletState } from '../hooks/useOnchainState.js'
+import { createLoadController } from '../lib/loadState.js'
 import type { AccountState } from '../types/app.js'
 
 function createDeferred<T>() {
@@ -15,8 +16,13 @@ function createDeferred<T>() {
 	return { promise, reject, resolve }
 }
 
+async function flushAsyncUpdates() {
+	await Promise.resolve()
+	await Promise.resolve()
+}
+
 void describe('loadWalletState', () => {
-	void test('waits for the balance lookup before resolving', async () => {
+	void test('resolves after scheduling wallet loads and applies updates as each load completes', async () => {
 		const chainIdDeferred = createDeferred<string>()
 		const ethBalanceDeferred = createDeferred<bigint>()
 		const wethBalanceDeferred = createDeferred<bigint>()
@@ -40,29 +46,74 @@ void describe('loadWalletState', () => {
 			setErrorMessage: message => {
 				errorMessage = message
 			},
+			trackLoad: async work => await work(),
 			wethBalancePromise: wethBalanceDeferred.promise,
 		}).then(() => {
 			resolved = true
 		})
 
-		await Promise.resolve()
 		expect(resolved).toBe(false)
+		await Promise.resolve()
+		expect(resolved).toBe(true)
 
 		chainIdDeferred.resolve('0x1')
 		await Promise.resolve()
-		expect(resolved).toBe(false)
 		expect(accountState.chainId).toBe('0x1')
 
 		ethBalanceDeferred.resolve(123n)
 		await Promise.resolve()
-		expect(resolved).toBe(false)
+		expect(accountState.ethBalance).toBe(123n)
 
 		wethBalanceDeferred.resolve(456n)
-		await loadPromise
+		await flushAsyncUpdates()
 
-		expect(resolved).toBe(true)
+		await loadPromise
 		expect(errorMessage).toBe(undefined)
 		expect(accountState.address).toBe(zeroAddress)
+		expect(accountState.chainId).toBe('0x1')
+		expect(accountState.ethBalance).toBe(123n)
+		expect(accountState.wethBalance).toBe(456n)
+	})
+
+	void test('keeps tracked loading active until each scheduled wallet load settles', async () => {
+		const chainIdDeferred = createDeferred<string>()
+		const ethBalanceDeferred = createDeferred<bigint>()
+		const wethBalanceDeferred = createDeferred<bigint>()
+		const controller = createLoadController()
+		let accountState: AccountState = {
+			address: zeroAddress,
+			chainId: undefined,
+			ethBalance: undefined,
+			wethBalance: undefined,
+		}
+
+		await loadWalletState({
+			chainIdPromise: chainIdDeferred.promise,
+			connectedAddress: zeroAddress,
+			ethBalancePromise: ethBalanceDeferred.promise,
+			getAccountState: () => accountState,
+			isCurrent: () => true,
+			setAccountState: state => {
+				accountState = state
+			},
+			setErrorMessage: () => undefined,
+			trackLoad: controller.track,
+			wethBalancePromise: wethBalanceDeferred.promise,
+		})
+
+		expect(controller.isLoading.value).toBe(true)
+
+		chainIdDeferred.resolve('0x1')
+		await Promise.resolve()
+		expect(controller.isLoading.value).toBe(true)
+
+		ethBalanceDeferred.resolve(123n)
+		await Promise.resolve()
+		expect(controller.isLoading.value).toBe(true)
+
+		wethBalanceDeferred.resolve(456n)
+		await flushAsyncUpdates()
+		expect(controller.isLoading.value).toBe(false)
 		expect(accountState.chainId).toBe('0x1')
 		expect(accountState.ethBalance).toBe(123n)
 		expect(accountState.wethBalance).toBe(456n)


### PR DESCRIPTION
## Summary
- Track wallet state until ETH and WETH balance fetches both settle, and store WETH balance in account state.
- Show WETH balance in the account overview and surface WETH balance state in open oracle report details.
- Highlight whether token approvals are sufficient and streamline the approval amount field layout.
- Update open oracle WETH wrap messaging to distinguish when wrapping is needed versus when no extra WETH is required.
- Add coverage for approval tone helpers, open oracle submission logic, and wallet state loading behavior.

## Testing
- Not run (PR content only)
- Expected checks from repo guidance: `bun tsc`, `bun test`, `bun run format`, `bun run check`, `bun run knip`