### PR TITLE
Add live collateralization and trading state UI

### DIFF
--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -53,6 +53,11 @@ export function isForkWorkflowDisabled(selectedPoolState: SecurityPoolSystemStat
 	return selectedPoolState === undefined || selectedPoolState === 'operational'
 }
 
+export function getOracleLastPriceDisplay({ lastPrice, lastSettlementTimestamp }: { lastPrice: bigint; lastSettlementTimestamp: bigint }) {
+	if (lastSettlementTimestamp === 0n) return '-'
+	return lastPrice.toString()
+}
+
 export function SecurityPoolWorkflowSection({
 	accountState,
 	activeUniverseId,
@@ -251,7 +256,7 @@ export function SecurityPoolWorkflowSection({
 								) : (
 									<>
 										<div className='workflow-metric-grid'>
-											<MetricField label='Last Price'>{poolOracleManagerDetails.lastPrice.toString()}</MetricField>
+											<MetricField label='Last Price'>{getOracleLastPriceDisplay(poolOracleManagerDetails)}</MetricField>
 											<MetricField label='Set At'>
 												<TimestampValue timestamp={poolOracleManagerDetails.lastSettlementTimestamp} zeroText='Never' />
 											</MetricField>

--- a/ui/ts/tests/securityPoolWorkflow.test.ts
+++ b/ui/ts/tests/securityPoolWorkflow.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from 'bun:test'
-import { getSelectedPoolCardTitle, getSelectedPoolLookupDisplay, isForkWorkflowDisabled, shouldShowSelectedPoolWorkflowDetails } from '../components/SecurityPoolWorkflowSection.js'
+import { getOracleLastPriceDisplay, getSelectedPoolCardTitle, getSelectedPoolLookupDisplay, isForkWorkflowDisabled, shouldShowSelectedPoolWorkflowDetails } from '../components/SecurityPoolWorkflowSection.js'
 
 void describe('selected pool workflow lookup state', () => {
 	void test('uses a stable card title until a pool resolves', () => {
@@ -106,5 +106,32 @@ void describe('selected pool workflow visibility', () => {
 		expect(isForkWorkflowDisabled('poolForked')).toBe(false)
 		expect(isForkWorkflowDisabled('forkMigration')).toBe(false)
 		expect(isForkWorkflowDisabled('forkTruthAuction')).toBe(false)
+	})
+})
+
+void describe('selected pool oracle price display', () => {
+	void test('shows a dash when the oracle price has never been settled', () => {
+		expect(
+			getOracleLastPriceDisplay({
+				lastPrice: 0n,
+				lastSettlementTimestamp: 0n,
+			}),
+		).toBe('-')
+	})
+
+	void test('keeps settled prices numeric, including zero', () => {
+		expect(
+			getOracleLastPriceDisplay({
+				lastPrice: 0n,
+				lastSettlementTimestamp: 1n,
+			}),
+		).toBe('0')
+
+		expect(
+			getOracleLastPriceDisplay({
+				lastPrice: 42n,
+				lastSettlementTimestamp: 1n,
+			}),
+		).toBe('42')
 	})
 })


### PR DESCRIPTION
## Summary
- Show live REP/ETH collateralization metrics across the trading, security pool, and overview screens.
- Improve approval and balance displays with sufficiency states, better loading behavior, and clearer unset-price handling.
- Update fork auction, oracle, and trading flows to surface preview state, live balances, and more actionable guards.
- Add and expand UI tests for the updated trading, oracle, approval, and onchain state logic.

## Testing
- Not run (PR description only).
- Expected checks per repo guidelines: `bun tsc`, `bun test`, `bun run format`, `bun run check`, `bun run knip`.