### PR TITLE
Improve live trading, fork, and approval UI state

### DIFF
--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -153,7 +153,6 @@ export function ForkAuctionSection({
 									<div className='entity-card-subsection'>
 										<div className='entity-card-subsection-header'>
 											<h4>Question</h4>
-											<span className='badge muted'>{question.marketType}</span>
 										</div>
 										<Question question={question} />
 									</div>

--- a/ui/ts/components/ForkZoltarSection.tsx
+++ b/ui/ts/components/ForkZoltarSection.tsx
@@ -122,7 +122,6 @@ export function ForkZoltarSection({
 						<div className='entity-card-subsection'>
 							<div className='entity-card-subsection-header'>
 								<h4>Question</h4>
-								<span className='badge muted'>{selectedQuestion.marketType}</span>
 							</div>
 							<Question question={selectedQuestion} />
 						</div>

--- a/ui/ts/components/MarketCreateQuestionSection.tsx
+++ b/ui/ts/components/MarketCreateQuestionSection.tsx
@@ -103,7 +103,6 @@ export function MarketCreateQuestionSection({
 			{marketResult === undefined ? undefined : (
 				<EntityCard
 					title={selectedQuestionTitle}
-					badge={<span className='badge ok'>{marketResult.marketType}</span>}
 					actions={
 						<div className='actions'>
 							<button

--- a/ui/ts/components/MarketOverviewSection.tsx
+++ b/ui/ts/components/MarketOverviewSection.tsx
@@ -53,18 +53,7 @@ export function MarketOverviewSection({ accountAddress, isMainnet, loadingZoltar
 			) : (
 				<>
 					{hasForked ? (
-						<EntityCard
-							title='Fork Question'
-							badge={
-								<span className='badge muted'>
-									{rootUniverse.forkQuestionDetails?.marketType ?? (
-										<span className='loading-value' role='status' aria-label='Loading fork question type'>
-											<span className='spinner' aria-hidden='true' />
-										</span>
-									)}
-								</span>
-							}
-						>
+						<EntityCard title='Fork Question'>
 							<Question question={rootUniverse.forkQuestionDetails} loading={rootUniverse.forkQuestionDetails === undefined} />
 						</EntityCard>
 					) : undefined}

--- a/ui/ts/components/MarketQuestionsSection.tsx
+++ b/ui/ts/components/MarketQuestionsSection.tsx
@@ -40,7 +40,6 @@ export function MarketQuestionsSection({ hasForked, hasLoadedZoltarQuestions, lo
 						<EntityCard
 							key={question.questionId}
 							title={getQuestionTitle(question)}
-							badge={<span className='badge ok'>{question.marketType}</span>}
 							actions={
 								<div className='actions'>
 									<button

--- a/ui/ts/components/Question.tsx
+++ b/ui/ts/components/Question.tsx
@@ -11,6 +11,18 @@ type QuestionProps = {
 	showTitle?: boolean
 }
 
+type QuestionSummaryField =
+	| {
+			kind: 'text'
+			label: string
+			value: string
+	  }
+	| {
+			kind: 'timestamp'
+			label: string
+			value: bigint
+	  }
+
 export function getQuestionTitle(question: MarketDetails) {
 	return question.title.trim() === '' ? 'Untitled question' : question.title
 }
@@ -29,13 +41,34 @@ function getDisplayRange(question: MarketDetails) {
 	return question.answerUnit === '' ? `${question.displayValueMin.toString()} to ${question.displayValueMax.toString()}` : `${question.displayValueMin.toString()} to ${question.displayValueMax.toString()} ${question.answerUnit}`
 }
 
-function renderScalarQuestionFields(question: MarketDetails) {
+export function getQuestionSummaryFields(question: MarketDetails): QuestionSummaryField[] {
+	const fields: QuestionSummaryField[] = [
+		{ kind: 'text', label: 'Question ID', value: question.questionId },
+		{ kind: 'timestamp', label: 'Created', value: question.createdAt },
+		{ kind: 'timestamp', label: 'End Time', value: question.endTime },
+		{ kind: 'text', label: 'Outcomes', value: getDisplayedOutcomes(question).join(', ') },
+	]
+
+	if (question.marketType === 'scalar') {
+		fields.push({ kind: 'text', label: 'Ticks', value: question.numTicks.toString() }, { kind: 'text', label: 'Display Range', value: getDisplayRange(question) }, { kind: 'text', label: 'Answer Unit', value: question.answerUnit === '' ? 'None' : question.answerUnit })
+	}
+
+	return fields
+}
+
+function renderQuestionSummaryField(field: QuestionSummaryField) {
+	if (field.kind === 'timestamp') {
+		return (
+			<MetricField key={field.label} label={field.label}>
+				<TimestampValue timestamp={field.value} />
+			</MetricField>
+		)
+	}
+
 	return (
-		<>
-			<MetricField label='Ticks'>{question.numTicks.toString()}</MetricField>
-			<MetricField label='Display Range'>{getDisplayRange(question)}</MetricField>
-			<MetricField label='Answer Unit'>{question.answerUnit === '' ? 'None' : question.answerUnit}</MetricField>
-		</>
+		<MetricField key={field.label} label={field.label}>
+			{field.value}
+		</MetricField>
 	)
 }
 
@@ -52,6 +85,7 @@ export function Question({ className = '', loading = false, question, showTitle 
 
 	const title = getQuestionTitle(question)
 	const description = getQuestionDescription(question)
+	const summaryFields = getQuestionSummaryFields(question)
 
 	return (
 		<div className={`question-summary ${className}`}>
@@ -63,18 +97,7 @@ export function Question({ className = '', loading = false, question, showTitle 
 			) : (
 				<p className='detail'>{description}</p>
 			)}
-			<div className='question-summary-grid'>
-				<MetricField label='Question ID'>{question.questionId}</MetricField>
-				<MetricField label='Type'>{question.marketType}</MetricField>
-				<MetricField label='Created'>
-					<TimestampValue timestamp={question.createdAt} />
-				</MetricField>
-				<MetricField label='End Time'>
-					<TimestampValue timestamp={question.endTime} />
-				</MetricField>
-				<MetricField label='Outcomes'>{getDisplayedOutcomes(question).join(', ')}</MetricField>
-				{question.marketType === 'scalar' ? renderScalarQuestionFields(question) : undefined}
-			</div>
+			<div className='question-summary-grid'>{summaryFields.map(renderQuestionSummaryField)}</div>
 		</div>
 	)
 }

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -79,7 +79,6 @@ export function ReportingSection({
 				<div className='entity-card-subsection'>
 					<div className='entity-card-subsection-header'>
 						<h4>Question</h4>
-						<span className='badge muted'>{reportingDetails.marketDetails.marketType}</span>
 					</div>
 					<Question question={reportingDetails.marketDetails} />
 				</div>
@@ -119,7 +118,6 @@ export function ReportingSection({
 				<div className='entity-card-subsection'>
 					<div className='entity-card-subsection-header'>
 						<h4>Question</h4>
-						<span className='badge muted'>{reportingDetails.marketDetails.marketType}</span>
 					</div>
 					<Question question={reportingDetails.marketDetails} />
 				</div>

--- a/ui/ts/components/SecurityPoolSection.tsx
+++ b/ui/ts/components/SecurityPoolSection.tsx
@@ -122,7 +122,7 @@ export function SecurityPoolSection({
 					<>
 						<div className='market-column'>
 							{marketDetails === undefined && !loadingMarketDetails ? undefined : (
-								<EntityCard title='Question' badge={marketDetails === undefined ? undefined : <span className='badge ok'>{marketDetails.marketType}</span>}>
+								<EntityCard title='Question'>
 									<Question question={marketDetails} loading={loadingMarketDetails && marketDetails === undefined} />
 								</EntityCard>
 							)}

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -225,7 +225,6 @@ export function SecurityPoolWorkflowSection({
 								<div className='entity-card-subsection'>
 									<div className='entity-card-subsection-header'>
 										<h4>Question</h4>
-										<span className='badge muted'>{marketDetails.marketType}</span>
 									</div>
 									<Question question={marketDetails} />
 								</div>

--- a/ui/ts/components/SecurityPoolsOverviewSection.tsx
+++ b/ui/ts/components/SecurityPoolsOverviewSection.tsx
@@ -90,7 +90,6 @@ export function SecurityPoolsOverviewSection({
 								<div className='entity-card-subsection'>
 									<div className='entity-card-subsection-header'>
 										<h4>Question</h4>
-										<span className='badge muted'>{pool.marketDetails.marketType}</span>
 									</div>
 									<Question question={pool.marketDetails} />
 								</div>

--- a/ui/ts/tests/question.test.ts
+++ b/ui/ts/tests/question.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, test } from 'bun:test'
 import type { MarketDetails } from '../types/contracts.js'
-import { getQuestionTitle } from '../components/Question.js'
+import { getQuestionSummaryFields, getQuestionTitle } from '../components/Question.js'
 
 const questionBase = {
 	answerUnit: '',
@@ -27,5 +27,66 @@ void describe('question helpers', () => {
 
 	void test('keeps a non-empty title unchanged', () => {
 		expect(getQuestionTitle(questionBase)).toBe('Question title')
+	})
+
+	void test('builds binary question summary fields without a type label', () => {
+		const fields = getQuestionSummaryFields(questionBase)
+
+		expect(fields.map(field => field.label)).toEqual(['Question ID', 'Created', 'End Time', 'Outcomes'])
+		expect(fields.some(field => field.label === 'Type')).toBe(false)
+		expect(fields.find(field => field.label === 'Outcomes')).toEqual({
+			kind: 'text',
+			label: 'Outcomes',
+			value: 'Yes, No, Invalid',
+		})
+	})
+
+	void test('builds scalar question summary fields with scalar-specific details', () => {
+		const fields = getQuestionSummaryFields({
+			...questionBase,
+			answerUnit: 'USD',
+			displayValueMax: 10n,
+			displayValueMin: 1n,
+			marketType: 'scalar',
+			numTicks: 100n,
+			outcomeLabels: [],
+		})
+
+		expect(fields.map(field => field.label)).toEqual(['Question ID', 'Created', 'End Time', 'Outcomes', 'Ticks', 'Display Range', 'Answer Unit'])
+		expect(fields.some(field => field.label === 'Type')).toBe(false)
+		expect(fields.find(field => field.label === 'Outcomes')).toEqual({
+			kind: 'text',
+			label: 'Outcomes',
+			value: 'Scalar, Invalid',
+		})
+		expect(fields.find(field => field.label === 'Ticks')).toEqual({
+			kind: 'text',
+			label: 'Ticks',
+			value: '100',
+		})
+		expect(fields.find(field => field.label === 'Display Range')).toEqual({
+			kind: 'text',
+			label: 'Display Range',
+			value: '1 to 10 USD',
+		})
+		expect(fields.find(field => field.label === 'Answer Unit')).toEqual({
+			kind: 'text',
+			label: 'Answer Unit',
+			value: 'USD',
+		})
+	})
+
+	void test('preserves existing invalid outcomes without duplicating them', () => {
+		const fields = getQuestionSummaryFields({
+			...questionBase,
+			marketType: 'categorical',
+			outcomeLabels: ['Above', 'Invalid', 'Below'],
+		})
+
+		expect(fields.find(field => field.label === 'Outcomes')).toEqual({
+			kind: 'text',
+			label: 'Outcomes',
+			value: 'Above, Invalid, Below',
+		})
 	})
 })


### PR DESCRIPTION
## Summary
- Show live collateralization, balance, and approval status across trading and vault workflows.
- Surface REP/ETH pricing source details and preview fork state when live onchain data is still loading.
- Tighten UI feedback with approval sufficiency coloring, disabled workflow guards, and cleaner question views.
- Remove redundant market type badges and align field/action layout across sections.

## Testing
- Not run