### PR TITLE
Improve open oracle initial report refresh flow

### DIFF
--- a/ui/ts/components/OpenOracleSection.tsx
+++ b/ui/ts/components/OpenOracleSection.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'preact/hooks'
 import type { ComponentChildren } from 'preact'
 import { zeroAddress } from 'viem'
 import { AddressValue } from './AddressValue.js'
+import { ApprovedAmountValue } from './ApprovedAmountValue.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { EntityCard } from './EntityCard.js'
 import { EnumDropdown, type EnumDropdownOption } from './EnumDropdown.js'
@@ -114,6 +115,8 @@ function renderSelectedReportActionSection(
 		{ value: 'token1', label: token1Symbol },
 		{ value: 'token2', label: token2Symbol },
 	]
+	const showQuoteLoadingPlaceholder = openOracleInitialReportState.quoteLoading && openOracleForm.price.trim() === '' && openOracleInitialReportState.defaultPrice === undefined && openOracleInitialReportState.defaultPriceError === undefined
+
 	switch (actionMode) {
 		case 'initial-report':
 			return (
@@ -122,6 +125,71 @@ function renderSelectedReportActionSection(
 						<h4>Initial Report</h4>
 					</div>
 					<div className='form-grid'>
+						<div className='field-row'>
+							<label className='field'>
+								<span>{`Price (${token1Symbol} / ${token2Symbol})`}</span>
+								<input value={openOracleForm.price} onInput={event => onOpenOracleFormChange({ price: event.currentTarget.value })} placeholder='1.00' />
+							</label>
+							<div className='actions'>
+								<button className='secondary' onClick={onRefreshPrice} disabled={openOracleInitialReportState.quoteLoading}>
+									{openOracleInitialReportState.quoteLoading ? 'Fetching...' : 'Fetch price from Uniswap'}
+								</button>
+							</div>
+						</div>
+						<p className='detail'>Price source: {showQuoteLoadingPlaceholder ? <strong>Loading...</strong> : renderInitialPriceSourceLabel(initialReportSubmission.priceSource, initialReportSubmission.priceSourceUrl)}</p>
+						<div className='question-summary-grid'>
+							<MetricField label={`Required ${token1Symbol}`}>
+								<CurrencyValue value={initialReportSubmission.amount1} units={initialReportSubmission.token1Decimals ?? 18} suffix={token1Symbol} copyable={false} />
+							</MetricField>
+							<MetricField label={`Required ${token2Symbol}`}>
+								<CurrencyValue value={initialReportSubmission.amount2} units={initialReportSubmission.token2Decimals ?? 18} suffix={token2Symbol} copyable={false} />
+							</MetricField>
+							<MetricField label={`Wallet ${token1Symbol}`}>
+								<CurrencyValue
+									loading={openOracleInitialReportState.tokenAccessLoadingInitial && openOracleInitialReportState.token1Balance === undefined && openOracleInitialReportState.token1BalanceError === undefined}
+									value={openOracleInitialReportState.token1Balance}
+									units={initialReportSubmission.token1Decimals ?? 18}
+									suffix={token1Symbol}
+									copyable={false}
+								/>
+							</MetricField>
+							<MetricField label={`Wallet ${token2Symbol}`}>
+								<CurrencyValue
+									loading={openOracleInitialReportState.tokenAccessLoadingInitial && openOracleInitialReportState.token2Balance === undefined && openOracleInitialReportState.token2BalanceError === undefined}
+									value={openOracleInitialReportState.token2Balance}
+									units={initialReportSubmission.token2Decimals ?? 18}
+									suffix={token2Symbol}
+									copyable={false}
+								/>
+							</MetricField>
+							<MetricField label={`Approved ${token1Symbol}`}>
+								<ApprovedAmountValue loading={openOracleInitialReportState.token1Approval.loading} value={initialReportSubmission.token1Approval.approvedAmount} units={initialReportSubmission.token1Decimals ?? 18} suffix={token1Symbol} copyable={false} />
+							</MetricField>
+							<MetricField label={`Approved ${token2Symbol}`}>
+								<ApprovedAmountValue loading={openOracleInitialReportState.token2Approval.loading} value={initialReportSubmission.token2Approval.approvedAmount} units={initialReportSubmission.token2Decimals ?? 18} suffix={token2Symbol} copyable={false} />
+							</MetricField>
+						</div>
+						{!initialReportSubmission.hasWethWrapAction ? undefined : (
+							<div className='entity-card-subsection'>
+								{initialReportSubmission.requiredWethWrapAmount === undefined || initialReportSubmission.requiredWethWrapAmount <= 0n ? undefined : (
+									<p className='detail'>
+										Need <CurrencyValue value={initialReportSubmission.requiredWethWrapAmount} suffix='WETH' copyable={false} /> more WETH for this report.
+									</p>
+								)}
+								{initialReportSubmission.wrapRequiredWethMessage?.kind !== 'visible' ? undefined : <p className='detail'>{initialReportSubmission.wrapRequiredWethMessage.message}</p>}
+								<div className='actions'>
+									<button
+										className='secondary'
+										type='button'
+										onClick={onWrapWethForInitialReport}
+										disabled={!isConnected || !initialReportSubmission.canWrapRequiredWeth || openOracleActiveAction === 'wrapWeth'}
+										title={initialReportSubmission.wrapRequiredWethMessage?.kind === 'visible' ? initialReportSubmission.wrapRequiredWethMessage.message : undefined}
+									>
+										{openOracleActiveAction === 'wrapWeth' ? <LoadingText>Wrapping ETH...</LoadingText> : 'Wrap needed ETH to WETH'}
+									</button>
+								</div>
+							</div>
+						)}
 						<div className='entity-card-subsection'>
 							<div className='entity-card-subsection-header'>
 								<h4>{`${token1Symbol} Approval`}</h4>
@@ -161,44 +229,9 @@ function renderSelectedReportActionSection(
 								tokenUnits={initialReportSubmission.token2Decimals ?? 18}
 							/>
 						</div>
-						<div className='field-row'>
-							<label className='field'>
-								<span>{`Price (${token1Symbol} / ${token2Symbol})`}</span>
-								<input value={openOracleForm.price} onInput={event => onOpenOracleFormChange({ price: event.currentTarget.value })} placeholder='1.00' />
-							</label>
-							<div className='actions'>
-								<button className='secondary' onClick={onRefreshPrice} disabled={openOracleInitialReportState.loading}>
-									{openOracleInitialReportState.loading ? 'Fetching...' : 'Fetch price from Uniswap'}
-								</button>
-							</div>
-						</div>
-						<p className='detail'>Price source: {openOracleInitialReportState.loading ? <strong>Loading...</strong> : renderInitialPriceSourceLabel(initialReportSubmission.priceSource, initialReportSubmission.priceSourceUrl)}</p>
 						<ErrorNotice message={initialReportSubmission.blockMessage?.kind === 'visible' ? initialReportSubmission.blockMessage.message : undefined} />
-						{!initialReportSubmission.hasWethWrapAction ? undefined : (
-							<>
-								{initialReportSubmission.requiredWethWrapAmount === undefined || initialReportSubmission.requiredWethWrapAmount <= 0n ? (
-									<p className='detail'>This report uses WETH for the initial report deposit.</p>
-								) : (
-									<p className='detail'>
-										Need <CurrencyValue value={initialReportSubmission.requiredWethWrapAmount} suffix='WETH' copyable={false} /> more WETH for this report.
-									</p>
-								)}
-								{initialReportSubmission.wrapRequiredWethMessage?.kind !== 'visible' ? undefined : <p className='detail'>{initialReportSubmission.wrapRequiredWethMessage.message}</p>}
-							</>
-						)}
 						<div className='actions'>
-							{!initialReportSubmission.hasWethWrapAction ? undefined : (
-								<button
-									className='secondary'
-									type='button'
-									onClick={onWrapWethForInitialReport}
-									disabled={!isConnected || !initialReportSubmission.canWrapRequiredWeth || openOracleInitialReportState.loading || openOracleActiveAction === 'wrapWeth'}
-									title={initialReportSubmission.wrapRequiredWethMessage?.kind === 'visible' ? initialReportSubmission.wrapRequiredWethMessage.message : undefined}
-								>
-									{openOracleActiveAction === 'wrapWeth' ? <LoadingText>Wrapping ETH...</LoadingText> : 'Wrap needed ETH to WETH'}
-								</button>
-							)}
-							<button className='primary' onClick={onSubmitInitialReport} disabled={!isConnected || !initialReportSubmission.canSubmit || openOracleInitialReportState.loading || openOracleActiveAction === 'submitInitialReport'}>
+							<button className='primary' onClick={onSubmitInitialReport} disabled={!isConnected || !initialReportSubmission.canSubmit || openOracleActiveAction === 'submitInitialReport'}>
 								{openOracleActiveAction === 'submitInitialReport' ? <LoadingText>Submitting...</LoadingText> : 'Submit Initial Report'}
 							</button>
 						</div>

--- a/ui/ts/hooks/useOpenOracleOperations.ts
+++ b/ui/ts/hooks/useOpenOracleOperations.ts
@@ -6,7 +6,7 @@ import { useLoadController } from './useLoadController.js'
 import { approveErc20, createOpenOracleReportInstance, disputeOracleReport, getOpenOracleAddress, loadErc20Allowance, loadErc20Balance, loadOpenOracleReportDetails, settleOracleReport, submitInitialOracleReport, wrapWeth } from '../contracts.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
 import { getErrorDetail, getErrorMessage } from '../lib/errors.js'
-import { deriveOpenOracleInitialReportSubmissionDetails, formatOpenOraclePriceInput, loadOpenOracleInitialReportPriceResult } from '../lib/openOracle.js'
+import { deriveOpenOracleInitialReportSubmissionDetails, formatOpenOracleInitialReportWriteErrorMessage, formatOpenOraclePriceInput, getOpenOracleSelectedReportActionMode, loadOpenOracleInitialReportPriceResult } from '../lib/openOracle.js'
 import { parseAddressInput, parseBytes32Input, parseReportIdInput } from '../lib/inputs.js'
 import { getDefaultOpenOracleCreateFormState, getDefaultOpenOracleFormState, parseBigIntInput } from '../lib/marketForm.js'
 import { requireDefined } from '../lib/required.js'
@@ -23,9 +23,10 @@ type TokenAccessLoadResult = {
 	error: string | undefined
 }
 
-type OpenOracleInitialReportStateLoadResult = {
+type OpenOracleInitialReportPriceLoadResult = Awaited<ReturnType<typeof loadOpenOracleInitialReportPriceResult>>
+
+type OpenOracleInitialReportTokenAccessLoadResult = {
 	ethBalanceResult: TokenAccessLoadResult
-	initialPriceResult: Awaited<ReturnType<typeof loadOpenOracleInitialReportPriceResult>>
 	token1ApprovalResult: TokenApprovalState
 	token2ApprovalResult: TokenApprovalState
 	token1BalanceResult: TokenAccessLoadResult
@@ -37,10 +38,15 @@ type LoadedOracleReportResult = {
 	reportId: bigint
 }
 
+type RefreshOpenOracleInitialReportOptions = {
+	preserveExisting?: boolean
+}
+
 export function useOpenOracleOperations({ accountAddress, onTransaction, onTransactionFinished, onTransactionRequested, onTransactionSubmitted, refreshState }: UseOpenOracleOperationsParameters) {
 	const loadingOpenOracleCreate = useSignal(false)
 	const oracleReportLoad = useLoadController()
-	const openOracleInitialReportStateLoad = useLoadController()
+	const openOracleInitialReportPriceLoad = useLoadController()
+	const openOracleInitialReportTokenAccessLoad = useLoadController()
 	const { state: openOracleCreateForm, setState: setOpenOracleCreateForm } = useFormState<OpenOracleCreateFormState>(getDefaultOpenOracleCreateFormState())
 	const openOracleError = useSignal<string | undefined>(undefined)
 	const openOracleActiveAction = useSignal<OpenOracleActionResult['action'] | undefined>(undefined)
@@ -71,7 +77,25 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 	const openOracleInitialReportToken1BalanceError = useSignal<string | undefined>(undefined)
 	const openOracleInitialReportToken2Balance = useSignal<bigint | undefined>(undefined)
 	const openOracleInitialReportToken2BalanceError = useSignal<string | undefined>(undefined)
-	const nextOpenOracleInitialReportStateLoad = useRequestGuard()
+	const openOracleInitialReportTokenAccessLoadingInitial = useSignal(false)
+	const openOracleInitialReportTokenAccessRefreshing = useSignal(false)
+	const nextOpenOracleInitialReportPriceLoad = useRequestGuard()
+	const nextOpenOracleInitialReportTokenAccessLoad = useRequestGuard()
+
+	const setOpenOracleInitialReportTokenAccessMode = (mode: 'idle' | 'initial' | 'background') => {
+		openOracleInitialReportTokenAccessLoadingInitial.value = mode === 'initial'
+		openOracleInitialReportTokenAccessRefreshing.value = mode === 'background'
+	}
+
+	const resetOpenOracleInitialReportQuoteState = () => {
+		openOracleInitialReportDefaultPrice.value = undefined
+		openOracleInitialReportDefaultPriceError.value = undefined
+		openOracleInitialReportDefaultPriceSource.value = undefined
+		openOracleInitialReportDefaultPriceSourceUrl.value = undefined
+		openOracleInitialReportQuoteAttemptedSources.value = undefined
+		openOracleInitialReportQuoteFailureKind.value = undefined
+		openOracleInitialReportQuoteFailureReason.value = undefined
+	}
 
 	const resetOpenOracleTokenApprovalState = (loading: boolean) => {
 		openOracleInitialReportToken1Approval.value = {
@@ -95,116 +119,108 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 		openOracleInitialReportToken2BalanceError.value = undefined
 	}
 
-	const resetOpenOracleInitialReportState = (approvalLoading: boolean) => {
-		openOracleInitialReportDefaultPrice.value = undefined
-		openOracleInitialReportDefaultPriceError.value = undefined
-		openOracleInitialReportDefaultPriceSource.value = undefined
-		openOracleInitialReportDefaultPriceSourceUrl.value = undefined
-		openOracleInitialReportQuoteAttemptedSources.value = undefined
-		openOracleInitialReportQuoteFailureKind.value = undefined
-		openOracleInitialReportQuoteFailureReason.value = undefined
+	const resetOpenOracleInitialReportTokenAccessState = (approvalLoading: boolean) => {
 		resetOpenOracleTokenApprovalState(approvalLoading)
 		resetOpenOracleInitialReportBalanceState()
+		setOpenOracleInitialReportTokenAccessMode('idle')
 	}
 
-	const refreshOpenOracleInitialReportState = async (details: OpenOracleReportDetails | undefined) => {
+	const resetOpenOracleInitialReportState = (approvalLoading: boolean) => {
+		resetOpenOracleInitialReportQuoteState()
+		resetOpenOracleInitialReportTokenAccessState(approvalLoading)
+	}
+
+	const loadAllowance = async (tokenAddress: Address): Promise<TokenApprovalState> => {
+		if (accountAddress === undefined) {
+			return {
+				error: undefined,
+				loading: false,
+				value: undefined,
+			}
+		}
+
+		try {
+			return {
+				error: undefined,
+				loading: false,
+				value: await loadErc20Allowance(createConnectedReadClient(), tokenAddress, accountAddress, getOpenOracleAddress()),
+			}
+		} catch (error) {
+			const errorDetail = getErrorDetail(error)
+			return {
+				error: errorDetail === undefined ? 'Failed to load token approval' : `Failed to load token approval: ${errorDetail}`,
+				loading: false,
+				value: undefined,
+			}
+		}
+	}
+
+	const loadBalance = async (tokenAddress: Address): Promise<TokenAccessLoadResult> => {
+		if (accountAddress === undefined) {
+			return { amount: undefined, error: undefined }
+		}
+
+		try {
+			return {
+				amount: await loadErc20Balance(createConnectedReadClient(), tokenAddress, accountAddress),
+				error: undefined,
+			}
+		} catch (error) {
+			const errorDetail = getErrorDetail(error)
+			return {
+				amount: undefined,
+				error: errorDetail === undefined ? 'Failed to load token balance' : `Failed to load token balance: ${errorDetail}`,
+			}
+		}
+	}
+
+	const loadEthBalance = async (): Promise<TokenAccessLoadResult> => {
+		if (accountAddress === undefined) {
+			return { amount: undefined, error: undefined }
+		}
+
+		try {
+			return {
+				amount: await createConnectedReadClient().getBalance({ address: accountAddress }),
+				error: undefined,
+			}
+		} catch (error) {
+			const errorDetail = getErrorDetail(error)
+			return {
+				amount: undefined,
+				error: errorDetail === undefined ? 'Failed to load wallet ETH balance' : `Failed to load wallet ETH balance: ${errorDetail}`,
+			}
+		}
+	}
+
+	const applyLoadedOracleReport = (details: OpenOracleReportDetails, { resetPrice }: { resetPrice: boolean }) => {
+		openOracleReportDetails.value = details
+		loadedOpenOracleReportId.value = details.reportId
+		openOracleForm.value = {
+			...openOracleForm.value,
+			reportId: details.reportId.toString(),
+			stateHash: details.stateHash,
+			...(resetPrice ? { price: '' } : {}),
+		}
+	}
+
+	const refreshOpenOracleInitialReportQuote = async (details: OpenOracleReportDetails | undefined, { preserveExisting = false }: RefreshOpenOracleInitialReportOptions = {}) => {
 		const currentDetails = details
-		const isCurrent = nextOpenOracleInitialReportStateLoad()
+		const isCurrent = nextOpenOracleInitialReportPriceLoad()
 		if (currentDetails === undefined) {
-			resetOpenOracleInitialReportState(false)
+			resetOpenOracleInitialReportQuoteState()
 			return
 		}
 
-		await openOracleInitialReportStateLoad.run({
+		await openOracleInitialReportPriceLoad.run({
 			isCurrent,
 			onStart: () => {
-				resetOpenOracleInitialReportState(accountAddress !== undefined)
+				if (!preserveExisting) {
+					resetOpenOracleInitialReportQuoteState()
+				}
 			},
-			load: async () => {
-				const readClient = createConnectedReadClient()
-
-				const loadAllowance = async (tokenAddress: Address): Promise<TokenApprovalState> => {
-					if (accountAddress === undefined) {
-						return {
-							error: undefined,
-							loading: false,
-							value: undefined,
-						}
-					}
-
-					try {
-						return {
-							error: undefined,
-							loading: false,
-							value: await loadErc20Allowance(readClient, tokenAddress, accountAddress, getOpenOracleAddress()),
-						}
-					} catch (error) {
-						const errorDetail = getErrorDetail(error)
-						return {
-							error: errorDetail === undefined ? 'Failed to load token approval' : `Failed to load token approval: ${errorDetail}`,
-							loading: false,
-							value: undefined,
-						}
-					}
-				}
-
-				const loadBalance = async (tokenAddress: Address): Promise<TokenAccessLoadResult> => {
-					if (accountAddress === undefined) {
-						return { amount: undefined, error: undefined }
-					}
-
-					try {
-						return {
-							amount: await loadErc20Balance(readClient, tokenAddress, accountAddress),
-							error: undefined,
-						}
-					} catch (error) {
-						const errorDetail = getErrorDetail(error)
-						return {
-							amount: undefined,
-							error: errorDetail === undefined ? 'Failed to load token balance' : `Failed to load token balance: ${errorDetail}`,
-						}
-					}
-				}
-
-				const loadEthBalance = async (): Promise<TokenAccessLoadResult> => {
-					if (accountAddress === undefined) {
-						return { amount: undefined, error: undefined }
-					}
-
-					try {
-						return {
-							amount: await readClient.getBalance({ address: accountAddress }),
-							error: undefined,
-						}
-					} catch (error) {
-						const errorDetail = getErrorDetail(error)
-						return {
-							amount: undefined,
-							error: errorDetail === undefined ? 'Failed to load wallet ETH balance' : `Failed to load wallet ETH balance: ${errorDetail}`,
-						}
-					}
-				}
-
-				const [ethBalanceResult, initialPriceResult, token1ApprovalResult, token2ApprovalResult, token1BalanceResult, token2BalanceResult] = await Promise.all([
-					loadEthBalance(),
-					loadOpenOracleInitialReportPriceResult(readClient, currentDetails.token1, currentDetails.token2, currentDetails.exactToken1Report),
-					loadAllowance(currentDetails.token1),
-					loadAllowance(currentDetails.token2),
-					loadBalance(currentDetails.token1),
-					loadBalance(currentDetails.token2),
-				])
-
-				return {
-					ethBalanceResult,
-					initialPriceResult,
-					token1ApprovalResult,
-					token2ApprovalResult,
-					token1BalanceResult,
-					token2BalanceResult,
-				} satisfies OpenOracleInitialReportStateLoadResult
-			},
-			onSuccess: ({ ethBalanceResult, initialPriceResult, token1ApprovalResult, token2ApprovalResult, token1BalanceResult, token2BalanceResult }: OpenOracleInitialReportStateLoadResult) => {
+			load: async () => await loadOpenOracleInitialReportPriceResult(createConnectedReadClient(), currentDetails.token1, currentDetails.token2, currentDetails.exactToken1Report),
+			onSuccess: (initialPriceResult: OpenOracleInitialReportPriceLoadResult) => {
 				const initialPrice = initialPriceResult.status === 'success' ? initialPriceResult : undefined
 				const priceFailure = initialPriceResult.status === 'failure' ? initialPriceResult : undefined
 
@@ -215,14 +231,6 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 				openOracleInitialReportQuoteAttemptedSources.value = priceFailure?.attemptedSources
 				openOracleInitialReportQuoteFailureKind.value = priceFailure?.failureKind
 				openOracleInitialReportQuoteFailureReason.value = priceFailure?.reason
-				openOracleInitialReportEthBalance.value = ethBalanceResult.amount
-				openOracleInitialReportEthBalanceError.value = ethBalanceResult.error
-				openOracleInitialReportToken1Approval.value = token1ApprovalResult
-				openOracleInitialReportToken2Approval.value = token2ApprovalResult
-				openOracleInitialReportToken1Balance.value = token1BalanceResult.amount
-				openOracleInitialReportToken1BalanceError.value = token1BalanceResult.error
-				openOracleInitialReportToken2Balance.value = token2BalanceResult.amount
-				openOracleInitialReportToken2BalanceError.value = token2BalanceResult.error
 
 				if (openOracleForm.value.price.trim() === '' || openOracleForm.value.reportId.trim() !== currentDetails.reportId.toString()) {
 					openOracleForm.value = {
@@ -236,6 +244,65 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 			onError: () => undefined,
 		})
 	}
+
+	const refreshOpenOracleInitialReportTokenAccess = async (details: OpenOracleReportDetails | undefined, { preserveExisting = false }: RefreshOpenOracleInitialReportOptions = {}) => {
+		const currentDetails = details
+		const isCurrent = nextOpenOracleInitialReportTokenAccessLoad()
+		if (currentDetails === undefined) {
+			resetOpenOracleInitialReportTokenAccessState(false)
+			return
+		}
+
+		try {
+			await openOracleInitialReportTokenAccessLoad.run({
+				isCurrent,
+				onStart: () => {
+					setOpenOracleInitialReportTokenAccessMode(preserveExisting ? 'background' : 'initial')
+					if (!preserveExisting) {
+						resetOpenOracleInitialReportTokenAccessState(accountAddress !== undefined)
+						setOpenOracleInitialReportTokenAccessMode('initial')
+					} else {
+						openOracleInitialReportToken1Approval.value = {
+							...openOracleInitialReportToken1Approval.value,
+							loading: false,
+						}
+						openOracleInitialReportToken2Approval.value = {
+							...openOracleInitialReportToken2Approval.value,
+							loading: false,
+						}
+					}
+				},
+				load: async () => {
+					const [ethBalanceResult, token1ApprovalResult, token2ApprovalResult, token1BalanceResult, token2BalanceResult] = await Promise.all([loadEthBalance(), loadAllowance(currentDetails.token1), loadAllowance(currentDetails.token2), loadBalance(currentDetails.token1), loadBalance(currentDetails.token2)])
+
+					return {
+						ethBalanceResult,
+						token1ApprovalResult,
+						token2ApprovalResult,
+						token1BalanceResult,
+						token2BalanceResult,
+					} satisfies OpenOracleInitialReportTokenAccessLoadResult
+				},
+				onSuccess: ({ ethBalanceResult, token1ApprovalResult, token2ApprovalResult, token1BalanceResult, token2BalanceResult }: OpenOracleInitialReportTokenAccessLoadResult) => {
+					openOracleInitialReportEthBalance.value = ethBalanceResult.amount
+					openOracleInitialReportEthBalanceError.value = ethBalanceResult.error
+					openOracleInitialReportToken1Approval.value = token1ApprovalResult
+					openOracleInitialReportToken2Approval.value = token2ApprovalResult
+					openOracleInitialReportToken1Balance.value = token1BalanceResult.amount
+					openOracleInitialReportToken1BalanceError.value = token1BalanceResult.error
+					openOracleInitialReportToken2Balance.value = token2BalanceResult.amount
+					openOracleInitialReportToken2BalanceError.value = token2BalanceResult.error
+				},
+				onError: () => undefined,
+			})
+		} finally {
+			if (isCurrent()) {
+				setOpenOracleInitialReportTokenAccessMode('idle')
+			}
+		}
+	}
+
+	const loadOracleReportById = async (reportId: bigint) => await loadOpenOracleReportDetails(createConnectedReadClient(), getOpenOracleAddress(), reportId)
 
 	const loadOracleReport = async (reportIdInput?: string) => {
 		await oracleReportLoad.run({
@@ -251,17 +318,11 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 						reportId: reportIdValue,
 					}
 				}
-				const details = await loadOpenOracleReportDetails(createConnectedReadClient(), getOpenOracleAddress(), reportId)
+				const details = await loadOracleReportById(reportId)
 				return { details, reportId } satisfies LoadedOracleReportResult
 			},
-			onSuccess: ({ details, reportId }: LoadedOracleReportResult) => {
-				openOracleReportDetails.value = details
-				loadedOpenOracleReportId.value = reportId
-				openOracleForm.value = {
-					...openOracleForm.value,
-					price: '',
-					stateHash: details.stateHash,
-				}
+			onSuccess: ({ details }: LoadedOracleReportResult) => {
+				applyLoadedOracleReport(details, { resetPrice: true })
 			},
 			onError: (error: unknown) => {
 				openOracleReportDetails.value = undefined
@@ -272,18 +333,18 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 		})
 	}
 
-	const ensureLoadedSelectedReport = async () => {
+	const ensureLoadedSelectedReport = async ({ forceReload = false }: { forceReload?: boolean } = {}) => {
 		const reportId = parseReportIdInput(openOracleForm.value.reportId)
-		if (openOracleReportDetails.value !== undefined && loadedOpenOracleReportId.value === reportId) {
+		if (!forceReload && openOracleReportDetails.value !== undefined && loadedOpenOracleReportId.value === reportId) {
 			return { reportId, details: openOracleReportDetails.value }
 		}
 
-		await loadOracleReport()
-		const loadedReportDetails = requireDefined(openOracleReportDetails.value, 'Failed to load oracle report')
+		const details = await loadOracleReportById(reportId)
+		applyLoadedOracleReport(details, { resetPrice: false })
 
 		return {
-			details: loadedReportDetails,
-			reportId: loadedReportDetails.reportId,
+			details,
+			reportId,
 		}
 	}
 
@@ -310,11 +371,20 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 			walletEthBalance: openOracleInitialReportEthBalance.value,
 		})
 
-	const runOracleAction = async (actionName: OpenOracleActionResult['action'], action: (walletAddress: Address) => Promise<OpenOracleActionResult>, errorFallback: string) => {
+	const runOracleAction = async (
+		actionName: OpenOracleActionResult['action'],
+		action: (walletAddress: Address) => Promise<OpenOracleActionResult>,
+		errorFallback: string,
+		options?: {
+			formatErrorMessage?: (error: unknown, fallbackMessage: string) => string
+			refreshInitialReportTokenAccessOnSuccess?: boolean
+		},
+	) => {
 		try {
 			await runWriteAction(
 				{
 					...buildWriteActionConfig({ accountAddress, onTransaction, onTransactionFinished, onTransactionRequested, refreshState }, openOracleError, 'Connect a wallet before operating open oracle'),
+					formatErrorMessage: options?.formatErrorMessage,
 					refreshErrorFallback: 'Oracle transaction succeeded, but refreshing the selected report failed',
 				},
 				async walletAddress => {
@@ -329,10 +399,10 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 						openOracleCreateForm.value = getDefaultOpenOracleCreateFormState()
 					}
 					if (result.action !== 'createReportInstance' && openOracleForm.value.reportId.trim() !== '') {
-						await ensureLoadedSelectedReport()
+						await ensureLoadedSelectedReport({ forceReload: true })
 					}
-					if (result.action === 'approveToken1' || result.action === 'approveToken2' || result.action === 'wrapWeth') {
-						await refreshOpenOracleInitialReportState(openOracleReportDetails.value)
+					if (options?.refreshInitialReportTokenAccessOnSuccess === true) {
+						await refreshOpenOracleInitialReportTokenAccess(openOracleReportDetails.value, { preserveExisting: true })
 					}
 				},
 			)
@@ -354,6 +424,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 				return await approveErc20(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), reportDetails.token1, getOpenOracleAddress(), approvalAmount, 'approveToken1')
 			},
 			'Failed to approve token1',
+			{ refreshInitialReportTokenAccessOnSuccess: true },
 		)
 
 	const approveToken2 = async (amount?: bigint) =>
@@ -369,6 +440,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 				return await approveErc20(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), reportDetails.token2, getOpenOracleAddress(), approvalAmount, 'approveToken2')
 			},
 			'Failed to approve token2',
+			{ refreshInitialReportTokenAccessOnSuccess: true },
 		)
 
 	const createOpenOracleGame = async () => {
@@ -401,8 +473,13 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 		await runOracleAction(
 			'submitInitialReport',
 			async walletAddress => {
-				const reportDetails = requireDefined(openOracleReportDetails.value, 'Load an oracle report first')
-				await refreshOpenOracleInitialReportState(reportDetails)
+				const { details: reportDetails } = await ensureLoadedSelectedReport({ forceReload: true })
+				if (getOpenOracleSelectedReportActionMode(reportDetails) !== 'initial-report') {
+					const submission = getInitialReportSubmission(reportDetails)
+					throw new Error(submission.blockMessage?.message ?? 'This report already has an initial report.')
+				}
+
+				await refreshOpenOracleInitialReportTokenAccess(reportDetails, { preserveExisting: true })
 				const submission = getInitialReportSubmission(reportDetails)
 				if (!submission.canSubmit || submission.amount1 === undefined || submission.amount2 === undefined) {
 					throw new Error(submission.blockMessage?.message ?? 'Invalid price')
@@ -411,6 +488,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 				return await submitInitialOracleReport(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), getOpenOracleAddress(), reportDetails.reportId, submission.amount1, submission.amount2, parseBytes32Input(openOracleForm.value.stateHash, 'State hash'))
 			},
 			'Failed to submit initial report',
+			{ formatErrorMessage: formatOpenOracleInitialReportWriteErrorMessage },
 		)
 
 	const wrapWethForInitialReport = async () =>
@@ -418,7 +496,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 			'wrapWeth',
 			async walletAddress => {
 				const reportDetails = requireDefined(openOracleReportDetails.value, 'Load an oracle report first')
-				await refreshOpenOracleInitialReportState(reportDetails)
+				await refreshOpenOracleInitialReportTokenAccess(reportDetails, { preserveExisting: true })
 				const submission = getInitialReportSubmission(reportDetails)
 				const wrapAmount = submission.requiredWethWrapAmount
 				if (wrapAmount === undefined || wrapAmount <= 0n || !submission.canWrapRequiredWeth) {
@@ -428,6 +506,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 				return await wrapWeth(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), wrapAmount)
 			},
 			'Failed to wrap ETH to WETH',
+			{ refreshInitialReportTokenAccessOnSuccess: true },
 		)
 
 	const settleReport = async () => await runOracleAction('settle', async walletAddress => await settleOracleReport(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), getOpenOracleAddress(), parseReportIdInput(openOracleForm.value.reportId)), 'Failed to settle report')
@@ -455,10 +534,11 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 
 	useEffect(() => {
 		if (openOracleReportDetails.value === undefined) {
-			void refreshOpenOracleInitialReportState(undefined)
+			resetOpenOracleInitialReportState(false)
 			return
 		}
-		void refreshOpenOracleInitialReportState(openOracleReportDetails.value)
+		void refreshOpenOracleInitialReportQuote(openOracleReportDetails.value)
+		void refreshOpenOracleInitialReportTokenAccess(openOracleReportDetails.value)
 	}, [accountAddress, openOracleReportDetails.value?.reportId, openOracleReportDetails.value?.token1, openOracleReportDetails.value?.token2, openOracleReportDetails.value?.exactToken1Report])
 
 	return {
@@ -468,7 +548,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 		disputeReport,
 		loadOracleReport,
 		openOracleActiveAction: openOracleActiveAction.value,
-		refreshPrice: () => void refreshOpenOracleInitialReportState(openOracleReportDetails.value),
+		refreshPrice: () => void refreshOpenOracleInitialReportQuote(openOracleReportDetails.value),
 		loadingOpenOracleCreate: loadingOpenOracleCreate.value,
 		loadingOracleReport: oracleReportLoad.isLoading.value,
 		openOracleCreateForm: openOracleCreateForm.value,
@@ -481,7 +561,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 			defaultPriceSourceUrl: openOracleInitialReportDefaultPriceSourceUrl.value,
 			ethBalance: openOracleInitialReportEthBalance.value,
 			ethBalanceError: openOracleInitialReportEthBalanceError.value,
-			loading: openOracleInitialReportStateLoad.isLoading.value,
+			quoteLoading: openOracleInitialReportPriceLoad.isLoading.value,
 			quoteAttemptedSources: openOracleInitialReportQuoteAttemptedSources.value,
 			quoteFailureKind: openOracleInitialReportQuoteFailureKind.value,
 			quoteFailureReason: openOracleInitialReportQuoteFailureReason.value,
@@ -493,6 +573,8 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 			token2Balance: openOracleInitialReportToken2Balance.value,
 			token2BalanceError: openOracleInitialReportToken2BalanceError.value,
 			token2Decimals: openOracleReportDetails.value?.token2Decimals,
+			tokenAccessLoadingInitial: openOracleInitialReportTokenAccessLoadingInitial.value && openOracleInitialReportTokenAccessLoad.isLoading.value,
+			tokenAccessRefreshing: openOracleInitialReportTokenAccessRefreshing.value && openOracleInitialReportTokenAccessLoad.isLoading.value,
 		},
 		openOracleReportDetails: openOracleReportDetails.value,
 		openOracleResult: openOracleResult.value,

--- a/ui/ts/lib/openOracle.ts
+++ b/ui/ts/lib/openOracle.ts
@@ -1,7 +1,7 @@
-import { zeroAddress } from 'viem'
+import { zeroAddress, type Address } from 'viem'
 import type { OpenOracleReportSummary } from '../types/contracts.js'
 import { parseDecimalInput } from './decimal.js'
-import { getErrorDetail } from './errors.js'
+import { getErrorDetail, getErrorMessage } from './errors.js'
 import { formatCurrencyBalance, formatCurrencyInputBalance } from './formatters.js'
 import { deriveTokenApprovalRequirement, formatTokenApprovalUnavailableMessage, type TokenApprovalRequirement } from './tokenApproval.js'
 import { quoteBestExactInputWithSource, quoteBestV3ExactInputWithSource, quoteExactInput, WETH_ADDRESS } from './uniswapQuoter.js'
@@ -52,6 +52,51 @@ type OpenOracleInitialReportSubmissionDetails = {
 	token2Approval: TokenApprovalRequirement
 	token2Decimals: number | undefined
 	wrapRequiredWethMessage: OpenOracleGateMessage | undefined
+}
+
+function formatOpenOracleInitialReportLifecycleMessage(status: OpenOracleReportStatus) {
+	switch (status) {
+		case 'Pending':
+		case 'Disputed':
+			return 'This report already has an initial report.'
+		case 'Settled':
+			return 'This report is already settled and can no longer accept an initial report.'
+		case 'Awaiting Initial Report':
+			return undefined
+	}
+}
+
+export function formatOpenOracleInitialReportWriteErrorMessage(error: unknown, fallbackMessage = 'Failed to submit initial report') {
+	const genericMessage = getErrorMessage(error, fallbackMessage)
+	if (genericMessage === 'Action canceled in wallet.') {
+		return genericMessage
+	}
+
+	const detail = sanitizeOpenOracleFailureReason(getErrorDetail(error))?.toLowerCase()
+	if (detail === undefined) {
+		return 'Unable to submit the initial report. Reload the report and verify the wallet balances and approvals before trying again.'
+	}
+
+	if (detail.includes('report submitted')) {
+		return 'This report already has an initial report.'
+	}
+	if (detail.includes('report id')) {
+		return 'This report is no longer valid. Reload it before submitting the initial report again.'
+	}
+	if (detail.includes('token1 amount')) {
+		return 'The required token1 amount changed on-chain. Reload the report before submitting the initial report again.'
+	}
+	if (detail.includes('token2 amount')) {
+		return 'The selected price produces an invalid token2 amount for the initial report.'
+	}
+	if (detail.includes('state hash')) {
+		return 'This report changed on-chain. Reload the report before submitting the initial report again.'
+	}
+	if (detail.includes('allowance') || detail.includes('balance') || detail.includes('transfer amount exceeds') || detail.includes('transferfrom') || detail.includes('transfer from') || detail.includes('erc20insufficientallowance') || detail.includes('erc20insufficientbalance') || detail.includes('safeerc20')) {
+		return 'Wallet balance or token approval changed since the last refresh. Reload the report and verify both token balances and approvals before submitting the initial report again.'
+	}
+
+	return 'Unable to submit the initial report. Reload the report and verify the wallet balances and approvals before trying again.'
 }
 
 function createHiddenLoadingGateMessage(message: string): OpenOracleGateMessage {
@@ -315,7 +360,11 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 	quoteFailureReason: string | undefined
 	reportDetails:
 		| {
+				currentReporter: Address
+				disputeOccurred: boolean
 				exactToken1Report: bigint
+				isDistributed: boolean
+				reportTimestamp: bigint
 				token1?: string | undefined
 				token1Symbol?: string | undefined
 				token2?: string | undefined
@@ -355,6 +404,15 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 		tokenAddress: reportDetails?.token2,
 		tokenSymbol: reportDetails?.token2Symbol,
 	})
+	const reportStatus =
+		reportDetails === undefined
+			? undefined
+			: getOpenOracleReportStatus({
+					currentReporter: reportDetails.currentReporter,
+					disputeOccurred: reportDetails.disputeOccurred,
+					isDistributed: reportDetails.isDistributed,
+					reportTimestamp: reportDetails.reportTimestamp,
+				})
 	const token1Approval = deriveTokenApprovalRequirement(amount1, approvedToken1Amount)
 	const token2Approval = deriveTokenApprovalRequirement(amount2, approvedToken2Amount)
 	const token1BalanceShortage = amount1 === undefined || token1Balance === undefined || token1Balance >= amount1 ? undefined : amount1 - token1Balance
@@ -381,11 +439,13 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 				? createVisibleGateMessage(`Enter a valid ${token1Label} / ${token2Label} price to determine whether this report needs more WETH.`)
 				: (isCanonicalMainnetWeth(reportDetails?.token1) && token1Balance === undefined) || (isCanonicalMainnetWeth(reportDetails?.token2) && token2Balance === undefined)
 					? createHiddenLoadingGateMessage('Loading current WETH balance.')
-					: createVisibleGateMessage('No additional WETH is required for this report.')
+					: undefined
 
 	let blockMessage: OpenOracleGateMessage | undefined
 	if (reportDetails === undefined) {
 		blockMessage = createVisibleGateMessage('Load a report first')
+	} else if (reportStatus !== undefined && reportStatus !== 'Awaiting Initial Report') {
+		blockMessage = createVisibleGateMessage(formatOpenOracleInitialReportLifecycleMessage(reportStatus) ?? 'This report already has an initial report.')
 	} else if (resolvedPriceInput === '') {
 		blockMessage =
 			defaultPriceError !== undefined

--- a/ui/ts/lib/writeAction.ts
+++ b/ui/ts/lib/writeAction.ts
@@ -4,6 +4,7 @@ import type { WriteOperationsParameters } from '../types/app.js'
 
 type RunWriteActionParameters = {
 	accountAddress: Address | undefined
+	formatErrorMessage?: ((error: unknown, fallbackMessage: string) => string) | undefined
 	missingWalletMessage: string
 	onTransaction: (hash: Hash) => void
 	onTransactionFinished: () => void
@@ -42,7 +43,7 @@ export async function runWriteAction<TResult extends { hash: Hash }>(parameters:
 			if (result === undefined) return
 			await Promise.resolve(parameters.onTransaction(result.hash))
 		} catch (error) {
-			parameters.setErrorMessage(getErrorMessage(error, errorFallback))
+			parameters.setErrorMessage(parameters.formatErrorMessage?.(error, errorFallback) ?? getErrorMessage(error, errorFallback))
 			return
 		}
 

--- a/ui/ts/tests/openOracle.test.ts
+++ b/ui/ts/tests/openOracle.test.ts
@@ -10,6 +10,7 @@ import {
 	formatOpenOracleInitialReportApprovalStatusUnavailableMessage,
 	formatOpenOracleInitialReportBalanceStatusUnavailableMessage,
 	formatOpenOracleInitialReportPriceUnavailableMessage,
+	formatOpenOracleInitialReportWriteErrorMessage,
 	formatOpenOracleMultiplier,
 	getOpenOracleReportStatus,
 	getOpenOracleSelectedReportActionMode,
@@ -73,7 +74,11 @@ function createInitialReportSubmissionPreview(overrides: Partial<Parameters<type
 		quoteAttemptedSources: undefined,
 		quoteFailureReason: undefined,
 		reportDetails: {
+			currentReporter: zeroAddress,
+			disputeOccurred: false,
 			exactToken1Report: 100n,
+			isDistributed: false,
+			reportTimestamp: 0n,
 			token1: REP_ADDRESS,
 			token1Symbol: 'REP',
 			token2: WETH_ADDRESS,
@@ -293,7 +298,11 @@ describe('Open Oracle helpers', () => {
 			quoteAttemptedSources: ['Uniswap V4', 'Uniswap V3'],
 			quoteFailureReason: 'Failed to fetch price from Uniswap. Uniswap V4 quote failed: execution reverted for an unknown reason. Uniswap V3 quote failed: no pool',
 			reportDetails: {
+				currentReporter: zeroAddress,
+				disputeOccurred: false,
 				exactToken1Report: 100n,
+				isDistributed: false,
+				reportTimestamp: 0n,
 				token1: REP_ADDRESS,
 				token1Symbol: 'REP',
 				token2: ETH_ADDRESS,
@@ -319,7 +328,11 @@ describe('Open Oracle helpers', () => {
 			quoteAttemptedSources: ['Uniswap V4'],
 			quoteFailureReason: 'no pool',
 			reportDetails: {
+				currentReporter: zeroAddress,
+				disputeOccurred: false,
 				exactToken1Report: 100n,
+				isDistributed: false,
+				reportTimestamp: 0n,
 				token1: getAddress('0x00000000000000000000000000000000000000a1'),
 				token1Symbol: 'ABC',
 				token2: getAddress('0x00000000000000000000000000000000000000a2'),
@@ -394,7 +407,11 @@ describe('Open Oracle helpers', () => {
 	test('initial report submission helper hides token balance loading states such as REPv2 balance refresh', () => {
 		const preview = createInitialReportSubmissionPreview({
 			reportDetails: {
+				currentReporter: zeroAddress,
+				disputeOccurred: false,
 				exactToken1Report: 100n,
+				isDistributed: false,
+				reportTimestamp: 0n,
 				token1: REP_ADDRESS,
 				token1Symbol: 'REPv2',
 				token2: WETH_ADDRESS,
@@ -441,7 +458,11 @@ describe('Open Oracle helpers', () => {
 			approvedToken2Amount: 11_000_000n,
 			defaultPrice: '1',
 			reportDetails: {
+				currentReporter: zeroAddress,
+				disputeOccurred: false,
 				exactToken1Report: 11_000_000n,
+				isDistributed: false,
+				reportTimestamp: 0n,
 				token1: REP_ADDRESS,
 				token1Symbol: 'REP',
 				token2: WETH_ADDRESS,
@@ -485,7 +506,11 @@ describe('Open Oracle helpers', () => {
 			approvedToken2Amount: 11_000_000n,
 			defaultPrice: '1',
 			reportDetails: {
+				currentReporter: zeroAddress,
+				disputeOccurred: false,
 				exactToken1Report: 11_000_000n,
+				isDistributed: false,
+				reportTimestamp: 0n,
 				token1: REP_ADDRESS,
 				token1Symbol: 'REP',
 				token2: WETH_ADDRESS,
@@ -542,10 +567,7 @@ describe('Open Oracle helpers', () => {
 		expect(preview.hasWethWrapAction).toBe(true)
 		expect(preview.requiredWethWrapAmount).toBeUndefined()
 		expect(preview.canWrapRequiredWeth).toBe(false)
-		expect(preview.wrapRequiredWethMessage).toEqual({
-			kind: 'visible',
-			message: 'No additional WETH is required for this report.',
-		})
+		expect(preview.wrapRequiredWethMessage).toBeUndefined()
 	})
 
 	test('initial report submission helper explains that a price is needed before determining a WETH wrap amount', () => {
@@ -573,6 +595,76 @@ describe('Open Oracle helpers', () => {
 
 		expect(preview.canSubmit).toBe(true)
 		expect(preview.blockMessage).toBeUndefined()
+	})
+
+	test('initial report submission helper blocks reports that already moved past initial reporting', () => {
+		const reporter = getAddress(addressString(TEST_ADDRESSES[1]))
+
+		const pendingPreview = createInitialReportSubmissionPreview({
+			reportDetails: {
+				currentReporter: reporter,
+				disputeOccurred: false,
+				exactToken1Report: 100n,
+				isDistributed: false,
+				reportTimestamp: 1n,
+				token1: REP_ADDRESS,
+				token1Symbol: 'REP',
+				token2: WETH_ADDRESS,
+				token2Symbol: 'WETH',
+			},
+		})
+		expect(pendingPreview.canSubmit).toBe(false)
+		expect(pendingPreview.blockMessage).toEqual({
+			kind: 'visible',
+			message: 'This report already has an initial report.',
+		})
+
+		const disputedPreview = createInitialReportSubmissionPreview({
+			reportDetails: {
+				currentReporter: reporter,
+				disputeOccurred: true,
+				exactToken1Report: 100n,
+				isDistributed: false,
+				reportTimestamp: 1n,
+				token1: REP_ADDRESS,
+				token1Symbol: 'REP',
+				token2: WETH_ADDRESS,
+				token2Symbol: 'WETH',
+			},
+		})
+		expect(disputedPreview.canSubmit).toBe(false)
+		expect(disputedPreview.blockMessage).toEqual({
+			kind: 'visible',
+			message: 'This report already has an initial report.',
+		})
+
+		const settledPreview = createInitialReportSubmissionPreview({
+			reportDetails: {
+				currentReporter: reporter,
+				disputeOccurred: false,
+				exactToken1Report: 100n,
+				isDistributed: true,
+				reportTimestamp: 1n,
+				token1: REP_ADDRESS,
+				token1Symbol: 'REP',
+				token2: WETH_ADDRESS,
+				token2Symbol: 'WETH',
+			},
+		})
+		expect(settledPreview.canSubmit).toBe(false)
+		expect(settledPreview.blockMessage).toEqual({
+			kind: 'visible',
+			message: 'This report is already settled and can no longer accept an initial report.',
+		})
+	})
+
+	test('maps initial report write failures into friendly guidance', () => {
+		expect(formatOpenOracleInitialReportWriteErrorMessage(new Error('execution reverted: report submitted'))).toBe('This report already has an initial report.')
+		expect(formatOpenOracleInitialReportWriteErrorMessage(new Error('execution reverted: report id'))).toBe('This report is no longer valid. Reload it before submitting the initial report again.')
+		expect(formatOpenOracleInitialReportWriteErrorMessage(new Error('execution reverted: token1 amount'))).toBe('The required token1 amount changed on-chain. Reload the report before submitting the initial report again.')
+		expect(formatOpenOracleInitialReportWriteErrorMessage(new Error('execution reverted: token2 amount'))).toBe('The selected price produces an invalid token2 amount for the initial report.')
+		expect(formatOpenOracleInitialReportWriteErrorMessage(new Error('execution reverted: state hash'))).toBe('This report changed on-chain. Reload the report before submitting the initial report again.')
+		expect(formatOpenOracleInitialReportWriteErrorMessage(new Error('ERC20: transfer amount exceeds allowance'))).toBe('Wallet balance or token approval changed since the last refresh. Reload the report and verify both token balances and approvals before submitting the initial report again.')
 	})
 
 	test('formats unavailable approval status messages with sanitized reasons', () => {
@@ -676,6 +768,46 @@ describe('Open Oracle helpers', () => {
 		expect(managerDetails.lastSettlementTimestamp).toBeGreaterThan(0n)
 		expect(managerDetails.isPriceValid).toBe(true)
 		expect(managerDetails.priceValidUntilTimestamp).toBe(managerDetails.lastSettlementTimestamp + ORACLE_MANAGER_PRICE_VALID_FOR_SECONDS)
+	})
+
+	test('submitInitialOracleReport rejects a second initial report for the same report', async () => {
+		await requestOraclePrice(uiWriteClient, managerAddress)
+
+		const reportId = (await loadOracleManagerDetails(uiReadClient, managerAddress)).pendingReportId
+		const { exactToken1Report } = await loadOpenOracleReportDetails(uiReadClient, getOpenOracleAddress(), reportId)
+		const PRICE_PRECISION = 10n ** 18n
+		const amount1 = exactToken1Report
+		const amount2 = (amount1 * PRICE_PRECISION) / reportedRepEthPrice
+
+		const openOracleAddress = getOpenOracleAddress()
+		await approveToken(client, addressString(GENESIS_REPUTATION_TOKEN), openOracleAddress)
+		await approveToken(client, WETH_ADDRESS, openOracleAddress)
+		await wrapWethTestHelper(client, amount2)
+
+		const stateHash = (await getOpenOracleExtraData(client, reportId)).stateHash
+		await submitInitialOracleReport(uiWriteClient, openOracleAddress, reportId, amount1, amount2, stateHash)
+
+		await expect(submitInitialOracleReport(uiWriteClient, openOracleAddress, reportId, amount1, amount2, stateHash)).rejects.toThrow(/report submitted/i)
+	})
+
+	test('submitInitialOracleReport rejects an invalid state hash', async () => {
+		await requestOraclePrice(uiWriteClient, managerAddress)
+
+		const reportId = (await loadOracleManagerDetails(uiReadClient, managerAddress)).pendingReportId
+		const { exactToken1Report } = await loadOpenOracleReportDetails(uiReadClient, getOpenOracleAddress(), reportId)
+		const PRICE_PRECISION = 10n ** 18n
+		const amount1 = exactToken1Report
+		const amount2 = (amount1 * PRICE_PRECISION) / reportedRepEthPrice
+
+		const openOracleAddress = getOpenOracleAddress()
+		await approveToken(client, addressString(GENESIS_REPUTATION_TOKEN), openOracleAddress)
+		await approveToken(client, WETH_ADDRESS, openOracleAddress)
+		await wrapWethTestHelper(client, amount2)
+
+		const stateHash = (await getOpenOracleExtraData(client, reportId)).stateHash
+		const invalidStateHash = stateHash === '0x0000000000000000000000000000000000000000000000000000000000000000' ? '0x0000000000000000000000000000000000000000000000000000000000000001' : '0x0000000000000000000000000000000000000000000000000000000000000000'
+
+		await expect(submitInitialOracleReport(uiWriteClient, openOracleAddress, reportId, amount1, amount2, invalidStateHash)).rejects.toThrow(/state hash/i)
 	})
 
 	test('ui wrapWeth helper deposits ETH into WETH and reports the wrap action', async () => {

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -285,7 +285,7 @@ export type OpenOracleRouteContentProps = {
 		defaultPriceSourceUrl: string | undefined
 		ethBalance: bigint | undefined
 		ethBalanceError: string | undefined
-		loading: boolean
+		quoteLoading: boolean
 		quoteAttemptedSources: OpenOracleInitialReportQuoteSource[] | undefined
 		quoteFailureKind: OpenOracleInitialReportQuoteFailureKind | undefined
 		quoteFailureReason: string | undefined
@@ -297,6 +297,8 @@ export type OpenOracleRouteContentProps = {
 		token2Balance: bigint | undefined
 		token2BalanceError: string | undefined
 		token2Decimals: number | undefined
+		tokenAccessLoadingInitial: boolean
+		tokenAccessRefreshing: boolean
 	}
 	openOracleCreateForm: OpenOracleCreateFormState
 	openOracleForm: OpenOracleFormState


### PR DESCRIPTION
## Summary
- Split open oracle initial-report loading into separate quote and token-access refresh paths to avoid unnecessary resets and reduce UI flicker.
- Make the initial-report action state-aware, including better handling for report lifecycle changes, refreshed balances/approvals after writes, and clearer write error messages.
- Update the open oracle UI to use the new loading flags and remove redundant loading states from submit, wrap, and price fetch controls.
- Expand open oracle tests to cover the new initial-report submission and error-formatting behavior.

## Testing
- Not run