### PR TITLE
Hide redundant trading guard copy in the UI

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,5 +1,5 @@
 {
-	"entry": ["solidity/ts/compile.ts", "solidity/ts/gas-costs.ts", "solidity/ts/tests/**/*.ts", "solidity/ts/types/bun-test.d.ts", "solidity/ts/types/index.d.ts", "ui/ts/tests/**/*.ts", "ui/ts/index.ts", "ui/build/vendor.mts", "ui/build/tests.mts"],
+	"entry": ["solidity/ts/compile.ts", "solidity/ts/gas-costs.ts", "solidity/ts/tests/**/*.ts", "solidity/ts/types/bun-test.d.ts", "solidity/ts/types/index.d.ts", "ui/ts/tests/**/*.ts", "ui/ts/tests/**/*.tsx", "ui/ts/index.ts", "ui/build/vendor.mts", "ui/build/tests.mts"],
 	"project": ["solidity/ts/**/*.ts", "ui/ts/**/*.ts", "ui/ts/**/*.tsx", "ui/build/**/*.mts"],
 	"ignoreDependencies": ["solc", "better-typescript-lib"]
 }

--- a/ui/ts/components/TradingSection.tsx
+++ b/ui/ts/components/TradingSection.tsx
@@ -9,7 +9,7 @@ import { UniverseLink } from './UniverseLink.js'
 import { formatCurrencyBalance, formatCurrencyInputBalance } from '../lib/formatters.js'
 import { isMainnetChain } from '../lib/network.js'
 import { REPORTING_OUTCOME_DROPDOWN_OPTIONS } from '../lib/reporting.js'
-import { getRemainingMintCapacity, getTradingMigrateSharesGuardMessage, getTradingMintGuardMessage, getTradingRedeemCompleteSetGuardMessage, getTradingRedeemSharesGuardMessage } from '../lib/trading.js'
+import { getRemainingMintCapacity, getTradingGuardDisplayMessage, getTradingMigrateSharesGuardMessage, getTradingMintGuardMessage, getTradingRedeemCompleteSetGuardMessage, getTradingRedeemSharesGuardMessage } from '../lib/trading.js'
 import type { TradingSectionProps } from '../types/components.js'
 
 export function TradingSection({
@@ -76,6 +76,10 @@ export function TradingSection({
 		systemState: selectedPool?.systemState,
 		universeHasForked: selectedPool?.universeHasForked,
 	})
+	const mintGuardDisplayMessage = getTradingGuardDisplayMessage(mintGuardMessage)
+	const redeemCompleteSetGuardDisplayMessage = getTradingGuardDisplayMessage(redeemCompleteSetGuardMessage)
+	const migrateSharesGuardDisplayMessage = getTradingGuardDisplayMessage(migrateSharesGuardMessage)
+	const redeemSharesGuardDisplayMessage = getTradingGuardDisplayMessage(redeemSharesGuardMessage)
 	const renderShareMetricValue = (value: bigint | undefined) => {
 		if (loadingTradingDetails) return 'Loading...'
 		if (value === undefined) return '—'
@@ -155,7 +159,7 @@ export function TradingSection({
 					<MetricField label='Yes'>{renderShareMetricValue(shareBalances?.yes)}</MetricField>
 					<MetricField label='No'>{renderShareMetricValue(shareBalances?.no)}</MetricField>
 					<MetricField label='Invalid'>{renderShareMetricValue(shareBalances?.invalid)}</MetricField>
-					<MetricField label='Max Complete Sets'>{renderShareMetricValue(maxRedeemableCompleteSets)}</MetricField>
+					<MetricField label='Total Complete Sets'>{renderShareMetricValue(maxRedeemableCompleteSets)}</MetricField>
 				</div>
 			</div>
 		)
@@ -170,11 +174,11 @@ export function TradingSection({
 				<input value={tradingForm.completeSetAmount} inputMode='decimal' onInput={event => onTradingFormChange({ completeSetAmount: event.currentTarget.value })} />
 			</label>
 			<div className='actions'>
-				<button className='primary' title={mintGuardMessage} onClick={onCreateCompleteSet} disabled={mintGuardMessage !== undefined}>
+				<button className='primary' title={mintGuardDisplayMessage} onClick={onCreateCompleteSet} disabled={mintGuardMessage !== undefined}>
 					Mint Complete Sets
 				</button>
 			</div>
-			{mintGuardMessage === undefined ? undefined : <p className='detail'>{mintGuardMessage}</p>}
+			{mintGuardDisplayMessage === undefined ? undefined : <p className='detail'>{mintGuardDisplayMessage}</p>}
 		</div>
 	)
 	const redeemCompleteSetSection = (
@@ -200,11 +204,11 @@ export function TradingSection({
 				</div>
 			</label>
 			<div className='actions'>
-				<button className='secondary' title={redeemCompleteSetGuardMessage} onClick={onRedeemCompleteSet} disabled={redeemCompleteSetGuardMessage !== undefined}>
+				<button className='secondary' title={redeemCompleteSetGuardDisplayMessage} onClick={onRedeemCompleteSet} disabled={redeemCompleteSetGuardMessage !== undefined}>
 					Redeem Complete Sets
 				</button>
 			</div>
-			{redeemCompleteSetGuardMessage === undefined ? undefined : <p className='detail'>{redeemCompleteSetGuardMessage}</p>}
+			{redeemCompleteSetGuardDisplayMessage === undefined ? undefined : <p className='detail'>{redeemCompleteSetGuardDisplayMessage}</p>}
 		</div>
 	)
 	const migrateSharesSection = (
@@ -217,11 +221,11 @@ export function TradingSection({
 				<EnumDropdown options={REPORTING_OUTCOME_DROPDOWN_OPTIONS} value={tradingForm.selectedOutcome} onChange={selectedOutcome => onTradingFormChange({ selectedOutcome })} />
 			</label>
 			<div className='actions'>
-				<button className='secondary' title={migrateSharesGuardMessage} onClick={onMigrateShares} disabled={migrateSharesGuardMessage !== undefined}>
+				<button className='secondary' title={migrateSharesGuardDisplayMessage} onClick={onMigrateShares} disabled={migrateSharesGuardMessage !== undefined}>
 					Migrate Shares
 				</button>
 			</div>
-			{migrateSharesGuardMessage === undefined ? undefined : <p className='detail'>{migrateSharesGuardMessage}</p>}
+			{migrateSharesGuardDisplayMessage === undefined ? undefined : <p className='detail'>{migrateSharesGuardDisplayMessage}</p>}
 		</div>
 	)
 	const redeemSharesSection = (
@@ -230,11 +234,11 @@ export function TradingSection({
 				<h4>Redeem Resolved Shares</h4>
 			</div>
 			<div className='actions'>
-				<button className='secondary' title={redeemSharesGuardMessage} onClick={onRedeemShares} disabled={redeemSharesGuardMessage !== undefined}>
+				<button className='secondary' title={redeemSharesGuardDisplayMessage} onClick={onRedeemShares} disabled={redeemSharesGuardMessage !== undefined}>
 					Redeem Shares
 				</button>
 			</div>
-			{redeemSharesGuardMessage === undefined ? undefined : <p className='detail'>{redeemSharesGuardMessage}</p>}
+			{redeemSharesGuardDisplayMessage === undefined ? undefined : <p className='detail'>{redeemSharesGuardDisplayMessage}</p>}
 		</div>
 	)
 	const tradingSections = (

--- a/ui/ts/lib/trading.ts
+++ b/ui/ts/lib/trading.ts
@@ -10,6 +10,13 @@ const PERCENT_MULTIPLIER = 100n
 type CollateralizationDisplayState = 'value' | 'noActiveAllowance' | 'unavailable'
 type CollateralizationTone = 'success' | 'danger'
 
+export const NO_MINT_CAPACITY_NO_ACTIVE_ALLOWANCE_MESSAGE = 'No mint capacity. No active security bond allowance.'
+export const NEED_MATCHING_COMPLETE_SET_SHARES_MESSAGE = 'Need matching Invalid, Yes, and No shares to redeem complete sets.'
+export const SHARE_MIGRATION_AFTER_FORK_MESSAGE = 'Share migration is only available after this universe has forked.'
+export const MARKET_NOT_FINALIZED_MESSAGE = 'This market has not finalized yet.'
+
+const HIDDEN_TRADING_GUARD_MESSAGES = [NO_MINT_CAPACITY_NO_ACTIVE_ALLOWANCE_MESSAGE, NEED_MATCHING_COMPLETE_SET_SHARES_MESSAGE, SHARE_MIGRATION_AFTER_FORK_MESSAGE, MARKET_NOT_FINALIZED_MESSAGE]
+
 export function getRemainingMintCapacity(totalSecurityBondAllowance: bigint | undefined, completeSetCollateralAmount: bigint | undefined) {
 	if (totalSecurityBondAllowance === undefined || completeSetCollateralAmount === undefined) return undefined
 	return totalSecurityBondAllowance > completeSetCollateralAmount ? totalSecurityBondAllowance - completeSetCollateralAmount : 0n
@@ -61,6 +68,16 @@ export function getSelectedOutcomeShareBalance(shareBalances: TradingShareBalanc
 	}
 }
 
+export function getTradingGuardDisplayMessage(message: string | undefined) {
+	if (message === undefined) return undefined
+
+	for (const hiddenMessage of HIDDEN_TRADING_GUARD_MESSAGES) {
+		if (message === hiddenMessage) return undefined
+	}
+
+	return message
+}
+
 export function getTradingMintGuardMessage({
 	accountAddress,
 	completeSetCollateralAmount,
@@ -94,7 +111,7 @@ export function getTradingMintGuardMessage({
 	if (remainingCapacity === undefined) return 'Loading mint capacity.'
 	if (remainingCapacity === 0n) {
 		if (hasRepBackedPoolWithNoActiveAllowance(totalRepDeposit, totalSecurityBondAllowance)) {
-			return 'No mint capacity. No active security bond allowance.'
+			return NO_MINT_CAPACITY_NO_ACTIVE_ALLOWANCE_MESSAGE
 		}
 
 		return 'No mint capacity remaining.'
@@ -145,7 +162,7 @@ export function getTradingRedeemCompleteSetGuardMessage({
 
 	const maxRedeemableCompleteSets = getMaxRedeemableCompleteSets(shareBalances)
 	if (maxRedeemableCompleteSets === undefined) return 'Loading wallet share balances.'
-	if (maxRedeemableCompleteSets === 0n) return 'Need matching Invalid, Yes, and No shares to redeem complete sets.'
+	if (maxRedeemableCompleteSets === 0n) return NEED_MATCHING_COMPLETE_SET_SHARES_MESSAGE
 
 	const trimmedAmount = redeemAmountInput.trim()
 	if (trimmedAmount === '') return 'Enter a redeem amount greater than zero.'
@@ -182,7 +199,7 @@ export function getTradingMigrateSharesGuardMessage({
 	if (!hasSelectedPool) return 'Load a pool before migrating shares.'
 	if (accountAddress === undefined) return 'Connect a wallet before migrating shares.'
 	if (!isMainnet) return 'Switch to Ethereum mainnet before migrating shares.'
-	if (universeHasForked !== true) return 'Share migration is only available after this universe has forked.'
+	if (universeHasForked !== true) return SHARE_MIGRATION_AFTER_FORK_MESSAGE
 	if (loadingTradingDetails) return 'Loading wallet share balances.'
 
 	const selectedOutcomeBalance = getSelectedOutcomeShareBalance(shareBalances, selectedOutcome)
@@ -211,6 +228,6 @@ export function getTradingRedeemSharesGuardMessage({
 	if (!isMainnet) return 'Switch to Ethereum mainnet before redeeming shares.'
 	if (universeHasForked === true) return 'Redeeming shares is unavailable after this universe has forked.'
 	if (systemState !== undefined && systemState !== 'operational') return 'Redeeming shares is only available while the pool is operational.'
-	if (questionOutcome === undefined || questionOutcome === 'none') return 'This market has not finalized yet.'
+	if (questionOutcome === undefined || questionOutcome === 'none') return MARKET_NOT_FINALIZED_MESSAGE
 	return undefined
 }

--- a/ui/ts/tests/trading.test.ts
+++ b/ui/ts/tests/trading.test.ts
@@ -2,12 +2,17 @@
 
 import { describe, expect, test } from 'bun:test'
 import {
+	MARKET_NOT_FINALIZED_MESSAGE,
+	NEED_MATCHING_COMPLETE_SET_SHARES_MESSAGE,
+	NO_MINT_CAPACITY_NO_ACTIVE_ALLOWANCE_MESSAGE,
+	SHARE_MIGRATION_AFTER_FORK_MESSAGE,
 	getCollateralizationDisplayState,
 	getCollateralizationTone,
 	getMaxRedeemableCompleteSets,
 	getPoolCollateralizationPercent,
 	getRemainingMintCapacity,
 	getSelectedOutcomeShareBalance,
+	getTradingGuardDisplayMessage,
 	getTradingMigrateSharesGuardMessage,
 	getTradingMintGuardMessage,
 	getTradingRedeemCompleteSetGuardMessage,
@@ -72,6 +77,15 @@ void describe('trading helpers', () => {
 		expect(getSelectedOutcomeShareBalance(shareBalances, 'yes')).toBe(3n * 10n ** 18n)
 		expect(getSelectedOutcomeShareBalance(shareBalances, 'no')).toBe(4n * 10n ** 18n)
 		expect(getSelectedOutcomeShareBalance(shareBalances, 'invalid')).toBe(2n * 10n ** 18n)
+	})
+
+	void test('suppresses only the targeted trading guard copy in the UI', () => {
+		expect(getTradingGuardDisplayMessage(NO_MINT_CAPACITY_NO_ACTIVE_ALLOWANCE_MESSAGE)).toBeUndefined()
+		expect(getTradingGuardDisplayMessage(NEED_MATCHING_COMPLETE_SET_SHARES_MESSAGE)).toBeUndefined()
+		expect(getTradingGuardDisplayMessage(SHARE_MIGRATION_AFTER_FORK_MESSAGE)).toBeUndefined()
+		expect(getTradingGuardDisplayMessage(MARKET_NOT_FINALIZED_MESSAGE)).toBeUndefined()
+		expect(getTradingGuardDisplayMessage('Loading wallet share balances.')).toBe('Loading wallet share balances.')
+		expect(getTradingGuardDisplayMessage(undefined)).toBeUndefined()
 	})
 
 	void test('blocks minting until a pool is loaded and the wallet is connected on mainnet', () => {

--- a/ui/ts/tests/tradingSection.test.tsx
+++ b/ui/ts/tests/tradingSection.test.tsx
@@ -1,0 +1,275 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { zeroAddress } from 'viem'
+import { MetricField } from '../components/MetricField.js'
+import { TradingSection } from '../components/TradingSection.js'
+import { MARKET_NOT_FINALIZED_MESSAGE, NEED_MATCHING_COMPLETE_SET_SHARES_MESSAGE, NO_MINT_CAPACITY_NO_ACTIVE_ALLOWANCE_MESSAGE, SHARE_MIGRATION_AFTER_FORK_MESSAGE } from '../lib/trading.js'
+import type { AccountState, TradingFormState } from '../types/app.js'
+import type { ListedSecurityPool, MarketDetails, TradingDetails, TradingShareBalances } from '../types/contracts.js'
+import type { TradingSectionProps } from '../types/components.js'
+
+type VNodeLike = {
+	props: Record<string, unknown>
+	type: unknown
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null
+}
+
+function isVNodeLike(value: unknown): value is VNodeLike {
+	return isObjectRecord(value) && 'type' in value && 'props' in value && isObjectRecord(value['props'])
+}
+
+function visitTree(node: unknown, visitor: (vnode: VNodeLike) => void) {
+	if (Array.isArray(node)) {
+		for (const child of node) {
+			visitTree(child, visitor)
+		}
+		return
+	}
+
+	if (!isVNodeLike(node)) return
+
+	visitor(node)
+	visitTree(node.props['children'], visitor)
+}
+
+function getTextContent(node: unknown): string {
+	if (typeof node === 'string' || typeof node === 'number') return String(node)
+	if (Array.isArray(node)) return node.map(child => getTextContent(child)).join('')
+	if (!isVNodeLike(node)) return ''
+	return getTextContent(node.props['children'])
+}
+
+function getMetricFieldLabels(node: unknown) {
+	const labels: string[] = []
+	visitTree(node, vnode => {
+		if (vnode.type !== MetricField) return
+		const label = vnode.props['label']
+		if (typeof label === 'string') labels.push(label)
+	})
+	return labels
+}
+
+function getDetailTexts(node: unknown) {
+	const detailTexts: string[] = []
+	visitTree(node, vnode => {
+		if (vnode.type !== 'p' || vnode.props['className'] !== 'detail') return
+		detailTexts.push(getTextContent(vnode.props['children']))
+	})
+	return detailTexts
+}
+
+function findButton(node: unknown, label: string) {
+	let matchingButton: VNodeLike | undefined
+	visitTree(node, vnode => {
+		if (matchingButton !== undefined || vnode.type !== 'button') return
+		if (getTextContent(vnode.props['children']).trim() === label) matchingButton = vnode
+	})
+	return matchingButton
+}
+
+function createMarketDetails(): MarketDetails {
+	return {
+		answerUnit: '',
+		createdAt: 1n,
+		description: 'Question description',
+		displayValueMax: 100n,
+		displayValueMin: 0n,
+		endTime: 2n,
+		exists: true,
+		marketType: 'binary',
+		numTicks: 2n,
+		outcomeLabels: ['Yes', 'No'],
+		questionId: '0x01',
+		startTime: 1n,
+		title: 'Will this resolve?',
+	}
+}
+
+function createSelectedPool(overrides: Partial<ListedSecurityPool> = {}): ListedSecurityPool {
+	return {
+		completeSetCollateralAmount: 0n,
+		currentRetentionRate: 10n,
+		forkOutcome: 'none',
+		forkOwnSecurityPool: false,
+		lastOraclePrice: undefined,
+		managerAddress: zeroAddress,
+		marketDetails: createMarketDetails(),
+		migratedRep: 0n,
+		parent: zeroAddress,
+		questionOutcome: 'yes',
+		questionId: '0x01',
+		securityMultiplier: 2n,
+		securityPoolAddress: zeroAddress,
+		systemState: 'operational',
+		totalRepDeposit: 0n,
+		totalSecurityBondAllowance: 5n * 10n ** 18n,
+		truthAuctionAddress: zeroAddress,
+		truthAuctionStartedAt: 0n,
+		universeHasForked: false,
+		universeId: 1n,
+		vaultCount: 0n,
+		vaults: [],
+		...overrides,
+	}
+}
+
+function createShareBalances(overrides: Partial<TradingShareBalances> = {}): TradingShareBalances {
+	return {
+		invalid: 2n * 10n ** 18n,
+		no: 4n * 10n ** 18n,
+		yes: 3n * 10n ** 18n,
+		...overrides,
+	}
+}
+
+function createTradingDetails(overrides: Partial<TradingDetails> = {}): TradingDetails {
+	const shareBalances = createShareBalances()
+	return {
+		maxRedeemableCompleteSets: 2n * 10n ** 18n,
+		shareBalances,
+		...overrides,
+	}
+}
+
+function createTradingForm(overrides: Partial<TradingFormState> = {}): TradingFormState {
+	return {
+		completeSetAmount: '1',
+		redeemAmount: '1',
+		securityPoolAddress: zeroAddress,
+		selectedOutcome: 'yes',
+		...overrides,
+	}
+}
+
+function createAccountState(overrides: Partial<AccountState> = {}): AccountState {
+	return {
+		address: zeroAddress,
+		chainId: '0x1',
+		ethBalance: 10n * 10n ** 18n,
+		wethBalance: 0n,
+		...overrides,
+	}
+}
+
+function createTradingSectionProps(overrides: Partial<TradingSectionProps> = {}): TradingSectionProps {
+	return {
+		accountState: createAccountState(),
+		embedInCard: true,
+		loadingTradingDetails: false,
+		onCreateCompleteSet: () => undefined,
+		onMigrateShares: () => undefined,
+		onRedeemCompleteSet: () => undefined,
+		onRedeemShares: () => undefined,
+		onTradingFormChange: () => undefined,
+		repEthPrice: undefined,
+		repEthSource: undefined,
+		repEthSourceUrl: undefined,
+		selectedPool: createSelectedPool(),
+		showHeader: false,
+		showSecurityPoolAddressInput: false,
+		tradingDetails: createTradingDetails(),
+		tradingError: undefined,
+		tradingForm: createTradingForm(),
+		tradingResult: undefined,
+		...overrides,
+	}
+}
+
+function renderTradingSection(overrides: Partial<TradingSectionProps> = {}) {
+	return TradingSection(createTradingSectionProps(overrides))
+}
+
+void describe('TradingSection', () => {
+	void test('renames the max complete sets metric to total complete sets', () => {
+		const section = renderTradingSection()
+		const metricFieldLabels = getMetricFieldLabels(section)
+
+		expect(metricFieldLabels).toContain('Total Complete Sets')
+		expect(metricFieldLabels).not.toContain('Max Complete Sets')
+	})
+
+	void test('keeps minting disabled silently when the pool has no active allowance', () => {
+		const section = renderTradingSection({
+			selectedPool: createSelectedPool({
+				completeSetCollateralAmount: 0n,
+				totalRepDeposit: 20n * 10n ** 18n,
+				totalSecurityBondAllowance: 0n,
+				universeHasForked: false,
+			}),
+			tradingForm: createTradingForm({ completeSetAmount: '100' }),
+		})
+		const mintButton = findButton(section, 'Mint Complete Sets')
+		const detailTexts = getDetailTexts(section)
+
+		expect(mintButton).toBeDefined()
+		expect(mintButton?.props['disabled']).toBe(true)
+		expect(mintButton?.props['title']).toBeUndefined()
+		expect(detailTexts).not.toContain(NO_MINT_CAPACITY_NO_ACTIVE_ALLOWANCE_MESSAGE)
+	})
+
+	void test('keeps complete-set redemption disabled silently when the wallet lacks matching shares', () => {
+		const section = renderTradingSection({
+			selectedPool: createSelectedPool({ universeHasForked: false }),
+			tradingDetails: createTradingDetails({
+				maxRedeemableCompleteSets: 0n,
+				shareBalances: createShareBalances({
+					invalid: 0n,
+					no: 2n * 10n ** 18n,
+					yes: 2n * 10n ** 18n,
+				}),
+			}),
+			tradingForm: createTradingForm({ redeemAmount: '1' }),
+		})
+		const redeemButton = findButton(section, 'Redeem Complete Sets')
+		const detailTexts = getDetailTexts(section)
+
+		expect(redeemButton).toBeDefined()
+		expect(redeemButton?.props['disabled']).toBe(true)
+		expect(redeemButton?.props['title']).toBeUndefined()
+		expect(detailTexts).not.toContain(NEED_MATCHING_COMPLETE_SET_SHARES_MESSAGE)
+	})
+
+	void test('keeps share migration disabled silently before the universe forks', () => {
+		const section = renderTradingSection({
+			selectedPool: createSelectedPool({ universeHasForked: false }),
+		})
+		const migrateButton = findButton(section, 'Migrate Shares')
+		const detailTexts = getDetailTexts(section)
+
+		expect(migrateButton).toBeDefined()
+		expect(migrateButton?.props['disabled']).toBe(true)
+		expect(migrateButton?.props['title']).toBeUndefined()
+		expect(detailTexts).not.toContain(SHARE_MIGRATION_AFTER_FORK_MESSAGE)
+	})
+
+	void test('keeps share redemption disabled silently before finalization', () => {
+		const section = renderTradingSection({
+			selectedPool: createSelectedPool({ questionOutcome: 'none' }),
+		})
+		const redeemSharesButton = findButton(section, 'Redeem Shares')
+		const detailTexts = getDetailTexts(section)
+
+		expect(redeemSharesButton).toBeDefined()
+		expect(redeemSharesButton?.props['disabled']).toBe(true)
+		expect(redeemSharesButton?.props['title']).toBeUndefined()
+		expect(detailTexts).not.toContain(MARKET_NOT_FINALIZED_MESSAGE)
+	})
+
+	void test('keeps non-suppressed trading guard messages visible', () => {
+		const section = renderTradingSection({
+			loadingTradingDetails: true,
+			tradingDetails: undefined,
+		})
+		const redeemButton = findButton(section, 'Redeem Complete Sets')
+		const detailTexts = getDetailTexts(section)
+
+		expect(redeemButton).toBeDefined()
+		expect(redeemButton?.props['disabled']).toBe(true)
+		expect(redeemButton?.props['title']).toBe('Loading wallet share balances.')
+		expect(detailTexts).toContain('Loading wallet share balances.')
+	})
+})


### PR DESCRIPTION
## Summary
- Suppress a small set of repetitive trading guard messages from the visible UI while keeping other guard copy intact.
- Route those guard strings through a display helper so button titles and inline notices only show the messages that add user value.
- Reorder the open oracle initial report controls to keep the approval and price entry flow clearer.
- Update tests to cover the hidden guard messages, preserved visible messages, and the renamed complete-set metric label.

## Testing
- `bun tsc`
- `bun test`
- `bun run format`
- `bun run check`
- `bun run knip`