### PR TITLE
Refactor fork auction UI into staged workflow panels

### DIFF
--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -1855,6 +1855,53 @@ button.currency-value.copyable:hover:not(:disabled) {
 	opacity: 0.72;
 }
 
+.fork-summary-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+	gap: 0.75rem;
+}
+
+.fork-stage-nav {
+	margin-top: 0.15rem;
+	padding-bottom: 0;
+	border-bottom: 0;
+}
+
+.fork-stage-panel {
+	display: grid;
+	gap: 0.85rem;
+	margin: 0;
+	padding: 0;
+	border: 0;
+}
+
+.fork-stage-panel:disabled {
+	opacity: 0.72;
+}
+
+.fork-stage-panel .entity-card-subsection {
+	gap: 0.95rem;
+	margin: 0;
+	padding: 0.95rem 1rem 1rem;
+	border: 1px solid var(--border-default);
+	background: linear-gradient(180deg, var(--surface-raised) 0%, var(--surface-card-end) 100%);
+	box-shadow:
+		var(--glow-inset-subtle),
+		0 10px 30px rgba(0, 0, 0, 0.12);
+}
+
+.fork-stage-panel .entity-card-subsection-header {
+	margin-bottom: -0.15rem;
+}
+
+.fork-stage-panel .entity-card-subsection-header h4 {
+	font-size: var(--font-base);
+}
+
+.fork-stage-panel .detail {
+	line-height: 1.45;
+}
+
 .workflow-create-section {
 	border-top-color: var(--border-strong);
 	padding-top: 1.25rem;
@@ -2254,6 +2301,7 @@ button:focus-visible {
 	.escalation-metrics,
 	.escalation-sides,
 	.categorical-outcome-row,
+	.fork-summary-grid,
 	.field-row,
 	.market-grid {
 		grid-template-columns: 1fr;

--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -1,16 +1,21 @@
 import { Fragment } from 'preact'
+import { useEffect, useRef, useState } from 'preact/hooks'
+import type { ComponentChildren } from 'preact'
 import { AddressValue } from './AddressValue.js'
 import { CurrencyValue } from './CurrencyValue.js'
+import { EntityCard } from './EntityCard.js'
 import { EnumDropdown } from './EnumDropdown.js'
 import { ErrorNotice } from './ErrorNotice.js'
+import { LatestActionSection } from './LatestActionSection.js'
 import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
 import { Question } from './Question.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { UniverseLink } from './UniverseLink.js'
 import { TimestampValue } from './TimestampValue.js'
+import { WorkflowSubsection } from './WorkflowSubsection.js'
+import { AUCTION_TIME_SECONDS, type ForkAuctionStageView, estimateRepPurchased, getForkAuctionStageView, getForkStageDescription, getForkStageDescriptionForState, getOutcomeActionLabel, getSystemStateLabel, getTimeRemaining, hasForkActivity, MIGRATION_TIME_SECONDS } from '../lib/forkAuction.js'
 import { formatDuration } from '../lib/formatters.js'
-import { AUCTION_TIME_SECONDS, estimateRepPurchased, getForkStageDescription, getForkStageDescriptionForState, getOutcomeActionLabel, getSystemStateLabel, getTimeRemaining, hasForkActivity, MIGRATION_TIME_SECONDS } from '../lib/forkAuction.js'
 import { isMainnetChain } from '../lib/network.js'
 import { REPORTING_OUTCOME_DROPDOWN_OPTIONS, getReportingOutcomeLabel } from '../lib/reporting.js'
 import type { ListedSecurityPool } from '../types/contracts.js'
@@ -18,6 +23,30 @@ import type { ForkAuctionSectionProps } from '../types/components.js'
 
 const UNKNOWN_VALUE = '—'
 const UNAVAILABLE_UNTIL_FORK = 'Unavailable until fork'
+const STAGE_VIEWS: readonly ForkAuctionStageView[] = ['initiate', 'migration', 'auction', 'settlement']
+const STAGE_LABELS: Record<ForkAuctionStageView, string> = {
+	initiate: 'Initiate',
+	migration: 'Migration',
+	auction: 'Auction',
+	settlement: 'Settlement',
+}
+const STAGE_BADGE_TONES: Record<ForkAuctionStageView, 'muted' | 'pending' | 'ok'> = {
+	initiate: 'muted',
+	migration: 'pending',
+	auction: 'pending',
+	settlement: 'ok',
+}
+const STAGE_ORDER: Record<ForkAuctionStageView, number> = {
+	initiate: 0,
+	migration: 1,
+	auction: 2,
+	settlement: 3,
+}
+
+type DisplayMetric = {
+	label: string
+	value: ComponentChildren
+}
 
 function getTruthAuctionWindow(startedAt: bigint | undefined) {
 	if (startedAt === undefined || startedAt === 0n) return undefined
@@ -59,10 +88,70 @@ function getPreviewMigrationSummary(previewPool: ListedSecurityPool | undefined,
 	return UNKNOWN_VALUE
 }
 
+function getStageLabel(stage: ForkAuctionStageView) {
+	return STAGE_LABELS[stage]
+}
+
+function getStageTone(stage: ForkAuctionStageView) {
+	return STAGE_BADGE_TONES[stage]
+}
+
+function getStageAheadMessage(stage: ForkAuctionStageView, currentStage: ForkAuctionStageView) {
+	if (STAGE_ORDER[stage] <= STAGE_ORDER[currentStage]) return undefined
+
+	switch (stage) {
+		case 'migration':
+			return `This pool is currently in ${getStageLabel(currentStage)}. Migration controls become meaningful once the pool has forked.`
+		case 'auction':
+			return `This pool is currently in ${getStageLabel(currentStage)}. Auction controls become meaningful after migration completes and the truth auction starts.`
+		case 'settlement':
+			return `This pool is currently in ${getStageLabel(currentStage)}. Settlement controls become meaningful after bidding progresses or the truth auction finalizes.`
+		case 'initiate':
+			return undefined
+		default:
+			return undefined
+	}
+}
+
+function renderSummaryMetricGrid(metrics: DisplayMetric[]) {
+	return (
+		<div className='fork-summary-grid'>
+			{metrics.map(metric => (
+				<MetricField key={metric.label} className='entity-metric' label={metric.label}>
+					{metric.value}
+				</MetricField>
+			))}
+		</div>
+	)
+}
+
+function renderWorkflowMetricGrid(metrics: DisplayMetric[]) {
+	return (
+		<div className='workflow-metric-grid'>
+			{metrics.map(metric => (
+				<MetricField key={metric.label} label={metric.label}>
+					{metric.value}
+				</MetricField>
+			))}
+		</div>
+	)
+}
+
+function estimateBidRep(bidAmount: string, selectedAuctionPrice: bigint | undefined) {
+	if (selectedAuctionPrice === undefined) return undefined
+
+	try {
+		return estimateRepPurchased(BigInt(bidAmount === '' ? '0' : bidAmount), selectedAuctionPrice)
+	} catch {
+		return undefined
+	}
+}
+
 export function ForkAuctionSection({
 	accountState,
 	disabled = false,
 	disabledMessage,
+	embedInCard = false,
 	forkAuctionDetails,
 	forkAuctionError,
 	forkAuctionForm,
@@ -89,7 +178,7 @@ export function ForkAuctionSection({
 }: ForkAuctionSectionProps) {
 	const isMainnet = isMainnetChain(accountState.chainId)
 	const selectedAuctionPrice = forkAuctionDetails?.truthAuction?.clearingPrice
-	const estimatedRep = selectedAuctionPrice === undefined ? undefined : estimateRepPurchased(BigInt(forkAuctionForm.bidAmount || '0'), selectedAuctionPrice)
+	const estimatedRep = estimateBidRep(forkAuctionForm.submitBidAmount, selectedAuctionPrice)
 	const migrationTimeRemaining = forkAuctionDetails === undefined ? undefined : getTimeRemaining(forkAuctionDetails.migrationEndsAt, forkAuctionDetails.currentTime)
 	const previewAuctionWindow = getTruthAuctionWindow(previewPool?.truthAuctionStartedAt)
 	const auctionWindow = forkAuctionDetails === undefined ? previewAuctionWindow : getTruthAuctionWindow(forkAuctionDetails.truthAuctionStartedAt)
@@ -100,11 +189,423 @@ export function ForkAuctionSection({
 	const parentSecurityPoolAddress = forkAuctionDetails?.parentSecurityPoolAddress ?? previewPool?.parent
 	const systemState = forkAuctionDetails?.systemState ?? previewPool?.systemState
 	const forkOutcome = forkAuctionDetails?.forkOutcome ?? previewPool?.forkOutcome
+	const questionOutcome = forkAuctionDetails?.questionOutcome ?? previewPool?.questionOutcome
 	const truthAuctionAddress = forkAuctionDetails?.truthAuctionAddress ?? previewPool?.truthAuctionAddress
 	const hasPreviewForkActivity = previewPool === undefined ? false : hasForkActivity(previewPool)
 	const forkOnlyFallbackText = getForkOnlyFallbackText(hasPreviewForkActivity)
 	const forkStageDescription = forkAuctionDetails === undefined ? (systemState === undefined ? undefined : getForkStageDescriptionForState(systemState)) : getForkStageDescription(forkAuctionDetails)
 	const migrationSummaryText = forkAuctionDetails === undefined ? getPreviewMigrationSummary(previewPool, hasPreviewForkActivity) : undefined
+	const hasLoadedPoolContext = securityPoolAddress !== undefined && systemState !== undefined
+	const currentStage =
+		systemState === undefined
+			? 'initiate'
+			: getForkAuctionStageView({
+					claimingAvailable: forkAuctionDetails?.claimingAvailable ?? false,
+					forkOutcome: forkOutcome ?? 'none',
+					migratedRep: forkAuctionDetails?.migratedRep ?? previewPool?.migratedRep ?? 0n,
+					systemState,
+					truthAuction: forkAuctionDetails?.truthAuction,
+					truthAuctionStartedAt: forkAuctionDetails?.truthAuctionStartedAt ?? previewPool?.truthAuctionStartedAt ?? 0n,
+				})
+	const [selectedStage, setSelectedStage] = useState<ForkAuctionStageView>(currentStage)
+	const lastPoolKeyRef = useRef<string | undefined>(undefined)
+	const selectedStageAheadMessage = getStageAheadMessage(selectedStage, currentStage)
+	const selectedStageBadge = <span className={`badge ${getStageTone(currentStage)}`}>{getStageLabel(currentStage)}</span>
+	const truthAuctionFallback = forkAuctionDetails?.truthAuction === undefined ? forkOnlyFallbackText : UNKNOWN_VALUE
+	const truthAuctionStatus = forkAuctionDetails?.truthAuction
+	const startedDisplay =
+		forkAuctionDetails === undefined
+			? previewPool?.truthAuctionStartedAt === undefined || previewPool.truthAuctionStartedAt === 0n
+				? 'Not started'
+				: renderTimestamp(previewPool.truthAuctionStartedAt, 'Not started')
+			: forkAuctionDetails.truthAuctionStartedAt === 0n
+				? 'Not started'
+				: renderTimestamp(forkAuctionDetails.truthAuctionStartedAt, 'Not started')
+	const endsDisplay = auctionWindow === undefined ? 'Not started' : <TimestampValue timestamp={auctionWindow.endsAt} />
+	const timeLeftDisplay = forkAuctionDetails?.truthAuction?.timeRemaining === undefined ? (forkAuctionDetails?.truthAuction === undefined ? forkOnlyFallbackText : formatDuration(AUCTION_TIME_SECONDS)) : formatDuration(forkAuctionDetails.truthAuction.timeRemaining)
+	const ethRaisedCapDisplay =
+		forkAuctionDetails?.truthAuction === undefined ? (
+			forkOnlyFallbackText
+		) : (
+			<Fragment>
+				<CurrencyValue value={forkAuctionDetails.truthAuction.ethRaised} suffix='ETH' /> / <CurrencyValue value={forkAuctionDetails.truthAuction.ethRaiseCap} suffix='ETH' />
+			</Fragment>
+		)
+	const clearingPriceDisplay = forkAuctionDetails?.truthAuction === undefined ? forkOnlyFallbackText : renderMetricValue(forkAuctionDetails.truthAuction.clearingPrice, 'REP', UNKNOWN_VALUE)
+	const finalizedDisplay = forkAuctionDetails?.truthAuction === undefined ? forkOnlyFallbackText : forkAuctionDetails.truthAuction.finalized ? 'Yes' : 'No'
+	const underfundedDisplay = forkAuctionDetails?.truthAuction === undefined ? forkOnlyFallbackText : forkAuctionDetails.truthAuction.underfunded ? 'Yes' : 'No'
+	const claimingAvailableDisplay = forkAuctionDetails === undefined ? (hasPreviewForkActivity ? UNKNOWN_VALUE : UNAVAILABLE_UNTIL_FORK) : forkAuctionDetails.claimingAvailable ? 'Yes' : 'No'
+
+	useEffect(() => {
+		if (lastPoolKeyRef.current === securityPoolAddress) return
+		lastPoolKeyRef.current = securityPoolAddress
+		setSelectedStage(currentStage)
+	}, [currentStage, securityPoolAddress])
+
+	const poolSummaryMetrics: DisplayMetric[] = [
+		{ label: 'Security Pool', value: renderAddress(securityPoolAddress) },
+		{ label: 'Universe', value: universeId === undefined ? UNKNOWN_VALUE : <UniverseLink universeId={universeId} /> },
+		{ label: 'Parent Pool', value: renderAddress(parentSecurityPoolAddress) },
+		{ label: 'System State', value: systemState === undefined ? UNKNOWN_VALUE : getSystemStateLabel(systemState) },
+		{ label: 'Fork Type', value: forkAuctionDetails === undefined ? getPreviewForkType(previewPool, hasPreviewForkActivity) : forkAuctionDetails.forkOwnSecurityPool ? 'Own escalation fork' : 'Parent/Zoltar fork' },
+		{ label: 'Question Outcome', value: questionOutcome === undefined ? UNKNOWN_VALUE : getReportingOutcomeLabel(questionOutcome) },
+		{ label: 'Fork Outcome', value: forkOutcome === undefined ? UNKNOWN_VALUE : getReportingOutcomeLabel(forkOutcome) },
+		{ label: 'Collateral', value: renderMetricValue(forkAuctionDetails?.completeSetCollateralAmount ?? previewPool?.completeSetCollateralAmount, 'ETH', UNKNOWN_VALUE) },
+	]
+
+	const liveSnapshotMetrics: DisplayMetric[] =
+		selectedStage === 'initiate'
+			? [
+					{ label: 'REP At Fork', value: forkAuctionDetails === undefined ? forkOnlyFallbackText : <CurrencyValue value={forkAuctionDetails.repAtFork} suffix='REP' /> },
+					{ label: 'Fork Type', value: forkAuctionDetails === undefined ? getPreviewForkType(previewPool, hasPreviewForkActivity) : forkAuctionDetails.forkOwnSecurityPool ? 'Own escalation fork' : 'Parent/Zoltar fork' },
+					{ label: 'Parent Pool', value: renderAddress(parentSecurityPoolAddress) },
+					{ label: 'Migration Window', value: formatDuration(MIGRATION_TIME_SECONDS) },
+				]
+			: selectedStage === 'migration'
+				? [
+						{ label: 'REP At Fork', value: forkAuctionDetails === undefined ? forkOnlyFallbackText : <CurrencyValue value={forkAuctionDetails.repAtFork} suffix='REP' /> },
+						{ label: 'Migrated REP', value: renderMetricValue(forkAuctionDetails?.migratedRep ?? previewPool?.migratedRep, 'REP', UNKNOWN_VALUE) },
+						{ label: 'Migration Ends', value: forkAuctionDetails === undefined ? migrationSummaryText : forkAuctionDetails.migrationEndsAt === undefined ? 'Started/finished' : <TimestampValue timestamp={forkAuctionDetails.migrationEndsAt} /> },
+						{ label: 'Time Left', value: forkAuctionDetails === undefined ? forkOnlyFallbackText : migrationTimeRemaining === undefined ? formatDuration(MIGRATION_TIME_SECONDS) : formatDuration(migrationTimeRemaining) },
+					]
+				: selectedStage === 'auction'
+					? [
+							{ label: 'Started', value: startedDisplay },
+							{ label: 'Ends', value: endsDisplay },
+							{ label: 'ETH Raised / Cap', value: ethRaisedCapDisplay },
+							{ label: 'Clearing Price', value: clearingPriceDisplay },
+						]
+					: [
+							{ label: 'Finalized', value: finalizedDisplay },
+							{ label: 'Underfunded', value: underfundedDisplay },
+							{ label: 'Auctioned Allowance', value: forkAuctionDetails === undefined ? forkOnlyFallbackText : <CurrencyValue value={forkAuctionDetails.auctionedSecurityBondAllowance} suffix='ETH' /> },
+							{ label: 'Claiming Available', value: claimingAvailableDisplay },
+						]
+
+	const initiateStatusMetrics: DisplayMetric[] = [
+		{ label: 'Current Stage', value: getStageLabel(currentStage) },
+		{ label: 'REP At Fork', value: forkAuctionDetails === undefined ? forkOnlyFallbackText : <CurrencyValue value={forkAuctionDetails.repAtFork} suffix='REP' /> },
+		{ label: 'Fork Type', value: forkAuctionDetails === undefined ? getPreviewForkType(previewPool, hasPreviewForkActivity) : forkAuctionDetails.forkOwnSecurityPool ? 'Own escalation fork' : 'Parent/Zoltar fork' },
+		{ label: 'Migration Window', value: formatDuration(MIGRATION_TIME_SECONDS) },
+	]
+
+	const migrationStatusMetrics: DisplayMetric[] = [
+		{ label: 'REP At Fork', value: forkAuctionDetails === undefined ? forkOnlyFallbackText : <CurrencyValue value={forkAuctionDetails.repAtFork} suffix='REP' /> },
+		{ label: 'Migrated REP', value: renderMetricValue(forkAuctionDetails?.migratedRep ?? previewPool?.migratedRep, 'REP', UNKNOWN_VALUE) },
+		{ label: 'Collateral', value: renderMetricValue(forkAuctionDetails?.completeSetCollateralAmount ?? previewPool?.completeSetCollateralAmount, 'ETH', UNKNOWN_VALUE) },
+		{ label: 'Migration Ends', value: forkAuctionDetails === undefined ? migrationSummaryText : forkAuctionDetails.migrationEndsAt === undefined ? 'Started/finished' : <TimestampValue timestamp={forkAuctionDetails.migrationEndsAt} /> },
+		{ label: 'Time Left', value: forkAuctionDetails === undefined ? forkOnlyFallbackText : migrationTimeRemaining === undefined ? formatDuration(MIGRATION_TIME_SECONDS) : formatDuration(migrationTimeRemaining) },
+		{ label: 'Fork Type', value: forkAuctionDetails === undefined ? getPreviewForkType(previewPool, hasPreviewForkActivity) : forkAuctionDetails.forkOwnSecurityPool ? 'Own escalation fork' : 'Parent/Zoltar fork' },
+	]
+
+	const auctionStatusMetrics: DisplayMetric[] = [
+		{ label: 'Auction Address', value: renderAddress(truthAuctionAddress) },
+		{ label: 'Started', value: startedDisplay },
+		{ label: 'Ends', value: endsDisplay },
+		{ label: 'Time Left', value: timeLeftDisplay },
+		{ label: 'ETH Raised / Cap', value: ethRaisedCapDisplay },
+		{ label: 'REP Purchased', value: truthAuctionStatus === undefined ? forkOnlyFallbackText : <CurrencyValue value={truthAuctionStatus.totalRepPurchased} suffix='REP' /> },
+		{ label: 'Clearing Tick', value: truthAuctionStatus?.clearingTick?.toString() ?? truthAuctionFallback },
+		{ label: 'Clearing Price', value: clearingPriceDisplay },
+		{ label: 'Min Bid Size', value: truthAuctionStatus === undefined ? forkOnlyFallbackText : <CurrencyValue value={truthAuctionStatus.minBidSize} suffix='ETH' /> },
+		{ label: 'Max REP Being Sold', value: truthAuctionStatus === undefined ? forkOnlyFallbackText : <CurrencyValue value={truthAuctionStatus.maxRepBeingSold} suffix='REP' /> },
+		{ label: 'Finalized', value: finalizedDisplay },
+		{ label: 'Underfunded', value: underfundedDisplay },
+	]
+
+	const settlementStatusMetrics: DisplayMetric[] = [
+		{ label: 'Finalized', value: finalizedDisplay },
+		{ label: 'Underfunded', value: underfundedDisplay },
+		{ label: 'Auctioned Allowance', value: forkAuctionDetails === undefined ? forkOnlyFallbackText : <CurrencyValue value={forkAuctionDetails.auctionedSecurityBondAllowance} suffix='ETH' /> },
+		{ label: 'Claiming Available', value: claimingAvailableDisplay },
+		{ label: 'ETH Raised / Cap', value: ethRaisedCapDisplay },
+		{ label: 'REP Purchased', value: truthAuctionStatus === undefined ? forkOnlyFallbackText : <CurrencyValue value={truthAuctionStatus.totalRepPurchased} suffix='REP' /> },
+	]
+
+	const stagePanel =
+		selectedStage === 'initiate' ? (
+			<fieldset className='fork-stage-panel' disabled={disabled}>
+				<WorkflowSubsection title='Fork Trigger' badge={<span className='badge muted'>{systemState === undefined ? UNKNOWN_VALUE : getSystemStateLabel(systemState)}</span>} className='fork-stage-metrics'>
+					{renderWorkflowMetricGrid(initiateStatusMetrics)}
+					<div className='actions'>
+						<button className='primary' onClick={onForkWithOwnEscalation} disabled={disabled || accountState.address === undefined || !isMainnet}>
+							Fork With Own Escalation
+						</button>
+						<button className='secondary' onClick={onInitiateFork} disabled={disabled || accountState.address === undefined || !isMainnet}>
+							Initiate Pool Fork
+						</button>
+					</div>
+				</WorkflowSubsection>
+
+				<WorkflowSubsection title='Direct Universe Fork' className='fork-stage-actions'>
+					<div className='form-grid'>
+						<div className='field-row'>
+							<label className='field'>
+								<span>Direct Fork Universe ID</span>
+								<input value={forkAuctionForm.directForkUniverseId} onInput={event => onForkAuctionFormChange({ directForkUniverseId: event.currentTarget.value })} />
+							</label>
+							<label className='field'>
+								<span>Direct Fork Question ID</span>
+								<input value={forkAuctionForm.directForkQuestionId} onInput={event => onForkAuctionFormChange({ directForkQuestionId: event.currentTarget.value })} placeholder='0x...' />
+							</label>
+						</div>
+						<div className='actions'>
+							<button className='secondary' onClick={onForkUniverse} disabled={disabled || accountState.address === undefined || !isMainnet}>
+								Fork Universe Directly
+							</button>
+						</div>
+					</div>
+				</WorkflowSubsection>
+			</fieldset>
+		) : selectedStage === 'migration' ? (
+			<fieldset className='fork-stage-panel' disabled={disabled}>
+				<WorkflowSubsection title='Migration Status' badge={<span className='badge pending'>Window open</span>} className='fork-stage-metrics'>
+					{renderWorkflowMetricGrid(migrationStatusMetrics)}
+				</WorkflowSubsection>
+
+				<WorkflowSubsection title='Create Child Universe' className='fork-stage-actions'>
+					<div className='form-grid'>
+						<label className='field'>
+							<span>Outcome</span>
+							<EnumDropdown options={REPORTING_OUTCOME_DROPDOWN_OPTIONS} value={forkAuctionForm.selectedOutcome} onChange={selectedOutcome => onForkAuctionFormChange({ selectedOutcome })} />
+						</label>
+						<div className='actions'>
+							<button className='primary' onClick={onCreateChildUniverse} disabled={disabled || accountState.address === undefined || !isMainnet}>
+								Create {getOutcomeActionLabel(forkAuctionForm.selectedOutcome)} Child Universe
+							</button>
+						</div>
+					</div>
+				</WorkflowSubsection>
+
+				<WorkflowSubsection title='Migrate REP' className='fork-stage-actions'>
+					<div className='form-grid'>
+						<label className='field'>
+							<span>REP Migration Outcomes</span>
+							<input value={forkAuctionForm.repMigrationOutcomes} onInput={event => onForkAuctionFormChange({ repMigrationOutcomes: event.currentTarget.value })} placeholder='yes,no,invalid' />
+						</label>
+						<div className='actions'>
+							<button className='secondary' onClick={onMigrateRepToZoltar} disabled={disabled || accountState.address === undefined || !isMainnet}>
+								Migrate REP To Zoltar
+							</button>
+						</div>
+					</div>
+				</WorkflowSubsection>
+
+				<WorkflowSubsection title='Migrate Vault / Deposits' className='fork-stage-actions'>
+					<div className='form-grid'>
+						<label className='field'>
+							<span>Outcome</span>
+							<EnumDropdown options={REPORTING_OUTCOME_DROPDOWN_OPTIONS} value={forkAuctionForm.selectedOutcome} onChange={selectedOutcome => onForkAuctionFormChange({ selectedOutcome })} />
+						</label>
+						<label className='field'>
+							<span>Vault Address</span>
+							<input value={forkAuctionForm.vaultAddress} onInput={event => onForkAuctionFormChange({ vaultAddress: event.currentTarget.value })} placeholder='Leave empty to use connected wallet' />
+						</label>
+						<label className='field'>
+							<span>Escalation Deposit Indexes</span>
+							<input value={forkAuctionForm.depositIndexes} onInput={event => onForkAuctionFormChange({ depositIndexes: event.currentTarget.value })} placeholder='0,1,2' />
+						</label>
+						<div className='actions'>
+							<button className='primary' onClick={onMigrateVault} disabled={disabled || accountState.address === undefined || !isMainnet}>
+								Migrate Vault
+							</button>
+							<button className='secondary' onClick={onMigrateEscalationDeposits} disabled={disabled || accountState.address === undefined || !isMainnet}>
+								Migrate Escalation Deposits
+							</button>
+						</div>
+					</div>
+				</WorkflowSubsection>
+			</fieldset>
+		) : selectedStage === 'auction' ? (
+			<fieldset className='fork-stage-panel' disabled={disabled}>
+				<WorkflowSubsection title='Auction Status' badge={<span className='badge pending'>Live auction</span>} className='fork-stage-metrics'>
+					{renderWorkflowMetricGrid(auctionStatusMetrics)}
+				</WorkflowSubsection>
+
+				<WorkflowSubsection title='Start Truth Auction' className='fork-stage-actions'>
+					<div className='form-grid'>
+						<div className='actions'>
+							<button className='primary' onClick={onStartTruthAuction} disabled={disabled || accountState.address === undefined || !isMainnet}>
+								Start Truth Auction
+							</button>
+						</div>
+					</div>
+				</WorkflowSubsection>
+
+				<WorkflowSubsection title='Submit Bid' className='fork-stage-actions'>
+					<div className='form-grid'>
+						<label className='field'>
+							<span>Bid Tick</span>
+							<input value={forkAuctionForm.submitBidTick} onInput={event => onForkAuctionFormChange({ submitBidTick: event.currentTarget.value })} />
+						</label>
+						<label className='field'>
+							<span>Bid Amount (ETH)</span>
+							<input value={forkAuctionForm.submitBidAmount} onInput={event => onForkAuctionFormChange({ submitBidAmount: event.currentTarget.value })} />
+						</label>
+						{selectedAuctionPrice === undefined ? undefined : <p className='detail'>At the current clearing price, this bid would buy roughly {estimatedRep === undefined ? UNKNOWN_VALUE : <CurrencyValue value={estimatedRep} suffix='REP' />} if it clears.</p>}
+						<div className='actions'>
+							<button className='secondary' onClick={onSubmitBid} disabled={disabled || accountState.address === undefined || !isMainnet}>
+								Submit Bid
+							</button>
+						</div>
+					</div>
+				</WorkflowSubsection>
+			</fieldset>
+		) : (
+			<fieldset className='fork-stage-panel' disabled={disabled}>
+				<WorkflowSubsection title='Settlement Status' badge={<span className='badge ok'>Claims / cleanup</span>} className='fork-stage-metrics'>
+					{renderWorkflowMetricGrid(settlementStatusMetrics)}
+				</WorkflowSubsection>
+
+				<WorkflowSubsection title='Finalize Truth Auction' className='fork-stage-actions'>
+					<div className='form-grid'>
+						<div className='actions'>
+							<button className='secondary' onClick={onFinalizeTruthAuction} disabled={disabled || accountState.address === undefined || !isMainnet}>
+								Finalize Truth Auction
+							</button>
+						</div>
+					</div>
+				</WorkflowSubsection>
+
+				<WorkflowSubsection title='Refund Losing Bid' className='fork-stage-actions'>
+					<div className='form-grid'>
+						<label className='field'>
+							<span>Refund Tick</span>
+							<input value={forkAuctionForm.refundTick} onInput={event => onForkAuctionFormChange({ refundTick: event.currentTarget.value })} />
+						</label>
+						<label className='field'>
+							<span>Refund Bid Index</span>
+							<input value={forkAuctionForm.refundBidIndex} onInput={event => onForkAuctionFormChange({ refundBidIndex: event.currentTarget.value })} />
+						</label>
+						<div className='actions'>
+							<button className='primary' onClick={onRefundLosingBids} disabled={disabled || accountState.address === undefined || !isMainnet}>
+								Refund Losing Bid
+							</button>
+						</div>
+					</div>
+				</WorkflowSubsection>
+
+				<WorkflowSubsection title='Claim Auction Proceeds' className='fork-stage-actions'>
+					<div className='form-grid'>
+						<label className='field'>
+							<span>Vault Address</span>
+							<input value={forkAuctionForm.vaultAddress} onInput={event => onForkAuctionFormChange({ vaultAddress: event.currentTarget.value })} placeholder='Leave empty to use connected wallet' />
+						</label>
+						<div className='field-row'>
+							<label className='field'>
+								<span>Claim Bid Tick</span>
+								<input value={forkAuctionForm.claimBidTick} onInput={event => onForkAuctionFormChange({ claimBidTick: event.currentTarget.value })} />
+							</label>
+							<label className='field'>
+								<span>Claim Bid Index</span>
+								<input value={forkAuctionForm.claimBidIndex} onInput={event => onForkAuctionFormChange({ claimBidIndex: event.currentTarget.value })} />
+							</label>
+						</div>
+						<div className='actions'>
+							<button className='primary' onClick={onClaimAuctionProceeds} disabled={disabled || accountState.address === undefined || !isMainnet}>
+								Claim Auction Proceeds
+							</button>
+						</div>
+					</div>
+				</WorkflowSubsection>
+
+				<WorkflowSubsection title='Withdraw Bids' className='fork-stage-actions'>
+					<div className='form-grid'>
+						<div className='field-row'>
+							<label className='field'>
+								<span>Withdraw For Address</span>
+								<input value={forkAuctionForm.withdrawForAddress} onInput={event => onForkAuctionFormChange({ withdrawForAddress: event.currentTarget.value })} placeholder='Leave empty to use connected wallet' />
+							</label>
+							<label className='field'>
+								<span>Withdraw Tick</span>
+								<input value={forkAuctionForm.withdrawTick} onInput={event => onForkAuctionFormChange({ withdrawTick: event.currentTarget.value })} />
+							</label>
+						</div>
+						<label className='field'>
+							<span>Withdraw Bid Index</span>
+							<input value={forkAuctionForm.withdrawBidIndex} onInput={event => onForkAuctionFormChange({ withdrawBidIndex: event.currentTarget.value })} />
+						</label>
+						<div className='actions'>
+							<button className='secondary' onClick={onWithdrawBids} disabled={disabled || accountState.address === undefined || !isMainnet}>
+								Withdraw Bids
+							</button>
+						</div>
+					</div>
+				</WorkflowSubsection>
+			</fieldset>
+		)
+
+	const content = (
+		<>
+			<WorkflowSubsection title='Pool Summary' badge={selectedStageBadge}>
+				<div className='form-grid'>
+					{showSecurityPoolAddressInput ? (
+						<label className='field'>
+							<span>Security Pool Address</span>
+							<input value={forkAuctionForm.securityPoolAddress} onInput={event => onForkAuctionFormChange({ securityPoolAddress: event.currentTarget.value })} placeholder='0x...' />
+						</label>
+					) : undefined}
+
+					<div className='actions'>
+						<button className='secondary' onClick={onLoadForkAuction} disabled={loadingForkAuctionDetails}>
+							{loadingForkAuctionDetails ? <LoadingText>Loading fork...</LoadingText> : 'Refresh fork'}
+						</button>
+					</div>
+
+					{hasLoadedPoolContext ? renderSummaryMetricGrid(poolSummaryMetrics) : <p className='detail'>Load a pool to inspect fork progress, migration, and the truth auction.</p>}
+					{disabledMessage === undefined ? undefined : <p className='detail'>{disabledMessage}</p>}
+					{forkStageDescription === undefined ? undefined : <p className='detail'>{forkStageDescription}</p>}
+				</div>
+			</WorkflowSubsection>
+
+			{question === undefined ? undefined : (
+				<WorkflowSubsection title='Question'>
+					<Question question={question} />
+				</WorkflowSubsection>
+			)}
+
+			{hasLoadedPoolContext ? (
+				<WorkflowSubsection title='Live Snapshot' badge={<span className='badge muted'>{getStageLabel(selectedStage)}</span>}>
+					{renderSummaryMetricGrid(liveSnapshotMetrics)}
+				</WorkflowSubsection>
+			) : undefined}
+
+			{forkAuctionResult === undefined ? undefined : (
+				<LatestActionSection
+					title='Latest Fork / Auction Action'
+					embedInCard
+					badge={<span className='badge ok'>{forkAuctionResult.action}</span>}
+					rows={[
+						{ label: 'Action', value: forkAuctionResult.action },
+						{ label: 'Pool', value: <AddressValue address={forkAuctionResult.securityPoolAddress} /> },
+						{ label: 'Universe', value: <UniverseLink universeId={forkAuctionResult.universeId} /> },
+						{ label: 'Transaction', value: <TransactionHashLink hash={forkAuctionResult.hash} /> },
+					]}
+				/>
+			)}
+
+			{hasLoadedPoolContext ? (
+				<WorkflowSubsection title='Lifecycle' badge={<span className={`badge ${getStageTone(currentStage)}`}>{getStageLabel(currentStage)}</span>}>
+					<div className='subtab-nav fork-stage-nav' role='tablist' aria-label='Fork lifecycle stages'>
+						{STAGE_VIEWS.map(stageView => (
+							<button key={stageView} className={`subtab-link ${selectedStage === stageView ? 'active' : ''}`} type='button' onClick={() => setSelectedStage(stageView)} aria-pressed={selectedStage === stageView}>
+								{getStageLabel(stageView)}
+							</button>
+						))}
+					</div>
+					{selectedStageAheadMessage === undefined ? undefined : <p className='detail'>{selectedStageAheadMessage}</p>}
+				</WorkflowSubsection>
+			) : undefined}
+
+			{hasLoadedPoolContext ? stagePanel : undefined}
+
+			<ErrorNotice message={forkAuctionError} />
+		</>
+	)
+
+	if (embedInCard) {
+		return content
+	}
 
 	return (
 		<section className='panel market-panel'>
@@ -119,260 +620,9 @@ export function ForkAuctionSection({
 
 			<div className='market-grid'>
 				<div className='market-column'>
-					{securityPoolAddress === undefined ? undefined : (
-						<>
-							<div className='status-card'>
-								<p className='panel-label'>Loaded Pool</p>
-								<ul className='status-list hashes'>
-									<li>
-										<span>Security Pool</span>
-										<strong>{renderAddress(securityPoolAddress)}</strong>
-									</li>
-									<li>
-										<span>Universe</span>
-										<strong>{universeId === undefined ? UNKNOWN_VALUE : <UniverseLink universeId={universeId} />}</strong>
-									</li>
-									<li>
-										<span>Parent Pool</span>
-										<strong>{renderAddress(parentSecurityPoolAddress)}</strong>
-									</li>
-									<li>
-										<span>System State</span>
-										<strong>{systemState === undefined ? UNKNOWN_VALUE : getSystemStateLabel(systemState)}</strong>
-									</li>
-									<li>
-										<span>Final Question Outcome</span>
-										<strong>{forkAuctionDetails === undefined ? UNKNOWN_VALUE : getReportingOutcomeLabel(forkAuctionDetails.questionOutcome)}</strong>
-									</li>
-									<li>
-										<span>Fork Outcome</span>
-										<strong>{forkOutcome === undefined ? UNKNOWN_VALUE : getReportingOutcomeLabel(forkOutcome)}</strong>
-									</li>
-								</ul>
-								{question === undefined ? undefined : (
-									<div className='entity-card-subsection'>
-										<div className='entity-card-subsection-header'>
-											<h4>Question</h4>
-										</div>
-										<Question question={question} />
-									</div>
-								)}
-								{forkStageDescription === undefined ? undefined : <p className='detail'>{forkStageDescription}</p>}
-							</div>
-
-							<div className='status-card'>
-								<p className='panel-label'>Fork Metrics</p>
-								<div className='escalation-metrics'>
-									<MetricField label='REP At Fork'>{forkAuctionDetails === undefined ? forkOnlyFallbackText : <CurrencyValue value={forkAuctionDetails.repAtFork} suffix='REP' />}</MetricField>
-									<MetricField label='Migrated REP'>{renderMetricValue(forkAuctionDetails?.migratedRep ?? previewPool?.migratedRep, 'REP', UNKNOWN_VALUE)}</MetricField>
-									<MetricField label='Collateral'>{renderMetricValue(forkAuctionDetails?.completeSetCollateralAmount ?? previewPool?.completeSetCollateralAmount, 'REP', UNKNOWN_VALUE)}</MetricField>
-									<MetricField label='Fork Type'>{forkAuctionDetails === undefined ? getPreviewForkType(previewPool, hasPreviewForkActivity) : forkAuctionDetails.forkOwnSecurityPool ? 'Own escalation fork' : 'Parent/Zoltar fork'}</MetricField>
-									<MetricField label='Migration Ends'>{forkAuctionDetails === undefined ? migrationSummaryText : forkAuctionDetails.migrationEndsAt === undefined ? 'Started/finished' : <TimestampValue timestamp={forkAuctionDetails.migrationEndsAt} />}</MetricField>
-									<MetricField label='Migration Time Left'>{forkAuctionDetails === undefined ? forkOnlyFallbackText : migrationTimeRemaining === undefined ? formatDuration(MIGRATION_TIME_SECONDS) : formatDuration(migrationTimeRemaining)}</MetricField>
-								</div>
-							</div>
-
-							<div className='status-card'>
-								<p className='panel-label'>Truth Auction</p>
-								<div className='escalation-metrics'>
-									<MetricField label='Auction Address'>{renderAddress(truthAuctionAddress)}</MetricField>
-									<MetricField label='Started'>
-										{forkAuctionDetails === undefined
-											? previewPool?.truthAuctionStartedAt === undefined || previewPool.truthAuctionStartedAt === 0n
-												? 'Not started'
-												: renderTimestamp(previewPool.truthAuctionStartedAt, 'Not started')
-											: forkAuctionDetails.truthAuctionStartedAt === 0n
-												? 'Not started'
-												: renderTimestamp(forkAuctionDetails.truthAuctionStartedAt, 'Not started')}
-									</MetricField>
-									<MetricField label='Ends'>{auctionWindow === undefined ? 'Not started' : <TimestampValue timestamp={auctionWindow.endsAt} />}</MetricField>
-									<MetricField label='Time Left'>{forkAuctionDetails?.truthAuction?.timeRemaining === undefined ? (forkAuctionDetails?.truthAuction === undefined ? forkOnlyFallbackText : formatDuration(AUCTION_TIME_SECONDS)) : formatDuration(forkAuctionDetails.truthAuction.timeRemaining)}</MetricField>
-									<MetricField label='ETH Raised / Cap'>
-										{forkAuctionDetails?.truthAuction === undefined ? (
-											forkOnlyFallbackText
-										) : (
-											<Fragment>
-												<CurrencyValue value={forkAuctionDetails.truthAuction.ethRaised} suffix='ETH' /> / <CurrencyValue value={forkAuctionDetails.truthAuction.ethRaiseCap} suffix='ETH' />
-											</Fragment>
-										)}
-									</MetricField>
-									<MetricField label='REP Purchased'>{forkAuctionDetails?.truthAuction === undefined ? forkOnlyFallbackText : <CurrencyValue value={forkAuctionDetails.truthAuction.totalRepPurchased} suffix='REP' />}</MetricField>
-									<MetricField label='Clearing Tick'>{forkAuctionDetails?.truthAuction?.clearingTick?.toString() ?? (forkAuctionDetails?.truthAuction === undefined ? forkOnlyFallbackText : UNKNOWN_VALUE)}</MetricField>
-									<MetricField label='Clearing Price'>{forkAuctionDetails?.truthAuction === undefined ? forkOnlyFallbackText : renderMetricValue(forkAuctionDetails.truthAuction.clearingPrice, 'REP', UNKNOWN_VALUE)}</MetricField>
-									<MetricField label='Underfunded'>{forkAuctionDetails?.truthAuction === undefined ? forkOnlyFallbackText : forkAuctionDetails.truthAuction.underfunded ? 'Yes' : 'No'}</MetricField>
-									<MetricField label='Finalized'>{forkAuctionDetails?.truthAuction === undefined ? forkOnlyFallbackText : forkAuctionDetails.truthAuction.finalized ? 'Yes' : 'No'}</MetricField>
-								</div>
-								<p className='detail'>At the current clearing price, this bid would buy roughly {estimatedRep === undefined ? UNKNOWN_VALUE : <CurrencyValue value={estimatedRep} suffix='REP' />} if it clears.</p>
-							</div>
-
-							{forkAuctionResult === undefined ? undefined : (
-								<div className='status-card'>
-									<p className='panel-label'>Latest Fork / Auction Action</p>
-									<p className='detail'>Action: {forkAuctionResult.action}</p>
-									<p className='detail'>
-										Pool: <AddressValue address={forkAuctionResult.securityPoolAddress} />
-									</p>
-									<p className='detail'>
-										Universe: <UniverseLink universeId={forkAuctionResult.universeId} />
-									</p>
-									<p className='detail'>
-										Transaction: <TransactionHashLink hash={forkAuctionResult.hash} />
-									</p>
-								</div>
-							)}
-						</>
-					)}
-				</div>
-
-				<div className='market-column'>
-					<div className='form-grid'>
-						{showSecurityPoolAddressInput ? (
-							<label className='field'>
-								<span>Security Pool Address</span>
-								<input value={forkAuctionForm.securityPoolAddress} onInput={event => onForkAuctionFormChange({ securityPoolAddress: event.currentTarget.value })} placeholder='0x...' />
-							</label>
-						) : undefined}
-
-						<div className='actions'>
-							<button className='secondary' onClick={onLoadForkAuction} disabled={loadingForkAuctionDetails}>
-								{loadingForkAuctionDetails ? <LoadingText>Loading fork...</LoadingText> : 'Refresh fork'}
-							</button>
-						</div>
-
-						{disabledMessage === undefined ? undefined : <p className='detail'>{disabledMessage}</p>}
-
-						<fieldset className='fork-auction-controls' disabled={disabled}>
-							<label className='field'>
-								<span>Outcome</span>
-								<EnumDropdown options={REPORTING_OUTCOME_DROPDOWN_OPTIONS} value={forkAuctionForm.selectedOutcome} onChange={selectedOutcome => onForkAuctionFormChange({ selectedOutcome })} />
-							</label>
-
-							<label className='field'>
-								<span>REP Migration Outcomes</span>
-								<input value={forkAuctionForm.repMigrationOutcomes} onInput={event => onForkAuctionFormChange({ repMigrationOutcomes: event.currentTarget.value })} placeholder='yes,no,invalid' />
-							</label>
-
-							<label className='field'>
-								<span>Vault Address</span>
-								<input value={forkAuctionForm.claimVaultAddress} onInput={event => onForkAuctionFormChange({ claimVaultAddress: event.currentTarget.value })} placeholder='Leave empty to use connected wallet' />
-							</label>
-
-							<label className='field'>
-								<span>Escalation Deposit Indexes</span>
-								<input value={forkAuctionForm.depositIndexes} onInput={event => onForkAuctionFormChange({ depositIndexes: event.currentTarget.value })} placeholder='0,1,2' />
-							</label>
-
-							<div className='actions'>
-								<button className='primary' onClick={onForkWithOwnEscalation} disabled={disabled || accountState.address === undefined || !isMainnet}>
-									Fork With Own Escalation
-								</button>
-								<button className='secondary' onClick={onInitiateFork} disabled={disabled || accountState.address === undefined || !isMainnet}>
-									Initiate Pool Fork
-								</button>
-							</div>
-
-							<div className='field-row'>
-								<label className='field'>
-									<span>Direct Fork Universe ID</span>
-									<input value={forkAuctionForm.directForkUniverseId} onInput={event => onForkAuctionFormChange({ directForkUniverseId: event.currentTarget.value })} />
-								</label>
-								<label className='field'>
-									<span>Direct Fork Question ID</span>
-									<input value={forkAuctionForm.directForkQuestionId} onInput={event => onForkAuctionFormChange({ directForkQuestionId: event.currentTarget.value })} placeholder='0x...' />
-								</label>
-							</div>
-
-							<div className='actions'>
-								<button className='secondary' onClick={onForkUniverse} disabled={disabled || accountState.address === undefined || !isMainnet}>
-									Fork Universe Directly
-								</button>
-							</div>
-
-							<div className='actions'>
-								<button className='primary' onClick={onCreateChildUniverse} disabled={disabled || accountState.address === undefined || !isMainnet}>
-									Create {getOutcomeActionLabel(forkAuctionForm.selectedOutcome)} Child Universe
-								</button>
-								<button className='secondary' onClick={onMigrateRepToZoltar} disabled={disabled || accountState.address === undefined || !isMainnet}>
-									Migrate REP To Zoltar
-								</button>
-							</div>
-
-							<div className='actions'>
-								<button className='primary' onClick={onMigrateVault} disabled={disabled || accountState.address === undefined || !isMainnet}>
-									Migrate Vault
-								</button>
-								<button className='secondary' onClick={onMigrateEscalationDeposits} disabled={disabled || accountState.address === undefined || !isMainnet}>
-									Migrate Escalation Deposits
-								</button>
-							</div>
-
-							<label className='field'>
-								<span>Bid Tick</span>
-								<input value={forkAuctionForm.bidTick} onInput={event => onForkAuctionFormChange({ bidTick: event.currentTarget.value })} />
-							</label>
-							<label className='field'>
-								<span>Bid Amount (ETH)</span>
-								<input value={forkAuctionForm.bidAmount} onInput={event => onForkAuctionFormChange({ bidAmount: event.currentTarget.value })} />
-							</label>
-							<div className='actions'>
-								<button className='primary' onClick={onStartTruthAuction} disabled={disabled || accountState.address === undefined || !isMainnet}>
-									Start Truth Auction
-								</button>
-								<button className='secondary' onClick={onSubmitBid} disabled={disabled || accountState.address === undefined || !isMainnet}>
-									Submit Bid
-								</button>
-							</div>
-
-							<label className='field'>
-								<span>Refund Tick</span>
-								<input value={forkAuctionForm.refundTick} onInput={event => onForkAuctionFormChange({ refundTick: event.currentTarget.value })} />
-							</label>
-							<label className='field'>
-								<span>Refund Bid Index</span>
-								<input value={forkAuctionForm.refundBidIndex} onInput={event => onForkAuctionFormChange({ refundBidIndex: event.currentTarget.value })} />
-							</label>
-							<div className='actions'>
-								<button className='primary' onClick={onRefundLosingBids} disabled={disabled || accountState.address === undefined || !isMainnet}>
-									Refund Losing Bid
-								</button>
-								<button className='secondary' onClick={onFinalizeTruthAuction} disabled={disabled || accountState.address === undefined || !isMainnet}>
-									Finalize Truth Auction
-								</button>
-							</div>
-
-							<label className='field'>
-								<span>Claim Bid Index</span>
-								<input value={forkAuctionForm.bidIndex} onInput={event => onForkAuctionFormChange({ bidIndex: event.currentTarget.value })} />
-							</label>
-							<div className='actions'>
-								<button className='primary' onClick={onClaimAuctionProceeds} disabled={disabled || accountState.address === undefined || !isMainnet}>
-									Claim Auction Proceeds
-								</button>
-							</div>
-
-							<div className='field-row'>
-								<label className='field'>
-									<span>Withdraw For Address</span>
-									<input value={forkAuctionForm.withdrawForAddress} onInput={event => onForkAuctionFormChange({ withdrawForAddress: event.currentTarget.value })} placeholder='Leave empty to use connected wallet' />
-								</label>
-								<label className='field'>
-									<span>Withdraw Tick</span>
-									<input value={forkAuctionForm.withdrawTick} onInput={event => onForkAuctionFormChange({ withdrawTick: event.currentTarget.value })} />
-								</label>
-							</div>
-							<label className='field'>
-								<span>Withdraw Bid Index</span>
-								<input value={forkAuctionForm.withdrawBidIndex} onInput={event => onForkAuctionFormChange({ withdrawBidIndex: event.currentTarget.value })} />
-							</label>
-							<div className='actions'>
-								<button className='secondary' onClick={onWithdrawBids} disabled={disabled || accountState.address === undefined || !isMainnet}>
-									Withdraw Bids
-								</button>
-							</div>
-						</fieldset>
-					</div>
-
-					<ErrorNotice message={forkAuctionError} />
+					<EntityCard title='Fork & Truth Auction' badge={hasLoadedPoolContext ? selectedStageBadge : undefined}>
+						{content}
+					</EntityCard>
 				</div>
 			</div>
 		</section>

--- a/ui/ts/components/LatestActionSection.tsx
+++ b/ui/ts/components/LatestActionSection.tsx
@@ -1,0 +1,37 @@
+import type { ComponentChildren } from 'preact'
+import { EntityCard } from './EntityCard.js'
+import { WorkflowSubsection } from './WorkflowSubsection.js'
+
+type LatestActionSectionRow = {
+	label: string
+	value: ComponentChildren
+}
+
+type LatestActionSectionProps = {
+	badge?: ComponentChildren
+	embedInCard?: boolean
+	rows: LatestActionSectionRow[]
+	title: string
+}
+
+export function LatestActionSection({ badge, embedInCard = false, rows, title }: LatestActionSectionProps) {
+	const content = rows.map((row, index) => (
+		<p key={`${row.label}:${index.toString()}`} className='detail'>
+			{row.label}: {row.value}
+		</p>
+	))
+
+	if (embedInCard) {
+		return (
+			<WorkflowSubsection title={title} badge={badge}>
+				{content}
+			</WorkflowSubsection>
+		)
+	}
+
+	return (
+		<EntityCard title={title} badge={badge}>
+			{content}
+		</EntityCard>
+	)
+}

--- a/ui/ts/components/OpenOracleSection.tsx
+++ b/ui/ts/components/OpenOracleSection.tsx
@@ -6,12 +6,14 @@ import { CurrencyValue } from './CurrencyValue.js'
 import { EntityCard } from './EntityCard.js'
 import { EnumDropdown, type EnumDropdownOption } from './EnumDropdown.js'
 import { ErrorNotice } from './ErrorNotice.js'
+import { LatestActionSection } from './LatestActionSection.js'
 import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
 import { StateHint } from './StateHint.js'
 import { TokenApprovalControl } from './TokenApprovalControl.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { TimestampValue } from './TimestampValue.js'
+import { WorkflowSubsection } from './WorkflowSubsection.js'
 import { useLoadController } from '../hooks/useLoadController.js'
 import { createConnectedReadClient } from '../lib/clients.js'
 import { deriveOpenOracleInitialReportSubmissionDetails, formatOpenOracleFeePercentage, formatOpenOracleMultiplier, getOpenOracleReportStatus, getOpenOracleReportStatusTone, getOpenOracleSelectedReportActionMode, type OpenOracleSelectedReportActionMode } from '../lib/openOracle.js'
@@ -34,12 +36,9 @@ function renderReportField(label: string, value: ComponentChildren) {
 
 function renderReportSection(title: string, fields: Array<{ label: string; value: ComponentChildren }>) {
 	return (
-		<div className='entity-card-subsection'>
-			<div className='entity-card-subsection-header'>
-				<h4>{title}</h4>
-			</div>
+		<WorkflowSubsection title={title}>
 			<div className='question-summary-grid'>{fields.map(field => renderReportField(field.label, field.value))}</div>
-		</div>
+		</WorkflowSubsection>
 	)
 }
 
@@ -514,12 +513,14 @@ function renderLatestActionCard(action: OpenOracleSectionProps['openOracleResult
 	if (action === undefined) return undefined
 
 	return (
-		<EntityCard title='Latest Oracle Action' badge={<span className='badge ok'>{action.action}</span>}>
-			<p className='detail'>Action: {action.action}</p>
-			<p className='detail'>
-				Transaction: <TransactionHashLink hash={action.hash} />
-			</p>
-		</EntityCard>
+		<LatestActionSection
+			title='Latest Oracle Action'
+			badge={<span className='badge ok'>{action.action}</span>}
+			rows={[
+				{ label: 'Action', value: action.action },
+				{ label: 'Transaction', value: <TransactionHashLink hash={action.hash} /> },
+			]}
+		/>
 	)
 }
 

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -4,6 +4,7 @@ import { EnumDropdown } from './EnumDropdown.js'
 import { EntityCard } from './EntityCard.js'
 import { ErrorNotice } from './ErrorNotice.js'
 import { EscalationSide } from './EscalationSide.js'
+import { LatestActionSection } from './LatestActionSection.js'
 import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
 import { Question } from './Question.js'
@@ -189,38 +190,19 @@ export function ReportingSection({
 			</div>
 		)
 	const latestReportingAction =
-		reportingResult === undefined ? undefined : embedInCard ? (
-			<div className='entity-card-subsection'>
-				<div className='entity-card-subsection-header'>
-					<h4>Latest Reporting Action</h4>
-					<span className='badge ok'>{getReportingOutcomeLabel(reportingResult.outcome)}</span>
-				</div>
-				<p className='detail'>Action: {reportingResult.action}</p>
-				<p className='detail'>Outcome: {getReportingOutcomeLabel(reportingResult.outcome)}</p>
-				<p className='detail'>
-					Pool: <AddressValue address={reportingResult.securityPoolAddress} />
-				</p>
-				<p className='detail'>
-					Universe: <UniverseLink universeId={reportingResult.universeId} />
-				</p>
-				<p className='detail'>
-					Transaction: <TransactionHashLink hash={reportingResult.hash} />
-				</p>
-			</div>
-		) : (
-			<EntityCard title='Latest Reporting Action' badge={<span className='badge ok'>{getReportingOutcomeLabel(reportingResult.outcome)}</span>}>
-				<p className='detail'>Action: {reportingResult.action}</p>
-				<p className='detail'>Outcome: {getReportingOutcomeLabel(reportingResult.outcome)}</p>
-				<p className='detail'>
-					Pool: <AddressValue address={reportingResult.securityPoolAddress} />
-				</p>
-				<p className='detail'>
-					Universe: <UniverseLink universeId={reportingResult.universeId} />
-				</p>
-				<p className='detail'>
-					Transaction: <TransactionHashLink hash={reportingResult.hash} />
-				</p>
-			</EntityCard>
+		reportingResult === undefined ? undefined : (
+			<LatestActionSection
+				title='Latest Reporting Action'
+				badge={<span className='badge ok'>{getReportingOutcomeLabel(reportingResult.outcome)}</span>}
+				embedInCard={embedInCard}
+				rows={[
+					{ label: 'Action', value: reportingResult.action },
+					{ label: 'Outcome', value: getReportingOutcomeLabel(reportingResult.outcome) },
+					{ label: 'Pool', value: <AddressValue address={reportingResult.securityPoolAddress} /> },
+					{ label: 'Universe', value: <UniverseLink universeId={reportingResult.universeId} /> },
+					{ label: 'Transaction', value: <TransactionHashLink hash={reportingResult.hash} /> },
+				]}
+			/>
 		)
 	const actionsSection = (
 		<div className='form-grid'>

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -19,6 +19,7 @@ import { CurrencyValue } from './CurrencyValue.js'
 import { TimestampValue } from './TimestampValue.js'
 import { normalizeAddress, sameAddress } from '../lib/address.js'
 import { sameCaseInsensitiveText } from '../lib/caseInsensitive.js'
+import { hasForkActivity } from '../lib/forkAuction.js'
 import { resolveRequestedLoadableValueState, type LoadableValueState } from '../lib/loadState.js'
 import { isMainnetChain } from '../lib/network.js'
 import { getSelectedVaultAddress, isSelectedVaultOwnedByAccount as isSelectedVaultOwnedByAccountHelper } from '../lib/securityVault.js'
@@ -49,8 +50,8 @@ export function getSelectedPoolLookupDisplay({ hasSelectedPoolAddress, selectedP
 	return selectedPoolLookupState
 }
 
-export function isForkWorkflowDisabled(selectedPoolState: SecurityPoolSystemState | undefined) {
-	return selectedPoolState === undefined || selectedPoolState === 'operational'
+export function isForkWorkflowDisabled(selectedPoolState: SecurityPoolSystemState | undefined, selectedPoolHasForkActivity = false) {
+	return selectedPoolState === undefined || (selectedPoolState === 'operational' && !selectedPoolHasForkActivity)
 }
 
 export function getOracleLastPriceDisplay({ lastPrice, lastSettlementTimestamp }: { lastPrice: bigint; lastSettlementTimestamp: bigint }) {
@@ -104,9 +105,10 @@ export function SecurityPoolWorkflowSection({
 	})
 	const marketDetails = selectedPool?.marketDetails ?? reporting.reportingDetails?.marketDetails ?? forkAuction.forkAuctionDetails?.marketDetails
 	const selectedPoolState = selectedPool?.systemState ?? forkAuction.forkAuctionDetails?.systemState
+	const selectedPoolHasForkActivity = selectedPool !== undefined ? hasForkActivity(selectedPool) : forkAuction.forkAuctionDetails !== undefined ? hasForkActivity(forkAuction.forkAuctionDetails) : false
 	const currentTimestamp = reporting.reportingDetails?.currentTime ?? BigInt(Math.floor(Date.now() / 1000))
 	const reportingReady = marketDetails !== undefined && marketDetails.endTime <= currentTimestamp
-	const forkWorkflowDisabled = isForkWorkflowDisabled(selectedPoolState)
+	const forkWorkflowDisabled = isForkWorkflowDisabled(selectedPoolState, selectedPoolHasForkActivity)
 	const selectedPoolUniverseMismatch = selectedPool !== undefined && selectedPool.universeId !== activeUniverseId
 	const hasSelectedPoolAddress = securityPoolAddress.trim() !== ''
 	const showSelectedPoolWorkflowDetails = shouldShowSelectedPoolWorkflowDetails({
@@ -406,7 +408,15 @@ export function SecurityPoolWorkflowSection({
 								) : undefined}
 
 								<EntityCard className='selected-pool-card' title='Fork & Truth Auction' badge={<span className={`badge ${forkWorkflowDisabled ? 'blocked' : 'ok'}`}>{forkWorkflowDisabled ? 'Locked until fork' : 'Available'}</span>}>
-									<ForkAuctionSection {...forkAuction} disabled={forkWorkflowDisabled} disabledMessage={forkWorkflowDisabled ? 'This pool is currently operational, so fork and truth auction actions are read only.' : undefined} previewPool={selectedPool} showHeader={false} showSecurityPoolAddressInput={false} />
+									<ForkAuctionSection
+										{...forkAuction}
+										disabled={forkWorkflowDisabled}
+										disabledMessage={forkWorkflowDisabled ? 'This pool is currently operational, so fork and truth auction actions are read only.' : undefined}
+										embedInCard
+										previewPool={selectedPool}
+										showHeader={false}
+										showSecurityPoolAddressInput={false}
+									/>
 								</EntityCard>
 							</div>
 						) : undefined}

--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -5,6 +5,7 @@ import { CollateralizationMetricField } from './CollateralizationMetricField.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { EntityCard } from './EntityCard.js'
 import { ErrorNotice } from './ErrorNotice.js'
+import { LatestActionSection } from './LatestActionSection.js'
 import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
 import { StateHint } from './StateHint.js'
@@ -219,15 +220,14 @@ export function SecurityVaultSection({
 
 	const latestAction =
 		securityVaultResult === undefined ? undefined : (
-			<div className='entity-card-subsection'>
-				<div className='entity-card-subsection-header'>
-					<h4>Latest Vault Action</h4>
-				</div>
-				<p className='detail'>Action: {latestActionLabel}</p>
-				<p className='detail'>
-					Transaction: <TransactionHashLink hash={securityVaultResult.hash} />
-				</p>
-			</div>
+			<LatestActionSection
+				title='Latest Vault Action'
+				embedInCard
+				rows={[
+					{ label: 'Action', value: latestActionLabel ?? securityVaultResult.action },
+					{ label: 'Transaction', value: <TransactionHashLink hash={securityVaultResult.hash} /> },
+				]}
+			/>
 		)
 
 	const vaultDepositSection = (
@@ -356,16 +356,13 @@ export function SecurityVaultSection({
 					<EntityCard title='Selected Vault'>{vaultSummarySection}</EntityCard>
 
 					{securityVaultResult === undefined ? undefined : (
-						<EntityCard title='Latest Vault Action'>
-							<div className='entity-metric-grid'>
-								<MetricField className='entity-metric' label='Action'>
-									{securityVaultResult.action}
-								</MetricField>
-								<MetricField className='entity-metric' label='Transaction'>
-									<TransactionHashLink hash={securityVaultResult.hash} />
-								</MetricField>
-							</div>
-						</EntityCard>
+						<LatestActionSection
+							title='Latest Vault Action'
+							rows={[
+								{ label: 'Action', value: latestActionLabel ?? securityVaultResult.action },
+								{ label: 'Transaction', value: <TransactionHashLink hash={securityVaultResult.hash} /> },
+							]}
+						/>
 					)}
 				</div>
 

--- a/ui/ts/components/TradingSection.tsx
+++ b/ui/ts/components/TradingSection.tsx
@@ -2,6 +2,7 @@ import { AddressValue } from './AddressValue.js'
 import { EnumDropdown } from './EnumDropdown.js'
 import { EntityCard } from './EntityCard.js'
 import { ErrorNotice } from './ErrorNotice.js'
+import { LatestActionSection } from './LatestActionSection.js'
 import { MetricField } from './MetricField.js'
 import { OpenInterestCapacityMetrics } from './OpenInterestCapacityMetrics.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
@@ -82,32 +83,18 @@ export function TradingSection({
 		return formatCurrencyBalance(value)
 	}
 	const latestTradingAction =
-		tradingResult === undefined ? undefined : embedInCard ? (
-			<div className='entity-card-subsection'>
-				<div className='entity-card-subsection-header'>
-					<h4>Latest Trading Action</h4>
-					<span className='badge ok'>{tradingResult.action}</span>
-				</div>
-				<p className='detail'>Action: {tradingResult.action}</p>
-				<p className='detail'>Pool: {tradingResult.securityPoolAddress}</p>
-				<p className='detail'>
-					Universe: <UniverseLink universeId={tradingResult.universeId} />
-				</p>
-				<p className='detail'>
-					Transaction: <TransactionHashLink hash={tradingResult.hash} />
-				</p>
-			</div>
-		) : (
-			<EntityCard title='Latest Trading Action' badge={<span className='badge ok'>{tradingResult.action}</span>}>
-				<p className='detail'>Action: {tradingResult.action}</p>
-				<p className='detail'>Pool: {tradingResult.securityPoolAddress}</p>
-				<p className='detail'>
-					Universe: <UniverseLink universeId={tradingResult.universeId} />
-				</p>
-				<p className='detail'>
-					Transaction: <TransactionHashLink hash={tradingResult.hash} />
-				</p>
-			</EntityCard>
+		tradingResult === undefined ? undefined : (
+			<LatestActionSection
+				title='Latest Trading Action'
+				badge={<span className='badge ok'>{tradingResult.action}</span>}
+				embedInCard={embedInCard}
+				rows={[
+					{ label: 'Action', value: tradingResult.action },
+					{ label: 'Pool', value: tradingResult.securityPoolAddress },
+					{ label: 'Universe', value: <UniverseLink universeId={tradingResult.universeId} /> },
+					{ label: 'Transaction', value: <TransactionHashLink hash={tradingResult.hash} /> },
+				]}
+			/>
 		)
 	const poolSection =
 		!showSecurityPoolAddressInput && selectedPool === undefined ? undefined : (

--- a/ui/ts/components/WorkflowSubsection.tsx
+++ b/ui/ts/components/WorkflowSubsection.tsx
@@ -1,0 +1,22 @@
+import type { ComponentChildren } from 'preact'
+
+type WorkflowSubsectionProps = {
+	badge?: ComponentChildren
+	children: ComponentChildren
+	className?: string
+	title?: ComponentChildren
+}
+
+export function WorkflowSubsection({ badge, children, className = '', title }: WorkflowSubsectionProps) {
+	return (
+		<div className={`entity-card-subsection ${className}`.trim()}>
+			{title === undefined && badge === undefined ? undefined : (
+				<div className='entity-card-subsection-header'>
+					{title === undefined ? <span /> : <h4>{title}</h4>}
+					{badge}
+				</div>
+			)}
+			{children}
+		</div>
+	)
+}

--- a/ui/ts/hooks/useForkAuctionOperations.ts
+++ b/ui/ts/hooks/useForkAuctionOperations.ts
@@ -88,7 +88,7 @@ export function useForkAuctionOperations({ accountAddress, onTransaction, onTran
 
 	const migrateEscalation = async () =>
 		await runForkAuctionAction(async (walletAddress, details) => {
-			const vaultAddress = resolveOptionalAddressInput(forkAuctionForm.value.claimVaultAddress, walletAddress, 'Vault address')
+			const vaultAddress = resolveOptionalAddressInput(forkAuctionForm.value.vaultAddress, walletAddress, 'Vault address')
 			return await migrateEscalationDeposits(
 				createWalletWriteClient(walletAddress, { onTransactionSubmitted }),
 				details.securityPoolAddress,
@@ -104,7 +104,7 @@ export function useForkAuctionOperations({ accountAddress, onTransaction, onTran
 	const submitBid = async () =>
 		await runForkAuctionAction(async (walletAddress, details) => {
 			const truthAuctionAddress = requireDefined(details.truthAuctionAddress, 'Truth auction not available')
-			return await submitTruthAuctionBid(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), details.securityPoolAddress, details.universeId, truthAuctionAddress, parseBigIntInput(forkAuctionForm.value.bidTick, 'Bid tick'), parseBigIntInput(forkAuctionForm.value.bidAmount, 'Bid amount'))
+			return await submitTruthAuctionBid(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), details.securityPoolAddress, details.universeId, truthAuctionAddress, parseBigIntInput(forkAuctionForm.value.submitBidTick, 'Bid tick'), parseBigIntInput(forkAuctionForm.value.submitBidAmount, 'Bid amount'))
 		}, 'Failed to submit truth auction bid')
 
 	const refundLosingBids = async () =>
@@ -124,8 +124,8 @@ export function useForkAuctionOperations({ accountAddress, onTransaction, onTran
 
 	const claimAuctionProceeds = async () =>
 		await runForkAuctionAction(async (walletAddress, details) => {
-			const vaultAddress = resolveOptionalAddressInput(forkAuctionForm.value.claimVaultAddress, walletAddress, 'Vault address')
-			return await claimSecurityPoolAuctionProceeds(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), details.securityPoolAddress, details.universeId, vaultAddress, parseBigIntInput(forkAuctionForm.value.bidTick, 'Bid tick'), parseBigIntInput(forkAuctionForm.value.bidIndex, 'Bid index'))
+			const vaultAddress = resolveOptionalAddressInput(forkAuctionForm.value.vaultAddress, walletAddress, 'Vault address')
+			return await claimSecurityPoolAuctionProceeds(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), details.securityPoolAddress, details.universeId, vaultAddress, parseBigIntInput(forkAuctionForm.value.claimBidTick, 'Bid tick'), parseBigIntInput(forkAuctionForm.value.claimBidIndex, 'Bid index'))
 		}, 'Failed to claim auction proceeds')
 
 	const forkUniverse = async () =>

--- a/ui/ts/lib/forkAuction.ts
+++ b/ui/ts/lib/forkAuction.ts
@@ -1,4 +1,4 @@
-import type { ForkAuctionDetails, ListedSecurityPool, ReportingOutcomeKey, SecurityPoolSystemState } from '../types/contracts.js'
+import type { ForkAuctionDetails, ListedSecurityPool, ReportingOutcomeKey, SecurityPoolSystemState, TruthAuctionMetrics } from '../types/contracts.js'
 import { assertNever } from './assert.js'
 import { getTimeRemaining as getSharedTimeRemaining } from './time.js'
 import { getReportingOutcomeLabel } from './reporting.js'
@@ -8,6 +8,17 @@ const SECONDS_PER_WEEK = 7n * 24n * 60n * 60n
 export const MIGRATION_TIME_SECONDS = 8n * SECONDS_PER_WEEK
 export const AUCTION_TIME_SECONDS = SECONDS_PER_WEEK
 const PRICE_PRECISION = 10n ** 18n
+
+export type ForkAuctionStageView = 'initiate' | 'migration' | 'auction' | 'settlement'
+
+type ForkAuctionStageSource = {
+	claimingAvailable?: boolean
+	forkOutcome: ReportingOutcomeKey | 'none'
+	migratedRep: bigint
+	systemState: SecurityPoolSystemState
+	truthAuction?: Pick<TruthAuctionMetrics, 'finalized'> | undefined
+	truthAuctionStartedAt: bigint
+}
 
 export function getSystemStateLabel(state: SecurityPoolSystemState) {
 	switch (state) {
@@ -49,6 +60,19 @@ export function getForkStageDescription(details: ForkAuctionDetails) {
 
 export function hasForkActivity(pool: Pick<ListedSecurityPool, 'forkOutcome' | 'migratedRep' | 'systemState' | 'truthAuctionStartedAt'>) {
 	return pool.systemState !== 'operational' || pool.truthAuctionStartedAt > 0n || pool.migratedRep > 0n || pool.forkOutcome !== 'none'
+}
+
+export function getForkAuctionStageView(source: ForkAuctionStageSource): ForkAuctionStageView {
+	if (source.truthAuction !== undefined) {
+		if (!source.truthAuction.finalized) return 'auction'
+		return 'settlement'
+	}
+
+	if (source.systemState === 'forkTruthAuction') return 'auction'
+	if (source.claimingAvailable === true) return 'settlement'
+	if (source.systemState === 'operational' && hasForkActivity(source)) return 'settlement'
+	if (source.systemState === 'poolForked' || source.systemState === 'forkMigration' || source.migratedRep > 0n) return 'migration'
+	return 'initiate'
 }
 
 export function getTimeRemaining(targetTime: bigint | undefined, currentTime: bigint) {

--- a/ui/ts/lib/marketForm.ts
+++ b/ui/ts/lib/marketForm.ts
@@ -85,10 +85,8 @@ export function getDefaultReportingFormState(): ReportingFormState {
 
 export function getDefaultForkAuctionFormState(): ForkAuctionFormState {
 	return {
-		bidAmount: '0',
-		bidIndex: '0',
-		bidTick: '0',
-		claimVaultAddress: '',
+		claimBidIndex: '0',
+		claimBidTick: '0',
 		depositIndexes: '',
 		directForkQuestionId: '',
 		directForkUniverseId: '0',
@@ -97,6 +95,9 @@ export function getDefaultForkAuctionFormState(): ForkAuctionFormState {
 		repMigrationOutcomes: 'yes',
 		securityPoolAddress: '',
 		selectedOutcome: 'yes',
+		submitBidAmount: '0',
+		submitBidTick: '0',
+		vaultAddress: '',
 		withdrawBidIndex: '0',
 		withdrawForAddress: '',
 		withdrawTick: '0',

--- a/ui/ts/tests/forkAuction.test.ts
+++ b/ui/ts/tests/forkAuction.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from 'bun:test'
-import { getForkStageDescriptionForState, getOutcomeActionLabel, hasForkActivity } from '../lib/forkAuction.js'
+import { getForkAuctionStageView, getForkStageDescriptionForState, getOutcomeActionLabel, hasForkActivity } from '../lib/forkAuction.js'
 
 void describe('fork auction helpers', () => {
 	void test('getOutcomeActionLabel reuses reporting labels', () => {
@@ -44,5 +44,51 @@ void describe('fork auction helpers', () => {
 				truthAuctionStartedAt: 0n,
 			}),
 		).toBe(true)
+	})
+
+	void test('derives lifecycle stage for pre-fork, migration, auction, and settlement states', () => {
+		expect(
+			getForkAuctionStageView({
+				claimingAvailable: false,
+				forkOutcome: 'none',
+				migratedRep: 0n,
+				systemState: 'operational',
+				truthAuction: undefined,
+				truthAuctionStartedAt: 0n,
+			}),
+		).toBe('initiate')
+
+		expect(
+			getForkAuctionStageView({
+				claimingAvailable: false,
+				forkOutcome: 'none',
+				migratedRep: 1n,
+				systemState: 'forkMigration',
+				truthAuction: undefined,
+				truthAuctionStartedAt: 0n,
+			}),
+		).toBe('migration')
+
+		expect(
+			getForkAuctionStageView({
+				claimingAvailable: false,
+				forkOutcome: 'none',
+				migratedRep: 1n,
+				systemState: 'forkTruthAuction',
+				truthAuction: { finalized: false },
+				truthAuctionStartedAt: 1n,
+			}),
+		).toBe('auction')
+
+		expect(
+			getForkAuctionStageView({
+				claimingAvailable: false,
+				forkOutcome: 'yes',
+				migratedRep: 1n,
+				systemState: 'operational',
+				truthAuction: undefined,
+				truthAuctionStartedAt: 1n,
+			}),
+		).toBe('settlement')
 	})
 })

--- a/ui/ts/tests/securityPoolWorkflow.test.ts
+++ b/ui/ts/tests/securityPoolWorkflow.test.ts
@@ -103,6 +103,7 @@ void describe('selected pool workflow visibility', () => {
 	void test('disables the fork workflow only while the selected pool remains operational', () => {
 		expect(isForkWorkflowDisabled(undefined)).toBe(true)
 		expect(isForkWorkflowDisabled('operational')).toBe(true)
+		expect(isForkWorkflowDisabled('operational', true)).toBe(false)
 		expect(isForkWorkflowDisabled('poolForked')).toBe(false)
 		expect(isForkWorkflowDisabled('forkMigration')).toBe(false)
 		expect(isForkWorkflowDisabled('forkTruthAuction')).toBe(false)

--- a/ui/ts/types/app.ts
+++ b/ui/ts/types/app.ts
@@ -86,10 +86,8 @@ export type ReportingFormState = {
 }
 
 export type ForkAuctionFormState = {
-	bidAmount: string
-	bidIndex: string
-	bidTick: string
-	claimVaultAddress: string
+	claimBidIndex: string
+	claimBidTick: string
 	depositIndexes: string
 	directForkQuestionId: string
 	directForkUniverseId: string
@@ -98,6 +96,9 @@ export type ForkAuctionFormState = {
 	repMigrationOutcomes: string
 	securityPoolAddress: string
 	selectedOutcome: ReportingOutcomeKey
+	submitBidAmount: string
+	submitBidTick: string
+	vaultAddress: string
 	withdrawBidIndex: string
 	withdrawForAddress: string
 	withdrawTick: string

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -378,6 +378,7 @@ export type ForkAuctionRouteContentProps = {
 export type ForkAuctionSectionProps = ForkAuctionRouteContentProps & {
 	disabled?: boolean
 	disabledMessage?: string | undefined
+	embedInCard?: boolean
 	previewPool?: ListedSecurityPool | undefined
 	showSecurityPoolAddressInput?: boolean
 	showHeader?: boolean


### PR DESCRIPTION
## Summary
- Reworked the fork and truth auction section into stage-based panels for initiate, migration, auction, and settlement flows.
- Added a new workflow subsection component and refreshed styling for summary metrics and staged controls.
- Expanded fork auction state handling, form fields, and helpers to support the staged UI and clearer action grouping.
- Updated related sections and tests to align with the new fork auction flow and reordered oracle controls.

## Testing
- Not run