### PR TITLE
Refresh pool data only when reopening the same selection

### DIFF
--- a/ui/ts/components/SecurityPoolsSection.tsx
+++ b/ui/ts/components/SecurityPoolsSection.tsx
@@ -2,13 +2,17 @@ import { useState } from 'preact/hooks'
 import { SecurityPoolSection } from './SecurityPoolSection.js'
 import { SecurityPoolWorkflowSection } from './SecurityPoolWorkflowSection.js'
 import { SecurityPoolsOverviewSection } from './SecurityPoolsOverviewSection.js'
+import { sameCaseInsensitiveText } from '../lib/caseInsensitive.js'
 import { resolveFirstMatchingValue } from '../lib/viewState.js'
 import type { SecurityPoolsSectionProps } from '../types/components.js'
 
 type SecurityPoolsView = 'browse' | 'create' | 'operate'
 
-export function shouldRefreshSelectedPoolDataOnViewOpen({ nextView, securityPoolAddress }: { nextView: SecurityPoolsView; securityPoolAddress: string }) {
-	return nextView === 'operate' && securityPoolAddress.trim() !== ''
+export function shouldRefreshSelectedPoolDataOnViewOpen({ currentSecurityPoolAddress, nextSecurityPoolAddress, nextView }: { currentSecurityPoolAddress: string; nextSecurityPoolAddress?: string | undefined; nextView: SecurityPoolsView }) {
+	if (nextView !== 'operate') return false
+	const resolvedSecurityPoolAddress = nextSecurityPoolAddress ?? currentSecurityPoolAddress
+	if (resolvedSecurityPoolAddress.trim() === '') return false
+	return sameCaseInsensitiveText(currentSecurityPoolAddress, resolvedSecurityPoolAddress)
 }
 
 export function SecurityPoolsSection({ createPool, overview, workflow }: SecurityPoolsSectionProps) {
@@ -21,9 +25,17 @@ export function SecurityPoolsSection({ createPool, overview, workflow }: Securit
 			'browse',
 		),
 	)
-	const openView = (nextView: SecurityPoolsView) => {
+	const openView = (nextView: SecurityPoolsView, nextSecurityPoolAddress?: string) => {
 		setView(nextView)
-		if (!shouldRefreshSelectedPoolDataOnViewOpen({ nextView, securityPoolAddress: workflow.securityPoolAddress })) return
+		if (
+			!shouldRefreshSelectedPoolDataOnViewOpen({
+				currentSecurityPoolAddress: workflow.securityPoolAddress,
+				nextSecurityPoolAddress,
+				nextView,
+			})
+		) {
+			return
+		}
 		workflow.onRefreshSelectedPoolData()
 	}
 
@@ -46,7 +58,7 @@ export function SecurityPoolsSection({ createPool, overview, workflow }: Securit
 					{...overview}
 					onSelectSecurityPool={securityPoolAddress => {
 						workflow.onSecurityPoolAddressChange(securityPoolAddress)
-						setView('operate')
+						openView('operate', securityPoolAddress)
 					}}
 				/>
 			) : undefined}
@@ -57,7 +69,7 @@ export function SecurityPoolsSection({ createPool, overview, workflow }: Securit
 					showHeader={false}
 					onOpenCreatedPool={securityPoolAddress => {
 						workflow.onSecurityPoolAddressChange(securityPoolAddress)
-						setView('operate')
+						openView('operate', securityPoolAddress)
 					}}
 				/>
 			) : undefined}

--- a/ui/ts/tests/securityPoolsSection.test.ts
+++ b/ui/ts/tests/securityPoolsSection.test.ts
@@ -4,35 +4,48 @@ import { describe, expect, test } from 'bun:test'
 import { shouldRefreshSelectedPoolDataOnViewOpen } from '../components/SecurityPoolsSection.js'
 
 void describe('security pools selected tab refresh', () => {
-	const securityPoolAddress = '0x1234567890123456789012345678901234567890'
+	const currentSecurityPoolAddress = '0x1234567890123456789012345678901234567890'
+	const nextSecurityPoolAddress = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
 
-	void test('refreshes selected pool data only when opening the selected pool view with a filled address', () => {
+	void test('refreshes selected pool data only when reopening the selected pool view for the same address', () => {
 		expect(
 			shouldRefreshSelectedPoolDataOnViewOpen({
+				currentSecurityPoolAddress,
 				nextView: 'browse',
-				securityPoolAddress,
+				nextSecurityPoolAddress: currentSecurityPoolAddress,
 			}),
 		).toBe(false)
 
 		expect(
 			shouldRefreshSelectedPoolDataOnViewOpen({
+				currentSecurityPoolAddress,
 				nextView: 'create',
-				securityPoolAddress,
+				nextSecurityPoolAddress: currentSecurityPoolAddress,
 			}),
 		).toBe(false)
 
 		expect(
 			shouldRefreshSelectedPoolDataOnViewOpen({
+				currentSecurityPoolAddress,
 				nextView: 'operate',
-				securityPoolAddress: '',
+				nextSecurityPoolAddress: '',
 			}),
 		).toBe(false)
 
 		expect(
 			shouldRefreshSelectedPoolDataOnViewOpen({
+				currentSecurityPoolAddress,
 				nextView: 'operate',
-				securityPoolAddress,
+				nextSecurityPoolAddress: currentSecurityPoolAddress,
 			}),
 		).toBe(true)
+
+		expect(
+			shouldRefreshSelectedPoolDataOnViewOpen({
+				currentSecurityPoolAddress,
+				nextView: 'operate',
+				nextSecurityPoolAddress,
+			}),
+		).toBe(false)
 	})
 })


### PR DESCRIPTION
## Summary
- Updated `SecurityPoolsSection` so selected pool data refreshes only when reopening the operate view for the same pool address.
- Added case-insensitive address comparison to avoid unnecessary refreshes when selecting a different pool.
- Expanded tests to cover browse, create, empty-address, same-address, and different-address cases.

## Testing
- Not run (PR content only)
- Covered by updated unit test assertions in `ui/ts/tests/securityPoolsSection.test.ts`