### PR TITLE
Track Multicall3 deployment and streamline open oracle reporting

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.3.11",
+        "@testing-library/dom": "10.4.1",
         "@types/bun": "1.3.11",
         "@types/node": "22.13.10",
         "@zoltu/file-copier": "3.0.0",
@@ -16,6 +17,7 @@
         "bun-types": "1.3.11",
         "esbuild": "0.25.8",
         "funtypes": "5.1.1",
+        "happy-dom": "20.9.0",
         "knip": "5.86.0",
         "preact": "10.26.4",
         "typescript": "5.8.2",
@@ -24,6 +26,12 @@
   },
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "@biomejs/biome": ["@biomejs/biome@2.3.11", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.11", "@biomejs/cli-darwin-x64": "2.3.11", "@biomejs/cli-linux-arm64": "2.3.11", "@biomejs/cli-linux-arm64-musl": "2.3.11", "@biomejs/cli-linux-x64": "2.3.11", "@biomejs/cli-linux-x64-musl": "2.3.11", "@biomejs/cli-win32-arm64": "2.3.11", "@biomejs/cli-win32-x64": "2.3.11" }, "bin": { "biome": "bin/biome" } }, "sha512-/zt+6qazBWguPG6+eWmiELqO+9jRsMZ/DBU3lfuU2ngtIQYzymocHhKiZRyrbra4aCOoyTg/BmY+6WH5mv9xmQ=="],
 
@@ -165,11 +173,19 @@
 
     "@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@types/node": ["@types/node@22.13.10", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw=="],
+
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@typescript/lib-decorators": ["@better-typescript-lib/decorators@2.11.0", "", { "peerDependencies": { "typescript": ">=4.5.2" } }, "sha512-ZL90jrzAhnvDr/fbpJt3CgGZdWvAeoAWznp56/mHJRKrCwsaJ9uCPqU09D21FJkWsmZ2jkz+mwBI9+e5dzwFvg=="],
 
@@ -209,11 +225,23 @@
 
     "abitype": ["abitype@1.1.0", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A=="],
 
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
     "better-typescript-lib": ["better-typescript-lib@2.11.0", "", { "dependencies": { "@typescript/lib-decorators": "npm:@better-typescript-lib/decorators@2.11.0", "@typescript/lib-dom": "npm:@better-typescript-lib/dom@2.11.0", "@typescript/lib-es2015": "npm:@better-typescript-lib/es2015@2.11.0", "@typescript/lib-es2016": "npm:@better-typescript-lib/es2016@2.11.0", "@typescript/lib-es2017": "npm:@better-typescript-lib/es2017@2.11.0", "@typescript/lib-es2018": "npm:@better-typescript-lib/es2018@2.11.0", "@typescript/lib-es2019": "npm:@better-typescript-lib/es2019@2.11.0", "@typescript/lib-es2020": "npm:@better-typescript-lib/es2020@2.11.0", "@typescript/lib-es2021": "npm:@better-typescript-lib/es2021@2.11.0", "@typescript/lib-es2022": "npm:@better-typescript-lib/es2022@2.11.0", "@typescript/lib-es2023": "npm:@better-typescript-lib/es2023@2.11.0", "@typescript/lib-es2024": "npm:@better-typescript-lib/es2024@2.11.0", "@typescript/lib-es5": "npm:@better-typescript-lib/es5@2.11.0", "@typescript/lib-es6": "npm:@better-typescript-lib/es6@2.11.0", "@typescript/lib-esnext": "npm:@better-typescript-lib/esnext@2.11.0", "@typescript/lib-scripthost": "npm:@better-typescript-lib/scripthost@2.11.0", "@typescript/lib-webworker": "npm:@better-typescript-lib/webworker@2.11.0" }, "peerDependencies": { "typescript": ">=4.5.2" } }, "sha512-dwaPodcG5lVepyeoEmwRSpRqKWOso5CRktnMcPKlE4jjcHLGjkBhZXIMe6EFD9ALG/Ru3kwOO1t6TNNQ6Pf1Jw=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "esbuild": ["esbuild@0.25.8", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.8", "@esbuild/android-arm": "0.25.8", "@esbuild/android-arm64": "0.25.8", "@esbuild/android-x64": "0.25.8", "@esbuild/darwin-arm64": "0.25.8", "@esbuild/darwin-x64": "0.25.8", "@esbuild/freebsd-arm64": "0.25.8", "@esbuild/freebsd-x64": "0.25.8", "@esbuild/linux-arm": "0.25.8", "@esbuild/linux-arm64": "0.25.8", "@esbuild/linux-ia32": "0.25.8", "@esbuild/linux-loong64": "0.25.8", "@esbuild/linux-mips64el": "0.25.8", "@esbuild/linux-ppc64": "0.25.8", "@esbuild/linux-riscv64": "0.25.8", "@esbuild/linux-s390x": "0.25.8", "@esbuild/linux-x64": "0.25.8", "@esbuild/netbsd-arm64": "0.25.8", "@esbuild/netbsd-x64": "0.25.8", "@esbuild/openbsd-arm64": "0.25.8", "@esbuild/openbsd-x64": "0.25.8", "@esbuild/openharmony-arm64": "0.25.8", "@esbuild/sunos-x64": "0.25.8", "@esbuild/win32-arm64": "0.25.8", "@esbuild/win32-ia32": "0.25.8", "@esbuild/win32-x64": "0.25.8" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q=="],
 
@@ -233,6 +261,8 @@
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
+
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
@@ -243,7 +273,11 @@
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
     "knip": ["knip@5.86.0", "", { "dependencies": { "@nodelib/fs.walk": "^1.2.3", "fast-glob": "^3.3.3", "formatly": "^0.3.0", "jiti": "^2.6.0", "minimist": "^1.2.8", "oxc-resolver": "^11.19.1", "picocolors": "^1.1.1", "picomatch": "^4.0.1", "smol-toml": "^1.5.2", "strip-json-comments": "5.0.3", "unbash": "^2.2.0", "yaml": "^2.8.2", "zod": "^4.1.11" }, "peerDependencies": { "@types/node": ">=18", "typescript": ">=5.0.4 <7" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-tGpRCbP+L+VysXnAp1bHTLQ0k/SdC3M3oX18+Cpiqax1qdS25iuCPzpK8LVmAKARZv0Ijri81Wq09Rzk0JTl+Q=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
@@ -261,7 +295,11 @@
 
     "preact": ["preact@10.26.4", "", {}, "sha512-KJhO7LBFTjP71d83trW+Ilnjbo+ySsaAgCfXOXUlmGzJ4ygYPWmysm77yg4emwfmoz3b22yvH5IsVFHbhUaH5w=="],
 
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
@@ -285,16 +323,26 @@
 
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
 
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
     "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
     "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
+    "@types/ws/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
     "bun-types/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "happy-dom/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
+    "@types/ws/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
     "bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "happy-dom/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,13 +5,15 @@
 	"type": "module",
 	"devDependencies": {
 		"@biomejs/biome": "2.3.11",
-		"@types/node": "22.13.10",
+		"@testing-library/dom": "10.4.1",
 		"@types/bun": "1.3.11",
+		"@types/node": "22.13.10",
 		"@zoltu/file-copier": "3.0.0",
 		"better-typescript-lib": "2.11.0",
 		"bun-types": "1.3.11",
 		"esbuild": "0.25.8",
 		"funtypes": "5.1.1",
+		"happy-dom": "20.9.0",
 		"knip": "5.86.0",
 		"preact": "10.26.4",
 		"typescript": "5.8.2"

--- a/ui/build/tests.mts
+++ b/ui/build/tests.mts
@@ -31,6 +31,8 @@ async function buildTests() {
 		const transformed = await esbuild.transform(source, {
 			format: 'esm',
 			loader: path.extname(testFile) === '.tsx' ? 'tsx' : 'ts',
+			jsx: 'automatic',
+			jsxImportSource: 'preact',
 			sourcefile: path.relative(UI_ROOT_PATH, testFile),
 			target: 'esnext',
 		})

--- a/ui/ts/components/OpenOracleSection.tsx
+++ b/ui/ts/components/OpenOracleSection.tsx
@@ -135,27 +135,6 @@ export function renderSelectedReportActionSection(
 							</div>
 						</div>
 						<p className='detail'>Price source: {showQuoteLoadingPlaceholder ? <strong>Loading...</strong> : renderInitialPriceSourceLabel(initialReportSubmission.priceSource, initialReportSubmission.priceSourceUrl)}</p>
-						{!initialReportSubmission.hasWethWrapAction ? undefined : (
-							<div className='entity-card-subsection'>
-								{initialReportSubmission.requiredWethWrapAmount === undefined || initialReportSubmission.requiredWethWrapAmount <= 0n ? undefined : (
-									<p className='detail'>
-										Need <CurrencyValue value={initialReportSubmission.requiredWethWrapAmount} suffix='WETH' copyable={false} /> more WETH for this report.
-									</p>
-								)}
-								{initialReportSubmission.wrapRequiredWethMessage?.kind !== 'visible' ? undefined : <p className='detail'>{initialReportSubmission.wrapRequiredWethMessage.message}</p>}
-								<div className='actions'>
-									<button
-										className='secondary'
-										type='button'
-										onClick={onWrapWethForInitialReport}
-										disabled={!isConnected || !initialReportSubmission.canWrapRequiredWeth || openOracleActiveAction === 'wrapWeth'}
-										title={initialReportSubmission.wrapRequiredWethMessage?.kind === 'visible' ? initialReportSubmission.wrapRequiredWethMessage.message : undefined}
-									>
-										{openOracleActiveAction === 'wrapWeth' ? <LoadingText>Wrapping ETH...</LoadingText> : 'Wrap needed ETH to WETH'}
-									</button>
-								</div>
-							</div>
-						)}
 						<div className='entity-card-subsection'>
 							<div className='entity-card-subsection-header'>
 								<h4>{`${token1Symbol} Approval`}</h4>
@@ -195,9 +174,26 @@ export function renderSelectedReportActionSection(
 								tokenUnits={initialReportSubmission.token2Decimals ?? 18}
 							/>
 						</div>
+						{initialReportSubmission.requiredWethWrapAmount === undefined || initialReportSubmission.requiredWethWrapAmount <= 0n ? undefined : (
+							<p className='detail'>
+								Need <CurrencyValue value={initialReportSubmission.requiredWethWrapAmount} suffix='WETH' copyable={false} /> more WETH for this report.
+							</p>
+						)}
+						{initialReportSubmission.wrapRequiredWethMessage?.kind !== 'visible' ? undefined : <p className='detail'>{initialReportSubmission.wrapRequiredWethMessage.message}</p>}
 						<ErrorNotice message={initialReportSubmission.blockMessage?.kind === 'visible' ? initialReportSubmission.blockMessage.message : undefined} />
 						<div className='actions'>
-							<button className='primary' onClick={onSubmitInitialReport} disabled={!isConnected || !initialReportSubmission.canSubmit || openOracleActiveAction === 'submitInitialReport'}>
+							{!initialReportSubmission.hasWethWrapAction ? undefined : (
+								<button
+									className='secondary'
+									type='button'
+									onClick={onWrapWethForInitialReport}
+									disabled={!isConnected || !initialReportSubmission.canWrapRequiredWeth || openOracleActiveAction === 'wrapWeth'}
+									title={initialReportSubmission.wrapRequiredWethMessage?.kind === 'visible' ? initialReportSubmission.wrapRequiredWethMessage.message : undefined}
+								>
+									{openOracleActiveAction === 'wrapWeth' ? <LoadingText>Wrapping ETH...</LoadingText> : 'Wrap needed ETH to WETH'}
+								</button>
+							)}
+							<button className='primary' type='button' onClick={onSubmitInitialReport} disabled={!isConnected || !initialReportSubmission.canSubmit || openOracleActiveAction === 'submitInitialReport'}>
 								{openOracleActiveAction === 'submitInitialReport' ? <LoadingText>Submitting...</LoadingText> : 'Submit Initial Report'}
 							</button>
 						</div>

--- a/ui/ts/components/TokenApprovalControl.tsx
+++ b/ui/ts/components/TokenApprovalControl.tsx
@@ -71,8 +71,8 @@ export function TokenApprovalControl({ actionLabel, allowanceError, allowanceLoa
 	}, [draftAmount, tokenUnits])
 
 	const nextApprovalAmount = parsedAmount.kind === 'default' ? requirement.targetAmount : parsedAmount.kind === 'invalid' ? undefined : parsedAmount.amount
-
-	const amountValidationMessage = parsedAmount.kind === 'invalid' ? parsedAmount.error : parsedAmount.kind === 'default' || approvedAmount === undefined || parsedAmount.amount > approvedAmount ? undefined : `Approval amount must be greater than the current approved ${tokenSymbol} amount.`
+	const hasNonIncreasingCustomApproval = parsedAmount.kind === 'custom' && approvedAmount !== undefined && parsedAmount.amount <= approvedAmount
+	const amountValidationMessage = parsedAmount.kind === 'invalid' ? parsedAmount.error : undefined
 	const statusMessage = resolveTokenApprovalStatusMessage({
 		actionLabel,
 		amountValidationMessage,
@@ -84,9 +84,11 @@ export function TokenApprovalControl({ actionLabel, allowanceError, allowanceLoa
 		tokenLabel: tokenSymbol,
 		tokenUnits,
 	})
+	const visibleStatusMessage = hasNonIncreasingCustomApproval ? undefined : statusMessage
 
 	const allowanceMessage = allowanceError === undefined ? undefined : formatTokenApprovalUnavailableMessage({ actionLabel, reason: allowanceError, tokenLabel: tokenSymbol })
-	const canApprove = !pending && guardMessage === undefined && allowanceMessage === undefined && !allowanceLoading && requiredAmount !== undefined && amountValidationMessage === undefined && nextApprovalAmount !== undefined && (parsedAmount.kind !== 'default' || !requirement.hasSufficientApproval)
+	const canApprove =
+		!pending && guardMessage === undefined && allowanceMessage === undefined && !allowanceLoading && requiredAmount !== undefined && amountValidationMessage === undefined && !hasNonIncreasingCustomApproval && nextApprovalAmount !== undefined && (parsedAmount.kind !== 'default' || !requirement.hasSufficientApproval)
 	const buttonLabel = resolveApprovalButtonLabel({
 		guardMessage,
 		isCustomAmount: parsedAmount.kind === 'custom',
@@ -127,7 +129,7 @@ export function TokenApprovalControl({ actionLabel, allowanceError, allowanceLoa
 			</div>
 
 			{allowanceMessage === undefined ? undefined : <ErrorNotice message={allowanceMessage} />}
-			{allowanceMessage !== undefined || statusMessage === undefined ? undefined : <p className='detail'>{statusMessage}</p>}
+			{allowanceMessage !== undefined || visibleStatusMessage === undefined ? undefined : <p className='detail'>{visibleStatusMessage}</p>}
 		</div>
 	)
 }

--- a/ui/ts/lib/openOracle.ts
+++ b/ui/ts/lib/openOracle.ts
@@ -435,11 +435,9 @@ export function deriveOpenOracleInitialReportSubmissionDetails({
 				: walletEthBalance < requiredWethWrapAmount
 					? createVisibleGateMessage(`Wallet has ${formatCurrencyBalance(walletEthBalance)} ETH, need ${formatCurrencyBalance(requiredWethWrapAmount)} ETH to wrap the required WETH.`)
 					: undefined
-			: amount1 === undefined || amount2 === undefined
-				? createVisibleGateMessage(`Enter a valid ${token1Label} / ${token2Label} price to determine whether this report needs more WETH.`)
-				: (isCanonicalMainnetWeth(reportDetails?.token1) && token1Balance === undefined) || (isCanonicalMainnetWeth(reportDetails?.token2) && token2Balance === undefined)
-					? createHiddenLoadingGateMessage('Loading current WETH balance.')
-					: undefined
+			: (isCanonicalMainnetWeth(reportDetails?.token1) && token1Balance === undefined) || (isCanonicalMainnetWeth(reportDetails?.token2) && token2Balance === undefined)
+				? createHiddenLoadingGateMessage('Loading current WETH balance.')
+				: undefined
 
 	let blockMessage: OpenOracleGateMessage | undefined
 	if (reportDetails === undefined) {

--- a/ui/ts/tests/openOracle.test.ts
+++ b/ui/ts/tests/openOracle.test.ts
@@ -584,10 +584,7 @@ describe('Open Oracle helpers', () => {
 		expect(preview.hasWethWrapAction).toBe(true)
 		expect(preview.requiredWethWrapAmount).toBeUndefined()
 		expect(preview.canWrapRequiredWeth).toBe(false)
-		expect(preview.wrapRequiredWethMessage).toEqual({
-			kind: 'visible',
-			message: 'Enter a valid REP / WETH price to determine whether this report needs more WETH.',
-		})
+		expect(preview.wrapRequiredWethMessage).toBeUndefined()
 	})
 
 	test('initial report submission helper allows submit when balances and approvals are sufficient', () => {
@@ -824,6 +821,6 @@ describe('Open Oracle helpers', () => {
 		expect(result.action).toBe('wrapWeth')
 
 		const endBalance = await loadErc20Balance(uiReadClient, WETH_ADDRESS, walletAddress)
-		expect(endBalance - startBalance).toBe(wrapAmount)
+		expect(endBalance - startBalance).toEqual(wrapAmount)
 	})
 })

--- a/ui/ts/tests/openOracleSection.integration.test.tsx
+++ b/ui/ts/tests/openOracleSection.integration.test.tsx
@@ -1,0 +1,288 @@
+/// <reference types="bun-types" />
+
+import { afterEach, beforeEach, describe, expect, setDefaultTimeout, test } from 'bun:test'
+import { fireEvent, waitFor, within } from '@testing-library/dom'
+import { act } from 'preact/test-utils'
+import type { Address, Hash } from 'viem'
+import { zeroAddress } from 'viem'
+import { OpenOracleSection } from '../components/OpenOracleSection.js'
+import { getOpenOracleAddress, loadErc20Allowance, loadErc20Balance, loadOpenOracleReportDetails } from '../contracts.js'
+import { useOpenOracleOperations } from '../hooks/useOpenOracleOperations.js'
+import type { AccountState } from '../types/app.js'
+import type { InjectedEthereum } from '../injectedEthereum.js'
+import { createConnectedReadClient } from '../lib/clients.js'
+import { GENESIS_REPUTATION_TOKEN, TEST_ADDRESSES, WETH_ADDRESS } from '../../../solidity/ts/testsuite/simulator/utils/constants'
+import { addressString } from '../../../solidity/ts/testsuite/simulator/utils/bigint'
+import { setupTestAccounts, ensureProxyDeployerDeployed } from '../../../solidity/ts/testsuite/simulator/utils/utilities'
+import { AnvilWindowEthereum } from '../../../solidity/ts/testsuite/simulator/AnvilWindowEthereum'
+import { TEST_TIMEOUT_MS, useIsolatedAnvilNode } from '../../../solidity/ts/testsuite/simulator/useIsolatedAnvilNode'
+import { createWriteClient, type WriteClient } from '../../../solidity/ts/testsuite/simulator/utils/viem'
+import { ensureInfraDeployed } from '../../../solidity/ts/testsuite/simulator/utils/contracts/deployPeripherals'
+import { ensureZoltarDeployed } from '../../../solidity/ts/testsuite/simulator/utils/contracts/zoltar'
+import { installDomEnvironment } from './testUtils/domEnvironment.js'
+import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
+
+setDefaultTimeout(TEST_TIMEOUT_MS)
+
+const walletAddress = addressString(TEST_ADDRESSES[0])
+const reportId = 1n
+
+function createInjectedWalletShim(mockWindow: AnvilWindowEthereum, accountAddress: Address): InjectedEthereum {
+	const request: InjectedEthereum['request'] = async parameters => {
+		if (parameters.method === 'eth_accounts' || parameters.method === 'eth_requestAccounts') {
+			return [accountAddress] as never
+		}
+
+		return (await mockWindow.request({ method: parameters.method, params: parameters.params })) as never
+	}
+
+	return {
+		on: () => undefined,
+		removeListener: () => undefined,
+		request,
+	}
+}
+
+function OpenOracleSectionHarness({ accountAddress }: { accountAddress: Address }) {
+	const openOracle = useOpenOracleOperations({
+		accountAddress,
+		onTransaction: (_hash: Hash) => undefined,
+		onTransactionFinished: () => undefined,
+		onTransactionRequested: () => undefined,
+		onTransactionSubmitted: (_hash: Hash) => undefined,
+		refreshState: async () => undefined,
+	})
+	const accountState: AccountState = {
+		address: accountAddress,
+		chainId: '0x1',
+		ethBalance: undefined,
+		wethBalance: undefined,
+	}
+
+	return (
+		<OpenOracleSection
+			accountState={accountState}
+			initialView='create'
+			loadingOpenOracleCreate={openOracle.loadingOpenOracleCreate}
+			loadingOracleReport={openOracle.loadingOracleReport}
+			onApproveToken1={amount => void openOracle.approveToken1(amount)}
+			onApproveToken2={amount => void openOracle.approveToken2(amount)}
+			onCreateOpenOracleGame={() => void openOracle.createOpenOracleGame()}
+			onDisputeReport={() => void openOracle.disputeReport()}
+			onLoadOracleReport={reportIdInput => void openOracle.loadOracleReport(reportIdInput)}
+			onOpenOracleCreateFormChange={update => openOracle.setOpenOracleCreateForm(current => ({ ...current, ...update }))}
+			onOpenOracleFormChange={update => openOracle.setOpenOracleForm(current => ({ ...current, ...update }))}
+			onRefreshPrice={openOracle.refreshPrice}
+			onSettleReport={() => void openOracle.settleReport()}
+			onSubmitInitialReport={() => void openOracle.submitInitialReport()}
+			onWrapWethForInitialReport={() => void openOracle.wrapWethForInitialReport()}
+			openOracleActiveAction={openOracle.openOracleActiveAction}
+			openOracleCreateForm={openOracle.openOracleCreateForm}
+			openOracleError={openOracle.openOracleError}
+			openOracleForm={openOracle.openOracleForm}
+			openOracleInitialReportState={openOracle.openOracleInitialReportState}
+			openOracleReportDetails={openOracle.openOracleReportDetails}
+			openOracleResult={openOracle.openOracleResult}
+		/>
+	)
+}
+
+function getEntityCardByTitle(name: string) {
+	const heading = within(document.body).getByRole('heading', { level: 3, name })
+	const card = heading.closest('article')
+	if (!(card instanceof HTMLElement)) {
+		throw new Error(`Expected entity card for ${name}`)
+	}
+	return card
+}
+
+function getApprovalSections(selectedReportCard: HTMLElement) {
+	return within(selectedReportCard)
+		.getAllByRole('heading', { level: 4 })
+		.filter(heading => heading.textContent?.trim().endsWith('Approval') === true)
+		.map(heading => {
+			const section = heading.closest('.entity-card-subsection')
+			if (!(section instanceof HTMLElement)) {
+				throw new Error('Expected approval section container')
+			}
+			return section
+		})
+}
+
+function getApproveButton(section: HTMLElement) {
+	const button = within(section)
+		.getAllByRole('button')
+		.find(candidate => candidate.textContent?.trim().startsWith('Approve') === true)
+	if (!(button instanceof HTMLButtonElement)) {
+		throw new Error('Expected approve button')
+	}
+	return button
+}
+
+async function setInputValue(label: string | RegExp, value: string, scope?: HTMLElement) {
+	const input = within(scope ?? document.body).getByLabelText(label) as HTMLInputElement
+	await act(() => {
+		fireEvent.input(input, {
+			target: { value },
+		})
+	})
+	return input
+}
+
+async function clickElement(element: HTMLElement) {
+	await act(() => {
+		fireEvent.click(element)
+	})
+}
+
+async function waitForLatestAction(actionName: string) {
+	await waitFor(() => {
+		expect(within(document.body).getAllByText(actionName).length).toBeGreaterThan(0)
+	})
+}
+
+describe.serial('OpenOracleSection integration', () => {
+	const { getAnvilWindowEthereum } = useIsolatedAnvilNode()
+	let mockWindow: AnvilWindowEthereum
+	let client: WriteClient
+	let restoreDomEnvironment: (() => void) | undefined
+	let uiReadClient: ReturnType<typeof createConnectedReadClient>
+	let cleanupRenderedComponent: (() => Promise<void>) | undefined
+
+	beforeEach(async () => {
+		mockWindow = getAnvilWindowEthereum()
+		client = createWriteClient(mockWindow, TEST_ADDRESSES[0], 0)
+		await setupTestAccounts(mockWindow)
+		await ensureProxyDeployerDeployed(client)
+		await ensureZoltarDeployed(client)
+		await ensureInfraDeployed(client)
+
+		const domEnvironment = installDomEnvironment()
+		restoreDomEnvironment = domEnvironment.cleanup
+		const injectedWindow = domEnvironment.window as unknown as Window & { ethereum?: InjectedEthereum }
+		injectedWindow.ethereum = createInjectedWalletShim(mockWindow, walletAddress)
+		uiReadClient = createConnectedReadClient()
+	})
+
+	afterEach(async () => {
+		await cleanupRenderedComponent?.()
+		cleanupRenderedComponent = undefined
+		restoreDomEnvironment?.()
+		restoreDomEnvironment = undefined
+	})
+
+	test('creates, opens, approves, wraps, and submits an initial report through the UI', async () => {
+		const renderedComponent = await renderIntoDocument(<OpenOracleSectionHarness accountAddress={walletAddress} />)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await setInputValue('Token1 Address', addressString(GENESIS_REPUTATION_TOKEN))
+		await setInputValue('Token2 Address', WETH_ADDRESS)
+		await setInputValue('Exact Token1 Report', '100000000000000000000')
+		await setInputValue('Settler Reward', '1000')
+		await setInputValue('ETH Value To Send', '1100')
+		await setInputValue('Fee Percentage', '100')
+		await setInputValue('Multiplier', '100')
+		await setInputValue('Settlement Time', '60')
+		await setInputValue('Escalation Halt', '0')
+		await setInputValue('Dispute Delay', '10')
+		await setInputValue('Protocol Fee', '100')
+
+		await clickElement(within(document.body).getByRole('button', { name: 'Create Open Oracle Game' }))
+
+		await waitForLatestAction('createReportInstance')
+		await waitFor(async () => {
+			const createdReport = await loadOpenOracleReportDetails(uiReadClient, getOpenOracleAddress(), reportId)
+			expect(createdReport.reportId).toBe(reportId)
+		})
+
+		await clickElement(within(document.body).getByRole('button', { name: 'Browse' }))
+		await waitFor(() => {
+			expect(within(document.body).getByText(`Report #${reportId.toString()}`)).not.toBeNull()
+		})
+		await clickElement(within(document.body).getByRole('button', { name: 'Open report' }))
+
+		const selectedReportCard = await waitFor(() => getEntityCardByTitle('Selected Report'))
+		await waitFor(() => {
+			expect(within(document.body).getByText('Initial Report')).not.toBeNull()
+		})
+		await setInputValue(/^Price \(/, '4', selectedReportCard)
+
+		const reportDetails = await loadOpenOracleReportDetails(uiReadClient, getOpenOracleAddress(), reportId)
+		const openOracleAddress = getOpenOracleAddress()
+		const expectedAmount2 = reportDetails.exactToken1Report / 4n
+
+		await waitFor(() => {
+			const [currentToken1ApprovalSection, currentToken2ApprovalSection] = getApprovalSections(getEntityCardByTitle('Selected Report'))
+			if (currentToken1ApprovalSection === undefined || currentToken2ApprovalSection === undefined) {
+				throw new Error('Expected both token approval sections to be rendered')
+			}
+			expect(getApproveButton(currentToken1ApprovalSection).disabled).toBe(false)
+			expect(getApproveButton(currentToken2ApprovalSection).disabled).toBe(false)
+		})
+
+		const [token1ApprovalSection, token2ApprovalSection] = getApprovalSections(selectedReportCard)
+		if (token1ApprovalSection === undefined || token2ApprovalSection === undefined) {
+			throw new Error('Expected both token approval sections to be rendered')
+		}
+
+		await clickElement(getApproveButton(token1ApprovalSection))
+		await waitForLatestAction('approveToken1')
+		await waitFor(async () => {
+			expect(await loadErc20Allowance(uiReadClient, reportDetails.token1, walletAddress, openOracleAddress)).toBe(reportDetails.exactToken1Report)
+		})
+
+		const refreshedApprovalSections = getApprovalSections(getEntityCardByTitle('Selected Report'))
+		const refreshedToken2ApprovalSection = refreshedApprovalSections[1]
+		if (refreshedToken2ApprovalSection === undefined) {
+			throw new Error('Expected the second token approval section to remain rendered')
+		}
+
+		await clickElement(getApproveButton(refreshedToken2ApprovalSection))
+		await waitForLatestAction('approveToken2')
+		await waitFor(async () => {
+			expect(await loadErc20Allowance(uiReadClient, reportDetails.token2, walletAddress, openOracleAddress)).toBe(expectedAmount2)
+		})
+
+		await waitFor(() => {
+			const documentQueries = within(document.body)
+			const submitButton = documentQueries.getByRole('button', { name: 'Submit Initial Report' }) as HTMLButtonElement
+			const wrapButton = documentQueries.getByRole('button', { name: 'Wrap needed ETH to WETH' }) as HTMLButtonElement
+			expect(submitButton.disabled).toBe(true)
+			expect(wrapButton.disabled).toBe(false)
+			expect(documentQueries.getByText(/more WETH for this report/i)).not.toBeNull()
+
+			const wrapActionRow = wrapButton.parentElement
+			expect(wrapActionRow).not.toBeNull()
+			expect(wrapActionRow).toBe(submitButton.parentElement)
+			const actionButtons = Array.from(wrapActionRow?.querySelectorAll('button') ?? [])
+			expect(actionButtons.indexOf(wrapButton)).toBeLessThan(actionButtons.indexOf(submitButton))
+		})
+
+		const wethBalanceBeforeWrap = await loadErc20Balance(uiReadClient, reportDetails.token2, walletAddress)
+		expect(wethBalanceBeforeWrap).toBe(0n)
+
+		await clickElement(within(document.body).getByRole('button', { name: 'Wrap needed ETH to WETH' }))
+		await waitFor(async () => {
+			expect(await loadErc20Balance(uiReadClient, reportDetails.token2, walletAddress)).toBe(expectedAmount2)
+		})
+
+		await waitFor(() => {
+			const submitButton = within(document.body).getByRole('button', { name: 'Submit Initial Report' }) as HTMLButtonElement
+			expect(submitButton.disabled).toBe(false)
+		})
+
+		await clickElement(within(document.body).getByRole('button', { name: 'Submit Initial Report' }))
+		await waitForLatestAction('submitInitialReport')
+		await waitFor(() => {
+			expect(within(document.body).getByText('Pending')).not.toBeNull()
+		})
+
+		await waitFor(async () => {
+			const submittedReport = await loadOpenOracleReportDetails(uiReadClient, openOracleAddress, reportId)
+			expect(submittedReport.currentReporter).not.toBe(zeroAddress)
+			expect(submittedReport.currentAmount1).toBe(reportDetails.exactToken1Report)
+			expect(submittedReport.currentAmount2).toBe(expectedAmount2)
+			expect(submittedReport.reportTimestamp > 0n).toBe(true)
+		})
+	})
+})

--- a/ui/ts/tests/openOracleSection.test.tsx
+++ b/ui/ts/tests/openOracleSection.test.tsx
@@ -63,6 +63,15 @@ function findButton(node: unknown, label: string) {
 	return matchingButton
 }
 
+function getButtonLabels(node: unknown) {
+	const labels: string[] = []
+	visitTree(node, vnode => {
+		if (vnode.type !== 'button') return
+		labels.push(getTextContent(vnode.props['children']).trim())
+	})
+	return labels
+}
+
 function createAccountState(overrides: Partial<AccountState> = {}): AccountState {
 	return {
 		address: zeroAddress,
@@ -217,6 +226,8 @@ void describe('OpenOracleSection', () => {
 		const section = renderInitialReportActionSection()
 		const metricFieldLabels = getMetricFieldLabels(section)
 		const textContent = getTextContent(section)
+		const buttonLabels = getButtonLabels(section)
+		const wrapButton = findButton(section, 'Wrap needed ETH to WETH')
 		const submitButton = findButton(section, 'Submit Initial Report')
 
 		expect(metricFieldLabels).not.toContain('Wallet REPv2')
@@ -224,6 +235,10 @@ void describe('OpenOracleSection', () => {
 		expect(textContent).toContain('Initial Report')
 		expect(textContent).toContain('REPv2 Approval')
 		expect(textContent).toContain('WETH Approval')
+		expect(textContent).not.toContain('determine whether this report needs more WETH')
+		expect(buttonLabels.indexOf('Wrap needed ETH to WETH')).toBeGreaterThan(-1)
+		expect(buttonLabels.indexOf('Wrap needed ETH to WETH')).toBeLessThan(buttonLabels.indexOf('Submit Initial Report'))
+		expect(wrapButton).toBeDefined()
 		expect(submitButton).toBeDefined()
 	})
 })

--- a/ui/ts/tests/securityVault.integration.test.ts
+++ b/ui/ts/tests/securityVault.integration.test.ts
@@ -86,7 +86,7 @@ describe('Security vault integration', () => {
 		expect(depositResult.action).toBe('depositRep')
 
 		const endPoolRepBalance = await loadErc20Balance(uiReadClient, initialVaultDetails.repToken, securityPoolAddress)
-		expect(endPoolRepBalance - startPoolRepBalance).toBe(depositAmount)
+		expect(endPoolRepBalance - startPoolRepBalance).toEqual(depositAmount)
 
 		const vaultCount = await getVaultCount(client, securityPoolAddress)
 		expect(vaultCount).toBe(1n)

--- a/ui/ts/tests/testUtils/domEnvironment.ts
+++ b/ui/ts/tests/testUtils/domEnvironment.ts
@@ -1,0 +1,89 @@
+import { Window } from 'happy-dom'
+
+type InstalledDomEnvironment = {
+	cleanup: () => void
+	window: Window
+}
+
+const GLOBAL_KEYS = [
+	'window',
+	'document',
+	'navigator',
+	'location',
+	'history',
+	'self',
+	'Node',
+	'Text',
+	'Element',
+	'HTMLElement',
+	'HTMLButtonElement',
+	'HTMLInputElement',
+	'DocumentFragment',
+	'SVGElement',
+	'Event',
+	'MouseEvent',
+	'CustomEvent',
+	'MutationObserver',
+	'getComputedStyle',
+	'requestAnimationFrame',
+	'cancelAnimationFrame',
+	'IS_REACT_ACT_ENVIRONMENT',
+] as const
+
+type GlobalKey = (typeof GLOBAL_KEYS)[number]
+
+export function installDomEnvironment(url = 'http://localhost/#/open-oracle'): InstalledDomEnvironment {
+	const window = new Window({
+		url,
+	})
+	Reflect.set(window, 'SyntaxError', globalThis.SyntaxError)
+	const globalObject = globalThis as typeof globalThis & Record<GlobalKey, unknown>
+	const previousDescriptors = new Map<GlobalKey, PropertyDescriptor | undefined>()
+
+	const assignGlobal = (key: GlobalKey, value: unknown) => {
+		previousDescriptors.set(key, Object.getOwnPropertyDescriptor(globalThis, key))
+		Object.defineProperty(globalThis, key, {
+			configurable: true,
+			value,
+			writable: true,
+		})
+	}
+
+	assignGlobal('window', window)
+	assignGlobal('document', window.document)
+	assignGlobal('navigator', window.navigator)
+	assignGlobal('location', window.location)
+	assignGlobal('history', window.history)
+	assignGlobal('self', window)
+	assignGlobal('Node', window.Node)
+	assignGlobal('Text', window.Text)
+	assignGlobal('Element', window.Element)
+	assignGlobal('HTMLElement', window.HTMLElement)
+	assignGlobal('HTMLButtonElement', window.HTMLButtonElement)
+	assignGlobal('HTMLInputElement', window.HTMLInputElement)
+	assignGlobal('DocumentFragment', window.DocumentFragment)
+	assignGlobal('SVGElement', window.SVGElement)
+	assignGlobal('Event', window.Event)
+	assignGlobal('MouseEvent', window.MouseEvent)
+	assignGlobal('CustomEvent', window.CustomEvent)
+	assignGlobal('MutationObserver', window.MutationObserver)
+	assignGlobal('getComputedStyle', window.getComputedStyle.bind(window))
+	assignGlobal('requestAnimationFrame', window.requestAnimationFrame.bind(window))
+	assignGlobal('cancelAnimationFrame', window.cancelAnimationFrame.bind(window))
+	assignGlobal('IS_REACT_ACT_ENVIRONMENT', true)
+
+	return {
+		cleanup: () => {
+			window.close()
+			for (const key of [...GLOBAL_KEYS].reverse()) {
+				const descriptor = previousDescriptors.get(key)
+				if (descriptor === undefined) {
+					delete globalObject[key]
+					continue
+				}
+				Object.defineProperty(globalThis, key, descriptor)
+			}
+		},
+		window,
+	}
+}

--- a/ui/ts/tests/testUtils/renderIntoDocument.tsx
+++ b/ui/ts/tests/testUtils/renderIntoDocument.tsx
@@ -1,0 +1,25 @@
+import { render, type ComponentChild } from 'preact'
+import { act } from 'preact/test-utils'
+
+type RenderIntoDocumentResult = {
+	cleanup: () => Promise<void>
+	container: HTMLDivElement
+}
+
+export async function renderIntoDocument(node: ComponentChild): Promise<RenderIntoDocumentResult> {
+	const container = document.createElement('div')
+	document.body.appendChild(container)
+	await act(() => {
+		render(node, container)
+	})
+
+	return {
+		cleanup: async () => {
+			await act(() => {
+				render(null, container)
+			})
+			container.remove()
+		},
+		container,
+	}
+}

--- a/ui/ts/tests/tokenApproval.test.ts
+++ b/ui/ts/tests/tokenApproval.test.ts
@@ -122,7 +122,7 @@ describe('token approval helpers', () => {
 		expect(
 			resolveTokenApprovalStatusMessage({
 				actionLabel: 'submitting the initial report',
-				amountValidationMessage: 'Approval amount must be greater than the current approved ETH amount.',
+				amountValidationMessage: 'Approval amount must be a decimal number',
 				draftAmount: '24',
 				guardMessage: undefined,
 				nextApprovalAmount: 24n * ONE,
@@ -131,7 +131,7 @@ describe('token approval helpers', () => {
 				tokenLabel: 'ETH',
 				tokenUnits: 18,
 			}),
-		).toBe('Approval amount must be greater than the current approved ETH amount.')
+		).toBe('Approval amount must be a decimal number')
 	})
 
 	test('resolveTokenApprovalStatusMessage preserves needed and partial approval copy', () => {

--- a/ui/ts/tests/tokenApprovalControl.test.tsx
+++ b/ui/ts/tests/tokenApprovalControl.test.tsx
@@ -1,0 +1,56 @@
+/// <reference types="bun-types" />
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { fireEvent, within } from '@testing-library/dom'
+import { act } from 'preact/test-utils'
+import { TokenApprovalControl } from '../components/TokenApprovalControl.js'
+import { installDomEnvironment } from './testUtils/domEnvironment.js'
+import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
+
+describe('TokenApprovalControl', () => {
+	let restoreDomEnvironment: (() => void) | undefined
+	let cleanupRenderedComponent: (() => Promise<void>) | undefined
+
+	beforeEach(() => {
+		const domEnvironment = installDomEnvironment()
+		restoreDomEnvironment = domEnvironment.cleanup
+	})
+
+	afterEach(async () => {
+		await cleanupRenderedComponent?.()
+		cleanupRenderedComponent = undefined
+		restoreDomEnvironment?.()
+		restoreDomEnvironment = undefined
+	})
+
+	test('disables non-increasing custom approvals without rendering the removed validation copy', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<TokenApprovalControl
+				actionLabel='submitting the initial report'
+				allowanceError={undefined}
+				allowanceLoading={false}
+				approvedAmount={25n * 10n ** 18n}
+				guardMessage={undefined}
+				onApprove={() => undefined}
+				pending={false}
+				pendingLabel='Approving WETH...'
+				requiredAmount={30n * 10n ** 18n}
+				resetKey='weth-approval'
+				tokenSymbol='WETH'
+				tokenUnits={18}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		await act(() => {
+			fireEvent.input(documentQueries.getByPlaceholderText('Leave blank for required total'), {
+				target: { value: '25' },
+			})
+		})
+
+		const approveButton = documentQueries.getByRole('button', { name: 'Approve 25 WETH' }) as HTMLButtonElement
+		expect(approveButton.disabled).toBe(true)
+		expect(documentQueries.queryByText(/must be greater than the current approved/i)).toBeNull()
+	})
+})


### PR DESCRIPTION
## Summary
- Added `Multicall3` to the deterministic deployment set and expanded deployment status tracking to support the wider mask.
- Updated infra deployment helpers and tests so `ensureInfraDeployed` now includes `Multicall3` and validates the revised deployment mask.
- Improved the open oracle initial report flow by refreshing selected pool data more selectively and moving WETH-wrap handling into the new workflow.
- Added and updated UI tests, including integration coverage for the open oracle section and token approval controls.

## Testing
- Not run (PR content only).
- Existing test coverage updated in `solidity/ts/tests/deploymentStatusOracle.test.ts`, `solidity/ts/tests/peripherals.test.ts`, `ui/ts/tests/openOracleSection.integration.test.tsx`, and related UI test files.