### PR TITLE
Temporarily disable open oracle dispute state hash check

### DIFF
--- a/solidity/contracts/peripherals/openOracle/OpenOracle.sol
+++ b/solidity/contracts/peripherals/openOracle/OpenOracle.sol
@@ -589,7 +589,9 @@ contract OpenOracle is ReentrancyGuard {
 
         _validateDispute(reportId, tokenToSwap, newAmount1, newAmount2, meta, status);
         if (status.currentAmount2 != amt2Expected) revert InvalidAmount2("amount2 doesn't match expectation");
-        if (stateHash != extraData[reportId].stateHash) revert InvalidStateHash("state hash");
+        // Temporarily disabled because `eth_simulate` changes the state hash while testing in
+        // Interceptor, so this validation must stay commented out for that flow.
+        // if (stateHash != extraData[reportId].stateHash) revert InvalidStateHash("state hash");
         if (disputer == address(0)) revert InvalidInput("disputer address");
 
         address protocolFeeRecipient = extraData[reportId].protocolFeeRecipient;
@@ -876,4 +878,3 @@ contract OpenOracle is ReentrancyGuard {
         return uint48(block.number);
     }
 }
-


### PR DESCRIPTION
## Summary
- comment out the Open Oracle dispute `stateHash` validation
- add a note that this is temporarily disabled because `eth_simulate` changes the state hash while testing in Interceptor
- leave the initial report state-hash validation unchanged

## Testing
- bun tsc
- bun test
- bun run format
- bun run check
- bun run knip