### PR TITLE
Relax OpenOracle state hash check for Interceptor

### DIFF
--- a/solidity/contracts/peripherals/openOracle/OpenOracle.sol
+++ b/solidity/contracts/peripherals/openOracle/OpenOracle.sol
@@ -494,7 +494,9 @@ contract OpenOracle is ReentrancyGuard {
         if (reportId >= nextReportId) revert InvalidInput("report id");
         if (amount1 != meta.exactToken1Report) revert InvalidInput("token1 amount");
         if (amount2 == 0) revert InvalidInput("token2 amount");
-        if (extra.stateHash != stateHash) revert InvalidStateHash("state hash");
+        // Temporarily disabled because `eth_simulate` changes the state hash while testing in
+        // Interceptor, so this validation must stay commented out for that flow.
+        // if (extra.stateHash != stateHash) revert InvalidStateHash("state hash");
         if (reporter == address(0)) revert InvalidInput("reporter address");
 
         _transferTokens(meta.token1, msg.sender, address(this), amount1);

--- a/ui/ts/tests/openOracle.test.ts
+++ b/ui/ts/tests/openOracle.test.ts
@@ -792,7 +792,9 @@ describe('Open Oracle helpers', () => {
 		await expect(submitInitialOracleReport(uiWriteClient, openOracleAddress, reportId, amount1, amount2, stateHash)).rejects.toThrow(/report submitted/i)
 	})
 
-	test('submitInitialOracleReport rejects an invalid state hash', async () => {
+	// Temporarily disabled because `eth_simulate` changes the state hash while testing in
+	// Interceptor, so this validation must stay commented out for that flow.
+	test('submitInitialOracleReport accepts an invalid state hash', async () => {
 		await requestOraclePrice(uiWriteClient, managerAddress)
 
 		const reportId = (await loadOracleManagerDetails(uiReadClient, managerAddress)).pendingReportId
@@ -809,7 +811,12 @@ describe('Open Oracle helpers', () => {
 		const stateHash = (await getOpenOracleExtraData(client, reportId)).stateHash
 		const invalidStateHash = stateHash === '0x0000000000000000000000000000000000000000000000000000000000000000' ? '0x0000000000000000000000000000000000000000000000000000000000000001' : '0x0000000000000000000000000000000000000000000000000000000000000000'
 
-		await expect(submitInitialOracleReport(uiWriteClient, openOracleAddress, reportId, amount1, amount2, invalidStateHash)).rejects.toThrow(/state hash/i)
+		await submitInitialOracleReport(uiWriteClient, openOracleAddress, reportId, amount1, amount2, invalidStateHash)
+
+		const reportDetails = await loadOpenOracleReportDetails(uiReadClient, openOracleAddress, reportId)
+		expect(reportDetails.currentAmount1).toBe(amount1)
+		expect(reportDetails.currentAmount2).toBe(amount2)
+		expect(getOpenOracleReportStatus(reportDetails)).toBe('Pending')
 	})
 
 	test('ui wrapWeth helper deposits ETH into WETH and reports the wrap action', async () => {


### PR DESCRIPTION
## Summary
- Temporarily disables the OpenOracle state hash validation so `eth_simulate`-based Interceptor flows can submit reports successfully.
- Updates the OpenOracle UI test to reflect the new behavior by accepting an invalid state hash and verifying the report is still recorded as pending.
- Keeps the surrounding report submission checks intact for amount and report state validation.

## Testing
- Not run (PR description only).