### PR TITLE
Gate Open Oracle dispute and settle by report lifecycle

### DIFF
--- a/ui/ts/components/OpenOracleSection.tsx
+++ b/ui/ts/components/OpenOracleSection.tsx
@@ -16,7 +16,17 @@ import { TimestampValue } from './TimestampValue.js'
 import { WorkflowSubsection } from './WorkflowSubsection.js'
 import { useLoadController } from '../hooks/useLoadController.js'
 import { createConnectedReadClient } from '../lib/clients.js'
-import { deriveOpenOracleInitialReportSubmissionDetails, formatOpenOracleFeePercentage, formatOpenOracleMultiplier, getOpenOracleReportStatus, getOpenOracleReportStatusTone, getOpenOracleSelectedReportActionMode, type OpenOracleSelectedReportActionMode } from '../lib/openOracle.js'
+import {
+	deriveOpenOracleInitialReportSubmissionDetails,
+	formatOpenOracleFeePercentage,
+	formatOpenOracleMultiplier,
+	getOpenOracleDisputeAvailability,
+	getOpenOracleReportStatus,
+	getOpenOracleReportStatusTone,
+	getOpenOracleSelectedReportActionMode,
+	getOpenOracleSettleAvailability,
+	type OpenOracleSelectedReportActionMode,
+} from '../lib/openOracle.js'
 import { loadOpenOracleReportSummaries } from '../contracts.js'
 import { getReportPresentation } from '../lib/userCopy.js'
 import { resolveFirstMatchingValue } from '../lib/viewState.js'
@@ -108,12 +118,15 @@ export function renderSelectedReportActionSection(
 	onSettleReport: () => void,
 	onSubmitInitialReport: () => void,
 	onWrapWethForInitialReport: () => void,
+	openOracleReportDetails?: OpenOracleReportDetails,
 ) {
 	const disputeTokenOptions: EnumDropdownOption<OpenOracleFormState['disputeTokenToSwap']>[] = [
 		{ value: 'token1', label: token1Symbol },
 		{ value: 'token2', label: token2Symbol },
 	]
 	const showQuoteLoadingPlaceholder = openOracleInitialReportState.quoteLoading && openOracleForm.price.trim() === '' && openOracleInitialReportState.defaultPrice === undefined && openOracleInitialReportState.defaultPriceError === undefined
+	const disputeAvailability = openOracleReportDetails === undefined ? { canAct: true, message: undefined } : getOpenOracleDisputeAvailability(openOracleReportDetails)
+	const settleAvailability = openOracleReportDetails === undefined ? { canAct: true, message: undefined } : getOpenOracleSettleAvailability(openOracleReportDetails)
 
 	switch (actionMode) {
 		case 'initial-report':
@@ -200,7 +213,9 @@ export function renderSelectedReportActionSection(
 					</div>
 				</div>
 			)
-		case 'dispute':
+		case 'dispute': {
+			const disputeDisabledMessage = !isConnected ? 'Connect a wallet before disputing reports.' : openOracleForm.reportId.trim() === '' ? 'Load a report first.' : disputeAvailability.message
+			const settleDisabledMessage = !isConnected ? 'Connect a wallet before settling reports.' : openOracleForm.reportId.trim() === '' ? 'Load a report first.' : settleAvailability.message
 			return (
 				<div className='entity-card-subsection'>
 					<div className='entity-card-subsection-header'>
@@ -222,18 +237,21 @@ export function renderSelectedReportActionSection(
 							</label>
 						</div>
 						<div className='actions'>
-							<button className='secondary' onClick={onDisputeReport} disabled={!isConnected || openOracleForm.reportId.trim() === ''}>
-								Dispute & Swap
+							<button className='secondary' onClick={onDisputeReport} disabled={!isConnected || openOracleForm.reportId.trim() === '' || !disputeAvailability.canAct || openOracleActiveAction === 'dispute'} title={disputeDisabledMessage}>
+								{openOracleActiveAction === 'dispute' ? <LoadingText>Disputing...</LoadingText> : 'Dispute & Swap'}
 							</button>
 						</div>
+						{disputeDisabledMessage === undefined ? undefined : <p className='detail'>{disputeDisabledMessage}</p>}
 						<div className='actions'>
-							<button className='secondary' onClick={onSettleReport} disabled={!isConnected || openOracleForm.reportId.trim() === ''}>
-								Settle Report
+							<button className='secondary' onClick={onSettleReport} disabled={!isConnected || openOracleForm.reportId.trim() === '' || !settleAvailability.canAct || openOracleActiveAction === 'settle'} title={settleDisabledMessage}>
+								{openOracleActiveAction === 'settle' ? <LoadingText>Settling...</LoadingText> : 'Settle Report'}
 							</button>
 						</div>
+						{settleDisabledMessage === undefined ? undefined : <p className='detail'>{settleDisabledMessage}</p>}
 					</div>
 				</div>
 			)
+		}
 		case 'read-only':
 			return (
 				<div className='entity-card-subsection'>
@@ -500,6 +518,7 @@ function renderReportDetailsCard(
 				onSettleReport,
 				onSubmitInitialReport,
 				onWrapWethForInitialReport,
+				openOracleReportDetails,
 			)}
 		</EntityCard>
 	)

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -139,6 +139,10 @@ function hasTimestamp(value: unknown): value is { timestamp: bigint } {
 	return isObjectRecord(value) && typeof value['timestamp'] === 'bigint'
 }
 
+function hasTimestampAndNumber(value: unknown): value is { timestamp: bigint; number: bigint } {
+	return isObjectRecord(value) && typeof value['timestamp'] === 'bigint' && typeof value['number'] === 'bigint'
+}
+
 type SecurityPoolDeploymentQueryResult = {
 	completeSetCollateralAmount: bigint
 	currentRetentionRate: bigint
@@ -393,6 +397,7 @@ type ContractRevertReasonParams = {
 	address: Address
 	args?: readonly unknown[]
 	functionName: string
+	gas?: bigint
 	value?: bigint
 }
 
@@ -407,6 +412,7 @@ async function getContractRevertReason<TCallParams extends ContractRevertReasonP
 		await client.call({
 			account,
 			data,
+			gas: params.gas,
 			to: params.address,
 			value: params.value,
 		})
@@ -441,6 +447,7 @@ async function writeContractAndWait<TCallParams extends ContractRevertReasonPara
 		hash = await client.sendTransaction({
 			account,
 			data,
+			gas: callParams.gas,
 			to: callParams.address,
 			value: callParams.value,
 		})
@@ -1501,29 +1508,33 @@ export async function loadOracleManagerDetails(client: ReadClient, managerAddres
 }
 
 export async function loadOpenOracleReportDetails(client: ReadClient, openOracleAddress: Address, reportId: bigint): Promise<import('./types/contracts.js').OpenOracleReportDetails> {
-	const [meta, status, extra] = await readRequiredMulticall(client, [
-		{
-			abi: peripherals_openOracle_OpenOracle_OpenOracle.abi,
-			functionName: 'reportMeta',
-			address: openOracleAddress,
-			args: [reportId],
-		},
-		{
-			abi: peripherals_openOracle_OpenOracle_OpenOracle.abi,
-			functionName: 'reportStatus',
-			address: openOracleAddress,
-			args: [reportId],
-		},
-		{
-			abi: peripherals_openOracle_OpenOracle_OpenOracle.abi,
-			functionName: 'extraData',
-			address: openOracleAddress,
-			args: [reportId],
-		},
+	const [[meta, status, extra], block] = await Promise.all([
+		readRequiredMulticall(client, [
+			{
+				abi: peripherals_openOracle_OpenOracle_OpenOracle.abi,
+				functionName: 'reportMeta',
+				address: openOracleAddress,
+				args: [reportId],
+			},
+			{
+				abi: peripherals_openOracle_OpenOracle_OpenOracle.abi,
+				functionName: 'reportStatus',
+				address: openOracleAddress,
+				args: [reportId],
+			},
+			{
+				abi: peripherals_openOracle_OpenOracle_OpenOracle.abi,
+				functionName: 'extraData',
+				address: openOracleAddress,
+				args: [reportId],
+			},
+		]),
+		client.getBlock(),
 	])
 	const reportMeta = meta as OpenOracleReportMetaTuple
 	const reportStatus = status as OpenOracleReportStatusTuple
 	const reportExtra = extra as OpenOracleExtraDataTuple
+	if (!hasTimestampAndNumber(block)) throw new Error('Unexpected block response')
 	if (reportMeta[4] === zeroAddress) throw new Error(`Oracle report #${reportId.toString()} does not exist`)
 	const [token1Decimals, token2Decimals, token1Symbol, token2Symbol] = await readRequiredMulticall(client, [
 		{
@@ -1555,6 +1566,8 @@ export async function loadOpenOracleReportDetails(client: ReadClient, openOracle
 	return {
 		reportId,
 		openOracleAddress,
+		currentTime: block.timestamp,
+		currentBlockNumber: block.number,
 		exactToken1Report: reportMeta[0],
 		escalationHalt: reportMeta[1],
 		fee: reportMeta[2],
@@ -1827,6 +1840,7 @@ export async function settleOracleReport(client: WriteClient, openOracleAddress:
 		address: openOracleAddress,
 		abi: peripherals_openOracle_OpenOracle_OpenOracle.abi,
 		functionName: 'settle',
+		gas: 5_000_000n,
 		args: [reportId],
 	}))
 	return {

--- a/ui/ts/hooks/useOpenOracleOperations.ts
+++ b/ui/ts/hooks/useOpenOracleOperations.ts
@@ -7,7 +7,17 @@ import { ABIS } from '../abis.js'
 import { approveErc20, createOpenOracleReportInstance, disputeOracleReport, getOpenOracleAddress, loadOpenOracleReportDetails, readOptionalMulticall, settleOracleReport, submitInitialOracleReport, wrapWeth } from '../contracts.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
 import { getErrorMessage } from '../lib/errors.js'
-import { deriveOpenOracleInitialReportSubmissionDetails, formatOpenOracleInitialReportWriteErrorMessage, formatOpenOraclePriceInput, getOpenOracleSelectedReportActionMode, loadOpenOracleInitialReportPriceResult } from '../lib/openOracle.js'
+import {
+	deriveOpenOracleInitialReportSubmissionDetails,
+	formatOpenOracleDisputeWriteErrorMessage,
+	formatOpenOracleInitialReportWriteErrorMessage,
+	formatOpenOraclePriceInput,
+	formatOpenOracleSettleWriteErrorMessage,
+	getOpenOracleDisputeAvailability,
+	getOpenOracleSelectedReportActionMode,
+	getOpenOracleSettleAvailability,
+	loadOpenOracleInitialReportPriceResult,
+} from '../lib/openOracle.js'
 import { parseAddressInput, parseBytes32Input, parseReportIdInput } from '../lib/inputs.js'
 import { getDefaultOpenOracleCreateFormState, getDefaultOpenOracleFormState, parseBigIntInput } from '../lib/marketForm.js'
 import { requireDefined } from '../lib/required.js'
@@ -544,13 +554,31 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 			{ refreshInitialReportTokenAccessOnSuccess: true },
 		)
 
-	const settleReport = async () => await runOracleAction('settle', async walletAddress => await settleOracleReport(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), getOpenOracleAddress(), parseReportIdInput(openOracleForm.value.reportId)), 'Failed to settle report')
+	const settleReport = async () =>
+		await runOracleAction(
+			'settle',
+			async walletAddress => {
+				const { details } = await ensureLoadedSelectedReport({ forceReload: true })
+				const settleAvailability = getOpenOracleSettleAvailability(details)
+				if (!settleAvailability.canAct) {
+					throw new Error(settleAvailability.message ?? 'This report is not ready to settle yet.')
+				}
+
+				return await settleOracleReport(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), getOpenOracleAddress(), details.reportId)
+			},
+			'Failed to settle report',
+			{ formatErrorMessage: formatOpenOracleSettleWriteErrorMessage },
+		)
 
 	const disputeReport = async () =>
 		await runOracleAction(
 			'dispute',
 			async walletAddress => {
-				const { details } = await ensureLoadedSelectedReport()
+				const { details } = await ensureLoadedSelectedReport({ forceReload: true })
+				const disputeAvailability = getOpenOracleDisputeAvailability(details)
+				if (!disputeAvailability.canAct) {
+					throw new Error(disputeAvailability.message ?? 'This report is not ready to dispute yet.')
+				}
 				const form = openOracleForm.value
 				const tokenToSwap = form.disputeTokenToSwap === 'token1' ? details.token1 : details.token2
 				return await disputeOracleReport(
@@ -565,6 +593,7 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 				)
 			},
 			'Failed to dispute report',
+			{ formatErrorMessage: formatOpenOracleDisputeWriteErrorMessage },
 		)
 
 	useEffect(() => {
@@ -575,6 +604,41 @@ export function useOpenOracleOperations({ accountAddress, onTransaction, onTrans
 		void refreshOpenOracleInitialReportQuote(openOracleReportDetails.value)
 		void refreshOpenOracleInitialReportTokenAccess(openOracleReportDetails.value)
 	}, [accountAddress, openOracleReportDetails.value?.reportId, openOracleReportDetails.value?.token1, openOracleReportDetails.value?.token2, openOracleReportDetails.value?.exactToken1Report])
+
+	useEffect(() => {
+		const loadedReport = openOracleReportDetails.value
+		if (loadedReport === undefined) return
+
+		let cancelled = false
+		const trackedReportId = loadedReport.reportId
+		const refreshChainClock = async () => {
+			try {
+				const block = await createConnectedReadClient().getBlock()
+				if (cancelled || typeof block.timestamp !== 'bigint' || typeof block.number !== 'bigint') return
+
+				const currentReport = openOracleReportDetails.value
+				if (currentReport === undefined || currentReport.reportId !== trackedReportId) return
+
+				openOracleReportDetails.value = {
+					...currentReport,
+					currentTime: block.timestamp,
+					currentBlockNumber: block.number,
+				}
+			} catch {
+				return
+			}
+		}
+
+		void refreshChainClock()
+		const intervalId = window.setInterval(() => {
+			void refreshChainClock()
+		}, 1000)
+
+		return () => {
+			cancelled = true
+			window.clearInterval(intervalId)
+		}
+	}, [openOracleReportDetails.value?.reportId])
 
 	return {
 		approveToken1,

--- a/ui/ts/lib/openOracle.ts
+++ b/ui/ts/lib/openOracle.ts
@@ -1,5 +1,5 @@
 import { zeroAddress, type Address } from 'viem'
-import type { OpenOracleReportSummary } from '../types/contracts.js'
+import type { OpenOracleReportDetails, OpenOracleReportSummary } from '../types/contracts.js'
 import { parseDecimalInput } from './decimal.js'
 import { formatWriteErrorMessage, getErrorDetail, sanitizeErrorDetail } from './errors.js'
 import { formatCurrencyBalance, formatCurrencyInputBalance } from './formatters.js'
@@ -18,6 +18,11 @@ export type OpenOracleInitialReportQuoteFailureKind = 'unsupported-pair' | 'quot
 type OpenOracleGateMessage = {
 	kind: 'hidden-loading' | 'visible'
 	message: string
+}
+
+type OpenOracleReportActionAvailability = {
+	canAct: boolean
+	message: string | undefined
 }
 
 type OpenOracleInitialReportPriceLoadResult =
@@ -113,6 +118,70 @@ export function formatOpenOracleInitialReportWriteErrorMessage(error: unknown, f
 	return `Transaction failed while submitting the initial report. Reason: ${detail}`
 }
 
+export function formatOpenOracleSettleWriteErrorMessage(error: unknown, fallbackMessage = 'Failed to settle report') {
+	const genericMessage = formatWriteErrorMessage(error, fallbackMessage)
+	if (genericMessage === 'Action canceled in wallet.') {
+		return genericMessage
+	}
+
+	const detail = getErrorDetail(error, fallbackMessage)
+	const normalizedDetail = detail?.toLowerCase()
+	if (normalizedDetail === undefined) {
+		return 'Transaction failed while settling the report. Reload the report and try again.'
+	}
+
+	if (genericMessage === detail) {
+		return detail
+	}
+
+	if (normalizedDetail.includes('0x98bdb2e0') || normalizedDetail.includes('invalidgaslimit') || normalizedDetail.includes('invalid gas limit')) {
+		return 'This report requires a higher settlement gas limit because it executes a callback on settlement. Retry with the updated UI.'
+	}
+	if (normalizedDetail.includes('settlement')) {
+		return 'This report is not ready to settle yet.'
+	}
+	if (normalizedDetail.includes('report settled')) {
+		return 'This report is already settled.'
+	}
+	if (normalizedDetail.includes('no initial report')) {
+		return 'Submit an initial report before settling this report.'
+	}
+
+	return `Transaction failed while settling the report. Reason: ${detail}`
+}
+
+export function formatOpenOracleDisputeWriteErrorMessage(error: unknown, fallbackMessage = 'Failed to dispute report') {
+	const genericMessage = formatWriteErrorMessage(error, fallbackMessage)
+	if (genericMessage === 'Action canceled in wallet.') {
+		return genericMessage
+	}
+
+	const detail = getErrorDetail(error, fallbackMessage)
+	const normalizedDetail = detail?.toLowerCase()
+	if (normalizedDetail === undefined) {
+		return 'Transaction failed while disputing the report. Reload the report and try again.'
+	}
+
+	if (genericMessage === detail) {
+		return detail
+	}
+
+	if (normalizedDetail.includes('dispute too early')) {
+		return 'This report is not ready to dispute yet.'
+	}
+	if (normalizedDetail.includes('dispute period expired')) {
+		return 'Dispute window closed. Settle Report instead.'
+	}
+	if (normalizedDetail.includes('report settled')) {
+		return 'This report is already settled.'
+	}
+	if (normalizedDetail.includes('no report to dispute')) {
+		return 'Submit an initial report before disputing this report.'
+	}
+
+	return `Transaction failed while disputing the report. Reason: ${detail}`
+}
+
 function createHiddenLoadingGateMessage(message: string): OpenOracleGateMessage {
 	return { kind: 'hidden-loading', message }
 }
@@ -164,6 +233,81 @@ export function getOpenOracleSelectedReportActionMode(report: Pick<OpenOracleRep
 			return 'dispute'
 		case 'Settled':
 			return 'read-only'
+	}
+}
+
+function hasOpenOracleInitialReport(report: Pick<OpenOracleReportDetails, 'currentReporter' | 'reportTimestamp'>) {
+	return report.reportTimestamp !== 0n && report.currentReporter !== zeroAddress
+}
+
+function getOpenOracleLifecycleClockValue(report: Pick<OpenOracleReportDetails, 'currentBlockNumber' | 'currentTime' | 'timeType'>) {
+	return report.timeType ? report.currentTime : report.currentBlockNumber
+}
+
+export function getOpenOracleDisputeAvailability(report: Pick<OpenOracleReportDetails, 'currentBlockNumber' | 'currentReporter' | 'currentTime' | 'disputeDelay' | 'isDistributed' | 'reportTimestamp' | 'settlementTime' | 'timeType'>): OpenOracleReportActionAvailability {
+	if (!hasOpenOracleInitialReport(report)) {
+		return {
+			canAct: false,
+			message: 'Submit an initial report before disputing this report.',
+		}
+	}
+	if (report.isDistributed) {
+		return {
+			canAct: false,
+			message: 'This report is already settled.',
+		}
+	}
+
+	const currentClock = getOpenOracleLifecycleClockValue(report)
+	const disputeStart = report.reportTimestamp + report.disputeDelay
+	const settlementStart = report.reportTimestamp + report.settlementTime
+
+	if (currentClock < disputeStart) {
+		return {
+			canAct: false,
+			message: 'This report is not ready to dispute yet.',
+		}
+	}
+	if (currentClock > settlementStart) {
+		return {
+			canAct: false,
+			message: 'Dispute window closed. Settle Report instead.',
+		}
+	}
+
+	return {
+		canAct: true,
+		message: undefined,
+	}
+}
+
+export function getOpenOracleSettleAvailability(report: Pick<OpenOracleReportDetails, 'currentBlockNumber' | 'currentReporter' | 'currentTime' | 'isDistributed' | 'reportTimestamp' | 'settlementTime' | 'timeType'>): OpenOracleReportActionAvailability {
+	if (!hasOpenOracleInitialReport(report)) {
+		return {
+			canAct: false,
+			message: 'Submit an initial report before settling this report.',
+		}
+	}
+	if (report.isDistributed) {
+		return {
+			canAct: false,
+			message: 'This report is already settled.',
+		}
+	}
+
+	const currentClock = getOpenOracleLifecycleClockValue(report)
+	const settlementStart = report.reportTimestamp + report.settlementTime
+
+	if (currentClock < settlementStart) {
+		return {
+			canAct: false,
+			message: 'This report is not ready to settle yet.',
+		}
+	}
+
+	return {
+		canAct: true,
+		message: undefined,
 	}
 }
 

--- a/ui/ts/tests/contracts.test.ts
+++ b/ui/ts/tests/contracts.test.ts
@@ -2,22 +2,22 @@
 
 import { describe, expect, test } from 'bun:test'
 import { decodeFunctionData, getAddress, type Address, type Hash, type Hex } from 'viem'
-import { migrateSharesFromUniverse } from '../contracts.js'
-import { peripherals_tokens_ShareToken_ShareToken } from '../contractArtifact.js'
+import { getOpenOracleAddress, migrateSharesFromUniverse, settleOracleReport } from '../contracts.js'
+import { peripherals_openOracle_OpenOracle_OpenOracle, peripherals_tokens_ShareToken_ShareToken } from '../contractArtifact.js'
 import type { WriteClient } from '../types/contracts.js'
 
 const securityPoolAddress = getAddress('0x00000000000000000000000000000000000000a1')
 const shareTokenAddress = getAddress('0x00000000000000000000000000000000000000b2')
 const transactionHash = '0x00000000000000000000000000000000000000000000000000000000000000c3' satisfies Hash
 
-function createMockWriteClient(onSendTransaction: (request: { data?: Hex | undefined; to?: Address | undefined }) => void): WriteClient {
+function createMockWriteClient(onSendTransaction: (request: { data?: Hex | undefined; gas?: bigint | undefined; to?: Address | undefined }) => void): WriteClient {
 	const client = {
 		readContract: async ({ functionName }: { functionName: string }) => {
 			if (functionName === 'universeId') return 12n
 			if (functionName === 'shareToken') return shareTokenAddress
 			throw new Error(`Unexpected readContract function: ${functionName}`)
 		},
-		sendTransaction: async (request: { data?: Hex | undefined; to?: Address | undefined }) => {
+		sendTransaction: async (request: { data?: Hex | undefined; gas?: bigint | undefined; to?: Address | undefined }) => {
 			onSendTransaction(request)
 			return transactionHash
 		},
@@ -47,5 +47,28 @@ describe('contracts helpers', () => {
 		expect(decodedCall.functionName).toBe('migrate')
 		expect(decodedCall.args?.[1]).toEqual([3n, 7n, 7n])
 		expect(result.targetOutcomeIndexes).toEqual([3n, 7n, 7n])
+	})
+
+	test('settleOracleReport sends settle with an explicit gas limit', async () => {
+		let capturedData: Hex | undefined
+		let capturedGas: bigint | undefined
+		let capturedTo: Address | undefined
+		const client = createMockWriteClient(request => {
+			capturedData = request.data
+			capturedGas = request.gas
+			capturedTo = request.to
+		})
+
+		await settleOracleReport(client, getOpenOracleAddress(), 7n)
+
+		expect(capturedTo).toBe(getOpenOracleAddress())
+		expect(capturedGas).toBe(5_000_000n)
+		expect(capturedData).toBeDefined()
+		const decodedCall = decodeFunctionData({
+			abi: peripherals_openOracle_OpenOracle_OpenOracle.abi,
+			data: capturedData ?? ('0x' satisfies Hex),
+		})
+		expect(decodedCall.functionName).toBe('settle')
+		expect(decodedCall.args).toEqual([7n])
 	})
 })

--- a/ui/ts/tests/openOracle.test.ts
+++ b/ui/ts/tests/openOracle.test.ts
@@ -6,14 +6,18 @@ import { createOpenOracleReportInstance, getOpenOracleAddress, loadErc20Balance,
 import {
 	addOpenOracleBountyBuffer,
 	deriveOpenOracleInitialReportSubmissionDetails,
+	formatOpenOracleDisputeWriteErrorMessage,
 	formatOpenOracleFeePercentage,
 	formatOpenOracleInitialReportApprovalStatusUnavailableMessage,
 	formatOpenOracleInitialReportBalanceStatusUnavailableMessage,
 	formatOpenOracleInitialReportPriceUnavailableMessage,
 	formatOpenOracleInitialReportWriteErrorMessage,
 	formatOpenOracleMultiplier,
+	formatOpenOracleSettleWriteErrorMessage,
+	getOpenOracleDisputeAvailability,
 	getOpenOracleReportStatus,
 	getOpenOracleSelectedReportActionMode,
+	getOpenOracleSettleAvailability,
 	loadOpenOracleInitialReportPrice,
 	loadOpenOracleInitialReportPriceResult,
 } from '../lib/openOracle.js'
@@ -95,6 +99,31 @@ function createInitialReportSubmissionPreview(overrides: Partial<Parameters<type
 		walletEthBalance: 10n,
 		...overrides,
 	})
+}
+
+function createOpenOracleLifecycleReport(
+	overrides: Partial<{
+		currentBlockNumber: bigint
+		currentReporter: Address
+		currentTime: bigint
+		disputeDelay: bigint
+		isDistributed: boolean
+		reportTimestamp: bigint
+		settlementTime: bigint
+		timeType: boolean
+	}> = {},
+) {
+	return {
+		currentBlockNumber: 0n,
+		currentReporter: getAddress(addressString(TEST_ADDRESSES[1])),
+		currentTime: 0n,
+		disputeDelay: 10n,
+		isDistributed: false,
+		reportTimestamp: 100n,
+		settlementTime: 60n,
+		timeType: true,
+		...overrides,
+	}
 }
 
 describe('Open Oracle helpers', () => {
@@ -702,6 +731,102 @@ describe('Open Oracle helpers', () => {
 		expect(getOpenOracleSelectedReportActionMode({ currentReporter: reporter, disputeOccurred: false, isDistributed: false, reportTimestamp: 1n })).toBe('dispute')
 		expect(getOpenOracleSelectedReportActionMode({ currentReporter: reporter, disputeOccurred: true, isDistributed: false, reportTimestamp: 1n })).toBe('dispute')
 		expect(getOpenOracleSelectedReportActionMode({ currentReporter: reporter, disputeOccurred: false, isDistributed: true, reportTimestamp: 1n })).toBe('read-only')
+	})
+
+	test('dispute and settle availability follow time-based report lifecycle', () => {
+		const beforeDisputeDelay = createOpenOracleLifecycleReport({ currentTime: 109n })
+		expect(getOpenOracleDisputeAvailability(beforeDisputeDelay)).toEqual({
+			canAct: false,
+			message: 'This report is not ready to dispute yet.',
+		})
+		expect(getOpenOracleSettleAvailability(beforeDisputeDelay)).toEqual({
+			canAct: false,
+			message: 'This report is not ready to settle yet.',
+		})
+
+		const insideDisputeWindow = createOpenOracleLifecycleReport({ currentTime: 110n })
+		expect(getOpenOracleDisputeAvailability(insideDisputeWindow)).toEqual({
+			canAct: true,
+			message: undefined,
+		})
+		expect(getOpenOracleSettleAvailability(insideDisputeWindow)).toEqual({
+			canAct: false,
+			message: 'This report is not ready to settle yet.',
+		})
+
+		const exactSettlementBoundary = createOpenOracleLifecycleReport({ currentTime: 160n })
+		expect(getOpenOracleDisputeAvailability(exactSettlementBoundary)).toEqual({
+			canAct: true,
+			message: undefined,
+		})
+		expect(getOpenOracleSettleAvailability(exactSettlementBoundary)).toEqual({
+			canAct: true,
+			message: undefined,
+		})
+
+		const afterSettlementWindow = createOpenOracleLifecycleReport({ currentTime: 161n })
+		expect(getOpenOracleDisputeAvailability(afterSettlementWindow)).toEqual({
+			canAct: false,
+			message: 'Dispute window closed. Settle Report instead.',
+		})
+		expect(getOpenOracleSettleAvailability(afterSettlementWindow)).toEqual({
+			canAct: true,
+			message: undefined,
+		})
+	})
+
+	test('dispute and settle availability use current block number for block-based reports', () => {
+		const blockBasedReport = createOpenOracleLifecycleReport({
+			currentBlockNumber: 111n,
+			currentTime: 1n,
+			timeType: false,
+		})
+
+		expect(getOpenOracleDisputeAvailability(blockBasedReport)).toEqual({
+			canAct: true,
+			message: undefined,
+		})
+		expect(getOpenOracleSettleAvailability(blockBasedReport)).toEqual({
+			canAct: false,
+			message: 'This report is not ready to settle yet.',
+		})
+	})
+
+	test('dispute and settle availability block reports without an initial report or already-settled reports', () => {
+		const noInitialReport = createOpenOracleLifecycleReport({
+			currentReporter: zeroAddress,
+			reportTimestamp: 0n,
+		})
+		expect(getOpenOracleDisputeAvailability(noInitialReport)).toEqual({
+			canAct: false,
+			message: 'Submit an initial report before disputing this report.',
+		})
+		expect(getOpenOracleSettleAvailability(noInitialReport)).toEqual({
+			canAct: false,
+			message: 'Submit an initial report before settling this report.',
+		})
+
+		const settledReport = createOpenOracleLifecycleReport({
+			currentTime: 200n,
+			isDistributed: true,
+		})
+		expect(getOpenOracleDisputeAvailability(settledReport)).toEqual({
+			canAct: false,
+			message: 'This report is already settled.',
+		})
+		expect(getOpenOracleSettleAvailability(settledReport)).toEqual({
+			canAct: false,
+			message: 'This report is already settled.',
+		})
+	})
+
+	test('maps dispute and settle write failures into friendly guidance', () => {
+		expect(formatOpenOracleSettleWriteErrorMessage(new Error('execution reverted: 0x98bdb2e0'))).toBe('This report requires a higher settlement gas limit because it executes a callback on settlement. Retry with the updated UI.')
+		expect(formatOpenOracleSettleWriteErrorMessage(new Error('execution reverted: settlement'))).toBe('This report is not ready to settle yet.')
+		expect(formatOpenOracleSettleWriteErrorMessage(new Error('execution reverted: no initial report'))).toBe('Submit an initial report before settling this report.')
+		expect(formatOpenOracleDisputeWriteErrorMessage(new Error('execution reverted: dispute too early'))).toBe('This report is not ready to dispute yet.')
+		expect(formatOpenOracleDisputeWriteErrorMessage(new Error('execution reverted: dispute period expired'))).toBe('Dispute window closed. Settle Report instead.')
+		expect(formatOpenOracleDisputeWriteErrorMessage(new Error('execution reverted: report settled'))).toBe('This report is already settled.')
 	})
 
 	test('loadOracleManagerDetails reflects initial manager state after deployment', async () => {

--- a/ui/ts/tests/openOracleSection.integration.test.tsx
+++ b/ui/ts/tests/openOracleSection.integration.test.tsx
@@ -285,4 +285,96 @@ describe.serial('OpenOracleSection integration', () => {
 			expect(submittedReport.reportTimestamp > 0n).toBe(true)
 		})
 	})
+
+	test('disables dispute and enables settle after the settlement window elapses', async () => {
+		const renderedComponent = await renderIntoDocument(<OpenOracleSectionHarness accountAddress={walletAddress} />)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await setInputValue('Token1 Address', addressString(GENESIS_REPUTATION_TOKEN))
+		await setInputValue('Token2 Address', WETH_ADDRESS)
+		await setInputValue('Exact Token1 Report', '100000000000000000000')
+		await setInputValue('Settler Reward', '1000')
+		await setInputValue('ETH Value To Send', '1100')
+		await setInputValue('Fee Percentage', '100')
+		await setInputValue('Multiplier', '100')
+		await setInputValue('Settlement Time', '60')
+		await setInputValue('Escalation Halt', '0')
+		await setInputValue('Dispute Delay', '10')
+		await setInputValue('Protocol Fee', '100')
+
+		await clickElement(within(document.body).getByRole('button', { name: 'Create Open Oracle Game' }))
+		await waitForLatestAction('createReportInstance')
+		await waitFor(async () => {
+			const createdReport = await loadOpenOracleReportDetails(uiReadClient, getOpenOracleAddress(), reportId)
+			expect(createdReport.reportId).toBe(reportId)
+		})
+
+		await clickElement(within(document.body).getByRole('button', { name: 'Browse' }))
+		await waitFor(() => {
+			expect(within(document.body).getByText(`Report #${reportId.toString()}`)).not.toBeNull()
+		})
+		await clickElement(within(document.body).getByRole('button', { name: 'Open report' }))
+
+		const selectedReportCard = await waitFor(() => getEntityCardByTitle('Selected Report'))
+		await waitFor(() => {
+			expect(within(document.body).getByText('Initial Report')).not.toBeNull()
+		})
+		await setInputValue(/^Price \(/, '4', selectedReportCard)
+
+		const reportDetails = await loadOpenOracleReportDetails(uiReadClient, getOpenOracleAddress(), reportId)
+		const openOracleAddress = getOpenOracleAddress()
+		const expectedAmount2 = reportDetails.exactToken1Report / 4n
+
+		const [token1ApprovalSection, token2ApprovalSection] = getApprovalSections(selectedReportCard)
+		if (token1ApprovalSection === undefined || token2ApprovalSection === undefined) {
+			throw new Error('Expected both token approval sections to be rendered')
+		}
+
+		await clickElement(getApproveButton(token1ApprovalSection))
+		await waitForLatestAction('approveToken1')
+		await waitFor(async () => {
+			expect(await loadErc20Allowance(uiReadClient, reportDetails.token1, walletAddress, openOracleAddress)).toBe(reportDetails.exactToken1Report)
+		})
+
+		const refreshedApprovalSections = getApprovalSections(getEntityCardByTitle('Selected Report'))
+		const refreshedToken2ApprovalSection = refreshedApprovalSections[1]
+		if (refreshedToken2ApprovalSection === undefined) {
+			throw new Error('Expected the second token approval section to remain rendered')
+		}
+
+		await clickElement(getApproveButton(refreshedToken2ApprovalSection))
+		await waitForLatestAction('approveToken2')
+		await waitFor(async () => {
+			expect(await loadErc20Allowance(uiReadClient, reportDetails.token2, walletAddress, openOracleAddress)).toBe(expectedAmount2)
+		})
+
+		await clickElement(within(document.body).getByRole('button', { name: 'Wrap needed ETH to WETH' }))
+		await waitFor(async () => {
+			expect(await loadErc20Balance(uiReadClient, reportDetails.token2, walletAddress)).toBe(expectedAmount2)
+		})
+
+		await waitFor(() => {
+			const submitButton = within(document.body).getByRole('button', { name: 'Submit Initial Report' }) as HTMLButtonElement
+			expect(submitButton.disabled).toBe(false)
+		})
+
+		await clickElement(within(document.body).getByRole('button', { name: 'Submit Initial Report' }))
+		await waitForLatestAction('submitInitialReport')
+		await waitFor(async () => {
+			const submittedReport = await loadOpenOracleReportDetails(uiReadClient, openOracleAddress, reportId)
+			expect(submittedReport.currentReporter).not.toBe(zeroAddress)
+			expect(submittedReport.reportTimestamp > 0n).toBe(true)
+		})
+
+		await mockWindow.advanceTime(61n)
+		await clickElement(within(document.body).getByRole('button', { name: 'Refresh report' }))
+
+		await waitFor(() => {
+			const disputeButton = within(document.body).getByRole('button', { name: 'Dispute & Swap' }) as HTMLButtonElement
+			const settleButton = within(document.body).getByRole('button', { name: 'Settle Report' }) as HTMLButtonElement
+			expect(disputeButton.disabled).toBe(true)
+			expect(settleButton.disabled).toBe(false)
+			expect(within(document.body).getByText('Dispute window closed. Settle Report instead.')).not.toBeNull()
+		})
+	})
 })

--- a/ui/ts/tests/openOracleSection.test.tsx
+++ b/ui/ts/tests/openOracleSection.test.tsx
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from 'bun:test'
-import { zeroAddress } from 'viem'
+import { getAddress, zeroAddress } from 'viem'
 import { ErrorNotice } from '../components/ErrorNotice.js'
 import { MetricField } from '../components/MetricField.js'
 import { renderSelectedReportActionSection } from '../components/OpenOracleSection.js'
@@ -106,9 +106,11 @@ function createOpenOracleReportDetails(overrides: Partial<OpenOracleReportDetail
 		callbackContract: zeroAddress,
 		callbackGasLimit: 0,
 		callbackSelector: '0x00000000',
+		currentBlockNumber: 0n,
 		currentAmount1: 0n,
 		currentAmount2: 0n,
 		currentReporter: zeroAddress,
+		currentTime: 0n,
 		disputeDelay: 3600n,
 		disputeOccurred: false,
 		escalationHalt: 5n * 10n ** 17n,
@@ -231,6 +233,59 @@ function renderInitialReportActionSection({
 	)
 }
 
+function renderDisputeActionSection({
+	accountState = createAccountState(),
+	openOracleForm = createOpenOracleForm(),
+	openOracleReportDetails = createOpenOracleReportDetails({
+		currentReporter: getAddress('0x3000000000000000000000000000000000000000'),
+		reportTimestamp: 100n,
+	}),
+}: {
+	accountState?: AccountState
+	openOracleForm?: OpenOracleFormState
+	openOracleReportDetails?: OpenOracleReportDetails
+} = {}) {
+	return renderSelectedReportActionSection(
+		'dispute',
+		accountState.address !== undefined,
+		undefined,
+		openOracleForm,
+		deriveOpenOracleInitialReportSubmissionDetails({
+			approvedToken1Amount: 0n,
+			approvedToken2Amount: 0n,
+			defaultPrice: undefined,
+			defaultPriceError: undefined,
+			defaultPriceSource: undefined,
+			defaultPriceSourceUrl: undefined,
+			priceInput: '',
+			quoteAttemptedSources: undefined,
+			quoteFailureReason: undefined,
+			reportDetails: undefined,
+			token1AllowanceError: undefined,
+			token1Balance: undefined,
+			token1BalanceError: undefined,
+			token1Decimals: openOracleReportDetails.token1Decimals,
+			token2AllowanceError: undefined,
+			token2Balance: undefined,
+			token2BalanceError: undefined,
+			token2Decimals: openOracleReportDetails.token2Decimals,
+			walletEthBalance: undefined,
+		}),
+		createOpenOracleInitialReportState(),
+		openOracleReportDetails.token1Symbol,
+		openOracleReportDetails.token2Symbol,
+		() => undefined,
+		() => undefined,
+		() => undefined,
+		() => undefined,
+		() => undefined,
+		() => undefined,
+		() => undefined,
+		() => undefined,
+		openOracleReportDetails,
+	)
+}
+
 void describe('OpenOracleSection', () => {
 	void test('removes the redundant wallet metric row from the selected initial report action', () => {
 		const section = renderInitialReportActionSection()
@@ -270,5 +325,50 @@ void describe('OpenOracleSection', () => {
 
 		expect(getTextContent(section)).toContain('WETH approval required')
 		expect(hasVNodeType(section, ErrorNotice)).toBe(false)
+	})
+
+	void test('disables dispute after settlement time elapses and guides the user to settle', () => {
+		const section = renderDisputeActionSection({
+			openOracleReportDetails: createOpenOracleReportDetails({
+				currentReporter: getAddress('0x3000000000000000000000000000000000000000'),
+				currentTime: 161n,
+				disputeDelay: 10n,
+				reportTimestamp: 100n,
+				settlementTime: 60n,
+			}),
+		})
+
+		const disputeButton = findButton(section, 'Dispute & Swap')
+		const settleButton = findButton(section, 'Settle Report')
+		if (disputeButton === undefined || settleButton === undefined) {
+			throw new Error('Expected dispute action buttons to render')
+		}
+
+		expect(disputeButton.props['disabled']).toBe(true)
+		expect(settleButton.props['disabled']).toBe(false)
+		expect(getTextContent(section)).toContain('Dispute window closed. Settle Report instead.')
+	})
+
+	void test('disables dispute before dispute delay and disables settle before settlement time', () => {
+		const section = renderDisputeActionSection({
+			openOracleReportDetails: createOpenOracleReportDetails({
+				currentReporter: getAddress('0x3000000000000000000000000000000000000000'),
+				currentTime: 109n,
+				disputeDelay: 10n,
+				reportTimestamp: 100n,
+				settlementTime: 60n,
+			}),
+		})
+
+		const disputeButton = findButton(section, 'Dispute & Swap')
+		const settleButton = findButton(section, 'Settle Report')
+		if (disputeButton === undefined || settleButton === undefined) {
+			throw new Error('Expected dispute action buttons to render')
+		}
+
+		expect(disputeButton.props['disabled']).toBe(true)
+		expect(settleButton.props['disabled']).toBe(true)
+		expect(getTextContent(section)).toContain('This report is not ready to dispute yet.')
+		expect(getTextContent(section)).toContain('This report is not ready to settle yet.')
 	})
 })

--- a/ui/ts/types/contracts.ts
+++ b/ui/ts/types/contracts.ts
@@ -186,6 +186,8 @@ export type OpenOracleReportDetails = {
 	// Identity
 	reportId: bigint
 	openOracleAddress: Address
+	currentTime: bigint
+	currentBlockNumber: bigint
 	// Meta
 	exactToken1Report: bigint
 	escalationHalt: bigint


### PR DESCRIPTION
## Summary
- Add lifecycle-aware availability checks for Open Oracle dispute and settle actions.
- Prevent premature or duplicate actions in the UI and surface clearer guidance when a report is not yet ready.
- Refresh report clock data from the chain so availability updates as time advances.
- Use a higher explicit gas limit for settle transactions and improve write-error messaging for dispute and settle flows.
- Extend contract, helper, and UI tests to cover lifecycle gating and settlement behavior.

## Testing
- Not run (PR content prepared from the code diff).
- Added/updated tests cover lifecycle availability, action gating, error mapping, and settle gas limit handling.