### PR TITLE
Fix escrow redemption accounting and split app header

### DIFF
--- a/solidity/contracts/peripherals/EscalationGame.sol
+++ b/solidity/contracts/peripherals/EscalationGame.sol
@@ -237,16 +237,18 @@ contract EscalationGame {
 		originalDepositAmount = deposit.amount;
 		uint256 maxWithdrawableBalance = getBindingCapital();
 		uint256 burnAmount;
-		if (deposit.cumulativeAmount > maxWithdrawableBalance) {
+		uint256 depositStart = deposit.cumulativeAmount - deposit.amount;
+		if (depositStart >= maxWithdrawableBalance) {
 			amountToWithdraw = deposit.amount;
 			burnAmount = 0;
-		} else if (deposit.cumulativeAmount + deposit.amount > maxWithdrawableBalance) {
-			uint256 excess = (deposit.cumulativeAmount + deposit.amount - maxWithdrawableBalance);
-			burnAmount = excess * 2 / 5;
-			amountToWithdraw = (deposit.amount - excess) + excess * 2 - burnAmount;
 		} else {
-			burnAmount = (deposit.amount * 2) / 5;
-			amountToWithdraw = deposit.amount * 2 - burnAmount;
+			uint256 withdrawableWithinBindingCapital = maxWithdrawableBalance - depositStart;
+			if (withdrawableWithinBindingCapital > deposit.amount) {
+				withdrawableWithinBindingCapital = deposit.amount;
+			}
+			uint256 withdrawableAboveBindingCapital = deposit.amount - withdrawableWithinBindingCapital;
+			burnAmount = (withdrawableWithinBindingCapital * 2) / 5;
+			amountToWithdraw = withdrawableAboveBindingCapital + withdrawableWithinBindingCapital * 2 - burnAmount;
 		}
 
 		// Adjust based on actual fork threshold

--- a/solidity/contracts/peripherals/SecurityPool.sol
+++ b/solidity/contracts/peripherals/SecurityPool.sol
@@ -339,12 +339,15 @@ contract SecurityPool is ISecurityPool {
 		require(sent, 'failed to send Ether');
 	}
 
-	function redeemShares() isOperational external {
+	function redeemShares() external {
+		require(systemState == SystemState.Operational, 'System is not operational');
 		BinaryOutcomes.BinaryOutcome outcome = ISecurityPoolForker(securityPoolForker).getQuestionOutcome(this);
 		require(outcome != BinaryOutcomes.BinaryOutcome.None, 'Question has not finalized!');
 		uint256 tokenId = shareToken.getTokenId(universeId, outcome);
 		uint256 amount = shareToken.burnTokenId(tokenId, msg.sender);
 		uint256 ethValue = sharesToCash(amount);
+		shareTokenSupply -= amount;
+		completeSetCollateralAmount -= ethValue;
 		(bool sent, ) = payable(msg.sender).call{ value: ethValue }('');
 		require(sent, 'failed to send Ether');
 		emit RedeemShares(msg.sender, amount, ethValue);

--- a/solidity/contracts/peripherals/SecurityPool.sol
+++ b/solidity/contracts/peripherals/SecurityPool.sol
@@ -206,6 +206,8 @@ contract SecurityPool is ISecurityPool {
 	}
 
 	function sharesToCash(uint256 completeSetAmount) public view returns (uint256) {
+		if (completeSetAmount == 0) return 0;
+		if (shareTokenSupply == 0) return 0;
 		return completeSetAmount * completeSetCollateralAmount / shareTokenSupply;
 	}
 

--- a/solidity/ts/tests/peripherals.test.ts
+++ b/solidity/ts/tests/peripherals.test.ts
@@ -29,6 +29,7 @@ import {
 	getCurrentRetentionRate,
 	getPoolOwnershipDenominator,
 	getRepToken,
+	getShareTokenSupply,
 	getSecurityPoolsEscalationGame,
 	getSecurityVault,
 	getSystemState,
@@ -96,6 +97,19 @@ describe('Peripherals Contract Test Suite', () => {
 			],
 		})) as Hash
 		await client.waitForTransactionReceipt({ hash })
+	}
+
+	const getVaultRepClaim = async (vaultAddress: Address) => {
+		const vault = await getSecurityVault(client, securityPoolAddresses.securityPool, vaultAddress)
+		return await poolOwnershipToRep(client, securityPoolAddresses.securityPool, vault.repDepositShare)
+	}
+
+	const finalizeQuestionAsYesWithoutFork = async () => {
+		const endTime = await getQuestionEndDate(client, questionId)
+		await mockWindow.setTime(endTime + 10000n)
+		await depositToEscalationGame(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes, reportBond)
+		await mockWindow.advanceTime(10n * DAY)
+		strictEqualTypeSafe(await getQuestionOutcome(client, securityPoolAddresses.securityPool), QuestionOutcome.Yes, 'question should finalize as yes')
 	}
 
 	beforeEach(async () => {
@@ -268,6 +282,29 @@ describe('Peripherals Contract Test Suite', () => {
 		const repClaimIncrease = await poolOwnershipToRep(client, securityPoolAddresses.securityPool, vaultAfterWithdrawal.repDepositShare - vaultBeforeWithdrawal.repDepositShare)
 		strictEqualTypeSafe(repClaimIncrease, 0n, 'single-sided withdrawal should only unlock the original deposit without changing ownership')
 		strictEqualTypeSafe(vaultAfterWithdrawal.lockedRepInEscalationGame, 0n, 'escalation lock should be released after withdrawal')
+	})
+
+	test('withdrawFromEscalationGame pays mixed binding-capital deposits without double counting', async () => {
+		const endTime = await getQuestionEndDate(client, questionId)
+		await mockWindow.setTime(endTime + 10000n)
+
+		const attackerClient = createWriteClient(mockWindow, TEST_ADDRESSES[1], 0)
+		await approveAndDepositRep(attackerClient, repDeposit, questionId)
+
+		await depositToEscalationGame(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes, 5n * 10n ** 18n)
+		await depositToEscalationGame(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes, 7n * 10n ** 18n)
+		await depositToEscalationGame(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes, 2n * 10n ** 18n)
+		await depositToEscalationGame(attackerClient, securityPoolAddresses.securityPool, QuestionOutcome.No, 10n * 10n ** 18n)
+		await mockWindow.advanceTime(10n * DAY)
+
+		const repClaimBeforeWithdrawal = await getVaultRepClaim(client.account.address)
+		await withdrawFromEscalationGame(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes, [0n, 1n, 2n])
+		const repClaimAfterWithdrawal = await getVaultRepClaim(client.account.address)
+		const vaultAfterWithdrawal = await getSecurityVault(client, securityPoolAddresses.securityPool, client.account.address)
+
+		strictEqualTypeSafe(await getQuestionResolution(client, securityPoolAddresses.escalationGame), QuestionOutcome.Yes, 'question should resolve to yes')
+		strictEqualTypeSafe(repClaimAfterWithdrawal - repClaimBeforeWithdrawal, 6n * 10n ** 18n, 'winning withdrawals should add only the boosted in-binding payout without double counting')
+		strictEqualTypeSafe(vaultAfterWithdrawal.lockedRepInEscalationGame, 0n, 'winning withdrawals should unlock all deposited REP')
 	})
 
 	test('can refund escalation deposits after zoltar forks on another question', async () => {
@@ -693,6 +730,72 @@ describe('Peripherals Contract Test Suite', () => {
 
 		const totalFeesOwedToVaultsAfterFork = await getTotalFeesOwedToVaults(client, securityPoolAddresses.securityPool)
 		strictEqualTypeSafe(totalFeesOwedToVaultsRightAfterFork, totalFeesOwedToVaultsAfterFork, "parent's fees should be frozen")
+	})
+
+	test('redeemShares updates security-pool accounting as winning shares are redeemed', async () => {
+		const securityPoolAllowance = repDeposit / 4n
+		await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, securityPoolAllowance)
+
+		const firstHolder = createWriteClient(mockWindow, TEST_ADDRESSES[2], 0)
+		const secondHolder = createWriteClient(mockWindow, TEST_ADDRESSES[3], 0)
+		await createCompleteSet(firstHolder, securityPoolAddresses.securityPool, 4n * 10n ** 18n)
+		await createCompleteSet(secondHolder, securityPoolAddresses.securityPool, 6n * 10n ** 18n)
+
+		const firstHolderShares = await balanceOfShares(firstHolder, securityPoolAddresses.shareToken, genesisUniverse, firstHolder.account.address)
+		const secondHolderShares = await balanceOfShares(secondHolder, securityPoolAddresses.shareToken, genesisUniverse, secondHolder.account.address)
+		const firstWinningShares = ensureDefined(firstHolderShares[1], 'first holder winning shares missing')
+		const secondWinningShares = ensureDefined(secondHolderShares[1], 'second holder winning shares missing')
+		const initialCollateral = await getCompleteSetCollateralAmount(client, securityPoolAddresses.securityPool)
+		const initialShareSupply = await getShareTokenSupply(client, securityPoolAddresses.securityPool)
+		const firstWinningCashValue = await sharesToCash(client, securityPoolAddresses.securityPool, firstWinningShares)
+		approximatelyEqual(initialCollateral, 10n * 10n ** 18n, 10n ** 11n, 'collateral should stay close to minted complete sets before finalization')
+		strictEqualTypeSafe(initialShareSupply, firstWinningShares + secondWinningShares, 'share supply should equal the minted winning-share balances')
+
+		await finalizeQuestionAsYesWithoutFork()
+		await redeemShares(firstHolder, securityPoolAddresses.securityPool)
+
+		approximatelyEqual(await getCompleteSetCollateralAmount(client, securityPoolAddresses.securityPool), initialCollateral - firstWinningCashValue, 10n, 'collateral should shrink after first winning redemption')
+		strictEqualTypeSafe(await getShareTokenSupply(client, securityPoolAddresses.securityPool), initialShareSupply - firstWinningShares, 'share supply should shrink after first winning redemption')
+		approximatelyEqual(await sharesToCash(client, securityPoolAddresses.securityPool, secondWinningShares), initialCollateral - firstWinningCashValue, 10n, 'remaining winning shares should not be double counted')
+
+		await redeemShares(secondHolder, securityPoolAddresses.securityPool)
+
+		strictEqualTypeSafe(await getCompleteSetCollateralAmount(client, securityPoolAddresses.securityPool), 0n, 'collateral should be empty after all winning shares are redeemed')
+		strictEqualTypeSafe(await getShareTokenSupply(client, securityPoolAddresses.securityPool), 0n, 'share supply should be empty after all winning shares are redeemed')
+	})
+
+	test('redeemShares stays available after an unrelated late fork once the question has finalized', async () => {
+		const securityPoolAllowance = repDeposit / 4n
+		await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, securityPoolAllowance)
+
+		const openInterestHolder = createWriteClient(mockWindow, TEST_ADDRESSES[2], 0)
+		await createCompleteSet(openInterestHolder, securityPoolAddresses.securityPool, 5n * 10n ** 18n)
+		await finalizeQuestionAsYesWithoutFork()
+
+		const attackerClient = createWriteClient(mockWindow, TEST_ADDRESSES[1], 0)
+		const repToken = await getRepToken(client, securityPoolAddresses.securityPool)
+		const repTotalSupplySlot = '0x' + 5n.toString(16).padStart(64, '0')
+		await mockWindow.addStateOverrides({
+			[repToken]: {
+				stateDiff: {
+					[repTotalSupplySlot]: repDeposit * 10n,
+				},
+			},
+		})
+
+		const lateForkQuestionData = {
+			...questionData,
+			title: 'late unrelated fork',
+			endTime: await mockWindow.getTime(),
+		}
+		const lateForkQuestionId = getQuestionId(lateForkQuestionData, outcomes)
+		await createQuestion(attackerClient, lateForkQuestionData, outcomes)
+		await approveToken(attackerClient, addressString(GENESIS_REPUTATION_TOKEN), getZoltarAddress())
+		await forkUniverse(attackerClient, genesisUniverse, lateForkQuestionId)
+
+		strictEqualTypeSafe(await getQuestionOutcome(client, securityPoolAddresses.securityPool), QuestionOutcome.Yes, 'late unrelated fork should not erase finalized market outcome')
+		await redeemShares(openInterestHolder, securityPoolAddresses.securityPool)
+		strictEqualTypeSafe(await getShareTokenSupply(client, securityPoolAddresses.securityPool), 0n, 'winning redemption should still complete after the unrelated fork')
 	})
 
 	test('two security pools with disagreement', async () => {

--- a/solidity/ts/tests/peripherals.test.ts
+++ b/solidity/ts/tests/peripherals.test.ts
@@ -291,20 +291,95 @@ describe('Peripherals Contract Test Suite', () => {
 		const attackerClient = createWriteClient(mockWindow, TEST_ADDRESSES[1], 0)
 		await approveAndDepositRep(attackerClient, repDeposit, questionId)
 
-		await depositToEscalationGame(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes, 5n * 10n ** 18n)
-		await depositToEscalationGame(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes, 7n * 10n ** 18n)
-		await depositToEscalationGame(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes, 2n * 10n ** 18n)
-		await depositToEscalationGame(attackerClient, securityPoolAddresses.securityPool, QuestionOutcome.No, 10n * 10n ** 18n)
+		const firstWinningDeposit = 5n * 10n ** 18n
+		const secondWinningDeposit = 7n * 10n ** 18n
+		const thirdWinningDeposit = 2n * 10n ** 18n
+		const losingDeposit = 10n * 10n ** 18n
+		const totalWinningPrincipal = firstWinningDeposit + secondWinningDeposit + thirdWinningDeposit
+		const totalPrincipalLocked = totalWinningPrincipal + losingDeposit
+		const expectedBindingCapital = losingDeposit
+		const expectedGrossWinningPayout = 20n * 10n ** 18n
+		const expectedWinnerProfit = expectedGrossWinningPayout - totalWinningPrincipal
+		const expectedResidualHaircut = totalPrincipalLocked - expectedGrossWinningPayout
+
+		// Payout breakdown:
+		// - first 5 REP sits entirely inside the 10 REP binding capital and pays 1.6x => 8 REP
+		// - second 7 REP crosses the boundary, so 5 REP pays 1.6x and 2 REP returns at par => 10 REP
+		// - final 2 REP sits entirely above the boundary and returns at par => 2 REP
+		// Winners therefore receive 20 REP total, which is 6 REP more than their 14 REP principal.
+		// The remaining 4 REP is the 40% haircut on the 10 REP binding-capital region and stays in the pool.
+		await depositToEscalationGame(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes, firstWinningDeposit)
+		await depositToEscalationGame(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes, secondWinningDeposit)
+		await depositToEscalationGame(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes, thirdWinningDeposit)
+		await depositToEscalationGame(attackerClient, securityPoolAddresses.securityPool, QuestionOutcome.No, losingDeposit)
 		await mockWindow.advanceTime(10n * DAY)
 
 		const repClaimBeforeWithdrawal = await getVaultRepClaim(client.account.address)
+		const lockedRepBeforeWithdrawal = (await getSecurityVault(client, securityPoolAddresses.securityPool, client.account.address)).lockedRepInEscalationGame
 		await withdrawFromEscalationGame(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes, [0n, 1n, 2n])
 		const repClaimAfterWithdrawal = await getVaultRepClaim(client.account.address)
 		const vaultAfterWithdrawal = await getSecurityVault(client, securityPoolAddresses.securityPool, client.account.address)
 
 		strictEqualTypeSafe(await getQuestionResolution(client, securityPoolAddresses.escalationGame), QuestionOutcome.Yes, 'question should resolve to yes')
-		strictEqualTypeSafe(repClaimAfterWithdrawal - repClaimBeforeWithdrawal, 6n * 10n ** 18n, 'winning withdrawals should add only the boosted in-binding payout without double counting')
+		strictEqualTypeSafe(lockedRepBeforeWithdrawal, totalWinningPrincipal, 'winner should have exactly the winning-side principal locked before withdrawal')
+		strictEqualTypeSafe(expectedBindingCapital, losingDeposit, 'single losing side should set the binding capital in this scenario')
+		strictEqualTypeSafe(expectedGrossWinningPayout, 8n * 10n ** 18n + 10n * 10n ** 18n + 2n * 10n ** 18n, 'gross winning payout should match the escalation payout schedule')
+		strictEqualTypeSafe(repClaimAfterWithdrawal - repClaimBeforeWithdrawal, expectedWinnerProfit, 'vault claim should increase only by winner profit; the original principal was already this vaults claim before it was locked')
+		strictEqualTypeSafe(totalPrincipalLocked - totalWinningPrincipal, losingDeposit, 'losing side should contribute 10 REP of principal')
+		strictEqualTypeSafe(expectedResidualHaircut, 4n * 10n ** 18n, '40% of the 10 REP binding-capital region should remain as slashed residual in the pool')
 		strictEqualTypeSafe(vaultAfterWithdrawal.lockedRepInEscalationGame, 0n, 'winning withdrawals should unlock all deposited REP')
+	})
+
+	test('withdrawFromEscalationGame pays a full 1.6x boost for deposits entirely inside the binding-capital region', async () => {
+		const endTime = await getQuestionEndDate(client, questionId)
+		await mockWindow.setTime(endTime + 10000n)
+
+		const supportingWinner = createWriteClient(mockWindow, TEST_ADDRESSES[1], 0)
+		const losingSide = createWriteClient(mockWindow, TEST_ADDRESSES[2], 0)
+		await approveAndDepositRep(supportingWinner, repDeposit, questionId)
+		await approveAndDepositRep(losingSide, repDeposit, questionId)
+
+		const boostedWinningDeposit = 5n * 10n ** 18n
+		const supportingWinningDeposit = 10n * 10n ** 18n
+		const losingDeposit = 10n * 10n ** 18n
+
+		await depositToEscalationGame(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes, boostedWinningDeposit)
+		await depositToEscalationGame(supportingWinner, securityPoolAddresses.securityPool, QuestionOutcome.Yes, supportingWinningDeposit)
+		await depositToEscalationGame(losingSide, securityPoolAddresses.securityPool, QuestionOutcome.No, losingDeposit)
+		await mockWindow.advanceTime(10n * DAY)
+
+		const repClaimBeforeWithdrawal = await getVaultRepClaim(client.account.address)
+		await withdrawFromEscalationGame(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes, [0n])
+		const repClaimAfterWithdrawal = await getVaultRepClaim(client.account.address)
+
+		strictEqualTypeSafe(await getQuestionResolution(client, securityPoolAddresses.escalationGame), QuestionOutcome.Yes, 'question should resolve to yes')
+		strictEqualTypeSafe(repClaimAfterWithdrawal - repClaimBeforeWithdrawal, 3n * 10n ** 18n, 'a 5 REP deposit fully inside the 10 REP binding-capital region should earn a 3 REP profit')
+	})
+
+	test('withdrawFromEscalationGame returns only principal for deposits entirely above the binding-capital region', async () => {
+		const endTime = await getQuestionEndDate(client, questionId)
+		await mockWindow.setTime(endTime + 10000n)
+
+		const firstWinner = createWriteClient(mockWindow, TEST_ADDRESSES[1], 0)
+		const losingSide = createWriteClient(mockWindow, TEST_ADDRESSES[2], 0)
+		await approveAndDepositRep(firstWinner, repDeposit, questionId)
+		await approveAndDepositRep(losingSide, repDeposit, questionId)
+
+		const inBindingWinningDeposit = 10n * 10n ** 18n
+		const aboveBindingWinningDeposit = 2n * 10n ** 18n
+		const losingDeposit = 10n * 10n ** 18n
+
+		await depositToEscalationGame(firstWinner, securityPoolAddresses.securityPool, QuestionOutcome.Yes, inBindingWinningDeposit)
+		await depositToEscalationGame(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes, aboveBindingWinningDeposit)
+		await depositToEscalationGame(losingSide, securityPoolAddresses.securityPool, QuestionOutcome.No, losingDeposit)
+		await mockWindow.advanceTime(10n * DAY)
+
+		const repClaimBeforeWithdrawal = await getVaultRepClaim(client.account.address)
+		await withdrawFromEscalationGame(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes, [1n])
+		const repClaimAfterWithdrawal = await getVaultRepClaim(client.account.address)
+
+		strictEqualTypeSafe(await getQuestionResolution(client, securityPoolAddresses.escalationGame), QuestionOutcome.Yes, 'question should resolve to yes')
+		strictEqualTypeSafe(repClaimAfterWithdrawal - repClaimBeforeWithdrawal, 0n, 'a 2 REP deposit entirely above the 10 REP binding-capital region should only unlock principal with no profit')
 	})
 
 	test('can refund escalation deposits after zoltar forks on another question', async () => {
@@ -764,6 +839,25 @@ describe('Peripherals Contract Test Suite', () => {
 		strictEqualTypeSafe(await getShareTokenSupply(client, securityPoolAddresses.securityPool), 0n, 'share supply should be empty after all winning shares are redeemed')
 	})
 
+	test('sharesToCash returns zero for stale non-winning shares after all winning shares are redeemed', async () => {
+		const completeSetAmount = 1n * 10n ** 18n
+		const securityPoolAllowance = repDeposit / 4n
+		await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, securityPoolAllowance)
+
+		const openInterestHolder = createWriteClient(mockWindow, TEST_ADDRESSES[3], 0)
+		await createCompleteSet(openInterestHolder, securityPoolAddresses.securityPool, completeSetAmount)
+		await finalizeQuestionAsYesWithoutFork()
+		const shareBalances = await balanceOfShares(client, securityPoolAddresses.shareToken, genesisUniverse, openInterestHolder.account.address)
+		const winningShares = ensureDefined(shareBalances[1], 'winning shares should exist before redemption')
+		const winningShareCashValue = await sharesToCash(client, securityPoolAddresses.securityPool, winningShares)
+
+		assert.ok(winningShareCashValue > 0n, 'winning shares should map to a positive cash value before redemption')
+		await redeemShares(openInterestHolder, securityPoolAddresses.securityPool)
+		strictEqualTypeSafe(await getCompleteSetCollateralAmount(client, securityPoolAddresses.securityPool), 0n, 'winning redemption should consume the remaining collateral')
+		strictEqualTypeSafe(await getShareTokenSupply(client, securityPoolAddresses.securityPool), 0n, 'winning redemption should consume the remaining share supply')
+		strictEqualTypeSafe(await sharesToCash(client, securityPoolAddresses.securityPool, winningShares), 0n, 'once winning supply is exhausted, leftover losing shares should no longer map to any cash value')
+	})
+
 	test('redeemShares stays available after an unrelated late fork once the question has finalized', async () => {
 		const securityPoolAllowance = repDeposit / 4n
 		await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, securityPoolAllowance)
@@ -935,12 +1029,10 @@ describe('Peripherals Contract Test Suite', () => {
 		const balancePriorYesRedeemal = await getETHBalance(client, addressString(TEST_ADDRESSES[2]))
 		await redeemShares(openInterestHolder, yesSecurityPool.securityPool)
 		const currentShares = await getCurrentOpenInterestArray()
-		const share0 = ensureDefined(currentShares[0], 'currentShares[0] is undefined')
-		const share2 = ensureDefined(currentShares[2], 'currentShares[2] is undefined')
 		const actualSharesAfterRedeem = await balanceOfSharesInCash(client, yesSecurityPool.securityPool, securityPoolAddresses.shareToken, yesUniverse, addressString(TEST_ADDRESSES[2]))
-		approximatelyEqual(actualSharesAfterRedeem[0], share0, 1000000000000000n, 'share0 after redeem should match')
+		assert.strictEqual(actualSharesAfterRedeem[0], 0n, 'non-winning invalid shares should be worthless after the only winning claimant redeems')
 		assert.strictEqual(actualSharesAfterRedeem[1], 0n, 'share1 should be zero')
-		approximatelyEqual(actualSharesAfterRedeem[2], share2, 1000000000000000n, 'share2 after redeem should match')
+		assert.strictEqual(actualSharesAfterRedeem[2], 0n, 'non-winning no shares should be worthless after the only winning claimant redeems')
 		const fees = (await getTotalFeesOwedToVaults(client, securityPoolAddresses.securityPool)) + (await getTotalFeesOwedToVaults(client, yesSecurityPool.securityPool))
 		approximatelyEqual(await getETHBalance(client, addressString(TEST_ADDRESSES[2])), balancePriorYesRedeemal + openInterestAmount - fees, 10n ** 15n, 'did not gain eth after redeeming yes shares')
 
@@ -974,8 +1066,8 @@ describe('Peripherals Contract Test Suite', () => {
 		const balancePriorNoRedeemal = await getETHBalance(client, addressString(TEST_ADDRESSES[2]))
 		await redeemShares(openInterestHolder, noSecurityPool.securityPool)
 		const actualNoSharesAfterRedeem = await balanceOfSharesInCash(client, noSecurityPool.securityPool, noSecurityPool.shareToken, noUniverse, addressString(TEST_ADDRESSES[2]))
-		approximatelyEqual(actualNoSharesAfterRedeem[0], currentShares[0], currentShares[0], 'no after redeem share0 should match')
-		approximatelyEqual(actualNoSharesAfterRedeem[1], currentShares[1], currentShares[1], 'no after redeem share1 should match')
+		assert.strictEqual(actualNoSharesAfterRedeem[0], 0n, 'non-winning invalid shares should be worthless after the only winning claimant redeems')
+		assert.strictEqual(actualNoSharesAfterRedeem[1], 0n, 'non-winning yes shares should be worthless after the only winning claimant redeems')
 		assert.strictEqual(actualNoSharesAfterRedeem[2], 0n, 'no after redeem share2 should be zero')
 		approximatelyEqual(await getETHBalance(client, addressString(TEST_ADDRESSES[2])), balancePriorNoRedeemal + openInterestAmount - fees, openInterestAmount, 'did not gain eth after redeeming no shares')
 

--- a/solidity/ts/testsuite/simulator/utils/contracts/securityPool.ts
+++ b/solidity/ts/testsuite/simulator/utils/contracts/securityPool.ts
@@ -73,6 +73,14 @@ export const getCompleteSetCollateralAmount = async (client: ReadClient, securit
 		args: [],
 	})
 
+export const getShareTokenSupply = async (client: ReadClient, securityPoolAddress: Address) =>
+	await client.readContract({
+		abi: peripherals_SecurityPool_SecurityPool.abi,
+		functionName: 'shareTokenSupply',
+		address: securityPoolAddress,
+		args: [],
+	})
+
 export const getSystemState = async (client: ReadClient, securityPoolAddress: Address): Promise<SystemState> =>
 	await client.readContract({
 		abi: peripherals_SecurityPool_SecurityPool.abi,

--- a/ui/build/sharedAssets.test.ts
+++ b/ui/build/sharedAssets.test.ts
@@ -26,7 +26,6 @@ test('shared helper assets are mirrored into deployable ui paths', () => {
 	expect(contractsSource).toContain("from './contracts/helpers.js'")
 	expect(contractsSource).toContain("from './contracts/deploymentHelpers.js'")
 	expect(contractsSource).not.toContain('../../shared/js/')
-	expect(deploymentHelpersSource).toContain("from '../shared/addressDerivation.js'")
 	expect(deploymentHelpersSource).toContain("from '../shared/deploymentAddresses.js'")
 	expect(deploymentHelpersSource).not.toContain('../../../shared/js/')
 

--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -1,16 +1,14 @@
 import { useSignal } from '@preact/signals'
 import type { Hash } from 'viem'
 import { useEffect } from 'preact/hooks'
+import { AppHeaderShell } from './components/AppHeaderShell.js'
+import { AppStatusNotices } from './components/AppStatusNotices.js'
 import { DeploymentRouteContent } from './components/DeploymentRouteContent.js'
 import { MainnetGateSection } from './components/MainnetGateSection.js'
-import { OverviewPanels } from './components/OverviewPanels.js'
 import { MarketSection } from './components/MarketSection.js'
 import { NotFoundSection } from './components/NotFoundSection.js'
 import { OpenOracleSection } from './components/OpenOracleSection.js'
-import { SimulationBanner } from './components/SimulationBanner.js'
-import { TabNavigation } from './components/TabNavigation.js'
 import { SecurityPoolsSection } from './components/SecurityPoolsSection.js'
-import { ErrorNotice } from './components/ErrorNotice.js'
 import { useDeploymentFlow } from './hooks/useDeploymentFlow.js'
 import { useForkAuctionOperations } from './hooks/useForkAuctionOperations.js'
 import { useHashRoute } from './hooks/useHashRoute.js'
@@ -35,8 +33,6 @@ import type { TransactionState } from './lib/transactionState.js'
 import { DEPLOY_ROUTE, OPEN_ORACLE_ROUTE, SECURITY_POOLS_ROUTE, ZOLTAR_ROUTE } from './lib/routing.js'
 import { getUniversePresentation, getWalletPresentation } from './lib/userCopy.js'
 import { formatUniverseCollectionLabel, formatUniverseLabel } from './lib/universe.js'
-import { TransactionHashLink } from './components/TransactionHashLink.js'
-import { TimestampValue } from './components/TimestampValue.js'
 
 export function App() {
 	const transactionState = useSignal<TransactionState>(createInitialTransactionState())
@@ -223,6 +219,35 @@ export function App() {
 	const universeLabel = formatUniverseCollectionLabel([activeUniverseId])
 	const universePresentation = showZoltarUniverseWarning ? getUniversePresentation(zoltarUniverseState) : undefined
 	const walletPresentation = getWalletPresentation({ accountAddress: accountState.address, hasWallet: hasInjectedWallet, isSupportedChain: isMainnet })
+	const overviewProps = {
+		accountState,
+		isConnectingWallet,
+		isLoadingRepPrices,
+		isLoadingUniverseRepBalance: loadingZoltarForkAccess,
+		onConnect: () => void connectWallet(),
+		onGoToGenesisUniverse: () => setActiveUniverseId(0n),
+		repPerEthPrice,
+		repPerEthSource,
+		repPerEthSourceUrl,
+		repUsdcPrice,
+		repUsdcSource,
+		repUsdcSourceUrl,
+		universePresentation,
+		universeLabel,
+		universeRepBalance: zoltarForkRepBalance,
+		isRefreshing,
+		walletBootstrapComplete,
+	}
+	const tabNavigationProps = {
+		route,
+		showDeployTab,
+		augurPlaceHolderDeployed: hasLoadedDeploymentStatuses && augurPlaceHolderDeployed === true && !showZoltarUniverseWarning,
+		deployRoute: DEPLOY_ROUTE,
+		marketRoute: ZOLTAR_ROUTE,
+		openOracleRoute: OPEN_ORACLE_ROUTE,
+		securityPoolsRoute: SECURITY_POOLS_ROUTE,
+		onRouteChange: navigate,
+	}
 	const selectedPool = securityPools.find(pool => pool.securityPoolAddress.toLowerCase() === securityPoolAddress.toLowerCase())
 	const refreshSelectedPoolData = () => {
 		if (!walletBootstrapComplete) return
@@ -567,64 +592,16 @@ export function App() {
 
 	return (
 		<main>
-			<div className='page-notices'>
-				{showZoltarUniverseForkedWarning && zoltarUniverse !== undefined ? (
-					<div className='notice error'>
-						{formatUniverseLabel(zoltarUniverse.universeId)} has forked on <TimestampValue timestamp={zoltarUniverse.forkTime} />.
-					</div>
-				) : undefined}
-				{showAugurPlaceHolderDeploymentWarning ? <div className='notice error'>Finish setup in Deploy before using the app.</div> : undefined}
-				{walletPresentation === undefined || hasInjectedWallet ? undefined : <p className='notice warning'>{walletPresentation.detail}</p>}
-				<ErrorNotice message={errorMessage} />
-				{transactionState.value.transactionInFlightCount > 0 ? (
-					<p className='notice success'>
-						<span className='spinner' aria-hidden='true' />
-						{transactionState.value.transactionSubmitted ? (
-							<>Transaction submitted, waiting for confirmation. {transactionState.value.lastTransactionHash === undefined ? <span>Pending wallet signature</span> : <TransactionHashLink hash={transactionState.value.lastTransactionHash} />}</>
-						) : (
-							'Awaiting wallet confirmation.'
-						)}
-					</p>
-				) : transactionState.value.lastTransactionHash === undefined ? undefined : (
-					<p className='notice success'>
-						Last transaction: <TransactionHashLink hash={transactionState.value.lastTransactionHash} />
-					</p>
-				)}
-			</div>
-			{simulationController === undefined ? undefined : <SimulationBanner controller={simulationController} onRefresh={refreshState} />}
-			<div className='top-shell'>
-				<div className='top-shell-content'>
-					<OverviewPanels
-						accountState={accountState}
-						isConnectingWallet={isConnectingWallet}
-						isLoadingRepPrices={isLoadingRepPrices}
-						isLoadingUniverseRepBalance={loadingZoltarForkAccess}
-						onConnect={() => void connectWallet()}
-						onGoToGenesisUniverse={() => setActiveUniverseId(0n)}
-						repPerEthPrice={repPerEthPrice}
-						repPerEthSource={repPerEthSource}
-						repPerEthSourceUrl={repPerEthSourceUrl}
-						repUsdcPrice={repUsdcPrice}
-						repUsdcSource={repUsdcSource}
-						repUsdcSourceUrl={repUsdcSourceUrl}
-						universePresentation={universePresentation}
-						universeLabel={universeLabel}
-						universeRepBalance={zoltarForkRepBalance}
-						isRefreshing={isRefreshing}
-						walletBootstrapComplete={walletBootstrapComplete}
-					/>
-				</div>
-				<TabNavigation
-					route={route}
-					showDeployTab={showDeployTab}
-					augurPlaceHolderDeployed={hasLoadedDeploymentStatuses && augurPlaceHolderDeployed === true && !showZoltarUniverseWarning}
-					deployRoute={DEPLOY_ROUTE}
-					marketRoute={ZOLTAR_ROUTE}
-					openOracleRoute={OPEN_ORACLE_ROUTE}
-					securityPoolsRoute={SECURITY_POOLS_ROUTE}
-					onRouteChange={navigate}
-				/>
-			</div>
+			<AppStatusNotices
+				errorMessage={errorMessage}
+				hasInjectedWallet={hasInjectedWallet}
+				showAugurPlaceHolderDeploymentWarning={showAugurPlaceHolderDeploymentWarning}
+				showZoltarUniverseForkedWarning={showZoltarUniverseForkedWarning}
+				transactionState={transactionState.value}
+				walletPresentation={walletPresentation}
+				zoltarUniverse={zoltarUniverse}
+			/>
+			<AppHeaderShell overview={overviewProps} simulationController={simulationController} tabNavigation={tabNavigationProps} onRefresh={refreshState} />
 
 			<fieldset className='route-shell' disabled={isRouteContentDisabled}>
 				{renderRouteContent()}

--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -1,14 +1,9 @@
 import { useSignal } from '@preact/signals'
-import type { Hash } from 'viem'
-import { useEffect } from 'preact/hooks'
+import type { Address, Hash } from 'viem'
 import { AppHeaderShell } from './components/AppHeaderShell.js'
+import { AppRouteContent } from './components/AppRouteContent.js'
 import { AppStatusNotices } from './components/AppStatusNotices.js'
-import { DeploymentRouteContent } from './components/DeploymentRouteContent.js'
-import { MainnetGateSection } from './components/MainnetGateSection.js'
-import { MarketSection } from './components/MarketSection.js'
-import { NotFoundSection } from './components/NotFoundSection.js'
-import { OpenOracleSection } from './components/OpenOracleSection.js'
-import { SecurityPoolsSection } from './components/SecurityPoolsSection.js'
+import { useAppRouteEffects } from './hooks/useAppRouteEffects.js'
 import { useDeploymentFlow } from './hooks/useDeploymentFlow.js'
 import { useForkAuctionOperations } from './hooks/useForkAuctionOperations.js'
 import { useHashRoute } from './hooks/useHashRoute.js'
@@ -32,7 +27,8 @@ import { createInitialTransactionState, markTransactionFinished, markTransaction
 import type { TransactionState } from './lib/transactionState.js'
 import { DEPLOY_ROUTE, OPEN_ORACLE_ROUTE, SECURITY_POOLS_ROUTE, ZOLTAR_ROUTE } from './lib/routing.js'
 import { getUniversePresentation, getWalletPresentation } from './lib/userCopy.js'
-import { formatUniverseCollectionLabel, formatUniverseLabel } from './lib/universe.js'
+import { formatUniverseCollectionLabel } from './lib/universe.js'
+import type { DeploymentRouteContentProps, MarketRouteContentProps, OpenOracleSectionProps, SecurityPoolsSectionProps } from './types/components.js'
 
 export function App() {
 	const transactionState = useSignal<TransactionState>(createInitialTransactionState())
@@ -254,322 +250,6 @@ export function App() {
 		if (!securityPoolAddress.startsWith('0x') || securityPoolAddress.length !== 42) return
 		void loadSecurityPools(securityPoolAddress)
 	}
-	const renderRouteContent = () => {
-		if (wrongNetworkMessage !== undefined) {
-			return <MainnetGateSection message={wrongNetworkMessage} />
-		}
-
-		switch (route) {
-			case 'deploy':
-				return (
-					<DeploymentRouteContent
-						accountAddress={accountState.address}
-						busyStepId={busyStepId}
-						deployNextMissingPending={deployNextMissingPending.value}
-						deploymentSections={deploymentSections}
-						deploymentStatuses={deploymentStatuses}
-						isLoadingDeploymentStatuses={isLoadingDeploymentStatuses}
-						isMainnet={isMainnet}
-						onDeploy={deployStep}
-						onDeployNextMissing={() => void onDeployNextMissing()}
-					/>
-				)
-			case 'zoltar':
-				return (
-					<MarketSection
-						accountState={accountState}
-						hasLoadedZoltarQuestions={hasLoadedZoltarQuestions}
-						loadingZoltarForkAccess={loadingZoltarForkAccess}
-						zoltarForkActiveAction={zoltarForkActiveAction}
-						loadingZoltarQuestionCount={loadingZoltarQuestionCount}
-						loadingZoltarQuestions={loadingZoltarQuestions}
-						loadingZoltarUniverse={loadingZoltarUniverse}
-						zoltarUniverseState={zoltarUniverseState}
-						onCreateChildUniverseForOutcomeIndex={outcomeIndex => void createZoltarChildUniverse(outcomeIndex)}
-						marketForm={marketForm}
-						marketCreating={marketCreating}
-						marketError={marketError}
-						marketResult={marketResult}
-						onApproveZoltarForkRep={amount => void approveZoltarForkRep(amount)}
-						onCreateMarket={() => void createMarket()}
-						onForkZoltar={() => void forkZoltar()}
-						onLoadZoltarQuestions={() => void loadZoltarQuestions()}
-						onMigrateInternalRep={() => void migrateInternalRep()}
-						onMarketFormChange={update => setMarketForm(current => ({ ...current, ...update }))}
-						onPrepareRepForMigration={() => void prepareRepForMigration()}
-						onResetMarket={resetMarket}
-						onUseQuestionForFork={questionId => setZoltarForkQuestionId(questionId)}
-						onUseQuestionForPool={onUseQuestionForPool}
-						onZoltarMigrationFormChange={update => setZoltarMigrationForm(current => ({ ...current, ...update }))}
-						zoltarQuestionCount={zoltarQuestionCount}
-						zoltarForkApproval={zoltarForkApproval}
-						zoltarForkError={zoltarForkError}
-						zoltarChildUniverseError={zoltarChildUniverseError}
-						zoltarChildUniversePendingOutcomeIndex={zoltarChildUniversePendingOutcomeIndex}
-						zoltarForkPending={zoltarForkPending}
-						zoltarForkQuestionId={zoltarForkQuestionId}
-						zoltarForkRepBalance={zoltarForkRepBalance}
-						zoltarMigrationError={zoltarMigrationError}
-						zoltarMigrationForm={zoltarMigrationForm}
-						zoltarMigrationChildRepBalances={zoltarMigrationChildRepBalances}
-						zoltarMigrationActiveAction={zoltarMigrationActiveAction}
-						zoltarMigrationPending={zoltarMigrationPending}
-						zoltarMigrationPreparedRepBalance={zoltarMigrationPreparedRepBalance}
-						zoltarMigrationResult={zoltarMigrationResult}
-						zoltarQuestions={zoltarQuestions}
-						zoltarUniverse={zoltarUniverse}
-						onZoltarForkQuestionIdChange={questionId => setZoltarForkQuestionId(questionId)}
-					/>
-				)
-			case 'security-pools':
-				return (
-					<SecurityPoolsSection
-						createPool={{
-							accountState,
-							checkingDuplicateOriginPool,
-							duplicateOriginPoolExists,
-							poolCreationMarketDetails,
-							onCreateSecurityPool: () => void createPool(),
-							onLoadMarket: () => void loadMarket(),
-							onLoadMarketById: loadMarketById,
-							loadingMarketDetails,
-							marketDetails,
-							onResetSecurityPoolCreation: resetSecurityPoolCreation,
-							onSecurityPoolFormChange: update => setSecurityPoolForm(current => ({ ...current, ...update })),
-							zoltarUniverseHasForked,
-							securityPools,
-							securityPoolCreating,
-							securityPoolError,
-							securityPoolForm,
-							securityPoolResult,
-							repPerEthPrice,
-							repPerEthSource,
-							repPerEthSourceUrl,
-						}}
-						overview={{
-							accountState,
-							checkedSecurityPoolAddress,
-							closeLiquidationModal: () => closeLiquidationModal(),
-							hasLoadedSecurityPools,
-							liquidationAmount,
-							liquidationManagerAddress,
-							liquidationModalOpen,
-							liquidationSecurityPoolAddress,
-							liquidationTargetVault,
-							loadingSecurityPools,
-							onLiquidationAmountChange: setLiquidationAmount,
-							onLiquidationTargetVaultChange: setLiquidationTargetVault,
-							onOpenLiquidationModal: (managerAddress, securityPoolAddress, vaultAddress) => openLiquidationModal(managerAddress, securityPoolAddress, vaultAddress),
-							onLoadSecurityPools: () => void loadSecurityPools(),
-							onQueueLiquidation: (managerAddress, securityPoolAddress) => void queueLiquidation(managerAddress, securityPoolAddress),
-							securityPoolOverviewActiveAction,
-							securityPoolOverviewError,
-							securityPoolOverviewResult,
-							securityPools,
-							repPerEthPrice,
-							repPerEthSource,
-							repPerEthSourceUrl,
-						}}
-						workflow={{
-							accountState,
-							activeUniverseId,
-							checkedSecurityPoolAddress,
-							closeLiquidationModal: () => closeLiquidationModal(),
-							forkAuction: {
-								accountState,
-								forkAuctionActiveAction,
-								forkAuctionDetails,
-								forkAuctionError,
-								forkAuctionForm,
-								forkAuctionResult,
-								loadingForkAuctionDetails,
-								onClaimAuctionProceeds: () => void claimAuctionProceeds(),
-								onCreateChildUniverse: () => void createChildUniverse(forkAuctionForm.selectedOutcome),
-								onFinalizeTruthAuction: () => void finalizeTruthAuction(),
-								onForkAuctionFormChange: update => setForkAuctionForm(current => ({ ...current, ...update })),
-								onForkUniverse: () => void forkUniverse(),
-								onForkWithOwnEscalation: () => void forkWithOwnEscalation(),
-								onInitiateFork: () => void initiateFork(),
-								onLoadForkAuction: () => void loadForkAuction(),
-								onMigrateEscalationDeposits: () => void migrateEscalation(),
-								onMigrateRepToZoltar: () => void migrateRepToZoltar(),
-								onMigrateVault: () => void migrateVault(),
-								onRefundLosingBids: () => void refundLosingBids(),
-								onStartTruthAuction: () => void startTruthAuction(),
-								onSubmitBid: () => void submitBid(),
-								onWithdrawBids: () => void withdrawBids(),
-							},
-							liquidationAmount,
-							liquidationManagerAddress,
-							liquidationModalOpen,
-							liquidationSecurityPoolAddress,
-							liquidationTargetVault,
-							onLiquidationAmountChange: setLiquidationAmount,
-							onLiquidationTargetVaultChange: setLiquidationTargetVault,
-							onOpenLiquidationModal: (managerAddress, securityPoolAddress, vaultAddress) => openLiquidationModal(managerAddress, securityPoolAddress, vaultAddress),
-							onQueueLiquidation: (managerAddress, securityPoolAddress) => void queueLiquidation(managerAddress, securityPoolAddress),
-							loadingPoolOracleManager,
-							loadingSecurityPools,
-							onLoadPoolOracleManager: managerAddress => void loadPoolOracleManager(managerAddress),
-							onRequestPoolPrice: managerAddress => void requestPoolPrice(managerAddress),
-							onRefreshSelectedPoolData: refreshSelectedPoolData,
-							onViewPendingReport: reportId => {
-								setOpenOracleForm(current => ({ ...current, reportId: reportId.toString() }))
-								navigate('open-oracle')
-								void loadOracleReport(reportId.toString())
-							},
-							securityPoolOverviewActiveAction,
-							poolOracleActiveAction,
-							poolOracleManagerDetails,
-							poolOracleManagerError,
-							poolPriceOracleResult,
-							onSecurityPoolAddressChange: value => {
-								setSecurityPoolAddress(value)
-							},
-							repPerEthPrice,
-							repPerEthSource,
-							repPerEthSourceUrl,
-							reporting: {
-								accountState,
-								loadingReportingDetails,
-								onLoadReporting: () => void loadReporting(),
-								onReportOutcome: () => void onReportOutcome(),
-								onReportingFormChange: update => setReportingForm(current => ({ ...current, ...update })),
-								onWithdrawEscalation: () => void withdrawEscalation(),
-								reportingActiveAction,
-								reportingDetails,
-								reportingError,
-								reportingForm,
-								reportingResult,
-							},
-							securityPoolAddress,
-							securityPools,
-							securityVault: {
-								accountState,
-								loadingSecurityVault,
-								onApproveRep: amount => void approveRep(amount),
-								onDepositRep: () => void depositRep(),
-								onLoadSecurityVault: vaultAddress => void loadSecurityVault(vaultAddress),
-								onRedeemFees: () => void redeemFees(),
-								onSetSecurityBondAllowance: () => void setSecurityBondAllowance(),
-								onSecurityVaultFormChange: update => setSecurityVaultForm(current => ({ ...current, ...update })),
-								onWithdrawRep: () => void withdrawRep(),
-								securityVaultActiveAction,
-								securityVaultDetails,
-								securityVaultError,
-								securityVaultForm,
-								securityVaultMissing,
-								securityVaultRepApproval,
-								securityVaultRepBalance,
-								securityVaultResult,
-								selectedPoolSecurityMultiplier: selectedPool?.securityMultiplier,
-								repPerEthPrice,
-								repPerEthSource,
-								repPerEthSourceUrl,
-								securityPoolVaults: selectedPool?.vaults,
-							},
-							trading: {
-								accountState,
-								loadingTradingForkUniverse,
-								loadingTradingDetails,
-								onCreateCompleteSet: () => void createCompleteSet(),
-								onMigrateShares: () => void migrateShares(),
-								onRedeemCompleteSet: () => void redeemCompleteSet(),
-								onRedeemShares: () => void redeemShares(),
-								onTradingFormChange: update => setTradingForm(current => ({ ...current, ...update })),
-								repPerEthPrice,
-								repPerEthSource,
-								repPerEthSourceUrl,
-								selectedPool,
-								tradingActiveAction,
-								tradingDetails,
-								tradingError,
-								tradingForm,
-								tradingForkUniverse,
-								tradingResult,
-							},
-						}}
-					/>
-				)
-			case 'open-oracle':
-				return (
-					<OpenOracleSection
-						accountState={accountState}
-						initialView={urlOpenOracleReportId === '' && openOracleForm.reportId === '' ? 'browse' : 'selected-report'}
-						loadingOracleReport={loadingOracleReport}
-						onApproveToken1={amount => void approveToken1(amount)}
-						onApproveToken2={amount => void approveToken2(amount)}
-						onCreateOpenOracleGame={() => void createOpenOracleGame()}
-						onDisputeReport={() => void disputeReport()}
-						onLoadOracleReport={reportId => void loadOracleReport(reportId)}
-						onRefreshPrice={refreshPrice}
-						onOpenOracleCreateFormChange={update => setOpenOracleCreateForm(current => ({ ...current, ...update }))}
-						onOpenOracleFormChange={update => setOpenOracleForm(current => ({ ...current, ...update }))}
-						onSettleReport={() => void settleReport()}
-						onSubmitInitialReport={() => void submitInitialReport()}
-						onWrapWethForInitialReport={() => void wrapWethForInitialReport()}
-						loadingOpenOracleCreate={loadingOpenOracleCreate}
-						openOracleActiveAction={openOracleActiveAction}
-						openOracleError={openOracleError}
-						openOracleCreateForm={openOracleCreateForm}
-						openOracleForm={openOracleForm}
-						openOracleInitialReportState={openOracleInitialReportState}
-						openOracleReportDetails={openOracleReportDetails}
-						openOracleResult={openOracleResult}
-					/>
-				)
-			case 'not-found':
-				return <NotFoundSection />
-			default:
-				return <NotFoundSection />
-		}
-	}
-
-	useEffect(() => {
-		if (urlOpenOracleReportId === '') return
-		void loadOracleReport(urlOpenOracleReportId)
-	}, [urlOpenOracleReportId])
-
-	useEffect(() => {
-		if (openOracleReportDetails !== undefined) {
-			setOpenOracleReport(openOracleReportDetails.reportId.toString())
-			return
-		}
-		if (openOracleForm.reportId.trim() !== '') {
-			setOpenOracleReport(openOracleForm.reportId)
-			return
-		}
-		setOpenOracleReport(undefined)
-	}, [openOracleForm.reportId, openOracleReportDetails])
-
-	useEffect(() => {
-		setSecurityVaultForm(current => (current.securityPoolAddress === securityPoolAddress ? current : { ...current, securityPoolAddress }))
-		setTradingForm(current => (current.securityPoolAddress === securityPoolAddress ? current : { ...current, securityPoolAddress }))
-		setForkAuctionForm(current => (current.securityPoolAddress === securityPoolAddress ? current : { ...current, securityPoolAddress }))
-		setReportingForm(current => (current.securityPoolAddress === securityPoolAddress ? current : { ...current, securityPoolAddress }))
-	}, [securityPoolAddress])
-
-	useEffect(() => {
-		if (selectedPool !== undefined) return
-		refreshSelectedPoolData()
-	}, [securityPoolAddress, selectedPool?.securityPoolAddress, walletBootstrapComplete])
-
-	useEffect(() => {
-		if (securityPoolResult === undefined) return
-		void loadSecurityPools()
-	}, [securityPoolResult?.deployPoolHash])
-
-	useEffect(() => {
-		if (tradingResult === undefined) return
-		refreshSelectedPoolData()
-	}, [tradingResult?.hash])
-
-	useEffect(() => {
-		if (!augurPlaceHolderDeploymentMissing) return
-		if (route === 'deploy') return
-		navigate('deploy')
-	}, [navigate, route, augurPlaceHolderDeploymentMissing])
-
 	const onDeployNextMissing = async () => {
 		if (deployNextMissingPending.value) return
 		deployNextMissingPending.value = true
@@ -590,6 +270,288 @@ export function App() {
 		navigate('security-pools')
 	}
 
+	useAppRouteEffects({
+		augurPlaceHolderDeploymentMissing,
+		loadOracleReport: async reportId => await loadOracleReport(reportId),
+		loadSecurityPools: async requestedSecurityPoolAddress => await loadSecurityPools(requestedSecurityPoolAddress),
+		navigate,
+		openOracleFormReportId: openOracleForm.reportId,
+		openOracleReportDetailsReportId: openOracleReportDetails?.reportId,
+		refreshSelectedPoolData,
+		route,
+		securityPoolAddress,
+		securityPoolResultHash: securityPoolResult?.deployPoolHash,
+		selectedPoolSecurityPoolAddress: selectedPool?.securityPoolAddress,
+		setForkAuctionFormSecurityPoolAddress: nextSecurityPoolAddress =>
+			setForkAuctionForm(current => (current.securityPoolAddress === nextSecurityPoolAddress ? current : { ...current, securityPoolAddress: nextSecurityPoolAddress })),
+		setOpenOracleReport,
+		setReportingFormSecurityPoolAddress: nextSecurityPoolAddress =>
+			setReportingForm(current => (current.securityPoolAddress === nextSecurityPoolAddress ? current : { ...current, securityPoolAddress: nextSecurityPoolAddress })),
+		setSecurityVaultFormSecurityPoolAddress: nextSecurityPoolAddress =>
+			setSecurityVaultForm(current => (current.securityPoolAddress === nextSecurityPoolAddress ? current : { ...current, securityPoolAddress: nextSecurityPoolAddress })),
+		setTradingFormSecurityPoolAddress: nextSecurityPoolAddress =>
+			setTradingForm(current => (current.securityPoolAddress === nextSecurityPoolAddress ? current : { ...current, securityPoolAddress: nextSecurityPoolAddress })),
+		tradingResultHash: tradingResult?.hash,
+		urlOpenOracleReportId,
+		walletBootstrapComplete,
+	})
+
+	const deployRouteContentProps: DeploymentRouteContentProps = {
+		accountAddress: accountState.address,
+		busyStepId,
+		deployNextMissingPending: deployNextMissingPending.value,
+		deploymentSections,
+		deploymentStatuses,
+		isLoadingDeploymentStatuses,
+		isMainnet,
+		onDeploy: deployStep,
+		onDeployNextMissing: () => void onDeployNextMissing(),
+	}
+
+	const marketRouteContentProps: MarketRouteContentProps = {
+		accountState,
+		hasLoadedZoltarQuestions,
+		loadingZoltarForkAccess,
+		zoltarForkActiveAction,
+		loadingZoltarQuestionCount,
+		loadingZoltarQuestions,
+		loadingZoltarUniverse,
+		zoltarUniverseState,
+		onCreateChildUniverseForOutcomeIndex: (outcomeIndex: bigint) => void createZoltarChildUniverse(outcomeIndex),
+		marketForm,
+		marketCreating,
+		marketError,
+		marketResult,
+		onApproveZoltarForkRep: amount => void approveZoltarForkRep(amount),
+		onCreateMarket: () => void createMarket(),
+		onForkZoltar: () => void forkZoltar(),
+		onLoadZoltarQuestions: () => void loadZoltarQuestions(),
+		onMigrateInternalRep: () => void migrateInternalRep(),
+		onMarketFormChange: update => setMarketForm(current => ({ ...current, ...update })),
+		onPrepareRepForMigration: () => void prepareRepForMigration(),
+		onResetMarket: resetMarket,
+		onUseQuestionForFork: (questionId: string) => setZoltarForkQuestionId(questionId),
+		onUseQuestionForPool,
+		onZoltarMigrationFormChange: update => setZoltarMigrationForm(current => ({ ...current, ...update })),
+		zoltarQuestionCount,
+		zoltarForkApproval,
+		zoltarForkError,
+		zoltarChildUniverseError,
+		zoltarChildUniversePendingOutcomeIndex,
+		zoltarForkPending,
+		zoltarForkQuestionId,
+		zoltarForkRepBalance,
+		zoltarMigrationError,
+		zoltarMigrationForm,
+		zoltarMigrationChildRepBalances,
+		zoltarMigrationActiveAction,
+		zoltarMigrationPending,
+		zoltarMigrationPreparedRepBalance,
+		zoltarMigrationResult,
+		zoltarQuestions,
+		zoltarUniverse,
+		onZoltarForkQuestionIdChange: (questionId: string) => setZoltarForkQuestionId(questionId),
+	}
+
+	const securityPoolsRouteContentProps: SecurityPoolsSectionProps = {
+		createPool: {
+			accountState,
+			checkingDuplicateOriginPool,
+			duplicateOriginPoolExists,
+			poolCreationMarketDetails,
+			onCreateSecurityPool: () => void createPool(),
+			onLoadMarket: () => void loadMarket(),
+			onLoadMarketById: loadMarketById,
+			loadingMarketDetails,
+			marketDetails,
+			onResetSecurityPoolCreation: resetSecurityPoolCreation,
+			onSecurityPoolFormChange: update => setSecurityPoolForm(current => ({ ...current, ...update })),
+			zoltarUniverseHasForked,
+			securityPools,
+			securityPoolCreating,
+			securityPoolError,
+			securityPoolForm,
+			securityPoolResult,
+			repPerEthPrice,
+			repPerEthSource,
+			repPerEthSourceUrl,
+		},
+		overview: {
+			accountState,
+			checkedSecurityPoolAddress,
+			closeLiquidationModal: () => closeLiquidationModal(),
+			hasLoadedSecurityPools,
+			liquidationAmount,
+			liquidationManagerAddress,
+			liquidationModalOpen,
+			liquidationSecurityPoolAddress,
+			liquidationTargetVault,
+			loadingSecurityPools,
+			onLiquidationAmountChange: setLiquidationAmount,
+			onLiquidationTargetVaultChange: setLiquidationTargetVault,
+			onOpenLiquidationModal: (managerAddress: Address, selectedSecurityPoolAddress: Address, vaultAddress: Address) => openLiquidationModal(managerAddress, selectedSecurityPoolAddress, vaultAddress),
+			onLoadSecurityPools: () => void loadSecurityPools(),
+			onQueueLiquidation: (managerAddress: Address, selectedSecurityPoolAddress: Address) => void queueLiquidation(managerAddress, selectedSecurityPoolAddress),
+			securityPoolOverviewActiveAction,
+			securityPoolOverviewError,
+			securityPoolOverviewResult,
+			securityPools,
+			repPerEthPrice,
+			repPerEthSource,
+			repPerEthSourceUrl,
+		},
+		workflow: {
+			accountState,
+			activeUniverseId,
+			checkedSecurityPoolAddress,
+			closeLiquidationModal: () => closeLiquidationModal(),
+			forkAuction: {
+				accountState,
+				forkAuctionActiveAction,
+				forkAuctionDetails,
+				forkAuctionError,
+				forkAuctionForm,
+				forkAuctionResult,
+				loadingForkAuctionDetails,
+				onClaimAuctionProceeds: () => void claimAuctionProceeds(),
+				onCreateChildUniverse: () => void createChildUniverse(forkAuctionForm.selectedOutcome),
+				onFinalizeTruthAuction: () => void finalizeTruthAuction(),
+				onForkAuctionFormChange: update => setForkAuctionForm(current => ({ ...current, ...update })),
+				onForkUniverse: () => void forkUniverse(),
+				onForkWithOwnEscalation: () => void forkWithOwnEscalation(),
+				onInitiateFork: () => void initiateFork(),
+				onLoadForkAuction: () => void loadForkAuction(),
+				onMigrateEscalationDeposits: () => void migrateEscalation(),
+				onMigrateRepToZoltar: () => void migrateRepToZoltar(),
+				onMigrateVault: () => void migrateVault(),
+				onRefundLosingBids: () => void refundLosingBids(),
+				onStartTruthAuction: () => void startTruthAuction(),
+				onSubmitBid: () => void submitBid(),
+				onWithdrawBids: () => void withdrawBids(),
+			},
+			liquidationAmount,
+			liquidationManagerAddress,
+			liquidationModalOpen,
+			liquidationSecurityPoolAddress,
+			liquidationTargetVault,
+			onLiquidationAmountChange: setLiquidationAmount,
+			onLiquidationTargetVaultChange: setLiquidationTargetVault,
+			onOpenLiquidationModal: (managerAddress: Address, selectedSecurityPoolAddress: Address, vaultAddress: Address) => openLiquidationModal(managerAddress, selectedSecurityPoolAddress, vaultAddress),
+			onQueueLiquidation: (managerAddress: Address, selectedSecurityPoolAddress: Address) => void queueLiquidation(managerAddress, selectedSecurityPoolAddress),
+			loadingPoolOracleManager,
+			loadingSecurityPools,
+			onLoadPoolOracleManager: (managerAddress: Address) => void loadPoolOracleManager(managerAddress),
+			onRequestPoolPrice: (managerAddress: Address) => void requestPoolPrice(managerAddress),
+			onRefreshSelectedPoolData: refreshSelectedPoolData,
+			onViewPendingReport: reportId => {
+				setOpenOracleForm(current => ({ ...current, reportId: reportId.toString() }))
+				navigate('open-oracle')
+				void loadOracleReport(reportId.toString())
+			},
+			securityPoolOverviewActiveAction,
+			poolOracleActiveAction,
+			poolOracleManagerDetails,
+			poolOracleManagerError,
+			poolPriceOracleResult,
+			onSecurityPoolAddressChange: value => {
+				setSecurityPoolAddress(value)
+			},
+			repPerEthPrice,
+			repPerEthSource,
+			repPerEthSourceUrl,
+			reporting: {
+				accountState,
+				loadingReportingDetails,
+				onLoadReporting: () => void loadReporting(),
+				onReportOutcome: () => void onReportOutcome(),
+				onReportingFormChange: update => setReportingForm(current => ({ ...current, ...update })),
+				onWithdrawEscalation: () => void withdrawEscalation(),
+				reportingActiveAction,
+				reportingDetails,
+				reportingError,
+				reportingForm,
+				reportingResult,
+			},
+			securityPoolAddress,
+			securityPools,
+			securityVault: {
+				accountState,
+				loadingSecurityVault,
+				onApproveRep: amount => void approveRep(amount),
+				onDepositRep: () => void depositRep(),
+				onLoadSecurityVault: vaultAddress => {
+					if (vaultAddress === undefined) return
+					void loadSecurityVault(vaultAddress)
+				},
+				onRedeemFees: () => void redeemFees(),
+				onSetSecurityBondAllowance: () => void setSecurityBondAllowance(),
+				onSecurityVaultFormChange: update => setSecurityVaultForm(current => ({ ...current, ...update })),
+				onWithdrawRep: () => void withdrawRep(),
+				securityVaultActiveAction,
+				securityVaultDetails,
+				securityVaultError,
+				securityVaultForm,
+				securityVaultMissing,
+				securityVaultRepApproval,
+				securityVaultRepBalance,
+				securityVaultResult,
+				selectedPoolSecurityMultiplier: selectedPool?.securityMultiplier,
+				repPerEthPrice,
+				repPerEthSource,
+				repPerEthSourceUrl,
+				securityPoolVaults: selectedPool?.vaults,
+			},
+			trading: {
+				accountState,
+				loadingTradingForkUniverse,
+				loadingTradingDetails,
+				onCreateCompleteSet: () => void createCompleteSet(),
+				onMigrateShares: () => void migrateShares(),
+				onRedeemCompleteSet: () => void redeemCompleteSet(),
+				onRedeemShares: () => void redeemShares(),
+				onTradingFormChange: update => setTradingForm(current => ({ ...current, ...update })),
+				repPerEthPrice,
+				repPerEthSource,
+				repPerEthSourceUrl,
+				selectedPool,
+				tradingActiveAction,
+				tradingDetails,
+				tradingError,
+				tradingForm,
+				tradingForkUniverse,
+				tradingResult,
+			},
+		},
+	}
+
+	const openOracleRouteContentProps: OpenOracleSectionProps = {
+		accountState,
+		initialView: urlOpenOracleReportId === '' && openOracleForm.reportId === '' ? 'browse' : 'selected-report',
+		loadingOracleReport,
+		onApproveToken1: amount => void approveToken1(amount),
+		onApproveToken2: amount => void approveToken2(amount),
+		onCreateOpenOracleGame: () => void createOpenOracleGame(),
+		onDisputeReport: () => void disputeReport(),
+		onLoadOracleReport: reportId => {
+			if (reportId === undefined) return
+			void loadOracleReport(reportId)
+		},
+		onRefreshPrice: refreshPrice,
+		onOpenOracleCreateFormChange: update => setOpenOracleCreateForm(current => ({ ...current, ...update })),
+		onOpenOracleFormChange: update => setOpenOracleForm(current => ({ ...current, ...update })),
+		onSettleReport: () => void settleReport(),
+		onSubmitInitialReport: () => void submitInitialReport(),
+		onWrapWethForInitialReport: () => void wrapWethForInitialReport(),
+		loadingOpenOracleCreate,
+		openOracleActiveAction,
+		openOracleError,
+		openOracleCreateForm,
+		openOracleForm,
+		openOracleInitialReportState,
+		openOracleReportDetails,
+		openOracleResult,
+	}
+
 	return (
 		<main>
 			<AppStatusNotices
@@ -604,7 +566,14 @@ export function App() {
 			<AppHeaderShell overview={overviewProps} simulationController={simulationController} tabNavigation={tabNavigationProps} onRefresh={refreshState} />
 
 			<fieldset className='route-shell' disabled={isRouteContentDisabled}>
-				{renderRouteContent()}
+				<AppRouteContent
+					deploy={deployRouteContentProps}
+					market={marketRouteContentProps}
+					openOracle={openOracleRouteContentProps}
+					route={route}
+					securityPools={securityPoolsRouteContentProps}
+					wrongNetworkMessage={wrongNetworkMessage}
+				/>
 			</fieldset>
 		</main>
 	)

--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -282,15 +282,11 @@ export function App() {
 		securityPoolAddress,
 		securityPoolResultHash: securityPoolResult?.deployPoolHash,
 		selectedPoolSecurityPoolAddress: selectedPool?.securityPoolAddress,
-		setForkAuctionFormSecurityPoolAddress: nextSecurityPoolAddress =>
-			setForkAuctionForm(current => (current.securityPoolAddress === nextSecurityPoolAddress ? current : { ...current, securityPoolAddress: nextSecurityPoolAddress })),
+		setForkAuctionFormSecurityPoolAddress: nextSecurityPoolAddress => setForkAuctionForm(current => (current.securityPoolAddress === nextSecurityPoolAddress ? current : { ...current, securityPoolAddress: nextSecurityPoolAddress })),
 		setOpenOracleReport,
-		setReportingFormSecurityPoolAddress: nextSecurityPoolAddress =>
-			setReportingForm(current => (current.securityPoolAddress === nextSecurityPoolAddress ? current : { ...current, securityPoolAddress: nextSecurityPoolAddress })),
-		setSecurityVaultFormSecurityPoolAddress: nextSecurityPoolAddress =>
-			setSecurityVaultForm(current => (current.securityPoolAddress === nextSecurityPoolAddress ? current : { ...current, securityPoolAddress: nextSecurityPoolAddress })),
-		setTradingFormSecurityPoolAddress: nextSecurityPoolAddress =>
-			setTradingForm(current => (current.securityPoolAddress === nextSecurityPoolAddress ? current : { ...current, securityPoolAddress: nextSecurityPoolAddress })),
+		setReportingFormSecurityPoolAddress: nextSecurityPoolAddress => setReportingForm(current => (current.securityPoolAddress === nextSecurityPoolAddress ? current : { ...current, securityPoolAddress: nextSecurityPoolAddress })),
+		setSecurityVaultFormSecurityPoolAddress: nextSecurityPoolAddress => setSecurityVaultForm(current => (current.securityPoolAddress === nextSecurityPoolAddress ? current : { ...current, securityPoolAddress: nextSecurityPoolAddress })),
+		setTradingFormSecurityPoolAddress: nextSecurityPoolAddress => setTradingForm(current => (current.securityPoolAddress === nextSecurityPoolAddress ? current : { ...current, securityPoolAddress: nextSecurityPoolAddress })),
 		tradingResultHash: tradingResult?.hash,
 		urlOpenOracleReportId,
 		walletBootstrapComplete,
@@ -566,14 +562,7 @@ export function App() {
 			<AppHeaderShell overview={overviewProps} simulationController={simulationController} tabNavigation={tabNavigationProps} onRefresh={refreshState} />
 
 			<fieldset className='route-shell' disabled={isRouteContentDisabled}>
-				<AppRouteContent
-					deploy={deployRouteContentProps}
-					market={marketRouteContentProps}
-					openOracle={openOracleRouteContentProps}
-					route={route}
-					securityPools={securityPoolsRouteContentProps}
-					wrongNetworkMessage={wrongNetworkMessage}
-				/>
+				<AppRouteContent deploy={deployRouteContentProps} market={marketRouteContentProps} openOracle={openOracleRouteContentProps} route={route} securityPools={securityPoolsRouteContentProps} wrongNetworkMessage={wrongNetworkMessage} />
 			</fieldset>
 		</main>
 	)

--- a/ui/ts/components/AppHeaderShell.tsx
+++ b/ui/ts/components/AppHeaderShell.tsx
@@ -1,0 +1,26 @@
+import { OverviewPanels } from './OverviewPanels.js'
+import { SimulationBanner } from './SimulationBanner.js'
+import { TabNavigation } from './TabNavigation.js'
+import type { OverviewPanelsProps, TabNavigationProps } from '../types/components.js'
+import type { SimulationController } from '../simulation/controller.js'
+
+type AppHeaderShellProps = {
+	overview: OverviewPanelsProps
+	simulationController: SimulationController | undefined
+	tabNavigation: TabNavigationProps
+	onRefresh: () => Promise<void>
+}
+
+export function AppHeaderShell({ overview, simulationController, tabNavigation, onRefresh }: AppHeaderShellProps) {
+	return (
+		<>
+			{simulationController === undefined ? undefined : <SimulationBanner controller={simulationController} onRefresh={onRefresh} />}
+			<div className='top-shell'>
+				<div className='top-shell-content'>
+					<OverviewPanels {...overview} />
+				</div>
+				<TabNavigation {...tabNavigation} />
+			</div>
+		</>
+	)
+}

--- a/ui/ts/components/AppRouteContent.tsx
+++ b/ui/ts/components/AppRouteContent.tsx
@@ -1,0 +1,39 @@
+import type { ComponentProps } from 'preact'
+import { DeploymentRouteContent } from './DeploymentRouteContent.js'
+import { MainnetGateSection } from './MainnetGateSection.js'
+import { MarketSection } from './MarketSection.js'
+import { NotFoundSection } from './NotFoundSection.js'
+import { OpenOracleSection } from './OpenOracleSection.js'
+import { SecurityPoolsSection } from './SecurityPoolsSection.js'
+
+type AppRoute = 'deploy' | 'not-found' | 'open-oracle' | 'security-pools' | 'zoltar'
+
+type Props = {
+	deploy: ComponentProps<typeof DeploymentRouteContent>
+	market: ComponentProps<typeof MarketSection>
+	openOracle: ComponentProps<typeof OpenOracleSection>
+	route: AppRoute
+	securityPools: ComponentProps<typeof SecurityPoolsSection>
+	wrongNetworkMessage: string | undefined
+}
+
+export function AppRouteContent({ deploy, market, openOracle, route, securityPools, wrongNetworkMessage }: Props) {
+	if (wrongNetworkMessage !== undefined) {
+		return <MainnetGateSection message={wrongNetworkMessage} />
+	}
+
+	switch (route) {
+		case 'deploy':
+			return <DeploymentRouteContent {...deploy} />
+		case 'zoltar':
+			return <MarketSection {...market} />
+		case 'security-pools':
+			return <SecurityPoolsSection {...securityPools} />
+		case 'open-oracle':
+			return <OpenOracleSection {...openOracle} />
+		case 'not-found':
+			return <NotFoundSection />
+		default:
+			return <NotFoundSection />
+	}
+}

--- a/ui/ts/components/AppStatusNotices.tsx
+++ b/ui/ts/components/AppStatusNotices.tsx
@@ -16,15 +16,7 @@ type AppStatusNoticesProps = {
 	zoltarUniverse: ZoltarUniverseSummary | undefined
 }
 
-export function AppStatusNotices({
-	errorMessage,
-	hasInjectedWallet,
-	showAugurPlaceHolderDeploymentWarning,
-	showZoltarUniverseForkedWarning,
-	transactionState,
-	walletPresentation,
-	zoltarUniverse,
-}: AppStatusNoticesProps) {
+export function AppStatusNotices({ errorMessage, hasInjectedWallet, showAugurPlaceHolderDeploymentWarning, showZoltarUniverseForkedWarning, transactionState, walletPresentation, zoltarUniverse }: AppStatusNoticesProps) {
 	return (
 		<div className='page-notices'>
 			{showZoltarUniverseForkedWarning && zoltarUniverse !== undefined ? (
@@ -38,11 +30,7 @@ export function AppStatusNotices({
 			{transactionState.transactionInFlightCount > 0 ? (
 				<p className='notice success'>
 					<span className='spinner' aria-hidden='true' />
-					{transactionState.transactionSubmitted ? (
-						<>Transaction submitted, waiting for confirmation. {transactionState.lastTransactionHash === undefined ? <span>Pending wallet signature</span> : <TransactionHashLink hash={transactionState.lastTransactionHash} />}</>
-					) : (
-						'Awaiting wallet confirmation.'
-					)}
+					{transactionState.transactionSubmitted ? <>Transaction submitted, waiting for confirmation. {transactionState.lastTransactionHash === undefined ? <span>Pending wallet signature</span> : <TransactionHashLink hash={transactionState.lastTransactionHash} />}</> : 'Awaiting wallet confirmation.'}
 				</p>
 			) : transactionState.lastTransactionHash === undefined ? undefined : (
 				<p className='notice success'>

--- a/ui/ts/components/AppStatusNotices.tsx
+++ b/ui/ts/components/AppStatusNotices.tsx
@@ -1,0 +1,54 @@
+import { ErrorNotice } from './ErrorNotice.js'
+import { TimestampValue } from './TimestampValue.js'
+import { TransactionHashLink } from './TransactionHashLink.js'
+import { formatUniverseLabel } from '../lib/universe.js'
+import type { UserMessagePresentation } from '../lib/userCopy.js'
+import type { TransactionState } from '../lib/transactionState.js'
+import type { ZoltarUniverseSummary } from '../types/contracts.js'
+
+type AppStatusNoticesProps = {
+	errorMessage: string | undefined
+	hasInjectedWallet: boolean
+	showAugurPlaceHolderDeploymentWarning: boolean
+	showZoltarUniverseForkedWarning: boolean
+	transactionState: TransactionState
+	walletPresentation: UserMessagePresentation | undefined
+	zoltarUniverse: ZoltarUniverseSummary | undefined
+}
+
+export function AppStatusNotices({
+	errorMessage,
+	hasInjectedWallet,
+	showAugurPlaceHolderDeploymentWarning,
+	showZoltarUniverseForkedWarning,
+	transactionState,
+	walletPresentation,
+	zoltarUniverse,
+}: AppStatusNoticesProps) {
+	return (
+		<div className='page-notices'>
+			{showZoltarUniverseForkedWarning && zoltarUniverse !== undefined ? (
+				<div className='notice error'>
+					{formatUniverseLabel(zoltarUniverse.universeId)} has forked on <TimestampValue timestamp={zoltarUniverse.forkTime} />.
+				</div>
+			) : undefined}
+			{showAugurPlaceHolderDeploymentWarning ? <div className='notice error'>Finish setup in Deploy before using the app.</div> : undefined}
+			{walletPresentation === undefined || hasInjectedWallet ? undefined : <p className='notice warning'>{walletPresentation.detail}</p>}
+			<ErrorNotice message={errorMessage} />
+			{transactionState.transactionInFlightCount > 0 ? (
+				<p className='notice success'>
+					<span className='spinner' aria-hidden='true' />
+					{transactionState.transactionSubmitted ? (
+						<>Transaction submitted, waiting for confirmation. {transactionState.lastTransactionHash === undefined ? <span>Pending wallet signature</span> : <TransactionHashLink hash={transactionState.lastTransactionHash} />}</>
+					) : (
+						'Awaiting wallet confirmation.'
+					)}
+				</p>
+			) : transactionState.lastTransactionHash === undefined ? undefined : (
+				<p className='notice success'>
+					Last transaction: <TransactionHashLink hash={transactionState.lastTransactionHash} />
+				</p>
+			)}
+		</div>
+	)
+}

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -1,33 +1,22 @@
-import { encodeAbiParameters, encodeDeployData, encodeFunctionData, getAddress, getCreate2Address, keccak256, parseAbiItem, zeroAddress, RpcError, type Abi, type Account, type Address, type ContractFunctionParameters, type Hash, type Hex, type MulticallReturnType } from 'viem'
+import { encodeFunctionData, parseAbiItem, zeroAddress, RpcError, type Abi, type Account, type Address, type ContractFunctionParameters, type Hash, type Hex, type MulticallReturnType, type TransactionReceipt } from 'viem'
 import { ABIS } from './abis.js'
 import { sortBigIntsAscending } from './shared/bigInt.js'
-import { createDeploymentStatusOracleAddressHelper } from './shared/deploymentAddresses.js'
 import { assertNever } from './lib/assert.js'
 import { getOracleManagerPriceValidUntilTimestamp } from './lib/securityVault.js'
 import { addOpenOracleBountyBuffer } from './lib/openOracle.js'
 import { getWethAddress } from './lib/uniswapQuoter.js'
-import { getGenesisReputationTokenAddress } from './lib/universe.js'
 import {
-	DeploymentStatusOracle_DeploymentStatusOracle,
-	ReputationToken_ReputationToken,
-	ScalarOutcomes_ScalarOutcomes,
 	Zoltar_Zoltar,
-	ZoltarQuestionData_ZoltarQuestionData,
 	peripherals_EscalationGame_EscalationGame,
 	peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator,
 	peripherals_SecurityPool_SecurityPool,
 	peripherals_SecurityPoolForker_SecurityPoolForker,
-	peripherals_SecurityPoolUtils_SecurityPoolUtils,
 	peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction,
-	peripherals_factories_PriceOracleManagerAndOperatorQueuerFactory_PriceOracleManagerAndOperatorQueuerFactory,
 	peripherals_factories_SecurityPoolFactory_SecurityPoolFactory,
-	peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory,
 	peripherals_openOracle_OpenOracle_OpenOracle,
 	peripherals_tokens_ShareToken_ShareToken,
 } from './contractArtifact.js'
 import type {
-	DeploymentStatusSnapshot,
-	DeploymentStep,
 	DeploymentStepId,
 	EscalationDeposit,
 	EscalationSide,
@@ -35,23 +24,17 @@ import type {
 	ForkAuctionActionResult,
 	ForkAuctionDetails,
 	ListedSecurityPool,
-	MarketCreationResult,
-	MarketDetails,
-	MarketType,
 	OpenOracleActionResult,
 	OracleManagerDetails,
 	OracleQueueOperation,
-	QuestionData,
 	ReadClient,
 	OpenOracleReportSummary,
 	OpenOracleReportSummaryPage,
 	ReportingActionResult,
 	ReportingDetails,
 	ReportingOutcomeKey,
-	SecurityPoolCreationResult,
 	SecurityPoolVaultSummary,
 	SecurityVaultActionResult,
-	SecurityVaultDetails,
 	TradingActionResult,
 	TradingDetails,
 	TradingShareBalances,
@@ -60,13 +43,10 @@ import type {
 	ZoltarChildUniverseActionResult,
 	ZoltarForkActionResult,
 	ZoltarMigrationActionResult,
-	ZoltarUniverseSummary,
 } from './types/contracts.js'
 import {
 	getEscalationSideLabel,
-	getMarketType,
 	getMinBigintValue,
-	getQuestionId,
 	getQuestionIdHex,
 	getReportingOutcomeKey,
 	getReportingOutcomeValue,
@@ -75,60 +55,30 @@ import {
 	hasTimestampAndNumber,
 	isBigintTriple,
 	isEscalationDepositPage,
-	isStringArray,
 	requireOpenOracleExtraDataTuple,
 	requireOpenOracleReportMetaTuple,
 	requireOpenOracleReportMetaTupleArray,
 	requireOpenOracleReportStatusTuple,
 	requireOpenOracleReportStatusTupleArray,
 	requireSecurityVaultTupleArray,
-	requireUniverseTupleArray,
 	toUint8Array,
-	type SecurityVaultTuple,
-	type UniverseTuple,
 } from './contracts/helpers.js'
-import {
-	PROXY_DEPLOYER_ADDRESS,
-	ZERO_SALT,
-	MULTICALL3_BYTECODE,
-	getEscalationGameFactoryByteCode,
-	getInfraContractAddresses,
-	getMulticall3Address,
-	getOpenOracleAddress,
-	getSecurityPoolAddresses,
-	getSecurityPoolForkerByteCode,
-	getSecurityPoolFactoryByteCode,
-	getShareTokenFactoryByteCode,
-	getZoltarAddress,
-	getZoltarInitCode,
-	getZoltarQuestionDataByteCode,
-} from './contracts/deploymentHelpers.js'
+import { getInfraContractAddresses, getMulticall3Address, getOpenOracleAddress } from './contracts/deploymentHelpers.js'
+export { getDeploymentSteps, loadDeploymentStatusOracleSnapshot, loadErc20Allowance, loadErc20Balance } from './contracts/deployment.js'
+import { getDeploymentSteps } from './contracts/deployment.js'
+export { createSecurityPool, loadSecurityVaultDetails, originSecurityPoolExists } from './contracts/securityPools.js'
+export { createMarket, loadAllZoltarQuestions, loadMarketDetails, loadZoltarQuestionCount, loadZoltarUniverseSummary } from './contracts/zoltar.js'
+import { loadMarketDetails } from './contracts/zoltar.js'
 
 export { getMulticall3Address, getOpenOracleAddress, getZoltarAddress } from './contracts/deploymentHelpers.js'
-
-const PROXY_DEPLOYER_SIGNER = getAddress('0x4c8d290a1b368ac4728d83a9e8321fc3af2b39b1')
-const PROXY_DEPLOYER_RAW_TRANSACTION = '0xf87e8085174876e800830186a08080ad601f80600e600039806000f350fe60003681823780368234f58015156014578182fd5b80825250506014600cf31ba02222222222222222222222222222222222222222222222222222222222222222a02222222222222222222222222222222222222222222222222222222222222222' satisfies Hex
-const PROXY_DEPLOYER_RUNTIME_CODE = '0x60003681823780368234f58015156014578182fd5b80825250506014600cf3' satisfies Hex
-const ZERO_HASH = '0x0000000000000000000000000000000000000000000000000000000000000000' satisfies Hash
-const FUND_PROXY_DEPLOYER_SIGNER_AMOUNT = 10000000000000000n
 const LIQUIDATION_OPERATION_TYPE = 0
 const ESCALATION_TIME_LENGTH = 4_233_600n
 const MIGRATION_TIME_LENGTH = 4_838_400n
 const TRUTH_AUCTION_TIME_LENGTH = 604_800n
 const QUESTION_OUTCOME_ABI = [parseAbiItem('function getQuestionOutcome(address securityPool) view returns (uint8 outcome)')]
-const ANSWER_OPTION_ABI = [parseAbiItem('function getAnswerOptionName(uint256 questionId, uint256 answer) view returns (string memory)')]
 
 const CONTRACT_PAGE_SIZE = 30n
 
-type DeployedChildUniverseRecord = {
-	forkQuestionId: bigint
-	forkTime: bigint
-	forkingOutcomeIndex: bigint
-	parentUniverseId: bigint
-	reputationToken: Address
-}
-type DeployedChildUniversesPage = readonly [readonly bigint[], readonly bigint[], readonly DeployedChildUniverseRecord[]]
-type QuestionTuple = readonly [string, string, bigint, bigint, bigint, bigint, bigint, string]
 type ForkDataTuple = readonly [bigint, Address, bigint, bigint, bigint, boolean, number]
 type AuctionClearingTuple = readonly [boolean, bigint, bigint, bigint]
 
@@ -144,63 +94,6 @@ type SecurityPoolDeploymentQueryResult = {
 	truthAuction: Address
 	universeId: bigint
 }
-
-function getDeploymentStatusOracleStepAddresses() {
-	const addresses = getInfraContractAddresses()
-	return [
-		PROXY_DEPLOYER_ADDRESS,
-		addresses.multicall3,
-		addresses.uniformPriceDualCapBatchAuctionFactory,
-		addresses.scalarOutcomes,
-		addresses.securityPoolUtils,
-		addresses.openOracle,
-		addresses.zoltarQuestionData,
-		addresses.zoltar,
-		addresses.shareTokenFactory,
-		addresses.priceOracleManagerAndOperatorQueuerFactory,
-		addresses.securityPoolForker,
-		addresses.escalationGameFactory,
-		addresses.securityPoolFactory,
-	] satisfies Address[]
-}
-
-function getDeploymentStatusOracleByteCode() {
-	return encodeDeployData({
-		abi: DeploymentStatusOracle_DeploymentStatusOracle.abi,
-		bytecode: `0x${DeploymentStatusOracle_DeploymentStatusOracle.evm.bytecode.object}`,
-		args: [getDeploymentStatusOracleStepAddresses()],
-	})
-}
-
-function getDeploymentStatusSnapshot(deployedMask: bigint, deploymentStatusOracleDeployed: boolean): DeploymentStatusSnapshot {
-	const steps = getDeploymentSteps()
-	let maskIndex = 0n
-	const deploymentStatuses = steps.map(step => {
-		if (step.id === 'deploymentStatusOracle') {
-			return {
-				...step,
-				deployed: deploymentStatusOracleDeployed,
-			}
-		}
-
-		const deployed = (deployedMask & (1n << maskIndex)) !== 0n
-		maskIndex += 1n
-		return {
-			...step,
-			deployed,
-		}
-	})
-	return {
-		augurPlaceHolderDeployed: deploymentStatuses.every(step => step.deployed),
-		deploymentStatuses,
-	}
-}
-
-const { getDeploymentStatusOracleAddress } = createDeploymentStatusOracleAddressHelper({
-	deploymentStatusOracleBytecode: getDeploymentStatusOracleByteCode,
-	proxyDeployerAddress: PROXY_DEPLOYER_ADDRESS,
-	zeroSalt: ZERO_SALT,
-})
 async function readRequiredMulticall<const TContracts extends readonly unknown[]>(client: Pick<ReadClient, 'multicall'>, contracts: TContracts): Promise<MulticallReturnType<TContracts, false>> {
 	return (await client.multicall({
 		allowFailure: false,
@@ -215,15 +108,6 @@ export async function readOptionalMulticall<const TContracts extends readonly un
 		contracts: contracts as readonly ContractFunctionParameters[],
 		multicallAddress: getMulticall3Address(),
 	})) as MulticallReturnType<TContracts, true>
-}
-
-async function deployViaProxy(client: WriteClient, bytecode: Hex) {
-	const hash = await client.sendTransaction({
-		to: PROXY_DEPLOYER_ADDRESS,
-		data: bytecode,
-	})
-	await client.waitForTransactionReceipt({ hash })
-	return hash
 }
 
 type ContractRevertReasonParams = {
@@ -270,6 +154,11 @@ function getOriginalErrorMessage(error: unknown) {
 }
 
 async function writeContractAndWait<TCallParams extends ContractRevertReasonParams>(client: WriteClient, getCallParams: () => TCallParams) {
+	const { hash } = await writeContractAndWaitForReceipt(client, getCallParams)
+	return hash
+}
+
+async function writeContractAndWaitForReceipt<TCallParams extends ContractRevertReasonParams>(client: WriteClient, getCallParams: () => TCallParams): Promise<{ hash: Hash; receipt: TransactionReceipt }> {
 	const callParams = getCallParams()
 	const data = encodeFunctionData({
 		abi: callParams.abi,
@@ -295,7 +184,7 @@ async function writeContractAndWait<TCallParams extends ContractRevertReasonPara
 		const reason = await getContractRevertReason(client, callParams)
 		throw new Error(reason ?? 'Transaction reverted')
 	}
-	return hash
+	return { hash, receipt }
 }
 
 async function readSecurityPoolUniverseId(client: Pick<ReadClient, 'readContract'>, securityPoolAddress: Address) {
@@ -307,231 +196,10 @@ async function readSecurityPoolUniverseId(client: Pick<ReadClient, 'readContract
 	})
 }
 
-async function securityPoolExists(client: Pick<ReadClient, 'getCode'>, securityPoolAddress: Address) {
-	const code = await client.getCode({ address: securityPoolAddress })
-	return code !== undefined && code !== '0x'
-}
-
-async function ensureProxyDeployerDeployed(client: WriteClient) {
-	const code = await client.getCode({ address: PROXY_DEPLOYER_ADDRESS })
-	if (code !== undefined && code !== '0x') return undefined
-	if (client.installSimulationProxyDeployer !== undefined) {
-		await client.installSimulationProxyDeployer({
-			address: PROXY_DEPLOYER_ADDRESS,
-			runtimeCode: PROXY_DEPLOYER_RUNTIME_CODE,
-		})
-		return ZERO_HASH
-	}
-
-	const fundHash = await client.sendTransaction({
-		to: PROXY_DEPLOYER_SIGNER,
-		value: FUND_PROXY_DEPLOYER_SIGNER_AMOUNT,
-	})
-	await client.waitForTransactionReceipt({ hash: fundHash })
-
-	const deployHash = await client.sendRawTransaction({
-		serializedTransaction: PROXY_DEPLOYER_RAW_TRANSACTION,
-	})
-	await client.waitForTransactionReceipt({ hash: deployHash })
-	return deployHash
-}
-
-export function getDeploymentSteps(): DeploymentStep[] {
-	const addresses = getInfraContractAddresses()
-
-	return [
-		{
-			id: 'proxyDeployer',
-			label: 'Proxy Deployer',
-			address: PROXY_DEPLOYER_ADDRESS,
-			dependencies: [],
-			deploy: async client => {
-				const hash = await ensureProxyDeployerDeployed(client)
-				return hash ?? ZERO_HASH
-			},
-		},
-		{
-			id: 'deploymentStatusOracle',
-			label: 'Deployment Status Oracle',
-			address: getDeploymentStatusOracleAddress(),
-			dependencies: ['proxyDeployer'],
-			deploy: async client => await deployViaProxy(client, getDeploymentStatusOracleByteCode()),
-		},
-		{
-			id: 'multicall3',
-			label: 'Multicall3',
-			address: addresses.multicall3,
-			dependencies: ['proxyDeployer'],
-			deploy: async client => await deployViaProxy(client, MULTICALL3_BYTECODE),
-		},
-		{
-			id: 'uniformPriceDualCapBatchAuctionFactory',
-			label: 'UniformPriceDualCapBatchAuctionFactory',
-			address: addresses.uniformPriceDualCapBatchAuctionFactory,
-			dependencies: ['proxyDeployer'],
-			deploy: async client => await deployViaProxy(client, `0x${peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory.evm.bytecode.object}`),
-		},
-		{
-			id: 'scalarOutcomes',
-			label: 'ScalarOutcomes',
-			address: addresses.scalarOutcomes,
-			dependencies: ['proxyDeployer'],
-			deploy: async client => await deployViaProxy(client, `0x${ScalarOutcomes_ScalarOutcomes.evm.bytecode.object}`),
-		},
-		{
-			id: 'securityPoolUtils',
-			label: 'SecurityPoolUtils',
-			address: addresses.securityPoolUtils,
-			dependencies: ['proxyDeployer'],
-			deploy: async client => await deployViaProxy(client, `0x${peripherals_SecurityPoolUtils_SecurityPoolUtils.evm.bytecode.object}`),
-		},
-		{
-			id: 'openOracle',
-			label: 'OpenOracle',
-			address: addresses.openOracle,
-			dependencies: ['proxyDeployer'],
-			deploy: async client => await deployViaProxy(client, `0x${peripherals_openOracle_OpenOracle_OpenOracle.evm.bytecode.object}`),
-		},
-		{
-			id: 'zoltarQuestionData',
-			label: 'ZoltarQuestionData',
-			address: addresses.zoltarQuestionData,
-			dependencies: ['proxyDeployer', 'scalarOutcomes'],
-			deploy: async client => await deployViaProxy(client, getZoltarQuestionDataByteCode()),
-		},
-		{
-			id: 'zoltar',
-			label: 'Zoltar',
-			address: addresses.zoltar,
-			dependencies: ['proxyDeployer', 'zoltarQuestionData'],
-			deploy: async client => {
-				const hash = await deployViaProxy(client, getZoltarInitCode(addresses.zoltarQuestionData))
-				await client.patchSimulationGenesisRepToken?.({
-					repAddress: getGenesisReputationTokenAddress(),
-					zoltarAddress: addresses.zoltar,
-				})
-				return hash
-			},
-		},
-		{
-			id: 'shareTokenFactory',
-			label: 'ShareTokenFactory',
-			address: addresses.shareTokenFactory,
-			dependencies: ['proxyDeployer', 'zoltar'],
-			deploy: async client => await deployViaProxy(client, getShareTokenFactoryByteCode(addresses.zoltar)),
-		},
-		{
-			id: 'priceOracleManagerAndOperatorQueuerFactory',
-			label: 'PriceOracleManagerAndOperatorQueuerFactory',
-			address: addresses.priceOracleManagerAndOperatorQueuerFactory,
-			dependencies: ['proxyDeployer'],
-			deploy: async client => await deployViaProxy(client, `0x${peripherals_factories_PriceOracleManagerAndOperatorQueuerFactory_PriceOracleManagerAndOperatorQueuerFactory.evm.bytecode.object}`),
-		},
-		{
-			id: 'securityPoolForker',
-			label: 'SecurityPoolForker',
-			address: addresses.securityPoolForker,
-			dependencies: ['proxyDeployer', 'scalarOutcomes', 'securityPoolUtils', 'zoltar'],
-			deploy: async client => await deployViaProxy(client, getSecurityPoolForkerByteCode(addresses.zoltar)),
-		},
-		{
-			id: 'escalationGameFactory',
-			label: 'EscalationGameFactory',
-			address: addresses.escalationGameFactory,
-			dependencies: ['proxyDeployer'],
-			deploy: async client => await deployViaProxy(client, getEscalationGameFactoryByteCode()),
-		},
-		{
-			id: 'securityPoolFactory',
-			label: 'SecurityPoolFactory',
-			address: addresses.securityPoolFactory,
-			dependencies: ['proxyDeployer', 'securityPoolForker', 'zoltarQuestionData', 'escalationGameFactory', 'openOracle', 'zoltar', 'shareTokenFactory', 'uniformPriceDualCapBatchAuctionFactory', 'priceOracleManagerAndOperatorQueuerFactory', 'securityPoolUtils'],
-			deploy: async client =>
-				await deployViaProxy(
-					client,
-					getSecurityPoolFactoryByteCode({
-						escalationGameFactory: addresses.escalationGameFactory,
-						openOracle: addresses.openOracle,
-						priceOracleManagerAndOperatorQueuerFactory: addresses.priceOracleManagerAndOperatorQueuerFactory,
-						securityPoolForker: addresses.securityPoolForker,
-						shareTokenFactory: addresses.shareTokenFactory,
-						uniformPriceDualCapBatchAuctionFactory: addresses.uniformPriceDualCapBatchAuctionFactory,
-						zoltar: addresses.zoltar,
-						zoltarQuestionData: addresses.zoltarQuestionData,
-					}),
-				),
-		},
-	]
-}
-
-async function loadDeploymentStatusOracleMask(client: Pick<ReadClient, 'readContract'>): Promise<bigint> {
-	return BigInt(
-		await client.readContract({
-			abi: DeploymentStatusOracle_DeploymentStatusOracle.abi,
-			functionName: 'getDeploymentMask',
-			address: getDeploymentStatusOracleAddress(),
-			args: [],
-		}),
-	)
-}
-
-export async function loadDeploymentStatusOracleSnapshot(client: Pick<ReadClient, 'readContract' | 'getCode'>): Promise<DeploymentStatusSnapshot> {
-	const deploymentStatusOracleAddress = getDeploymentStatusOracleAddress()
-	const deploymentStatusOracleCode = await client.getCode({ address: deploymentStatusOracleAddress })
-	if (deploymentStatusOracleCode === undefined || deploymentStatusOracleCode === '0x') {
-		const proxyDeployerCode = await client.getCode({ address: PROXY_DEPLOYER_ADDRESS })
-		const proxyDeployerDeployed = proxyDeployerCode !== undefined && proxyDeployerCode !== '0x'
-		return getDeploymentStatusSnapshot(proxyDeployerDeployed ? 1n : 0n, false)
-	}
-
-	const deployedMask = await loadDeploymentStatusOracleMask(client)
-	return getDeploymentStatusSnapshot(deployedMask, true)
-}
-
-export async function loadErc20Balance(client: ReadClient, tokenAddress: Address, ownerAddress: Address) {
-	return await client.readContract({
-		abi: ABIS.mainnet.erc20,
-		functionName: 'balanceOf',
-		address: tokenAddress,
-		args: [ownerAddress],
-	})
-}
-
-export async function loadErc20Allowance(client: ReadClient, tokenAddress: Address, ownerAddress: Address, spenderAddress: Address) {
-	return await client.readContract({
-		abi: ABIS.mainnet.erc20,
-		functionName: 'allowance',
-		address: tokenAddress,
-		args: [ownerAddress, spenderAddress],
-	})
-}
-
 function getDeploymentStep(id: DeploymentStepId) {
 	const step = getDeploymentSteps().find(candidate => candidate.id === id)
 	if (step === undefined) throw new Error(`Unknown deployment step: ${id}`)
 	return step
-}
-
-async function loadOutcomeLabels(client: ReadClient, questionId: bigint) {
-	let currentIndex = 0n
-	const outcomeLabels: string[] = []
-
-	while (true) {
-		const page = await client.readContract({
-			abi: ZoltarQuestionData_ZoltarQuestionData.abi,
-			functionName: 'getOutcomeLabels',
-			address: getDeploymentStep('zoltarQuestionData').address,
-			args: [questionId, currentIndex, CONTRACT_PAGE_SIZE],
-		})
-		if (!isStringArray(page)) throw new Error('Unexpected outcome labels response')
-
-		const labels = page.filter(label => label.length > 0)
-		outcomeLabels.push(...labels)
-		if (BigInt(labels.length) !== CONTRACT_PAGE_SIZE) break
-		currentIndex += CONTRACT_PAGE_SIZE
-	}
-
-	return outcomeLabels
 }
 
 async function loadEscalationDeposits(client: ReadClient, escalationGameAddress: Address, outcome: ReportingOutcomeKey): Promise<EscalationDeposit[]> {
@@ -564,243 +232,6 @@ async function loadEscalationDeposits(client: ReadClient, escalationGameAddress:
 	return deposits
 }
 
-export async function loadMarketDetails(client: ReadClient, questionId: bigint): Promise<MarketDetails> {
-	const [question, createdAt] = await readRequiredMulticall(client, [
-		{
-			abi: ZoltarQuestionData_ZoltarQuestionData.abi,
-			functionName: 'questions',
-			address: getDeploymentStep('zoltarQuestionData').address,
-			args: [questionId],
-		},
-		{
-			abi: ZoltarQuestionData_ZoltarQuestionData.abi,
-			functionName: 'questionCreatedTimestamp',
-			address: getDeploymentStep('zoltarQuestionData').address,
-			args: [questionId],
-		},
-	])
-	const questionData: QuestionTuple = question
-	const [title, description, startTime, endTime, numTicks, displayValueMin, displayValueMax, answerUnit] = questionData
-
-	const exists = createdAt > 0n || title !== '' || description !== '' || startTime !== 0n || endTime !== 0n || numTicks !== 0n
-	const outcomeLabels = exists ? await loadOutcomeLabels(client, questionId) : []
-
-	return {
-		answerUnit,
-		createdAt,
-		description,
-		displayValueMax,
-		displayValueMin,
-		endTime,
-		exists,
-		marketType: getMarketType({ title, description, startTime, endTime, numTicks, displayValueMin, displayValueMax, answerUnit }, outcomeLabels),
-		outcomeLabels,
-		numTicks,
-		questionId: getQuestionIdHex(questionId),
-		startTime,
-		title,
-	}
-}
-
-async function loadQuestionIds(client: ReadClient): Promise<bigint[]> {
-	const questionCount = await client.readContract({
-		abi: ZoltarQuestionData_ZoltarQuestionData.abi,
-		functionName: 'getQuestionCount',
-		address: getDeploymentStep('zoltarQuestionData').address,
-		args: [],
-	})
-
-	let currentIndex = 0n
-	const questionIds: bigint[] = []
-	while (currentIndex < questionCount) {
-		const page = await client.readContract({
-			abi: ZoltarQuestionData_ZoltarQuestionData.abi,
-			functionName: 'getQuestions',
-			address: getDeploymentStep('zoltarQuestionData').address,
-			args: [currentIndex, CONTRACT_PAGE_SIZE],
-		})
-		if (!Array.isArray(page)) throw new Error('Unexpected question id page response')
-
-		const normalizedPage = page.filter((questionId): questionId is bigint => typeof questionId === 'bigint' && questionId !== 0n).slice(0, Number(CONTRACT_PAGE_SIZE))
-		questionIds.push(...normalizedPage)
-		if (BigInt(normalizedPage.length) !== CONTRACT_PAGE_SIZE) break
-		currentIndex += CONTRACT_PAGE_SIZE
-	}
-
-	return questionIds
-}
-
-export async function loadAllZoltarQuestions(client: ReadClient): Promise<MarketDetails[]> {
-	const questionIds = await loadQuestionIds(client)
-	return await Promise.all(questionIds.map(async questionId => await loadMarketDetails(client, questionId)))
-}
-
-export async function loadZoltarQuestionCount(client: ReadClient) {
-	return await client.readContract({
-		abi: ZoltarQuestionData_ZoltarQuestionData.abi,
-		functionName: 'getQuestionCount',
-		address: getDeploymentStep('zoltarQuestionData').address,
-		args: [],
-	})
-}
-
-export async function loadZoltarUniverseSummary(client: ReadClient, universeId: bigint): Promise<ZoltarUniverseSummary | undefined> {
-	const zoltarAddress = getDeploymentStep('zoltar').address
-	const [repToken, universe, forkTime, forkThreshold] = await readRequiredMulticall(client, [
-		{
-			abi: Zoltar_Zoltar.abi,
-			functionName: 'getRepToken',
-			address: zoltarAddress,
-			args: [universeId],
-		},
-		{
-			abi: Zoltar_Zoltar.abi,
-			functionName: 'universes',
-			address: zoltarAddress,
-			args: [universeId],
-		},
-		{
-			abi: Zoltar_Zoltar.abi,
-			functionName: 'getForkTime',
-			address: zoltarAddress,
-			args: [universeId],
-		},
-		{
-			abi: Zoltar_Zoltar.abi,
-			functionName: 'getForkThreshold',
-			address: zoltarAddress,
-			args: [universeId],
-		},
-	])
-	if (repToken === zeroAddress) return undefined
-
-	const totalTheoreticalSupply = await client.readContract({
-		abi: ReputationToken_ReputationToken.abi,
-		functionName: 'getTotalTheoreticalSupply',
-		address: repToken,
-		args: [],
-	})
-	const universeData: UniverseTuple = universe
-	const [storedForkTime, forkQuestionId, forkingOutcomeIndex, , parentUniverseId] = universeData
-	const hasForked = forkTime > 0n || storedForkTime > 0n
-
-	let childUniverses: ZoltarUniverseSummary['childUniverses'] = []
-	let forkQuestionDetails: MarketDetails | undefined = undefined
-	if (hasForked && forkQuestionId > 0n) {
-		const marketDetails = await loadMarketDetails(client, forkQuestionId)
-		forkQuestionDetails = marketDetails
-		if (marketDetails.marketType === 'scalar') {
-			const deployedChildUniverses: ZoltarUniverseSummary['childUniverses'] = []
-			let currentIndex = 0n
-			while (true) {
-				const page: DeployedChildUniversesPage = await client.readContract({
-					abi: Zoltar_Zoltar.abi,
-					functionName: 'getDeployedChildUniverses',
-					address: getDeploymentStep('zoltar').address,
-					args: [universeId, currentIndex, CONTRACT_PAGE_SIZE],
-				})
-				const [outcomeIndexes, childUniverseIds, childUniverseTuples] = page
-				const outcomeLabels =
-					outcomeIndexes.length === 0
-						? []
-						: (
-								await readRequiredMulticall(
-									client,
-									outcomeIndexes.map(outcomeIndex => ({
-										abi: ANSWER_OPTION_ABI,
-										functionName: 'getAnswerOptionName',
-										address: getDeploymentStep('zoltarQuestionData').address,
-										args: [forkQuestionId, outcomeIndex],
-									})),
-								)
-							).map(outcomeLabel => String(outcomeLabel))
-				const pageChildren = outcomeIndexes.map((outcomeIndex, index) => {
-					const childUniverse = childUniverseTuples[index]
-					if (childUniverse === undefined) throw new Error('Unexpected deployed child universe response')
-					const { forkTime: childForkTime, parentUniverseId: childParentUniverseId, reputationToken: childReputationToken } = childUniverse
-					const outcomeLabel = outcomeLabels[index]
-					if (outcomeLabel === undefined) throw new Error('Unexpected outcome label response')
-					const childUniverseId = childUniverseIds[index]
-					if (childUniverseId === undefined) throw new Error('Unexpected deployed child universe response')
-					return {
-						exists: childReputationToken !== zeroAddress,
-						forkTime: childForkTime,
-						outcomeIndex,
-						outcomeLabel,
-						parentUniverseId: childParentUniverseId,
-						reputationToken: childReputationToken,
-						universeId: childUniverseId,
-					}
-				})
-				deployedChildUniverses.push(...pageChildren)
-				if (BigInt(pageChildren.length) !== CONTRACT_PAGE_SIZE) break
-				currentIndex += CONTRACT_PAGE_SIZE
-			}
-			childUniverses = deployedChildUniverses
-		} else {
-			const childOutcomeEntries = [
-				{ outcomeIndex: 0n, outcomeLabel: 'Invalid' },
-				...marketDetails.outcomeLabels.map((outcomeLabel, outcomeIndex) => ({
-					outcomeIndex: BigInt(outcomeIndex + 1),
-					outcomeLabel,
-				})),
-			]
-			const childUniverseIds = (
-				await readRequiredMulticall(
-					client,
-					childOutcomeEntries.map(({ outcomeIndex }) => ({
-						abi: Zoltar_Zoltar.abi,
-						functionName: 'getChildUniverseId',
-						address: getDeploymentStep('zoltar').address,
-						args: [universeId, outcomeIndex],
-					})),
-				)
-			).map(childUniverseId => BigInt(childUniverseId))
-			const childUniverseTuples = requireUniverseTupleArray(
-				await readRequiredMulticall(
-					client,
-					childUniverseIds.map(childUniverseId => ({
-						abi: Zoltar_Zoltar.abi,
-						functionName: 'universes',
-						address: getDeploymentStep('zoltar').address,
-						args: [childUniverseId],
-					})),
-				),
-				'child universe tuple',
-			)
-
-			childUniverses = childOutcomeEntries.map(({ outcomeIndex, outcomeLabel }, index) => {
-				const childUniverseId = childUniverseIds[index]
-				if (childUniverseId === undefined) throw new Error('Unexpected child universe id response')
-				const childUniverseData = childUniverseTuples[index]
-				if (childUniverseData === undefined) throw new Error('Unexpected child universe response')
-				const [childForkTime, , , childReputationToken, childParentUniverseId] = childUniverseData
-				return {
-					exists: childReputationToken !== zeroAddress,
-					forkTime: childForkTime,
-					outcomeIndex,
-					outcomeLabel,
-					parentUniverseId: childParentUniverseId,
-					reputationToken: childReputationToken,
-					universeId: childUniverseId,
-				}
-			})
-		}
-	}
-
-	return {
-		childUniverses,
-		forkThreshold,
-		forkQuestionDetails,
-		forkTime,
-		forkingOutcomeIndex,
-		hasForked,
-		parentUniverseId,
-		reputationToken: repToken,
-		totalTheoreticalSupply,
-		universeId,
-	}
-}
 
 export async function loadReportingDetails(client: ReadClient, securityPoolAddress: Address, accountAddress: Address | undefined): Promise<ReportingDetails> {
 	const [questionId, escalationGameAddress, completeSetCollateralAmount, universeId] = await readRequiredMulticall(client, [
@@ -908,142 +339,6 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 	}
 }
 
-export async function createMarket(
-	client: WriteClient,
-	parameters: {
-		marketType: MarketType
-		outcomeLabels: string[]
-		questionData: QuestionData
-	},
-) {
-	const questionId = getQuestionId(parameters.questionData, parameters.outcomeLabels)
-	const createQuestionHash = await writeContractAndWait(client, () => ({
-		address: getDeploymentStep('zoltarQuestionData').address,
-		abi: ZoltarQuestionData_ZoltarQuestionData.abi,
-		functionName: 'createQuestion',
-		args: [parameters.questionData, parameters.outcomeLabels],
-	}))
-
-	return {
-		questionId: getQuestionIdHex(questionId),
-		createQuestionHash,
-		marketType: parameters.marketType,
-	} satisfies MarketCreationResult
-}
-
-export async function createSecurityPool(
-	client: WriteClient,
-	parameters: {
-		currentRetentionRate: bigint
-		questionId: bigint
-		securityMultiplier: bigint
-	},
-) {
-	const deployPoolHash = await writeContractAndWait(client, () => ({
-		address: getDeploymentStep('securityPoolFactory').address,
-		abi: peripherals_factories_SecurityPoolFactory_SecurityPoolFactory.abi,
-		functionName: 'deployOriginSecurityPool',
-		args: [0n, parameters.questionId, parameters.securityMultiplier, parameters.currentRetentionRate],
-	}))
-
-	return {
-		deployPoolHash,
-		questionId: getQuestionIdHex(parameters.questionId),
-		securityPoolAddress: getSecurityPoolAddresses(zeroAddress, 0n, parameters.questionId, parameters.securityMultiplier).securityPool,
-		securityMultiplier: parameters.securityMultiplier,
-		universeId: 0n,
-	} satisfies SecurityPoolCreationResult
-}
-
-function getOriginSecurityPoolShareTokenSalt(questionId: bigint, securityMultiplier: bigint) {
-	return keccak256(encodeAbiParameters([{ type: 'uint256' }, { type: 'uint256' }], [securityMultiplier, questionId]))
-}
-
-function getOriginSecurityPoolShareTokenAddress(questionId: bigint, securityMultiplier: bigint) {
-	return getCreate2Address({
-		from: getInfraContractAddresses().shareTokenFactory,
-		salt: getOriginSecurityPoolShareTokenSalt(questionId, securityMultiplier),
-		bytecode: encodeDeployData({
-			abi: peripherals_tokens_ShareToken_ShareToken.abi,
-			bytecode: `0x${peripherals_tokens_ShareToken_ShareToken.evm.bytecode.object}`,
-			args: [getInfraContractAddresses().securityPoolFactory, getZoltarAddress(), questionId],
-		}),
-	})
-}
-
-export async function originSecurityPoolExists(client: Pick<ReadClient, 'getCode'>, questionId: bigint, securityMultiplier: bigint) {
-	const shareTokenAddress = getOriginSecurityPoolShareTokenAddress(questionId, securityMultiplier)
-	const code = await client.getCode({ address: shareTokenAddress })
-	return code !== undefined && code !== '0x'
-}
-
-export async function loadSecurityVaultDetails(client: ReadClient, securityPoolAddress: Address, vaultAddress: Address): Promise<SecurityVaultDetails | undefined> {
-	if (!(await securityPoolExists(client, securityPoolAddress))) return undefined
-
-	const [currentRetentionRate, managerAddress, poolOwnershipDenominator, repToken, totalSecurityBondAllowance, universeId, vaultData] = await readRequiredMulticall(client, [
-		{
-			abi: peripherals_SecurityPool_SecurityPool.abi,
-			functionName: 'currentRetentionRate',
-			address: securityPoolAddress,
-			args: [],
-		},
-		{
-			abi: peripherals_SecurityPool_SecurityPool.abi,
-			functionName: 'priceOracleManagerAndOperatorQueuer',
-			address: securityPoolAddress,
-			args: [],
-		},
-		{
-			abi: peripherals_SecurityPool_SecurityPool.abi,
-			functionName: 'poolOwnershipDenominator',
-			address: securityPoolAddress,
-			args: [],
-		},
-		{
-			abi: peripherals_SecurityPool_SecurityPool.abi,
-			functionName: 'repToken',
-			address: securityPoolAddress,
-			args: [],
-		},
-		{
-			abi: peripherals_SecurityPool_SecurityPool.abi,
-			functionName: 'totalSecurityBondAllowance',
-			address: securityPoolAddress,
-			args: [],
-		},
-		{
-			abi: peripherals_SecurityPool_SecurityPool.abi,
-			functionName: 'universeId',
-			address: securityPoolAddress,
-			args: [],
-		},
-		{
-			abi: peripherals_SecurityPool_SecurityPool.abi,
-			functionName: 'securityVaults',
-			address: securityPoolAddress,
-			args: [vaultAddress],
-		},
-	])
-	const vaultDataTuple: SecurityVaultTuple = vaultData
-	const [poolOwnership, securityBondAllowance, unpaidEthFees, , lockedRepInEscalationGame] = vaultDataTuple
-	const repDepositShare = poolOwnership === 0n || poolOwnershipDenominator === 0n ? 0n : await poolOwnershipToRep(client, securityPoolAddress, poolOwnership)
-
-	return {
-		currentRetentionRate: currentRetentionRate,
-		lockedRepInEscalationGame,
-		managerAddress,
-		poolOwnershipDenominator: poolOwnershipDenominator,
-		repDepositShare,
-		repToken,
-		securityBondAllowance,
-		securityPoolAddress,
-		totalSecurityBondAllowance: totalSecurityBondAllowance,
-		unpaidEthFees,
-		universeId,
-		vaultAddress,
-	}
-}
-
 async function getSecurityPoolVaultCount(client: ReadClient, securityPoolAddress: Address) {
 	return await client.readContract({
 		abi: peripherals_SecurityPool_SecurityPool.abi,
@@ -1059,15 +354,6 @@ async function getSecurityPoolVaults(client: ReadClient, securityPoolAddress: Ad
 		functionName: 'getVaults',
 		address: securityPoolAddress,
 		args: [startIndex, count],
-	})
-}
-
-async function poolOwnershipToRep(client: ReadClient, securityPoolAddress: Address, poolOwnership: bigint) {
-	return await client.readContract({
-		abi: peripherals_SecurityPool_SecurityPool.abi,
-		functionName: 'poolOwnershipToRep',
-		address: securityPoolAddress,
-		args: [poolOwnership],
 	})
 }
 

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -232,7 +232,6 @@ async function loadEscalationDeposits(client: ReadClient, escalationGameAddress:
 	return deposits
 }
 
-
 export async function loadReportingDetails(client: ReadClient, securityPoolAddress: Address, accountAddress: Address | undefined): Promise<ReportingDetails> {
 	const [questionId, escalationGameAddress, completeSetCollateralAmount, universeId] = await readRequiredMulticall(client, [
 		{

--- a/ui/ts/contracts/deployment.ts
+++ b/ui/ts/contracts/deployment.ts
@@ -4,26 +4,12 @@ import { createDeploymentStatusOracleAddressHelper } from '../shared/deploymentA
 import {
 	DeploymentStatusOracle_DeploymentStatusOracle,
 	ScalarOutcomes_ScalarOutcomes,
-	Zoltar_Zoltar,
-	ZoltarQuestionData_ZoltarQuestionData,
 	peripherals_SecurityPoolUtils_SecurityPoolUtils,
 	peripherals_factories_PriceOracleManagerAndOperatorQueuerFactory_PriceOracleManagerAndOperatorQueuerFactory,
-	peripherals_factories_SecurityPoolFactory_SecurityPoolFactory,
 	peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory,
 	peripherals_openOracle_OpenOracle_OpenOracle,
 } from '../contractArtifact.js'
-import {
-	MULTICALL3_BYTECODE,
-	PROXY_DEPLOYER_ADDRESS,
-	ZERO_SALT,
-	getEscalationGameFactoryByteCode,
-	getInfraContractAddresses,
-	getSecurityPoolFactoryByteCode,
-	getSecurityPoolForkerByteCode,
-	getShareTokenFactoryByteCode,
-	getZoltarInitCode,
-	getZoltarQuestionDataByteCode,
-} from './deploymentHelpers.js'
+import { MULTICALL3_BYTECODE, PROXY_DEPLOYER_ADDRESS, ZERO_SALT, getEscalationGameFactoryByteCode, getInfraContractAddresses, getSecurityPoolFactoryByteCode, getSecurityPoolForkerByteCode, getShareTokenFactoryByteCode, getZoltarInitCode, getZoltarQuestionDataByteCode } from './deploymentHelpers.js'
 import type { DeploymentStatusSnapshot, DeploymentStep, ReadClient, WriteClient } from '../types/contracts.js'
 import { getGenesisReputationTokenAddress } from '../lib/universe.js'
 

--- a/ui/ts/contracts/deployment.ts
+++ b/ui/ts/contracts/deployment.ts
@@ -1,0 +1,294 @@
+import { encodeDeployData, getAddress, type Address, type Hash, type Hex } from 'viem'
+import { ABIS } from '../abis.js'
+import { createDeploymentStatusOracleAddressHelper } from '../shared/deploymentAddresses.js'
+import {
+	DeploymentStatusOracle_DeploymentStatusOracle,
+	ScalarOutcomes_ScalarOutcomes,
+	Zoltar_Zoltar,
+	ZoltarQuestionData_ZoltarQuestionData,
+	peripherals_SecurityPoolUtils_SecurityPoolUtils,
+	peripherals_factories_PriceOracleManagerAndOperatorQueuerFactory_PriceOracleManagerAndOperatorQueuerFactory,
+	peripherals_factories_SecurityPoolFactory_SecurityPoolFactory,
+	peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory,
+	peripherals_openOracle_OpenOracle_OpenOracle,
+} from '../contractArtifact.js'
+import {
+	MULTICALL3_BYTECODE,
+	PROXY_DEPLOYER_ADDRESS,
+	ZERO_SALT,
+	getEscalationGameFactoryByteCode,
+	getInfraContractAddresses,
+	getSecurityPoolFactoryByteCode,
+	getSecurityPoolForkerByteCode,
+	getShareTokenFactoryByteCode,
+	getZoltarInitCode,
+	getZoltarQuestionDataByteCode,
+} from './deploymentHelpers.js'
+import type { DeploymentStatusSnapshot, DeploymentStep, ReadClient, WriteClient } from '../types/contracts.js'
+import { getGenesisReputationTokenAddress } from '../lib/universe.js'
+
+const PROXY_DEPLOYER_SIGNER = getAddress('0x4c8d290a1b368ac4728d83a9e8321fc3af2b39b1')
+const PROXY_DEPLOYER_RAW_TRANSACTION = '0xf87e8085174876e800830186a08080ad601f80600e600039806000f350fe60003681823780368234f58015156014578182fd5b80825250506014600cf31ba02222222222222222222222222222222222222222222222222222222222222222a02222222222222222222222222222222222222222222222222222222222222222' satisfies Hex
+const PROXY_DEPLOYER_RUNTIME_CODE = '0x60003681823780368234f58015156014578182fd5b80825250506014600cf3' satisfies Hex
+const ZERO_HASH = '0x0000000000000000000000000000000000000000000000000000000000000000' satisfies Hash
+const FUND_PROXY_DEPLOYER_SIGNER_AMOUNT = 10000000000000000n
+
+function getDeploymentStatusOracleStepAddresses() {
+	const addresses = getInfraContractAddresses()
+	return [
+		PROXY_DEPLOYER_ADDRESS,
+		addresses.multicall3,
+		addresses.uniformPriceDualCapBatchAuctionFactory,
+		addresses.scalarOutcomes,
+		addresses.securityPoolUtils,
+		addresses.openOracle,
+		addresses.zoltarQuestionData,
+		addresses.zoltar,
+		addresses.shareTokenFactory,
+		addresses.priceOracleManagerAndOperatorQueuerFactory,
+		addresses.securityPoolForker,
+		addresses.escalationGameFactory,
+		addresses.securityPoolFactory,
+	] satisfies Address[]
+}
+
+function getDeploymentStatusOracleByteCode() {
+	return encodeDeployData({
+		abi: DeploymentStatusOracle_DeploymentStatusOracle.abi,
+		bytecode: `0x${DeploymentStatusOracle_DeploymentStatusOracle.evm.bytecode.object}`,
+		args: [getDeploymentStatusOracleStepAddresses()],
+	})
+}
+
+function getDeploymentStatusSnapshot(deployedMask: bigint, deploymentStatusOracleDeployed: boolean): DeploymentStatusSnapshot {
+	const steps = getDeploymentSteps()
+	let maskIndex = 0n
+	const deploymentStatuses = steps.map(step => {
+		if (step.id === 'deploymentStatusOracle') {
+			return {
+				...step,
+				deployed: deploymentStatusOracleDeployed,
+			}
+		}
+
+		const deployed = (deployedMask & (1n << maskIndex)) !== 0n
+		maskIndex += 1n
+		return {
+			...step,
+			deployed,
+		}
+	})
+	return {
+		augurPlaceHolderDeployed: deploymentStatuses.every(step => step.deployed),
+		deploymentStatuses,
+	}
+}
+
+const { getDeploymentStatusOracleAddress } = createDeploymentStatusOracleAddressHelper({
+	deploymentStatusOracleBytecode: getDeploymentStatusOracleByteCode,
+	proxyDeployerAddress: PROXY_DEPLOYER_ADDRESS,
+	zeroSalt: ZERO_SALT,
+})
+
+async function deployViaProxy(client: WriteClient, bytecode: Hex) {
+	const hash = await client.sendTransaction({
+		to: PROXY_DEPLOYER_ADDRESS,
+		data: bytecode,
+	})
+	await client.waitForTransactionReceipt({ hash })
+	return hash
+}
+
+async function ensureProxyDeployerDeployed(client: WriteClient) {
+	const code = await client.getCode({ address: PROXY_DEPLOYER_ADDRESS })
+	if (code !== undefined && code !== '0x') return undefined
+	if (client.installSimulationProxyDeployer !== undefined) {
+		await client.installSimulationProxyDeployer({
+			address: PROXY_DEPLOYER_ADDRESS,
+			runtimeCode: PROXY_DEPLOYER_RUNTIME_CODE,
+		})
+		return ZERO_HASH
+	}
+
+	const fundHash = await client.sendTransaction({
+		to: PROXY_DEPLOYER_SIGNER,
+		value: FUND_PROXY_DEPLOYER_SIGNER_AMOUNT,
+	})
+	await client.waitForTransactionReceipt({ hash: fundHash })
+
+	const deployHash = await client.sendRawTransaction({
+		serializedTransaction: PROXY_DEPLOYER_RAW_TRANSACTION,
+	})
+	await client.waitForTransactionReceipt({ hash: deployHash })
+	return deployHash
+}
+
+async function loadDeploymentStatusOracleMask(client: Pick<ReadClient, 'readContract'>): Promise<bigint> {
+	return BigInt(
+		await client.readContract({
+			abi: DeploymentStatusOracle_DeploymentStatusOracle.abi,
+			functionName: 'getDeploymentMask',
+			address: getDeploymentStatusOracleAddress(),
+			args: [],
+		}),
+	)
+}
+
+export function getDeploymentSteps(): DeploymentStep[] {
+	const addresses = getInfraContractAddresses()
+
+	return [
+		{
+			id: 'proxyDeployer',
+			label: 'Proxy Deployer',
+			address: PROXY_DEPLOYER_ADDRESS,
+			dependencies: [],
+			deploy: async client => {
+				const hash = await ensureProxyDeployerDeployed(client)
+				return hash ?? ZERO_HASH
+			},
+		},
+		{
+			id: 'deploymentStatusOracle',
+			label: 'Deployment Status Oracle',
+			address: getDeploymentStatusOracleAddress(),
+			dependencies: ['proxyDeployer'],
+			deploy: async client => await deployViaProxy(client, getDeploymentStatusOracleByteCode()),
+		},
+		{
+			id: 'multicall3',
+			label: 'Multicall3',
+			address: addresses.multicall3,
+			dependencies: ['proxyDeployer'],
+			deploy: async client => await deployViaProxy(client, MULTICALL3_BYTECODE),
+		},
+		{
+			id: 'uniformPriceDualCapBatchAuctionFactory',
+			label: 'UniformPriceDualCapBatchAuctionFactory',
+			address: addresses.uniformPriceDualCapBatchAuctionFactory,
+			dependencies: ['proxyDeployer'],
+			deploy: async client => await deployViaProxy(client, `0x${peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory.evm.bytecode.object}`),
+		},
+		{
+			id: 'scalarOutcomes',
+			label: 'ScalarOutcomes',
+			address: addresses.scalarOutcomes,
+			dependencies: ['proxyDeployer'],
+			deploy: async client => await deployViaProxy(client, `0x${ScalarOutcomes_ScalarOutcomes.evm.bytecode.object}`),
+		},
+		{
+			id: 'securityPoolUtils',
+			label: 'SecurityPoolUtils',
+			address: addresses.securityPoolUtils,
+			dependencies: ['proxyDeployer'],
+			deploy: async client => await deployViaProxy(client, `0x${peripherals_SecurityPoolUtils_SecurityPoolUtils.evm.bytecode.object}`),
+		},
+		{
+			id: 'openOracle',
+			label: 'OpenOracle',
+			address: addresses.openOracle,
+			dependencies: ['proxyDeployer'],
+			deploy: async client => await deployViaProxy(client, `0x${peripherals_openOracle_OpenOracle_OpenOracle.evm.bytecode.object}`),
+		},
+		{
+			id: 'zoltarQuestionData',
+			label: 'ZoltarQuestionData',
+			address: addresses.zoltarQuestionData,
+			dependencies: ['proxyDeployer', 'scalarOutcomes'],
+			deploy: async client => await deployViaProxy(client, getZoltarQuestionDataByteCode()),
+		},
+		{
+			id: 'zoltar',
+			label: 'Zoltar',
+			address: addresses.zoltar,
+			dependencies: ['proxyDeployer', 'zoltarQuestionData'],
+			deploy: async client => {
+				const hash = await deployViaProxy(client, getZoltarInitCode(addresses.zoltarQuestionData))
+				await client.patchSimulationGenesisRepToken?.({
+					repAddress: getGenesisReputationTokenAddress(),
+					zoltarAddress: addresses.zoltar,
+				})
+				return hash
+			},
+		},
+		{
+			id: 'shareTokenFactory',
+			label: 'ShareTokenFactory',
+			address: addresses.shareTokenFactory,
+			dependencies: ['proxyDeployer', 'zoltar'],
+			deploy: async client => await deployViaProxy(client, getShareTokenFactoryByteCode(addresses.zoltar)),
+		},
+		{
+			id: 'priceOracleManagerAndOperatorQueuerFactory',
+			label: 'Price Oracle Manager Factory',
+			address: addresses.priceOracleManagerAndOperatorQueuerFactory,
+			dependencies: ['proxyDeployer'],
+			deploy: async client => await deployViaProxy(client, `0x${peripherals_factories_PriceOracleManagerAndOperatorQueuerFactory_PriceOracleManagerAndOperatorQueuerFactory.evm.bytecode.object}`),
+		},
+		{
+			id: 'securityPoolForker',
+			label: 'Security Pool Forker',
+			address: addresses.securityPoolForker,
+			dependencies: ['proxyDeployer', 'scalarOutcomes', 'securityPoolUtils', 'zoltar'],
+			deploy: async client => await deployViaProxy(client, getSecurityPoolForkerByteCode(addresses.zoltar)),
+		},
+		{
+			id: 'escalationGameFactory',
+			label: 'Escalation Game Factory',
+			address: addresses.escalationGameFactory,
+			dependencies: ['proxyDeployer'],
+			deploy: async client => await deployViaProxy(client, getEscalationGameFactoryByteCode()),
+		},
+		{
+			id: 'securityPoolFactory',
+			label: 'Security Pool Factory',
+			address: addresses.securityPoolFactory,
+			dependencies: ['proxyDeployer', 'securityPoolForker', 'zoltarQuestionData', 'escalationGameFactory', 'openOracle', 'zoltar', 'shareTokenFactory', 'uniformPriceDualCapBatchAuctionFactory', 'priceOracleManagerAndOperatorQueuerFactory', 'securityPoolUtils'],
+			deploy: async client =>
+				await deployViaProxy(
+					client,
+					getSecurityPoolFactoryByteCode({
+						escalationGameFactory: addresses.escalationGameFactory,
+						openOracle: addresses.openOracle,
+						priceOracleManagerAndOperatorQueuerFactory: addresses.priceOracleManagerAndOperatorQueuerFactory,
+						securityPoolForker: addresses.securityPoolForker,
+						shareTokenFactory: addresses.shareTokenFactory,
+						uniformPriceDualCapBatchAuctionFactory: addresses.uniformPriceDualCapBatchAuctionFactory,
+						zoltar: addresses.zoltar,
+						zoltarQuestionData: addresses.zoltarQuestionData,
+					}),
+				),
+		},
+	]
+}
+
+export async function loadDeploymentStatusOracleSnapshot(client: Pick<ReadClient, 'readContract' | 'getCode'>): Promise<DeploymentStatusSnapshot> {
+	const deploymentStatusOracleAddress = getDeploymentStatusOracleAddress()
+	const deploymentStatusOracleCode = await client.getCode({ address: deploymentStatusOracleAddress })
+	if (deploymentStatusOracleCode === undefined || deploymentStatusOracleCode === '0x') {
+		const proxyDeployerCode = await client.getCode({ address: PROXY_DEPLOYER_ADDRESS })
+		const proxyDeployerDeployed = proxyDeployerCode !== undefined && proxyDeployerCode !== '0x'
+		return getDeploymentStatusSnapshot(proxyDeployerDeployed ? 1n : 0n, false)
+	}
+
+	const deployedMask = await loadDeploymentStatusOracleMask(client)
+	return getDeploymentStatusSnapshot(deployedMask, true)
+}
+
+export async function loadErc20Balance(client: ReadClient, tokenAddress: Address, ownerAddress: Address) {
+	return await client.readContract({
+		abi: ABIS.mainnet.erc20,
+		functionName: 'balanceOf',
+		address: tokenAddress,
+		args: [ownerAddress],
+	})
+}
+
+export async function loadErc20Allowance(client: ReadClient, tokenAddress: Address, ownerAddress: Address, spenderAddress: Address) {
+	return await client.readContract({
+		abi: ABIS.mainnet.erc20,
+		functionName: 'allowance',
+		address: tokenAddress,
+		args: [ownerAddress, spenderAddress],
+	})
+}

--- a/ui/ts/contracts/deploymentHelpers.ts
+++ b/ui/ts/contracts/deploymentHelpers.ts
@@ -1,27 +1,19 @@
 import { encodeDeployData, getCreate2Address, keccak256, toHex, type Address, type Hex } from 'viem'
-import { createRepTokenAddressHelper, createSecurityPoolAddressHelper } from '../shared/addressDerivation.js'
 import { createApplyLinkedLibrariesHelper, createInfraContractAddressHelper, createZoltarAddressHelpers } from '../shared/deploymentAddresses.js'
-import { MAINNET_NETWORK_PROFILE } from '../lib/networkProfile.js'
 import { bigintToAddress } from './helpers.js'
 import {
-	ReputationToken_ReputationToken,
 	ScalarOutcomes_ScalarOutcomes,
 	Zoltar_Zoltar,
 	ZoltarQuestionData_ZoltarQuestionData,
-	peripherals_EscalationGame_EscalationGame,
 	peripherals_Multicall3_Multicall3,
-	peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator,
-	peripherals_SecurityPool_SecurityPool,
 	peripherals_SecurityPoolForker_SecurityPoolForker,
 	peripherals_SecurityPoolUtils_SecurityPoolUtils,
-	peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction,
 	peripherals_factories_EscalationGameFactory_EscalationGameFactory,
 	peripherals_factories_PriceOracleManagerAndOperatorQueuerFactory_PriceOracleManagerAndOperatorQueuerFactory,
 	peripherals_factories_SecurityPoolFactory_SecurityPoolFactory,
 	peripherals_factories_ShareTokenFactory_ShareTokenFactory,
 	peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory,
 	peripherals_openOracle_OpenOracle_OpenOracle,
-	peripherals_tokens_ShareToken_ShareToken,
 } from '../contractArtifact.js'
 
 export const PROXY_DEPLOYER_ADDRESS = bigintToAddress(0x7a0d94f55792c434d74a40883c6ed8545e406d12n)
@@ -118,17 +110,6 @@ export const { getZoltarAddress, getZoltarQuestionDataAddress } = createZoltarAd
 	zoltarQuestionDataBytecode: getZoltarQuestionDataByteCode,
 })
 
-const { getRepTokenAddress } = createRepTokenAddressHelper({
-	genesisRepTokenAddress: MAINNET_NETWORK_PROFILE.genesisRepTokenAddress,
-	getReputationTokenInitCode: zoltarAddress =>
-		encodeDeployData({
-			abi: ReputationToken_ReputationToken.abi,
-			bytecode: `0x${ReputationToken_ReputationToken.evm.bytecode.object}`,
-			args: [zoltarAddress],
-		}),
-	getZoltarAddress,
-})
-
 export const { getInfraContractAddresses } = createInfraContractAddressHelper({
 	getEscalationGameFactoryByteCode,
 	getSecurityPoolFactoryByteCode,
@@ -144,41 +125,6 @@ export const { getInfraContractAddresses } = createInfraContractAddressHelper({
 	securityPoolUtilsBytecode: `0x${peripherals_SecurityPoolUtils_SecurityPoolUtils.evm.bytecode.object}`,
 	uniformPriceDualCapBatchAuctionFactoryBytecode: `0x${peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory.evm.bytecode.object}`,
 	zeroSalt: ZERO_SALT,
-})
-
-export const { getSecurityPoolAddresses } = createSecurityPoolAddressHelper({
-	getEscalationGameInitCode: securityPool =>
-		encodeDeployData({
-			abi: peripherals_EscalationGame_EscalationGame.abi,
-			bytecode: `0x${peripherals_EscalationGame_EscalationGame.evm.bytecode.object}`,
-			args: [securityPool],
-		}),
-	getInfraContracts: () => getInfraContractAddresses(),
-	getPriceOracleManagerAndOperatorQueuerInitCode: (openOracle, repToken) =>
-		encodeDeployData({
-			abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
-			bytecode: `0x${peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.evm.bytecode.object}`,
-			args: [openOracle, repToken],
-		}),
-	getRepTokenAddress,
-	getSecurityPoolInitCode: ({ escalationGameFactory, openOracle, parent, priceOracleManagerAndOperatorQueuer, questionId, securityMultiplier, securityPoolFactory, securityPoolForker, shareToken, truthAuction, universeId, zoltar, zoltarQuestionData }) =>
-		encodeDeployData({
-			abi: peripherals_SecurityPool_SecurityPool.abi,
-			bytecode: applyLibraries(peripherals_SecurityPool_SecurityPool.evm.bytecode.object),
-			args: [securityPoolForker, securityPoolFactory, zoltarQuestionData, escalationGameFactory, priceOracleManagerAndOperatorQueuer, shareToken, openOracle, parent, zoltar, universeId, questionId, securityMultiplier, truthAuction],
-		}),
-	getShareTokenInitCode: (securityPoolFactory, zoltarAddress, questionId) =>
-		encodeDeployData({
-			abi: peripherals_tokens_ShareToken_ShareToken.abi,
-			bytecode: `0x${peripherals_tokens_ShareToken_ShareToken.evm.bytecode.object}`,
-			args: [securityPoolFactory, zoltarAddress, questionId],
-		}),
-	getTruthAuctionInitCode: securityPoolForker =>
-		encodeDeployData({
-			abi: peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.abi,
-			bytecode: `0x${peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.evm.bytecode.object}`,
-			args: [securityPoolForker],
-		}),
 })
 
 export function getOpenOracleAddress() {

--- a/ui/ts/contracts/helpers.ts
+++ b/ui/ts/contracts/helpers.ts
@@ -3,7 +3,7 @@ import type { MarketType, QuestionData, ReportingOutcomeKey, SecurityPoolSystemS
 
 type IntegerLike = bigint | number
 
-export type SecurityVaultTuple = readonly [bigint, bigint, bigint, bigint, bigint]
+type SecurityVaultTuple = readonly [bigint, bigint, bigint, bigint, bigint]
 export type UniverseTuple = readonly [bigint, bigint, bigint, Address, bigint]
 type OpenOracleReportMetaTuple = readonly [bigint, bigint, bigint, bigint, Address, IntegerLike, Address, boolean, IntegerLike, IntegerLike, IntegerLike, IntegerLike]
 type OpenOracleReportStatusTuple = readonly [bigint, bigint, bigint, Address, IntegerLike, IntegerLike, Address, IntegerLike, boolean, boolean]

--- a/ui/ts/contracts/securityPools.ts
+++ b/ui/ts/contracts/securityPools.ts
@@ -1,9 +1,5 @@
 import { encodeAbiParameters, encodeDeployData, encodeFunctionData, getCreate2Address, keccak256, RpcError, type Abi, type Account, type Address, type Hash, type TransactionReceipt } from 'viem'
-import {
-	peripherals_SecurityPool_SecurityPool,
-	peripherals_factories_SecurityPoolFactory_SecurityPoolFactory,
-	peripherals_tokens_ShareToken_ShareToken,
-} from '../contractArtifact.js'
+import { peripherals_SecurityPool_SecurityPool, peripherals_factories_SecurityPoolFactory_SecurityPoolFactory, peripherals_tokens_ShareToken_ShareToken } from '../contractArtifact.js'
 import type { SecurityPoolCreationResult, SecurityVaultDetails, WriteClient, ReadClient } from '../types/contracts.js'
 import { getQuestionIdHex } from './helpers.js'
 import { getDeploymentSteps } from './deployment.js'

--- a/ui/ts/contracts/securityPools.ts
+++ b/ui/ts/contracts/securityPools.ts
@@ -1,0 +1,200 @@
+import { encodeAbiParameters, encodeDeployData, encodeFunctionData, getCreate2Address, keccak256, RpcError, type Abi, type Account, type Address, type Hash, type TransactionReceipt } from 'viem'
+import {
+	peripherals_SecurityPool_SecurityPool,
+	peripherals_factories_SecurityPoolFactory_SecurityPoolFactory,
+	peripherals_tokens_ShareToken_ShareToken,
+} from '../contractArtifact.js'
+import type { SecurityPoolCreationResult, SecurityVaultDetails, WriteClient, ReadClient } from '../types/contracts.js'
+import { getQuestionIdHex } from './helpers.js'
+import { getDeploymentSteps } from './deployment.js'
+import { getInfraContractAddresses, getZoltarAddress } from './deploymentHelpers.js'
+
+type ContractRevertReasonParams = {
+	account?: Account | Address | undefined | null
+	abi: Abi | readonly unknown[]
+	address: Address
+	args?: readonly unknown[]
+	functionName: string
+	gas?: bigint
+	value?: bigint
+}
+
+function getDeploymentStepAddress(id: 'securityPoolFactory' | 'zoltarQuestionData') {
+	const step = getDeploymentSteps().find(candidate => candidate.id === id)
+	if (step === undefined) throw new Error(`Unknown deployment step: ${id}`)
+	return step.address
+}
+
+async function getContractRevertReason<TCallParams extends ContractRevertReasonParams>(client: ReadClient | WriteClient, params: TCallParams) {
+	try {
+		const data = encodeFunctionData({
+			abi: params.abi,
+			functionName: params.functionName,
+			args: params.args,
+		})
+		const account = params.account ?? undefined
+		await client.call({
+			account,
+			data,
+			gas: params.gas,
+			to: params.address,
+			value: params.value,
+		})
+		return undefined
+	} catch (error) {
+		if (error instanceof RpcError) {
+			return error.shortMessage ?? error.message ?? (error.cause instanceof Error ? error.cause.message : undefined)
+		}
+		if (error instanceof Error) return error.message
+		return undefined
+	}
+}
+
+function getOriginalErrorMessage(error: unknown) {
+	if (error instanceof RpcError) {
+		return error.shortMessage ?? error.message ?? (error.cause instanceof Error ? error.cause.message : undefined)
+	}
+	if (error instanceof Error) return error.message
+	return undefined
+}
+
+async function writeContractAndWaitForReceipt<TCallParams extends ContractRevertReasonParams>(client: WriteClient, getCallParams: () => TCallParams): Promise<{ hash: Hash; receipt: TransactionReceipt }> {
+	const callParams = getCallParams()
+	const data = encodeFunctionData({
+		abi: callParams.abi,
+		functionName: callParams.functionName,
+		args: callParams.args,
+	})
+	const account = callParams.account ?? undefined
+	let hash: Hash
+	try {
+		hash = await client.sendTransaction({
+			account,
+			data,
+			gas: callParams.gas,
+			to: callParams.address,
+			value: callParams.value,
+		})
+	} catch (error) {
+		const reason = await getContractRevertReason(client, callParams)
+		throw new Error(reason ?? getOriginalErrorMessage(error) ?? 'Transaction reverted')
+	}
+	const receipt = await client.waitForTransactionReceipt({ hash })
+	if (receipt.status === 'reverted') {
+		const reason = await getContractRevertReason(client, callParams)
+		throw new Error(reason ?? 'Transaction reverted')
+	}
+	return { hash, receipt }
+}
+
+async function getLatestDeployedSecurityPoolAddress(client: Pick<WriteClient, 'readContract'>) {
+	const deploymentCount = await client.readContract({
+		address: getDeploymentStepAddress('securityPoolFactory'),
+		abi: peripherals_factories_SecurityPoolFactory_SecurityPoolFactory.abi,
+		functionName: 'securityPoolDeploymentCount',
+		args: [],
+	})
+	if (deploymentCount === 0n) throw new Error('Security pool deployment transaction succeeded without recording a deployment')
+
+	const deployments = await client.readContract({
+		address: getDeploymentStepAddress('securityPoolFactory'),
+		abi: peripherals_factories_SecurityPoolFactory_SecurityPoolFactory.abi,
+		functionName: 'securityPoolDeploymentsRange',
+		args: [deploymentCount - 1n, 1n],
+	})
+	const latestDeployment = deployments[0]
+	if (latestDeployment === undefined) throw new Error('Missing latest security pool deployment record')
+	return latestDeployment.securityPool
+}
+
+function getOriginSecurityPoolShareTokenSalt(questionId: bigint, securityMultiplier: bigint) {
+	return keccak256(encodeAbiParameters([{ type: 'uint256' }, { type: 'uint256' }], [securityMultiplier, questionId]))
+}
+
+function getOriginSecurityPoolShareTokenAddress(questionId: bigint, securityMultiplier: bigint) {
+	return getCreate2Address({
+		from: getInfraContractAddresses().shareTokenFactory,
+		salt: getOriginSecurityPoolShareTokenSalt(questionId, securityMultiplier),
+		bytecode: encodeDeployData({
+			abi: peripherals_tokens_ShareToken_ShareToken.abi,
+			bytecode: `0x${peripherals_tokens_ShareToken_ShareToken.evm.bytecode.object}`,
+			args: [getInfraContractAddresses().securityPoolFactory, getZoltarAddress(), questionId],
+		}),
+	})
+}
+
+async function securityPoolExists(client: Pick<ReadClient, 'getCode'>, securityPoolAddress: Address) {
+	const code = await client.getCode({ address: securityPoolAddress })
+	return code !== undefined && code !== '0x'
+}
+
+async function poolOwnershipToRep(client: ReadClient, securityPoolAddress: Address, poolOwnership: bigint) {
+	return await client.readContract({
+		abi: peripherals_SecurityPool_SecurityPool.abi,
+		functionName: 'poolOwnershipToRep',
+		address: securityPoolAddress,
+		args: [poolOwnership],
+	})
+}
+
+export async function createSecurityPool(
+	client: WriteClient,
+	parameters: {
+		currentRetentionRate: bigint
+		questionId: bigint
+		securityMultiplier: bigint
+	},
+) {
+	const { hash: deployPoolHash } = await writeContractAndWaitForReceipt(client, () => ({
+		address: getDeploymentStepAddress('securityPoolFactory'),
+		abi: peripherals_factories_SecurityPoolFactory_SecurityPoolFactory.abi,
+		functionName: 'deployOriginSecurityPool',
+		args: [0n, parameters.questionId, parameters.securityMultiplier, parameters.currentRetentionRate],
+	}))
+
+	return {
+		deployPoolHash,
+		questionId: getQuestionIdHex(parameters.questionId),
+		securityPoolAddress: await getLatestDeployedSecurityPoolAddress(client),
+		securityMultiplier: parameters.securityMultiplier,
+		universeId: 0n,
+	} satisfies SecurityPoolCreationResult
+}
+
+export async function originSecurityPoolExists(client: Pick<ReadClient, 'getCode'>, questionId: bigint, securityMultiplier: bigint) {
+	const shareTokenAddress = getOriginSecurityPoolShareTokenAddress(questionId, securityMultiplier)
+	const code = await client.getCode({ address: shareTokenAddress })
+	return code !== undefined && code !== '0x'
+}
+
+export async function loadSecurityVaultDetails(client: ReadClient, securityPoolAddress: Address, vaultAddress: Address): Promise<SecurityVaultDetails | undefined> {
+	if (!(await securityPoolExists(client, securityPoolAddress))) return undefined
+
+	const [currentRetentionRate, managerAddress, poolOwnershipDenominator, repToken, totalSecurityBondAllowance, universeId, vaultData] = await Promise.all([
+		client.readContract({ abi: peripherals_SecurityPool_SecurityPool.abi, functionName: 'currentRetentionRate', address: securityPoolAddress, args: [] }),
+		client.readContract({ abi: peripherals_SecurityPool_SecurityPool.abi, functionName: 'priceOracleManagerAndOperatorQueuer', address: securityPoolAddress, args: [] }),
+		client.readContract({ abi: peripherals_SecurityPool_SecurityPool.abi, functionName: 'poolOwnershipDenominator', address: securityPoolAddress, args: [] }),
+		client.readContract({ abi: peripherals_SecurityPool_SecurityPool.abi, functionName: 'repToken', address: securityPoolAddress, args: [] }),
+		client.readContract({ abi: peripherals_SecurityPool_SecurityPool.abi, functionName: 'totalSecurityBondAllowance', address: securityPoolAddress, args: [] }),
+		client.readContract({ abi: peripherals_SecurityPool_SecurityPool.abi, functionName: 'universeId', address: securityPoolAddress, args: [] }),
+		client.readContract({ abi: peripherals_SecurityPool_SecurityPool.abi, functionName: 'securityVaults', address: securityPoolAddress, args: [vaultAddress] }),
+	])
+
+	const [poolOwnership, securityBondAllowance, unpaidEthFees, , lockedRepInEscalationGame] = vaultData
+	const repDepositShare = poolOwnershipDenominator === 0n || poolOwnership === 0n ? 0n : await poolOwnershipToRep(client, securityPoolAddress, poolOwnership)
+
+	return {
+		currentRetentionRate,
+		lockedRepInEscalationGame,
+		managerAddress,
+		poolOwnershipDenominator,
+		repDepositShare,
+		repToken,
+		securityBondAllowance,
+		securityPoolAddress,
+		totalSecurityBondAllowance,
+		unpaidEthFees,
+		universeId,
+		vaultAddress,
+	}
+}

--- a/ui/ts/contracts/zoltar.ts
+++ b/ui/ts/contracts/zoltar.ts
@@ -1,18 +1,7 @@
 import { encodeFunctionData, parseAbiItem, zeroAddress, RpcError, type Abi, type Account, type Address, type ContractFunctionParameters, type Hash, type MulticallReturnType } from 'viem'
-import {
-	ReputationToken_ReputationToken,
-	Zoltar_Zoltar,
-	ZoltarQuestionData_ZoltarQuestionData,
-} from '../contractArtifact.js'
+import { ReputationToken_ReputationToken, Zoltar_Zoltar, ZoltarQuestionData_ZoltarQuestionData } from '../contractArtifact.js'
 import type { MarketCreationResult, MarketDetails, MarketType, QuestionData, ReadClient, WriteClient, ZoltarUniverseSummary } from '../types/contracts.js'
-import {
-	getMarketType,
-	getQuestionId,
-	getQuestionIdHex,
-	isStringArray,
-	requireUniverseTupleArray,
-	type UniverseTuple,
-} from './helpers.js'
+import { getMarketType, getQuestionId, getQuestionIdHex, isStringArray, requireUniverseTupleArray, type UniverseTuple } from './helpers.js'
 import { getDeploymentSteps } from './deployment.js'
 import { getMulticall3Address } from './deploymentHelpers.js'
 

--- a/ui/ts/contracts/zoltar.ts
+++ b/ui/ts/contracts/zoltar.ts
@@ -1,0 +1,400 @@
+import { encodeFunctionData, parseAbiItem, zeroAddress, RpcError, type Abi, type Account, type Address, type ContractFunctionParameters, type Hash, type MulticallReturnType } from 'viem'
+import {
+	ReputationToken_ReputationToken,
+	Zoltar_Zoltar,
+	ZoltarQuestionData_ZoltarQuestionData,
+} from '../contractArtifact.js'
+import type { MarketCreationResult, MarketDetails, MarketType, QuestionData, ReadClient, WriteClient, ZoltarUniverseSummary } from '../types/contracts.js'
+import {
+	getMarketType,
+	getQuestionId,
+	getQuestionIdHex,
+	isStringArray,
+	requireUniverseTupleArray,
+	type UniverseTuple,
+} from './helpers.js'
+import { getDeploymentSteps } from './deployment.js'
+import { getMulticall3Address } from './deploymentHelpers.js'
+
+const CONTRACT_PAGE_SIZE = 30n
+const ANSWER_OPTION_ABI = [parseAbiItem('function getAnswerOptionName(uint256 questionId, uint256 answer) view returns (string memory)')]
+
+type DeployedChildUniverseRecord = {
+	forkQuestionId: bigint
+	forkTime: bigint
+	forkingOutcomeIndex: bigint
+	parentUniverseId: bigint
+	reputationToken: Address
+}
+
+type DeployedChildUniversesPage = readonly [readonly bigint[], readonly bigint[], readonly DeployedChildUniverseRecord[]]
+type QuestionTuple = readonly [string, string, bigint, bigint, bigint, bigint, bigint, string]
+
+type ContractRevertReasonParams = {
+	account?: Account | Address | undefined | null
+	abi: Abi | readonly unknown[]
+	address: Address
+	args?: readonly unknown[]
+	functionName: string
+	gas?: bigint
+	value?: bigint
+}
+
+function getDeploymentStepAddress(id: 'zoltar' | 'zoltarQuestionData') {
+	const step = getDeploymentSteps().find(candidate => candidate.id === id)
+	if (step === undefined) throw new Error(`Unknown deployment step: ${id}`)
+	return step.address
+}
+
+async function readRequiredMulticall<const TContracts extends readonly unknown[]>(client: Pick<ReadClient, 'multicall'>, contracts: TContracts): Promise<MulticallReturnType<TContracts, false>> {
+	return (await client.multicall({
+		allowFailure: false,
+		contracts: contracts as readonly ContractFunctionParameters[],
+		multicallAddress: getMulticall3Address(),
+	})) as MulticallReturnType<TContracts, false>
+}
+
+async function getContractRevertReason<TCallParams extends ContractRevertReasonParams>(client: ReadClient | WriteClient, params: TCallParams) {
+	try {
+		const data = encodeFunctionData({
+			abi: params.abi,
+			functionName: params.functionName,
+			args: params.args,
+		})
+		const account = params.account ?? undefined
+		await client.call({
+			account,
+			data,
+			gas: params.gas,
+			to: params.address,
+			value: params.value,
+		})
+		return undefined
+	} catch (error) {
+		if (error instanceof RpcError) {
+			return error.shortMessage ?? error.message ?? (error.cause instanceof Error ? error.cause.message : undefined)
+		}
+		if (error instanceof Error) return error.message
+		return undefined
+	}
+}
+
+function getOriginalErrorMessage(error: unknown) {
+	if (error instanceof RpcError) {
+		return error.shortMessage ?? error.message ?? (error.cause instanceof Error ? error.cause.message : undefined)
+	}
+	if (error instanceof Error) return error.message
+	return undefined
+}
+
+async function writeContractAndWait<TCallParams extends ContractRevertReasonParams>(client: WriteClient, getCallParams: () => TCallParams) {
+	const callParams = getCallParams()
+	const data = encodeFunctionData({
+		abi: callParams.abi,
+		functionName: callParams.functionName,
+		args: callParams.args,
+	})
+	const account = callParams.account ?? undefined
+	let hash: Hash
+	try {
+		hash = await client.sendTransaction({
+			account,
+			data,
+			gas: callParams.gas,
+			to: callParams.address,
+			value: callParams.value,
+		})
+	} catch (error) {
+		const reason = await getContractRevertReason(client, callParams)
+		throw new Error(reason ?? getOriginalErrorMessage(error) ?? 'Transaction reverted')
+	}
+	const receipt = await client.waitForTransactionReceipt({ hash })
+	if (receipt.status === 'reverted') {
+		const reason = await getContractRevertReason(client, callParams)
+		throw new Error(reason ?? 'Transaction reverted')
+	}
+	return hash
+}
+
+async function loadOutcomeLabels(client: ReadClient, questionId: bigint) {
+	let currentIndex = 0n
+	const outcomeLabels: string[] = []
+
+	while (true) {
+		const page = await client.readContract({
+			abi: ZoltarQuestionData_ZoltarQuestionData.abi,
+			functionName: 'getOutcomeLabels',
+			address: getDeploymentStepAddress('zoltarQuestionData'),
+			args: [questionId, currentIndex, CONTRACT_PAGE_SIZE],
+		})
+		if (!isStringArray(page)) throw new Error('Unexpected outcome labels response')
+
+		const labels = page.filter(label => label.length > 0)
+		outcomeLabels.push(...labels)
+		if (BigInt(labels.length) !== CONTRACT_PAGE_SIZE) break
+		currentIndex += CONTRACT_PAGE_SIZE
+	}
+
+	return outcomeLabels
+}
+
+async function loadQuestionIds(client: ReadClient): Promise<bigint[]> {
+	const questionCount = await client.readContract({
+		abi: ZoltarQuestionData_ZoltarQuestionData.abi,
+		functionName: 'getQuestionCount',
+		address: getDeploymentStepAddress('zoltarQuestionData'),
+		args: [],
+	})
+
+	let currentIndex = 0n
+	const questionIds: bigint[] = []
+	while (currentIndex < questionCount) {
+		const page = await client.readContract({
+			abi: ZoltarQuestionData_ZoltarQuestionData.abi,
+			functionName: 'getQuestions',
+			address: getDeploymentStepAddress('zoltarQuestionData'),
+			args: [currentIndex, CONTRACT_PAGE_SIZE],
+		})
+		if (!Array.isArray(page)) throw new Error('Unexpected question id page response')
+
+		const normalizedPage = page.filter((questionId): questionId is bigint => typeof questionId === 'bigint' && questionId !== 0n).slice(0, Number(CONTRACT_PAGE_SIZE))
+		questionIds.push(...normalizedPage)
+		if (BigInt(normalizedPage.length) !== CONTRACT_PAGE_SIZE) break
+		currentIndex += CONTRACT_PAGE_SIZE
+	}
+
+	return questionIds
+}
+
+export async function loadMarketDetails(client: ReadClient, questionId: bigint): Promise<MarketDetails> {
+	const [question, createdAt] = await readRequiredMulticall(client, [
+		{
+			abi: ZoltarQuestionData_ZoltarQuestionData.abi,
+			functionName: 'questions',
+			address: getDeploymentStepAddress('zoltarQuestionData'),
+			args: [questionId],
+		},
+		{
+			abi: ZoltarQuestionData_ZoltarQuestionData.abi,
+			functionName: 'questionCreatedTimestamp',
+			address: getDeploymentStepAddress('zoltarQuestionData'),
+			args: [questionId],
+		},
+	])
+	const questionData: QuestionTuple = question
+	const [title, description, startTime, endTime, numTicks, displayValueMin, displayValueMax, answerUnit] = questionData
+
+	const exists = createdAt > 0n || title !== '' || description !== '' || startTime !== 0n || endTime !== 0n || numTicks !== 0n
+	const outcomeLabels = exists ? await loadOutcomeLabels(client, questionId) : []
+
+	return {
+		answerUnit,
+		createdAt,
+		description,
+		displayValueMax,
+		displayValueMin,
+		endTime,
+		exists,
+		marketType: getMarketType({ title, description, startTime, endTime, numTicks, displayValueMin, displayValueMax, answerUnit }, outcomeLabels),
+		outcomeLabels,
+		numTicks,
+		questionId: getQuestionIdHex(questionId),
+		startTime,
+		title,
+	}
+}
+
+export async function loadAllZoltarQuestions(client: ReadClient): Promise<MarketDetails[]> {
+	const questionIds = await loadQuestionIds(client)
+	return await Promise.all(questionIds.map(async questionId => await loadMarketDetails(client, questionId)))
+}
+
+export async function loadZoltarQuestionCount(client: ReadClient) {
+	return await client.readContract({
+		abi: ZoltarQuestionData_ZoltarQuestionData.abi,
+		functionName: 'getQuestionCount',
+		address: getDeploymentStepAddress('zoltarQuestionData'),
+		args: [],
+	})
+}
+
+export async function loadZoltarUniverseSummary(client: ReadClient, universeId: bigint): Promise<ZoltarUniverseSummary | undefined> {
+	const zoltarAddress = getDeploymentStepAddress('zoltar')
+	const [repToken, universe, forkTime, forkThreshold] = await readRequiredMulticall(client, [
+		{
+			abi: Zoltar_Zoltar.abi,
+			functionName: 'getRepToken',
+			address: zoltarAddress,
+			args: [universeId],
+		},
+		{
+			abi: Zoltar_Zoltar.abi,
+			functionName: 'universes',
+			address: zoltarAddress,
+			args: [universeId],
+		},
+		{
+			abi: Zoltar_Zoltar.abi,
+			functionName: 'getForkTime',
+			address: zoltarAddress,
+			args: [universeId],
+		},
+		{
+			abi: Zoltar_Zoltar.abi,
+			functionName: 'getForkThreshold',
+			address: zoltarAddress,
+			args: [universeId],
+		},
+	])
+	if (repToken === zeroAddress) return undefined
+
+	const totalTheoreticalSupply = await client.readContract({
+		abi: ReputationToken_ReputationToken.abi,
+		functionName: 'getTotalTheoreticalSupply',
+		address: repToken,
+		args: [],
+	})
+	const universeData: UniverseTuple = universe
+	const [storedForkTime, forkQuestionId, forkingOutcomeIndex, , parentUniverseId] = universeData
+	const hasForked = forkTime > 0n || storedForkTime > 0n
+
+	let childUniverses: ZoltarUniverseSummary['childUniverses'] = []
+	let forkQuestionDetails: MarketDetails | undefined = undefined
+	if (hasForked && forkQuestionId > 0n) {
+		const marketDetails = await loadMarketDetails(client, forkQuestionId)
+		forkQuestionDetails = marketDetails
+		if (marketDetails.marketType === 'scalar') {
+			const deployedChildUniverses: ZoltarUniverseSummary['childUniverses'] = []
+			let currentIndex = 0n
+			while (true) {
+				const page: DeployedChildUniversesPage = await client.readContract({
+					abi: Zoltar_Zoltar.abi,
+					functionName: 'getDeployedChildUniverses',
+					address: getDeploymentStepAddress('zoltar'),
+					args: [universeId, currentIndex, CONTRACT_PAGE_SIZE],
+				})
+				const [outcomeIndexes, childUniverseIds, childUniverseTuples] = page
+				const outcomeLabels =
+					outcomeIndexes.length === 0
+						? []
+						: (
+								await readRequiredMulticall(
+									client,
+									outcomeIndexes.map(outcomeIndex => ({
+										abi: ANSWER_OPTION_ABI,
+										functionName: 'getAnswerOptionName',
+										address: getDeploymentStepAddress('zoltarQuestionData'),
+										args: [forkQuestionId, outcomeIndex],
+									})),
+								)
+							).map(outcomeLabel => String(outcomeLabel))
+				const pageChildren = outcomeIndexes.map((outcomeIndex, index) => {
+					const childUniverse = childUniverseTuples[index]
+					if (childUniverse === undefined) throw new Error('Unexpected deployed child universe response')
+					const { forkTime: childForkTime, parentUniverseId: childParentUniverseId, reputationToken: childReputationToken } = childUniverse
+					const outcomeLabel = outcomeLabels[index]
+					if (outcomeLabel === undefined) throw new Error('Unexpected outcome label response')
+					const childUniverseId = childUniverseIds[index]
+					if (childUniverseId === undefined) throw new Error('Unexpected deployed child universe response')
+					return {
+						exists: childReputationToken !== zeroAddress,
+						forkTime: childForkTime,
+						outcomeIndex,
+						outcomeLabel,
+						parentUniverseId: childParentUniverseId,
+						reputationToken: childReputationToken,
+						universeId: childUniverseId,
+					}
+				})
+				deployedChildUniverses.push(...pageChildren)
+				if (BigInt(pageChildren.length) !== CONTRACT_PAGE_SIZE) break
+				currentIndex += CONTRACT_PAGE_SIZE
+			}
+			childUniverses = deployedChildUniverses
+		} else {
+			const childOutcomeEntries = [
+				{ outcomeIndex: 0n, outcomeLabel: 'Invalid' },
+				...marketDetails.outcomeLabels.map((outcomeLabel, outcomeIndex) => ({
+					outcomeIndex: BigInt(outcomeIndex + 1),
+					outcomeLabel,
+				})),
+			]
+			const childUniverseIds = (
+				await readRequiredMulticall(
+					client,
+					childOutcomeEntries.map(({ outcomeIndex }) => ({
+						abi: Zoltar_Zoltar.abi,
+						functionName: 'getChildUniverseId',
+						address: getDeploymentStepAddress('zoltar'),
+						args: [universeId, outcomeIndex],
+					})),
+				)
+			).map(childUniverseId => BigInt(childUniverseId))
+			const childUniverseTuples = requireUniverseTupleArray(
+				await readRequiredMulticall(
+					client,
+					childUniverseIds.map(childUniverseId => ({
+						abi: Zoltar_Zoltar.abi,
+						functionName: 'universes',
+						address: getDeploymentStepAddress('zoltar'),
+						args: [childUniverseId],
+					})),
+				),
+				'child universe tuple',
+			)
+
+			childUniverses = childOutcomeEntries.map(({ outcomeIndex, outcomeLabel }, index) => {
+				const childUniverseId = childUniverseIds[index]
+				if (childUniverseId === undefined) throw new Error('Unexpected child universe id response')
+				const childUniverseData = childUniverseTuples[index]
+				if (childUniverseData === undefined) throw new Error('Unexpected child universe response')
+				const [childForkTime, , , childReputationToken, childParentUniverseId] = childUniverseData
+				return {
+					exists: childReputationToken !== zeroAddress,
+					forkTime: childForkTime,
+					outcomeIndex,
+					outcomeLabel,
+					parentUniverseId: childParentUniverseId,
+					reputationToken: childReputationToken,
+					universeId: childUniverseId,
+				}
+			})
+		}
+	}
+
+	return {
+		childUniverses,
+		forkQuestionDetails,
+		forkThreshold,
+		forkTime,
+		forkingOutcomeIndex,
+		hasForked,
+		parentUniverseId,
+		reputationToken: repToken,
+		totalTheoreticalSupply,
+		universeId,
+	}
+}
+
+export async function createMarket(
+	client: WriteClient,
+	parameters: {
+		marketType: MarketType
+		outcomeLabels: string[]
+		questionData: QuestionData
+	},
+) {
+	const questionId = getQuestionId(parameters.questionData, parameters.outcomeLabels)
+	const createQuestionHash = await writeContractAndWait(client, () => ({
+		address: getDeploymentStepAddress('zoltarQuestionData'),
+		abi: ZoltarQuestionData_ZoltarQuestionData.abi,
+		functionName: 'createQuestion',
+		args: [parameters.questionData, parameters.outcomeLabels],
+	}))
+
+	return {
+		questionId: getQuestionIdHex(questionId),
+		createQuestionHash,
+		marketType: parameters.marketType,
+	} satisfies MarketCreationResult
+}

--- a/ui/ts/hooks/useAppRouteEffects.ts
+++ b/ui/ts/hooks/useAppRouteEffects.ts
@@ -1,0 +1,90 @@
+import { useEffect } from 'preact/hooks'
+
+type Props = {
+	augurPlaceHolderDeploymentMissing: boolean
+	loadOracleReport: (reportId: string) => Promise<void>
+	loadSecurityPools: (securityPoolAddress?: string) => Promise<void>
+	navigate: (route: 'deploy' | 'open-oracle' | 'security-pools' | 'zoltar') => void
+	openOracleFormReportId: string
+	openOracleReportDetailsReportId: bigint | undefined
+	refreshSelectedPoolData: () => void
+	route: 'deploy' | 'not-found' | 'open-oracle' | 'security-pools' | 'zoltar'
+	securityPoolAddress: string
+	securityPoolResultHash: string | undefined
+	selectedPoolSecurityPoolAddress: string | undefined
+	setForkAuctionFormSecurityPoolAddress: (securityPoolAddress: string) => void
+	setOpenOracleReport: (reportId: string | undefined) => void
+	setReportingFormSecurityPoolAddress: (securityPoolAddress: string) => void
+	setSecurityVaultFormSecurityPoolAddress: (securityPoolAddress: string) => void
+	setTradingFormSecurityPoolAddress: (securityPoolAddress: string) => void
+	tradingResultHash: string | undefined
+	urlOpenOracleReportId: string
+	walletBootstrapComplete: boolean
+}
+
+export function useAppRouteEffects({
+	augurPlaceHolderDeploymentMissing,
+	loadOracleReport,
+	loadSecurityPools,
+	navigate,
+	openOracleFormReportId,
+	openOracleReportDetailsReportId,
+	refreshSelectedPoolData,
+	route,
+	securityPoolAddress,
+	securityPoolResultHash,
+	selectedPoolSecurityPoolAddress,
+	setForkAuctionFormSecurityPoolAddress,
+	setOpenOracleReport,
+	setReportingFormSecurityPoolAddress,
+	setSecurityVaultFormSecurityPoolAddress,
+	setTradingFormSecurityPoolAddress,
+	tradingResultHash,
+	urlOpenOracleReportId,
+	walletBootstrapComplete,
+}: Props) {
+	useEffect(() => {
+		if (urlOpenOracleReportId === '') return
+		void loadOracleReport(urlOpenOracleReportId)
+	}, [loadOracleReport, urlOpenOracleReportId])
+
+	useEffect(() => {
+		if (openOracleReportDetailsReportId !== undefined) {
+			setOpenOracleReport(openOracleReportDetailsReportId.toString())
+			return
+		}
+		if (openOracleFormReportId.trim() !== '') {
+			setOpenOracleReport(openOracleFormReportId)
+			return
+		}
+		setOpenOracleReport(undefined)
+	}, [openOracleFormReportId, openOracleReportDetailsReportId, setOpenOracleReport])
+
+	useEffect(() => {
+		setSecurityVaultFormSecurityPoolAddress(securityPoolAddress)
+		setTradingFormSecurityPoolAddress(securityPoolAddress)
+		setForkAuctionFormSecurityPoolAddress(securityPoolAddress)
+		setReportingFormSecurityPoolAddress(securityPoolAddress)
+	}, [securityPoolAddress, setForkAuctionFormSecurityPoolAddress, setReportingFormSecurityPoolAddress, setSecurityVaultFormSecurityPoolAddress, setTradingFormSecurityPoolAddress])
+
+	useEffect(() => {
+		if (selectedPoolSecurityPoolAddress !== undefined) return
+		refreshSelectedPoolData()
+	}, [refreshSelectedPoolData, securityPoolAddress, selectedPoolSecurityPoolAddress, walletBootstrapComplete])
+
+	useEffect(() => {
+		if (securityPoolResultHash === undefined) return
+		void loadSecurityPools()
+	}, [loadSecurityPools, securityPoolResultHash])
+
+	useEffect(() => {
+		if (tradingResultHash === undefined) return
+		refreshSelectedPoolData()
+	}, [refreshSelectedPoolData, tradingResultHash])
+
+	useEffect(() => {
+		if (!augurPlaceHolderDeploymentMissing) return
+		if (route === 'deploy') return
+		navigate('deploy')
+	}, [augurPlaceHolderDeploymentMissing, navigate, route])
+}


### PR DESCRIPTION
## Summary
- Fixed `EscalationGame` withdrawal math so deposits that straddle binding capital are handled without double counting.
- Updated `SecurityPool.redeemShares()` to keep `shareTokenSupply` and `completeSetCollateralAmount` in sync as winning shares are redeemed.
- Added contract tests covering mixed escrow withdrawals, redemption accounting, and late unrelated fork behavior.
- Split the UI header into smaller components for notices, simulation banner, overview panels, and tab navigation.
- Added deployment helpers for loading and deploying the status oracle and related contract steps.

## Testing
- Not run