### PR TITLE
Allow security vault reloads without an address

### DIFF
--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -22,6 +22,7 @@ import { getActiveSimulationController } from './lib/activeEnvironment.js'
 import { getDeploymentSections } from './lib/deployment.js'
 import { resolveLoadableValueState } from './lib/loadState.js'
 import { getWrongNetworkMessage, isSupportedAppChain } from './lib/network.js'
+import { createLoadSecurityVaultHandler } from './lib/securityVaultHandlers.js'
 import { getUseQuestionForPoolState } from './lib/securityPoolNavigation.js'
 import { createInitialTransactionState, markTransactionFinished, markTransactionRequested, markTransactionSubmitted } from './lib/transactionState.js'
 import type { TransactionState } from './lib/transactionState.js'
@@ -499,10 +500,7 @@ export function App() {
 				loadingSecurityVault,
 				onApproveRep: amount => void approveRep(amount),
 				onDepositRep: () => void depositRep(),
-				onLoadSecurityVault: vaultAddress => {
-					if (vaultAddress === undefined) return
-					void loadSecurityVault(vaultAddress)
-				},
+				onLoadSecurityVault: createLoadSecurityVaultHandler(loadSecurityVault),
 				onRedeemFees: () => void redeemFees(),
 				onSetSecurityBondAllowance: () => void setSecurityBondAllowance(),
 				onSecurityVaultFormChange: update => setSecurityVaultForm(current => ({ ...current, ...update })),

--- a/ui/ts/lib/securityVaultHandlers.ts
+++ b/ui/ts/lib/securityVaultHandlers.ts
@@ -1,0 +1,5 @@
+export function createLoadSecurityVaultHandler(loadSecurityVault: (vaultAddress?: string) => Promise<void>) {
+	return (vaultAddress?: string) => {
+		void loadSecurityVault(vaultAddress)
+	}
+}

--- a/ui/ts/tests/app.test.ts
+++ b/ui/ts/tests/app.test.ts
@@ -1,0 +1,20 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { createLoadSecurityVaultHandler } from '../lib/securityVaultHandlers.js'
+
+describe('App', () => {
+	test('forwards vault refresh requests without requiring an explicit vault address', async () => {
+		const calls: Array<string | undefined> = []
+		const handleLoadSecurityVault = createLoadSecurityVaultHandler(async vaultAddress => {
+			calls.push(vaultAddress)
+		})
+
+		handleLoadSecurityVault()
+		handleLoadSecurityVault('0x123')
+
+		await Promise.resolve()
+
+		expect(calls).toEqual([undefined, '0x123'])
+	})
+})


### PR DESCRIPTION
## Summary
- Allow security vault reload actions to run even when no vault address is provided.
- Extract the load handler into `createLoadSecurityVaultHandler` so the app can forward optional addresses consistently.
- Add a test covering both undefined and explicit vault address reload requests.

## Testing
- Not run (PR content only)