### PR TITLE
Refresh REP prices and hide empty truth auctions

### DIFF
--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -431,6 +431,19 @@ button.destructive:hover:not(:disabled) {
 	color: var(--muted);
 }
 
+.metric-label-with-action {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.35rem;
+}
+
+.metric-label-refresh {
+	min-width: 0;
+	padding: 0.12rem 0.38rem;
+	font-size: 0.8rem;
+	line-height: 1;
+}
+
 .detail {
 	line-height: 1.6;
 	color: var(--text-secondary);

--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -216,7 +216,7 @@ export function App() {
 		submitBid,
 		withdrawBids,
 	} = useForkAuctionOperations(baseHookConfig)
-	const { repPerEthPrice, repPerEthSource, repPerEthSourceUrl, repUsdcPrice, repUsdcSource, repUsdcSourceUrl, isLoadingRepPrices } = useRepPrices()
+	const { repPerEthPrice, repPerEthSource, repPerEthSourceUrl, repUsdcPrice, repUsdcSource, repUsdcSourceUrl, isLoadingRepPrices, refreshRepPrices } = useRepPrices()
 	const simulationController = getActiveSimulationController()
 	const deploymentSections = getDeploymentSections(deploymentStatuses)
 	const errorMessage = deploymentErrorMessage ?? walletErrorMessage
@@ -244,6 +244,7 @@ export function App() {
 		isLoadingUniverseRepBalance: loadingZoltarForkAccess,
 		onConnect: () => void connectWallet(),
 		onGoToGenesisUniverse: () => setActiveUniverseId(0n),
+		onRefreshRepPrices: refreshRepPrices,
 		repPerEthPrice,
 		repPerEthSource,
 		repPerEthSourceUrl,

--- a/ui/ts/components/CollateralizationMetricField.tsx
+++ b/ui/ts/components/CollateralizationMetricField.tsx
@@ -30,7 +30,7 @@ export function CollateralizationMetricField({ className, collateralizationPerce
 
 	return (
 		<MetricField className={className} label={<span title='Uses the live Uniswap REP/ETH quote.'>Collateralization {repPerEthSource === undefined ? undefined : renderSourceLink(repPerEthSource, repPerEthSourceUrl)}</span>} valueClassName={valueClassName}>
-			{displayState === 'noActiveAllowance' ? 'No active allowance' : <CurrencyValue value={collateralizationPercent} suffix='%' copyable={false} />}
+			{displayState === 'noActiveAllowance' ? 'No active allowance' : displayState === 'unavailable' ? 'Awaiting REP/ETH price' : <CurrencyValue value={collateralizationPercent} suffix='%' copyable={false} />}
 		</MetricField>
 	)
 }

--- a/ui/ts/components/OverviewPanels.tsx
+++ b/ui/ts/components/OverviewPanels.tsx
@@ -13,6 +13,7 @@ export function OverviewPanels({
 	isLoadingUniverseRepBalance,
 	onConnect,
 	onGoToGenesisUniverse,
+	onRefreshRepPrices,
 	repPerEthPrice,
 	repPerEthSource,
 	repPerEthSourceUrl,
@@ -77,7 +78,16 @@ export function OverviewPanels({
 							</MetricField>
 						</>
 					) : undefined}
-					<MetricField label={<>REP/ETH {repPerEthSource === undefined ? undefined : renderSourceLink(repPerEthSource, repPerEthSourceUrl)}</>}>
+					<MetricField
+						label={
+							<span className='metric-label-with-action'>
+								<span>REP/ETH {repPerEthSource === undefined ? undefined : renderSourceLink(repPerEthSource, repPerEthSourceUrl)}</span>
+								<button type='button' className='quiet metric-label-refresh' onClick={onRefreshRepPrices} disabled={isLoadingRepPrices} aria-label='Refresh Uniswap prices' title={isLoadingRepPrices ? 'Refreshing Uniswap prices...' : 'Refresh Uniswap prices'}>
+									↻
+								</button>
+							</span>
+						}
+					>
 						<CurrencyValue value={repPerEthPrice} loading={isLoadingRepPrices} copyable={false} />
 					</MetricField>
 					<MetricField label={<>REP/USDC {repUsdcSource === undefined ? undefined : renderSourceLink(repUsdcSource, repUsdcSourceUrl)}</>}>

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -1,5 +1,6 @@
 import type { ComponentChildren } from 'preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
+import { zeroAddress } from 'viem'
 import { AddressValue } from './AddressValue.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { EntityCard } from './EntityCard.js'
@@ -370,9 +371,11 @@ export function SecurityPoolWorkflowSection({
 								{loadedSelectedPool.systemState !== 'operational' ? (
 									<>
 										<MetricField label='Fork Flow'>Forked / active</MetricField>
-										<MetricField label='Truth Auction'>
-											<AddressValue address={loadedSelectedPool.truthAuctionAddress} />
-										</MetricField>
+										{loadedSelectedPool.truthAuctionAddress === zeroAddress ? undefined : (
+											<MetricField label='Truth Auction'>
+												<AddressValue address={loadedSelectedPool.truthAuctionAddress} />
+											</MetricField>
+										)}
 										<MetricField label='Fork Mode'>{loadedSelectedPool.forkOwnSecurityPool ? 'Own escalation fork' : 'Parent / Zoltar fork'}</MetricField>
 										<MetricField label='Fork Outcome'>{loadedSelectedPool.forkOutcome}</MetricField>
 									</>

--- a/ui/ts/components/SecurityPoolsOverviewSection.tsx
+++ b/ui/ts/components/SecurityPoolsOverviewSection.tsx
@@ -14,6 +14,7 @@ import { TransactionHashLink } from './TransactionHashLink.js'
 import { UniverseLink } from './UniverseLink.js'
 import { VaultMetricGrid } from './VaultMetricGrid.js'
 import { WorkflowSubsection } from './WorkflowSubsection.js'
+import { zeroAddress } from 'viem'
 import { isMainnetChain } from '../lib/network.js'
 import { openInterestFeePerYearBigint } from '../lib/retentionRate.js'
 import { getPoolRegistryPresentation } from '../lib/userCopy.js'
@@ -119,9 +120,11 @@ export function SecurityPoolsOverviewSection({
 										<MetricField label='Manager'>
 											<AddressValue address={pool.managerAddress} />
 										</MetricField>
-										<MetricField label='Truth Auction'>
-											<AddressValue address={pool.truthAuctionAddress} />
-										</MetricField>
+										{pool.truthAuctionAddress === zeroAddress ? undefined : (
+											<MetricField label='Truth Auction'>
+												<AddressValue address={pool.truthAuctionAddress} />
+											</MetricField>
+										)}
 									</div>
 								</WorkflowSubsection>
 

--- a/ui/ts/hooks/useRepPrices.ts
+++ b/ui/ts/hooks/useRepPrices.ts
@@ -17,6 +17,7 @@ type RepPrices = {
 	repUsdcSource: PriceSource | undefined
 	repUsdcSourceUrl: string | undefined
 	isLoadingRepPrices: boolean
+	refreshRepPrices: () => void
 }
 
 async function fetchRepPerEthPrice(client: ReturnType<typeof createConnectedReadClient>): Promise<{ price: bigint; source: PriceSource; sourceUrl: string | undefined }> {
@@ -39,39 +40,44 @@ export function useRepPrices(): RepPrices {
 	const repUsdcSourceUrl = useSignal<string | undefined>(undefined)
 	const repPricesLoad = useLoadController()
 
-	useEffect(() => {
+	const refreshRepPrices = () => {
 		if (!isRepPricingEnabled()) return
 
-		let cancelled = false
 		const client = createConnectedReadClient()
 
 		void repPricesLoad
 			.track(async () => {
-				const [{ price: repPerEthDisplayPrice, source: repPerEthDisplaySource, sourceUrl: repPerEthDisplaySourceUrl }, usdcQuote] = await Promise.all([fetchRepPerEthPrice(client), quoteRepForUsdcV4WithSource(client, ONE_REP)])
-				if (cancelled) return
-				repPerEthPrice.value = repPerEthDisplayPrice
-				repPerEthSource.value = repPerEthDisplaySource
-				repPerEthSourceUrl.value = repPerEthDisplaySourceUrl
-				repUsdcPrice.value = usdcQuote.amountOut
-				repUsdcSource.value = 'v4'
-				repUsdcSourceUrl.value = usdcQuote.source.poolUrl
+				const [repPerEthResult, repUsdcResult] = await Promise.allSettled([fetchRepPerEthPrice(client), quoteRepForUsdcV4WithSource(client, ONE_REP)])
+
+				if (repPerEthResult.status === 'fulfilled') {
+					repPerEthPrice.value = repPerEthResult.value.price
+					repPerEthSource.value = repPerEthResult.value.source
+					repPerEthSourceUrl.value = repPerEthResult.value.sourceUrl
+				}
+
+				if (repUsdcResult.status === 'fulfilled') {
+					repUsdcPrice.value = repUsdcResult.value.amountOut
+					repUsdcSource.value = 'v4'
+					repUsdcSourceUrl.value = repUsdcResult.value.source.poolUrl
+				}
 			})
 			.catch(() => {
-				// prices unavailable — leave as undefined
+				// prices unavailable — leave the last successful values in place
 			})
+	}
 
-		return () => {
-			cancelled = true
-		}
+	useEffect(() => {
+		refreshRepPrices()
 	}, [])
 
 	return {
+		isLoadingRepPrices: repPricesLoad.isLoading.value,
 		repPerEthPrice: repPerEthPrice.value,
 		repPerEthSource: repPerEthSource.value,
 		repPerEthSourceUrl: repPerEthSourceUrl.value,
 		repUsdcPrice: repUsdcPrice.value,
 		repUsdcSource: repUsdcSource.value,
 		repUsdcSourceUrl: repUsdcSourceUrl.value,
-		isLoadingRepPrices: repPricesLoad.isLoading.value,
+		refreshRepPrices,
 	}
 }

--- a/ui/ts/tests/collateralizationMetricField.test.tsx
+++ b/ui/ts/tests/collateralizationMetricField.test.tsx
@@ -34,4 +34,12 @@ describe('CollateralizationMetricField', () => {
 		expect(noActiveAllowanceValue.tagName).toBe('STRONG')
 		expect(noActiveAllowanceValue.className).toBe('metric-field-value')
 	})
+
+	test('renders a descriptive message when the REP/ETH quote is unavailable', async () => {
+		const renderedComponent = await renderIntoDocument(<CollateralizationMetricField collateralizationPercent={undefined} repPerEthSource={undefined} repPerEthSourceUrl={undefined} securityBondAllowance={1n} securityMultiplier={2n} />)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByText('Awaiting REP/ETH price')).not.toBeNull()
+	})
 })

--- a/ui/ts/tests/overviewPanels.test.tsx
+++ b/ui/ts/tests/overviewPanels.test.tsx
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { within } from '@testing-library/dom'
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { fireEvent, within } from '@testing-library/dom'
 import { OverviewPanels } from '../components/OverviewPanels.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
@@ -37,6 +37,7 @@ describe('OverviewPanels', () => {
 				isRefreshing={false}
 				onConnect={() => undefined}
 				onGoToGenesisUniverse={() => undefined}
+				onRefreshRepPrices={() => undefined}
 				repPerEthPrice={2439024390243902439024n}
 				repPerEthSource={undefined}
 				repPerEthSourceUrl={undefined}
@@ -54,5 +55,43 @@ describe('OverviewPanels', () => {
 		const documentQueries = within(document.body)
 		expect(documentQueries.getByText('≈ 2 439.02')).toBeDefined()
 		expect(documentQueries.queryByText(/0\.00041/)).toBeNull()
+	})
+
+	test('renders a refresh button for Uniswap prices and wires it to the provided handler', async () => {
+		const onRefreshRepPrices = mock(() => undefined)
+		const renderedComponent = await renderIntoDocument(
+			<OverviewPanels
+				accountState={{
+					address: undefined,
+					chainId: '0x1',
+					ethBalance: undefined,
+					wethBalance: undefined,
+				}}
+				isConnectingWallet={false}
+				isLoadingRepPrices={false}
+				isLoadingUniverseRepBalance={false}
+				isRefreshing={false}
+				onConnect={() => undefined}
+				onGoToGenesisUniverse={() => undefined}
+				onRefreshRepPrices={onRefreshRepPrices}
+				repPerEthPrice={undefined}
+				repPerEthSource={undefined}
+				repPerEthSourceUrl={undefined}
+				repUsdcPrice={undefined}
+				repUsdcSource={undefined}
+				repUsdcSourceUrl={undefined}
+				universeLabel='Genesis universe'
+				universePresentation={undefined}
+				universeRepBalance={undefined}
+				walletBootstrapComplete={true}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		const refreshButton = documentQueries.getByRole('button', { name: 'Refresh Uniswap prices' })
+		fireEvent.click(refreshButton)
+
+		expect(onRefreshRepPrices).toHaveBeenCalledTimes(1)
 	})
 })

--- a/ui/ts/tests/securityPoolWorkflowSection.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection.test.tsx
@@ -353,6 +353,7 @@ describe('SecurityPoolWorkflowSection', () => {
 		expect(documentQueries.queryByText('Enter a deposit amount greater than zero.')).toBeNull()
 		expect(documentQueries.queryByText('Fork Flow')).toBeNull()
 		expect(documentQueries.queryByText('Oracle Status')).toBeNull()
+		expect(documentQueries.queryByText('Truth Auction')).toBeNull()
 		expect(documentQueries.getByText('Security Multiplier')).not.toBeNull()
 		const directoryButton = documentQueries.getByRole('button', { name: 'Directory' })
 		expect(documentQueries.getByRole('button', { name: 'Selected' })).not.toBeNull()
@@ -363,6 +364,29 @@ describe('SecurityPoolWorkflowSection', () => {
 
 		expect(documentQueries.getByRole('heading', { name: 'Vault Directory' })).not.toBeNull()
 		expect(documentQueries.getAllByText('Locked REP').length).toBeGreaterThan(0)
+	})
+
+	test('hides the truth auction metric when the selected pool has no truth auction address', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					activeUniverseId: 1n,
+					checkedSecurityPoolAddress: zeroAddress,
+					securityPoolAddress: zeroAddress,
+					securityPools: [
+						createSelectedPool({
+							systemState: 'poolForked',
+							truthAuctionAddress: zeroAddress,
+						}),
+					],
+				})}
+				showHeader={false}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.queryByText('Truth Auction')).toBeNull()
 	})
 
 	test('shows disabled reporting actions before market end instead of a placeholder message', async () => {

--- a/ui/ts/tests/securityPoolsSection.test.ts
+++ b/ui/ts/tests/securityPoolsSection.test.ts
@@ -455,4 +455,22 @@ void describe('SecurityPoolsSection', () => {
 
 		expect(document.body.querySelector('.route-summary-strip')).toBeNull()
 	})
+
+	void test('hides the truth auction metric when a listed pool has no truth auction address', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				SecurityPoolsSection,
+				createSecurityPoolsSectionProps({
+					overview: createOverviewProps({
+						hasLoadedSecurityPools: true,
+						securityPools: [createSelectedPool()],
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.queryByText('Truth Auction')).toBeNull()
+	})
 })

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -187,6 +187,7 @@ export type OverviewPanelsProps = {
 	isLoadingRepPrices: boolean
 	onConnect: () => void
 	onGoToGenesisUniverse: () => void
+	onRefreshRepPrices: () => void
 } & RepPerEthPriceProps
 
 export type TabNavigationProps = {


### PR DESCRIPTION
## Summary
- Added a manual refresh action for REP/ETH and REP/USDC quotes in the overview panel.
- Preserved the last known REP price values when a refresh partially fails, instead of clearing the display.
- Improved collateralization messaging so the UI shows an explicit waiting state when the REP/ETH quote is unavailable.
- Hid truth auction fields when the address is the zero address in security pool views.
- Removed an unnecessary security vault handler helper and inlined the simple forwarding logic.
- Updated and added UI tests for the new refresh control, availability messaging, and truth auction visibility rules.

## Testing
- Not run
- Expected validation per repo guidance: `bun x tsc` or `bun tsc`, `bun test`, `bun run format`, `bun run check`, `bun run knip`