### PR TITLE
Auto-load market and security pool data on view open

### DIFF
--- a/ui/ts/components/MarketSection.tsx
+++ b/ui/ts/components/MarketSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'preact/hooks'
+import { useEffect, useRef } from 'preact/hooks'
 import { DataGrid } from './DataGrid.js'
 import { ForkZoltarSection } from './ForkZoltarSection.js'
 import { MarketCreateQuestionSection } from './MarketCreateQuestionSection.js'
@@ -60,6 +60,7 @@ export function MarketSection({
 	const isMainnet = isMainnetChain(accountState.chainId)
 	const view = activeView
 	const showUniverseSummary = view === 'questions' && zoltarUniverse !== undefined
+	const lastAutoLoadedQuestionsUniverseId = useRef<bigint | undefined>(undefined)
 
 	useEffect(() => {
 		if (view !== 'migrate') return
@@ -67,6 +68,17 @@ export function MarketSection({
 		if (hasForked) return
 		onActiveViewChange('questions')
 	}, [hasForked, onActiveViewChange, view, zoltarUniverse])
+
+	useEffect(() => {
+		if (view !== 'questions') return
+		if (loadingZoltarQuestions) return
+		if (hasLoadedZoltarQuestions) return
+		if (zoltarQuestionCount === 0n) return
+		const currentUniverseId = zoltarUniverse?.universeId
+		if (currentUniverseId !== undefined && lastAutoLoadedQuestionsUniverseId.current === currentUniverseId) return
+		lastAutoLoadedQuestionsUniverseId.current = currentUniverseId
+		onLoadZoltarQuestions()
+	}, [hasLoadedZoltarQuestions, loadingZoltarQuestions, onLoadZoltarQuestions, view, zoltarQuestionCount, zoltarUniverse?.universeId])
 
 	const renderModeTabs = () => (
 		<SectionModeTabs

--- a/ui/ts/components/SecurityPoolsSection.tsx
+++ b/ui/ts/components/SecurityPoolsSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'preact/hooks'
+import { useEffect, useRef, useState } from 'preact/hooks'
 import { SectionModeTabs } from './SectionModeTabs.js'
 import { SecurityPoolSection } from './SecurityPoolSection.js'
 import { SecurityPoolWorkflowSection } from './SecurityPoolWorkflowSection.js'
@@ -26,6 +26,17 @@ export function SecurityPoolsSection({ createPool, overview, workflow }: Securit
 			'browse',
 		),
 	)
+	const autoLoadedBrowsePools = useRef(false)
+
+	useEffect(() => {
+		if (view !== 'browse') return
+		if (overview.loadingSecurityPools) return
+		if (overview.hasLoadedSecurityPools) return
+		if (autoLoadedBrowsePools.current) return
+		autoLoadedBrowsePools.current = true
+		overview.onLoadSecurityPools()
+	}, [overview.hasLoadedSecurityPools, overview.loadingSecurityPools, overview.onLoadSecurityPools, view])
+
 	const openView = (nextView: SecurityPoolsView, nextSecurityPoolAddress?: string) => {
 		setView(nextView)
 		const resolvedSecurityPoolAddress = nextSecurityPoolAddress ?? workflow.securityPoolAddress

--- a/ui/ts/tests/marketSection.test.tsx
+++ b/ui/ts/tests/marketSection.test.tsx
@@ -2,6 +2,8 @@
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { h } from 'preact'
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
 import { zeroAddress } from 'viem'
 import { MarketSection } from '../components/MarketSection.js'
 import { getDefaultMarketFormState, getDefaultZoltarMigrationFormState } from '../lib/marketForm.js'
@@ -130,5 +132,55 @@ describe('MarketSection', () => {
 		const migrateRepButton = tabButtons.find(button => button.textContent?.trim() === 'Migrate REP')
 		if (!(migrateRepButton instanceof HTMLButtonElement)) throw new Error('Expected to find the Migrate REP button')
 		expect(migrateRepButton.disabled).toBe(true)
+	})
+
+	test('auto-loads questions once when opening the questions view without loaded data', async () => {
+		const calls: string[] = []
+		const initialProps = createMarketSectionProps({
+			hasLoadedZoltarQuestions: false,
+			loadingZoltarQuestions: false,
+			onLoadZoltarQuestions: () => {
+				calls.push('load')
+			},
+			zoltarQuestionCount: 3n,
+			zoltarUniverse: createZoltarUniverse({ universeId: 7n }),
+		})
+
+		const renderedComponent = await renderIntoDocument(h(MarketSection, initialProps))
+		cleanupRenderedComponent = renderedComponent.cleanup
+		expect(calls).toEqual(['load'])
+
+		await act(() => {
+			render(
+				h(MarketSection, {
+					...initialProps,
+					onLoadZoltarQuestions: () => {
+						calls.push('rerender')
+					},
+				}),
+				renderedComponent.container,
+			)
+		})
+
+		expect(calls).toEqual(['load'])
+	})
+
+	test('does not auto-load questions when they are already loaded', async () => {
+		const calls: string[] = []
+		const renderedComponent = await renderIntoDocument(
+			h(
+				MarketSection,
+				createMarketSectionProps({
+					hasLoadedZoltarQuestions: true,
+					onLoadZoltarQuestions: () => {
+						calls.push('load')
+					},
+					zoltarQuestionCount: 3n,
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(calls).toEqual([])
 	})
 })

--- a/ui/ts/tests/securityPoolsSection.test.ts
+++ b/ui/ts/tests/securityPoolsSection.test.ts
@@ -3,6 +3,8 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { within } from '@testing-library/dom'
 import { h } from 'preact'
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
 import { zeroAddress } from 'viem'
 import { SecurityPoolsSection, shouldRefreshSelectedPoolDataOnViewOpen } from '../components/SecurityPoolsSection.js'
 import type { AccountState } from '../types/app.js'
@@ -411,6 +413,41 @@ void describe('SecurityPoolsSection', () => {
 		expect(documentQueries.queryByText('Selected pool')).toBeNull()
 		expect(documentQueries.queryByText('Pool status')).toBeNull()
 		expect(documentQueries.queryByText('Next step')).toBeNull()
+	})
+
+	void test('auto-loads pool browse data once when opening the browse view without loaded pools', async () => {
+		const calls: string[] = []
+		const initialProps = createSecurityPoolsSectionProps({
+			overview: createOverviewProps({
+				hasLoadedSecurityPools: false,
+				loadingSecurityPools: false,
+				onLoadSecurityPools: () => {
+					calls.push('load')
+				},
+			}),
+		})
+
+		const renderedComponent = await renderIntoDocument(h(SecurityPoolsSection, initialProps))
+		cleanupRenderedComponent = renderedComponent.cleanup
+		expect(calls).toEqual(['load'])
+
+		await act(() => {
+			render(
+				h(SecurityPoolsSection, {
+					...initialProps,
+					overview: createOverviewProps({
+						hasLoadedSecurityPools: false,
+						loadingSecurityPools: false,
+						onLoadSecurityPools: () => {
+							calls.push('rerender')
+						},
+					}),
+				}),
+				renderedComponent.container,
+			)
+		})
+
+		expect(calls).toEqual(['load'])
 	})
 
 	void test('keeps the route summary hidden even when the selected pool is resolved in operate mode', async () => {


### PR DESCRIPTION
## Summary
- Auto-load Zoltar questions when opening the Questions view if data has not been loaded yet.
- Auto-load security pool browse data when opening the Browse view if pools have not been loaded yet.
- Simplify security vault loading by inlining the handler in `App` and removing the redundant helper.
- Add regression tests to verify auto-load only happens once and is skipped when data is already present.

## Testing
- Not run (PR content prepared from existing diff)
- Added/updated UI tests in `ui/ts/tests/marketSection.test.tsx` and `ui/ts/tests/securityPoolsSection.test.ts` to cover the new auto-load behavior