### PR TITLE
Add simulation REP pricing fallback and simplify fork migration flow

### DIFF
--- a/ui/ts/components/SimulationBanner.tsx
+++ b/ui/ts/components/SimulationBanner.tsx
@@ -20,6 +20,7 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 	const isBootstrapping = useSignal(controller.isBootstrapping)
 	const queryDelayMilliseconds = useSignal(controller.queryDelayMilliseconds.toString())
 	const repPerEthPrice = useSignal(formatCurrencyInputBalance(controller.repPerEthPrice))
+	const repPerUsdcPrice = useSignal(formatCurrencyInputBalance(controller.repPerUsdcPrice, 6))
 	const selectedAccount = useSignal(controller.selectedAccount)
 	const bootstrapError = useSignal(controller.bootstrapError)
 	const bootstrapLabel = useSignal(controller.bootstrapLabel)
@@ -40,6 +41,7 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 				isBootstrapping.value = controller.isBootstrapping
 				queryDelayMilliseconds.value = controller.queryDelayMilliseconds.toString()
 				repPerEthPrice.value = formatCurrencyInputBalance(controller.repPerEthPrice)
+				repPerUsdcPrice.value = formatCurrencyInputBalance(controller.repPerUsdcPrice, 6)
 				selectedAccount.value = controller.selectedAccount
 				transactionCountSinceReset.value = controller.transactionCountSinceReset
 				transactionDelayMilliseconds.value = controller.transactionDelayMilliseconds.toString()
@@ -188,6 +190,26 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 								/>
 							</label>
 							<label className='simulation-delay-field'>
+								<span className='simulation-delay-label'>REP / USDC mock price</span>
+								<input
+									className='simulation-control-input'
+									type='text'
+									inputMode='decimal'
+									value={repPerUsdcPrice.value}
+									disabled={busy.value}
+									onInput={event => {
+										repPerUsdcPrice.value = event.currentTarget.value
+									}}
+									onChange={event => {
+										try {
+											controller.setRepPerUsdcPrice(parseDecimalInput(event.currentTarget.value, 'REP / USDC mock price', 6))
+										} catch {
+											repPerUsdcPrice.value = formatCurrencyInputBalance(controller.repPerUsdcPrice, 6)
+										}
+									}}
+								/>
+							</label>
+							<label className='simulation-delay-field'>
 								<span className='simulation-delay-label'>Transaction receipt delay (ms)</span>
 								<input
 									className='simulation-control-input'
@@ -206,7 +228,7 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 								/>
 							</label>
 						</div>
-						<p className='detail'>Query delay slows simulation reads. The REP / ETH mock applies to every REP token in simulation mode. Transaction delay slows receipt confirmation so loading states stay visible.</p>
+						<p className='detail'>Query delay slows simulation reads. The REP / ETH and REP / USDC mocks apply to every REP token in simulation mode. Transaction delay slows receipt confirmation so loading states stay visible.</p>
 					</div>
 					<div className='button-row'>
 						<button className='secondary' onClick={() => void runControl(async () => await controller.reset())} disabled={busy.value || !isBootstrapped.value}>

--- a/ui/ts/hooks/useRepPrices.ts
+++ b/ui/ts/hooks/useRepPrices.ts
@@ -55,7 +55,7 @@ export function useRepPrices(): RepPrices {
 
 				if (repUsdcResult.status === 'fulfilled') {
 					repUsdcPrice.value = repUsdcResult.value.amountOut
-					repUsdcSource.value = 'v4'
+					repUsdcSource.value = repUsdcResult.value.source.protocol === 'mock' ? 'mock' : 'v4'
 					repUsdcSourceUrl.value = repUsdcResult.value.source.poolUrl
 				} else if (!isRepPricingEnabled()) {
 					repUsdcPrice.value = undefined

--- a/ui/ts/lib/uniswapQuoter.ts
+++ b/ui/ts/lib/uniswapQuoter.ts
@@ -162,6 +162,14 @@ function getMockRepPrice() {
 	return controller.repPerEthPrice
 }
 
+function getMockRepUsdcPrice() {
+	const controller = getActiveSimulationController()
+	if (controller === undefined) {
+		throw new Error('Simulation REP/USDC mock pricing is unavailable')
+	}
+	return controller.repPerUsdcPrice
+}
+
 function calculateMockAmountOut(tokenIn: Address, tokenOut: Address, amountIn: bigint) {
 	const repPerEthPrice = getMockRepPrice()
 	const tokenInIsEth = tokenIn === ETH_ADDRESS || tokenIn === getWethAddress()
@@ -176,18 +184,37 @@ function calculateMockAmountOut(tokenIn: Address, tokenOut: Address, amountIn: b
 	throw new Error('Simulation REP/ETH mock pricing only supports REP paired with ETH or WETH')
 }
 
+function calculateMockUsdcAmountOut(tokenIn: Address, tokenOut: Address, amountIn: bigint) {
+	const repPerUsdcPrice = getMockRepUsdcPrice()
+	const tokenInIsUsdc = tokenIn === USDC_ADDRESS
+	const tokenOutIsUsdc = tokenOut === USDC_ADDRESS
+
+	if (!tokenInIsUsdc && tokenOutIsUsdc) {
+		return (amountIn * repPerUsdcPrice) / 10n ** 18n
+	}
+	if (tokenInIsUsdc && !tokenOutIsUsdc) {
+		return (amountIn * 10n ** 18n) / repPerUsdcPrice
+	}
+	throw new Error('Simulation REP/USDC mock pricing only supports REP paired with USDC')
+}
+
 async function maybeQuoteMockRepPair(client: ReadClient, tokenIn: Address, tokenOut: Address, amountIn: bigint): Promise<{ amountOut: bigint; source: MockQuoteSource } | undefined> {
 	if (!isMockRepPricingEnabled()) return undefined
 
 	const tokenInIsEth = tokenIn === ETH_ADDRESS || tokenIn === getWethAddress()
 	const tokenOutIsEth = tokenOut === ETH_ADDRESS || tokenOut === getWethAddress()
-	if (tokenInIsEth === tokenOutIsEth) return undefined
+	const tokenInIsUsdc = tokenIn === USDC_ADDRESS
+	const tokenOutIsUsdc = tokenOut === USDC_ADDRESS
 
-	const repToken = tokenInIsEth ? tokenOut : tokenIn
+	if (!tokenInIsEth && !tokenOutIsEth && !tokenInIsUsdc && !tokenOutIsUsdc) return undefined
+	if ((tokenInIsEth || tokenOutIsEth) && (tokenInIsUsdc || tokenOutIsUsdc)) return undefined
+	if (tokenInIsEth === tokenOutIsEth && tokenInIsUsdc === tokenOutIsUsdc) return undefined
+
+	const repToken = tokenInIsEth || tokenInIsUsdc ? tokenOut : tokenIn
 	if (!(await isRepToken(client, repToken))) return undefined
 
 	return {
-		amountOut: calculateMockAmountOut(tokenIn, tokenOut, amountIn),
+		amountOut: tokenInIsUsdc || tokenOutIsUsdc ? calculateMockUsdcAmountOut(tokenIn, tokenOut, amountIn) : calculateMockAmountOut(tokenIn, tokenOut, amountIn),
 		source: {
 			label: 'MOCK',
 			poolUrl: undefined,
@@ -202,7 +229,7 @@ async function assertMockPairSupported(client: ReadClient, tokenIn: Address, tok
 	if (mockResult !== undefined) {
 		return mockResult
 	}
-	throw new Error('Simulation mock pricing only supports REP / ETH and REP / WETH pairs.')
+	throw new Error('Simulation mock pricing only supports REP / ETH, REP / WETH, and REP / USDC pairs.')
 }
 
 export function buildUniswapV4PoolId(tokenA: Address, tokenB: Address, poolConfig: PoolConfig): Hex {

--- a/ui/ts/simulation/controller.ts
+++ b/ui/ts/simulation/controller.ts
@@ -16,10 +16,12 @@ export type SimulationController = {
 	mineBlock(): Promise<void>
 	queryDelayMilliseconds: number
 	repPerEthPrice: bigint
+	repPerUsdcPrice: bigint
 	reset(): Promise<void>
 	selectAccount(address: Address): Promise<void>
 	selectedAccount: Address
 	setRepPerEthPrice(value: bigint): void
+	setRepPerUsdcPrice(value: bigint): void
 	setQueryDelayMilliseconds(value: number): void
 	subscribe(handler: () => void): () => void
 	transactionCountSinceReset: bigint

--- a/ui/ts/simulation/tevmBackend.ts
+++ b/ui/ts/simulation/tevmBackend.ts
@@ -280,6 +280,9 @@ export async function createSimulationBackend({ scenario }: { scenario: Simulati
 		get repPerEthPrice() {
 			return requireState().repPerEthPrice
 		},
+		get repPerUsdcPrice() {
+			return requireState().repPerUsdcPrice
+		},
 		requestAccounts: async () => await callWorker('getAccounts', undefined),
 		reset: async () => {
 			await callWorker('reset', undefined)
@@ -295,6 +298,12 @@ export async function createSimulationBackend({ scenario }: { scenario: Simulati
 				repPerEthPrice: value,
 			})
 			void callWorker('setRepPerEthPrice', { value })
+		},
+		setRepPerUsdcPrice: value => {
+			patchState({
+				repPerUsdcPrice: value,
+			})
+			void callWorker('setRepPerUsdcPrice', { value })
 		},
 		setQueryDelayMilliseconds: value => {
 			patchState({

--- a/ui/ts/simulation/tevmEngine.ts
+++ b/ui/ts/simulation/tevmEngine.ts
@@ -218,6 +218,7 @@ type SimulationEngine = {
 	reset(): Promise<void>
 	selectAccount(address: Address): Promise<void>
 	setRepPerEthPrice(value: bigint): void
+	setRepPerUsdcPrice(value: bigint): void
 	setQueryDelayMilliseconds(value: number): void
 	setTransactionDelayMilliseconds(value: number): void
 	subscribe(handler: () => void): () => void
@@ -255,6 +256,7 @@ export async function createSimulationEngine({ scenario }: { scenario: Simulatio
 	let currentTimestamp = 0n
 	let queryDelayMilliseconds = 0
 	let repPerEthPrice = 10n ** 18n
+	let repPerUsdcPrice = 10n ** 6n
 	let selectedAccount = primaryAccount
 	let transactionCountSinceReset = 0n
 	let transactionDelayMilliseconds = 1_000
@@ -538,6 +540,7 @@ export async function createSimulationEngine({ scenario }: { scenario: Simulatio
 		isBootstrapping: bootstrapping,
 		queryDelayMilliseconds,
 		repPerEthPrice,
+		repPerUsdcPrice,
 		selectedAccount,
 		transactionCountSinceReset,
 		transactionDelayMilliseconds,
@@ -583,6 +586,7 @@ export async function createSimulationEngine({ scenario }: { scenario: Simulatio
 			selectedAccount = primaryAccount
 			transactionCountSinceReset = baselineTransactionCount
 			repPerEthPrice = 10n ** 18n
+			repPerUsdcPrice = 10n ** 6n
 			await refreshSimulationState()
 			emitState()
 		},
@@ -599,6 +603,13 @@ export async function createSimulationEngine({ scenario }: { scenario: Simulatio
 				throw new Error('Simulation REP/ETH price must be greater than zero')
 			}
 			repPerEthPrice = value
+			emitState()
+		},
+		setRepPerUsdcPrice: value => {
+			if (value <= 0n) {
+				throw new Error('Simulation REP/USDC price must be greater than zero')
+			}
+			repPerUsdcPrice = value
 			emitState()
 		},
 		setQueryDelayMilliseconds: value => {

--- a/ui/ts/simulation/tevmWorker.ts
+++ b/ui/ts/simulation/tevmWorker.ts
@@ -50,6 +50,9 @@ async function handleCall(message: SimulationWorkerCallMessage) {
 		case 'setRepPerEthPrice':
 			engine.setRepPerEthPrice(message.params.value)
 			return undefined
+		case 'setRepPerUsdcPrice':
+			engine.setRepPerUsdcPrice(message.params.value)
+			return undefined
 		case 'setQueryDelayMilliseconds':
 			engine.setQueryDelayMilliseconds(message.params.value)
 			return undefined

--- a/ui/ts/simulation/tevmWorkerProtocol.ts
+++ b/ui/ts/simulation/tevmWorkerProtocol.ts
@@ -12,6 +12,7 @@ export type SimulationWorkerState = {
 	isBootstrapping: boolean
 	queryDelayMilliseconds: number
 	repPerEthPrice: bigint
+	repPerUsdcPrice: bigint
 	selectedAccount: Address
 	transactionCountSinceReset: bigint
 	transactionDelayMilliseconds: number
@@ -28,6 +29,7 @@ export type SimulationWorkerCallMap = {
 	reset: { params: undefined; result: undefined }
 	selectAccount: { params: { address: Address }; result: undefined }
 	setRepPerEthPrice: { params: { value: bigint }; result: undefined }
+	setRepPerUsdcPrice: { params: { value: bigint }; result: undefined }
 	setQueryDelayMilliseconds: { params: { value: number }; result: undefined }
 	setTransactionDelayMilliseconds: { params: { value: number }; result: undefined }
 	waitForTransactionReceipt: { params: { hash: Hash }; result: TransactionReceipt }

--- a/ui/ts/tests/activeEnvironment.test.ts
+++ b/ui/ts/tests/activeEnvironment.test.ts
@@ -57,6 +57,7 @@ void describe('simulation backend', () => {
 		expect(backend.isBootstrapped).toBe(false)
 		expect(backend.isBootstrapping).toBe(false)
 		expect(backend.repPerEthPrice).toBe(10n ** 18n)
+		expect(backend.repPerUsdcPrice).toBe(10n ** 6n)
 	})
 
 	void test('tracks simulation bootstrap readiness state', async () => {
@@ -206,9 +207,12 @@ void describe('simulation backend', () => {
 
 		backend.setRepPerEthPrice(3n * 10n ** 18n)
 		expect(backend.repPerEthPrice).toBe(3n * 10n ** 18n)
+		backend.setRepPerUsdcPrice(7n * 10n ** 6n)
+		expect(backend.repPerUsdcPrice).toBe(7n * 10n ** 6n)
 
 		await backend.reset()
 		expect(backend.repPerEthPrice).toBe(10n ** 18n)
+		expect(backend.repPerUsdcPrice).toBe(10n ** 6n)
 	}, 30_000)
 
 	void test('bootstraps the deployed scenario with app contracts already deployed', async () => {

--- a/ui/ts/tests/uniswapQuoter.test.ts
+++ b/ui/ts/tests/uniswapQuoter.test.ts
@@ -6,6 +6,7 @@ import {
 	DEFAULT_POOL_CONFIG,
 	ETH_ADDRESS,
 	REP_ADDRESS,
+	USDC_ADDRESS,
 	UNISWAP_V4_QUOTER_ADDRESS,
 	WETH_ADDRESS,
 	buildUniswapV3PoolUrl,
@@ -126,7 +127,7 @@ void describe('quoteExactInput', () => {
 		)
 
 		const { client } = createCapturingClient(1n)
-		await expect(quoteRepForEth(client, 1n)).rejects.toThrow('Simulation mock pricing only supports REP / ETH and REP / WETH pairs.')
+		await expect(quoteRepForEth(client, 1n)).rejects.toThrow('Simulation mock pricing only supports REP / ETH, REP / WETH, and REP / USDC pairs.')
 	})
 
 	void test('returns simulation mock REP/ETH quotes when simulation mode is active', async () => {
@@ -150,10 +151,12 @@ void describe('quoteExactInput', () => {
 				mineBlock: async () => undefined,
 				queryDelayMilliseconds: 0,
 				repPerEthPrice: 2n * 10n ** 18n,
+				repPerUsdcPrice: 5n * 10n ** 6n,
 				reset: async () => undefined,
 				selectAccount: async () => undefined,
 				selectedAccount: getAddress('0x00000000000000000000000000000000000000a1'),
 				setRepPerEthPrice: () => undefined,
+				setRepPerUsdcPrice: () => undefined,
 				setQueryDelayMilliseconds: () => undefined,
 				subscribe: () => () => undefined,
 				transactionCountSinceReset: 0n,
@@ -168,6 +171,8 @@ void describe('quoteExactInput', () => {
 
 		await expect(quoteEthForToken(client, profile.genesisRepTokenAddress, 3n * 10n ** 18n)).resolves.toBe(6n * 10n ** 18n)
 		await expect(quoteTokenForEth(client, profile.genesisRepTokenAddress, 6n * 10n ** 18n)).resolves.toBe(3n * 10n ** 18n)
+		await expect(quoteExactInput(client, profile.genesisRepTokenAddress, USDC_ADDRESS, 2n * 10n ** 18n)).resolves.toBe(10n * 10n ** 6n)
+		await expect(quoteExactInput(client, USDC_ADDRESS, profile.genesisRepTokenAddress, 10n * 10n ** 6n)).resolves.toBe(2n * 10n ** 18n)
 	})
 
 	void test('returns amountOut from the quoter result', async () => {


### PR DESCRIPTION
## Summary
- Added mock REP/USDC pricing support for simulation mode so quote-dependent UI flows can keep working without mainnet liquidity.
- Simplified `SecurityPoolForker` child-pool creation and migration handling to transfer child REP directly into new pools and remove the old deferred sweep path.
- Adjusted auction settlement and `redeemRep` behavior to work with the new fork/migration assumptions.
- Updated tests and repo docs to match the revised setup and quality-check commands.

## Testing
- Not run (changes were provided as an existing commit set).
- Expected validation per repo instructions: `bun tsc`, `bun test`, `bun run format`, `bun run check`, `bun run knip`.