### PR TITLE
Refresh simulation state after mock price edits

### DIFF
--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -219,6 +219,10 @@ export function App() {
 	} = useForkAuctionOperations(baseHookConfig)
 	const { repPerEthPrice, repPerEthSource, repPerEthSourceUrl, repUsdcPrice, repUsdcSource, repUsdcSourceUrl, isLoadingRepPrices, refreshRepPrices } = useRepPrices()
 	const simulationController = getActiveSimulationController()
+	const refreshSimulationView = async () => {
+		await refreshState()
+		refreshRepPrices()
+	}
 	const deploymentSections = getDeploymentSections(deploymentStatuses)
 	const errorMessage = deploymentErrorMessage ?? walletErrorMessage
 	const isMainnet = isSupportedAppChain(accountState.chainId)
@@ -583,7 +587,7 @@ export function App() {
 				walletPresentation={walletPresentation}
 				zoltarUniverse={zoltarUniverse}
 			/>
-			<AppHeaderShell overview={overviewProps} simulationController={simulationController} tabNavigation={tabNavigationProps} onRefresh={refreshState} />
+			<AppHeaderShell overview={overviewProps} simulationController={simulationController} tabNavigation={tabNavigationProps} onRefresh={refreshSimulationView} />
 
 			<fieldset className='route-shell' disabled={isRouteContentDisabled}>
 				<AppRouteContent deploy={deployRouteContentProps} market={marketRouteContentProps} openOracle={openOracleRouteContentProps} route={route} securityPools={securityPoolsRouteContentProps} wrongNetworkMessage={wrongNetworkMessage} />

--- a/ui/ts/components/SimulationBanner.tsx
+++ b/ui/ts/components/SimulationBanner.tsx
@@ -182,7 +182,9 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 									}}
 									onChange={event => {
 										try {
-											controller.setRepPerEthPrice(parseDecimalInput(event.currentTarget.value, 'REP / ETH mock price'))
+											void runControl(async () => {
+												controller.setRepPerEthPrice(parseDecimalInput(event.currentTarget.value, 'REP / ETH mock price'))
+											})
 										} catch {
 											repPerEthPrice.value = formatCurrencyInputBalance(controller.repPerEthPrice)
 										}
@@ -202,7 +204,9 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 									}}
 									onChange={event => {
 										try {
-											controller.setRepPerUsdcPrice(parseDecimalInput(event.currentTarget.value, 'REP / USDC mock price', 6))
+											void runControl(async () => {
+												controller.setRepPerUsdcPrice(parseDecimalInput(event.currentTarget.value, 'REP / USDC mock price', 6))
+											})
 										} catch {
 											repPerUsdcPrice.value = formatCurrencyInputBalance(controller.repPerUsdcPrice, 6)
 										}

--- a/ui/ts/hooks/useZoltarOperations.ts
+++ b/ui/ts/hooks/useZoltarOperations.ts
@@ -33,7 +33,9 @@ export function useZoltarOperations({ accountAddress, activeUniverseId, activeZo
 		onTransactionSubmitted,
 		refreshState,
 		refreshZoltarUniverse,
-		shouldAutoLoadForkAccess: activeZoltarView === 'fork' || activeZoltarView === 'migrate',
+		// The overview header always displays the connected wallet's REP balance.
+		// Keep fork access loaded whenever the app has enough context to do so.
+		shouldAutoLoadForkAccess: autoLoadInitialData || activeZoltarView === 'fork' || activeZoltarView === 'migrate',
 		zoltarUniverse: universe.zoltarUniverse,
 	})
 	const refreshZoltarForkAccess = useCallback(async () => {

--- a/ui/ts/tests/simulationBanner.test.tsx
+++ b/ui/ts/tests/simulationBanner.test.tsx
@@ -1,0 +1,80 @@
+/// <reference types="bun-types" />
+
+import { fireEvent, waitFor, within } from '@testing-library/dom'
+import { describe, expect, mock, test } from 'bun:test'
+import type { Address } from 'viem'
+import { SimulationBanner } from '../components/SimulationBanner.js'
+import type { SimulationController } from '../simulation/controller.js'
+import { installDomEnvironment } from './testUtils/domEnvironment.js'
+import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
+
+function createSimulationController(overrides: Partial<SimulationController> = {}): SimulationController {
+	const selectedAccount = '0x00000000000000000000000000000000000000a1' as Address
+
+	return {
+		accounts: [selectedAccount],
+		advanceTime: async () => undefined,
+		bootstrapError: undefined,
+		bootstrapLabel: undefined,
+		bootstrapProgress: undefined,
+		blockCountSinceReset: 0n,
+		currentTimestamp: 1n,
+		currentScenario: 'baseline',
+		dispose: async () => undefined,
+		isActive: true,
+		isBootstrapped: true,
+		isBootstrapping: false,
+		mineBlock: async () => undefined,
+		queryDelayMilliseconds: 0,
+		repPerEthPrice: 10n ** 18n,
+		repPerUsdcPrice: 10n ** 6n,
+		reset: async () => undefined,
+		selectAccount: async () => undefined,
+		selectedAccount,
+		setQueryDelayMilliseconds: () => undefined,
+		setRepPerEthPrice: () => undefined,
+		setRepPerUsdcPrice: () => undefined,
+		setTransactionDelayMilliseconds: () => undefined,
+		subscribe: () => () => undefined,
+		transactionCountSinceReset: 0n,
+		transactionDelayMilliseconds: 0,
+		waitUntilReady: async () => undefined,
+		...overrides,
+	}
+}
+
+describe('SimulationBanner', () => {
+	test('refreshes the app after updating the REP/ETH mock price', async () => {
+		const domEnvironment = installDomEnvironment()
+		const onRefresh = mock(async () => undefined)
+		const setRepPerEthPrice = mock(() => undefined)
+		const controller = createSimulationController({ setRepPerEthPrice })
+		const renderedComponent = await renderIntoDocument(<SimulationBanner controller={controller} onRefresh={onRefresh} />)
+
+		try {
+			const documentQueries = within(renderedComponent.container)
+			const repPerEthLabel = documentQueries.getByText('REP / ETH mock price')
+			const repPerEthInput = repPerEthLabel.parentElement?.querySelector('input')
+			if (!(repPerEthInput instanceof HTMLInputElement)) {
+				throw new Error('Expected a REP / ETH mock price input')
+			}
+
+			fireEvent.input(repPerEthInput, {
+				currentTarget: { value: '2' },
+				target: { value: '2' },
+			})
+			fireEvent.change(repPerEthInput, {
+				currentTarget: { value: '2' },
+				target: { value: '2' },
+			})
+
+			await waitFor(() => {
+				expect(setRepPerEthPrice).toHaveBeenCalledWith(2n * 10n ** 18n)
+				expect(onRefresh).toHaveBeenCalledTimes(1)
+			})
+		} finally {
+			await renderedComponent.cleanup()
+			domEnvironment.cleanup()
+		}
+	})
+})

--- a/ui/ts/tests/uniswapQuoter.test.ts
+++ b/ui/ts/tests/uniswapQuoter.test.ts
@@ -145,6 +145,7 @@ void describe('quoteExactInput', () => {
 				blockCountSinceReset: 0n,
 				currentTimestamp: 0n,
 				currentScenario: 'baseline',
+				dispose: async () => undefined,
 				isActive: true,
 				isBootstrapped: true,
 				isBootstrapping: false,


### PR DESCRIPTION
## Summary
- Refreshes app state after simulation mock price updates so the UI reflects the new values immediately.
- Ensures simulation price edits are routed through the control flow used by other async actions.
- Expands fork-access auto-loading so the overview header can stay in sync with connected-wallet REP balance.
- Adds a regression test covering REP/ETH mock price updates triggering a refresh.

## Testing
- `bun run tsc`
- `bun test`
- `bun run format`
- `bun run check`
- `bun run knip`