### PR TITLE
Add operator-focused UI guide

### DIFF
--- a/docs/new_ui.md
+++ b/docs/new_ui.md
@@ -126,6 +126,14 @@ This redesign is not intended to:
 
 ## Core Design Changes
 
+When the redesign has to choose between competing priorities, use this order:
+
+1. preserve workflow correctness
+2. preserve clarity of state and blockers
+3. reduce visual and interaction noise
+4. improve speed of execution
+5. improve visual refinement
+
 ### 1. Stronger Route Structure
 
 Each major route should follow a stricter composition:
@@ -383,6 +391,14 @@ What stays the same:
 - report deep-linking and route handoffs
 
 ## Route Specs
+
+This section describes the target route behavior and the intended user-facing structure for each major workspace.
+
+Use it to answer:
+
+- what the redesigned route should feel like
+- what changes from the current UI
+- which actions stay inline versus move to modal execution
 
 ## Route-by-Route Redesign
 
@@ -832,6 +848,19 @@ The right split is:
 ## Implementation Blueprint
 
 Someone implementing this redesign should apply the same page contract everywhere.
+
+### Canonical rules
+
+When sections in this document overlap, use these as the controlling rules:
+
+- route = state, scope, readiness, and action choice
+- modal = execution, confirmation, and operation-specific inputs
+- global blockers appear once per route
+- action cards show only local blockers
+- creation flows usually stay inline unless this document explicitly says otherwise
+- selected object identity and lifecycle stage stay visible while working
+- advanced detail remains available but visually secondary
+- copy stays short and high-signal by default
 
 ### Shared page contract
 
@@ -1742,6 +1771,15 @@ Do not regress on:
 
 ## Implementation
 
+This section is the build-facing layer of the document.
+
+Use it to answer:
+
+- which shared modules should exist
+- how current controls map into the redesign
+- which states must remain supported
+- how to phase the rollout without losing important behavior
+
 ## Route Implementation Requirements
 
 This section is the practical build checklist for the redesign. It should be enough for an implementer to translate the existing UI into the redesigned one without inventing the interaction model from scratch.
@@ -2235,11 +2273,11 @@ If the redesign is implemented incrementally, use this dependency order:
 
 If this redesign is implemented incrementally, start here:
 
-1. convert vault actions to modal-first
-2. convert trading actions to modal-first
-3. convert reporting actions to modal-first
-4. convert Open Oracle selected-report actions to modal-first
-5. add `ActionReadinessPanel`, `NextActionPanel`, and `RequirementsChecklist` to the main routes
+1. build the shared action-card, modal, notice, and sticky-context foundations
+2. convert vault actions to modal-first
+3. convert trading actions to modal-first
+4. convert reporting actions to modal-first
+5. convert Open Oracle selected-report actions to modal-first
 
 This would capture most of the clarity benefit without redesigning every page at once.
 

--- a/docs/new_ui.md
+++ b/docs/new_ui.md
@@ -1,0 +1,2261 @@
+# New UI Proposal
+
+This document proposes a redesign of the UI. Unlike [`docs/ui.md`](./ui.md), which describes the existing interface, this document describes a new target UI intended to reduce operator friction, simplify dense workflows, and make transaction-heavy actions easier to understand.
+
+## Executive Summary
+
+The redesign keeps the current protocol capabilities and top-level route model, but changes how the UI presents state and actions.
+
+What stays the same:
+
+- the four top-level routes
+- the core workflows and protocol actions
+- explicit gating, deep linking, and operator seriousness
+
+What changes:
+
+- large inline transaction forms move into focused execution modals
+- pages show readiness and blockers before the user clicks
+- lifecycle stage becomes much more visible
+- dense tables and metric walls are replaced with clearer grouped summaries
+- advanced detail remains available, but becomes visually secondary
+
+The core interaction model is:
+
+- page = state, scope, readiness, and action choice
+- modal = execution
+
+The first implementation slice should focus on:
+
+1. shared action-card and modal patterns
+2. `Security Pools > Operate`
+3. `Open Oracle > Selected Report`
+4. shared notice, stage, and sticky-context systems
+
+## How To Use This Document
+
+This document should be treated as an implementation spec for the redesigned UI.
+
+Use [`docs/ui.md`](./ui.md) for the inventory of existing screens, controls, and flows.
+Use this document for:
+
+- the target interaction model
+- the target page structure
+- which flows move to modal-first execution
+- which elements remain inline
+- how route state, blockers, stage, and cross-route handoffs should be presented
+
+If a designer or engineer needs to implement the redesign, the default rule should be:
+
+- preserve the same protocol capabilities unless this document explicitly says otherwise
+- change presentation, action grouping, execution flow, and hierarchy to match this redesign
+- keep the route model intact unless this document explicitly proposes a different structure
+
+## Document Structure
+
+This document is organized into three layers:
+
+1. principles
+   - the target interaction model, clarity rules, and visual rules
+2. route specs
+   - how each route and major workspace should be redesigned
+3. implementation
+   - migration mapping, modal inventory, state contracts, rollout order, and acceptance criteria
+
+Quick readers should start with:
+
+- `Executive Summary`
+- `Goals`
+- `Route Before vs After`
+- `Recommended First Pass`
+
+Implementers should then use:
+
+- `Route Implementation Requirements`
+- `Route Layout Contracts`
+- `Current-To-New Control Migration Map`
+- `Modal Inventory`
+- `Redesign Acceptance Criteria`
+
+## Redesign Contract
+
+The redesigned UI should preserve:
+
+- the four top-level routes
+- the same operational capabilities described in [`docs/ui.md`](./ui.md)
+- deep-linkable route and object context
+- visibility into protocol state and workflow blockers
+
+The redesigned UI should change:
+
+- where actions are presented
+- how actions are launched
+- how approvals are handled
+- how stage and readiness are explained
+- how dense technical detail is prioritized on the page
+
+## Goals
+
+The redesign should:
+
+- keep the current route model and core product capabilities
+- reduce the amount of always-visible form chrome on each screen
+- make the next required action more obvious
+- keep all available actions visible before the user clicks into execution
+- show requirements and blockers inline instead of revealing them late
+- separate read-only context from write actions more clearly
+- standardize high-risk transaction flows
+- make approvals feel like part of an operation, not a separate page-level workflow
+
+The redesign should not:
+
+- remove advanced operator capabilities
+- hide critical protocol state
+- turn the app into a consumer UI
+- reduce precision where the current UI is intentionally explicit
+
+## Non-Goals
+
+This redesign is not intended to:
+
+- remove advanced or low-frequency protocol actions
+- replace explicit lifecycle state with vague abstractions
+- hide blockers until the user attempts an action
+- optimize for decorative UI over operational clarity
+- turn the interface into a beginner-oriented tutorial product
+
+## Core Design Changes
+
+### 1. Stronger Route Structure
+
+Each major route should follow a stricter composition:
+
+1. route header
+2. top-level context summary
+3. action readiness panel
+4. supporting detail sections
+5. advanced or lifecycle sections
+
+The intent is to make every route answer these questions immediately:
+
+- where am I?
+- what object am I operating on?
+- what actions are available here?
+- which action is recommended next?
+- what is blocked, and why?
+
+Universal environment blockers should be handled once at the route or app-shell level, not repeated on every action card.
+
+### 2. Read-Only Context First, Actions Second
+
+The current UI mixes state summaries and transaction forms inside the same panels. The redesign should separate them:
+
+- read-only context panels explain the current onchain state
+- route-level environment gates show universal blockers only when they are failing
+- action cards stay visible on the route and show readiness, blockers, and intent
+- action launchers open focused transaction modals
+- advanced diagnostics stay available, but lower on the page
+
+This keeps route surfaces lighter and lowers scanning cost.
+
+### 3. Modal-First Transaction Flows
+
+Many write actions should work like the current liquidation flow:
+
+- the main route shows the action, readiness state, and blockers
+- clicking the action opens a focused modal
+- the modal contains inputs, approval state, validation, warnings, and final submit
+
+This is the biggest proposed interaction change.
+
+## Modal-First Transaction Pattern
+
+### Pattern
+
+Every modal-first write flow should follow the same structure:
+
+1. modal title
+2. short purpose text
+3. read-only context summary
+4. input fields for that one operation
+5. approval state if the operation needs approvals
+6. requirement checklist
+7. final submit action
+
+The route that launches the modal should still show:
+
+- what the action does
+- whether it is ready now
+- which local requirements are missing
+- any important balance, approval, or lifecycle blocker
+
+The modal should also have:
+
+- a cancel button
+- explicit error surface
+- explicit success surface or close-on-success behavior with route-level success notice
+- stable pending state inside the submit button
+
+### Why this is better
+
+This pattern would:
+
+- remove large clusters of inputs from the base route
+- make each action feel intentional and bounded
+- let approvals live inside the operation that needs them
+- keep prerequisite discovery on the page instead of in the modal
+- reduce confusion about which field belongs to which transaction
+- make high-risk actions feel more deliberate
+
+### Approval Handling
+
+Approvals should move into the modal for the specific action that requires them.
+
+Example:
+
+- today: `Deposit REP` sits on the page, and REP approval lives directly in the route
+- proposed: `Deposit REP` is a button on the page, which opens a `Deposit REP` modal
+- inside the modal:
+  - deposit amount
+  - wallet balance
+  - current allowance
+  - `Approve REP`
+  - `Deposit REP`
+
+This keeps the main route cleaner and preserves all current safety checks.
+
+The page should still tell the user that approval is required before they open the modal. The modal should execute the approval, not surprise the user with the need for it.
+
+## Global vs Local Readiness
+
+The redesign should separate universal environment state from action-specific readiness.
+
+### Global environment gates
+
+These should live at the app-shell or route level and should only become prominent when they are failing:
+
+- wallet disconnected
+- wrong network
+- setup or deployment incomplete
+
+If these states are healthy, they should not be repeated on every action card.
+
+Simulation mode should not be treated as a blocker or prerequisite by default. It should remain a lightweight environment indicator and only be mentioned near a specific action when simulation changes the meaning of that action.
+
+### Action-specific readiness
+
+Action cards should only show blockers that are local to that action, such as:
+
+- insufficient REP
+- approval required
+- no selected vault
+- report not in the correct stage
+- pool belongs to a different universe
+- child universe not created yet
+
+This keeps readiness useful without repeating the same environment checks across the entire page.
+
+### Flows that should move to modal-first
+
+These are strong candidates:
+
+- vault deposit REP
+- vault withdraw REP
+- set security bond allowance
+- claim fees
+- mint complete sets
+- redeem complete sets
+- migrate shares
+- redeem shares
+- report outcome / contribute
+- withdraw escalation deposits
+- create child universe
+- migrate REP to Zoltar from pool flow
+- migrate vault
+- migrate escalation deposits
+- start truth auction
+- submit bid
+- refund losing bid
+- claim auction proceeds
+- withdraw bids
+- initial report submission
+- dispute report
+- settle report
+- fork Zoltar
+- prepare REP
+- split REP
+
+### Flows that can stay inline
+
+Some lightweight actions can remain inline if they do not need extra inputs:
+
+- refresh actions
+- navigation actions
+- open/select actions
+- simple deploy actions
+- route tab switches
+
+## Route Before vs After
+
+This section summarizes the redesign at the route level for readers who want a fast comparison with the current UI.
+
+### Deploy
+
+Before:
+
+- already one of the clearer routes
+- still somewhat list-driven and step-driven
+- deployment state and next action compete for attention
+
+After:
+
+- deployment summary appears first
+- the next recommended deploy step is visually primary
+- completed groups collapse by default
+- per-step controls remain available but become secondary
+
+What stays the same:
+
+- deterministic deployment workflow
+- `Deploy Next Missing`
+- per-step deployment access
+
+### Zoltar
+
+Before:
+
+- good route split, but post-fork state is not visually dominant enough
+- question browsing, forking, and migration are present but not sequenced strongly
+
+After:
+
+- universe stage becomes much more visible
+- post-fork actions become more prominent when relevant
+- `Fork Zoltar`, `Prepare REP`, and `Split REP` move to modal execution
+- question-to-pool and question-to-fork handoffs become more explicit
+
+What stays the same:
+
+- `Questions`, `Create Question`, `Fork`, and `Migration`
+- inline question creation
+- question-driven pool and fork flows
+
+### Security Pools
+
+Before:
+
+- the densest route in the app
+- `Operate` mixes state, inputs, approvals, and lifecycle details
+- many unrelated amount inputs are visible at once
+
+After:
+
+- `Browse`, `Create`, and `Operate` remain, but `Operate` is restructured
+- selected-pool context becomes sticky
+- action cards replace long inline transaction panels
+- most state-changing actions move into focused modals
+- fork and reporting stages become easier to read as workflows
+
+What stays the same:
+
+- browse, create, and operate capabilities
+- pool, vault, trading, reporting, and fork workflows
+- liquidation as an available high-risk action
+
+### Open Oracle
+
+Before:
+
+- selected-report pages mix heavy read-only detail with action flows
+- report stage is present but not visually dominant enough
+
+After:
+
+- report stage becomes the first thing the user sees
+- action mode becomes visually primary
+- initial report, dispute, and settle become focused modal flows
+- long report details move lower and become easier to collapse
+
+What stays the same:
+
+- browse, create, and selected-report entry structure
+- initial report, dispute, and settle capabilities
+- report deep-linking and route handoffs
+
+## Route Specs
+
+## Route-by-Route Redesign
+
+### App Shell
+
+The top shell should stay, but with clearer priority:
+
+- wallet and universe summary stay visible
+- pricing stays visible
+- route tabs stay visible
+- global notices stay visible
+
+Improvements:
+
+- make the active universe and network state more prominent
+- group status notices into one consistent notice stack
+- keep only one obvious wallet action in the header
+
+### Deploy
+
+The current `Deploy` route is already relatively clear. It mostly needs stronger next-action framing.
+
+Proposed structure:
+
+- route header with deployment summary
+- `Action Readiness` panel showing all deploy actions and the next recommended step
+- deployment group list
+- advanced per-step actions
+
+Improvements:
+
+- make `Deploy Next Missing` the obvious primary action
+- collapse already-complete groups by default
+- keep individual deploy buttons available, but visually secondary
+
+### Zoltar
+
+The current `Zoltar` route is functionally good but could be sequenced more clearly.
+
+Proposed view model:
+
+- `Questions`
+- `Create Question`
+- `Fork`
+- `Migration`
+
+#### Questions
+
+The `Questions` view should emphasize:
+
+- active universe summary
+- question list
+- next available universe-level action
+
+Improvements:
+
+- keep the question list primary
+- move child-universe deployment into a dedicated `Post-Fork Universe Actions` block
+- when the universe is forked, show a clear banner explaining that question creation is no longer the primary lifecycle
+
+#### Create Question
+
+Improvements:
+
+- keep the form inline
+- add a compact live validation summary near the submit action
+- after creation, show a stronger handoff block:
+  - `Fork this question`
+  - `Use for pool creation`
+  - `Create another`
+
+#### Fork
+
+This should become a modal-first action.
+
+Base route should show:
+
+- fork threshold
+- selected question summary
+- readiness checklist
+
+Primary action:
+
+- `Fork Zoltar`
+
+Modal contents:
+
+- selected question
+- fork threshold
+- wallet REP balance
+- approval state
+- approval action
+- final fork action
+
+#### Migration
+
+This should also become modal-first for the actual write operations.
+
+Base route should show:
+
+- migration balance
+- wallet REP balance
+- selected child universes
+- split-capacity summary
+
+Primary actions:
+
+- `Prepare REP`
+- `Split REP`
+
+Each opens its own modal or a shared two-step migration modal.
+
+### Security Pools
+
+This route has the largest improvement opportunity.
+
+Proposed top-level structure:
+
+- `Browse`
+- `Create`
+- `Operate`
+
+#### Browse
+
+Keep the browse registry, but improve action hierarchy:
+
+- pool cards remain visible
+- pool summary stays read-only
+- `Open Pool` remains primary
+- `Liquidate Vault` remains a modal launcher
+
+Improvements:
+
+- make `Refresh pools` secondary and less visually heavy
+- keep liquidation clearly marked as destructive/high-risk
+- add clearer separation between pool metrics and vault actions
+
+#### Create
+
+Keep the create form inline, but simplify the result flow:
+
+- compact question context
+- existing-pools summary
+- creation form
+- post-success handoff card
+
+Improvements:
+
+- stronger validation summary
+- show why creation is blocked in one dedicated requirements strip
+
+#### Operate
+
+This should become much more structured.
+
+Proposed layout:
+
+1. selected pool header
+2. pool summary
+3. action readiness panel
+4. workflow tabs
+5. advanced details
+
+The pool summary should stay read-only. Actions should move into modals.
+
+##### Vaults
+
+Current issue:
+
+- too many inputs and approvals live directly in the route
+
+Proposed change:
+
+- keep vault directory inline
+- keep selected vault summary inline
+- replace inline write forms with action launchers
+
+Main vault actions:
+
+- `Deposit REP`
+- `Withdraw REP`
+- `Set Bond Allowance`
+- `Claim Fees`
+- `Liquidate Vault`
+
+Each opens a modal with:
+
+- selected vault summary
+- relevant balances and allowances
+- one focused input
+- approval control if needed
+- submit button
+
+Result:
+
+- remove most always-visible input fields from the route
+- keep the page focused on vault state, not vault forms
+
+##### Trading
+
+Current issue:
+
+- four separate transaction sections create a long action stack
+
+Proposed change:
+
+- replace inline forms with action cards:
+  - `Mint Complete Sets`
+  - `Redeem Complete Sets`
+  - `Migrate Shares`
+  - `Redeem Shares`
+
+Each opens a focused modal.
+
+Benefits:
+
+- no more always-visible amount fields for unrelated actions
+- per-flow validation stays local to the action
+
+##### Reporting
+
+Current issue:
+
+- escalation context is good, but the write panel is dense
+
+Proposed change:
+
+- keep escalation metrics and side summaries inline
+- move write actions to modals:
+  - `Report / Contribute`
+  - `Withdraw Deposits`
+
+Each modal should show:
+
+- selected outcome side
+- current bond and threshold context
+- user stake on that side
+- amount or deposit-index input
+- submit action
+
+##### Fork
+
+Current issue:
+
+- the route exposes many lifecycle operations simultaneously
+
+Proposed change:
+
+- keep lifecycle tabs and read-only state inline
+- make every actual fork/auction operation modal-first
+
+Examples:
+
+- `Initiate Pool Fork`
+- `Create Child Universe`
+- `Migrate Vault`
+- `Submit Bid`
+- `Claim Auction Proceeds`
+
+Each modal should carry the exact stage context needed for that one action.
+
+### Open Oracle
+
+This route is a good candidate for stronger separation between read-only report state and write actions.
+
+#### Browse
+
+Mostly fine now. Improvements:
+
+- keep browse list primary
+- keep selected report route as the deep workspace
+
+#### Create Open Oracle Game
+
+This should stay inline as a standalone creation flow.
+
+Base route:
+
+- compact explanation of what direct game creation does
+- grouped creation fields
+- validation summary
+- `Create Open Oracle Game`
+
+Rationale:
+
+- it creates a new record rather than mutating an existing one
+- it fits the document's broader rule that creation flows usually stay page-native
+- it is technical, but not improved by hiding the whole form behind a launcher
+
+#### Selected Report
+
+Current issue:
+
+- report details and action workflow compete for visual priority
+
+Proposed change:
+
+- keep report summary at top
+- move long read-only sections into collapsible panels
+- make the active action mode the primary call to action
+
+Action-mode changes:
+
+- `Initial Report` action opens `Submit Initial Report` modal
+- `Dispute Report` action opens `Dispute & Swap` modal
+- `Settle Report` action opens `Settle Report` confirmation modal
+
+Benefits:
+
+- the selected report page reads like a report viewer
+- the modal handles the actual transaction workflow
+
+## Standard UI Components To Add
+
+The redesign should introduce a small shared set of higher-level components:
+
+- `NextActionPanel`
+  - shows the recommended next action and why without hiding other available actions
+  - should be treated as a recommendation surface, not a single-path workflow surface
+- `ActionReadinessPanel`
+  - shows the full set of available actions plus action-specific readiness and blockers for the current object
+- `EnvironmentGate`
+  - shows global blockers such as disconnected wallet, wrong network, or incomplete setup only when they are failing
+- `RequirementsChecklist`
+  - shows local requirements for the selected action, such as approval, balance, selected object, or lifecycle stage
+- `ActionLauncherCard`
+  - read-only action summary with readiness state, blockers, and a single primary launcher
+- `OperationModal`
+  - shared shell for modal-first transactions after the user has already seen the requirements on-page
+- `ReadOnlyDetailAccordion`
+  - collapsible technical detail sections
+- `ResultBanner`
+  - consistent success state after a write action
+- `LifecycleStageBanner`
+  - shows the current object stage, what it means, and which actions are unlocked
+- `ContextBreadcrumb`
+  - shows how the current route or record relates to the previous workflow step
+- `OutcomeSummary`
+  - explains what changed after a completed action and what the operator should do next
+
+## Shared Module Architecture
+
+The redesigned UI should be implemented as a layered module system rather than as one-off route-specific panels.
+
+The goal is to share structure, interaction patterns, and state presentation across routes without forcing unrelated workflows into the same component.
+
+### 1. UI Primitives
+
+Reusable low-level building blocks:
+
+- buttons
+- badges
+- icons
+- cards
+- section wrappers
+- metric rows
+- form fields
+- inline status labels
+
+These should define the visual language but not contain route-specific workflow logic.
+
+### 2. Shared Workflow Modules
+
+Reusable higher-level workflow surfaces:
+
+- `EnvironmentGate`
+- `LifecycleStageBanner`
+- `StickyObjectContext`
+- `ActionReadinessPanel`
+- `NextActionPanel`
+- `ActionLauncherCard`
+- `RequirementsChecklist`
+- `BlockedReason`
+- `RiskNotice`
+- `ResultBanner`
+- `OutcomeSummary`
+- `WorkflowSummaryStrip`
+- `ReadOnlyDetailAccordion`
+
+These should capture repeated interaction patterns across Zoltar, Security Pools, and Open Oracle.
+
+### 3. Shared Data Presentation Modules
+
+Reusable state-display modules:
+
+- `ObjectIdentityCard`
+- `RegistryList`
+- `MetricGroup`
+- `ComparisonMetrics`
+- `StatusBadge`
+- `StateChipRow`
+- `EmptyState`
+- `LoadingState`
+- `ErrorState`
+
+These should replace one-off summary panels and make the information hierarchy more consistent.
+
+### 4. Shared State And Navigation Modules
+
+Reusable non-visual or lightly visual modules:
+
+- URL-backed selected-object state
+- route handoff helpers
+- transaction queue state
+- global notice stack state
+- modal state orchestration
+- refresh and stale-state tracking
+
+These should preserve continuity across routes and keep route behavior consistent.
+
+### 5. Domain-Specific Workspace Shells
+
+Reusable domain-aware composition layers:
+
+- `ZoltarWorkspaceShell`
+- `PoolWorkspaceShell`
+- `ReportWorkspaceShell`
+- `ForkWorkspaceShell`
+- `QuestionWorkflowShell`
+
+These should compose shared modules into domain-appropriate screens without collapsing all workflows into one generic layout.
+
+### 6. Route Implementations
+
+Top-level routes should mostly assemble shared modules and domain shells rather than inventing new workflow patterns.
+
+The default implementation rule should be:
+
+- prefer a new composition of shared modules before inventing a new custom interaction surface
+- create a new domain-specific shell only when multiple related screens need the same structure
+- avoid creating route-local one-off controls when an existing shared workflow module can be extended cleanly
+
+### Modularity Guidance
+
+The redesign should avoid two failure modes:
+
+- over-generic components that hide domain meaning
+- route-specific components that duplicate shared interaction patterns
+
+The right split is:
+
+- shared primitives for look and feel
+- shared workflow modules for repeated UX patterns
+- domain shells for protocol-specific structure
+- route pages for final composition
+
+## Implementation Blueprint
+
+Someone implementing this redesign should apply the same page contract everywhere.
+
+### Shared page contract
+
+Every route or deep object workspace should be built from these layers:
+
+1. route header
+2. object or route summary
+3. environment gate if failing
+4. lifecycle stage banner when relevant
+5. action readiness panel
+6. action launcher cards
+7. supporting read-only records
+8. advanced diagnostics or historical details
+
+### Shared interaction contract
+
+Every action in the UI should be classified as one of these types:
+
+- navigation
+  - changes route, tab, or selected object
+- refresh
+  - reloads state without changing onchain data
+- inline creation
+  - creates a new record and stays page-native
+- modal execution
+  - changes state on an existing record through a focused transaction modal
+- destructive or high-risk execution
+  - uses the same modal pattern with stronger warnings and confirmation language
+
+### Shared implementation rules
+
+Apply these rules across all routes:
+
+- global blockers such as disconnected wallet, wrong network, or incomplete setup appear once per route
+- action cards only show local blockers
+- if an action needs approval, the route should say approval is needed and the modal should execute it
+- if an action is blocked by stage, the stage banner and the action card should agree on why
+- if an action completes, the result surface should explain the state change and next step
+- if a record is selected, its identity and stage should remain visible while the user works
+- if a list is the entry point to a workflow, it should support search, filtering, and empty-state guidance
+
+## Additional Redesign Priorities
+
+The modal-first pattern is only one part of the redesign. The UI should also improve clarity around stage, continuity, hierarchy, and protocol comprehension.
+
+### 1. Lifecycle Stage Clarity
+
+Many workflows are really stage-driven rather than form-driven. The UI should make that explicit.
+
+Add a visible stage banner to the top of any object workspace that has meaningful lifecycle transitions, such as:
+
+- active universe before fork
+- universe after fork
+- report awaiting initial report
+- report in dispute
+- report ready to settle
+- pool fork available
+- truth auction active
+
+Each stage banner should show:
+
+- the current stage name
+- a one-line explanation of what the stage means
+- which actions are available in this stage
+- which actions are blocked until the next stage
+
+This should reduce the need for operators to infer lifecycle state from scattered badges and disabled controls.
+
+Route examples:
+
+- `Zoltar`
+  - when a universe is forked, the page should clearly state that question creation is no longer the primary workflow and migration is now relevant
+- `Security Pools > Reporting`
+  - the route should explain whether the pool is awaiting a report, in escalation, or ready for withdrawal
+- `Security Pools > Fork`
+  - the route should explain whether the operator is before fork, in child-universe creation, in migration, in auction, or in settlement
+- `Open Oracle > Selected Report`
+  - the page should state whether the report is waiting for initial report, disputable, or settleable
+
+### 2. Cross-Route Continuity
+
+The app already has important route-to-route handoffs. The redesign should make them visible so the product feels like one workflow instead of several separate tools.
+
+Add lightweight context breadcrumbs or handoff summaries such as:
+
+- `Came from: Question`
+- `Linked pool`
+- `Linked report`
+- `Current universe`
+- `Return to previous workflow`
+
+These should appear when the user arrived from a meaningful upstream action or when the current object is strongly tied to another object.
+
+Route examples:
+
+- after creating a question in `Zoltar`, the handoff into pool creation should name the question that is being carried forward
+- when opening a report from a pool workflow, the report page should say which pool triggered the handoff
+- when a pool belongs to a different universe than the active one, the relationship should be explained as a contextual mismatch rather than just a warning
+
+### 3. Better Post-Action Feedback
+
+The UI should not stop at `transaction submitted` or `confirmed`. After a write action, the operator should understand the outcome.
+
+Add a consistent outcome summary that tells the user:
+
+- what just changed
+- whether the page has already refreshed
+- whether a follow-up action is now available
+- what the recommended next step is
+
+This matters most for actions where the chain update changes the operator's available workflows immediately.
+
+Examples:
+
+- after `Deposit REP`, show the new vault balance and whether the vault is now eligible for the next operation
+- after `Fork Zoltar`, explain that migration or child-universe actions are now relevant
+- after `Submit Initial Report`, explain whether the report is now awaiting dispute or already on a path to settlement
+
+### 4. Stronger Visual Hierarchy
+
+The redesign should assign stricter visual priority across the page so that everything does not compete equally for attention.
+
+Use this order:
+
+1. current object and stage
+2. available actions and blockers
+3. key balances and operational metrics
+4. technical diagnostics and deep detail
+5. historical or rarely used supporting information
+
+This should be reflected in spacing, heading weight, panel emphasis, and default collapse behavior.
+
+Route examples:
+
+- `Security Pools > Operate`
+  - pool state and current actionable workflows should sit above vault tables, technical summaries, and low-frequency lifecycle detail
+- `Open Oracle > Selected Report`
+  - the action mode and report stage should have stronger emphasis than long record details
+
+### 5. Better Terminology and Risk Framing
+
+The UI should stay precise without assuming every operator remembers every protocol term instantly.
+
+Add compact inline explanations for specialized concepts such as:
+
+- universe
+- fork
+- child universe
+- escalation
+- complete sets
+- truth auction
+
+These should be short, contextual, and easy to ignore once understood.
+
+Risk framing should also be more deliberate:
+
+- routine actions should look routine
+- high-risk or irreversible actions should look weightier
+- destructive actions should explain consequences before submit
+
+Examples:
+
+- `Liquidate Vault` should clearly communicate that it is a punitive or corrective action, not a neutral maintenance step
+- `Create Child Universe`, `Migrate Vault`, and `Claim Auction Proceeds` should explain why the action exists and what state change it finalizes
+
+### 6. Reduce Tab Ambiguity
+
+The redesigned UI should make it obvious what each tab is changing.
+
+When a page has multiple layers of navigation, the UI should distinguish between:
+
+- route-level tabs
+- workflow tabs inside the selected object
+- record selection inside a list
+- modal execution for the selected action
+
+Each tab set should have a short scope label such as:
+
+- `Route`
+- `Pool Workflow`
+- `Report Action`
+- `Selected Vault`
+
+This should prevent the user from confusing a tab change with an object change.
+
+### 7. Sticky Selected-Object Context
+
+When the user selects a pool, report, question, or vault, that identity should remain visible while scrolling.
+
+Add a compact sticky context bar for deep workspaces that shows:
+
+- object name, id, or address
+- current universe
+- lifecycle stage
+- current selected child object if relevant
+- the current primary or recommended action
+
+This is most important for:
+
+- `Security Pools > Operate`
+- `Open Oracle > Selected Report`
+- `Zoltar` after a question is selected for forking
+
+### 8. Better List Scanning And Filtering
+
+Lists should be treated as operational search tools, not just static registries.
+
+Add filtering and sorting to:
+
+- questions
+- security pools
+- vaults
+- reports
+
+Useful controls include:
+
+- search by question id, report id, pool address, or vault address
+- filter by lifecycle stage
+- filter by active universe versus different universe
+- filter by user-relevant records versus all records
+- sort by recency, pending status, or operational priority
+
+### 9. Normalize Button Semantics
+
+The UI should use a clearer visual language for different button intents.
+
+At minimum, distinguish between:
+
+- navigation
+- refresh
+- modal open
+- approve
+- submit
+- destructive action
+
+`Refresh`, `Approve`, `Open`, and `Execute` should not look interchangeable.
+
+### 10. Transaction Queue Visibility
+
+Pending transactions should be visible outside the local panel where they started.
+
+Add a persistent transaction tray or queue surface that shows:
+
+- action name
+- target object
+- current transaction status
+- a link back to the related route or object
+
+This should help operators who perform multiple transactions across routes.
+
+### 11. Better Empty And Blocked States
+
+Every empty or blocked state should answer three questions:
+
+- why is this empty or blocked?
+- is that normal?
+- what can I do next?
+
+Examples that need explicit handling:
+
+- no pools yet
+- no selected report
+- migration unavailable before fork
+- no child universes created yet
+- no vault selected
+
+### 12. Refresh Trust And State Freshness
+
+The UI should make freshness easier to understand.
+
+Important records should show:
+
+- last updated time
+- whether the data was auto-refreshed or manually refreshed
+- whether a recent transaction result has already been incorporated
+
+After a transaction, the UI should clearly state whether the displayed record is already updated.
+
+### 13. Compact Blocker Explanations
+
+Disabled actions should have a short, direct explanation available next to them.
+
+Use patterns like:
+
+- `Blocked: requires REP approval`
+- `Blocked: no vault selected`
+- `Blocked: report is not in dispute stage`
+- `Blocked: pool belongs to a different universe`
+
+This should reduce the need to scan the rest of the page to understand one disabled control.
+
+### 14. Responsive Priority
+
+The redesigned UI should preserve the same workflow hierarchy on smaller screens.
+
+For narrow layouts:
+
+- keep object identity and stage visible first
+- keep action readiness above deep detail
+- collapse lower-priority summaries earlier
+- avoid tables as the only way to inspect important state
+
+### 15. Workflow Summaries For Advanced Routes
+
+The most complicated routes should begin with a short workflow summary strip.
+
+This should:
+
+- show 3 to 5 steps
+- highlight the current step
+- explain what the operator is trying to achieve in that route
+- stay short enough to obey the copy constraints in this document
+
+Best candidates:
+
+- `Security Pools > Reporting`
+- `Security Pools > Fork`
+- `Open Oracle > Selected Report`
+- `Zoltar` after fork
+
+### 16. Scenario-Driven Entry Points
+
+The UI should not rely only on route names to help users begin work.
+
+Add compact scenario entry points where appropriate, especially on top-level route landing surfaces.
+
+Examples:
+
+- `Create a question`
+- `Create a security pool`
+- `Report an outcome`
+- `Handle a fork`
+- `Migrate REP`
+- `Operate a vault`
+
+These should act as clear workflow starts for users who think in tasks rather than in route taxonomy.
+
+### 17. Before / Now / Next Framing
+
+Important workspaces should communicate time and sequence more clearly.
+
+Where lifecycle matters, the UI should show:
+
+- the last meaningful event
+- the current stage
+- the next available step
+
+This should not become a long timeline by default. It should be a compact framing surface that reduces the need for the user to reconstruct workflow state mentally.
+
+Best candidates:
+
+- reporting flows
+- fork flows
+- auction flows
+- migration flows
+
+### 18. Make Numbers Easier To Compare
+
+Important numeric values should be presented comparatively, not just listed.
+
+Prefer:
+
+- aligned side-by-side values
+- threshold versus current comparisons
+- `Current`, `Required`, and `Needed` labels
+- delta or gap indicators
+
+Avoid making the user compare multiple precise numbers mentally across different parts of the page.
+
+### 19. Reduce Address-First Presentation
+
+Technical identifiers are necessary, but they should not dominate first read.
+
+Prefer:
+
+- human meaning first
+- technical id second
+- full identifier on demand
+
+For example:
+
+- `Pool for Question X`
+- smaller address below
+- copy action still available
+
+This should make the UI easier to scan without hiding technical identity.
+
+### 20. Group Actions By Operator Intent
+
+Actions should be grouped by what the user is trying to achieve, not only by the underlying contract mechanics.
+
+Examples:
+
+- `Prepare`, `Approve`, `Submit`
+- `Create`, `Open`, `Operate`
+- `Report`, `Dispute`, `Settle`
+
+This should make action areas read like workflows rather than implementation surfaces.
+
+### 21. Stronger Transition States
+
+The UI should visually distinguish between intermediate states such as:
+
+- loading
+- waiting for dependency
+- waiting for wallet interaction
+- waiting for chain confirmation
+- refreshing after confirmation
+
+These states should not all collapse into the same spinner treatment.
+
+### 22. Make Advanced Detail Truly Secondary
+
+Advanced and technical detail should remain available without competing with routine operation.
+
+Use patterns like:
+
+- expandable advanced sections
+- compact default operator view
+- optional technical mode for power users
+
+The goal is to preserve seriousness while making the default workflow easier to read.
+
+### 23. Improve Page Endings
+
+The bottom of complex pages should feel intentional.
+
+Each page should end with one of these:
+
+- advanced detail
+- recent related activity
+- no further content
+
+Avoid random low-priority leftovers at the bottom of the page.
+
+### 24. Distinguish Object Types Visually
+
+Questions, pools, vaults, reports, universes, and auctions should not all feel visually identical.
+
+Use:
+
+- distinct icons
+- stable accent colors
+- consistent header patterns
+- consistent summary-card structure per object type
+
+This should improve orientation without adding extra text.
+
+### 25. Make Success Feel Conclusive
+
+After an action succeeds, the UI should make completion feel final and trustworthy.
+
+Do this by:
+
+- clearly marking the completed action state
+- retiring or de-emphasizing the action that was just completed
+- elevating the next available action
+- updating nearby summaries quickly
+
+The user should feel that the interface and chain state are aligned, not merely that a transaction was accepted.
+
+## Clarity Principles
+
+The redesign should make the UI clearer without depending on large amounts of explanatory text.
+
+The default communication order should be:
+
+1. layout and hierarchy
+2. color and emphasis
+3. iconography
+4. short labels
+5. short helper text only when needed
+
+Long explanatory copy should be avoided in the main workflow surfaces.
+
+### 1. Lead With A Stage Sentence
+
+Every actionable workspace should communicate one short state sentence near the top of the page.
+
+Examples:
+
+- `Report open for dispute`
+- `Pool in reporting stage`
+- `Universe forked`
+- `Auction active`
+
+This should usually be a compact label or banner, not a paragraph.
+
+### 2. Lead With A Recommended Action Sentence
+
+Near the primary action area, show one short sentence describing what the operator can do now.
+
+Examples:
+
+- `You can dispute this report now`
+- `You can migrate REP now`
+- `Select a vault to continue`
+
+This should remain short enough to scan instantly.
+
+### 3. Prefer Visual Meaning Over Explanatory Copy
+
+Use visual systems to communicate meaning before adding text.
+
+Examples:
+
+- color-coded stage badges
+- warning icons for risky actions
+- success icons for completed steps
+- muted styling for unavailable workflows
+- stronger button treatment for the main action
+
+The UI should not rely on paragraphs to explain ordinary state transitions.
+
+### 4. Use Short Meaning Text For Advanced Actions
+
+Some actions still need explanation, but it should be minimal.
+
+Use one short supporting line for advanced or domain-heavy actions such as:
+
+- `Create Child Universe`
+- `Prepare REP`
+- `Split REP`
+- `Migrate Vault`
+- `Claim Auction Proceeds`
+
+The supporting line should explain purpose, not mechanics.
+
+Good:
+
+- `Finalize the child universe for the winning fork outcome`
+
+Bad:
+
+- a multi-sentence explanation of every step that follows
+
+### 5. Separate State, Action, And Mechanics
+
+To reduce cognitive load, every major screen should clearly separate:
+
+- current state
+- available actions
+- execution mechanics
+
+That means:
+
+- the page shows what is true
+- the action area shows what can be done
+- the modal shows how to do it
+
+The user should not need to read long text to distinguish those layers.
+
+### 6. Reduce Duplicate Summaries
+
+Do not repeat the same information in multiple formats on the same screen.
+
+Each summary surface should have one job:
+
+- header summary
+  - object identity
+- stage banner
+  - lifecycle status
+- action card
+  - readiness and intent
+- modal summary
+  - execution context
+
+Reducing duplicate summaries will make the interface feel simpler without removing information.
+
+### 7. Make Disabled States Decisive
+
+Blocked actions should use short, direct labels.
+
+Preferred patterns:
+
+- `Blocked: requires REP approval`
+- `Blocked: no vault selected`
+- `Blocked: report not disputable`
+
+Avoid generic disabled states that force the user to search elsewhere on the page for the reason.
+
+### 8. Distinguish Informational Surfaces From Actionable Ones
+
+The UI should make it immediately obvious whether a surface is:
+
+- read-only information
+- a selector
+- navigation
+- an action launcher
+- a submit action
+
+This should be done with spacing, button style, icon usage, and hover or focus behavior rather than extra explanation text.
+
+### 9. Show Consequences Before Commitment
+
+Risky actions should communicate consequences before the submit step.
+
+This should be done with:
+
+- warning tone
+- short consequence label
+- clear object identification
+- explicit final action wording
+
+Examples:
+
+- `Liquidate selected vault`
+- `Start truth auction`
+- `Create child universe`
+
+The user should understand impact before confirming without needing to read long paragraphs.
+
+### 10. Keep Scope Visible
+
+In dense workflows, the UI should continuously show what object the user is acting on.
+
+Scope should be visible through:
+
+- sticky context bars
+- compact object headers
+- selected-row emphasis
+- modal headers that repeat the target object
+
+This is especially important when moving between pool-level, vault-level, report-level, and universe-level actions.
+
+### 11. Make Modes Explicit
+
+When a page can be in different modes, show that with short labels instead of relying on the user to infer it from the surrounding layout.
+
+Examples:
+
+- `Browsing Pools`
+- `Operating on Pool`
+- `Submitting Initial Report`
+- `Reviewing Fork State`
+
+These mode labels should be compact and visually integrated into the page header or stage area.
+
+### 12. Teach Through Empty States
+
+Empty states should explain what to do next with one short sentence, not a long explanation block.
+
+Good examples:
+
+- `No pools exist for this question yet`
+- `Select a report to continue`
+- `Migration becomes available after fork`
+
+Short follow-up actions or links are better than longer descriptive text.
+
+### 13. Avoid Metric Blobs
+
+The redesign should avoid presenting large groups of metrics as undifferentiated tables or dense numeric walls by default.
+
+When data is important, the UI should decide which values are:
+
+- primary operational signals
+- secondary supporting context
+- deep technical detail
+
+Those categories should not be rendered with equal visual weight.
+
+Preferred patterns:
+
+- small grouped metric cards for the most important values
+- paired value-and-status rows for closely related numbers
+- segmented summaries that group metrics by meaning
+- expandable detail sections for low-priority technical values
+- charts, timelines, or progress-style visuals when they communicate state better than raw numbers
+
+Avoid:
+
+- wide tables of unrelated metrics
+- long stacks of equally styled key-value rows
+- repeated summary cards that all look equally important
+- showing every available number at the top of the page
+
+This matters most in:
+
+- pool summaries
+- vault summaries
+- reporting and fork state
+- open oracle report detail
+
+The goal is not to remove data. The goal is to present data in a way that reveals hierarchy, status, and relationships at a glance.
+
+## Modal Design Rules
+
+All transactional modals should follow these rules:
+
+- one modal should represent one transaction intent
+- approvals should live in the same modal as the operation that needs them
+- destructive operations should have a stronger warning tone
+- the final submit button should be the only primary action in the modal footer
+- loading spinners should stay inside the action button that initiated the transaction
+- the modal can repeat blocked requirements, but the route should already show them before click
+- the modal should be for execution, not first-time discovery of core prerequisites
+
+## What Should Stay Inline
+
+Not everything should become modal-first.
+
+Keep these inline:
+
+- selectors that choose context for the page
+- route-level environment gates
+- readiness summaries and blocker explanations
+- refresh actions
+- tabs
+- lightweight deploy actions
+- read-only summaries
+- question creation form
+- pool creation form
+
+Rationale:
+
+- context selection belongs to the route
+- object creation forms that define a new record can remain page-native
+- transactional state changes on existing records benefit most from modals
+
+## State And URL Contract
+
+The redesign must preserve the current UI's ability to restore working context through URL state.
+
+At minimum, the redesigned UI should preserve URL-backed state for:
+
+- top-level route
+- active universe context
+- selected security pool
+- selected report
+- selected Zoltar subview
+- simulation mode and scenario
+
+The redesign should follow these rules:
+
+- refreshing the page should preserve the current working object whenever that object is URL-backed
+- browser back and forward should restore prior route and selected-object context without a full reset
+- cross-route handoffs should update URL state immediately when a new route context becomes active
+- modal open state does not need to be URL-backed by default
+- transient form inputs inside a modal do not need to be URL-backed by default
+- invalid URL-backed object state should degrade into a clear missing-state surface, not a broken page
+
+Examples:
+
+- opening a pool from `Browse` should update the URL-backed pool selection
+- opening a pending report from a pool should update the selected report state as part of the route transition
+- switching Zoltar views should remain deep-linkable
+
+## Simulation Mode Treatment
+
+Simulation should remain a clearly separated environment mode, not a redesign driver for the normal operator workflow.
+
+The redesign should preserve these principles:
+
+- simulation is informational context, not a blocker
+- simulation controls remain visually distinct from production route UI
+- simulation-specific caveats only appear near the features they affect
+- simulation should not overload normal action readiness unless it changes a specific action's meaning
+
+Examples:
+
+- mock pricing controls belong in the simulation banner or a simulation-only surface, not inside normal price widgets
+- if simulation disables live quote behavior, only quote-dependent actions should mention that limitation
+
+## Exceptional-State Design
+
+The redesign must explicitly handle non-happy-path states as first-class screens or panels.
+
+These states include:
+
+- wrong network
+- setup incomplete
+- missing selected object
+- invalid deep link
+- unsupported route
+- loading with partial data
+- hard data-load failure
+
+Design rules:
+
+- wrong network should remain a full-page gate for route content, not a small inline warning
+- setup-incomplete state should clearly redirect or funnel the user toward `Deploy`
+- missing selected object state should explain what object is missing and how to recover
+- invalid deep-link state should preserve the route but show a recoverable missing-state surface
+- unsupported route state should remain a dedicated `404` experience with clear recovery actions
+- loading states should prefer purposeful skeletons or staged loading surfaces over blank panels
+- hard failures should state what failed and whether retry is possible from the current screen
+
+## Global Notice System
+
+The redesign should formalize the app-wide notice stack instead of leaving notices as loosely related banners.
+
+The notice system should support at least these categories:
+
+- blocking environment notices
+- warning notices
+- transaction progress notices
+- transaction success notices
+- simulation bootstrap issues
+- wallet guidance
+
+Global notices should follow these rules:
+
+- blocking notices appear above warning and status notices
+- transaction progress should have a single global source of truth
+- route-local result surfaces should complement global notices, not duplicate them
+- success notices can fade or collapse once the route-level outcome summary is visible
+- persistent warnings such as fork-state warnings should remain visible until the underlying state changes
+
+## Fork And Auction Layout Contract
+
+The current fork and auction workflows are too important to leave abstract in the redesign spec. The redesigned UI should keep their stages explicit.
+
+### Fork `Initiate`
+
+This stage should show:
+
+- current pool or universe fork status
+- direct initiation options
+- recommended initiation path
+- blocking conditions
+
+Action area:
+
+- `Initiate Pool Fork`
+- `Fork With Own Escalation`
+- any direct-fork launcher if still supported
+
+### Fork `Migration`
+
+This stage should show:
+
+- created versus missing child universes
+- REP migration availability
+- vault migration availability
+- escalation-deposit migration availability
+
+Action area:
+
+- `Create Child Universe`
+- `Migrate REP To Zoltar`
+- `Migrate Vault`
+- `Migrate Escalation Deposits`
+
+### Fork `Auction`
+
+This stage should show:
+
+- truth-auction status
+- current best bid or bid state
+- whether auction start, bidding, refund, or finalization is available
+
+Action area:
+
+- `Start Truth Auction`
+- `Submit Bid`
+- `Refund Losing Bid`
+- `Finalize Truth Auction`
+
+### Fork `Settlement`
+
+This stage should show:
+
+- whether proceeds are claimable
+- whether bids are withdrawable
+- any remaining settlement dependencies
+
+Action area:
+
+- `Claim Auction Proceeds`
+- `Withdraw Bids`
+
+Across all fork stages:
+
+- use one stage banner
+- keep only the current stage's main actions visually primary
+- move lower-priority technical fields and historical detail below the stage action area
+
+## Visual System Contract
+
+The redesign should define a lightweight but explicit visual system so the interface does not regress into generic cards and tables.
+
+At minimum, define:
+
+- color roles for routine, warning, destructive, success, and informational states
+- icon roles for object type, risk level, and status
+- badge roles for lifecycle stage and readiness state
+- spacing tiers for page, section, card, and inline grouping
+- stable card patterns for questions, pools, vaults, reports, universes, and auctions
+- default replacements for dense tables, such as grouped cards, segmented summaries, and expandable details
+- responsive collapse rules for small screens
+
+The goal is to make the UI more legible and more visually intentional without becoming decorative.
+
+## Do Not Regress
+
+The redesign must not lose the current UI's strongest operational properties.
+
+Do not regress on:
+
+- disabled actions explaining why they are unavailable
+- explicit cross-route handoffs
+- visible object identity while operating
+- advanced protocol actions remaining available somewhere in the UI
+- deep-linkable working context
+- simulation usefulness for QA
+- obvious mainnet and setup gating
+
+## Implementation
+
+## Route Implementation Requirements
+
+This section is the practical build checklist for the redesign. It should be enough for an implementer to translate the existing UI into the redesigned one without inventing the interaction model from scratch.
+
+### App Shell Requirements
+
+Keep these elements visible:
+
+- wallet summary
+- balance summary
+- active universe summary
+- pricing summary
+- top-level route tabs
+- global notice stack
+
+Change the shell in these ways:
+
+- show route-level environment gates only when failing
+- keep simulation as a lightweight environment context, not a blocker
+- make the active universe and route context easier to identify at a glance
+- normalize notice styling so blocking notices, warnings, and transaction notices feel like one system
+
+### Deploy Requirements
+
+Keep these capabilities:
+
+- deployment progress visibility
+- individual deploy actions
+- `Deploy Next Missing`
+
+Redesign requirements:
+
+- show the deployment summary before the action list
+- make the next recommended deploy action visually primary
+- keep per-step actions available but secondary
+- collapse already-complete deployment groups by default
+- show blocked deployment reasons in one place rather than across multiple rows
+
+### Zoltar Requirements
+
+Keep these capabilities:
+
+- browse questions
+- create question
+- select question for fork
+- fork Zoltar
+- prepare and split REP
+- post-fork universe actions
+
+Redesign requirements:
+
+- keep `Create Question` inline
+- keep `Questions`, `Fork`, and `Migration` as distinct workflow surfaces
+- show the active universe stage clearly above the question registry
+- when forked, elevate migration and child-universe actions above routine question browsing
+- keep question-to-pool handoffs explicit and visible
+
+### Security Pools Requirements
+
+Keep these capabilities:
+
+- browse pools
+- create pool
+- open selected pool
+- liquidate vault
+- operate on vaults
+- trading flows
+- reporting flows
+- fork and auction flows
+
+Redesign requirements:
+
+- keep `Browse`, `Create`, and `Operate` as the main route modes
+- make `Browse` searchable and easier to scan
+- keep `Create` inline with a stronger requirements strip and clearer post-success handoff
+- make `Operate` use a sticky selected-pool context bar
+- separate `Pool State`, `Action Readiness`, `Workflow Tabs`, and `Advanced Details`
+- convert state-changing operations on existing records to modal execution
+- keep lists and read-only summaries visible while modals handle execution
+
+#### Security Pools `Operate > Vaults`
+
+Build this surface around:
+
+- selected pool summary
+- selected vault summary
+- vault list or directory
+- action launcher cards for write operations
+
+Do not keep multiple unrelated amount inputs open on the page at the same time.
+
+#### Security Pools `Operate > Trading`
+
+Build this surface around:
+
+- trading state summary
+- action launcher cards for mint, redeem, migrate, and share redemption
+- compact readiness and result surfaces
+
+#### Security Pools `Operate > Reporting`
+
+Build this surface around:
+
+- reporting stage banner
+- escalation metrics
+- outcome-side context
+- modal launchers for reporting and withdrawal
+
+#### Security Pools `Operate > Fork`
+
+Build this surface around:
+
+- fork stage banner
+- workflow summary strip
+- currently available lifecycle actions
+- lower-priority historical or technical detail below the main action area
+
+### Open Oracle Requirements
+
+Keep these capabilities:
+
+- browse reports
+- open selected report
+- create open oracle game
+- initial report
+- dispute and swap
+- settle report
+
+Redesign requirements:
+
+- keep `Browse Reports` as the main entry surface
+- keep report details accessible but reduce their visual competition with the active action
+- make selected-report pages stage-driven
+- move transaction-heavy selected-report actions into modals
+- keep the linked pool or route handoff visible when present
+
+### Shared Delivery Requirements
+
+Across all routes:
+
+- selected object identity should remain visible while working
+- blocked actions should have compact local explanations
+- lists should support search or filtering when they are the main entry to work
+- success states should describe the resulting workflow state, not only the transaction state
+- refresh behavior should expose whether data is fresh enough to trust
+
+## Route Layout Contracts
+
+These are the default layout contracts for the major redesigned workspaces. They are intended to reduce ambiguity when implementing page structure.
+
+### Deploy Layout Contract
+
+Use this order:
+
+1. route header and deployment progress
+2. environment gate if failing
+3. action readiness panel for deployment
+4. `Deploy Next Missing`
+5. grouped deployment sections
+6. advanced per-step controls
+
+### Zoltar Layout Contract
+
+Use this order:
+
+1. route header and universe identity
+2. universe stage banner
+3. subview tabs
+4. active subview summary
+5. action readiness or next-action area
+6. main working surface
+7. advanced or historical detail
+
+### Security Pools Layout Contract
+
+For `Browse`:
+
+1. route header
+2. search and filter controls
+3. browse summary
+4. pool registry
+5. liquidation launcher or related modal entry
+
+For `Create`:
+
+1. route header
+2. carried-forward question context if present
+3. requirements strip
+4. create form
+5. post-success handoff
+
+For `Operate`:
+
+1. sticky selected-pool context
+2. pool stage banner
+3. workflow tabs
+4. action readiness panel
+5. action launcher group
+6. supporting data panels
+7. advanced details
+
+### Open Oracle Layout Contract
+
+For `Browse`:
+
+1. route header
+2. browse summary
+3. report list
+4. pagination and filters
+
+For `Selected Report`:
+
+1. sticky report context
+2. report stage banner
+3. action mode selector if needed
+4. action readiness and launcher area
+5. report summary
+6. supporting report detail
+7. advanced detail
+
+## Current-To-New Control Migration Map
+
+This section maps the most important current UI controls into their redesigned homes.
+
+### App Shell
+
+- `Connect wallet`
+  - stays in the shell
+  - remains primary only when disconnected
+- top route tabs
+  - stay in the shell
+  - keep the same route model
+- REP price refresh
+  - stays inline as a lightweight refresh action
+- `Go to Genesis universe`
+  - stays route-level or shell-level as a recovery action
+  - should be visually secondary
+
+### Zoltar
+
+- `Create Question`
+  - stays inline
+  - remains page-native because it creates a new record
+- `Use For Fork`
+  - stays inline on question records
+  - becomes a stronger handoff action
+- `Use For Create Pool`
+  - stays inline on question records
+  - becomes a stronger handoff action
+- `Fork Zoltar`
+  - moves from inline workflow to modal execution
+- `Prepare REP`
+  - moves to modal execution
+- `Split REP`
+  - moves to modal execution
+- child-universe deployment actions
+  - remain visible in post-fork actions
+  - can launch focused execution modals if inputs are needed
+
+### Security Pools
+
+- `Create Pool`
+  - stays inline
+  - remains page-native because it creates a new record
+- `Open Pool`
+  - stays inline as navigation
+- `Liquidate Vault`
+  - keeps the existing modal-first pattern
+  - becomes the reference interaction for other state-changing actions
+- `Deposit REP`
+  - moves from inline form to action card plus modal
+- `Withdraw REP`
+  - moves from inline form to action card plus modal
+- `Set Security Bond Allowance`
+  - moves from inline form to action card plus modal
+- `Claim Fees`
+  - moves from inline button to action card plus modal or confirmation modal
+- `Mint Complete Sets`
+  - moves to action card plus modal
+- `Redeem Complete Sets`
+  - moves to action card plus modal
+- `Migrate Shares`
+  - moves to action card plus modal
+- `Redeem Shares`
+  - moves to action card plus modal
+- `Report / Contribute`
+  - moves to action card plus modal
+- `Withdraw Escalation Deposits`
+  - moves to action card plus modal
+- fork and auction actions
+  - remain visible in stage-specific action groups
+  - execute through focused modals
+
+### Open Oracle
+
+- `Create Open Oracle Game`
+  - stays inline as a route-level creation form
+- `Open report`
+  - stays inline as navigation
+- `Submit Initial Report`
+  - moves to action card plus modal
+- `Dispute & Swap`
+  - moves to action card plus modal
+- `Settle Report`
+  - moves to action card plus confirmation modal
+
+## Modal Inventory
+
+The redesign should define and build these modal surfaces explicitly.
+
+### Core Modal Types
+
+- `Deposit REP`
+- `Withdraw REP`
+- `Set Security Bond Allowance`
+- `Claim Fees`
+- `Mint Complete Sets`
+- `Redeem Complete Sets`
+- `Migrate Shares`
+- `Redeem Shares`
+- `Report / Contribute`
+- `Withdraw Escalation Deposits`
+- `Fork Zoltar`
+- `Prepare REP`
+- `Split REP`
+- `Create Child Universe`
+- `Migrate REP To Zoltar`
+- `Migrate Vault`
+- `Migrate Escalation Deposits`
+- `Start Truth Auction`
+- `Submit Bid`
+- `Refund Losing Bid`
+- `Claim Auction Proceeds`
+- `Withdraw Bids`
+- `Submit Initial Report`
+- `Dispute & Swap`
+- `Settle Report`
+
+### Modal Contract
+
+Each modal definition should specify:
+
+- modal name
+- triggering route and subview
+- target object type
+- fields shown
+- approvals handled inside the modal
+- success and result behavior
+- risk level
+- whether it is a simple confirm modal or an input-driven modal
+
+## State Matrix
+
+The redesign should keep a compact state matrix for the most lifecycle-driven objects.
+
+At minimum, define matrices for:
+
+- universe state
+- selected pool state
+- selected report state
+- fork stage
+- truth-auction stage
+
+Each matrix should document:
+
+- current stage
+- visible stage banner
+- visible actions
+- blocked actions
+- recommended next action
+- local blockers that must be shown
+
+## Information Priority System
+
+The redesign should classify information into four tiers so visibility decisions stay consistent.
+
+- critical
+  - object identity, lifecycle stage, global blockers, current primary action
+- important
+  - local action blockers, balances needed for the current workflow, result state, linked context
+- supporting
+  - secondary metrics, neighboring actions, historical context
+- advanced
+  - deep technical diagnostics, raw ids, detailed breakdowns, low-frequency maintenance controls
+
+This priority system should drive:
+
+- default visibility
+- sticky context inclusion
+- collapse behavior
+- modal summaries
+- section ordering
+
+## Reusable Presentation Patterns
+
+The redesign should define a small set of presentation patterns and reuse them consistently.
+
+- registry list
+  - searchable, filterable, state-tagged list of records
+- selected-object card
+  - compact identity, stage, and key state summary
+- comparison metrics group
+  - side-by-side current, required, and needed values
+- lifecycle summary
+  - before / now / next framing
+- action card group
+  - local blockers plus execution launchers
+- advanced detail accordion
+  - collapsible technical detail
+
+This should reduce one-off layouts and make the interface easier to learn.
+
+## Copy Constraints
+
+The redesigned UI should stay concise by default.
+
+Apply these constraints:
+
+- stage messaging should usually be one short sentence or less
+- recommended-action messaging should usually be one short sentence or less
+- helper text should be reserved for high-risk, domain-heavy, or unusual actions
+- primary workflow surfaces should avoid paragraph-length explanation
+- empty-state guidance should be short and action-oriented
+- repeated helper text should be avoided when the same meaning can be conveyed with structure or labels
+
+## Redesign Acceptance Criteria
+
+The redesign should be considered successful only if these conditions are met.
+
+- a user can identify the current object and its stage quickly from the top of the workspace
+- blocked actions always show a local reason
+- no current state-changing operation is lost
+- deep-linkable working context still works for core objects and routes
+- transaction success always produces a visible state-change summary
+- advanced actions remain accessible without dominating the default workflow
+- pages no longer rely on dense inline transaction forms for routine state changes on existing records
+- metric-heavy surfaces no longer default to large undifferentiated tables or numeric walls
+
+## Patterns To Avoid
+
+Avoid these redesign regressions:
+
+- too many equally weighted cards on the same screen
+- repeating global blockers on every action card
+- revealing basic prerequisites only after opening a modal
+- raw metric dumps without hierarchy
+- address-first headers
+- duplicate summaries that restate the same information
+- long explanatory paragraphs inside primary action areas
+- multiple unrelated amount inputs open at once on the same workflow surface
+
+## Rollout Sequence By Dependency
+
+If the redesign is implemented incrementally, use this dependency order:
+
+1. shared visual system and presentation patterns
+2. environment gate and notice system
+3. sticky selected-object context
+4. action readiness and blocker presentation
+5. modal shells and modal contracts
+6. route-by-route action migration
+7. advanced-detail cleanup and metric presentation improvements
+
+## Risks and Tradeoffs
+
+### Benefits
+
+- cleaner routes
+- fewer visible inputs at once
+- stronger action clarity
+- approvals feel attached to real tasks
+- easier operator scanning
+
+### Risks
+
+- too many modals could feel heavy if overused
+- advanced users may prefer inline power workflows
+- modals need careful keyboard/focus handling
+- some multi-step flows may need staged modal design, not a single simple dialog
+
+### Mitigation
+
+- use modal-first mainly for state-changing operations on existing entities
+- keep action prerequisites and blockers visible on the route
+- show universal environment blockers once per route instead of duplicating them per action
+- keep object creation inline where it improves flow
+- support deep links back to the underlying route context
+- preserve advanced read-only details outside the modal
+
+## Recommended First Pass
+
+If this redesign is implemented incrementally, start here:
+
+1. convert vault actions to modal-first
+2. convert trading actions to modal-first
+3. convert reporting actions to modal-first
+4. convert Open Oracle selected-report actions to modal-first
+5. add `ActionReadinessPanel`, `NextActionPanel`, and `RequirementsChecklist` to the main routes
+
+This would capture most of the clarity benefit without redesigning every page at once.
+
+## Relationship To Current UI
+
+The current UI should continue to be documented in [`docs/ui.md`](./ui.md).
+
+This proposal keeps:
+
+- the same route model
+- the same protocol actions
+- the same operational seriousness
+
+This proposal changes:
+
+- action placement
+- write-flow interaction model
+- balance between inline forms and modal workflows
+- visual priority between state display and action execution

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -42,9 +42,17 @@ If the user is connected to an unsupported chain, the route content is replaced 
 
 ### App Shell Controls
 
-- `Connect wallet` connects the injected wallet when no account is connected.
-- The REP/ETH refresh button reloads the displayed REP pricing source.
-- The top route tabs switch between `Deploy`, `Zoltar`, `Security Pools`, and `Open Oracle`.
+| Control | Purpose | Validation | Disabled when |
+| --- | --- | --- | --- |
+| `Connect wallet` | Connect the injected wallet. | No field input. | Disabled while a wallet connection is already in progress. |
+| REP/ETH refresh | Reload the displayed REP/ETH quote. | No field input. | Disabled while REP prices are already refreshing. |
+| `Go to Genesis universe` | Reset the active universe context back to universe `0`. | No field input. | Only shown when the overview renders a universe-state hint that offers recovery back to the genesis universe. |
+| Top route tabs | Switch between `Deploy`, `Zoltar`, `Security Pools`, and `Open Oracle`. | No field input. | Non-deploy routes are disabled until setup prerequisites are satisfied. |
+
+### App Shell Read-Only Surfaces
+
+- The overview can show source labels or links for REP pricing, including Uniswap and simulation mock sources.
+- The overview can show a universe-state hint when the active universe context needs correction or recovery.
 
 ## Global Notices and Transaction State
 
@@ -57,6 +65,12 @@ Above the route content, the app can show page-wide notices for:
 - transaction progress and the most recent transaction hash
 
 Transaction state is shared across the app. While a transaction is waiting on wallet confirmation or onchain confirmation, the UI shows a global pending notice. Buttons that launched pending actions also keep their loading state in place and stay disabled until the action resolves.
+
+### Global Notice Variants
+
+- A pending transaction notice can show `Awaiting wallet confirmation.` before a signature is submitted.
+- After submission, the pending notice can show the transaction hash while confirmation is still pending.
+- After the pending state resolves, the app can keep showing the last transaction hash as a success notice.
 
 ## Simulation Mode
 
@@ -75,16 +89,18 @@ Simulation mode is intended for walletless or repeatable manual QA. It seeds kno
 
 ### Simulation Controls
 
-- The scenario selector changes the seeded simulation scenario and reloads the page into that scenario.
-- The QA account selector switches which seeded account the UI uses.
-- `Query delay (ms)` adds artificial latency to read calls.
-- `REP / ETH mock price` sets the simulated REP/ETH price.
-- `REP / USDC mock price` sets the simulated REP/USDC price.
-- `Transaction receipt delay (ms)` adds artificial latency before simulated transactions confirm.
-- `Reset scenario` resets the simulation back to its seeded state.
-- `Mine block` advances the simulation by one block.
-- `+1 hour` advances simulation time by one hour.
-- `+1 day` advances simulation time by one day.
+| Control | Purpose | Validation | Disabled when |
+| --- | --- | --- | --- |
+| Scenario selector | Switch the seeded simulation scenario and reload the page into that scenario. | Must be one of the known simulation scenarios. | Disabled while the simulation is busy or bootstrapping. |
+| QA account selector | Switch the active seeded account. | Must match one of the available simulated accounts. | Disabled while the simulation is busy or before bootstrap finishes. |
+| `Query delay (ms)` | Add artificial latency to read calls. | Numeric milliseconds. | Not disabled in normal simulation operation. |
+| `REP / ETH mock price` | Set the simulated REP/ETH price. | Must parse as a decimal price. Invalid edits revert to the current controller value. | Disabled while the simulation is busy. |
+| `REP / USDC mock price` | Set the simulated REP/USDC price. | Must parse as a decimal price. Invalid edits revert to the current controller value. | Disabled while the simulation is busy. |
+| `Transaction receipt delay (ms)` | Add artificial latency before simulated transactions confirm. | Numeric milliseconds. | Disabled while the simulation is busy. |
+| `Reset scenario` | Reset the simulation back to its seeded state. | No field input. | Disabled while busy or before bootstrap finishes. |
+| `Mine block` | Advance the simulation by one block. | No field input. | Disabled while busy or before bootstrap finishes. |
+| `+1 hour` | Advance simulation time by one hour. | No field input. | Disabled while busy or before bootstrap finishes. |
+| `+1 day` | Advance simulation time by one day. | No field input. | Disabled while busy or before bootstrap finishes. |
 
 ## URL-Driven State and Deep Linking
 
@@ -124,9 +140,10 @@ When setup is incomplete, this route becomes the prerequisite path for the rest 
 
 #### Deploy Controls
 
-- `Deploy Next Missing` submits the next deployable deterministic deployment step.
-- Per-group deployment actions deploy individual contracts inside the grouped deployment sections.
-- The route header summary is read-only and shows deployment progress rather than accepting input.
+| Control | Purpose | Validation | Disabled when |
+| --- | --- | --- | --- |
+| `Deploy Next Missing` | Submit the next deployable deterministic deployment step. | No text input. Uses the next undeployed eligible step. | Disabled when no account is connected, the wallet is not on mainnet, no deployable step exists, another deployment is busy, or a deploy-next action is already pending. |
+| Per-step deploy actions | Deploy one explicit contract step inside a deployment group. | No text input. Step prerequisites must already be satisfied. | Disabled when no account is connected, the wallet is not on mainnet, the step is already deployed, the step is blocked by prerequisites, or another deployment is already busy. |
 
 ### Zoltar
 
@@ -143,316 +160,248 @@ The top tabbed block summarizes the active universe. In `Questions`, it can show
 
 The `Questions` view is used to fetch and browse questions in the active universe.
 
-It supports:
+#### Questions Controls
 
-- loading or refreshing the question list
-- reviewing each question in a record card
-- sending a question into the fork flow with `Use For Fork`
-- sending a binary question into the pool-creation flow with `Use For Create Pool`
+| Control | Purpose | Validation | Disabled when |
+| --- | --- | --- | --- |
+| `Questions`, `Create Question`, `Fork Zoltar`, `Migrate REP` tabs | Switch between Zoltar subviews. | No field input. | `Migrate REP` is disabled until the universe has forked. |
+| `Fetch Questions` | Load questions for the active universe. | No field input. | Disabled while questions are loading or when question count is zero. |
+| `Refresh Questions` | Reload the question list. | No field input. | Disabled while questions are loading. |
+| `Use For Fork` | Copy the selected question into the fork flow and open `Fork Zoltar`. | Question must already exist in the loaded list. | Disabled after the universe has already forked. |
+| `Use For Create Pool` | Copy a binary question into Security Pools create mode. | Question must already exist in the loaded list. | Disabled for non-binary questions. |
+| `Deploy Universe` in `Child Universes` | Deploy one not-yet-deployed child universe after fork. | Requires connected wallet, mainnet, a forked universe, and a child universe entry that does not already exist. | Disabled when no wallet is connected, the wallet is not on mainnet, the universe has not forked yet, or the selected child universe already exists. |
+| Scalar child-universe deployment controls | Deploy scalar child universes from the scalar-specific deployment panel. | Require connected wallet, mainnet, a forked scalar universe, and a valid selected scalar outcome. | Disabled whenever the scalar child-universe deployment flow's wallet, network, fork-state, or outcome-selection guards fail. |
 
-If the universe has already forked, the fork action is disabled and replaced with an already-forked state.
+#### Questions Read-Only Surfaces
 
-##### Questions Controls
-
-- `Questions`, `Create Question`, `Fork Zoltar`, and `Migrate REP` are the Zoltar view tabs.
-- `Fetch Questions` loads the question list the first time.
-- `Refresh Questions` reloads the question list after an earlier load.
-- `No Questions` appears as a disabled state when the universe has no questions.
-- `Use For Fork` copies the selected question into the fork workflow and opens the `Fork Zoltar` tab.
-- `Use For Create Pool` copies a binary question into the Security Pools create flow and navigates there.
+- The overview can show universe status, fork time, fork threshold, reputation token, and total theoretical supply.
+- After fork, the overview can show the selected fork question as a dedicated record card.
+- Child universes render with existence status, outcome details, and deployment availability.
 
 #### Create Question
 
-The `Create Question` view creates new Zoltar questions. The form supports:
+The `Create Question` view creates new Zoltar questions. The form supports `Binary`, `Categorical`, and `Scalar`.
 
-- `Binary`
-- `Categorical`
-- `Scalar`
+#### Create Question Controls
 
-The operator can set title, description, timing, and type-specific fields. Scalar questions also show a live preview once the scalar inputs are valid enough to derive the outcome ticks.
-
-After creation, the UI shows the created question as a record card and exposes follow-up actions:
-
-- `Use For Fork`
-- `Use For Create Pool`
-- `Create Another Question`
-
-This makes the view both a creation flow and a handoff point into downstream workflows.
-
-##### Create Question Fields and Buttons
-
-- `Question Type` chooses between `Binary`, `Categorical`, and `Scalar`.
-- `Title` sets the market title shown in question cards and summaries.
-- `Description` adds optional explanatory text for the question.
-- `Start Time` sets when the market becomes active.
-- `End Time` sets when the market closes.
-- `Outcomes` appears for categorical markets and lets the operator add, edit, and remove categorical labels.
-- `Add Outcome` adds another categorical outcome row.
-- `Remove` deletes one categorical outcome row.
-- `Scalar Min`, `Scalar Increment`, `Scalar Max`, and `Answer Unit` appear for scalar markets and define the scalar range and display unit.
-- The scalar preview is read-only and shows how the scalar tick slider resolves from the entered bounds.
-- `Create Question` submits the new question.
-- After creation, `Use For Fork` passes the new question into the fork flow.
-- After creation, `Use For Create Pool` passes the new question into pool creation when the question is binary.
-- `Create Another Question` clears the result card and returns to the input form.
+| Control | Purpose | Validation | Disabled when |
+| --- | --- | --- | --- |
+| `Question Type` | Choose between `Binary`, `Categorical`, and `Scalar`. | Must be one of the supported market types. | Never disabled in the base form. |
+| `Title` | Set the market title. | Required. | Never disabled in the base form. |
+| `Description` | Add optional explanatory text. | Free text. | Never disabled in the base form. |
+| `Start Time` | Set when the market becomes active. | Optional, but if present must parse as a valid timestamp. | Never disabled in the base form. |
+| `End Time` | Set when the market closes. | Required and must parse as a valid timestamp later than `Start Time`. | Never disabled in the base form. |
+| `Outcomes` | Enter categorical outcome labels. | For `Categorical`, needs at least two non-empty unique outcomes. | Only shown for categorical questions. |
+| `Add Outcome` | Add another categorical outcome row. | No direct validation. | Only shown for categorical questions. |
+| `Remove` | Remove one categorical outcome row. | No direct validation. | Only shown for categorical questions. |
+| `Scalar Min` | Define the scalar lower bound. | Required for scalar questions and must participate in a valid scalar range. | Only shown for scalar questions. |
+| `Scalar Increment` | Define the scalar tick spacing. | Required for scalar questions and must parse into a valid scalar increment. | Only shown for scalar questions. |
+| `Scalar Max` | Define the scalar upper bound. | Required for scalar questions and must be greater than `Scalar Min`. | Only shown for scalar questions. |
+| `Answer Unit` | Define the scalar display unit. | Free text. | Only shown for scalar questions. |
+| Scalar preview | Show how the scalar tick space resolves. | Requires valid scalar inputs. | Hidden until scalar inputs are sufficiently valid. |
+| `Create Question` | Submit the new question. | Requires a connected wallet, Ethereum mainnet, and a valid form. | Disabled until the wallet is connected, the wallet is on mainnet, and the full form validates. |
+| `Use For Fork` after creation | Send the created question into the fork flow. | Created question must exist. | Disabled after the universe has already forked. |
+| `Use For Create Pool` after creation | Send the created question into pool creation. | Created question must be binary. | Disabled for non-binary questions. |
+| `Create Another Question` | Clear the result state and return to the form. | No field input. | Not disabled in the success state. |
 
 #### Fork Zoltar
 
-The `Fork Zoltar` view is focused on selecting the fork question and executing the fork path. It surfaces:
+The `Fork Zoltar` view is focused on selecting the fork question and executing the fork path.
 
-- the selected question context
-- REP approval state
-- fork eligibility and block reasons
-- the active fork transaction state
+#### Fork Zoltar Controls
 
-Operators typically arrive here by selecting `Use For Fork` from the questions list or from a newly created question.
-
-##### Fork Zoltar Fields and Buttons
-
-- The REP approval control approves enough REP to satisfy the fork threshold.
-- `Fork Question ID` selects the question that will trigger the universe fork.
-- The selected-question card is read-only and confirms which question will be used.
-- `Fork Zoltar` submits the fork transaction once wallet, network, REP balance, approval, and question selection all satisfy the guard conditions.
+| Control | Purpose | Validation | Disabled when |
+| --- | --- | --- | --- |
+| REP approval control | Approve enough REP to satisfy the fork threshold. | Required amount is the universe fork threshold. | Blocked when no wallet is connected, the wallet is not on mainnet, or Zoltar is already forked. |
+| `Fork Question ID` | Select the question that will trigger the fork. | Must resolve to a valid question from the loaded question set. | Disabled after Zoltar has already forked or while a fork is pending. |
+| Selected question card | Confirm which question will be used. | Read-only. | Hidden until a valid selected question resolves. |
+| `Fork Zoltar` | Submit the fork transaction. | Requires connected wallet, mainnet, loaded universe, valid selected question, enough REP balance, and enough REP approval. | Disabled whenever any fork guard condition fails. |
 
 #### Migrate REP
 
 The `Migrate REP` view handles post-fork REP preparation and migration into child universes.
 
-It only becomes usable after the universe has forked. Before that, the tab remains disabled and shows the reason directly in the UI. Once enabled, it supports preparing REP for migration and executing migration actions into child-universe balances.
+#### Migrate REP Controls
 
-##### Migrate REP Fields and Buttons
-
-- `Migration Amount` sets how much REP should move through the migration workflow.
-- `Max` fills `Migration Amount` with all wallet REP plus already prepared migration REP available in the universe.
-- The REP approval control approves any additional REP still needed to prepare the chosen migration amount.
-- The migration outcome selector lists child universes and lets the operator choose which outcome universes receive the split.
-- `Add Next Outcome` adds the next unselected child universe to the split set.
-- Outcome toggles select or deselect individual target universes.
-- `Prepare REP` moves wallet REP into the migration balance for the active universe.
-- `Split REP` splits prepared migration REP across the selected outcome universes.
-- The migration summary card is read-only and shows the last migration action, amount, and selected outcomes.
+| Control | Purpose | Validation | Disabled when |
+| --- | --- | --- | --- |
+| `Migration Amount` | Set how much REP moves through the migration workflow. | Must parse into a REP amount greater than zero. | Disabled while migration is pending or before the universe has forked. |
+| `Max` | Fill `Migration Amount` with all available wallet REP plus prepared migration REP. | No direct validation beyond available balance. | Disabled while migration is pending, before fork, or when no REP is available. |
+| REP approval control | Approve any additional REP still needed to prepare the selected amount. | Required amount is the missing preparation amount. | Blocked by missing wallet, wrong network, missing universe, no valid amount, or no fork. |
+| Outcome universe selector | Choose which child universes receive split REP. | Selected outcomes must parse as valid outcome indexes and map to valid child universes. | Disabled while migration is pending. |
+| `Add Next Outcome` | Add the next unselected outcome universe. | No direct validation. | Disabled while migration is pending or when no further outcome exists. |
+| Outcome toggles | Select or deselect individual target universes. | Target set must remain parseable into valid indexes. | Disabled while migration is pending. |
+| `Prepare REP` | Move wallet REP into migration balance. | Requires connected wallet, mainnet, loaded universe, valid amount, forked universe, enough wallet REP, and enough approval. | Disabled whenever preparation is unnecessary or any guard condition fails. |
+| `Split REP` | Split prepared migration REP across selected outcomes. | Requires connected wallet, mainnet, loaded universe, valid amount, enough prepared REP, at least one selected outcome, and sufficient split capacity. | Disabled whenever any split guard condition fails. |
 
 ### Security Pools
 
-The `Security Pools` route has three high-level modes:
-
-- `Browse`
-- `Create`
-- `Operate`
+The `Security Pools` route has three high-level modes: `Browse`, `Create`, and `Operate`.
 
 #### Browse
 
-`Browse` loads the pool registry and lists deployed pools. From here, the operator can:
+`Browse` loads the pool registry and lists deployed pools.
 
-- inspect deployed pool records
-- open a selected pool into the `Operate` workspace
-- access liquidation entry points where the loaded pool and vault context exposes them
+#### Browse Controls
 
-The route auto-loads pool data when this view opens for the first time.
+| Control | Purpose | Validation | Disabled when |
+| --- | --- | --- | --- |
+| `Browse`, `Create`, `Operate` tabs | Switch between Security Pools modes. | No field input. | Not disabled by default, though `Operate` only becomes useful once a pool is selected. |
+| `Refresh pools` | Reload the pool registry and all listed pool summaries. | No field input. | Disabled while pool registry loading is already in progress. |
+| Pool selection actions | Open a listed pool into `Operate`. | Pool must exist in the loaded list. | Not disabled in the normal browse state. |
+| Liquidation entry actions | Open liquidation from a listed vault. | Requires a pool/vault context that supports liquidation. | Disabled when the wallet is missing, not on mainnet, or the price-oracle state makes liquidation unavailable. |
+| Queued-liquidation success notice | Show the most recent queued liquidation transaction hash. | Read-only. | Only shown after a liquidation queue action succeeds. |
 
-##### Browse Controls
+##### Liquidation Modal Controls
 
-- `Browse`, `Create`, and `Operate` are the Security Pools route tabs.
-- Pool selection actions open the selected pool inside `Operate`.
-- Liquidation entry buttons appear only where the loaded vault and oracle-manager context makes liquidation available.
+| Control | Purpose | Validation | Disabled when |
+| --- | --- | --- | --- |
+| `Target Vault` | Choose which vault address should be liquidated. | Required non-empty address input for the queue action to proceed. | Not disabled while the modal is open. |
+| `Liquidation Amount` | Set the liquidation amount to queue. | Required non-empty amount input for the queue action to proceed. | Not disabled while the modal is open. |
+| `Cancel` | Close the liquidation modal without submitting. | No field input. | Not disabled while the modal is open. |
+| `Close` | Close the liquidation modal from the header. | No field input. | Not disabled while the modal is open. |
+| `Queue Liquidation` | Submit the liquidation-queue transaction for the selected manager, pool, vault, and amount. | Requires connected wallet, mainnet, loaded manager address, loaded pool address, non-empty target vault, and non-empty liquidation amount. | Disabled whenever any of those queue-liquidation guard conditions fail. |
+
+#### Browse Read-Only Surfaces
+
+- Each pool card exposes question details, pool metrics, manager address, and truth-auction address when one exists.
+- Each vault card in browse mode exposes vault metrics even before the operator opens the full vault workflow.
+- The browse screen can render empty, loading, and error states through the pool-registry presentation hint and error notice.
 
 #### Create
 
-`Create` is the pool-deployment workflow. It guides the operator through:
+`Create` is the pool-deployment workflow.
 
-- loading or confirming the binary market question context
-- checking for existing pools tied to the same origin question
-- reviewing existing pool records for that question
-- configuring pool parameters such as the security multiplier and retention rate
-- deploying the pool
+#### Create Controls
 
-This view is designed to receive a binary question from Zoltar through the `Use For Create Pool` handoff.
-
-##### Create Fields and Buttons
-
-- `Question ID` selects the binary question used as the pool's origin market.
-- `Security Multiplier` sets the collateralization multiplier for the pool.
-- `Open Interest Fee / Year (%)` sets the pool's retention-rate-based open-interest fee.
-- `Create Pool` submits a pool deployment for the entered question and settings.
-- `Open Pool` appears after a successful deployment and jumps into the new pool's `Operate` workspace.
-- `Create Another Pool` appears after a successful deployment and resets the create form.
-- The `Question Context` section is read-only and shows the loaded market.
-- The `Existing Pools` section is read-only and lists pools already created for the same question.
+| Control | Purpose | Validation | Disabled when |
+| --- | --- | --- | --- |
+| `Question ID` | Select the binary question used as the pool's origin market. | Must parse as a valid decimal or hex bigint. | Never disabled in the base form. |
+| `Security Multiplier` | Set the pool collateralization multiplier. | Must parse as a bigint. | Never disabled in the base form. |
+| `Open Interest Fee / Year (%)` | Set the retention-rate-based open-interest fee. | Must parse as a valid retention-rate percentage. | Never disabled in the base form. |
+| `Create Pool` | Submit the pool deployment. | Requires connected wallet, mainnet, no pending duplicate check, no pending pool creation, loaded binary market, no matching duplicate pool, and no Zoltar fork. | Disabled whenever any of those guards fail. |
+| `Open Pool` | Jump into the created pool's `Operate` workspace. | Requires a successful pool creation result. | Only shown after a successful deployment. |
+| `Create Another Pool` | Reset the create flow after a success. | No field input. | Only shown after a successful deployment. |
 
 #### Operate
 
-`Operate` opens a selected-pool workspace. If the app has a valid `securityPool` query param but has not yet loaded that pool into the registry view, it refreshes selected-pool data automatically.
+`Operate` opens a selected-pool workspace with `Vaults`, `Trading`, `Reporting`, and `Fork` subviews.
 
-The selected pool workspace includes summary data such as:
+#### Operate Controls
 
-- pool status and question context
-- the pool's oracle-manager context
-- price-oracle refresh controls
-- a `Request New Price` action when the oracle-manager state allows it
+| Control | Purpose | Validation | Disabled when |
+| --- | --- | --- | --- |
+| Vertical workflow tabs | Switch between `Vaults`, `Trading`, `Reporting`, and `Fork`. | No field input. | Individual views can be disabled when pool state or universe state locks the workflow. |
+| `Security Pool Address` | Select the pool that should be opened in the selected-pool workspace. | Free-form address interpreted by the selected-pool loader. | Not disabled in the normal selected-pool header. |
+| `Refresh pool` | Reload the selected pool from chain state. | No field input. | Disabled when no pool address is present or while pool loading is already in progress. |
+| `Refresh Oracle` | Reload the pool oracle-manager view. | No field input. | Disabled while oracle-manager details are loading. |
+| `Load Price Oracle` | Load oracle-manager details for the first time. | No field input. | Disabled while oracle-manager details are loading. |
+| `Request New Price` | Queue or request a fresh price. | Requires a loaded oracle-manager and any pool-level oracle preconditions. | Disabled when the local guard message says price request is not currently available. |
+| Pending report link | Open the current pending report inside `Open Oracle`. | Requires a loaded oracle-manager with a non-zero pending report id. | Hidden when there is no pending report. |
 
-If the selected pool belongs to a different universe than the app's active universe, the UI shows a universe mismatch warning and tells the operator to switch to the same universe before using the pool.
+#### Operate Read-Only Surfaces
 
-Inside `Operate`, the main subviews are:
-
-- `Vaults`
-- `Trading`
-- `Reporting`
-- `Fork`
-
-##### Operate Controls
-
-- The vertical workflow tabs switch between `Vaults`, `Trading`, `Reporting`, and `Fork`.
-- `Refresh Oracle` reloads the pool oracle-manager view.
-- `Request New Price` asks the oracle-manager flow to queue or request a fresh price when allowed.
-- The pool summary and question cards are read-only and anchor the active pool context.
+- The selected-pool header can show a lookup-state hint before a pool resolves.
+- The `Pool Summary` surface shows status, vault count, security multiplier, open interest fee, total security bond allowance, manager address, last price, settlement timestamp, expiry, and, when relevant, fork and truth-auction data.
+- A success notice can appear after requesting a new price.
+- If the selected pool belongs to a different universe than the app's active universe, a dedicated `Universe Mismatch` warning appears.
+- If the selected pool has not reached a usable state for the chosen workflow, the UI can replace that workflow with a locked-state hint instead of the action panel.
 
 ##### Vaults
 
-The `Vaults` subview is split again into:
+The `Vaults` subview has `Directory` and `Selected` modes.
 
-- `Directory`
-- `Selected`
+###### Vaults Controls
 
-`Directory` lists vaults for the selected pool. From there, the operator can:
-
-- choose a vault with `Select Vault`
-- open liquidation for a vault when the loaded context allows it
-
-`Selected` focuses on a single vault and its actions. The vault workflow supports:
-
-- claiming fees
-- depositing REP
-- setting security bond allowance
-- withdrawing REP
-
-If the selected vault is not owned by the connected account, the UI keeps the vault visible but explains that the actions are read-only until the operator selects their own vault.
-
-###### Vaults Fields and Buttons
-
-- `Directory` and `Selected` are the vault-local view tabs inside the `Vaults` workspace.
-- `Selected Vault Address` chooses which vault to inspect or operate on.
-- `Refresh` reloads the selected vault from chain state.
-- `Select Vault` copies a vault from the directory into the selected-vault workflow.
-- `Liquidate Vault` opens the liquidation flow for that vault when the current pool and oracle state allows it.
-- `Claim Fees` redeems claimable ETH fees from the selected owned vault.
-- `REP Deposit Amount` sets the REP deposit amount.
-- Deposit `Max` fills the REP deposit field from the wallet REP balance.
-- The REP approval control approves enough REP for the deposit amount.
-- `Create / Deposit REP` creates a new vault if needed or deposits REP into the selected owned vault.
-- `Security Bond Allowance Amount` sets the new security bond allowance in ETH terms.
-- `Set Security Bond Allowance` queues the allowance update for the selected owned vault.
-- `REP Withdraw Amount` sets how much withdrawable REP to remove from the vault.
-- Withdraw `Max` fills the withdrawal field with the vault's currently withdrawable REP.
-- `Withdraw REP` queues the REP withdrawal for the selected owned vault.
+| Control | Purpose | Validation | Disabled when |
+| --- | --- | --- | --- |
+| `Directory` / `Selected` tabs | Switch between vault directory and selected-vault workflow. | No field input. | Not disabled by default. |
+| `Selected Vault Address` | Choose which vault to inspect or operate on. | Free-form address input interpreted by the vault load flow. | Not disabled in the normal selected-pool state. |
+| `Refresh` | Reload the selected vault from chain state. | No field input. | Disabled while vault loading is in progress. |
+| `Select Vault` | Copy a directory vault into the selected-vault workflow. | Vault must exist in the listed pool vaults. | Not disabled in the normal directory state. |
+| `Liquidate Vault` | Open liquidation for the chosen vault. | Requires pool/oracle context that allows liquidation. | Disabled when the wallet is missing, not on mainnet, or oracle state blocks liquidation. |
+| `Claim Fees` | Redeem claimable ETH fees from the selected owned vault. | Requires loaded vault details with claimable fees. | Disabled unless the selected vault is owned by the account, the wallet is on mainnet, and fees are claimable. |
+| `REP Deposit Amount` | Set the REP deposit amount. | Must parse into a valid REP amount. | Not disabled in the normal selected-vault state. |
+| Deposit `Max` | Fill the deposit field from wallet REP balance. | No direct validation. | Disabled when wallet REP balance is unavailable. |
+| REP approval control | Approve enough REP for the selected deposit amount. | Required amount is the parsed deposit amount. | Blocked when the wallet is missing, the selected vault is not owned, the pool is missing, or the vault has not been refreshed. |
+| `Create / Deposit REP` | Create a new vault if needed or deposit REP into the selected owned vault. | Requires connected wallet, mainnet, owned vault, sufficient REP approval, sufficient REP balance, and at least `10 REP` for a brand-new vault. | Disabled whenever any deposit guard condition fails. |
+| `Security Bond Allowance Amount` | Set the new security bond allowance in ETH terms. | Must parse into a valid REP-style amount greater than zero. | Not disabled in the normal selected-vault state. |
+| `Set Security Bond Allowance` | Queue the allowance update. | Requires connected wallet, mainnet, owned vault, loaded vault details, valid oracle price, and positive allowance amount. | Disabled whenever any allowance guard condition fails. |
+| `REP Withdraw Amount` | Set how much withdrawable REP to remove. | Must parse into a valid REP amount. | Not disabled in the normal selected-vault state. |
+| Withdraw `Max` | Fill the withdrawal amount with currently withdrawable REP. | No direct validation. | Disabled when withdrawable REP is unavailable. |
+| `Withdraw REP` | Queue the REP withdrawal. | Requires connected wallet, mainnet, owned vault, valid oracle price, non-zero withdraw amount, and available withdrawable REP. | Disabled whenever any withdraw guard condition fails. |
 
 ##### Trading
 
-The `Trading` subview handles share and complete-set flows for the selected pool. It supports:
+The `Trading` subview handles complete-set and share flows.
 
-- minting complete sets
-- redeeming complete sets
-- migrating forked shares
-- redeeming resolved shares
+###### Trading Controls
 
-This is the pool-level share operations workspace rather than a general exchange UI.
-
-###### Trading Fields and Buttons
-
-- `Security Pool Address` appears when the trading section is used standalone and selects the target pool.
-- `Mint Complete Sets Amount` sets how many complete sets to mint.
-- `Mint Complete Sets` submits the mint transaction.
-- `Redeem Complete Sets Amount` sets how many complete sets to redeem back into collateral.
-- Redeem `Max` fills the redemption amount from the wallet's maximum redeemable complete sets.
-- `Redeem Complete Sets` submits the complete-set redemption.
-- `Share Outcome To Migrate` chooses which share side is being migrated after a fork.
-- The share-migration target selector chooses the destination child outcomes for migrated shares.
-- `Select All` in the target selector fills all available destination outcomes.
-- `Clear` clears the selected migration targets.
-- Individual target toggles add or remove a destination outcome.
-- `Migrate Shares` submits the share migration.
-- `Redeem Shares` redeems finalized or otherwise redeemable shares.
-- The `Your Shares` metrics are read-only and show wallet balances for `Yes`, `No`, `Invalid`, and `Total Complete Sets`.
+| Control | Purpose | Validation | Disabled when |
+| --- | --- | --- | --- |
+| `Security Pool Address` | Select the target pool when trading is used standalone. | Free-form address interpreted by the selected pool loader. | Hidden in embedded pool workflows. |
+| `Mint Complete Sets Amount` | Set how many complete sets to mint. | Must parse into a positive trading amount within remaining mint capacity. | Not disabled in the normal form, but action depends on the guard. |
+| `Mint Complete Sets` | Submit the mint transaction. | Requires loaded pool, connected wallet, mainnet, unforked universe, operational pool, available capacity, valid amount, and enough ETH. | Disabled whenever any mint guard condition fails. |
+| `Redeem Complete Sets Amount` | Set how many complete sets to redeem. | Must parse into a positive trading amount not above the wallet maximum. | Not disabled in the normal form. |
+| Redeem `Max` | Fill the redemption amount from the wallet maximum. | No direct validation. | Disabled when the redeemable maximum is unavailable or zero. |
+| `Redeem Complete Sets` | Submit complete-set redemption. | Requires loaded pool, connected wallet, mainnet, unforked universe, operational pool, loaded balances, and a valid redeem amount within the maximum. | Disabled whenever any redeem-complete-set guard condition fails. |
+| `Share Outcome To Migrate` | Choose which share side is being migrated after a fork. | Must be one of the supported reporting outcomes. | Disabled until the universe has forked. |
+| Share migration target selector | Choose destination child outcomes for migrated shares. | Target child universes must parse and resolve as valid destinations. | Disabled until the universe has forked. |
+| `Select All` / `Clear` / target toggles | Manage migration target selection. | Target set must remain valid. | Disabled until the universe has forked. |
+| `Migrate Shares` | Submit share migration. | Requires loaded pool, connected wallet, mainnet, forked universe, loaded fork targets, at least one valid target, loaded share balances, and wallet balance for the selected share side. | Disabled whenever any share-migration guard condition fails. |
+| `Redeem Shares` | Redeem finalized or otherwise redeemable shares. | Requires loaded pool, connected wallet, mainnet, unforked universe, operational pool, and finalized market outcome. | Disabled whenever any redeem-shares guard condition fails. |
 
 ##### Reporting
 
-The `Reporting` subview focuses on escalation and reporting for the selected pool. It shows the reporting context and supports:
+The `Reporting` subview handles reporting and escalation.
 
-- loading the reporting or escalation state
-- reporting an outcome
-- withdrawing escalation deposits
+###### Reporting Controls
 
-It is the main operator view for the pool's reporting and dispute lifecycle.
-
-###### Reporting Fields and Buttons
-
-- `Security Pool Address` appears when the reporting section is used standalone and selects the target pool.
-- `Refresh reporting` loads or reloads escalation and reporting state for the selected pool.
-- `Outcome Side` chooses which reporting side the next contribution or withdrawal targets.
-- `Report / Contribution Amount` sets the REP amount to stake on the selected reporting side.
-- `Report / Contribute On Selected Side` submits the reporting or contribution transaction.
-- `Withdraw Deposit Indexes` optionally narrows withdrawal to specific deposit indexes on the selected side.
-- Leaving `Withdraw Deposit Indexes` empty means withdraw all of the operator's deposits on that side.
-- `Withdraw Escalation Deposits` submits the withdrawal transaction.
-- The reporting preview text is read-only and estimates possible profit if the selected side wins and later contributions do not change the pool.
-- The escalation metrics and side cards are read-only and summarize bond size, threshold, timer, leading outcome, and user stake.
+| Control | Purpose | Validation | Disabled when |
+| --- | --- | --- | --- |
+| `Security Pool Address` | Select the target pool when reporting is used standalone. | Free-form address interpreted by the reporting loader. | Hidden in embedded pool workflows. |
+| `Refresh reporting` | Load or reload escalation/reporting state. | No field input. | Disabled while reporting details are loading or when the workflow is locked by pool state. |
+| `Outcome Side` | Choose the reporting side for contribution or withdrawal. | Must be one of the supported reporting outcomes. | Disabled when the workflow is locked. |
+| `Report / Contribution Amount` | Set the REP amount to stake on the selected side. | Must parse into a valid positive REP amount. | Disabled when the workflow is locked. |
+| `Report / Contribute On Selected Side` | Submit reporting or contribution. | Requires unlocked workflow, connected wallet, mainnet, loaded reporting details, and valid positive amount. | Disabled whenever any reporting guard condition fails. |
+| `Withdraw Deposit Indexes` | Optionally narrow withdrawal to specific deposits. | Optional input. If used, it must match the downstream withdrawal parser's expected format. | Disabled when the workflow is locked. |
+| `Withdraw Escalation Deposits` | Submit the withdrawal. | Requires unlocked workflow, connected wallet, mainnet, loaded reporting details, and at least one withdrawable user deposit on the selected side. | Disabled whenever any withdrawal guard condition fails. |
 
 ##### Fork
 
-The `Fork` subview is the selected pool's fork and truth-auction workspace. It covers the lifecycle from fork initiation through migration and auction settlement.
+The `Fork` subview handles the selected pool's fork and truth-auction lifecycle.
 
-The actions exposed here include:
+###### Fork Controls
 
-- forking with the operator's own escalation
-- initiating a pool fork
-- direct universe fork actions
-- creating child universes
-- migrating REP, vault state, and escalation deposits
-- starting the truth auction
-- submitting bids
-- finalizing the truth auction
-- refunding losing bids
-- claiming auction proceeds
-- withdrawing bids
-
-This is the deepest lifecycle workspace in the Security Pools route.
-
-###### Fork Fields and Buttons
-
-- `Security Pool Address` selects the pool whose fork and auction lifecycle is being inspected.
-- `Refresh fork` loads or reloads the fork and truth-auction state.
-- `Initiate`, `Migration`, `Auction`, and `Settlement` are lifecycle tabs for the fork workspace.
-- `Fork With Own Escalation` starts a fork using the operator's own escalation path.
-- `Initiate Pool Fork` triggers the pool-level fork path.
-- `Direct Fork Universe ID` sets the universe to fork directly.
-- `Direct Fork Question ID` sets the direct fork question.
-- `Fork Universe Directly` submits the direct universe fork.
-- `Outcome` in `Create Child Universe` selects which child outcome universe to deploy.
-- `Create ... Child Universe` deploys the child universe for the selected outcome.
-- `REP Migration Outcomes` lists the REP migration outcome names or keys used when migrating REP into Zoltar from the pool flow.
-- `Migrate REP To Zoltar` submits that REP migration.
-- `Outcome` in `Migrate Vault` selects which child outcome receives the migrated vault.
-- `Vault Address` in `Migrate Vault` chooses which vault to migrate. Leaving it empty uses the connected wallet's vault context.
-- `Migrate Vault` submits the vault migration.
-- `Outcome` in `Migrate Escalation Deposits` selects which child outcome receives the migrated deposits.
-- `Escalation Deposit Indexes` selects which deposit indexes to migrate.
-- `Migrate Escalation Deposits` submits the escalation deposit migration.
-- `Start Truth Auction` starts the truth auction once the lifecycle reaches that stage.
-- `Bid Tick` sets the tick for the submitted bid.
-- `Bid Amount (ETH)` sets the ETH amount offered in the bid.
-- `Submit Bid` submits the auction bid.
-- The bid estimate text is read-only and shows the approximate REP that would be purchased at the current clearing price.
-- `Finalize Truth Auction` finalizes the auction once it is ready.
-- `Refund Tick` selects the tick for a losing-bid refund.
-- `Refund Bid Index` selects the bid index to refund.
-- `Refund Losing Bid` submits the refund.
-- `Vault Address` in `Claim Auction Proceeds` selects the vault that should claim auction proceeds. Leaving it empty uses the connected wallet's vault context.
-- `Claim Bid Tick` selects the winning bid tick to claim against.
-- `Claim Bid Index` selects the winning bid index to claim against.
-- `Claim Auction Proceeds` claims proceeds for that bid position.
-- `Withdraw For Address` selects the address whose bids should be withdrawn. Leaving it empty uses the connected wallet.
-- `Withdraw Tick` selects the auction tick to withdraw from.
-- `Withdraw Bid Index` selects the bid index to withdraw.
-- `Withdraw Bids` submits the withdrawal.
+| Control | Purpose | Validation | Disabled when |
+| --- | --- | --- | --- |
+| `Security Pool Address` | Select the pool whose fork lifecycle is being inspected. | Free-form address interpreted by the fork loader. | Hidden in embedded pool workflows. |
+| `Refresh fork` | Load or reload fork and truth-auction state. | No field input. | Disabled while fork details are loading. |
+| Lifecycle tabs | Switch between `Initiate`, `Migration`, `Auction`, and `Settlement`. | No field input. | Not disabled by default, though later stages can show explanatory messages when the pool has not progressed that far. |
+| `Fork With Own Escalation` | Start a fork using the operator's own escalation path. | No extra field input. | Disabled when the wallet is missing, not on mainnet, or the broader workflow is disabled. |
+| `Initiate Pool Fork` | Trigger the pool-level fork path. | No extra field input. | Disabled when the wallet is missing, not on mainnet, or the broader workflow is disabled. |
+| `Direct Fork Universe ID` | Set the universe to fork directly. | Must be parseable by the direct-fork action path. | Field itself is not disabled in the active stage panel. |
+| `Direct Fork Question ID` | Set the direct fork question. | Must be parseable by the direct-fork action path. | Field itself is not disabled in the active stage panel. |
+| `Fork Universe Directly` | Submit the direct universe fork. | Requires connected wallet, mainnet, enabled workflow, and parseable direct-fork inputs. | Disabled whenever the base fork action guard fails. |
+| `Outcome` in child/migration actions | Choose the child outcome used by the action. | Must be one of the supported reporting outcomes. | Not disabled unless the broader stage panel is disabled. |
+| `Create ... Child Universe` | Deploy the child universe for the selected outcome. | Requires connected wallet, mainnet, enabled workflow, and a selected outcome. | Disabled whenever the base fork action guard fails. |
+| `REP Migration Outcomes` | Describe which outcomes should receive migrated REP through the pool flow. | Must be parseable by the migration action path. | Not disabled unless the broader stage panel is disabled. |
+| `Migrate REP To Zoltar` | Submit REP migration to Zoltar through the pool flow. | Requires connected wallet, mainnet, enabled workflow, and parseable migration outcomes. | Disabled whenever the base fork action guard fails. |
+| `Vault Address` in `Migrate Vault` | Choose which vault to migrate. | Optional. Empty falls back to connected-wallet vault context. | Not disabled unless the broader stage panel is disabled. |
+| `Migrate Vault` | Submit vault migration. | Requires connected wallet, mainnet, enabled workflow, and any required parseable fields. | Disabled whenever the base fork action guard fails. |
+| `Escalation Deposit Indexes` | Choose which escalation deposits to migrate. | Must be parseable by the deposit-migration path. | Not disabled unless the broader stage panel is disabled. |
+| `Migrate Escalation Deposits` | Submit escalation deposit migration. | Requires connected wallet, mainnet, enabled workflow, and parseable indexes. | Disabled whenever the base fork action guard fails. |
+| `Start Truth Auction` | Start the truth auction. | No extra field input. | Disabled when the wallet is missing, not on mainnet, or the broader workflow is disabled. |
+| `Bid Tick` | Set the tick for a bid. | Must be parseable by the bid action path. | Field itself is not disabled unless the stage panel is disabled. |
+| `Bid Amount (ETH)` | Set the ETH amount for a bid. | Must be parseable by the bid action path. | Field itself is not disabled unless the stage panel is disabled. |
+| `Submit Bid` | Submit the truth-auction bid. | Requires connected wallet, mainnet, enabled workflow, and parseable bid inputs. | Disabled whenever the base fork action guard fails. |
+| `Finalize Truth Auction` | Finalize the auction once ready. | No extra field input. | Disabled when the wallet is missing, not on mainnet, or the broader workflow is disabled. |
+| `Refund Tick` / `Refund Bid Index` | Choose a losing bid to refund. | Must be parseable by the refund action path. | Fields themselves are not disabled unless the stage panel is disabled. |
+| `Refund Losing Bid` | Submit the refund. | Requires connected wallet, mainnet, enabled workflow, and parseable refund inputs. | Disabled whenever the base fork action guard fails. |
+| `Vault Address` / `Claim Bid Tick` / `Claim Bid Index` | Choose which vault and winning bid position to claim against. | Must be parseable by the claim action path. Vault address is optional and can fall back to the connected wallet. | Fields themselves are not disabled unless the stage panel is disabled. |
+| `Claim Auction Proceeds` | Claim proceeds for a winning bid position. | Requires connected wallet, mainnet, enabled workflow, and parseable claim inputs. | Disabled whenever the base fork action guard fails. |
+| `Withdraw For Address` / `Withdraw Tick` / `Withdraw Bid Index` | Choose which bids to withdraw. | Must be parseable by the withdraw action path. Withdraw-for address is optional and can fall back to the connected wallet. | Fields themselves are not disabled unless the stage panel is disabled. |
+| `Withdraw Bids` | Submit bid withdrawal. | Requires connected wallet, mainnet, enabled workflow, and parseable withdraw inputs. | Disabled whenever the base fork action guard fails. |
 
 #### Security Pools Route Handoffs
 
@@ -475,130 +424,110 @@ The first two are route-level entry points. The third becomes the focused report
 
 #### Browse Reports
 
-`Browse` loads paginated Open Oracle report summaries. The route header shows:
+`Browse` loads paginated Open Oracle report summaries.
 
-- total browse count
-- page
-- the selected report id, if any
+#### Browse Controls
 
-Inside the browse section, the operator can:
+| Control | Purpose | Validation | Disabled when |
+| --- | --- | --- | --- |
+| `Browse`, `Create`, `Selected Report` tabs | Switch between Open Oracle views. | No field input. | `Selected Report` is still reachable even before a report is loaded, but it will show a loading or missing state until a report resolves. |
+| `Previous Page` | Load the previous report-summary page. | No field input. | Disabled on the first page or while browse data is loading. |
+| `Next Page` | Load the next report-summary page. | No field input. | Disabled on the last page or while browse data is loading. |
+| `Open report` | Load a selected report into the selected-report workspace. | Report id comes from the loaded report card. | Not disabled in the normal browse list. |
 
-- page through report summaries
-- inspect per-report status badges
-- open a report with `Open report`
+#### Browse Read-Only Surfaces
 
-The page size is fixed.
-
-##### Browse Fields and Buttons
-
-- `Browse`, `Create`, and `Selected Report` are the Open Oracle route tabs.
-- `Previous Page` loads the prior report-summary page.
-- `Next Page` loads the next report-summary page.
-- `Open report` loads a selected report into the `Selected Report` workspace.
-- The route header metrics are read-only and show browse count, page, and selected report id.
+- Each report summary card exposes token pair, current price, current reporter, current token amounts, report timestamp, and settlement timestamp.
+- A latest-action card can appear after a recent Oracle action, including report creation.
+- The browse route can render loading, empty, and error states when report summaries are being fetched.
 
 #### Create Open Oracle Game
 
-`Create` is a direct report-instance creation flow. It is separate from any pool oracle-manager workflow and creates a standalone Open Oracle game.
+`Create` is a direct report-instance creation flow.
 
-The form exposes fields for:
+#### Create Open Oracle Game Controls
 
-- token addresses
-- exact token1 report amount
-- settler reward
-- ETH value to send
-- fee percentage
-- multiplier
-- settlement time
-- escalation halt
-- dispute delay
-- protocol fee
+| Control | Purpose | Validation | Disabled when |
+| --- | --- | --- | --- |
+| `Token1 Address` | Set the first token contract. | Parsed by the create-game action path. | Never disabled in the base form. |
+| `Token2 Address` | Set the second token contract. | Parsed by the create-game action path. | Never disabled in the base form. |
+| `Exact Token1 Report` | Set the exact token1 report amount. | Parsed by the create-game action path. | Never disabled in the base form. |
+| `Settler Reward` | Set the ETH reward paid to the settler. | Parsed by the create-game action path. | Never disabled in the base form. |
+| `ETH Value To Send` | Set the ETH value attached to creation. | Parsed by the create-game action path. | Never disabled in the base form. |
+| `Fee Percentage` | Set the fee percentage. | Parsed by the create-game action path. | Never disabled in the base form. |
+| `Multiplier` | Set the oracle multiplier. | Parsed by the create-game action path. | Never disabled in the base form. |
+| `Settlement Time` | Set the base settlement delay. | Parsed by the create-game action path. | Never disabled in the base form. |
+| `Escalation Halt` | Set the escalation halt threshold. | Parsed by the create-game action path. | Never disabled in the base form. |
+| `Dispute Delay` | Set the dispute delay. | Parsed by the create-game action path. | Never disabled in the base form. |
+| `Protocol Fee` | Set the protocol fee share. | Parsed by the create-game action path. | Never disabled in the base form. |
+| `Create Open Oracle Game` | Submit the standalone game creation. | Requires a connected wallet. Most field correctness is enforced by the action path rather than by front-end validation in this component. | Disabled until a wallet is connected. |
 
-The main action is `Create Open Oracle Game`.
+#### Create Open Oracle Game Read-Only Surfaces
 
-##### Create Open Oracle Game Fields and Buttons
-
-- `Token1 Address` sets the first token contract for the oracle game.
-- `Token2 Address` sets the second token contract.
-- `Exact Token1 Report` sets the exact token1 amount that reports must satisfy.
-- `Settler Reward` sets the ETH reward paid to the settler.
-- `ETH Value To Send` sets the ETH value attached to the creation transaction.
-- `Fee Percentage` sets the report fee percentage.
-- `Multiplier` sets the oracle multiplier.
-- `Settlement Time` sets the base settlement delay.
-- `Escalation Halt` sets the escalation halt threshold.
-- `Dispute Delay` sets the delay before disputes or settlement progression.
-- `Protocol Fee` sets the protocol fee share.
-- `Create Open Oracle Game` submits the standalone game creation.
+- A latest-action card can appear after recent Open Oracle create actions.
+- The create route can show an error notice below the form when the action fails.
 
 #### Selected Report
 
-`Selected Report` is the loaded report workspace. The UI chooses the visible action mode from the report state and presents one of the following paths.
+`Selected Report` is the loaded report workspace.
 
-##### Selected Report Fields and Buttons
+#### Selected Report Controls
 
-- `Report ID` chooses which report to load in the selected-report workspace.
-- `Open report` loads the report if nothing is loaded yet.
-- `Refresh report` reloads the report if it is already loaded.
-- The report summary and identity/economics/status/settlement/callback sections are read-only and expose the full report state.
+| Control | Purpose | Validation | Disabled when |
+| --- | --- | --- | --- |
+| `Report ID` | Choose which report to load in the selected-report workspace. | Must identify a loadable report for the workspace to become actionable. | Never disabled in the base selected-report form. |
+| `Open report` | Load the selected report when no report is currently loaded. | Uses the entered report id. | Disabled while a report is already loading. |
+| `Refresh report` | Reload the selected report when one is already loaded. | Uses the current report id. | Disabled while a report is already loading. |
+
+#### Selected Report Read-Only Surfaces
+
+- The loaded report card shows a status badge such as awaiting initial report, pending, disputed, or settled.
+- The top summary grid exposes report id, oracle address, current reporter, current price, and settlement timestamp.
+- The report body is broken into read-only sections for `Identity`, `Economics`, `Status`, `Settlement`, and `Callback / Extra`.
+- When no report is loaded, the selected-report screen can show an explicit missing or loading state hint rather than the full report body.
 
 ##### Initial Report
 
-When the report still needs its first report, the UI exposes:
+The `Initial Report` mode appears while the report still needs its first report.
 
-- manual price entry
-- `Fetch price from Uniswap`
-- token approval controls for both tokens
-- optional ETH-to-WETH wrapping when needed
-- `Submit Initial Report`
+###### Initial Report Controls
 
-The section also shows the price source and any visible prerequisite or blocking messages.
-
-###### Initial Report Fields and Buttons
-
-- `Price (token1 / token2)` sets the initial reported price.
-- `Fetch price from Uniswap` asks the UI to populate the price from the quote source.
-- The token approval controls approve enough `token1` and `token2` to satisfy the initial report deposit requirements.
-- `Wrap needed ETH to WETH` appears only when the report needs additional WETH and wrapping is possible.
-- `Submit Initial Report` submits the first report.
-- The price source line and WETH requirement messages are read-only and explain how the current submission values were derived.
+| Control | Purpose | Validation | Disabled when |
+| --- | --- | --- | --- |
+| `Price (token1 / token2)` | Set the initial reported price. | Must parse into a valid price before token2 approval and full submission can resolve. | Not disabled in the normal initial-report state. |
+| `Fetch price from Uniswap` | Populate the price from the quote source. | No field input. | Disabled while quote loading is already in progress. |
+| Token1 approval control | Approve enough token1 for the initial report. | Required amount is derived from the report requirements. | Disabled when no wallet is connected. |
+| Token2 approval control | Approve enough token2 for the initial report. | Required amount depends on a valid price-derived token2 amount. | Disabled when no wallet is connected or until a valid price produces a valid token2 amount. |
+| `Wrap needed ETH to WETH` | Wrap ETH into WETH when additional WETH is required. | Wrap requirement is derived from the report state and wallet balances. | Hidden unless wrap is needed. When shown, disabled unless the wallet is connected and wrapping is currently possible. |
+| `Submit Initial Report` | Submit the first report. | Requires connected wallet, report still awaiting initial report, valid price-derived amounts, satisfied token approvals, and satisfied WETH wrap requirements if any. | Disabled whenever any submission guard condition fails. |
 
 ##### Dispute Report
 
-When the report is in a disputable state, the UI exposes:
+The `Dispute Report` mode appears while a report is in a disputable lifecycle window.
 
-- token selection for the swap-out side
-- new token amounts
-- `Dispute & Swap`
+###### Dispute Report Controls
 
-If settlement is also eligible, the selected report view can show a parallel `Settle Report` action alongside the dispute flow.
-
-###### Dispute Report Fields and Buttons
-
-- `Token to Swap Out` chooses which side of the pair is swapped out during dispute.
-- `New token1 Amount` sets the replacement amount for token1.
-- `New token2 Amount` sets the replacement amount for token2.
-- `Dispute & Swap` submits the dispute transaction.
-- `Settle Report` may also appear here when settlement is already allowed in parallel with dispute.
+| Control | Purpose | Validation | Disabled when |
+| --- | --- | --- | --- |
+| `Token to Swap Out` | Choose which side of the pair is swapped out during dispute. | Must be one of the supported pair tokens. | Not disabled in normal dispute mode. |
+| `New token1 Amount` | Set the replacement amount for token1. | Must parse by the downstream dispute flow. | Not disabled in normal dispute mode. |
+| `New token2 Amount` | Set the replacement amount for token2. | Must parse by the downstream dispute flow. | Not disabled in normal dispute mode. |
+| `Dispute & Swap` | Submit the dispute transaction. | Requires connected wallet, loaded report, and report state that is currently disputable. | Disabled whenever any dispute guard condition fails. |
+| `Settle Report` in dispute mode | Settle if the report has already reached settlement eligibility. | Requires connected wallet, loaded report, and report state that is currently settleable. | Disabled whenever any settle guard condition fails. |
 
 ##### Settle Report
 
-When the report is ready for settlement, the selected report workspace exposes settlement directly through `Settle Report`.
+The `Settle Report` mode appears when dispute is no longer allowed but settlement is ready.
 
-###### Settle Report Buttons
+###### Settle Report Controls
 
-- `Settle Report` finalizes the report when the report lifecycle and timing allow settlement.
+| Control | Purpose | Validation | Disabled when |
+| --- | --- | --- | --- |
+| `Settle Report` | Finalize the report. | Requires connected wallet, loaded report, initial report already present, report not already settled, and settlement window already open. | Disabled whenever any settle guard condition fails. |
 
 ##### Settled Report
 
 Once settled, the report stays available in a read-oriented state with status and summary fields, but the actionable lifecycle moves to a completed presentation.
-
-Across these modes, button availability is used heavily to communicate unmet prerequisites such as:
-
-- no connected wallet
-- no loaded report
-- invalid approval or token state
-- report-state-specific restrictions on dispute or settlement
 
 ## Common Journeys
 
@@ -619,6 +548,12 @@ These handoffs are part of the operator flow, not separate apps.
 - Query params can reopen prior working context, so a page refresh may return to a previously selected universe, pool, report, or Zoltar subview.
 - Simulation mode changes both the backend and the data assumptions. It is useful for QA, but it is not a mainnet-equivalent environment.
 - Once a universe has forked, several actions change availability. In particular, some fork-related setup actions disappear or become disabled, while migration actions become relevant.
+
+## Exceptional States
+
+- If the user lands on an unsupported hash route, the app renders a dedicated `404` route with `Return to Deploy`, `Open Zoltar`, and `Open Security Pools`.
+- If the wallet is on the wrong network, the app replaces the selected route content with a mainnet-gate route that instructs the operator to switch to Ethereum mainnet.
+- Across the app, many sections use explicit empty, loading, missing, blocked, and success presentations instead of leaving panels blank.
 
 ## Contributor Note
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -1,0 +1,640 @@
+# UI Guide
+
+This document explains how the UI works from an operator's perspective. It is intended to provide a text explanation of the interface alongside the UI itself.
+
+## Reading the UI
+
+The UI is built as a restrained operations interface. Each route follows the same general rhythm:
+
+- a route header or top summary
+- a context strip or overview
+- tabs when a route has multiple working modes
+- one or more task sections for the active workflow
+
+Most content appears inside section-level wrappers. Record-style cards are reserved for concrete things such as questions, reports, pools, or vaults. Actions that the UI can already determine are unavailable are disabled before submission, and the UI shows the reason directly instead of letting the user send a known-failing transaction.
+
+## App Shell and Navigation
+
+The app shell has two main layers:
+
+- the top overview area, which shows wallet state, balances, REP pricing, and the active universe
+- the route navigation tabs, which switch between the main app sections
+
+The UI uses hash routing. The top-level routes are:
+
+- `#/deploy`
+- `#/zoltar`
+- `#/security-pools`
+- `#/open-oracle`
+
+If the page loads without a hash, the app defaults to `#/zoltar`.
+
+Outside the `Deploy` route, the main workflows are gated behind setup. Until the required Augur PLACEHOLDER deployment state is ready, the non-deploy tabs stay disabled and explain that deployment must be completed first. If setup becomes incomplete while the user is on another route, the app redirects back to `Deploy`.
+
+The overview panel shows:
+
+- wallet connection state and the connected address
+- ETH, WETH, and REP balances when a wallet is connected
+- REP/ETH and REP/USDC price references, with a refresh control for the REP/ETH quote
+- the active universe label
+
+If the user is connected to an unsupported chain, the route content is replaced by a mainnet gate message instead of rendering the selected route workflow.
+
+### App Shell Controls
+
+- `Connect wallet` connects the injected wallet when no account is connected.
+- The REP/ETH refresh button reloads the displayed REP pricing source.
+- The top route tabs switch between `Deploy`, `Zoltar`, `Security Pools`, and `Open Oracle`.
+
+## Global Notices and Transaction State
+
+Above the route content, the app can show page-wide notices for:
+
+- simulation bootstrap failures
+- the active Zoltar universe having already forked
+- setup being incomplete and the app requiring the `Deploy` flow
+- wallet availability guidance when no injected wallet is present
+- transaction progress and the most recent transaction hash
+
+Transaction state is shared across the app. While a transaction is waiting on wallet confirmation or onchain confirmation, the UI shows a global pending notice. Buttons that launched pending actions also keep their loading state in place and stay disabled until the action resolves.
+
+## Simulation Mode
+
+Appending `?simulate=1` switches the app from the injected-wallet backend to the browser simulation backend. In this mode, a simulation banner appears above the normal top shell.
+
+The simulation banner exposes:
+
+- the active simulation scenario, selected with `simScenario`
+- the active QA account
+- query delay controls for slower read paths
+- REP/ETH and REP/USDC mock price controls
+- transaction receipt delay controls
+- reset, mine block, `+1 hour`, and `+1 day` controls
+
+Simulation mode is intended for walletless or repeatable manual QA. It seeds known accounts and lets the operator move blockchain time forward without leaving the browser. Per the repo guidance, Uniswap-backed REP pricing is intentionally disabled in simulation mode, so quote-dependent features are expected to degrade gracefully rather than assume mainnet liquidity.
+
+### Simulation Controls
+
+- The scenario selector changes the seeded simulation scenario and reloads the page into that scenario.
+- The QA account selector switches which seeded account the UI uses.
+- `Query delay (ms)` adds artificial latency to read calls.
+- `REP / ETH mock price` sets the simulated REP/ETH price.
+- `REP / USDC mock price` sets the simulated REP/USDC price.
+- `Transaction receipt delay (ms)` adds artificial latency before simulated transactions confirm.
+- `Reset scenario` resets the simulation back to its seeded state.
+- `Mine block` advances the simulation by one block.
+- `+1 hour` advances simulation time by one hour.
+- `+1 day` advances simulation time by one day.
+
+## URL-Driven State and Deep Linking
+
+In addition to the hash route, the UI stores several pieces of user-visible state in query params:
+
+- `universe`
+- `reportId`
+- `securityPool`
+- `zoltarView`
+- `simulate`
+- `simScenario`
+
+These params let the UI restore or deep-link into working context:
+
+- `universe` controls the active Zoltar and pool universe context
+- `reportId` reopens or preloads a selected Open Oracle report
+- `securityPool` reopens a selected pool inside Security Pools
+- `zoltarView` reopens the selected Zoltar subview
+- `simulate` and `simScenario` choose the simulated backend and seeded scenario
+
+The app updates these values with browser history APIs, so back and forward navigation preserve them without a full page reload.
+
+## Route Guide
+
+### Deploy
+
+`Deploy` is the setup route for deterministic contract deployment. It exists to bring the shared app contracts into the expected deployed state before the rest of the UI is usable.
+
+The route header summarizes:
+
+- how many deployment steps are already deployed
+- the next deployable step
+
+The primary action is `Deploy Next Missing`. Below that, the route groups deployment steps into deployment sections, so operators can see which contracts belong together and can also trigger individual deployment actions where needed.
+
+When setup is incomplete, this route becomes the prerequisite path for the rest of the app.
+
+#### Deploy Controls
+
+- `Deploy Next Missing` submits the next deployable deterministic deployment step.
+- Per-group deployment actions deploy individual contracts inside the grouped deployment sections.
+- The route header summary is read-only and shows deployment progress rather than accepting input.
+
+### Zoltar
+
+The `Zoltar` route is the main universe and question-management area. It has four subviews:
+
+- `Questions`
+- `Create Question`
+- `Fork Zoltar`
+- `Migrate REP`
+
+The top tabbed block summarizes the active universe. In `Questions`, it can show a fuller universe overview. In the other views, it compresses that into smaller universe, status, and question-count metrics.
+
+#### Questions
+
+The `Questions` view is used to fetch and browse questions in the active universe.
+
+It supports:
+
+- loading or refreshing the question list
+- reviewing each question in a record card
+- sending a question into the fork flow with `Use For Fork`
+- sending a binary question into the pool-creation flow with `Use For Create Pool`
+
+If the universe has already forked, the fork action is disabled and replaced with an already-forked state.
+
+##### Questions Controls
+
+- `Questions`, `Create Question`, `Fork Zoltar`, and `Migrate REP` are the Zoltar view tabs.
+- `Fetch Questions` loads the question list the first time.
+- `Refresh Questions` reloads the question list after an earlier load.
+- `No Questions` appears as a disabled state when the universe has no questions.
+- `Use For Fork` copies the selected question into the fork workflow and opens the `Fork Zoltar` tab.
+- `Use For Create Pool` copies a binary question into the Security Pools create flow and navigates there.
+
+#### Create Question
+
+The `Create Question` view creates new Zoltar questions. The form supports:
+
+- `Binary`
+- `Categorical`
+- `Scalar`
+
+The operator can set title, description, timing, and type-specific fields. Scalar questions also show a live preview once the scalar inputs are valid enough to derive the outcome ticks.
+
+After creation, the UI shows the created question as a record card and exposes follow-up actions:
+
+- `Use For Fork`
+- `Use For Create Pool`
+- `Create Another Question`
+
+This makes the view both a creation flow and a handoff point into downstream workflows.
+
+##### Create Question Fields and Buttons
+
+- `Question Type` chooses between `Binary`, `Categorical`, and `Scalar`.
+- `Title` sets the market title shown in question cards and summaries.
+- `Description` adds optional explanatory text for the question.
+- `Start Time` sets when the market becomes active.
+- `End Time` sets when the market closes.
+- `Outcomes` appears for categorical markets and lets the operator add, edit, and remove categorical labels.
+- `Add Outcome` adds another categorical outcome row.
+- `Remove` deletes one categorical outcome row.
+- `Scalar Min`, `Scalar Increment`, `Scalar Max`, and `Answer Unit` appear for scalar markets and define the scalar range and display unit.
+- The scalar preview is read-only and shows how the scalar tick slider resolves from the entered bounds.
+- `Create Question` submits the new question.
+- After creation, `Use For Fork` passes the new question into the fork flow.
+- After creation, `Use For Create Pool` passes the new question into pool creation when the question is binary.
+- `Create Another Question` clears the result card and returns to the input form.
+
+#### Fork Zoltar
+
+The `Fork Zoltar` view is focused on selecting the fork question and executing the fork path. It surfaces:
+
+- the selected question context
+- REP approval state
+- fork eligibility and block reasons
+- the active fork transaction state
+
+Operators typically arrive here by selecting `Use For Fork` from the questions list or from a newly created question.
+
+##### Fork Zoltar Fields and Buttons
+
+- The REP approval control approves enough REP to satisfy the fork threshold.
+- `Fork Question ID` selects the question that will trigger the universe fork.
+- The selected-question card is read-only and confirms which question will be used.
+- `Fork Zoltar` submits the fork transaction once wallet, network, REP balance, approval, and question selection all satisfy the guard conditions.
+
+#### Migrate REP
+
+The `Migrate REP` view handles post-fork REP preparation and migration into child universes.
+
+It only becomes usable after the universe has forked. Before that, the tab remains disabled and shows the reason directly in the UI. Once enabled, it supports preparing REP for migration and executing migration actions into child-universe balances.
+
+##### Migrate REP Fields and Buttons
+
+- `Migration Amount` sets how much REP should move through the migration workflow.
+- `Max` fills `Migration Amount` with all wallet REP plus already prepared migration REP available in the universe.
+- The REP approval control approves any additional REP still needed to prepare the chosen migration amount.
+- The migration outcome selector lists child universes and lets the operator choose which outcome universes receive the split.
+- `Add Next Outcome` adds the next unselected child universe to the split set.
+- Outcome toggles select or deselect individual target universes.
+- `Prepare REP` moves wallet REP into the migration balance for the active universe.
+- `Split REP` splits prepared migration REP across the selected outcome universes.
+- The migration summary card is read-only and shows the last migration action, amount, and selected outcomes.
+
+### Security Pools
+
+The `Security Pools` route has three high-level modes:
+
+- `Browse`
+- `Create`
+- `Operate`
+
+#### Browse
+
+`Browse` loads the pool registry and lists deployed pools. From here, the operator can:
+
+- inspect deployed pool records
+- open a selected pool into the `Operate` workspace
+- access liquidation entry points where the loaded pool and vault context exposes them
+
+The route auto-loads pool data when this view opens for the first time.
+
+##### Browse Controls
+
+- `Browse`, `Create`, and `Operate` are the Security Pools route tabs.
+- Pool selection actions open the selected pool inside `Operate`.
+- Liquidation entry buttons appear only where the loaded vault and oracle-manager context makes liquidation available.
+
+#### Create
+
+`Create` is the pool-deployment workflow. It guides the operator through:
+
+- loading or confirming the binary market question context
+- checking for existing pools tied to the same origin question
+- reviewing existing pool records for that question
+- configuring pool parameters such as the security multiplier and retention rate
+- deploying the pool
+
+This view is designed to receive a binary question from Zoltar through the `Use For Create Pool` handoff.
+
+##### Create Fields and Buttons
+
+- `Question ID` selects the binary question used as the pool's origin market.
+- `Security Multiplier` sets the collateralization multiplier for the pool.
+- `Open Interest Fee / Year (%)` sets the pool's retention-rate-based open-interest fee.
+- `Create Pool` submits a pool deployment for the entered question and settings.
+- `Open Pool` appears after a successful deployment and jumps into the new pool's `Operate` workspace.
+- `Create Another Pool` appears after a successful deployment and resets the create form.
+- The `Question Context` section is read-only and shows the loaded market.
+- The `Existing Pools` section is read-only and lists pools already created for the same question.
+
+#### Operate
+
+`Operate` opens a selected-pool workspace. If the app has a valid `securityPool` query param but has not yet loaded that pool into the registry view, it refreshes selected-pool data automatically.
+
+The selected pool workspace includes summary data such as:
+
+- pool status and question context
+- the pool's oracle-manager context
+- price-oracle refresh controls
+- a `Request New Price` action when the oracle-manager state allows it
+
+If the selected pool belongs to a different universe than the app's active universe, the UI shows a universe mismatch warning and tells the operator to switch to the same universe before using the pool.
+
+Inside `Operate`, the main subviews are:
+
+- `Vaults`
+- `Trading`
+- `Reporting`
+- `Fork`
+
+##### Operate Controls
+
+- The vertical workflow tabs switch between `Vaults`, `Trading`, `Reporting`, and `Fork`.
+- `Refresh Oracle` reloads the pool oracle-manager view.
+- `Request New Price` asks the oracle-manager flow to queue or request a fresh price when allowed.
+- The pool summary and question cards are read-only and anchor the active pool context.
+
+##### Vaults
+
+The `Vaults` subview is split again into:
+
+- `Directory`
+- `Selected`
+
+`Directory` lists vaults for the selected pool. From there, the operator can:
+
+- choose a vault with `Select Vault`
+- open liquidation for a vault when the loaded context allows it
+
+`Selected` focuses on a single vault and its actions. The vault workflow supports:
+
+- claiming fees
+- depositing REP
+- setting security bond allowance
+- withdrawing REP
+
+If the selected vault is not owned by the connected account, the UI keeps the vault visible but explains that the actions are read-only until the operator selects their own vault.
+
+###### Vaults Fields and Buttons
+
+- `Directory` and `Selected` are the vault-local view tabs inside the `Vaults` workspace.
+- `Selected Vault Address` chooses which vault to inspect or operate on.
+- `Refresh` reloads the selected vault from chain state.
+- `Select Vault` copies a vault from the directory into the selected-vault workflow.
+- `Liquidate Vault` opens the liquidation flow for that vault when the current pool and oracle state allows it.
+- `Claim Fees` redeems claimable ETH fees from the selected owned vault.
+- `REP Deposit Amount` sets the REP deposit amount.
+- Deposit `Max` fills the REP deposit field from the wallet REP balance.
+- The REP approval control approves enough REP for the deposit amount.
+- `Create / Deposit REP` creates a new vault if needed or deposits REP into the selected owned vault.
+- `Security Bond Allowance Amount` sets the new security bond allowance in ETH terms.
+- `Set Security Bond Allowance` queues the allowance update for the selected owned vault.
+- `REP Withdraw Amount` sets how much withdrawable REP to remove from the vault.
+- Withdraw `Max` fills the withdrawal field with the vault's currently withdrawable REP.
+- `Withdraw REP` queues the REP withdrawal for the selected owned vault.
+
+##### Trading
+
+The `Trading` subview handles share and complete-set flows for the selected pool. It supports:
+
+- minting complete sets
+- redeeming complete sets
+- migrating forked shares
+- redeeming resolved shares
+
+This is the pool-level share operations workspace rather than a general exchange UI.
+
+###### Trading Fields and Buttons
+
+- `Security Pool Address` appears when the trading section is used standalone and selects the target pool.
+- `Mint Complete Sets Amount` sets how many complete sets to mint.
+- `Mint Complete Sets` submits the mint transaction.
+- `Redeem Complete Sets Amount` sets how many complete sets to redeem back into collateral.
+- Redeem `Max` fills the redemption amount from the wallet's maximum redeemable complete sets.
+- `Redeem Complete Sets` submits the complete-set redemption.
+- `Share Outcome To Migrate` chooses which share side is being migrated after a fork.
+- The share-migration target selector chooses the destination child outcomes for migrated shares.
+- `Select All` in the target selector fills all available destination outcomes.
+- `Clear` clears the selected migration targets.
+- Individual target toggles add or remove a destination outcome.
+- `Migrate Shares` submits the share migration.
+- `Redeem Shares` redeems finalized or otherwise redeemable shares.
+- The `Your Shares` metrics are read-only and show wallet balances for `Yes`, `No`, `Invalid`, and `Total Complete Sets`.
+
+##### Reporting
+
+The `Reporting` subview focuses on escalation and reporting for the selected pool. It shows the reporting context and supports:
+
+- loading the reporting or escalation state
+- reporting an outcome
+- withdrawing escalation deposits
+
+It is the main operator view for the pool's reporting and dispute lifecycle.
+
+###### Reporting Fields and Buttons
+
+- `Security Pool Address` appears when the reporting section is used standalone and selects the target pool.
+- `Refresh reporting` loads or reloads escalation and reporting state for the selected pool.
+- `Outcome Side` chooses which reporting side the next contribution or withdrawal targets.
+- `Report / Contribution Amount` sets the REP amount to stake on the selected reporting side.
+- `Report / Contribute On Selected Side` submits the reporting or contribution transaction.
+- `Withdraw Deposit Indexes` optionally narrows withdrawal to specific deposit indexes on the selected side.
+- Leaving `Withdraw Deposit Indexes` empty means withdraw all of the operator's deposits on that side.
+- `Withdraw Escalation Deposits` submits the withdrawal transaction.
+- The reporting preview text is read-only and estimates possible profit if the selected side wins and later contributions do not change the pool.
+- The escalation metrics and side cards are read-only and summarize bond size, threshold, timer, leading outcome, and user stake.
+
+##### Fork
+
+The `Fork` subview is the selected pool's fork and truth-auction workspace. It covers the lifecycle from fork initiation through migration and auction settlement.
+
+The actions exposed here include:
+
+- forking with the operator's own escalation
+- initiating a pool fork
+- direct universe fork actions
+- creating child universes
+- migrating REP, vault state, and escalation deposits
+- starting the truth auction
+- submitting bids
+- finalizing the truth auction
+- refunding losing bids
+- claiming auction proceeds
+- withdrawing bids
+
+This is the deepest lifecycle workspace in the Security Pools route.
+
+###### Fork Fields and Buttons
+
+- `Security Pool Address` selects the pool whose fork and auction lifecycle is being inspected.
+- `Refresh fork` loads or reloads the fork and truth-auction state.
+- `Initiate`, `Migration`, `Auction`, and `Settlement` are lifecycle tabs for the fork workspace.
+- `Fork With Own Escalation` starts a fork using the operator's own escalation path.
+- `Initiate Pool Fork` triggers the pool-level fork path.
+- `Direct Fork Universe ID` sets the universe to fork directly.
+- `Direct Fork Question ID` sets the direct fork question.
+- `Fork Universe Directly` submits the direct universe fork.
+- `Outcome` in `Create Child Universe` selects which child outcome universe to deploy.
+- `Create ... Child Universe` deploys the child universe for the selected outcome.
+- `REP Migration Outcomes` lists the REP migration outcome names or keys used when migrating REP into Zoltar from the pool flow.
+- `Migrate REP To Zoltar` submits that REP migration.
+- `Outcome` in `Migrate Vault` selects which child outcome receives the migrated vault.
+- `Vault Address` in `Migrate Vault` chooses which vault to migrate. Leaving it empty uses the connected wallet's vault context.
+- `Migrate Vault` submits the vault migration.
+- `Outcome` in `Migrate Escalation Deposits` selects which child outcome receives the migrated deposits.
+- `Escalation Deposit Indexes` selects which deposit indexes to migrate.
+- `Migrate Escalation Deposits` submits the escalation deposit migration.
+- `Start Truth Auction` starts the truth auction once the lifecycle reaches that stage.
+- `Bid Tick` sets the tick for the submitted bid.
+- `Bid Amount (ETH)` sets the ETH amount offered in the bid.
+- `Submit Bid` submits the auction bid.
+- The bid estimate text is read-only and shows the approximate REP that would be purchased at the current clearing price.
+- `Finalize Truth Auction` finalizes the auction once it is ready.
+- `Refund Tick` selects the tick for a losing-bid refund.
+- `Refund Bid Index` selects the bid index to refund.
+- `Refund Losing Bid` submits the refund.
+- `Vault Address` in `Claim Auction Proceeds` selects the vault that should claim auction proceeds. Leaving it empty uses the connected wallet's vault context.
+- `Claim Bid Tick` selects the winning bid tick to claim against.
+- `Claim Bid Index` selects the winning bid index to claim against.
+- `Claim Auction Proceeds` claims proceeds for that bid position.
+- `Withdraw For Address` selects the address whose bids should be withdrawn. Leaving it empty uses the connected wallet.
+- `Withdraw Tick` selects the auction tick to withdraw from.
+- `Withdraw Bid Index` selects the bid index to withdraw.
+- `Withdraw Bids` submits the withdrawal.
+
+#### Security Pools Route Handoffs
+
+The route-level handoffs are:
+
+- a Zoltar question can prefill the pool creation workflow
+- a selected pool can open a pending report inside `Open Oracle`
+
+When the user opens a pending report from the selected pool workspace, the app navigates to `#/open-oracle`, fills the report id, and loads that report.
+
+### Open Oracle
+
+The `Open Oracle` route has three working states exposed through tabs:
+
+- `Browse`
+- `Create`
+- `Selected Report`
+
+The first two are route-level entry points. The third becomes the focused report workspace once a specific report is loaded or selected.
+
+#### Browse Reports
+
+`Browse` loads paginated Open Oracle report summaries. The route header shows:
+
+- total browse count
+- page
+- the selected report id, if any
+
+Inside the browse section, the operator can:
+
+- page through report summaries
+- inspect per-report status badges
+- open a report with `Open report`
+
+The page size is fixed.
+
+##### Browse Fields and Buttons
+
+- `Browse`, `Create`, and `Selected Report` are the Open Oracle route tabs.
+- `Previous Page` loads the prior report-summary page.
+- `Next Page` loads the next report-summary page.
+- `Open report` loads a selected report into the `Selected Report` workspace.
+- The route header metrics are read-only and show browse count, page, and selected report id.
+
+#### Create Open Oracle Game
+
+`Create` is a direct report-instance creation flow. It is separate from any pool oracle-manager workflow and creates a standalone Open Oracle game.
+
+The form exposes fields for:
+
+- token addresses
+- exact token1 report amount
+- settler reward
+- ETH value to send
+- fee percentage
+- multiplier
+- settlement time
+- escalation halt
+- dispute delay
+- protocol fee
+
+The main action is `Create Open Oracle Game`.
+
+##### Create Open Oracle Game Fields and Buttons
+
+- `Token1 Address` sets the first token contract for the oracle game.
+- `Token2 Address` sets the second token contract.
+- `Exact Token1 Report` sets the exact token1 amount that reports must satisfy.
+- `Settler Reward` sets the ETH reward paid to the settler.
+- `ETH Value To Send` sets the ETH value attached to the creation transaction.
+- `Fee Percentage` sets the report fee percentage.
+- `Multiplier` sets the oracle multiplier.
+- `Settlement Time` sets the base settlement delay.
+- `Escalation Halt` sets the escalation halt threshold.
+- `Dispute Delay` sets the delay before disputes or settlement progression.
+- `Protocol Fee` sets the protocol fee share.
+- `Create Open Oracle Game` submits the standalone game creation.
+
+#### Selected Report
+
+`Selected Report` is the loaded report workspace. The UI chooses the visible action mode from the report state and presents one of the following paths.
+
+##### Selected Report Fields and Buttons
+
+- `Report ID` chooses which report to load in the selected-report workspace.
+- `Open report` loads the report if nothing is loaded yet.
+- `Refresh report` reloads the report if it is already loaded.
+- The report summary and identity/economics/status/settlement/callback sections are read-only and expose the full report state.
+
+##### Initial Report
+
+When the report still needs its first report, the UI exposes:
+
+- manual price entry
+- `Fetch price from Uniswap`
+- token approval controls for both tokens
+- optional ETH-to-WETH wrapping when needed
+- `Submit Initial Report`
+
+The section also shows the price source and any visible prerequisite or blocking messages.
+
+###### Initial Report Fields and Buttons
+
+- `Price (token1 / token2)` sets the initial reported price.
+- `Fetch price from Uniswap` asks the UI to populate the price from the quote source.
+- The token approval controls approve enough `token1` and `token2` to satisfy the initial report deposit requirements.
+- `Wrap needed ETH to WETH` appears only when the report needs additional WETH and wrapping is possible.
+- `Submit Initial Report` submits the first report.
+- The price source line and WETH requirement messages are read-only and explain how the current submission values were derived.
+
+##### Dispute Report
+
+When the report is in a disputable state, the UI exposes:
+
+- token selection for the swap-out side
+- new token amounts
+- `Dispute & Swap`
+
+If settlement is also eligible, the selected report view can show a parallel `Settle Report` action alongside the dispute flow.
+
+###### Dispute Report Fields and Buttons
+
+- `Token to Swap Out` chooses which side of the pair is swapped out during dispute.
+- `New token1 Amount` sets the replacement amount for token1.
+- `New token2 Amount` sets the replacement amount for token2.
+- `Dispute & Swap` submits the dispute transaction.
+- `Settle Report` may also appear here when settlement is already allowed in parallel with dispute.
+
+##### Settle Report
+
+When the report is ready for settlement, the selected report workspace exposes settlement directly through `Settle Report`.
+
+###### Settle Report Buttons
+
+- `Settle Report` finalizes the report when the report lifecycle and timing allow settlement.
+
+##### Settled Report
+
+Once settled, the report stays available in a read-oriented state with status and summary fields, but the actionable lifecycle moves to a completed presentation.
+
+Across these modes, button availability is used heavily to communicate unmet prerequisites such as:
+
+- no connected wallet
+- no loaded report
+- invalid approval or token state
+- report-state-specific restrictions on dispute or settlement
+
+## Common Journeys
+
+Common cross-route journeys include:
+
+- finish `Deploy`, then move into `Zoltar`, `Security Pools`, or `Open Oracle`
+- create or review a Zoltar question, then send it into pool creation
+- browse pools, then open a specific pool into `Operate`
+- move from a selected pool into a pending Open Oracle report
+- fork a universe, then return to `Zoltar` and continue in `Migrate REP`
+
+These handoffs are part of the operator flow, not separate apps.
+
+## Current Constraints and Gotchas
+
+- Outside simulation mode, the app expects an injected wallet and Ethereum mainnet-compatible context for normal operation.
+- Some routes and buttons are intentionally disabled until prerequisites are satisfied, especially deployment prerequisites, network prerequisites, and fork-state prerequisites.
+- Query params can reopen prior working context, so a page refresh may return to a previously selected universe, pool, report, or Zoltar subview.
+- Simulation mode changes both the backend and the data assumptions. It is useful for QA, but it is not a mainnet-equivalent environment.
+- Once a universe has forked, several actions change availability. In particular, some fork-related setup actions disappear or become disabled, while migration actions become relevant.
+
+## Contributor Note
+
+For contributors verifying or updating this document, the main behavior described here is driven by:
+
+- [`ui/ts/App.tsx`](../ui/ts/App.tsx)
+- [`ui/ts/components/DeploymentRouteContent.tsx`](../ui/ts/components/DeploymentRouteContent.tsx)
+- [`ui/ts/components/MarketSection.tsx`](../ui/ts/components/MarketSection.tsx)
+- [`ui/ts/components/ForkZoltarSection.tsx`](../ui/ts/components/ForkZoltarSection.tsx)
+- [`ui/ts/components/ZoltarMigrationSection.tsx`](../ui/ts/components/ZoltarMigrationSection.tsx)
+- [`ui/ts/components/SecurityPoolsSection.tsx`](../ui/ts/components/SecurityPoolsSection.tsx)
+- [`ui/ts/components/SecurityPoolSection.tsx`](../ui/ts/components/SecurityPoolSection.tsx)
+- [`ui/ts/components/SecurityPoolWorkflowSection.tsx`](../ui/ts/components/SecurityPoolWorkflowSection.tsx)
+- [`ui/ts/components/SecurityVaultSection.tsx`](../ui/ts/components/SecurityVaultSection.tsx)
+- [`ui/ts/components/TradingSection.tsx`](../ui/ts/components/TradingSection.tsx)
+- [`ui/ts/components/ReportingSection.tsx`](../ui/ts/components/ReportingSection.tsx)
+- [`ui/ts/components/ForkAuctionSection.tsx`](../ui/ts/components/ForkAuctionSection.tsx)
+- [`ui/ts/components/OpenOracleSection.tsx`](../ui/ts/components/OpenOracleSection.tsx)
+- [`ui/ts/components/SimulationBanner.tsx`](../ui/ts/components/SimulationBanner.tsx)


### PR DESCRIPTION
## Summary
- Add a new `docs/ui.md` guide that explains the UI from an operator workflow perspective.
- Document the app shell, global notices, simulation mode, URL-driven state, and the main route flows for Deploy, Zoltar, Security Pools, and Open Oracle.
- Include route-level control references and contributor pointers to the key UI components that drive each workflow.

## Testing
- Not run (documentation-only change).
- Not run: `bun run tsc`
- Not run: `bun run test`
- Not run: `bun run format`
- Not run: `bun run check`
- Not run: `bun run knip`