### PR TITLE
Fix simulation deployment and fork accounting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ This test-driven approach ensures:
 
 - - The UI supports a browser-local simulation harness behind the `?simulate=1` URL flag. Use `bun run ui:serve` and open `http://localhost:12345/?simulate=1` for walletless manual QA.
 - - Simulation mode is Tevm-backed, seeds QA accounts with ETH/WETH/REP, leaves the app contracts undeployed so the Deploy flow can be tested, and exposes developer-only controls in the yellow simulation banner.
-- - The supported simulation scenario query param is `simScenario=baseline`.
+- - Supported simulation scenarios are `simScenario=baseline`, `simScenario=deployed`, and `simScenario=security-pool`.
 - - Uniswap-backed REP pricing is intentionally disabled in simulation mode. Quote-dependent features should degrade gracefully rather than assuming mainnet liquidity exists.
 - - This is a TypeScript project. Do not inspect or work from `js/` files anywhere in the repository when there is a corresponding TypeScript source file.
 - - The project type-checks TypeScript before testing (`bun run tsc`). Generated JS or shared asset refreshes come from the setup/build scripts, not from `bun run tsc`.

--- a/scripts/ensure-contract-artifacts.mts
+++ b/scripts/ensure-contract-artifacts.mts
@@ -13,9 +13,21 @@ const sharedSourceRoot = path.join(sharedRoot, 'ts')
 
 const requiredOutputs = [path.join(solidityRoot, 'artifacts', 'Contracts.json'), path.join(solidityRoot, 'ts', 'types', 'contractArtifact.ts'), path.join(solidityRoot, 'types', 'contractArtifact.ts'), path.join(repositoryRoot, 'ui', 'ts', 'contractArtifact.ts'), path.join(repositoryRoot, 'ui', 'ts', 'abis.ts')]
 const requiredSharedOutputs = [path.join(sharedRoot, 'js', 'addressDerivation.js'), path.join(sharedRoot, 'js', 'bigInt.js'), path.join(sharedRoot, 'js', 'deploymentAddresses.js')]
+const requiredUiSharedOutputs = [
+	path.join(repositoryRoot, 'ui', 'js', 'shared', 'addressDerivation.js'),
+	path.join(repositoryRoot, 'ui', 'js', 'shared', 'bigInt.js'),
+	path.join(repositoryRoot, 'ui', 'js', 'shared', 'deploymentAddresses.js'),
+	path.join(repositoryRoot, 'ui', 'ts', 'shared', 'addressDerivation.js'),
+	path.join(repositoryRoot, 'ui', 'ts', 'shared', 'bigInt.js'),
+	path.join(repositoryRoot, 'ui', 'ts', 'shared', 'deploymentAddresses.js'),
+	path.join(repositoryRoot, 'ui', 'ts', 'shared', 'addressDerivation.d.ts'),
+	path.join(repositoryRoot, 'ui', 'ts', 'shared', 'bigInt.d.ts'),
+	path.join(repositoryRoot, 'ui', 'ts', 'shared', 'deploymentAddresses.d.ts'),
+]
 
 const freshnessInputs = [path.join(solidityRoot, 'bun.lock'), path.join(solidityRoot, 'package.json'), path.join(solidityRoot, 'tsconfig-compile.json'), path.join(solidityRoot, 'ts', 'abi', 'abis.ts'), path.join(solidityRoot, 'ts', 'compile.ts'), path.join(repositoryRoot, 'ui', 'build', 'projectArtifacts.mts')]
 const sharedFreshnessInputs = [path.join(sharedRoot, 'tsconfig.json')]
+const uiSharedFreshnessInputs = [path.join(repositoryRoot, 'ui', 'build', 'shared.mts')]
 
 async function exists(filePath: string): Promise<boolean> {
 	try {
@@ -92,6 +104,10 @@ async function runSharedBuild(): Promise<void> {
 	await runBunScript(['run', 'shared:build'], `bun run shared:build`)
 }
 
+async function runUiSharedMirror(): Promise<void> {
+	await runBunScript(['run', 'ui:shared'], `bun run ui:shared`)
+}
+
 async function runBunScript(args: string[], label: string): Promise<void> {
 	await new Promise<void>((resolve, reject) => {
 		const child = spawn(process.execPath, args, {
@@ -124,11 +140,30 @@ async function getSharedBuildRegenerationReason(): Promise<string | undefined> {
 	return undefined
 }
 
+async function getUiSharedMirrorRegenerationReason(): Promise<string | undefined> {
+	for (const outputPath of requiredUiSharedOutputs) {
+		if (!(await exists(outputPath))) return `missing ui shared mirror output: ${path.relative(repositoryRoot, outputPath)}`
+	}
+
+	const newestInputMtime = await getNewestMtime([...uiSharedFreshnessInputs, ...requiredSharedOutputs])
+	const oldestOutputMtime = await getOldestMtime(requiredUiSharedOutputs)
+
+	if (newestInputMtime > oldestOutputMtime) return 'UI shared mirror outputs are older than the shared build outputs or mirror script'
+
+	return undefined
+}
+
 export async function ensureContractArtifactsAreCurrent(): Promise<void> {
 	const sharedRegenerationReason = await getSharedBuildRegenerationReason()
 	if (sharedRegenerationReason !== undefined) {
 		console.log(`Regenerating shared build outputs before tests: ${sharedRegenerationReason}`)
 		await runSharedBuild()
+	}
+
+	const uiSharedMirrorReason = await getUiSharedMirrorRegenerationReason()
+	if (uiSharedMirrorReason !== undefined) {
+		console.log(`Regenerating ui shared mirror outputs before tests: ${uiSharedMirrorReason}`)
+		await runUiSharedMirror()
 	}
 
 	const regenerationReason = await getArtifactRegenerationReason()

--- a/solidity/contracts/peripherals/EscalationGame.sol
+++ b/solidity/contracts/peripherals/EscalationGame.sol
@@ -203,13 +203,14 @@ contract EscalationGame {
 
 		// Check if new balance ties with existing maximum and another outcome has that maximum, and max is below threshold.
 		// Ties at/above threshold are allowed (to trigger nonDecision/fork).
-		bool otherHasMax = (outcomeIdx == 0) ? (b1 == maxBal || b2 == maxBal) :
-		                    (outcomeIdx == 1) ? (b0 == maxBal || b2 == maxBal) :
-		                    (b0 == maxBal || b1 == maxBal);
-		if (newBalance == maxBal && otherHasMax && maxBal < nonDecisionThreshold) {
-			effectiveDeposit -= 1;
-			newBalance = currentBalance + effectiveDeposit;
-		}
+			bool otherHasMax = (outcomeIdx == 0) ? (b1 == maxBal || b2 == maxBal) :
+			                    (outcomeIdx == 1) ? (b0 == maxBal || b2 == maxBal) :
+			                    (b0 == maxBal || b1 == maxBal);
+			if (newBalance == maxBal && otherHasMax && maxBal < nonDecisionThreshold) {
+				effectiveDeposit -= 1;
+				require(effectiveDeposit >= startBond, 'tie adjustment would break min deposit');
+				newBalance = currentBalance + effectiveDeposit;
+			}
 
 		// Update the balance
 		balances[outcomeIdx] = newBalance;

--- a/solidity/contracts/peripherals/SecurityPoolForker.sol
+++ b/solidity/contracts/peripherals/SecurityPoolForker.sol
@@ -159,11 +159,13 @@ contract SecurityPoolForker is ISecurityPoolForker {
 		require(zoltar.getForkTime(universe) > 0, 'Zoltar needs to have forked before Security Pool can do so');
 		require(securityPool.systemState() == SystemState.Operational, 'System is not operational');
 		require(address(escalationGame) == address(0x0) || escalationGame.getQuestionResolution() == BinaryOutcomes.BinaryOutcome.None, 'question has been finalized already');
-		securityPool.activateForkMode();
 		ReputationToken rep = securityPool.repToken();
+		uint256 repBalanceBefore = rep.balanceOf(address(this));
+		securityPool.activateForkMode();
 		SecurityPoolMigrationProxy migrationProxy = _getOrDeployMigrationProxy(securityPool);
 		uint256 previousMigrationBalance = zoltar.getMigrationRepBalance(address(migrationProxy), universe);
-		uint256 repToLock = rep.balanceOf(address(this));
+		uint256 repBalanceAfter = rep.balanceOf(address(this));
+		uint256 repToLock = repBalanceAfter - repBalanceBefore;
 		if (repToLock > 0) rep.transfer(address(migrationProxy), repToLock);
 		uint256 proxyRepBalance = rep.balanceOf(address(migrationProxy));
 		if (proxyRepBalance > 0) migrationProxy.lockRep(proxyRepBalance);
@@ -273,7 +275,10 @@ contract SecurityPoolForker is ISecurityPoolForker {
 					return;
 				}
 				// Sell effectively all REP for ETH while leaving only a tiny migrated-rep residue unsold.
-				// We cannot sell literally all REP because `poolOwnershipDenominator` still needs a finite anchor.
+				// This intentionally parses as `repAtFork - (migratedRep / divisor)`: the parent
+				// pool keeps its full REP-at-fork anchor, and only the tiny unsold residue is scaled
+				// down by the haircut divisor. We cannot sell literally all REP because
+				// `poolOwnershipDenominator` still needs a finite anchor.
 				forkDataByPool[securityPool].truthAuction.startAuction(ethToBuy, forkDataByPool[parent].repAtFork - forkDataByPool[securityPool].migratedRep / SecurityPoolUtils.MAX_AUCTION_VAULT_HAIRCUT_DIVISOR);
 			}
 		}
@@ -315,11 +320,13 @@ contract SecurityPoolForker is ISecurityPoolForker {
 	function forkZoltarWithOwnEscalationGame(ISecurityPool securityPool) public {
 		EscalationGame escalationGame = securityPool.escalationGame();
 		require(address(escalationGame) != address(0x0) && escalationGame.nonDecisionTimestamp() > 0, 'escalation game has not triggered fork');
+		ReputationToken rep = securityPool.repToken();
+		uint256 repBalanceBefore = rep.balanceOf(address(this));
 		securityPool.drainAllRep();
 		forkDataByPool[securityPool].ownFork = true;
 		SecurityPoolMigrationProxy migrationProxy = _getOrDeployMigrationProxy(securityPool);
-		ReputationToken rep = securityPool.repToken();
-		uint256 repToFork = rep.balanceOf(address(this));
+		uint256 repBalanceAfter = rep.balanceOf(address(this));
+		uint256 repToFork = repBalanceAfter - repBalanceBefore;
 		if (repToFork > 0) rep.transfer(address(migrationProxy), repToFork);
 		migrationProxy.forkUniverse(securityPool.questionId());
 	}

--- a/solidity/contracts/peripherals/SecurityPoolOracleCoordinator.sol
+++ b/solidity/contracts/peripherals/SecurityPoolOracleCoordinator.sol
@@ -15,11 +15,6 @@ enum OperationType {
 	SetSecurityBondsAllowance
 }
 
-uint256 constant gasConsumedOpenOracleReportPrice = 100000; // TODO
-uint32 constant gasConsumedSettlement = 1000000; // TODO
-
-IWeth9 constant WETH = IWeth9(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
-
 struct StagedOperation {
 	OperationType operation;
 	address initiatorVault;
@@ -39,6 +34,20 @@ contract SecurityPoolOracleCoordinator {
 	ReputationToken immutable reputationToken;
 	ISecurityPool public securityPool;
 	OpenOracle public immutable openOracle;
+	IWeth9 public immutable weth;
+	uint256 public immutable gasConsumedOpenOracleReportPrice;
+	uint32 public immutable gasConsumedSettlement;
+	uint256 public immutable exactToken1Report;
+	uint48 public immutable settlementTime;
+	uint24 public immutable disputeDelay;
+	uint24 public immutable protocolFee;
+	uint24 public immutable feePercentage;
+	uint16 public immutable multiplier;
+	bool public immutable timeType;
+	bool public immutable trackDisputes;
+	bool public immutable keepFee;
+	address public immutable protocolFeeRecipient;
+	bool public immutable feeToken;
 
 	event PriceReported(uint256 reportId, uint256 price);
 	event ExecutedStagedOperation(uint256 operationId, OperationType operation, bool success, string errorMessage);
@@ -48,9 +57,40 @@ contract SecurityPoolOracleCoordinator {
 	uint256 public stagedOperationCounter;
 	mapping(uint256 => StagedOperation) public stagedOperations;
 
-	constructor(OpenOracle _openOracle, ReputationToken _reputationToken) {
+	constructor(
+		OpenOracle _openOracle,
+		ReputationToken _reputationToken,
+		IWeth9 _weth,
+		uint256 _gasConsumedOpenOracleReportPrice,
+		uint32 _gasConsumedSettlement,
+		uint256 _exactToken1Report,
+		uint48 _settlementTime,
+		uint24 _disputeDelay,
+		uint24 _protocolFee,
+		uint24 _feePercentage,
+		uint16 _multiplier,
+		bool _timeType,
+		bool _trackDisputes,
+		bool _keepFee,
+		address _protocolFeeRecipient,
+		bool _feeToken
+	) {
 		reputationToken = _reputationToken;
 		openOracle = _openOracle;
+		weth = _weth;
+		gasConsumedOpenOracleReportPrice = _gasConsumedOpenOracleReportPrice;
+		gasConsumedSettlement = _gasConsumedSettlement;
+		exactToken1Report = _exactToken1Report;
+		settlementTime = _settlementTime;
+		disputeDelay = _disputeDelay;
+		protocolFee = _protocolFee;
+		feePercentage = _feePercentage;
+		multiplier = _multiplier;
+		timeType = _timeType;
+		trackDisputes = _trackDisputes;
+		keepFee = _keepFee;
+		protocolFeeRecipient = _protocolFeeRecipient;
+		feeToken = _feeToken;
 	}
 
 	function setSecurityPool(ISecurityPool _securityPool) public {
@@ -63,38 +103,37 @@ contract SecurityPoolOracleCoordinator {
 		lastPrice = _lastPrice;
 	}
 
-	function getRequestPriceEthCost() public view returns (uint256) {// TODO, probably something else
+	function getRequestPriceEthCost() public view returns (uint256) {
 		// https://github.com/j0i0m0b0o/openOracleBase/blob/feeTokenChange/src/OpenOracle.sol#L100
-		uint256 ethCost = block.basefee * 4 * (gasConsumedSettlement + gasConsumedOpenOracleReportPrice) + 101; // TODO, probably something else
+		uint256 ethCost = block.basefee * 4 * (gasConsumedSettlement + gasConsumedOpenOracleReportPrice) + 101;
 		return ethCost;
 	}
 	function requestPrice() public payable {
 		require(pendingReportId == 0, 'Already pending request');
 		// https://github.com/j0i0m0b0o/openOracleBase/blob/feeTokenChange/src/OpenOracle.sol#L100
-		uint256 ethCost = getRequestPriceEthCost();// TODO, probably something else
+		uint256 ethCost = getRequestPriceEthCost();
 		require(msg.value >= ethCost, 'not big enough eth bounty');
 
-		// TODO, research more on how to set these params
 		OpenOracle.CreateReportParams memory reportparams = OpenOracle.CreateReportParams({
-			exactToken1Report: 26392439800,//block.basefee * 200 / lastPrice, // initial oracle liquidity in token1
+			exactToken1Report: exactToken1Report,
 			escalationHalt: reputationToken.totalSupply() / 100000, // amount of token1 past which escalation stops but disputes can still happen
 			settlerReward: block.basefee * 2 * gasConsumedOpenOracleReportPrice, // eth paid to settler in wei
 			token1Address: address(reputationToken), // address of token1 in the oracle report instance
-			settlementTime: 15 * 12,//~15 blocks // report instance can settle if no disputes within this timeframe
-			disputeDelay: 0, // time disputes must wait after every new report
-			protocolFee: 0, // fee paid to protocolFeeRecipient. 1000 = 0.01%
-			token2Address: address(WETH), // address of token2 in the oracle report instance
+			settlementTime: settlementTime,
+			disputeDelay: disputeDelay,
+			protocolFee: protocolFee,
+			token2Address: address(weth), // address of token2 in the oracle report instance
 			callbackGasLimit: gasConsumedSettlement, // gas the settlement callback must use
-			feePercentage: 10000, // 0.1% atm, TODO,// fee paid to previous reporter. 1000 = 0.01%
-			multiplier: 140, // amount by which newAmount1 must increase versus old amount1. 140 = 1.4x
-			timeType: true, // true for block timestamp, false for block number
-			trackDisputes: false, // true keeps a readable dispute history for smart contracts
-			keepFee: false, // true means initial reporter keeps the initial reporter reward. if false, it goes to protocolFeeRecipient
+			feePercentage: feePercentage,
+			multiplier: multiplier,
+			timeType: timeType,
+			trackDisputes: trackDisputes,
+			keepFee: keepFee,
 			callbackContract: address(this), // contract address for settle to call back into
 			callbackSelector: this.openOracleReportPrice.selector, // method in the callbackContract you want called.
-			protocolFeeRecipient: address(0x0), // address that receives protocol fees and initial reporter rewards if keepFee set to false
-			feeToken: true //if true, protocol fees + fees paid to previous reporter are in tokenToSwap. if false, in not(tokenToSwap)
-		}); //typically if feeToken true, fees are paid in less valuable token, if false, fees paid in more valuable token
+			protocolFeeRecipient: protocolFeeRecipient,
+			feeToken: feeToken
+		});
 
 		pendingReportId = openOracle.createReportInstance{value: ethCost}(reportparams);
 

--- a/solidity/contracts/peripherals/factories/PriceOracleManagerAndOperatorQueuerFactory.sol
+++ b/solidity/contracts/peripherals/factories/PriceOracleManagerAndOperatorQueuerFactory.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity 0.8.33;
+import { IWeth9 } from '../interfaces/IWeth9.sol';
 import { ShareToken } from '../tokens/ShareToken.sol';
 import { ISecurityPool } from '../interfaces/ISecurityPool.sol';
 import { Zoltar } from '../../Zoltar.sol';
@@ -8,7 +9,71 @@ import { ReputationToken } from '../../ReputationToken.sol';
 import { SecurityPoolOracleCoordinator } from '../SecurityPoolOracleCoordinator.sol';
 
 contract PriceOracleManagerAndOperatorQueuerFactory {
+	IWeth9 public immutable weth;
+	uint256 public immutable gasConsumedOpenOracleReportPrice;
+	uint32 public immutable gasConsumedSettlement;
+	uint256 public immutable exactToken1Report;
+	uint48 public immutable settlementTime;
+	uint24 public immutable disputeDelay;
+	uint24 public immutable protocolFee;
+	uint24 public immutable feePercentage;
+	uint16 public immutable multiplier;
+	bool public immutable timeType;
+	bool public immutable trackDisputes;
+	bool public immutable keepFee;
+	address public immutable protocolFeeRecipient;
+	bool public immutable feeToken;
+
+	constructor(
+		IWeth9 _weth,
+		uint256 _gasConsumedOpenOracleReportPrice,
+		uint32 _gasConsumedSettlement,
+		uint256 _exactToken1Report,
+		uint48 _settlementTime,
+		uint24 _disputeDelay,
+		uint24 _protocolFee,
+		uint24 _feePercentage,
+		uint16 _multiplier,
+		bool _timeType,
+		bool _trackDisputes,
+		bool _keepFee,
+		address _protocolFeeRecipient,
+		bool _feeToken
+	) {
+		weth = _weth;
+		gasConsumedOpenOracleReportPrice = _gasConsumedOpenOracleReportPrice;
+		gasConsumedSettlement = _gasConsumedSettlement;
+		exactToken1Report = _exactToken1Report;
+		settlementTime = _settlementTime;
+		disputeDelay = _disputeDelay;
+		protocolFee = _protocolFee;
+		feePercentage = _feePercentage;
+		multiplier = _multiplier;
+		timeType = _timeType;
+		trackDisputes = _trackDisputes;
+		keepFee = _keepFee;
+		protocolFeeRecipient = _protocolFeeRecipient;
+		feeToken = _feeToken;
+	}
+
 	function deployPriceOracleManagerAndOperatorQueuer(OpenOracle _openOracle, ReputationToken _reputationToken, bytes32 salt) external returns (SecurityPoolOracleCoordinator) {
-		return new SecurityPoolOracleCoordinator{ salt: keccak256(abi.encode(msg.sender, salt)) }(_openOracle, _reputationToken);
+		return new SecurityPoolOracleCoordinator{ salt: keccak256(abi.encode(msg.sender, salt)) }(
+			_openOracle,
+			_reputationToken,
+			weth,
+			gasConsumedOpenOracleReportPrice,
+			gasConsumedSettlement,
+			exactToken1Report,
+			settlementTime,
+			disputeDelay,
+			protocolFee,
+			feePercentage,
+			multiplier,
+			timeType,
+			trackDisputes,
+			keepFee,
+			protocolFeeRecipient,
+			feeToken
+		);
 	}
 }

--- a/solidity/ts/tests/escalationGame.test.ts
+++ b/solidity/ts/tests/escalationGame.test.ts
@@ -169,6 +169,15 @@ describe('Escalation Game Test Suite', () => {
 		await assert.rejects(depositOnOutcome(client, escalationGame, client.account.address, 255 as QuestionOutcome, reportBond))
 	})
 
+	test('depositOnOutcome rejects tie adjustments that would drop the accepted deposit below the minimum bond', async () => {
+		const { escalationGameAddress, testSecurityPoolAddress } = await deployEscalationGameTestSecurityPool()
+		await depositOnOutcomeViaTestSecurityPool(testSecurityPoolAddress, client.account.address, QuestionOutcome.Invalid, reportBond)
+		await assert.rejects(depositOnOutcomeViaTestSecurityPool(testSecurityPoolAddress, client.account.address, QuestionOutcome.Yes, reportBond), /tie adjustment would break min deposit/i)
+		const balances = await getBalances(client, escalationGameAddress)
+		assert.strictEqual(balances.invalid, reportBond, 'original leading balance should stay untouched')
+		assert.strictEqual(balances.yes, 0n, 'tying minimum deposit should not be partially accepted')
+	})
+
 	test('getEscalationGameDeposits paginates deposits without adding synthetic entries', async () => {
 		const escalationGame = await deployEscalationGame(client, reportBond, nonDecisionThreshold)
 		await depositOnOutcome(client, escalationGame, client.account.address, QuestionOutcome.Yes, reportBond)

--- a/solidity/ts/tests/peripherals.test.ts
+++ b/solidity/ts/tests/peripherals.test.ts
@@ -124,6 +124,27 @@ describe('Peripherals Contract Test Suite', () => {
 		await client.waitForTransactionReceipt({ hash })
 	}
 
+	const transferRepToAddress = async (sender: WriteClient, recipient: Address, amount: bigint) => {
+		const hash = await sender.writeContract({
+			abi: [
+				{
+					type: 'function',
+					name: 'transfer',
+					stateMutability: 'nonpayable',
+					inputs: [
+						{ name: 'recipient', type: 'address' },
+						{ name: 'amount', type: 'uint256' },
+					],
+					outputs: [{ name: '', type: 'bool' }],
+				},
+			],
+			address: getRepTokenAddress(genesisUniverse),
+			functionName: 'transfer',
+			args: [recipient, amount],
+		})
+		await sender.waitForTransactionReceipt({ hash })
+	}
+
 	const getVaultRepClaim = async (vaultAddress: Address) => {
 		const vault = await getSecurityVault(client, securityPoolAddresses.securityPool, vaultAddress)
 		return await poolOwnershipToRep(client, securityPoolAddresses.securityPool, vault.repDepositShare)
@@ -594,7 +615,7 @@ describe('Peripherals Contract Test Suite', () => {
 		const attackerClient = createWriteClient(mockWindow, TEST_ADDRESSES[1], 0)
 		await approveAndDepositRep(attackerClient, repDeposit, questionId)
 
-		await depositToEscalationGame(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes, reportBond)
+		await depositToEscalationGame(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes, reportBond + 1n)
 		await depositToEscalationGame(attackerClient, securityPoolAddresses.securityPool, QuestionOutcome.No, reportBond)
 
 		const aliceDeposits = await getEscalationGameDeposits(client, securityPoolAddresses.escalationGame, QuestionOutcome.Yes)
@@ -705,7 +726,7 @@ describe('Peripherals Contract Test Suite', () => {
 		const attackerClient = createWriteClient(mockWindow, TEST_ADDRESSES[1], 0)
 		await approveAndDepositRep(attackerClient, repDeposit, questionId)
 
-		await depositToEscalationGame(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes, reportBond)
+		await depositToEscalationGame(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes, reportBond + 1n)
 		await depositToEscalationGame(attackerClient, securityPoolAddresses.securityPool, QuestionOutcome.No, reportBond)
 
 		await mockWindow.advanceTime(10n * DAY)
@@ -832,6 +853,42 @@ describe('Peripherals Contract Test Suite', () => {
 		strictEqualTypeSafe(childCurrentRetentionRate, MAX_RETENTION_RATE, 'child retention rate should match')
 		strictEqualTypeSafe(childCompleteSetCollateralAmount, 0n, 'child complete set collateral should default to zero during fork')
 		strictEqualTypeSafe(await getLastPrice(client, childManagerAddress), await getLastPrice(client, securityPoolAddresses.priceOracleManagerAndOperatorQueuer), 'child manager should inherit the parent price')
+	})
+
+	test('forkZoltarWithOwnEscalationGame ignores stray REP already sitting on the forker', async () => {
+		const endTime = await getQuestionEndDate(client, questionId)
+		const strayRep = 7n * 10n ** 18n
+		const forkThreshold = (await getTotalTheoreticalSupply(client, await getRepToken(client, securityPoolAddresses.securityPool))) / 20n / securityMultiplier
+		const zoltarForkThreshold = await getZoltarForkThreshold(client, genesisUniverse)
+		const burnAmount = zoltarForkThreshold / 5n
+
+		await mockWindow.setTime(endTime + 10000n)
+		await depositRep(client, securityPoolAddresses.securityPool, 2n * forkThreshold)
+		const repBalance = await getERC20Balance(client, getRepTokenAddress(genesisUniverse), securityPoolAddresses.securityPool)
+		await transferRepToAddress(client, getInfraContractAddresses().securityPoolForker, strayRep)
+		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
+		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
+
+		const forkData = await getSecurityPoolForkerForkData(client, securityPoolAddresses.securityPool)
+		strictEqualTypeSafe(forkData.repAtFork, repBalance - burnAmount, 'repAtFork should only track the parent pool REP after the own-game fork')
+	})
+
+	test('initiateSecurityPoolFork ignores stray REP transferred to the forker after the own-game fork', async () => {
+		const endTime = await getQuestionEndDate(client, questionId)
+		const strayRep = 9n * 10n ** 18n
+		const forkThreshold = (await getTotalTheoreticalSupply(client, await getRepToken(client, securityPoolAddresses.securityPool))) / 20n / securityMultiplier
+		const zoltarForkThreshold = await getZoltarForkThreshold(client, genesisUniverse)
+		const burnAmount = zoltarForkThreshold / 5n
+
+		await mockWindow.setTime(endTime + 10000n)
+		await depositRep(client, securityPoolAddresses.securityPool, 2n * forkThreshold)
+		const repBalance = await getERC20Balance(client, getRepTokenAddress(genesisUniverse), securityPoolAddresses.securityPool)
+		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
+		await transferRepToAddress(client, getInfraContractAddresses().securityPoolForker, strayRep)
+		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
+
+		const forkData = await getSecurityPoolForkerForkData(client, securityPoolAddresses.securityPool)
+		strictEqualTypeSafe(forkData.repAtFork, repBalance - burnAmount, 'repAtFork should ignore unrelated REP transferred to the forker after the own-game fork')
 	})
 
 	test('Can Liquidate', async () => {

--- a/solidity/ts/testsuite/simulator/utils/contracts/deployPeripherals.ts
+++ b/solidity/ts/testsuite/simulator/utils/contracts/deployPeripherals.ts
@@ -31,6 +31,20 @@ import { getRepTokenAddress } from './zoltar'
 
 const ZERO_SALT: Hex = toHex(0, { size: 32 })
 const MULTICALL3_BYTECODE = `0x${peripherals_Multicall3_Multicall3.evm.bytecode.object}` satisfies Hex
+const MAINNET_WETH_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' satisfies Address
+const ORACLE_REPORT_GAS = 100000n
+const ORACLE_SETTLEMENT_GAS = 1000000
+const ORACLE_EXACT_TOKEN1_REPORT = 26392439800n
+const ORACLE_SETTLEMENT_TIME = 15 * 12
+const ORACLE_DISPUTE_DELAY = 0
+const ORACLE_PROTOCOL_FEE = 0
+const ORACLE_FEE_PERCENTAGE = 10000
+const ORACLE_MULTIPLIER = 140
+const ORACLE_TIME_TYPE = true
+const ORACLE_TRACK_DISPUTES = false
+const ORACLE_KEEP_FEE = false
+const ORACLE_PROTOCOL_FEE_RECIPIENT = addressString(0x0n)
+const ORACLE_FEE_TOKEN = true
 
 const getSecurityPoolUtilsAddress = () => getCreate2Address({ bytecode: `0x${peripherals_SecurityPoolUtils_SecurityPoolUtils.evm.bytecode.object}`, from: addressString(PROXY_DEPLOYER_ADDRESS), salt: ZERO_SALT })
 
@@ -45,6 +59,14 @@ function getDeploymentStatusOracleByteCode() {
 		abi: DeploymentStatusOracle_DeploymentStatusOracle.abi,
 		bytecode: `0x${DeploymentStatusOracle_DeploymentStatusOracle.evm.bytecode.object}`,
 		args: [getDeploymentStepAddresses()],
+	})
+}
+
+function getPriceOracleManagerAndOperatorQueuerFactoryByteCode(): Hex {
+	return encodeDeployData({
+		abi: peripherals_factories_PriceOracleManagerAndOperatorQueuerFactory_PriceOracleManagerAndOperatorQueuerFactory.abi,
+		bytecode: `0x${peripherals_factories_PriceOracleManagerAndOperatorQueuerFactory_PriceOracleManagerAndOperatorQueuerFactory.evm.bytecode.object}`,
+		args: [MAINNET_WETH_ADDRESS, ORACLE_REPORT_GAS, ORACLE_SETTLEMENT_GAS, ORACLE_EXACT_TOKEN1_REPORT, ORACLE_SETTLEMENT_TIME, ORACLE_DISPUTE_DELAY, ORACLE_PROTOCOL_FEE, ORACLE_FEE_PERCENTAGE, ORACLE_MULTIPLIER, ORACLE_TIME_TYPE, ORACLE_TRACK_DISPUTES, ORACLE_KEEP_FEE, ORACLE_PROTOCOL_FEE_RECIPIENT, ORACLE_FEE_TOKEN],
 	})
 }
 
@@ -127,7 +149,7 @@ export const { getInfraContractAddresses } = createInfraContractAddressHelper({
 	getZoltarQuestionDataAddress,
 	multicall3Bytecode: MULTICALL3_BYTECODE,
 	openOracleBytecode: `0x${peripherals_openOracle_OpenOracle_OpenOracle.evm.bytecode.object}`,
-	priceOracleManagerAndOperatorQueuerFactoryBytecode: `0x${peripherals_factories_PriceOracleManagerAndOperatorQueuerFactory_PriceOracleManagerAndOperatorQueuerFactory.evm.bytecode.object}`,
+	priceOracleManagerAndOperatorQueuerFactoryBytecode: getPriceOracleManagerAndOperatorQueuerFactoryByteCode(),
 	proxyDeployerAddress: addressString(PROXY_DEPLOYER_ADDRESS),
 	scalarOutcomesBytecode: `0x${ScalarOutcomes_ScalarOutcomes.evm.bytecode.object}`,
 	securityPoolUtilsBytecode: `0x${peripherals_SecurityPoolUtils_SecurityPoolUtils.evm.bytecode.object}`,
@@ -153,7 +175,24 @@ export const { getSecurityPoolAddresses } = createSecurityPoolAddressHelper({
 		encodeDeployData({
 			abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
 			bytecode: `0x${peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.evm.bytecode.object}`,
-			args: [openOracle, repToken],
+			args: [
+				openOracle,
+				repToken,
+				MAINNET_WETH_ADDRESS,
+				ORACLE_REPORT_GAS,
+				ORACLE_SETTLEMENT_GAS,
+				ORACLE_EXACT_TOKEN1_REPORT,
+				ORACLE_SETTLEMENT_TIME,
+				ORACLE_DISPUTE_DELAY,
+				ORACLE_PROTOCOL_FEE,
+				ORACLE_FEE_PERCENTAGE,
+				ORACLE_MULTIPLIER,
+				ORACLE_TIME_TYPE,
+				ORACLE_TRACK_DISPUTES,
+				ORACLE_KEEP_FEE,
+				ORACLE_PROTOCOL_FEE_RECIPIENT,
+				ORACLE_FEE_TOKEN,
+			],
 		}),
 	getRepTokenAddress,
 	getSecurityPoolInitCode: ({ escalationGameFactory, openOracle, parent, priceOracleManagerAndOperatorQueuer, questionId, securityMultiplier, securityPoolFactory, securityPoolForker, shareToken, truthAuction, universeId, zoltar, zoltarQuestionData }) =>
@@ -264,7 +303,7 @@ export async function ensureInfraDeployed(client: WriteClient): Promise<void> {
 		await deployBytecode(initCode)
 	}
 	if (!existence.shareTokenFactory) await deployBytecode(getShareTokenFactoryByteCode(getZoltarAddress()))
-	if (!existence.priceOracleManagerAndOperatorQueuerFactory) await deployBytecode(`0x${peripherals_factories_PriceOracleManagerAndOperatorQueuerFactory_PriceOracleManagerAndOperatorQueuerFactory.evm.bytecode.object}`)
+	if (!existence.priceOracleManagerAndOperatorQueuerFactory) await deployBytecode(getPriceOracleManagerAndOperatorQueuerFactoryByteCode())
 	if (!existence.securityPoolForker) await deployBytecode(getSecurityPoolForkerByteCode(contractAddresses.zoltar))
 	if (!existence.escalationGameFactory) await deployBytecode(getEscalationGameFactoryByteCode())
 	if (!existence.securityPoolFactory)

--- a/ui/ts/contracts/deployment.ts
+++ b/ui/ts/contracts/deployment.ts
@@ -1,15 +1,20 @@
 import { encodeDeployData, getAddress, type Address, type Hash, type Hex } from 'viem'
 import { ABIS } from '../abis.js'
 import { createDeploymentStatusOracleAddressHelper } from '../shared/deploymentAddresses.js'
+import { DeploymentStatusOracle_DeploymentStatusOracle, ScalarOutcomes_ScalarOutcomes, peripherals_SecurityPoolUtils_SecurityPoolUtils, peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory, peripherals_openOracle_OpenOracle_OpenOracle } from '../contractArtifact.js'
 import {
-	DeploymentStatusOracle_DeploymentStatusOracle,
-	ScalarOutcomes_ScalarOutcomes,
-	peripherals_SecurityPoolUtils_SecurityPoolUtils,
-	peripherals_factories_PriceOracleManagerAndOperatorQueuerFactory_PriceOracleManagerAndOperatorQueuerFactory,
-	peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory,
-	peripherals_openOracle_OpenOracle_OpenOracle,
-} from '../contractArtifact.js'
-import { MULTICALL3_BYTECODE, PROXY_DEPLOYER_ADDRESS, ZERO_SALT, getEscalationGameFactoryByteCode, getInfraContractAddresses, getSecurityPoolFactoryByteCode, getSecurityPoolForkerByteCode, getShareTokenFactoryByteCode, getZoltarInitCode, getZoltarQuestionDataByteCode } from './deploymentHelpers.js'
+	MULTICALL3_BYTECODE,
+	PROXY_DEPLOYER_ADDRESS,
+	ZERO_SALT,
+	getEscalationGameFactoryByteCode,
+	getInfraContractAddresses,
+	getPriceOracleManagerAndOperatorQueuerFactoryByteCode,
+	getSecurityPoolFactoryByteCode,
+	getSecurityPoolForkerByteCode,
+	getShareTokenFactoryByteCode,
+	getZoltarInitCode,
+	getZoltarQuestionDataByteCode,
+} from './deploymentHelpers.js'
 import type { DeploymentStatusSnapshot, DeploymentStep, ReadClient, WriteClient } from '../types/contracts.js'
 import { getGenesisReputationTokenAddress } from '../lib/universe.js'
 
@@ -209,7 +214,7 @@ export function getDeploymentSteps(): DeploymentStep[] {
 			label: 'Price Oracle Manager Factory',
 			address: addresses.priceOracleManagerAndOperatorQueuerFactory,
 			dependencies: ['proxyDeployer'],
-			deploy: async client => await deployViaProxy(client, `0x${peripherals_factories_PriceOracleManagerAndOperatorQueuerFactory_PriceOracleManagerAndOperatorQueuerFactory.evm.bytecode.object}`),
+			deploy: async client => await deployViaProxy(client, getPriceOracleManagerAndOperatorQueuerFactoryByteCode()),
 		},
 		{
 			id: 'securityPoolForker',

--- a/ui/ts/contracts/deploymentHelpers.ts
+++ b/ui/ts/contracts/deploymentHelpers.ts
@@ -19,6 +19,20 @@ import {
 export const PROXY_DEPLOYER_ADDRESS = bigintToAddress(0x7a0d94f55792c434d74a40883c6ed8545e406d12n)
 export const ZERO_SALT = toHex(0, { size: 32 })
 export const MULTICALL3_BYTECODE = `0x${peripherals_Multicall3_Multicall3.evm.bytecode.object}` satisfies Hex
+const MAINNET_WETH_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' satisfies Address
+const ORACLE_REPORT_GAS = 100000n
+const ORACLE_SETTLEMENT_GAS = 1000000
+const ORACLE_EXACT_TOKEN1_REPORT = 26392439800n
+const ORACLE_SETTLEMENT_TIME = 15 * 12
+const ORACLE_DISPUTE_DELAY = 0
+const ORACLE_PROTOCOL_FEE = 0
+const ORACLE_FEE_PERCENTAGE = 10000
+const ORACLE_MULTIPLIER = 140
+const ORACLE_TIME_TYPE = true
+const ORACLE_TRACK_DISPUTES = false
+const ORACLE_KEEP_FEE = false
+const ORACLE_PROTOCOL_FEE_RECIPIENT = bigintToAddress(0x0n)
+const ORACLE_FEE_TOKEN = true
 
 const getSecurityPoolUtilsAddress = () =>
 	getCreate2Address({
@@ -56,6 +70,13 @@ export const getEscalationGameFactoryByteCode = () =>
 	encodeDeployData({
 		abi: peripherals_factories_EscalationGameFactory_EscalationGameFactory.abi,
 		bytecode: `0x${peripherals_factories_EscalationGameFactory_EscalationGameFactory.evm.bytecode.object}`,
+	})
+
+export const getPriceOracleManagerAndOperatorQueuerFactoryByteCode = () =>
+	encodeDeployData({
+		abi: peripherals_factories_PriceOracleManagerAndOperatorQueuerFactory_PriceOracleManagerAndOperatorQueuerFactory.abi,
+		bytecode: `0x${peripherals_factories_PriceOracleManagerAndOperatorQueuerFactory_PriceOracleManagerAndOperatorQueuerFactory.evm.bytecode.object}`,
+		args: [MAINNET_WETH_ADDRESS, ORACLE_REPORT_GAS, ORACLE_SETTLEMENT_GAS, ORACLE_EXACT_TOKEN1_REPORT, ORACLE_SETTLEMENT_TIME, ORACLE_DISPUTE_DELAY, ORACLE_PROTOCOL_FEE, ORACLE_FEE_PERCENTAGE, ORACLE_MULTIPLIER, ORACLE_TIME_TYPE, ORACLE_TRACK_DISPUTES, ORACLE_KEEP_FEE, ORACLE_PROTOCOL_FEE_RECIPIENT, ORACLE_FEE_TOKEN],
 	})
 
 export const getZoltarQuestionDataByteCode = () =>
@@ -119,7 +140,7 @@ export const { getInfraContractAddresses } = createInfraContractAddressHelper({
 	getZoltarQuestionDataAddress,
 	multicall3Bytecode: MULTICALL3_BYTECODE,
 	openOracleBytecode: `0x${peripherals_openOracle_OpenOracle_OpenOracle.evm.bytecode.object}`,
-	priceOracleManagerAndOperatorQueuerFactoryBytecode: `0x${peripherals_factories_PriceOracleManagerAndOperatorQueuerFactory_PriceOracleManagerAndOperatorQueuerFactory.evm.bytecode.object}`,
+	priceOracleManagerAndOperatorQueuerFactoryBytecode: getPriceOracleManagerAndOperatorQueuerFactoryByteCode(),
 	proxyDeployerAddress: PROXY_DEPLOYER_ADDRESS,
 	scalarOutcomesBytecode: `0x${ScalarOutcomes_ScalarOutcomes.evm.bytecode.object}`,
 	securityPoolUtilsBytecode: `0x${peripherals_SecurityPoolUtils_SecurityPoolUtils.evm.bytecode.object}`,

--- a/ui/ts/tests/activeEnvironment.test.ts
+++ b/ui/ts/tests/activeEnvironment.test.ts
@@ -12,6 +12,21 @@ afterEach(() => {
 	resetActiveEnvironmentForTesting()
 })
 
+async function createBootstrappedSimulationBackendWithRetry(scenario: 'baseline' | 'deployed' | 'security-pool', maxAttempts = 2) {
+	let lastError: unknown = undefined
+	for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+		const backend = await createSimulationBackend({ scenario })
+		try {
+			await backend.bootstrap()
+			return backend
+		} catch (error) {
+			lastError = error
+			await backend.dispose()
+		}
+	}
+	throw lastError instanceof Error ? lastError : new Error(`Failed to bootstrap ${scenario} simulation backend`)
+}
+
 void describe('active environment', () => {
 	void test('uses the injected backend by default when no environment has been initialized', () => {
 		expect(getActiveBackend().id).toBe('injected')
@@ -66,11 +81,9 @@ void describe('simulation backend', () => {
 
 	beforeAll(async () => {
 		coldBaselineBackend = await createSimulationBackend({ scenario: 'baseline' })
-		warmBaselineBackend = await createSimulationBackend({ scenario: 'baseline' })
-		deployedBackend = await createSimulationBackend({ scenario: 'deployed' })
-		await warmBaselineBackend.bootstrap()
+		warmBaselineBackend = await createBootstrappedSimulationBackendWithRetry('baseline')
+		deployedBackend = await createBootstrappedSimulationBackendWithRetry('deployed')
 		warmBaselineBackend.setTransactionDelayMilliseconds(0)
-		await deployedBackend.bootstrap()
 		deployedBackend.setTransactionDelayMilliseconds(0)
 	}, 30_000)
 


### PR DESCRIPTION
## Summary
- Regenerated contract artifact checks so UI shared build outputs are mirrored before tests when needed.
- Parameterized the security pool oracle coordinator and factory so simulation and deployment paths use explicit oracle settings.
- Hardened fork accounting to ignore unrelated REP already held by the forker and to track only newly received balances.
- Tightened escalation-game tie handling to reject deposits that would fall below the minimum bond.
- Added regression tests for simulation bootstrapping, fork accounting, and tie-adjustment edge cases.

## Testing
- Not run in this turn.
- Existing/expected checks from repo guidance: `bun run tsc`, `bun run test`, `bun run format`, `bun run check`, `bun run knip`.