### PR TITLE
Move UI route state into the hash fragment

### DIFF
--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -27,16 +27,12 @@ import { createLoadSecurityVaultHandler } from './lib/securityVaultHandlers.js'
 import { getUseQuestionForPoolState } from './lib/securityPoolNavigation.js'
 import { createInitialTransactionState, markTransactionFinished, markTransactionRequested, markTransactionSubmitted } from './lib/transactionState.js'
 import type { TransactionState } from './lib/transactionState.js'
-import { DEPLOY_ROUTE, OPEN_ORACLE_ROUTE, SECURITY_POOLS_ROUTE, ZOLTAR_ROUTE } from './lib/routing.js'
+import { buildRouteHref, DEPLOY_ROUTE, getRouteHashSearch, OPEN_ORACLE_ROUTE, SECURITY_POOLS_ROUTE, ZOLTAR_ROUTE } from './lib/routing.js'
 import { writeOpenOracleViewQueryParam, writeSecurityPoolsViewQueryParam, writeZoltarViewQueryParam } from './lib/urlParams.js'
 import { getUniversePresentation, getWalletPresentation } from './lib/userCopy.js'
 import { formatUniverseCollectionLabel } from './lib/universe.js'
 import { resolveEnumValue, resolveFirstMatchingValue } from './lib/viewState.js'
 import type { DeploymentRouteContentProps, MarketRouteContentProps, OpenOracleSectionProps, OpenOracleView, SecurityPoolsSectionProps, SecurityPoolsView, ZoltarView } from './types/components.js'
-
-function getRouteHref(routeHash: string, nextSearch: string) {
-	return `${window.location.pathname}${nextSearch}${routeHash}`
-}
 
 export function App() {
 	const transactionState = useSignal<TransactionState>(createInitialTransactionState())
@@ -621,14 +617,14 @@ export function App() {
 				value={activeZoltarView}
 				onChange={view => setZoltarView(view)}
 				options={[
-					{ href: getRouteHref(ZOLTAR_ROUTE, writeZoltarViewQueryParam(window.location.search, 'questions')), label: 'Questions', value: 'questions' },
-					{ href: getRouteHref(ZOLTAR_ROUTE, writeZoltarViewQueryParam(window.location.search, 'create')), label: 'Create Question', value: 'create' },
-					{ href: getRouteHref(ZOLTAR_ROUTE, writeZoltarViewQueryParam(window.location.search, 'fork')), label: 'Fork Zoltar', value: 'fork' },
+					{ href: buildRouteHref(ZOLTAR_ROUTE, writeZoltarViewQueryParam(getRouteHashSearch(), 'questions')), label: 'Questions', value: 'questions' },
+					{ href: buildRouteHref(ZOLTAR_ROUTE, writeZoltarViewQueryParam(getRouteHashSearch(), 'create')), label: 'Create Question', value: 'create' },
+					{ href: buildRouteHref(ZOLTAR_ROUTE, writeZoltarViewQueryParam(getRouteHashSearch(), 'fork')), label: 'Fork Zoltar', value: 'fork' },
 					{
 						label: 'Migrate REP',
 						value: 'migrate',
 						disabled: zoltarUniverse?.hasForked !== true,
-						...(zoltarUniverse?.hasForked === true ? { href: getRouteHref(ZOLTAR_ROUTE, writeZoltarViewQueryParam(window.location.search, 'migrate')) } : { reason: 'Fork Zoltar before migrating REP.' }),
+						...(zoltarUniverse?.hasForked === true ? { href: buildRouteHref(ZOLTAR_ROUTE, writeZoltarViewQueryParam(getRouteHashSearch(), 'migrate')) } : { reason: 'Fork Zoltar before migrating REP.' }),
 					},
 				]}
 			/>
@@ -638,9 +634,9 @@ export function App() {
 				value={activeSecurityPoolsView}
 				onChange={view => setSecurityPoolsView(view)}
 				options={[
-					{ href: getRouteHref(SECURITY_POOLS_ROUTE, writeSecurityPoolsViewQueryParam(window.location.search, 'browse')), label: 'Browse', value: 'browse' },
-					{ href: getRouteHref(SECURITY_POOLS_ROUTE, writeSecurityPoolsViewQueryParam(window.location.search, 'create')), label: 'Create', value: 'create' },
-					{ href: getRouteHref(SECURITY_POOLS_ROUTE, writeSecurityPoolsViewQueryParam(window.location.search, 'operate')), label: 'Operate', value: 'operate' },
+					{ href: buildRouteHref(SECURITY_POOLS_ROUTE, writeSecurityPoolsViewQueryParam(getRouteHashSearch(), 'browse')), label: 'Browse', value: 'browse' },
+					{ href: buildRouteHref(SECURITY_POOLS_ROUTE, writeSecurityPoolsViewQueryParam(getRouteHashSearch(), 'create')), label: 'Create', value: 'create' },
+					{ href: buildRouteHref(SECURITY_POOLS_ROUTE, writeSecurityPoolsViewQueryParam(getRouteHashSearch(), 'operate')), label: 'Operate', value: 'operate' },
 				]}
 			/>
 		) : route === 'open-oracle' ? (
@@ -649,9 +645,9 @@ export function App() {
 				value={activeOpenOracleView}
 				onChange={view => setOpenOracleView(view)}
 				options={[
-					{ href: getRouteHref(OPEN_ORACLE_ROUTE, writeOpenOracleViewQueryParam(window.location.search, 'browse')), label: 'Browse', value: 'browse' },
-					{ href: getRouteHref(OPEN_ORACLE_ROUTE, writeOpenOracleViewQueryParam(window.location.search, 'create')), label: 'Create', value: 'create' },
-					{ href: getRouteHref(OPEN_ORACLE_ROUTE, writeOpenOracleViewQueryParam(window.location.search, 'selected-report')), label: 'Selected Report', value: 'selected-report' },
+					{ href: buildRouteHref(OPEN_ORACLE_ROUTE, writeOpenOracleViewQueryParam(getRouteHashSearch(), 'browse')), label: 'Browse', value: 'browse' },
+					{ href: buildRouteHref(OPEN_ORACLE_ROUTE, writeOpenOracleViewQueryParam(getRouteHashSearch(), 'create')), label: 'Create', value: 'create' },
+					{ href: buildRouteHref(OPEN_ORACLE_ROUTE, writeOpenOracleViewQueryParam(getRouteHashSearch(), 'selected-report')), label: 'Selected Report', value: 'selected-report' },
 				]}
 			/>
 		) : undefined

--- a/ui/ts/hooks/useUrlState.ts
+++ b/ui/ts/hooks/useUrlState.ts
@@ -1,5 +1,6 @@
 import { useSignal } from '@preact/signals'
 import { useCallback, useEffect } from 'preact/hooks'
+import { buildRouteHref, getCurrentRouteHash, getRouteHashSearch } from '../lib/routing.js'
 import {
 	readOpenOracleViewQueryParam,
 	readOpenOracleReportIdQueryParam,
@@ -49,33 +50,43 @@ function readUrlState(search: string): UrlState {
 	}
 }
 
+function getCurrentUrlStateSearch() {
+	return getRouteHashSearch()
+}
+
+function readCurrentUrlState() {
+	return readUrlState(getCurrentUrlStateSearch())
+}
+
 function pushCurrentUrl(nextSearch: string) {
-	window.history.pushState({}, '', `${window.location.pathname}${nextSearch}${window.location.hash}`)
+	window.history.pushState({}, '', buildRouteHref(getCurrentRouteHash(), nextSearch))
 }
 
 export function useUrlState(): UseUrlStateResult {
-	const urlState = useSignal<UrlState>(readUrlState(window.location.search))
+	const urlState = useSignal<UrlState>(readCurrentUrlState())
 
 	useEffect(() => {
-		const onPopState = () => {
-			urlState.value = readUrlState(window.location.search)
+		const syncUrlState = () => {
+			urlState.value = readCurrentUrlState()
 		}
 
-		window.addEventListener('popstate', onPopState)
+		window.addEventListener('hashchange', syncUrlState)
+		window.addEventListener('popstate', syncUrlState)
 		return () => {
-			window.removeEventListener('popstate', onPopState)
+			window.removeEventListener('hashchange', syncUrlState)
+			window.removeEventListener('popstate', syncUrlState)
 		}
 	}, [])
 
 	const applyUrlStateUpdate = useCallback((nextSearch: string) => {
-		if (nextSearch === window.location.search) return
+		if (nextSearch === getCurrentUrlStateSearch()) return
 		pushCurrentUrl(nextSearch)
 		urlState.value = readUrlState(nextSearch)
 	}, [])
 
 	const setActiveUniverseId = useCallback(
 		(universeId: bigint | undefined) => {
-			const nextSearch = writeUniverseQueryParam(window.location.search, universeId)
+			const nextSearch = writeUniverseQueryParam(getCurrentUrlStateSearch(), universeId)
 			applyUrlStateUpdate(nextSearch)
 		},
 		[applyUrlStateUpdate],
@@ -83,7 +94,7 @@ export function useUrlState(): UseUrlStateResult {
 
 	const setSecurityPoolAddress = useCallback(
 		(securityPoolAddress: string) => {
-			const nextSearch = writeSecurityPoolQueryParam(window.location.search, securityPoolAddress === '' ? undefined : securityPoolAddress)
+			const nextSearch = writeSecurityPoolQueryParam(getCurrentUrlStateSearch(), securityPoolAddress === '' ? undefined : securityPoolAddress)
 			applyUrlStateUpdate(nextSearch)
 		},
 		[applyUrlStateUpdate],
@@ -91,7 +102,7 @@ export function useUrlState(): UseUrlStateResult {
 
 	const setOpenOracleReport = useCallback(
 		(reportId: string | undefined) => {
-			const nextSearch = writeOpenOracleReportIdQueryParam(window.location.search, reportId === '' ? undefined : reportId)
+			const nextSearch = writeOpenOracleReportIdQueryParam(getCurrentUrlStateSearch(), reportId === '' ? undefined : reportId)
 			applyUrlStateUpdate(nextSearch)
 		},
 		[applyUrlStateUpdate],
@@ -99,7 +110,7 @@ export function useUrlState(): UseUrlStateResult {
 
 	const setOpenOracleView = useCallback(
 		(view: string | undefined) => {
-			const nextSearch = writeOpenOracleViewQueryParam(window.location.search, view === '' ? undefined : view)
+			const nextSearch = writeOpenOracleViewQueryParam(getCurrentUrlStateSearch(), view === '' ? undefined : view)
 			applyUrlStateUpdate(nextSearch)
 		},
 		[applyUrlStateUpdate],
@@ -107,7 +118,7 @@ export function useUrlState(): UseUrlStateResult {
 
 	const setSecurityPoolsView = useCallback(
 		(view: string | undefined) => {
-			const nextSearch = writeSecurityPoolsViewQueryParam(window.location.search, view === '' ? undefined : view)
+			const nextSearch = writeSecurityPoolsViewQueryParam(getCurrentUrlStateSearch(), view === '' ? undefined : view)
 			applyUrlStateUpdate(nextSearch)
 		},
 		[applyUrlStateUpdate],
@@ -115,7 +126,7 @@ export function useUrlState(): UseUrlStateResult {
 
 	const setSelectedPoolView = useCallback(
 		(view: string | undefined) => {
-			const nextSearch = writeSelectedPoolViewQueryParam(window.location.search, view === '' ? undefined : view)
+			const nextSearch = writeSelectedPoolViewQueryParam(getCurrentUrlStateSearch(), view === '' ? undefined : view)
 			applyUrlStateUpdate(nextSearch)
 		},
 		[applyUrlStateUpdate],
@@ -123,7 +134,7 @@ export function useUrlState(): UseUrlStateResult {
 
 	const setZoltarView = useCallback(
 		(view: string | undefined) => {
-			const nextSearch = writeZoltarViewQueryParam(window.location.search, view === '' ? undefined : view)
+			const nextSearch = writeZoltarViewQueryParam(getCurrentUrlStateSearch(), view === '' ? undefined : view)
 			applyUrlStateUpdate(nextSearch)
 		},
 		[applyUrlStateUpdate],

--- a/ui/ts/lib/activeEnvironment.ts
+++ b/ui/ts/lib/activeEnvironment.ts
@@ -6,6 +6,7 @@ import { createSimulationBackend } from '../simulation/tevmBackend.js'
 import { normalizeSimulationScenario, type SimulationScenario } from '../simulation/scenarios.js'
 
 type LocationLike = {
+	hash?: string
 	hostname: string
 	search: string
 }
@@ -15,13 +16,26 @@ const injectedBackend = createInjectedBackend()
 let activeBackend: ChainBackend | undefined = undefined
 let activeSimulationController: SimulationController | undefined = undefined
 
-export function shouldUseSimulationLocation(location: LocationLike) {
+function readLocationParams(location: LocationLike) {
 	const params = new URLSearchParams(location.search)
+	const hash = location.hash ?? ''
+	const queryIndex = hash.indexOf('?')
+	if (queryIndex === -1) return params
+
+	for (const [key, value] of new URLSearchParams(hash.slice(queryIndex))) {
+		params.set(key, value)
+	}
+
+	return params
+}
+
+export function shouldUseSimulationLocation(location: LocationLike) {
+	const params = readLocationParams(location)
 	return params.get('simulate') === '1'
 }
 
-function getSimulationScenario(search: string): SimulationScenario {
-	const params = new URLSearchParams(search)
+function getSimulationScenario(location: LocationLike): SimulationScenario {
+	const params = readLocationParams(location)
 	return normalizeSimulationScenario(params.get('simScenario') ?? undefined)
 }
 
@@ -37,7 +51,7 @@ export async function initializeActiveEnvironment(location: LocationLike = windo
 	}
 
 	const simulationBackend = await createSimulationBackend({
-		scenario: getSimulationScenario(location.search),
+		scenario: getSimulationScenario(location),
 	})
 	activeBackend = simulationBackend
 	activeSimulationController = simulationBackend

--- a/ui/ts/lib/routing.ts
+++ b/ui/ts/lib/routing.ts
@@ -18,6 +18,21 @@ const ROUTE_BY_HASH = ROUTE_NAMES.reduce<Partial<Record<string, Route>>>((routeB
 	return routeByHash
 }, {})
 
+function splitRouteHash(hash: string) {
+	const queryIndex = hash.indexOf('?')
+	if (queryIndex === -1) {
+		return {
+			routeHash: hash,
+			search: '',
+		}
+	}
+
+	return {
+		routeHash: hash.slice(0, queryIndex),
+		search: hash.slice(queryIndex),
+	}
+}
+
 export function ensureRouteHash() {
 	if (window.location.hash === '') {
 		window.location.hash = ROUTE_HASHES[DEFAULT_ROUTE]
@@ -25,9 +40,23 @@ export function ensureRouteHash() {
 }
 
 export function getCurrentRoute() {
-	return ROUTE_BY_HASH[window.location.hash] ?? (window.location.hash === '' ? DEFAULT_ROUTE : 'not-found')
+	const { routeHash } = splitRouteHash(window.location.hash)
+	return ROUTE_BY_HASH[routeHash] ?? (routeHash === '' ? DEFAULT_ROUTE : 'not-found')
 }
 
 export function getRouteHash(route: Exclude<Route, 'not-found'>) {
 	return ROUTE_HASHES[route]
+}
+
+export function getRouteHashSearch(hash = window.location.hash) {
+	return splitRouteHash(hash).search
+}
+
+export function getCurrentRouteHash() {
+	const { routeHash } = splitRouteHash(window.location.hash)
+	return routeHash === '' ? ROUTE_HASHES[DEFAULT_ROUTE] : routeHash
+}
+
+export function buildRouteHref(routeHash: string, search: string) {
+	return `${routeHash}${search}`
 }

--- a/ui/ts/lib/universe.ts
+++ b/ui/ts/lib/universe.ts
@@ -1,4 +1,5 @@
 import { getActiveNetworkProfile } from './activeEnvironment.js'
+import { buildRouteHref, getCurrentRouteHash, getRouteHashSearch } from './routing.js'
 import { readUniverseQueryParam, writeUniverseQueryParam } from './urlParams.js'
 
 export function getGenesisReputationTokenAddress() {
@@ -10,12 +11,12 @@ export function formatUniverseLabel(universeId: bigint) {
 }
 
 export function getUniverseLinkHref(universeId: bigint) {
-	const nextSearch = writeUniverseQueryParam(window.location.search, universeId)
-	return `${window.location.pathname}${nextSearch}${window.location.hash}`
+	const nextSearch = writeUniverseQueryParam(getRouteHashSearch(), universeId)
+	return buildRouteHref(getCurrentRouteHash(), nextSearch)
 }
 
 export function navigateToUniverse(universeId: bigint) {
-	const currentUniverseId = readUniverseQueryParam(window.location.search)
+	const currentUniverseId = readUniverseQueryParam(getRouteHashSearch())
 	if (currentUniverseId === universeId) return
 
 	window.history.pushState({}, '', getUniverseLinkHref(universeId))

--- a/ui/ts/simulation/tevmBackend.ts
+++ b/ui/ts/simulation/tevmBackend.ts
@@ -65,7 +65,8 @@ export async function createSimulationBackend({ scenario }: { scenario: Simulati
 	}
 	const profile = createSimulationProfile(predictSimulationTokenAddresses(primaryAccount))
 	const listeners = createListenerMap()
-	const worker = new Worker(resolveWorkerPath(), { type: 'module' })
+	const workerPath = resolveWorkerPath()
+	const worker = new Worker(workerPath, { type: 'module' })
 	const pendingRequests = new Map<number, PendingRequest>()
 	let nextRequestId = 1
 	let currentState: SimulationWorkerState | undefined = undefined
@@ -168,7 +169,11 @@ export async function createSimulationBackend({ scenario }: { scenario: Simulati
 			}
 		}
 		worker.onerror = event => {
-			reject(new Error(event.message || 'Simulation worker failed'))
+			const locationSuffix = event.filename === undefined || event.filename === '' ? '' : ` at ${event.filename}${event.lineno === 0 ? '' : `:${event.lineno}${event.colno === 0 ? '' : `:${event.colno}`}`}`
+			reject(new Error(`${event.message || 'Simulation worker failed'}${locationSuffix} (worker: ${workerPath.toString()})`))
+		}
+		worker.onmessageerror = () => {
+			reject(new Error(`Simulation worker message deserialization failed (worker: ${workerPath.toString()})`))
 		}
 		worker.postMessage({
 			scenario,

--- a/ui/ts/tests/activeEnvironment.test.ts
+++ b/ui/ts/tests/activeEnvironment.test.ts
@@ -38,6 +38,7 @@ void describe('active environment', () => {
 		expect(shouldUseSimulationLocation({ hostname: 'localhost', search: '?simulate=1' })).toBe(true)
 		expect(shouldUseSimulationLocation({ hostname: '127.0.0.1', search: '?foo=bar&simulate=1' })).toBe(true)
 		expect(shouldUseSimulationLocation({ hostname: 'example.com', search: '?simulate=1' })).toBe(true)
+		expect(shouldUseSimulationLocation({ hash: '#/zoltar?simulate=1', hostname: 'example.com', search: '' })).toBe(true)
 		expect(shouldUseSimulationLocation({ hostname: 'localhost', search: '?simulate=0' })).toBe(false)
 		expect(shouldUseSimulationLocation({ hostname: 'example.com', search: '?foo=bar' })).toBe(false)
 	})

--- a/ui/ts/tests/appRouteEffects.integration.test.tsx
+++ b/ui/ts/tests/appRouteEffects.integration.test.tsx
@@ -165,21 +165,21 @@ describe('app route effects integration', () => {
 		await act(() => {
 			fireEvent.click(within(document.body).getByRole('button', { name: 'Set Report' }))
 		})
-		expect(window.location.search).toContain('openOracleReportId=42')
+		expect(window.location.hash).toContain('openOracleReportId=42')
 		expect(document.getElementById('report-id')?.textContent).toBe('42')
 
 		await act(() => {
 			fireEvent.click(within(document.body).getByRole('button', { name: 'Set Pool' }))
 		})
-		expect(window.location.search).toContain('securityPool=0x84834d4Dccea071b363e53952BD300F7bf56a009')
+		expect(window.location.hash).toContain('securityPool=0x84834d4Dccea071b363e53952BD300F7bf56a009')
 
 		await act(() => {
 			window.history.back()
 			window.dispatchEvent(new Event('popstate'))
 		})
 
-		expect(window.location.search).toContain('openOracleReportId=42')
-		expect(window.location.search).not.toContain('securityPool=')
+		expect(window.location.hash).toContain('openOracleReportId=42')
+		expect(window.location.hash).not.toContain('securityPool=')
 		expect(document.getElementById('report-id')?.textContent).toBe('42')
 		expect(document.getElementById('security-pool')?.textContent).toBe('')
 

--- a/ui/ts/tests/routeSubNavigation.test.tsx
+++ b/ui/ts/tests/routeSubNavigation.test.tsx
@@ -29,8 +29,8 @@ describe('RouteSubNavigation', () => {
 				ariaLabel: 'Zoltar views',
 				onChange: () => undefined,
 				options: [
-					{ href: '/?zoltarView=questions#/zoltar', label: 'Questions', value: 'questions' },
-					{ href: '/?zoltarView=create#/zoltar', label: 'Create Question', value: 'create' },
+					{ href: '#/zoltar?zoltarView=questions', label: 'Questions', value: 'questions' },
+					{ href: '#/zoltar?zoltarView=create', label: 'Create Question', value: 'create' },
 				],
 				value: 'questions',
 			}),
@@ -44,6 +44,6 @@ describe('RouteSubNavigation', () => {
 
 		const questionsTab = documentQueries.getByRole('tab', { name: 'Questions' }) as HTMLAnchorElement
 		expect(questionsTab.tagName).toBe('A')
-		expect(questionsTab.getAttribute('href')).toBe('/?zoltarView=questions#/zoltar')
+		expect(questionsTab.getAttribute('href')).toBe('#/zoltar?zoltarView=questions')
 	})
 })

--- a/ui/ts/tests/routing.test.ts
+++ b/ui/ts/tests/routing.test.ts
@@ -1,0 +1,25 @@
+/// <reference types="bun-types" />
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { buildRouteHref, getCurrentRoute, getCurrentRouteHash, getRouteHashSearch, ZOLTAR_ROUTE } from '../lib/routing.js'
+import { installDomEnvironment } from './testUtils/domEnvironment.js'
+
+describe('routing', () => {
+	let cleanup: (() => void) | undefined
+
+	beforeEach(() => {
+		cleanup = installDomEnvironment('http://localhost/#/zoltar?zoltarView=create&simulate=1').cleanup
+	})
+
+	afterEach(() => {
+		cleanup?.()
+		cleanup = undefined
+	})
+
+	test('reads route and route-backed params from the hash fragment', () => {
+		expect(getCurrentRoute()).toBe('zoltar')
+		expect(getCurrentRouteHash()).toBe(ZOLTAR_ROUTE)
+		expect(getRouteHashSearch()).toBe('?zoltarView=create&simulate=1')
+		expect(buildRouteHref(ZOLTAR_ROUTE, '?zoltarView=questions')).toBe('#/zoltar?zoltarView=questions')
+	})
+})


### PR DESCRIPTION
## Summary
- Moved route-backed UI state from `window.location.search` into the hash fragment so navigation and tab state stay inside the client-side route.
- Updated URL state helpers, universe links, and route builders to read and write hash search params consistently.
- Extended simulation environment detection to recognize `simulate` and `simScenario` when they are present in the hash query.
- Added and updated tests covering hash-based routing, sub-navigation hrefs, and URL state behavior.

## Testing
- Not run (PR content only).
- Code changes include new/updated tests in `ui/ts/tests/routing.test.ts`, `ui/ts/tests/routeSubNavigation.test.tsx`, `ui/ts/tests/appRouteEffects.integration.test.tsx`, and `ui/ts/tests/activeEnvironment.test.ts`.