### PR TITLE
Hide security pool manager addresses

### DIFF
--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -592,9 +592,6 @@ export function SecurityPoolWorkflowSection({
 										priceValidUntilTimestamp={currentPoolOracleManagerDetails?.priceValidUntilTimestamp}
 									/>
 								</MetricField>
-								<MetricField label='Manager'>
-									<AddressValue address={loadedSelectedPool.managerAddress} />
-								</MetricField>
 								{loadedSelectedPool.systemState === 'operational' ? undefined : (
 									<>
 										<MetricField label='Fork Mode'>{loadedSelectedPool.forkOwnSecurityPool ? 'Own escalation fork' : 'Parent / Zoltar fork'}</MetricField>

--- a/ui/ts/components/SecurityPoolsOverviewSection.tsx
+++ b/ui/ts/components/SecurityPoolsOverviewSection.tsx
@@ -171,9 +171,6 @@ export function SecurityPoolsOverviewSection({
 											totalRepDeposit={pool.totalRepDeposit}
 											totalSecurityBondAllowance={pool.totalSecurityBondAllowance}
 										/>
-										<MetricField label='Manager'>
-											<AddressValue address={pool.managerAddress} />
-										</MetricField>
 										{pool.truthAuctionAddress === zeroAddress ? undefined : (
 											<MetricField label='Truth Auction'>
 												<AddressValue address={pool.truthAuctionAddress} />

--- a/ui/ts/tests/securityPoolWorkflowSection.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection.test.tsx
@@ -419,6 +419,7 @@ describe('SecurityPoolWorkflowSection', () => {
 		expect(documentQueries.queryByText(/^Blocked:/)).toBeNull()
 		expect(documentQueries.queryByText('Oracle Status')).toBeNull()
 		expect(documentQueries.queryByText('After market end')).toBeNull()
+		expect(documentQueries.queryByText('Manager')).toBeNull()
 		expect(documentQueries.queryByText('Truth Auction')).toBeNull()
 		expect(documentQueries.getByText('Security Multiplier')).not.toBeNull()
 		const directoryButton = documentQueries.getByRole('tab', { name: 'Directory' })

--- a/ui/ts/tests/securityPoolsSection.test.ts
+++ b/ui/ts/tests/securityPoolsSection.test.ts
@@ -577,6 +577,7 @@ void describe('SecurityPoolsSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const metricLabels = Array.from(document.body.querySelectorAll('.metric-label')).map(element => element.textContent?.trim() ?? '')
+		expect(metricLabels.includes('Manager')).toBe(false)
 		expect(metricLabels.includes('Truth Auction')).toBe(false)
 	})
 


### PR DESCRIPTION
## Summary
- Removed `Manager` address fields from the security pool workflow section and the security pools overview.
- Updated UI tests to assert that manager labels are no longer rendered.

## Testing
- Not run (PR content only).