### PR TITLE
Allow zero security bond allowances in the UI

### DIFF
--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -53,7 +53,16 @@ import { isMainnetChain } from '../lib/network.js'
 import { openInterestFeePerYearBigint } from '../lib/retentionRate.js'
 import { getVaultApprovalGuardMessage, getVaultClaimFeesGuardMessage, getVaultDepositGuardMessage, getVaultExecutePendingOperationGuardMessage, getVaultRequestPriceGuardMessage, getVaultSetSecurityBondAllowanceGuardMessage, getVaultWithdrawGuardMessage } from '../lib/securityVaultGuards.js'
 import { deriveTokenApprovalRequirement } from '../lib/tokenApproval.js'
-import { getSecurityVaultMaxBondAllowanceAmount, getSecurityVaultWithdrawableRepAmount, getSelectedVaultAddress, hasValidSecurityVaultOraclePrice, isSecurityVaultDepositBelowMinimum, isSelectedVaultOwnedByAccount as isSelectedVaultOwnedByAccountHelper, MIN_SECURITY_VAULT_REP_DEPOSIT } from '../lib/securityVault.js'
+import {
+	getSecurityVaultMaxBondAllowanceAmount,
+	getSecurityVaultWithdrawableRepAmount,
+	getSelectedVaultAddress,
+	hasValidSecurityVaultOraclePrice,
+	isSecurityVaultDepositBelowMinimum,
+	isSelectedVaultOwnedByAccount as isSelectedVaultOwnedByAccountHelper,
+	MIN_SECURITY_BOND_ALLOWANCE,
+	MIN_SECURITY_VAULT_REP_DEPOSIT,
+} from '../lib/securityVault.js'
 import { getPoolRegistryPresentation } from '../lib/userCopy.js'
 import { formatUniverseLabel } from '../lib/universe.js'
 import type { OracleManagerDetails, SecurityPoolSystemState } from '../types/contracts.js'
@@ -339,6 +348,7 @@ export function SecurityPoolWorkflowSection({
 		selectedVaultDetailsLoaded: selectedVaultDetails !== undefined,
 		selectedVaultIsOwnedByAccount,
 	})
+	const hasValidSecurityBondAllowanceAmount = securityBondAllowanceAmount !== undefined && securityBondAllowanceAmount >= 0n && (securityBondAllowanceAmount === 0n || securityBondAllowanceAmount >= MIN_SECURITY_BOND_ALLOWANCE)
 	const claimFeesGuardMessage = getVaultClaimFeesGuardMessage({
 		hasClaimableFees,
 		isMainnet,
@@ -1150,7 +1160,7 @@ export function SecurityPoolWorkflowSection({
 							items={[
 								{ key: 'owned', label: 'Selected vault is owned by the connected account', resolved: selectedVaultIsOwnedByAccount },
 								{ key: 'oracle', label: 'A valid oracle price is available', resolved: hasValidOraclePrice },
-								{ key: 'allowance', label: 'Allowance amount is greater than zero', resolved: securityBondAllowanceAmount !== undefined && securityBondAllowanceAmount > 0n },
+								{ key: 'allowance', label: `Allowance amount is zero or at least ${formatCurrencyBalance(MIN_SECURITY_BOND_ALLOWANCE)} ETH`, resolved: hasValidSecurityBondAllowanceAmount },
 							]}
 						/>
 						<div className='actions'>

--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -148,7 +148,6 @@ export function SecurityVaultSection({
 	const canClaimFees = selectedVaultIsOwnedByAccount && isMainnet && hasClaimableFees
 	const hasSufficientDepositAllowance = selectedVaultIsOwnedByAccount && depositAmount !== undefined && depositAmount > 0n && approvalRequirement.hasSufficientApproval
 	const hasInsufficientRepBalance = repBalanceGap !== undefined && repBalanceGap > 0n
-	const canSetSecurityBondAllowance = selectedVaultIsOwnedByAccount && isMainnet && securityVaultDetails !== undefined && hasValidOraclePrice && securityBondAllowanceAmount !== undefined && securityBondAllowanceAmount > 0n
 	const canWithdrawRep = selectedVaultIsOwnedByAccount && accountState.address !== undefined && isMainnet && hasValidOraclePrice && hasWithdrawAmount && withdrawableRepAmount !== undefined && withdrawableRepAmount > 0n
 	const claimFeesGuardMessage = getVaultClaimFeesGuardMessage({
 		hasClaimableFees,
@@ -361,7 +360,7 @@ export function SecurityVaultSection({
 								onClick={onSetSecurityBondAllowance}
 								pending={securityVaultActiveAction === 'queueSetSecurityBondAllowance'}
 								tone='secondary'
-								availability={{ disabled: !canSetSecurityBondAllowance, reason: setSecurityBondAllowanceGuardMessage }}
+								availability={{ disabled: setSecurityBondAllowanceGuardMessage !== undefined, reason: setSecurityBondAllowanceGuardMessage }}
 							/>
 						</div>
 					</>

--- a/ui/ts/hooks/useSecurityVaultOperations.ts
+++ b/ui/ts/hooks/useSecurityVaultOperations.ts
@@ -12,7 +12,7 @@ import { getErrorMessage } from '../lib/errors.js'
 import { parseAddressInput } from '../lib/inputs.js'
 import { getDefaultSecurityVaultFormState, parseRepAmountInput } from '../lib/marketForm.js'
 import { requireDefined } from '../lib/required.js'
-import { getSelectedVaultAddress } from '../lib/securityVault.js'
+import { getSelectedVaultAddress, MIN_SECURITY_BOND_ALLOWANCE } from '../lib/securityVault.js'
 import { buildWriteActionConfig, runWriteAction } from '../lib/writeAction.js'
 import { useRequestGuard } from '../lib/requestGuard.js'
 import type { SecurityVaultFormState, WriteOperationsParameters } from '../types/app.js'
@@ -224,7 +224,8 @@ export function useSecurityVaultOperations({ accountAddress, enabled, onTransact
 			'queueSetSecurityBondAllowance',
 			async (vaultAddress, securityPoolAddress) => {
 				const amount = parseRepAmountInput(securityVaultForm.value.securityBondAllowanceAmount, 'Security bond allowance')
-				if (amount <= 0n) throw new Error('Security bond allowance must be greater than zero')
+				if (amount < 0n) throw new Error('Security bond allowance must be zero or a positive amount')
+				if (amount !== 0n && amount < MIN_SECURITY_BOND_ALLOWANCE) throw new Error(`Security bond allowance must be zero or at least ${formatCurrencyBalance(MIN_SECURITY_BOND_ALLOWANCE)} ETH`)
 				const details = await loadExistingSecurityVaultDetails(securityPoolAddress, vaultAddress, 'Security pool does not exist')
 				if (details === undefined) return undefined
 				const managerDetails = await loadOracleManagerDetails(createConnectedReadClient(), details.managerAddress)

--- a/ui/ts/lib/securityVaultGuards.ts
+++ b/ui/ts/lib/securityVaultGuards.ts
@@ -82,8 +82,8 @@ export function getVaultSetSecurityBondAllowanceGuardMessage({
 	if (!isMainnet) return 'Switch to Ethereum mainnet before setting the security bond allowance.'
 	if (!selectedVaultDetailsLoaded) return 'Refresh the vault before setting the security bond allowance.'
 	if (!hasValidOraclePrice) return 'A valid oracle price is required before setting the security bond allowance.'
-	if (securityBondAllowanceAmount === undefined || securityBondAllowanceAmount <= 0n) return 'Enter a security bond allowance greater than zero.'
-	if (securityBondAllowanceAmount < MIN_SECURITY_BOND_ALLOWANCE) return `Enter at least ${formatCurrencyBalance(MIN_SECURITY_BOND_ALLOWANCE)} ETH for a non-zero allowance.`
+	if (securityBondAllowanceAmount === undefined || securityBondAllowanceAmount < 0n) return 'Enter a valid security bond allowance.'
+	if (securityBondAllowanceAmount !== 0n && securityBondAllowanceAmount < MIN_SECURITY_BOND_ALLOWANCE) return `Enter at least ${formatCurrencyBalance(MIN_SECURITY_BOND_ALLOWANCE)} ETH for a non-zero allowance.`
 	if (maxSecurityBondAllowanceAmount !== undefined && securityBondAllowanceAmount > maxSecurityBondAllowanceAmount) {
 		return `Reduce the security bond allowance to ${formatCurrencyBalance(maxSecurityBondAllowanceAmount)} ETH or less.`
 	}

--- a/ui/ts/tests/securityPoolWorkflowSection.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection.test.tsx
@@ -11,7 +11,7 @@ import type { ListedSecurityPool, MarketDetails, OracleManagerDetails, SecurityP
 import type { ForkAuctionRouteContentProps, ReportingRouteContentProps, SecurityPoolWorkflowRouteContentProps, SecurityVaultRouteContentProps, TradingRouteContentProps } from '../types/components.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
-import { expectTransactionButtonDisabled } from './testUtils/transactionActionButton.js'
+import { expectTransactionButtonDisabled, expectTransactionButtonEnabled } from './testUtils/transactionActionButton.js'
 
 function createAccountState(overrides: Partial<AccountState> = {}): AccountState {
 	return {
@@ -959,6 +959,57 @@ describe('SecurityPoolWorkflowSection', () => {
 		})
 
 		expect(formChanges.at(-1)).toEqual({ securityBondAllowanceAmount: '1.999999999999999999' })
+	})
+
+	test('allows clearing the bond allowance back to zero in the workflow modal', async () => {
+		const selectedPoolAddress = zeroAddress
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					accountState: createAccountState(),
+					poolOracleManagerDetails: createOracleManagerDetails({
+						isPriceValid: true,
+						lastPrice: 3n * 10n ** 18n,
+					}),
+					securityPoolAddress: selectedPoolAddress,
+					securityPools: [
+						createSelectedPool({
+							managerAddress: zeroAddress,
+							securityPoolAddress: selectedPoolAddress,
+							totalRepDeposit: 9n * 10n ** 18n,
+							totalSecurityBondAllowance: 2n * 10n ** 18n,
+						}),
+					],
+					securityVault: createSecurityVaultProps({
+						securityVaultDetails: createSecurityVaultDetails({
+							repDepositShare: 12n * 10n ** 18n,
+							securityBondAllowance: 1n * 10n ** 18n,
+							securityPoolAddress: selectedPoolAddress,
+							totalSecurityBondAllowance: 2n * 10n ** 18n,
+						}),
+						securityVaultForm: {
+							depositAmount: '',
+							repWithdrawAmount: '',
+							securityBondAllowanceAmount: '0',
+							securityPoolAddress: selectedPoolAddress,
+							selectedVaultAddress: zeroAddress,
+						},
+					}),
+					selectedPoolView: 'vaults',
+				})}
+				showHeader={false}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		await act(() => {
+			fireEvent.click(documentQueries.getAllByRole('button', { name: 'Set Bond Allowance' })[0] as HTMLElement)
+		})
+
+		const allowanceDialog = documentQueries.getByRole('dialog', { name: 'Set Bond Allowance' })
+		expect(within(allowanceDialog).queryByText(/^Blocked:/)).toBeNull()
+		expectTransactionButtonEnabled(allowanceDialog as HTMLElement, 'Set Security Bond Allowance')
 	})
 
 	test('hides the truth auction metric when the selected pool has no truth auction address', async () => {

--- a/ui/ts/tests/securityVaultGuards.test.ts
+++ b/ui/ts/tests/securityVaultGuards.test.ts
@@ -83,11 +83,22 @@ describe('security vault guards', () => {
 				hasValidOraclePrice: true,
 				isMainnet: true,
 				maxSecurityBondAllowanceAmount: undefined,
+				securityBondAllowanceAmount: undefined,
+				selectedVaultDetailsLoaded: true,
+				selectedVaultIsOwnedByAccount: true,
+			}),
+		).toBe('Enter a valid security bond allowance.')
+
+		expect(
+			getVaultSetSecurityBondAllowanceGuardMessage({
+				hasValidOraclePrice: true,
+				isMainnet: true,
+				maxSecurityBondAllowanceAmount: undefined,
 				securityBondAllowanceAmount: 0n,
 				selectedVaultDetailsLoaded: true,
 				selectedVaultIsOwnedByAccount: true,
 			}),
-		).toBe('Enter a security bond allowance greater than zero.')
+		).toBeUndefined()
 
 		expect(
 			getVaultSetSecurityBondAllowanceGuardMessage({

--- a/ui/ts/tests/securityVaultSection.test.tsx
+++ b/ui/ts/tests/securityVaultSection.test.tsx
@@ -9,6 +9,7 @@ import type { SecurityVaultDetails } from '../types/contracts.js'
 import type { SecurityVaultSectionProps } from '../types/components.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
+import { expectTransactionButtonDisabled, expectTransactionButtonEnabled } from './testUtils/transactionActionButton.js'
 
 function createAccountState(overrides: Partial<AccountState> = {}): AccountState {
 	return {
@@ -78,6 +79,25 @@ function createSecurityVaultSectionProps(overrides: Partial<SecurityVaultSection
 	}
 }
 
+function createOracleManagerDetails(): NonNullable<SecurityVaultSectionProps['oracleManagerDetails']> {
+	return {
+		callbackStateHash: undefined,
+		exactToken1Report: undefined,
+		isPriceValid: true,
+		lastPrice: 3n * 10n ** 18n,
+		lastSettlementTimestamp: 1n,
+		managerAddress: zeroAddress,
+		openOracleAddress: zeroAddress,
+		pendingOperation: undefined,
+		pendingOperationSlotId: 0n,
+		pendingReportId: 0n,
+		priceValidUntilTimestamp: 10n,
+		requestPriceEthCost: 0n,
+		token1: undefined,
+		token2: undefined,
+	}
+}
+
 describe('SecurityVaultSection', () => {
 	let restoreDomEnvironment: (() => void) | undefined
 	let cleanupRenderedComponent: (() => Promise<void>) | undefined
@@ -112,22 +132,7 @@ describe('SecurityVaultSection', () => {
 					onSecurityVaultFormChange: update => {
 						formChanges.push(update)
 					},
-					oracleManagerDetails: {
-						callbackStateHash: undefined,
-						exactToken1Report: undefined,
-						isPriceValid: true,
-						lastPrice: 3n * 10n ** 18n,
-						lastSettlementTimestamp: 1n,
-						managerAddress: zeroAddress,
-						openOracleAddress: zeroAddress,
-						pendingOperation: undefined,
-						pendingOperationSlotId: 0n,
-						pendingReportId: 0n,
-						priceValidUntilTimestamp: 10n,
-						requestPriceEthCost: 0n,
-						token1: undefined,
-						token2: undefined,
-					},
+					oracleManagerDetails: createOracleManagerDetails(),
 					securityVaultDetails: createSecurityVaultDetails({
 						repDepositShare: 6n * 10n ** 18n,
 						securityBondAllowance: 0n,
@@ -142,5 +147,45 @@ describe('SecurityVaultSection', () => {
 		fireEvent.click(documentQueries.getAllByRole('button', { name: 'Security Bond Allowance Amount' })[0] as HTMLElement)
 
 		expect(formChanges.at(-1)).toEqual({ securityBondAllowanceAmount: '1.999999999999999999' })
+	})
+
+	test('allows setting the security bond allowance to zero', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<SecurityVaultSection
+				{...createSecurityVaultSectionProps({
+					oracleManagerDetails: createOracleManagerDetails(),
+					securityVaultForm: {
+						depositAmount: '',
+						repWithdrawAmount: '',
+						securityBondAllowanceAmount: '0',
+						securityPoolAddress: zeroAddress,
+						selectedVaultAddress: zeroAddress,
+					},
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expectTransactionButtonEnabled(document.body, 'Set Security Bond Allowance')
+	})
+
+	test('blocks non-zero security bond allowances below the minimum', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<SecurityVaultSection
+				{...createSecurityVaultSectionProps({
+					oracleManagerDetails: createOracleManagerDetails(),
+					securityVaultForm: {
+						depositAmount: '',
+						repWithdrawAmount: '',
+						securityBondAllowanceAmount: '0.5',
+						securityPoolAddress: zeroAddress,
+						selectedVaultAddress: zeroAddress,
+					},
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expectTransactionButtonDisabled(document.body, 'Set Security Bond Allowance', 'Enter at least 1 ETH for a non-zero allowance.')
 	})
 })


### PR DESCRIPTION
## Summary
- Allow users to set a security bond allowance to `0` while still rejecting negative values and non-zero values below the minimum.
- Update security vault guard messages and workflow availability to treat zero as a valid allowance input.
- Hide manager addresses from the security pool overview and workflow details.
- Add and update tests covering zero-allowance behavior, minimum-threshold validation, and manager-address removal.

## Testing
- Not run (PR content only)
- Covered by updated unit tests in `ui/ts/tests/securityVaultGuards.test.ts`, `ui/ts/tests/securityVaultSection.test.tsx`, `ui/ts/tests/securityPoolWorkflowSection.test.tsx`, and `ui/ts/tests/securityPoolsSection.test.ts`