### PR TITLE
Add `securitypoolx2` simulation scenario and hide pool manager addresses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ This test-driven approach ensures:
 
 - - The UI supports a browser-local simulation harness behind the `?simulate=1` URL flag. Use `bun run ui:serve` and open `http://localhost:12345/?simulate=1` for walletless manual QA.
 - - Simulation mode is Tevm-backed, seeds QA accounts with ETH/WETH/REP, leaves the app contracts undeployed so the Deploy flow can be tested, and exposes developer-only controls in the yellow simulation banner.
-- - Supported simulation scenarios are `simScenario=baseline`, `simScenario=deployed`, and `simScenario=security-pool`.
+- - Supported simulation scenarios are `simScenario=baseline`, `simScenario=deployed`, `simScenario=security-pool`, and `simScenario=securitypoolx2`.
 - - Uniswap-backed REP pricing is intentionally disabled in simulation mode. Quote-dependent features should degrade gracefully rather than assuming mainnet liquidity exists.
 - - This is a TypeScript project. Do not inspect or work from `js/` files anywhere in the repository when there is a corresponding TypeScript source file.
 - - The project type-checks TypeScript before testing (`bun run tsc`). Generated JS or shared asset refreshes come from the setup/build scripts, not from `bun run tsc`.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Simulation mode details:
 
 - The activation flag is `?simulate=1`
 - The default seeded scenario is `?simulate=1&simScenario=baseline`
+- Supported seeded scenarios are `simScenario=baseline`, `simScenario=deployed`, `simScenario=security-pool`, and `simScenario=securitypoolx2`
 - The yellow simulation banner exposes developer-only controls for account switching, reset, block mining, time travel, blockchain time, block count, transaction count, and artificial transaction receipt delay
 - Uniswap-backed REP pricing is intentionally disabled in simulation mode, so quote-dependent UI paths degrade instead of using mainnet liquidity
 - The simulation chain is ephemeral and exists only in the current browser tab session

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -87,6 +87,8 @@ The simulation banner exposes:
 
 Simulation mode is intended for walletless or repeatable manual QA. It seeds known accounts and lets the operator move blockchain time forward without leaving the browser. Per the repo guidance, Uniswap-backed REP pricing is intentionally disabled in simulation mode, so quote-dependent features are expected to degrade gracefully rather than assume mainnet liquidity.
 
+Known simulation scenarios are `baseline`, `deployed`, `security-pool`, and `securitypoolx2`.
+
 ### Simulation Controls
 
 | Control | Purpose | Validation | Disabled when |

--- a/ui/ts/simulation/bootstrap.ts
+++ b/ui/ts/simulation/bootstrap.ts
@@ -15,7 +15,7 @@ import {
 	settleOracleReport,
 	submitInitialOracleReport,
 } from '../contracts.js'
-import { ReputationToken_ReputationToken, peripherals_WETH9_WETH9 } from '../contractArtifact.js'
+import { ReputationToken_ReputationToken, peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator, peripherals_WETH9_WETH9 } from '../contractArtifact.js'
 import type { ReadClient, WriteClient } from '../lib/chainBackend.js'
 import { MAINNET_WETH_ADDRESS, type NetworkProfile } from '../lib/networkProfile.js'
 import type { QuestionData } from '../types/contracts.js'
@@ -253,7 +253,39 @@ async function deploySimulationAppContracts(primaryWriteClient: WriteClient, mem
 	}
 }
 
-function createSecurityPoolSeedParameters(currentTimestamp: bigint): {
+type ProgressRange = {
+	end: number
+	start: number
+}
+
+type SeededSecurityPoolSpec = {
+	poolLabel: string
+	progressRange: ProgressRange
+	questionTitle: string
+	readyLabel: string
+	vaultAccounts: readonly Address[]
+}
+
+function createRangeProgressReporter(onProgress: BootstrapProgressHandler | undefined, range: ProgressRange, stepCount: number) {
+	let completedStepCount = 0
+
+	return async (label: string) => {
+		completedStepCount += 1
+		await reportBootstrapProgress(onProgress, label, range.start + (completedStepCount / Math.max(stepCount, 1)) * (range.end - range.start))
+	}
+}
+
+function requireQaAccount(account: Address | undefined, label: string) {
+	if (account === undefined) {
+		throw new Error(label)
+	}
+	return account
+}
+
+function createSecurityPoolSeedParameters(
+	currentTimestamp: bigint,
+	title: string,
+): {
 	marketType: 'binary'
 	outcomeLabels: string[]
 	questionData: QuestionData
@@ -269,12 +301,12 @@ function createSecurityPoolSeedParameters(currentTimestamp: bigint): {
 			endTime: currentTimestamp + 365n * DAY_IN_SECONDS,
 			numTicks: 0n,
 			startTime: 0n,
-			title: 'Will this resolve?',
+			title,
 		},
 	}
 }
 
-async function ensureSufficientWethBalance(readClient: ReadClient, writeClient: WriteClient, profile: NetworkProfile, accountAddress: Address, requiredAmount: bigint, onProgress: BootstrapProgressHandler | undefined) {
+async function ensureSufficientWethBalance(readClient: ReadClient, writeClient: WriteClient, profile: NetworkProfile, accountAddress: Address, requiredAmount: bigint) {
 	const currentBalance = await loadErc20Balance(readClient, profile.wethAddress, accountAddress)
 	if (currentBalance >= requiredAmount) return
 	const missingBalance = requiredAmount - currentBalance
@@ -283,94 +315,431 @@ async function ensureSufficientWethBalance(readClient: ReadClient, writeClient: 
 		value: missingBalance,
 	})
 	await writeClient.waitForTransactionReceipt({ hash })
-	await reportBootstrapProgress(onProgress, 'Wrapping additional WETH for seeded oracle report', 0.9)
 }
 
-async function seedSecurityPoolScenario({
-	createReadClient,
-	createWriteClient,
-	memoryClient,
-	onProgress,
-	primaryAccount,
-	profile,
-}: {
-	createReadClient: () => ReadClient
-	createWriteClient: (accountAddress: Address) => WriteClient
-	memoryClient: TevmLikeClient
-	onProgress: BootstrapProgressHandler | undefined
-	primaryAccount: Address
-	profile: NetworkProfile
-}) {
-	const primaryWriteClient = createWriteClient(primaryAccount)
-	const readClient = createReadClient()
-	const currentTimestamp = await getSimulationChainTimestamp(memoryClient)
-	const marketParameters = createSecurityPoolSeedParameters(currentTimestamp)
-	const marketResult = await createMarket(primaryWriteClient, marketParameters)
-	await reportBootstrapProgress(onProgress, 'Creating seeded market', 0.82)
+async function loadRequiredSeededPool(readClient: ReadClient, securityPoolAddress: Address, poolLabel: string) {
+	const seededPool = (await loadAllSecurityPools(readClient)).find(pool => pool.securityPoolAddress === securityPoolAddress)
+	if (seededPool === undefined) {
+		throw new Error(`Expected ${poolLabel} at ${securityPoolAddress}`)
+	}
+	return seededPool
+}
+
+async function loadRequiredSecurityVault(readClient: ReadClient, securityPoolAddress: Address, vaultAddress: Address, label: string) {
+	const vaultDetails = await loadSecurityVaultDetails(readClient, securityPoolAddress, vaultAddress)
+	if (vaultDetails === undefined) {
+		throw new Error(`Expected seeded security vault details for ${label}`)
+	}
+	return vaultDetails
+}
+
+async function createSeededSecurityPool({ createWriteClient, currentTimestamp, deployerAccount, questionTitle }: { createWriteClient: (accountAddress: Address) => WriteClient; currentTimestamp: bigint; deployerAccount: Address; questionTitle: string }) {
+	const deployerWriteClient = createWriteClient(deployerAccount)
+	const marketResult = await createMarket(deployerWriteClient, createSecurityPoolSeedParameters(currentTimestamp, questionTitle))
 	const questionId = BigInt(marketResult.questionId)
-	await createSecurityPool(primaryWriteClient, {
+	const poolResult = await createSecurityPool(deployerWriteClient, {
 		currentRetentionRate: MAX_RETENTION_RATE,
 		questionId,
 		securityMultiplier: SECURITY_MULTIPLIER,
 	})
-	await reportBootstrapProgress(onProgress, 'Deploying seeded security pool', 0.85)
-	const seededPool = (await loadAllSecurityPools(readClient))[0]
-	if (seededPool === undefined) {
-		throw new Error('Expected a seeded security pool after deployment')
+
+	return {
+		questionId,
+		securityPoolAddress: poolResult.securityPoolAddress,
+	}
+}
+
+async function validateSeededSecurityPool({ expectedVaultAccounts, poolLabel, readClient, securityPoolAddress }: { expectedVaultAccounts: readonly Address[]; poolLabel: string; readClient: ReadClient; securityPoolAddress: Address }) {
+	const seededPool = await loadRequiredSeededPool(readClient, securityPoolAddress, poolLabel)
+	const expectedVaultCount = BigInt(expectedVaultAccounts.length)
+	const expectedRepDeposit = SECURITY_POOL_REP_DEPOSIT * expectedVaultCount
+	const expectedSecurityBondAllowance = SECURITY_BOND_ALLOWANCE * expectedVaultCount
+
+	if (seededPool.vaultCount !== expectedVaultCount) {
+		throw new Error(`Expected ${poolLabel} to have ${expectedVaultCount.toString()} seeded vaults`)
+	}
+	if (seededPool.totalRepDeposit !== expectedRepDeposit) {
+		throw new Error(`Expected ${poolLabel} to have ${expectedRepDeposit.toString()} seeded REP`)
+	}
+	if (seededPool.totalSecurityBondAllowance !== expectedSecurityBondAllowance) {
+		throw new Error(`Expected ${poolLabel} to have ${expectedSecurityBondAllowance.toString()} seeded security bond allowance`)
 	}
 
-	await approveErc20(primaryWriteClient, profile.genesisRepTokenAddress, seededPool.securityPoolAddress, SECURITY_POOL_REP_DEPOSIT, 'approveRep')
-	await depositRepToSecurityPool(primaryWriteClient, seededPool.securityPoolAddress, SECURITY_POOL_REP_DEPOSIT)
-	await reportBootstrapProgress(onProgress, 'Funding seeded security vault', 0.88)
-
-	const vaultDetails = await loadSecurityVaultDetails(readClient, seededPool.securityPoolAddress, primaryAccount)
-	if (vaultDetails === undefined) {
-		throw new Error('Expected seeded security vault details')
+	for (const vaultAddress of expectedVaultAccounts) {
+		const vault = seededPool.vaults.find(candidate => candidate.vaultAddress === vaultAddress)
+		if (vault === undefined) {
+			throw new Error(`Expected ${poolLabel} to include seeded vault ${vaultAddress}`)
+		}
+		if (vault.repDepositShare !== SECURITY_POOL_REP_DEPOSIT) {
+			throw new Error(`Expected ${poolLabel} vault ${vaultAddress} to hold the seeded REP deposit`)
+		}
+		if (vault.securityBondAllowance !== SECURITY_BOND_ALLOWANCE) {
+			throw new Error(`Expected ${poolLabel} vault ${vaultAddress} to hold the seeded security bond allowance`)
+		}
 	}
+}
 
-	await queueOracleManagerOperation(primaryWriteClient, vaultDetails.managerAddress, 'setSecurityBondsAllowance', primaryAccount, SECURITY_BOND_ALLOWANCE)
-	const oracleManagerDetails = await loadOracleManagerDetails(readClient, vaultDetails.managerAddress)
-	await reportBootstrapProgress(onProgress, 'Configuring oracle manager', 0.9)
+async function configureSecurityBondAllowance({
+	accountAddress,
+	createWriteClient,
+	managerAddress,
+	memoryClient,
+	readClient,
+	securityPoolAddress,
+	profile,
+}: {
+	accountAddress: Address
+	createWriteClient: (accountAddress: Address) => WriteClient
+	managerAddress: Address
+	memoryClient: TevmLikeClient
+	profile: NetworkProfile
+	readClient: ReadClient
+	securityPoolAddress: Address
+}) {
+	const writeClient = createWriteClient(accountAddress)
+	const queueResult = await queueOracleManagerOperation(writeClient, managerAddress, 'setSecurityBondsAllowance', accountAddress, SECURITY_BOND_ALLOWANCE)
+	if (queueResult.stagedExecution?.success === false) {
+		throw new Error(queueResult.stagedExecution.errorMessage ?? `Failed to seed security bond allowance for ${accountAddress}`)
+	}
+	let updatedVault = await loadRequiredSecurityVault(readClient, securityPoolAddress, accountAddress, accountAddress)
+	if (updatedVault.securityBondAllowance !== SECURITY_BOND_ALLOWANCE) {
+		const managerDetails = await loadOracleManagerDetails(readClient, managerAddress)
+		if (managerDetails.pendingReportId > 0n) {
+			if (managerDetails.callbackStateHash === undefined || managerDetails.exactToken1Report === undefined || managerDetails.token1 === undefined || managerDetails.token2 === undefined) {
+				throw new Error(`Expected a pending oracle report for ${accountAddress}`)
+			}
 
+			const amount1 = managerDetails.exactToken1Report
+			const amount2 = (amount1 * 10n ** 18n) / SEEDED_REP_ETH_PRICE
+			await approveErc20(writeClient, managerDetails.token1, managerDetails.openOracleAddress, amount1, 'approveToken1')
+			await ensureSufficientWethBalance(readClient, writeClient, profile, accountAddress, amount2)
+			await approveErc20(writeClient, managerDetails.token2, managerDetails.openOracleAddress, amount2, 'approveToken2')
+			await submitInitialOracleReport(writeClient, managerDetails.openOracleAddress, managerDetails.pendingReportId, amount1, amount2, managerDetails.callbackStateHash)
+			await advanceSimulationTime(memoryClient, DAY_IN_SECONDS)
+			await settleOracleReport(writeClient, managerDetails.openOracleAddress, managerDetails.pendingReportId)
+		}
+
+		const refreshedManagerDetails = await loadOracleManagerDetails(readClient, managerAddress)
+		if (refreshedManagerDetails.pendingOperation?.operation === 'setSecurityBondsAllowance' && refreshedManagerDetails.pendingOperation.targetVault === accountAddress && refreshedManagerDetails.isPriceValid) {
+			const hash = await writeClient.writeContract({
+				address: managerAddress,
+				abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+				functionName: 'executeStagedOperation',
+				args: [refreshedManagerDetails.pendingOperation.operationId],
+			})
+			await writeClient.waitForTransactionReceipt({ hash })
+		}
+
+		updatedVault = await loadRequiredSecurityVault(readClient, securityPoolAddress, accountAddress, accountAddress)
+	}
+	if (updatedVault.securityBondAllowance !== SECURITY_BOND_ALLOWANCE) {
+		const finalManagerDetails = await loadOracleManagerDetails(readClient, managerAddress)
+		throw new Error(
+			`Expected seeded security bond allowance for ${accountAddress} (allowance=${updatedVault.securityBondAllowance.toString()}, pendingReportId=${finalManagerDetails.pendingReportId.toString()}, pendingOperation=${finalManagerDetails.pendingOperation?.operation ?? 'none'}, pendingTarget=${finalManagerDetails.pendingOperation?.targetVault ?? 'none'}, isPriceValid=${finalManagerDetails.isPriceValid ? 'true' : 'false'})`,
+		)
+	}
+}
+
+async function settleSeededOracleReport({
+	accountAddress,
+	createWriteClient,
+	managerAddress,
+	onProgressStep,
+	poolLabel,
+	profile,
+	readClient,
+}: {
+	accountAddress: Address
+	createWriteClient: (accountAddress: Address) => WriteClient
+	managerAddress: Address
+	onProgressStep: (label: string) => Promise<void>
+	poolLabel: string
+	profile: NetworkProfile
+	readClient: ReadClient
+}) {
+	const writeClient = createWriteClient(accountAddress)
+	await queueOracleManagerOperation(writeClient, managerAddress, 'setSecurityBondsAllowance', accountAddress, SECURITY_BOND_ALLOWANCE)
+	await onProgressStep(`Configuring oracle manager for ${poolLabel}`)
+
+	const oracleManagerDetails = await loadOracleManagerDetails(readClient, managerAddress)
 	if (oracleManagerDetails.pendingReportId === 0n || oracleManagerDetails.callbackStateHash === undefined || oracleManagerDetails.exactToken1Report === undefined || oracleManagerDetails.token1 === undefined || oracleManagerDetails.token2 === undefined) {
-		throw new Error('Expected a pending oracle report for the seeded security pool scenario')
+		throw new Error(`Expected a pending oracle report for ${poolLabel}`)
 	}
 
 	const amount1 = oracleManagerDetails.exactToken1Report
 	const amount2 = (amount1 * 10n ** 18n) / SEEDED_REP_ETH_PRICE
-	await approveErc20(primaryWriteClient, oracleManagerDetails.token1, oracleManagerDetails.openOracleAddress, amount1, 'approveToken1')
-	await ensureSufficientWethBalance(readClient, primaryWriteClient, profile, primaryAccount, amount2, onProgress)
-	await approveErc20(primaryWriteClient, oracleManagerDetails.token2, oracleManagerDetails.openOracleAddress, amount2, 'approveToken2')
-	await submitInitialOracleReport(primaryWriteClient, oracleManagerDetails.openOracleAddress, oracleManagerDetails.pendingReportId, amount1, amount2, oracleManagerDetails.callbackStateHash)
-	await reportBootstrapProgress(onProgress, 'Submitting seeded oracle report', 0.93)
-	await advanceSimulationTime(memoryClient, DAY_IN_SECONDS)
-	await settleOracleReport(primaryWriteClient, oracleManagerDetails.openOracleAddress, oracleManagerDetails.pendingReportId)
-	await reportBootstrapProgress(onProgress, 'Settling seeded oracle report', 0.96)
+	await approveErc20(writeClient, oracleManagerDetails.token1, oracleManagerDetails.openOracleAddress, amount1, 'approveToken1')
+	await ensureSufficientWethBalance(readClient, writeClient, profile, accountAddress, amount2)
+	await approveErc20(writeClient, oracleManagerDetails.token2, oracleManagerDetails.openOracleAddress, amount2, 'approveToken2')
+	await submitInitialOracleReport(writeClient, oracleManagerDetails.openOracleAddress, oracleManagerDetails.pendingReportId, amount1, amount2, oracleManagerDetails.callbackStateHash)
+	await onProgressStep(`Submitting seeded oracle report for ${poolLabel}`)
 
-	const seededReport = await loadOpenOracleReportDetails(readClient, oracleManagerDetails.openOracleAddress, oracleManagerDetails.pendingReportId)
-	if (!seededReport.isDistributed) {
-		throw new Error('Expected the seeded oracle report to be settled')
+	return {
+		openOracleAddress: oracleManagerDetails.openOracleAddress,
+		pendingReportId: oracleManagerDetails.pendingReportId,
 	}
-	await reportBootstrapProgress(onProgress, 'Seeded security-pool scenario is ready', 0.98)
 }
 
-async function applyScenario({
+async function seedSecurityPool({
 	createReadClient,
 	createWriteClient,
 	memoryClient,
 	onProgress,
-	primaryAccount,
+	poolSpec,
 	profile,
-	scenario,
+	seedTimestamp,
 }: {
 	createReadClient: () => ReadClient
 	createWriteClient: (accountAddress: Address) => WriteClient
 	memoryClient: TevmLikeClient
 	onProgress: BootstrapProgressHandler | undefined
-	primaryAccount: Address
+	poolSpec: SeededSecurityPoolSpec
+	profile: NetworkProfile
+	seedTimestamp: bigint
+}) {
+	const readClient = createReadClient()
+	const primaryVaultAccount = requireQaAccount(poolSpec.vaultAccounts[0], `Missing primary seeded vault account for ${poolSpec.poolLabel}`)
+	const additionalVaultAccounts = poolSpec.vaultAccounts.slice(1)
+	const stepCount = 2 + poolSpec.vaultAccounts.length + 3 + additionalVaultAccounts.length + 1
+	const reportStep = createRangeProgressReporter(onProgress, poolSpec.progressRange, stepCount)
+
+	const poolResult = await createSeededSecurityPool({
+		createWriteClient,
+		currentTimestamp: seedTimestamp,
+		deployerAccount: primaryVaultAccount,
+		questionTitle: poolSpec.questionTitle,
+	})
+	await reportStep(`Creating seeded market for ${poolSpec.poolLabel}`)
+	await reportStep(`Deploying seeded security pool for ${poolSpec.poolLabel}`)
+
+	for (const [index, vaultAccount] of poolSpec.vaultAccounts.entries()) {
+		const writeClient = createWriteClient(vaultAccount)
+		await approveErc20(writeClient, profile.genesisRepTokenAddress, poolResult.securityPoolAddress, SECURITY_POOL_REP_DEPOSIT, 'approveRep')
+		await depositRepToSecurityPool(writeClient, poolResult.securityPoolAddress, SECURITY_POOL_REP_DEPOSIT)
+		const seededVault = await loadRequiredSecurityVault(readClient, poolResult.securityPoolAddress, vaultAccount, vaultAccount)
+		if (seededVault.repDepositShare !== SECURITY_POOL_REP_DEPOSIT) {
+			throw new Error(`Expected seeded REP deposit for ${vaultAccount} in ${poolSpec.poolLabel}, got ${seededVault.repDepositShare.toString()}`)
+		}
+		await reportStep(`Funding seeded security vault ${index + 1} of ${poolSpec.vaultAccounts.length} for ${poolSpec.poolLabel}`)
+	}
+
+	const primaryVault = await loadRequiredSecurityVault(readClient, poolResult.securityPoolAddress, primaryVaultAccount, primaryVaultAccount)
+	const seededOracleReport = await settleSeededOracleReport({
+		accountAddress: primaryVaultAccount,
+		createWriteClient,
+		managerAddress: primaryVault.managerAddress,
+		onProgressStep: reportStep,
+		poolLabel: poolSpec.poolLabel,
+		profile,
+		readClient,
+	})
+	await advanceSimulationTime(memoryClient, DAY_IN_SECONDS)
+	await settleOracleReport(createWriteClient(primaryVaultAccount), seededOracleReport.openOracleAddress, seededOracleReport.pendingReportId)
+	await reportStep(`Settling seeded oracle report for ${poolSpec.poolLabel}`)
+
+	const seededReport = await loadOpenOracleReportDetails(readClient, seededOracleReport.openOracleAddress, seededOracleReport.pendingReportId)
+	if (!seededReport.isDistributed) {
+		throw new Error(`Expected the seeded oracle report to be settled for ${poolSpec.poolLabel}`)
+	}
+
+	const primaryVaultAfterSettlement = await loadRequiredSecurityVault(readClient, poolResult.securityPoolAddress, primaryVaultAccount, primaryVaultAccount)
+	if (primaryVaultAfterSettlement.securityBondAllowance !== SECURITY_BOND_ALLOWANCE) {
+		throw new Error(`Expected seeded security bond allowance for ${primaryVaultAccount}`)
+	}
+
+	for (const [index, vaultAccount] of additionalVaultAccounts.entries()) {
+		await configureSecurityBondAllowance({
+			accountAddress: vaultAccount,
+			createWriteClient,
+			managerAddress: primaryVault.managerAddress,
+			memoryClient,
+			profile,
+			readClient,
+			securityPoolAddress: poolResult.securityPoolAddress,
+		})
+		await reportStep(`Configuring seeded security vault ${index + 2} of ${poolSpec.vaultAccounts.length} for ${poolSpec.poolLabel}`)
+	}
+
+	await validateSeededSecurityPool({
+		expectedVaultAccounts: poolSpec.vaultAccounts,
+		poolLabel: poolSpec.poolLabel,
+		readClient,
+		securityPoolAddress: poolResult.securityPoolAddress,
+	})
+	await reportStep(poolSpec.readyLabel)
+}
+
+async function seedSecurityPoolScenario({
+	accounts,
+	createReadClient,
+	createWriteClient,
+	memoryClient,
+	onProgress,
+	profile,
+}: {
+	accounts: readonly Address[]
+	createReadClient: () => ReadClient
+	createWriteClient: (accountAddress: Address) => WriteClient
+	memoryClient: TevmLikeClient
+	onProgress: BootstrapProgressHandler | undefined
+	profile: NetworkProfile
+}) {
+	const primaryAccount = requireQaAccount(accounts[0], 'Expected seeded simulation QA account A1')
+	const currentTimestamp = await getSimulationChainTimestamp(memoryClient)
+
+	await seedSecurityPool({
+		createReadClient,
+		createWriteClient,
+		memoryClient,
+		onProgress,
+		poolSpec: {
+			poolLabel: 'seeded security pool',
+			progressRange: { start: 0.78, end: 0.98 },
+			questionTitle: 'Will this resolve?',
+			readyLabel: 'Seeded security-pool scenario is ready',
+			vaultAccounts: [primaryAccount],
+		},
+		profile,
+		seedTimestamp: currentTimestamp,
+	})
+}
+
+async function seedSecurityPoolX2Scenario({
+	accounts,
+	createReadClient,
+	createWriteClient,
+	memoryClient,
+	onProgress,
+	profile,
+}: {
+	accounts: readonly Address[]
+	createReadClient: () => ReadClient
+	createWriteClient: (accountAddress: Address) => WriteClient
+	memoryClient: TevmLikeClient
+	onProgress: BootstrapProgressHandler | undefined
+	profile: NetworkProfile
+}) {
+	const primaryAccount = requireQaAccount(accounts[0], 'Expected simulation QA account A1 for securitypoolx2')
+	const secondaryAccount = requireQaAccount(accounts[1], 'Expected simulation QA account B2 for securitypoolx2')
+	const currentTimestamp = await getSimulationChainTimestamp(memoryClient)
+	const readClient = createReadClient()
+	const reportStep = createRangeProgressReporter(onProgress, { start: 0.72, end: 0.98 }, 17)
+	const seededPools = [
+		{
+			poolLabel: 'securitypoolx2 pool 1',
+			questionTitle: 'Will this resolve? (securitypoolx2 #1)',
+			vaultAccounts: [primaryAccount, secondaryAccount],
+		},
+		{
+			poolLabel: 'securitypoolx2 pool 2',
+			questionTitle: 'Will this resolve? (securitypoolx2 #2)',
+			vaultAccounts: [primaryAccount, secondaryAccount],
+		},
+	] as const
+
+	const preparedPools = []
+
+	for (const seededPool of seededPools) {
+		const poolResult = await createSeededSecurityPool({
+			createWriteClient,
+			currentTimestamp,
+			deployerAccount: primaryAccount,
+			questionTitle: seededPool.questionTitle,
+		})
+		await reportStep(`Creating seeded market for ${seededPool.poolLabel}`)
+		await reportStep(`Deploying seeded security pool for ${seededPool.poolLabel}`)
+
+		for (const [index, vaultAccount] of seededPool.vaultAccounts.entries()) {
+			const writeClient = createWriteClient(vaultAccount)
+			await approveErc20(writeClient, profile.genesisRepTokenAddress, poolResult.securityPoolAddress, SECURITY_POOL_REP_DEPOSIT, 'approveRep')
+			await depositRepToSecurityPool(writeClient, poolResult.securityPoolAddress, SECURITY_POOL_REP_DEPOSIT)
+			const seededVault = await loadRequiredSecurityVault(readClient, poolResult.securityPoolAddress, vaultAccount, vaultAccount)
+			if (seededVault.repDepositShare !== SECURITY_POOL_REP_DEPOSIT) {
+				throw new Error(`Expected seeded REP deposit for ${vaultAccount} in ${seededPool.poolLabel}, got ${seededVault.repDepositShare.toString()}`)
+			}
+			await reportStep(`Funding seeded security vault ${index + 1} of ${seededPool.vaultAccounts.length} for ${seededPool.poolLabel}`)
+		}
+
+		const primaryVault = await loadRequiredSecurityVault(readClient, poolResult.securityPoolAddress, primaryAccount, primaryAccount)
+		const seededOracleReport = await settleSeededOracleReport({
+			accountAddress: primaryAccount,
+			createWriteClient,
+			managerAddress: primaryVault.managerAddress,
+			onProgressStep: reportStep,
+			poolLabel: seededPool.poolLabel,
+			profile,
+			readClient,
+		})
+
+		preparedPools.push({
+			managerAddress: primaryVault.managerAddress,
+			openOracleAddress: seededOracleReport.openOracleAddress,
+			poolLabel: seededPool.poolLabel,
+			pendingReportId: seededOracleReport.pendingReportId,
+			securityPoolAddress: poolResult.securityPoolAddress,
+			vaultAccounts: seededPool.vaultAccounts,
+		})
+	}
+
+	await advanceSimulationTime(memoryClient, DAY_IN_SECONDS)
+
+	for (const preparedPool of preparedPools) {
+		await settleOracleReport(createWriteClient(primaryAccount), preparedPool.openOracleAddress, preparedPool.pendingReportId)
+		await reportStep(`Settling seeded oracle report for ${preparedPool.poolLabel}`)
+
+		const seededReport = await loadOpenOracleReportDetails(readClient, preparedPool.openOracleAddress, preparedPool.pendingReportId)
+		if (!seededReport.isDistributed) {
+			throw new Error(`Expected the seeded oracle report to be settled for ${preparedPool.poolLabel}`)
+		}
+
+		const primaryVaultAfterSettlement = await loadRequiredSecurityVault(readClient, preparedPool.securityPoolAddress, primaryAccount, primaryAccount)
+		if (primaryVaultAfterSettlement.securityBondAllowance !== SECURITY_BOND_ALLOWANCE) {
+			throw new Error(`Expected seeded security bond allowance for ${primaryAccount}`)
+		}
+	}
+
+	for (const preparedPool of preparedPools) {
+		await configureSecurityBondAllowance({
+			accountAddress: secondaryAccount,
+			createWriteClient,
+			managerAddress: preparedPool.managerAddress,
+			memoryClient,
+			profile,
+			readClient,
+			securityPoolAddress: preparedPool.securityPoolAddress,
+		})
+		await reportStep(`Configuring seeded security vault 2 of 2 for ${preparedPool.poolLabel}`)
+
+		await validateSeededSecurityPool({
+			expectedVaultAccounts: preparedPool.vaultAccounts,
+			poolLabel: preparedPool.poolLabel,
+			readClient,
+			securityPoolAddress: preparedPool.securityPoolAddress,
+		})
+	}
+
+	await reportStep('Seeded securitypoolx2 scenario is ready')
+}
+
+async function applyScenario({
+	accounts,
+	createReadClient,
+	createWriteClient,
+	memoryClient,
+	onProgress,
+	profile,
+	scenario,
+}: {
+	accounts: readonly Address[]
+	createReadClient: () => ReadClient
+	createWriteClient: (accountAddress: Address) => WriteClient
+	memoryClient: TevmLikeClient
+	onProgress: BootstrapProgressHandler | undefined
 	profile: NetworkProfile
 	scenario: SimulationScenario
 }) {
+	const primaryAccount = requireQaAccount(accounts[0], 'Expected seeded simulation QA account A1')
+
 	switch (scenario) {
 		case 'baseline':
 			await reportBootstrapProgress(onProgress, 'Using baseline simulation scenario', 0.84)
@@ -381,11 +750,22 @@ async function applyScenario({
 		case 'security-pool':
 			await deploySimulationAppContracts(createWriteClient(primaryAccount), memoryClient, onProgress, { start: 0.32, end: 0.78 })
 			await seedSecurityPoolScenario({
+				accounts,
 				createReadClient,
 				createWriteClient,
 				memoryClient,
 				onProgress,
-				primaryAccount,
+				profile,
+			})
+			return
+		case 'securitypoolx2':
+			await deploySimulationAppContracts(createWriteClient(primaryAccount), memoryClient, onProgress, { start: 0.32, end: 0.7 })
+			await seedSecurityPoolX2Scenario({
+				accounts,
+				createReadClient,
+				createWriteClient,
+				memoryClient,
+				onProgress,
 				profile,
 			})
 			return
@@ -433,11 +813,11 @@ export async function bootstrapSimulationChain({
 	})
 	await seedWrappedEthBalances(createWriteClient, accounts, profile.wethAddress, onProgress)
 	await applyScenario({
+		accounts,
 		createReadClient,
 		createWriteClient,
 		memoryClient,
 		onProgress,
-		primaryAccount,
 		profile,
 		scenario,
 	})

--- a/ui/ts/simulation/scenarios.ts
+++ b/ui/ts/simulation/scenarios.ts
@@ -1,4 +1,4 @@
-export const SIMULATION_SCENARIOS = ['baseline', 'deployed', 'security-pool'] as const
+export const SIMULATION_SCENARIOS = ['baseline', 'deployed', 'security-pool', 'securitypoolx2'] as const
 
 export type SimulationScenario = (typeof SIMULATION_SCENARIOS)[number]
 
@@ -18,5 +18,7 @@ export function getSimulationScenarioLabel(scenario: SimulationScenario) {
 			return 'Deployed'
 		case 'security-pool':
 			return 'Security pool'
+		case 'securitypoolx2':
+			return 'Security pool x2'
 	}
 }

--- a/ui/ts/simulation/tevmEngine.ts
+++ b/ui/ts/simulation/tevmEngine.ts
@@ -401,7 +401,11 @@ export async function createSimulationEngine({ scenario }: { scenario: Simulatio
 		}
 
 		const sendTransaction: typeof baseClient.sendTransaction = async parameters => {
-			const hash = await sendTransactionInternal(parameters)
+			const senderAddress = normalizeRequestedAccount(parameters.account, accountAddress)
+			const hash = await sendTransactionInternal({
+				...parameters,
+				account: senderAddress,
+			})
 			callbacks.onTransactionSubmitted?.(hash)
 			return hash
 		}

--- a/ui/ts/tests/activeEnvironment.test.ts
+++ b/ui/ts/tests/activeEnvironment.test.ts
@@ -7,13 +7,17 @@ import { getWrongNetworkMessage, isSupportedAppChain } from '../lib/network.js'
 import { getSecurityVaultWithdrawableRepAmount } from '../lib/securityVault.js'
 import { getActiveBackend, initializeActiveEnvironment, installActiveEnvironmentForTesting, resetActiveEnvironmentForTesting, shouldUseSimulationLocation } from '../lib/activeEnvironment.js'
 import { createSimulationBackend } from '../simulation/tevmBackend.js'
+import type { SimulationScenario } from '../simulation/scenarios.js'
 import { createFakeBackend, createFakeSimulationProfile } from './testUtils/fakeBackend.js'
+
+const SEEDED_REP_DEPOSIT = 10_000n * 10n ** 18n
+const SEEDED_SECURITY_BOND_ALLOWANCE = SEEDED_REP_DEPOSIT / 4n
 
 afterEach(() => {
 	resetActiveEnvironmentForTesting()
 })
 
-async function createBootstrappedSimulationBackendWithRetry(scenario: 'baseline' | 'deployed' | 'security-pool', maxAttempts = 2) {
+async function createBootstrappedSimulationBackendWithRetry(scenario: SimulationScenario, maxAttempts = 2) {
 	let lastError: unknown = undefined
 	for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
 		const backend = await createSimulationBackend({ scenario })
@@ -344,11 +348,52 @@ void describe('simulation backend', () => {
 		expect(backend.currentScenario).toBe('security-pool')
 		expect(pools).toHaveLength(1)
 		expect(seededPool.vaultCount).toBe(1n)
-		expect(seededPool.totalRepDeposit).toBe(10_000n * 10n ** 18n)
-		expect(seededPool.totalSecurityBondAllowance).toBe(2_500n * 10n ** 18n)
-		expect(seededVault.repDepositShare).toBe(10_000n * 10n ** 18n)
-		expect(seededVault.securityBondAllowance).toBe(2_500n * 10n ** 18n)
+		expect(seededPool.totalRepDeposit).toBe(SEEDED_REP_DEPOSIT)
+		expect(seededPool.totalSecurityBondAllowance).toBe(SEEDED_SECURITY_BOND_ALLOWANCE)
+		expect(seededVault.repDepositShare).toBe(SEEDED_REP_DEPOSIT)
+		expect(seededVault.securityBondAllowance).toBe(SEEDED_SECURITY_BOND_ALLOWANCE)
 	}, 60_000)
+
+	void test('bootstraps the securitypoolx2 scenario with two seeded pools and two vaults in each pool', async () => {
+		const backend = await createBootstrappedSimulationBackendWithRetry('securitypoolx2')
+		backend.setTransactionDelayMilliseconds(0)
+
+		try {
+			const primaryAccount = backend.accounts[0]
+			const secondaryAccount = backend.accounts[1]
+			if (primaryAccount === undefined || secondaryAccount === undefined) {
+				throw new Error('Expected seeded simulation QA accounts A1 and B2')
+			}
+
+			const readClient = backend.createReadClient()
+			const pools = await loadAllSecurityPools(readClient)
+
+			expect(backend.currentScenario).toBe('securitypoolx2')
+			expect(pools).toHaveLength(2)
+			expect(pools.map(pool => pool.marketDetails.title)).toEqual(['Will this resolve? (securitypoolx2 #1)', 'Will this resolve? (securitypoolx2 #2)'])
+
+			for (const pool of pools) {
+				const primaryVault = await loadSecurityVaultDetails(readClient, pool.securityPoolAddress, primaryAccount)
+				const secondaryVault = await loadSecurityVaultDetails(readClient, pool.securityPoolAddress, secondaryAccount)
+				if (primaryVault === undefined || secondaryVault === undefined) {
+					throw new Error(`Expected seeded vaults for both A1 and B2 in pool ${pool.securityPoolAddress}`)
+				}
+
+				const managerDetails = await loadOracleManagerDetails(readClient, pool.managerAddress)
+
+				expect(pool.vaultCount).toBe(2n)
+				expect(pool.totalRepDeposit).toBe(2n * SEEDED_REP_DEPOSIT)
+				expect(pool.totalSecurityBondAllowance).toBe(2n * SEEDED_SECURITY_BOND_ALLOWANCE)
+				expect(primaryVault.repDepositShare).toBe(SEEDED_REP_DEPOSIT)
+				expect(primaryVault.securityBondAllowance).toBe(SEEDED_SECURITY_BOND_ALLOWANCE)
+				expect(secondaryVault.repDepositShare).toBe(SEEDED_REP_DEPOSIT)
+				expect(secondaryVault.securityBondAllowance).toBe(SEEDED_SECURITY_BOND_ALLOWANCE)
+				expect(managerDetails.isPriceValid).toBe(true)
+			}
+		} finally {
+			await backend.dispose()
+		}
+	}, 90_000)
 
 	void test('only allows the oracle-backed portion of the seeded REP deposit to be withdrawn in the security-pool scenario', async () => {
 		const backend = await createBootstrappedSimulationBackendWithRetry('security-pool')
@@ -385,8 +430,8 @@ void describe('simulation backend', () => {
 			})
 
 			expect(managerBefore.isPriceValid).toBe(true)
-			expect(seededVaultBefore.repDepositShare).toBe(10_000n * 10n ** 18n)
-			expect(seededPoolBefore.totalRepDeposit).toBe(10_000n * 10n ** 18n)
+			expect(seededVaultBefore.repDepositShare).toBe(SEEDED_REP_DEPOSIT)
+			expect(seededPoolBefore.totalRepDeposit).toBe(SEEDED_REP_DEPOSIT)
 			expect(maxWithdrawableRep !== undefined && maxWithdrawableRep > 0n).toBe(true)
 			expect(maxWithdrawableRep !== undefined && maxWithdrawableRep < seededVaultBefore.repDepositShare).toBe(true)
 

--- a/ui/ts/tests/simulationScenarios.test.ts
+++ b/ui/ts/tests/simulationScenarios.test.ts
@@ -1,0 +1,14 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { getSimulationScenarioLabel, normalizeSimulationScenario } from '../simulation/scenarios.js'
+
+void describe('simulation scenarios', () => {
+	void test('normalizes the securitypoolx2 scenario', () => {
+		expect(normalizeSimulationScenario('securitypoolx2')).toBe('securitypoolx2')
+	})
+
+	void test('returns the securitypoolx2 scenario label', () => {
+		expect(getSimulationScenarioLabel('securitypoolx2')).toBe('Security pool x2')
+	})
+})


### PR DESCRIPTION
## Summary
- Added a new `securitypoolx2` simulation scenario that boots two seeded security pools with two vaults each.
- Extended simulation bootstrap, scenario labels, and documentation to recognize the new seeded scenario.
- Removed manager address display from security pool UI sections and updated tests to match the new behavior.
- Added simulation backend coverage for the new scenario and tightened existing security-pool assertions.

## Testing
- Not run in this summary generation step.
- Updated and added tests covering scenario normalization/labels, security pool UI expectations, and `securitypoolx2` bootstrap behavior.
- Repository guidelines indicate the change set should be validated with `bun run tsc`, `bun run test`, `bun run format`, `bun run check`, and `bun run knip` before merge.