### PR TITLE
Improve REP pricing, metrics overflow, and wallet fallback

### DIFF
--- a/ui/ts/components/TradingSection.tsx
+++ b/ui/ts/components/TradingSection.tsx
@@ -1,21 +1,17 @@
 import { useEffect, useState } from 'preact/hooks'
 import { ActionLauncherCard } from './ActionLauncherCard.js'
-import { AddressValue } from './AddressValue.js'
-import { ResultBanner } from './ResultBanner.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { EnumDropdown } from './EnumDropdown.js'
 import { ErrorNotice } from './ErrorNotice.js'
 import { FormInput } from './FormInput.js'
-import { LatestActionSection } from './LatestActionSection.js'
 import { MetricField } from './MetricField.js'
 import { OperationModal } from './OperationModal.js'
+import { ResultBanner } from './ResultBanner.js'
 import { RouteWorkflowPanel } from './RouteWorkflowPanel.js'
 import { SectionBlock } from './SectionBlock.js'
 import { ShareMigrationTargetsSection } from './ShareMigrationTargetsSection.js'
 import { TransactionActionButton } from './TransactionActionButton.js'
-import { TransactionHashLink } from './TransactionHashLink.js'
-import { UniverseLink } from './UniverseLink.js'
-import { formatCurrencyBalance, formatCurrencyInputBalance } from '../lib/formatters.js'
+import { formatCurrencyInputBalance } from '../lib/formatters.js'
 import { isMainnetChain } from '../lib/network.js'
 import { getReportingOutcomeLabel, REPORTING_OUTCOME_DROPDOWN_OPTIONS } from '../lib/reporting.js'
 import {
@@ -208,26 +204,7 @@ export function TradingSection({
 			targetOutcomeIndexes: [...selectedTargetOutcomeIndexes, outcomeIndex].map(index => index.toString()).join(', '),
 		})
 	}
-	const renderShareMetricValue = (value: bigint | undefined) => {
-		if (loadingTradingDetails) return 'Loading...'
-		if (value === undefined) return '—'
-		return formatCurrencyBalance(value)
-	}
-	const latestTradingAction =
-		tradingResult === undefined ? undefined : (
-			<LatestActionSection
-				title='Latest Trading Action'
-				embedInCard={embedInCard}
-				rows={[
-					{ label: 'Action', value: tradingResult.action },
-					...(tradingResult.action !== 'migrateShares' || tradingResult.shareOutcome === undefined ? [] : [{ label: 'Share Outcome', value: tradingResult.shareOutcome }]),
-					...(tradingResult.action !== 'migrateShares' || tradingResult.targetOutcomeIndexes === undefined ? [] : [{ label: 'Target Outcome Indexes', value: tradingResult.targetOutcomeIndexes.join(', ') }]),
-					{ label: 'Pool', value: <AddressValue address={tradingResult.securityPoolAddress} /> },
-					{ label: 'Universe', value: <UniverseLink universeId={tradingResult.universeId} /> },
-					{ label: 'Transaction', value: <TransactionHashLink hash={tradingResult.hash} /> },
-				]}
-			/>
-		)
+	const renderShareMetricValue = (value: bigint | undefined) => <CurrencyValue loading={loadingTradingDetails} value={value} />
 	const tradingOutcome = getTradingOutcomePresentation(tradingResult)
 	const tradingLaunchers: ReadinessAction[] = [
 		{
@@ -282,8 +259,6 @@ export function TradingSection({
 					</label>
 				</SectionBlock>
 			)}
-
-			{latestTradingAction}
 
 			{selectedPool === undefined ? undefined : (
 				<SectionBlock title='Your Shares'>

--- a/ui/ts/tests/tradingSection.test.tsx
+++ b/ui/ts/tests/tradingSection.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { fireEvent, within } from '@testing-library/dom'
 import { useState } from 'preact/hooks'
 import { act } from 'preact/test-utils'
-import { getAddress, zeroAddress, zeroHash } from 'viem'
+import { zeroAddress, zeroHash } from 'viem'
 import { TradingSection } from '../components/TradingSection.js'
 import { MARKET_NOT_FINALIZED_MESSAGE, NEED_MATCHING_COMPLETE_SET_SHARES_MESSAGE, NO_MINT_CAPACITY_NO_ACTIVE_ALLOWANCE_MESSAGE, SHARE_MIGRATION_AFTER_FORK_MESSAGE } from '../lib/trading.js'
 import type { AccountState, TradingFormState } from '../types/app.js'
@@ -216,15 +216,14 @@ void describe('TradingSection', () => {
 		expect(documentQueries.getByRole('heading', { name: 'Redeem Resolved Shares' })).not.toBeNull()
 	})
 
-	void test('renders the latest trading action pool with the shared address value component', async () => {
-		const poolAddress = getAddress('0x00000000000000000000000000000000000000a1')
+	void test('renders the trading result banner without the latest trading action card', async () => {
 		const renderedComponent = await renderIntoDocument(
 			<TradingSection
 				{...createTradingSectionProps({
 					tradingResult: {
 						action: 'createCompleteSet',
 						hash: zeroHash,
-						securityPoolAddress: poolAddress,
+						securityPoolAddress: zeroAddress,
 						universeId: 1n,
 					},
 				})}
@@ -233,8 +232,35 @@ void describe('TradingSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		expect(documentQueries.getByRole('heading', { name: 'Latest Trading Action' })).not.toBeNull()
-		expect(documentQueries.getByRole('button', { name: `Copy address ${poolAddress}` })).not.toBeNull()
+		expect(documentQueries.getByRole('heading', { name: 'Complete sets minted' })).not.toBeNull()
+		expect(documentQueries.queryByRole('heading', { name: 'Latest Trading Action' })).toBeNull()
+		expect(documentQueries.queryByRole('button', { name: /Copy address/i })).toBeNull()
+	})
+
+	void test('renders your share metrics using rounded values with exact copy affordances', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<TradingSection
+				{...createTradingSectionProps({
+					tradingDetails: createTradingDetails({
+						maxRedeemableCompleteSets: 410000000000000n,
+						shareBalances: createShareBalances({
+							invalid: 410000000000000n,
+							no: 23000000000000000n,
+							yes: 1234000000000000000n,
+						}),
+					}),
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByText('≈ 1.23')).not.toBeNull()
+		expect(documentQueries.getByText('≈ 0.023')).not.toBeNull()
+		expect(documentQueries.getAllByText('≈ 0.00041')).toHaveLength(2)
+		expect(documentQueries.getByRole('button', { name: 'Copy exact value 1.234' })).not.toBeNull()
+		expect(documentQueries.getByRole('button', { name: 'Copy exact value 0.023' })).not.toBeNull()
+		expect(documentQueries.getAllByRole('button', { name: 'Copy exact value 0.00041' })).toHaveLength(2)
 	})
 
 	void test('shows the minting disabled reason on the launcher when the pool has no active allowance', async () => {


### PR DESCRIPTION
## Summary
- Unified REP price source labels across overview and liquidation flows, including simulation price reset behavior.
- Added compact currency rendering for overflowing metric values and updated metric/modal layouts for better readability.
- Simplified trading results by removing the inline latest-action panel and tightening share metric presentation.
- Improved market question auto-loading and error handling, plus added read-only RPC fallback guidance when no injected wallet is available.
- Refined several modal and status notice interactions for accessibility and clearer copy.

## Testing
- `bun run tsc`
- `bun run test`
- `bun run format`
- `bun run check`
- `bun run knip`