### PR TITLE
Refine Zoltar action labels and question auto-load behavior

### DIFF
--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -243,7 +243,7 @@ export function ForkAuctionSection({
 		{ key: 'mainnet', label: 'Ethereum mainnet selected', resolved: isMainnet, ...(isMainnet ? {} : { detail: 'Switch to Ethereum mainnet before creating a child universe.' }) },
 	]
 	const createChildUniverseLauncherAction: ReadinessAction = {
-		actionLabel: 'Open Child Universe Flow',
+		actionLabel: 'Create child universe',
 		description: 'Review the selected outcome and confirm the child-universe creation in a bounded execution modal.',
 		key: 'create-child-universe',
 		...(hasLoadedPoolContext ? { onAction: () => setChildUniverseModalOpen(true) } : {}),

--- a/ui/ts/components/MarketOverviewSection.tsx
+++ b/ui/ts/components/MarketOverviewSection.tsx
@@ -117,7 +117,7 @@ export function MarketOverviewSection({ accountAddress, isMainnet, loadingZoltar
 									reason:
 										accountAddress === undefined ? 'Connect a wallet before deploying a child universe.' : !isMainnet ? 'Switch to Ethereum mainnet before deploying a child universe.' : !hasForked ? 'Fork Zoltar before deploying child universes.' : child.exists ? 'This child universe is already deployed.' : undefined,
 								},
-								label: child.exists ? 'Deployed' : 'Open Universe Flow',
+								label: child.exists ? 'Deployed' : 'Create child universe',
 								onClick: () => setSelectedChildOutcomeIndex(child.outcomeIndex),
 								pending: zoltarChildUniversePendingOutcomeIndex === child.outcomeIndex,
 								pendingLabel: 'Opening...',

--- a/ui/ts/components/MarketSection.tsx
+++ b/ui/ts/components/MarketSection.tsx
@@ -173,7 +173,7 @@ export function MarketSection({
 						<SectionBlock title='Fork'>
 							<div className='actions'>
 								<button className='primary' type='button' onClick={() => setForkModalOpen(true)}>
-									Open Fork Flow
+									Fork Zoltar
 								</button>
 							</div>
 							{zoltarForkQuestionId.trim() === '' ? undefined : <p className='detail'>Selected fork question: {zoltarForkQuestionId}</p>}

--- a/ui/ts/components/ScalarDeploymentSection.tsx
+++ b/ui/ts/components/ScalarDeploymentSection.tsx
@@ -94,7 +94,7 @@ export function ScalarDeploymentSection({ accountAddress, childUniverses, hasFor
 			<ScalarOutcomePicker
 				action={
 					<TransactionActionButton
-						idleLabel={selectedScalarChildExists ? 'Deployed' : scalarOutcomeInvalid ? 'Open Invalid Universe Flow' : 'Open Universe Flow'}
+						idleLabel={selectedScalarChildExists ? 'Deployed' : scalarOutcomeInvalid ? 'Create invalid universe' : 'Create child universe'}
 						pendingLabel='Opening...'
 						onClick={() => {
 							try {

--- a/ui/ts/components/TradingSection.tsx
+++ b/ui/ts/components/TradingSection.tsx
@@ -231,7 +231,7 @@ export function TradingSection({
 	const tradingOutcome = getTradingOutcomePresentation(tradingResult)
 	const tradingLaunchers: ReadinessAction[] = [
 		{
-			actionLabel: 'Open Mint Flow',
+			actionLabel: 'Mint complete sets',
 			description: 'Review mint capacity, available backing, and the collateral amount before minting complete sets.',
 			key: 'mint-complete-sets',
 			readiness: mintLauncherBlocker === undefined ? 'ready' : 'blocked',
@@ -239,7 +239,7 @@ export function TradingSection({
 			...(mintLauncherBlocker === undefined ? { onAction: () => setActiveModal('mint') } : { blocker: mintLauncherBlocker }),
 		},
 		{
-			actionLabel: 'Open Redeem Flow',
+			actionLabel: 'Redeem complete sets',
 			description: 'Redeem matching yes, no, and invalid shares back into collateral using the available complete-set balance.',
 			key: 'redeem-complete-sets',
 			readiness: redeemCompleteSetsLauncherBlocker === undefined ? 'ready' : 'blocked',
@@ -247,7 +247,7 @@ export function TradingSection({
 			...(redeemCompleteSetsLauncherBlocker === undefined ? { onAction: () => setActiveModal('redeem-complete-sets') } : { blocker: redeemCompleteSetsLauncherBlocker }),
 		},
 		{
-			actionLabel: 'Open Migration Flow',
+			actionLabel: 'Migrate forked shares',
 			description: 'Select the source outcome and target child universes before migrating forked shares.',
 			key: 'migrate-shares',
 			readiness: migrateSharesLauncherBlocker === undefined ? 'ready' : 'blocked',
@@ -255,7 +255,7 @@ export function TradingSection({
 			...(migrateSharesLauncherBlocker === undefined ? { onAction: () => setActiveModal('migrate-shares') } : { blocker: migrateSharesLauncherBlocker }),
 		},
 		{
-			actionLabel: 'Open Redemption Flow',
+			actionLabel: 'Redeem resolved shares',
 			description: 'Redeem finalized winning shares once the selected pool has resolved.',
 			key: 'redeem-shares',
 			readiness: redeemSharesGuardMessage === undefined ? 'ready' : 'blocked',

--- a/ui/ts/tests/forkAuctionSection.test.tsx
+++ b/ui/ts/tests/forkAuctionSection.test.tsx
@@ -158,7 +158,7 @@ describe('ForkAuctionSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		fireEvent.click(documentQueries.getByRole('button', { name: 'Open Child Universe Flow' }))
+		fireEvent.click(documentQueries.getByRole('button', { name: 'Create child universe' }))
 		await Promise.resolve()
 
 		const modal = documentQueries.getByRole('dialog')

--- a/ui/ts/tests/marketSection.test.tsx
+++ b/ui/ts/tests/marketSection.test.tsx
@@ -378,13 +378,14 @@ describe('MarketSection', () => {
 
 		const documentQueries = within(document.body)
 		expect(documentQueries.queryByRole('dialog')).toBeNull()
-		const openForkButton = documentQueries.getByRole('button', { name: 'Open Fork Flow' })
+		const openForkButton = documentQueries.getByRole('button', { name: 'Fork Zoltar' })
 		await act(() => {
 			openForkButton.dispatchEvent(new window.MouseEvent('click', { bubbles: true }))
 		})
-		expect(documentQueries.getByRole('dialog')).not.toBeNull()
+		const modal = documentQueries.getByRole('dialog')
+		expect(modal).not.toBeNull()
 		expect(documentQueries.getAllByText('Fork Zoltar').length > 0).toBe(true)
-		expectTransactionButtonDisabled(document.body, 'Fork Zoltar', 'Select a valid fork question before forking Zoltar.')
+		expectTransactionButtonDisabled(modal as HTMLElement, 'Fork Zoltar', 'Select a valid fork question before forking Zoltar.')
 	})
 
 	test('opens root-universe child-universe deployment in a modal', async () => {
@@ -418,7 +419,7 @@ describe('MarketSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		fireEvent.click(documentQueries.getByRole('button', { name: 'Open Universe Flow' }))
+		fireEvent.click(documentQueries.getByRole('button', { name: 'Create child universe' }))
 		await Promise.resolve()
 
 		const modal = documentQueries.getByRole('dialog')

--- a/ui/ts/tests/tradingSection.test.tsx
+++ b/ui/ts/tests/tradingSection.test.tsx
@@ -210,8 +210,8 @@ void describe('TradingSection', () => {
 		expect(documentQueries.getByRole('heading', { name: 'Trading Action Launchers' })).not.toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Mint Complete Sets' })).not.toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Redeem Complete Sets' })).not.toBeNull()
-		expect(documentQueries.getByRole('button', { name: 'Open Mint Flow' })).not.toBeNull()
-		expect(documentQueries.getByRole('button', { name: 'Open Redeem Flow' })).not.toBeNull()
+		expect(documentQueries.getByRole('button', { name: 'Mint complete sets' })).not.toBeNull()
+		expect(documentQueries.getByRole('button', { name: 'Redeem complete sets' })).not.toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Migrate Forked Shares' })).not.toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Redeem Resolved Shares' })).not.toBeNull()
 	})
@@ -254,7 +254,7 @@ void describe('TradingSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		const mintButton = documentQueries.getByRole('button', { name: 'Open Mint Flow' }) as HTMLButtonElement
+		const mintButton = documentQueries.getByRole('button', { name: 'Mint complete sets' }) as HTMLButtonElement
 		expect(mintButton.disabled).toBe(true)
 		expect(mintButton.title).toBe(NO_MINT_CAPACITY_NO_ACTIVE_ALLOWANCE_MESSAGE)
 	})
@@ -279,7 +279,7 @@ void describe('TradingSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		const redeemButton = documentQueries.getByRole('button', { name: 'Open Redeem Flow' }) as HTMLButtonElement
+		const redeemButton = documentQueries.getByRole('button', { name: 'Redeem complete sets' }) as HTMLButtonElement
 		expect(redeemButton.disabled).toBe(true)
 		expect(redeemButton.title).toBe(NEED_MATCHING_COMPLETE_SET_SHARES_MESSAGE)
 	})
@@ -295,7 +295,7 @@ void describe('TradingSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		const migrateButton = documentQueries.getByRole('button', { name: 'Open Migration Flow' }) as HTMLButtonElement
+		const migrateButton = documentQueries.getByRole('button', { name: 'Migrate forked shares' }) as HTMLButtonElement
 		expect(migrateButton.disabled).toBe(true)
 		expect(migrateButton.title).toBe(SHARE_MIGRATION_AFTER_FORK_MESSAGE)
 	})
@@ -313,7 +313,7 @@ void describe('TradingSection', () => {
 
 		const documentQueries = within(document.body)
 		await act(() => {
-			fireEvent.click(documentQueries.getByRole('button', { name: 'Open Migration Flow' }))
+			fireEvent.click(documentQueries.getByRole('button', { name: 'Migrate forked shares' }))
 		})
 
 		const modalQueries = within(documentQueries.getByRole('dialog'))
@@ -333,7 +333,7 @@ void describe('TradingSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		const redeemSharesButton = documentQueries.getByRole('button', { name: 'Open Redemption Flow' }) as HTMLButtonElement
+		const redeemSharesButton = documentQueries.getByRole('button', { name: 'Redeem resolved shares' }) as HTMLButtonElement
 		expect(redeemSharesButton.disabled).toBe(true)
 		expect(redeemSharesButton.title).toBe(MARKET_NOT_FINALIZED_MESSAGE)
 	})
@@ -350,7 +350,7 @@ void describe('TradingSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		const redeemButton = documentQueries.getByRole('button', { name: 'Open Redeem Flow' }) as HTMLButtonElement
+		const redeemButton = documentQueries.getByRole('button', { name: 'Redeem complete sets' }) as HTMLButtonElement
 		expect(redeemButton.disabled).toBe(true)
 		expect(redeemButton.title).toBe('Loading wallet share balances.')
 	})
@@ -361,7 +361,7 @@ void describe('TradingSection', () => {
 
 		const documentQueries = within(document.body)
 		await act(() => {
-			fireEvent.click(documentQueries.getByRole('button', { name: 'Open Migration Flow' }))
+			fireEvent.click(documentQueries.getByRole('button', { name: 'Migrate forked shares' }))
 		})
 
 		const modalQueries = within(documentQueries.getByRole('dialog'))


### PR DESCRIPTION
## Summary
- Renamed several trading, fork, and universe action labels to be more direct and user-facing.
- Improved question auto-loading so it waits for question counts to resolve, skips empty counts, and avoids duplicate loads across rerenders.
- Propagated the active universe id through market route props so auto-load tracking is scoped correctly.
- Updated UI tests to cover the new labels and the revised auto-load behavior.

## Testing
- Not run in this branch review context.
- Existing test coverage was updated for the renamed buttons and new market auto-load scenarios.
- Recommended verification: `bun run tsc`, `bun run test`, `bun run format`, `bun run check`, `bun run knip`.