### PR TITLE
Improve simulation controls and question auto-loading

### DIFF
--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -1067,6 +1067,33 @@ button.currency-value.copyable:hover:not(:disabled) {
 	justify-content: flex-end;
 }
 
+.simulation-control-groups {
+	display: grid;
+	gap: 0.85rem;
+	justify-items: stretch;
+}
+
+.simulation-control-group {
+	display: grid;
+	gap: 0.45rem;
+	padding: 0.85rem;
+	border: 1px solid rgba(255, 227, 145, 0.24);
+	border-radius: 0.85rem;
+	background: rgba(56, 40, 7, 0.24);
+}
+
+.simulation-control-group-label {
+	font-family: "IBM Plex Mono", "Courier New", monospace;
+	font-size: var(--font-label);
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: rgba(255, 242, 213, 0.76);
+}
+
+.simulation-button-row {
+	justify-content: flex-end;
+}
+
 .simulation-delay-field {
 	display: grid;
 	gap: 0.45rem;

--- a/ui/ts/components/SimulationBanner.tsx
+++ b/ui/ts/components/SimulationBanner.tsx
@@ -6,6 +6,14 @@ import { parseDecimalInput } from '../lib/decimal.js'
 import { getSimulationScenarioLabel, SIMULATION_SCENARIOS } from '../simulation/scenarios.js'
 import { TimestampValue } from './TimestampValue.js'
 
+const SIMULATION_TIME_PRESETS = [
+	{ label: '+1 hour', seconds: 60n * 60n },
+	{ label: '+1 day', seconds: 24n * 60n * 60n },
+	{ label: '+1 week', seconds: 7n * 24n * 60n * 60n },
+	{ label: '+1 month', seconds: 30n * 24n * 60n * 60n },
+	{ label: '+1 year', seconds: 365n * 24n * 60n * 60n },
+] as const
+
 type SimulationBannerProps = {
 	controller: SimulationController
 	onRefresh: () => Promise<void>
@@ -234,19 +242,28 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 						</div>
 						<p className='detail'>Query delay slows simulation reads. The REP / ETH and REP / USDC mocks apply to every REP token in simulation mode. Transaction delay slows receipt confirmation so loading states stay visible.</p>
 					</div>
-					<div className='button-row'>
-						<button className='secondary' onClick={() => void runControl(async () => await controller.reset())} disabled={busy.value || !isBootstrapped.value}>
-							Reset scenario
-						</button>
-						<button className='secondary' onClick={() => void runControl(async () => await controller.mineBlock())} disabled={busy.value || !isBootstrapped.value}>
-							Mine block
-						</button>
-						<button className='secondary' onClick={() => void runControl(async () => await controller.advanceTime(60n * 60n))} disabled={busy.value || !isBootstrapped.value}>
-							+1 hour
-						</button>
-						<button className='secondary' onClick={() => void runControl(async () => await controller.advanceTime(24n * 60n * 60n))} disabled={busy.value || !isBootstrapped.value}>
-							+1 day
-						</button>
+					<div className='simulation-control-groups'>
+						<div className='simulation-control-group'>
+							<span className='simulation-control-group-label'>Actions</span>
+							<div className='button-row simulation-button-row'>
+								<button className='secondary' onClick={() => void runControl(async () => await controller.reset())} disabled={busy.value || !isBootstrapped.value}>
+									Reset scenario
+								</button>
+								<button className='secondary' onClick={() => void runControl(async () => await controller.mineBlock())} disabled={busy.value || !isBootstrapped.value}>
+									Mine block
+								</button>
+							</div>
+						</div>
+						<div className='simulation-control-group'>
+							<span className='simulation-control-group-label'>Time travel</span>
+							<div className='button-row simulation-button-row'>
+								{SIMULATION_TIME_PRESETS.map(preset => (
+									<button key={preset.label} className='secondary' onClick={() => void runControl(async () => await controller.advanceTime(preset.seconds))} disabled={busy.value || !isBootstrapped.value}>
+										{preset.label}
+									</button>
+								))}
+							</div>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/ui/ts/tests/simulationBanner.test.tsx
+++ b/ui/ts/tests/simulationBanner.test.tsx
@@ -77,4 +77,44 @@ describe('SimulationBanner', () => {
 			domEnvironment.cleanup()
 		}
 	})
+
+	test('renders grouped time presets and advances time for the new durations', async () => {
+		const domEnvironment = installDomEnvironment()
+		const onRefresh = mock(async () => undefined)
+		const advanceTime = mock(async () => undefined)
+		const controller = createSimulationController({ advanceTime })
+		const renderedComponent = await renderIntoDocument(<SimulationBanner controller={controller} onRefresh={onRefresh} />)
+
+		try {
+			const documentQueries = within(renderedComponent.container)
+			expect(documentQueries.getByText('Actions')).toBeTruthy()
+			expect(documentQueries.getByText('Time travel')).toBeTruthy()
+
+			const expectedPresets = [
+				{ label: '+1 hour', seconds: 60n * 60n },
+				{ label: '+1 day', seconds: 24n * 60n * 60n },
+				{ label: '+1 week', seconds: 7n * 24n * 60n * 60n },
+				{ label: '+1 month', seconds: 30n * 24n * 60n * 60n },
+				{ label: '+1 year', seconds: 365n * 24n * 60n * 60n },
+			] as const
+
+			for (const preset of expectedPresets) {
+				expect(documentQueries.getByRole('button', { name: preset.label })).toBeTruthy()
+			}
+
+			for (const preset of expectedPresets.slice(2)) {
+				fireEvent.click(documentQueries.getByRole('button', { name: preset.label }))
+				await waitFor(() => {
+					expect(advanceTime).toHaveBeenCalledWith(preset.seconds)
+				})
+			}
+
+			await waitFor(() => {
+				expect(onRefresh).toHaveBeenCalledTimes(3)
+			})
+		} finally {
+			await renderedComponent.cleanup()
+			domEnvironment.cleanup()
+		}
+	})
 })


### PR DESCRIPTION
## Summary
- Grouped simulation banner controls into labeled action and time-travel sections, and added longer time presets for faster scenario stepping.
- Updated market question loading so it waits for the question count to resolve before auto-fetching, and keys retries to the active universe instead of the universe object.
- Made question loading return a promise and propagate load errors, with updated prop types and app wiring.
- Expanded UI tests to cover the new simulation controls and the refined question auto-load behavior.

## Testing
- Not run (PR content only)
- Added/updated tests for `MarketSection` auto-load edge cases and universe re-render behavior.
- Added/updated tests for `SimulationBanner` grouped controls and time preset buttons.