### PR TITLE
Show liquidation outcome notices after queueing

### DIFF
--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -46,6 +46,7 @@ import {
 import { sameCaseInsensitiveText } from '../lib/caseInsensitive.js'
 import { balanceShortage } from '../lib/inputs.js'
 import { hasForkActivity } from '../lib/forkAuction.js'
+import { getLiquidationNoticeState } from '../lib/liquidationStatus.js'
 import { resolveRequestedLoadableValueState } from '../lib/loadState.js'
 import { formatCurrencyBalance, formatCurrencyInputBalance } from '../lib/formatters.js'
 import { parseRepAmountInput } from '../lib/marketForm.js'
@@ -274,6 +275,7 @@ export function SecurityPoolWorkflowSection({
 	const lastSelectedVaultAutoLoadKey = useRef<string | undefined>(undefined)
 	const lastQueuedOperationRefreshHash = useRef<string | undefined>(undefined)
 	const lastImmediateQueuedOperationRefreshHash = useRef<string | undefined>(undefined)
+	const lastLiquidationOutcomeRefreshKey = useRef<string | undefined>(undefined)
 	const lastExecutedOperationRefreshHash = useRef<string | undefined>(undefined)
 	const hasValidOraclePrice = hasValidSecurityVaultOraclePrice(selectedVaultDetails?.managerAddress, currentPoolOracleManagerDetails)
 	const depositAmount = (() => {
@@ -413,6 +415,12 @@ export function SecurityPoolWorkflowSection({
 		queuedVaultOperation,
 		securityVaultResult: securityVault.securityVaultResult,
 	})
+	const liquidationNoticeState = getLiquidationNoticeState({
+		currentPoolOracleManagerDetails,
+		liquidationTargetVault,
+		loadingPoolOracleManager,
+		securityPoolOverviewResult,
+	})
 	const selectedPoolQuestionDescription = marketDetails === undefined ? undefined : marketDetails.description.trim() === '' ? undefined : marketDetails.description
 	const loadedSelectedPool = selectedPool
 	const selectedPoolOracleMetricValues = loadedSelectedPool === undefined ? undefined : getSelectedPoolOracleMetricValues(loadedSelectedPool)
@@ -535,6 +543,20 @@ export function SecurityPoolWorkflowSection({
 	}, [currentPoolOracleManagerDetails, hasLoadedCurrentVault, loadingPoolOracleManager, onRefreshSelectedPoolData, queuedVaultOperation, securityVault.onLoadSecurityVault, securityVault.securityVaultResult, selectedPool?.securityPoolAddress, showSelectedPoolWorkflowDetails, view])
 
 	useEffect(() => {
+		const liquidationRefreshKey = securityPoolOverviewResult?.action !== 'queueLiquidation' || liquidationNoticeState === undefined || liquidationNoticeState === 'submitted' ? undefined : `${securityPoolOverviewResult.hash}:${liquidationNoticeState}`
+		if (liquidationRefreshKey === undefined) {
+			lastLiquidationOutcomeRefreshKey.current = undefined
+			return
+		}
+		if (lastLiquidationOutcomeRefreshKey.current === liquidationRefreshKey) return
+		lastLiquidationOutcomeRefreshKey.current = liquidationRefreshKey
+		void onRefreshSelectedPoolData(selectedPool?.securityPoolAddress)
+		if (showSelectedPoolWorkflowDetails && view === 'vaults' && hasLoadedCurrentVault) {
+			void securityVault.onLoadSecurityVault()
+		}
+	}, [hasLoadedCurrentVault, liquidationNoticeState, onRefreshSelectedPoolData, securityPoolOverviewResult, securityVault.onLoadSecurityVault, selectedPool?.securityPoolAddress, showSelectedPoolWorkflowDetails, view])
+
+	useEffect(() => {
 		if (poolPriceOracleResult?.action !== 'executeStagedOperation') {
 			lastExecutedOperationRefreshHash.current = undefined
 			return
@@ -553,6 +575,19 @@ export function SecurityPoolWorkflowSection({
 
 	return (
 		<RouteWorkflowPanel showHeader={showHeader} title='Selected Pool'>
+			{securityPoolOverviewResult === undefined || liquidationNoticeState === undefined ? undefined : liquidationNoticeState === 'failed' ? (
+				<div className='notice error'>
+					<strong>Liquidation failed</strong>
+					<p>
+						Pool <AddressValue address={securityPoolOverviewResult.securityPoolAddress} />: <TransactionHashLink hash={securityPoolOverviewResult.hash} />
+					</p>
+					{securityPoolOverviewResult.stagedExecution?.errorMessage === undefined ? undefined : <p>{securityPoolOverviewResult.stagedExecution.errorMessage}</p>}
+				</div>
+			) : (
+				<p className='notice success'>
+					{liquidationNoticeState === 'successful' ? 'Liquidation successful' : liquidationNoticeState === 'queued' ? 'Liquidation queued' : 'Liquidation submitted'} for <AddressValue address={securityPoolOverviewResult.securityPoolAddress} />: <TransactionHashLink hash={securityPoolOverviewResult.hash} />
+				</p>
+			)}
 			<StickyObjectContext {...(loadedSelectedPool === undefined ? {} : { badge: <span className={`badge ${getSecurityPoolStatusBadgeTone(loadedSelectedPool.systemState)}`}>{loadedSelectedPool.systemState}</span> })} sticky={false} title={getSelectedPoolCardTitle()} items={[]}>
 				<div className='selected-pool-context-controls'>
 					<div className='selected-pool-context-lookup'>

--- a/ui/ts/components/SecurityPoolsOverviewSection.tsx
+++ b/ui/ts/components/SecurityPoolsOverviewSection.tsx
@@ -18,6 +18,7 @@ import { VaultMetricGrid } from './VaultMetricGrid.js'
 import { WorkflowSubsection } from './WorkflowSubsection.js'
 import { zeroAddress } from 'viem'
 import { sameAddress } from '../lib/address.js'
+import { getLiquidationNoticeState } from '../lib/liquidationStatus.js'
 import { isMainnetChain } from '../lib/network.js'
 import { openInterestFeePerYearBigint } from '../lib/retentionRate.js'
 import { getPoolRegistryPresentation } from '../lib/userCopy.js'
@@ -65,6 +66,12 @@ export function SecurityPoolsOverviewSection({
 	const currentPoolOracleManagerDetails = selectedPool === undefined || liquidationManagerAddress === undefined || !sameAddress(poolOracleManagerDetails?.managerAddress, liquidationManagerAddress) ? undefined : poolOracleManagerDetails
 	const targetVaultSummary = selectedPool?.vaults.find(vault => sameAddress(vault.vaultAddress, liquidationTargetVault))
 	const callerVaultSummary = accountState.address === undefined ? undefined : selectedPool?.vaults.find(vault => sameAddress(vault.vaultAddress, accountState.address))
+	const liquidationNoticeState = getLiquidationNoticeState({
+		currentPoolOracleManagerDetails,
+		liquidationTargetVault,
+		loadingPoolOracleManager,
+		securityPoolOverviewResult,
+	})
 	const normalizedSearchText = searchText.trim().toLowerCase()
 	const filteredSecurityPools = securityPools.filter(pool => {
 		if (systemStateFilter !== 'all' && pool.systemState !== systemStateFilter) return false
@@ -87,9 +94,17 @@ export function SecurityPoolsOverviewSection({
 					</button>
 				}
 			>
-				{securityPoolOverviewResult === undefined ? undefined : (
+				{securityPoolOverviewResult === undefined || liquidationNoticeState === undefined ? undefined : liquidationNoticeState === 'failed' ? (
+					<div className='notice error'>
+						<strong>Liquidation failed</strong>
+						<p>
+							Pool <AddressValue address={securityPoolOverviewResult.securityPoolAddress} />: <TransactionHashLink hash={securityPoolOverviewResult.hash} />
+						</p>
+						{securityPoolOverviewResult.stagedExecution?.errorMessage === undefined ? undefined : <p>{securityPoolOverviewResult.stagedExecution.errorMessage}</p>}
+					</div>
+				) : (
 					<p className='notice success'>
-						Queued liquidation for <AddressValue address={securityPoolOverviewResult.securityPoolAddress} />: <TransactionHashLink hash={securityPoolOverviewResult.hash} />
+						{liquidationNoticeState === 'successful' ? 'Liquidation successful' : liquidationNoticeState === 'queued' ? 'Liquidation queued' : 'Liquidation submitted'} for <AddressValue address={securityPoolOverviewResult.securityPoolAddress} />: <TransactionHashLink hash={securityPoolOverviewResult.hash} />
 					</p>
 				)}
 				<ErrorNotice message={securityPoolOverviewError} />

--- a/ui/ts/hooks/useSecurityPoolsOverview.ts
+++ b/ui/ts/hooks/useSecurityPoolsOverview.ts
@@ -82,13 +82,15 @@ export function useSecurityPoolsOverview({ accountAddress, onTransaction, onTran
 					return await queueSecurityPoolLiquidation(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), managerAddress, targetVault, amount)
 				},
 				'Failed to queue liquidation',
-				result => {
+				async result => {
 					securityPoolOverviewResult.value = {
 						action: 'queueLiquidation',
 						hash: result.hash,
 						securityPoolAddress,
 						...(result.stagedExecution === undefined ? {} : { stagedExecution: result.stagedExecution }),
 					}
+					liquidationModalOpen.value = false
+					await loadSecurityPools(securityPoolAddress)
 				},
 			)
 		} finally {

--- a/ui/ts/lib/liquidationStatus.ts
+++ b/ui/ts/lib/liquidationStatus.ts
@@ -1,0 +1,25 @@
+import { sameAddress } from './address.js'
+import type { OracleManagerDetails, SecurityPoolOverviewActionResult } from '../types/contracts.js'
+
+type LiquidationNoticeState = 'failed' | 'queued' | 'submitted' | 'successful'
+
+export function getLiquidationNoticeState({
+	currentPoolOracleManagerDetails,
+	liquidationTargetVault,
+	loadingPoolOracleManager,
+	securityPoolOverviewResult,
+}: {
+	currentPoolOracleManagerDetails: OracleManagerDetails | undefined
+	liquidationTargetVault: string
+	loadingPoolOracleManager: boolean
+	securityPoolOverviewResult: SecurityPoolOverviewActionResult | undefined
+}): LiquidationNoticeState | undefined {
+	if (securityPoolOverviewResult?.action !== 'queueLiquidation') return undefined
+	if (securityPoolOverviewResult.stagedExecution !== undefined) return securityPoolOverviewResult.stagedExecution.success ? 'successful' : 'failed'
+	if (loadingPoolOracleManager || currentPoolOracleManagerDetails === undefined) return 'submitted'
+	if (currentPoolOracleManagerDetails.pendingOperation?.operation === 'liquidation' && sameAddress(currentPoolOracleManagerDetails.pendingOperation.targetVault, liquidationTargetVault)) {
+		return 'queued'
+	}
+	if (currentPoolOracleManagerDetails.isPriceValid) return 'successful'
+	return 'submitted'
+}

--- a/ui/ts/tests/securityPoolWorkflowSection.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection.test.tsx
@@ -736,6 +736,74 @@ describe('SecurityPoolWorkflowSection', () => {
 		expect(dialogQueries.queryByRole('button', { name: 'View In Staged Operations' })).toBeNull()
 	})
 
+	test('shows liquidation successful in the selected pool workflow after an immediate execution', async () => {
+		const selectedPoolAddress = zeroAddress
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					accountState: createAccountState(),
+					liquidationManagerAddress: zeroAddress,
+					liquidationSecurityPoolAddress: selectedPoolAddress,
+					liquidationTargetVault: zeroAddress,
+					poolOracleManagerDetails: createOracleManagerDetails({
+						isPriceValid: true,
+						managerAddress: zeroAddress,
+						pendingOperation: undefined,
+					}),
+					securityPoolAddress: selectedPoolAddress,
+					securityPoolOverviewResult: {
+						action: 'queueLiquidation',
+						hash: '0x00000000000000000000000000000000000000000000000000000000000000c1',
+						securityPoolAddress: selectedPoolAddress,
+					},
+					securityPools: [createSelectedPool({ managerAddress: zeroAddress, securityPoolAddress: selectedPoolAddress })],
+				})}
+				showHeader={false}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(within(document.body).getByText(/Liquidation successful/)).not.toBeNull()
+	})
+
+	test('shows liquidation failed in the selected pool workflow with the revert detail', async () => {
+		const selectedPoolAddress = zeroAddress
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					accountState: createAccountState(),
+					liquidationManagerAddress: zeroAddress,
+					liquidationSecurityPoolAddress: selectedPoolAddress,
+					liquidationTargetVault: zeroAddress,
+					poolOracleManagerDetails: createOracleManagerDetails({
+						isPriceValid: true,
+						managerAddress: zeroAddress,
+						pendingOperation: undefined,
+					}),
+					securityPoolAddress: selectedPoolAddress,
+					securityPoolOverviewResult: {
+						action: 'queueLiquidation',
+						hash: '0x00000000000000000000000000000000000000000000000000000000000000c2',
+						securityPoolAddress: selectedPoolAddress,
+						stagedExecution: {
+							errorMessage: 'Local Security Bond Allowance broken',
+							operation: 'liquidation',
+							operationId: 13n,
+							success: false,
+						},
+					},
+					securityPools: [createSelectedPool({ managerAddress: zeroAddress, securityPoolAddress: selectedPoolAddress })],
+				})}
+				showHeader={false}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByText('Liquidation failed')).not.toBeNull()
+		expect(documentQueries.getByText('Local Security Bond Allowance broken')).not.toBeNull()
+	})
+
 	test('refreshes the selected pool and loaded vault after an immediate REP withdrawal execution', async () => {
 		const refreshSelectedPoolCalls: Array<string | undefined> = []
 		const loadSecurityVaultCalls: Array<string | undefined> = []
@@ -769,6 +837,169 @@ describe('SecurityPoolWorkflowSection', () => {
 						securityVaultResult: {
 							action: 'queueWithdrawRep',
 							hash: '0x00000000000000000000000000000000000000000000000000000000000000dd',
+						},
+					}),
+					selectedPoolView: 'vaults',
+				})}
+				showHeader={false}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(refreshSelectedPoolCalls).toEqual([selectedPoolAddress])
+		expect(loadSecurityVaultCalls).toEqual([undefined])
+	})
+
+	test('refreshes the selected pool and loaded vault after a liquidation resolves as queued', async () => {
+		const refreshSelectedPoolCalls: Array<string | undefined> = []
+		const loadSecurityVaultCalls: Array<string | undefined> = []
+		const selectedPoolAddress = zeroAddress
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					accountState: createAccountState(),
+					liquidationManagerAddress: zeroAddress,
+					liquidationSecurityPoolAddress: selectedPoolAddress,
+					liquidationTargetVault: zeroAddress,
+					onRefreshSelectedPoolData: securityPoolAddressInput => {
+						refreshSelectedPoolCalls.push(securityPoolAddressInput)
+					},
+					poolOracleManagerDetails: createOracleManagerDetails({
+						isPriceValid: false,
+						managerAddress: zeroAddress,
+						pendingOperation: {
+							amount: 1n,
+							initiatorVault: zeroAddress,
+							operation: 'liquidation',
+							operationId: 10n,
+							targetVault: zeroAddress,
+						},
+						pendingOperationSlotId: 10n,
+					}),
+					securityPoolAddress: selectedPoolAddress,
+					securityPoolOverviewResult: {
+						action: 'queueLiquidation',
+						hash: '0x00000000000000000000000000000000000000000000000000000000000000d1',
+						securityPoolAddress: selectedPoolAddress,
+					},
+					securityPools: [createSelectedPool({ managerAddress: zeroAddress, securityPoolAddress: selectedPoolAddress })],
+					securityVault: createSecurityVaultProps({
+						onLoadSecurityVault: vaultAddress => {
+							loadSecurityVaultCalls.push(vaultAddress)
+						},
+						securityVaultDetails: createSecurityVaultDetails({ securityPoolAddress: selectedPoolAddress, vaultAddress: zeroAddress }),
+						securityVaultForm: {
+							depositAmount: '',
+							repWithdrawAmount: '',
+							securityBondAllowanceAmount: '',
+							securityPoolAddress: selectedPoolAddress,
+							selectedVaultAddress: zeroAddress,
+						},
+					}),
+					selectedPoolView: 'vaults',
+				})}
+				showHeader={false}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(refreshSelectedPoolCalls).toEqual([selectedPoolAddress])
+		expect(loadSecurityVaultCalls).toEqual([undefined])
+	})
+
+	test('refreshes the selected pool and loaded vault after an immediate liquidation execution', async () => {
+		const refreshSelectedPoolCalls: Array<string | undefined> = []
+		const loadSecurityVaultCalls: Array<string | undefined> = []
+		const selectedPoolAddress = zeroAddress
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					accountState: createAccountState(),
+					liquidationManagerAddress: zeroAddress,
+					liquidationSecurityPoolAddress: selectedPoolAddress,
+					liquidationTargetVault: zeroAddress,
+					onRefreshSelectedPoolData: securityPoolAddressInput => {
+						refreshSelectedPoolCalls.push(securityPoolAddressInput)
+					},
+					poolOracleManagerDetails: createOracleManagerDetails({
+						isPriceValid: true,
+						managerAddress: zeroAddress,
+						pendingOperation: undefined,
+					}),
+					securityPoolAddress: selectedPoolAddress,
+					securityPoolOverviewResult: {
+						action: 'queueLiquidation',
+						hash: '0x00000000000000000000000000000000000000000000000000000000000000d2',
+						securityPoolAddress: selectedPoolAddress,
+					},
+					securityPools: [createSelectedPool({ managerAddress: zeroAddress, securityPoolAddress: selectedPoolAddress })],
+					securityVault: createSecurityVaultProps({
+						onLoadSecurityVault: vaultAddress => {
+							loadSecurityVaultCalls.push(vaultAddress)
+						},
+						securityVaultDetails: createSecurityVaultDetails({ securityPoolAddress: selectedPoolAddress, vaultAddress: zeroAddress }),
+						securityVaultForm: {
+							depositAmount: '',
+							repWithdrawAmount: '',
+							securityBondAllowanceAmount: '',
+							securityPoolAddress: selectedPoolAddress,
+							selectedVaultAddress: zeroAddress,
+						},
+					}),
+					selectedPoolView: 'vaults',
+				})}
+				showHeader={false}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(refreshSelectedPoolCalls).toEqual([selectedPoolAddress])
+		expect(loadSecurityVaultCalls).toEqual([undefined])
+	})
+
+	test('refreshes the selected pool and loaded vault after a failed immediate liquidation execution', async () => {
+		const refreshSelectedPoolCalls: Array<string | undefined> = []
+		const loadSecurityVaultCalls: Array<string | undefined> = []
+		const selectedPoolAddress = zeroAddress
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					accountState: createAccountState(),
+					liquidationManagerAddress: zeroAddress,
+					liquidationSecurityPoolAddress: selectedPoolAddress,
+					liquidationTargetVault: zeroAddress,
+					onRefreshSelectedPoolData: securityPoolAddressInput => {
+						refreshSelectedPoolCalls.push(securityPoolAddressInput)
+					},
+					poolOracleManagerDetails: createOracleManagerDetails({
+						isPriceValid: true,
+						managerAddress: zeroAddress,
+						pendingOperation: undefined,
+					}),
+					securityPoolAddress: selectedPoolAddress,
+					securityPoolOverviewResult: {
+						action: 'queueLiquidation',
+						hash: '0x00000000000000000000000000000000000000000000000000000000000000d3',
+						securityPoolAddress: selectedPoolAddress,
+						stagedExecution: {
+							errorMessage: 'Local Security Bond Allowance broken',
+							operation: 'liquidation',
+							operationId: 14n,
+							success: false,
+						},
+					},
+					securityPools: [createSelectedPool({ managerAddress: zeroAddress, securityPoolAddress: selectedPoolAddress })],
+					securityVault: createSecurityVaultProps({
+						onLoadSecurityVault: vaultAddress => {
+							loadSecurityVaultCalls.push(vaultAddress)
+						},
+						securityVaultDetails: createSecurityVaultDetails({ securityPoolAddress: selectedPoolAddress, vaultAddress: zeroAddress }),
+						securityVaultForm: {
+							depositAmount: '',
+							repWithdrawAmount: '',
+							securityBondAllowanceAmount: '',
+							securityPoolAddress: selectedPoolAddress,
+							selectedVaultAddress: zeroAddress,
 						},
 					}),
 					selectedPoolView: 'vaults',

--- a/ui/ts/tests/securityPoolsSection.test.ts
+++ b/ui/ts/tests/securityPoolsSection.test.ts
@@ -8,7 +8,7 @@ import { act } from 'preact/test-utils'
 import { zeroAddress } from 'viem'
 import { SecurityPoolsSection, shouldRefreshSelectedPoolDataOnViewOpen } from '../components/SecurityPoolsSection.js'
 import type { AccountState } from '../types/app.js'
-import type { ListedSecurityPool, MarketDetails } from '../types/contracts.js'
+import type { ListedSecurityPool, MarketDetails, OracleManagerDetails } from '../types/contracts.js'
 import type { ForkAuctionRouteContentProps, ReportingRouteContentProps, SecurityPoolRouteContentProps, SecurityPoolsOverviewRouteContentProps, SecurityPoolsSectionProps, SecurityPoolWorkflowRouteContentProps, SecurityVaultRouteContentProps, TradingRouteContentProps } from '../types/components.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
@@ -202,6 +202,26 @@ function createSelectedPool(overrides: Partial<ListedSecurityPool> = {}): Listed
 		universeId: 1n,
 		vaultCount: 3n,
 		vaults: [],
+		...overrides,
+	}
+}
+
+function createOracleManagerDetails(overrides: Partial<OracleManagerDetails> = {}): OracleManagerDetails {
+	return {
+		callbackStateHash: undefined,
+		exactToken1Report: undefined,
+		isPriceValid: true,
+		lastPrice: 1n,
+		lastSettlementTimestamp: 1n,
+		managerAddress: zeroAddress,
+		openOracleAddress: zeroAddress,
+		pendingOperation: undefined,
+		pendingOperationSlotId: 0n,
+		pendingReportId: 0n,
+		priceValidUntilTimestamp: 1000n,
+		requestPriceEthCost: 1n,
+		token1: zeroAddress,
+		token2: zeroAddress,
 		...overrides,
 	}
 }
@@ -543,6 +563,106 @@ void describe('SecurityPoolsSection', () => {
 		expect(lookupPosition).toBeGreaterThanOrEqual(0)
 		expect(summaryPosition).toBeGreaterThanOrEqual(0)
 		expect(lookupPosition < summaryPosition).toBe(true)
+	})
+
+	void test('shows liquidation successful in browse mode after an immediate execution', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				SecurityPoolsSection,
+				createSecurityPoolsSectionProps({
+					overview: createOverviewProps({
+						liquidationManagerAddress: zeroAddress,
+						liquidationSecurityPoolAddress: zeroAddress,
+						liquidationTargetVault: zeroAddress,
+						poolOracleManagerDetails: createOracleManagerDetails({
+							isPriceValid: true,
+							managerAddress: zeroAddress,
+						}),
+						securityPoolOverviewResult: {
+							action: 'queueLiquidation',
+							hash: '0x00000000000000000000000000000000000000000000000000000000000000aa',
+							securityPoolAddress: zeroAddress,
+						},
+						securityPools: [createSelectedPool()],
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(within(document.body).getByText(/Liquidation successful/)).not.toBeNull()
+	})
+
+	void test('shows liquidation queued in browse mode when the refreshed manager reports a pending liquidation', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				SecurityPoolsSection,
+				createSecurityPoolsSectionProps({
+					overview: createOverviewProps({
+						liquidationManagerAddress: zeroAddress,
+						liquidationSecurityPoolAddress: zeroAddress,
+						liquidationTargetVault: zeroAddress,
+						poolOracleManagerDetails: createOracleManagerDetails({
+							isPriceValid: false,
+							managerAddress: zeroAddress,
+							pendingOperation: {
+								amount: 1n,
+								initiatorVault: zeroAddress,
+								operation: 'liquidation',
+								operationId: 4n,
+								targetVault: zeroAddress,
+							},
+							pendingOperationSlotId: 4n,
+						}),
+						securityPoolOverviewResult: {
+							action: 'queueLiquidation',
+							hash: '0x00000000000000000000000000000000000000000000000000000000000000ab',
+							securityPoolAddress: zeroAddress,
+						},
+						securityPools: [createSelectedPool()],
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(within(document.body).getByText(/Liquidation queued/)).not.toBeNull()
+	})
+
+	void test('shows liquidation failed in browse mode with the revert detail', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				SecurityPoolsSection,
+				createSecurityPoolsSectionProps({
+					overview: createOverviewProps({
+						liquidationManagerAddress: zeroAddress,
+						liquidationSecurityPoolAddress: zeroAddress,
+						liquidationTargetVault: zeroAddress,
+						poolOracleManagerDetails: createOracleManagerDetails({
+							isPriceValid: true,
+							managerAddress: zeroAddress,
+						}),
+						securityPoolOverviewResult: {
+							action: 'queueLiquidation',
+							hash: '0x00000000000000000000000000000000000000000000000000000000000000ac',
+							securityPoolAddress: zeroAddress,
+							stagedExecution: {
+								errorMessage: 'Local Security Bond Allowance broken',
+								operation: 'liquidation',
+								operationId: 9n,
+								success: false,
+							},
+						},
+						securityPools: [createSelectedPool()],
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByText('Liquidation failed')).not.toBeNull()
+		expect(documentQueries.getByText('Local Security Bond Allowance broken')).not.toBeNull()
 	})
 
 	void test('keeps the route summary hidden in operate mode until the selected pool resolves', async () => {


### PR DESCRIPTION
## Summary
- Adds shared liquidation notice state logic so the UI can distinguish submitted, queued, successful, and failed liquidation outcomes.
- Shows success and failure notices in both the overview and selected-pool workflow views after a liquidation is queued.
- Refreshes selected pool and vault data after queueing so the notice state updates from fresh on-chain data.
- Expands UI tests to cover immediate success, queued, and failed liquidation outcomes.

## Testing
- Not run (per request).
- Added/updated unit coverage in `ui/ts/tests/securityPoolWorkflowSection.test.tsx`.
- Added/updated unit coverage in `ui/ts/tests/securityPoolsSection.test.ts`.