### PR TITLE
Stabilize simulation timing and polish liquidation UI

### DIFF
--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -20,6 +20,7 @@ import { useSecurityVaultOperations } from './hooks/useSecurityVaultOperations.j
 import { useTradingOperations } from './hooks/useTradingOperations.js'
 import { useUrlState } from './hooks/useUrlState.js'
 import { getActiveSimulationController } from './lib/activeEnvironment.js'
+import { ChainTimestampContext } from './lib/chainTimestamp.js'
 import { getDeploymentSections } from './lib/deployment.js'
 import { resolveLoadableValueState } from './lib/loadState.js'
 import { getWrongNetworkMessage, isSupportedAppChain } from './lib/network.js'
@@ -59,6 +60,7 @@ export function App() {
 		accountState,
 		augurPlaceHolderDeployed,
 		connectWallet,
+		currentTimestamp,
 		deploymentStatuses,
 		environmentBootstrapError,
 		environmentReady,
@@ -652,22 +654,24 @@ export function App() {
 		) : undefined
 
 	return (
-		<main>
-			<AppStatusNotices
-				errorMessage={errorMessage}
-				wrongNetworkMessage={wrongNetworkMessage}
-				simulationBootstrapError={environmentBootstrapError}
-				showAugurPlaceHolderDeploymentWarning={showAugurPlaceHolderDeploymentWarning}
-				showTransactionSuccessNotice={showTransactionSuccessNotice}
-				showZoltarUniverseForkedWarning={showZoltarUniverseForkedWarning}
-				transactionState={transactionState.value}
-				zoltarUniverse={zoltarUniverse}
-			/>
-			<AppHeaderShell overview={overviewProps} simulationController={simulationController} subNavigation={routeSubNavigation} tabNavigation={tabNavigationProps} onRefresh={refreshSimulationView} />
+		<ChainTimestampContext.Provider value={currentTimestamp}>
+			<main>
+				<AppStatusNotices
+					errorMessage={errorMessage}
+					simulationBootstrapError={environmentBootstrapError}
+					showAugurPlaceHolderDeploymentWarning={showAugurPlaceHolderDeploymentWarning}
+					showTransactionSuccessNotice={showTransactionSuccessNotice}
+					showZoltarUniverseForkedWarning={showZoltarUniverseForkedWarning}
+					transactionState={transactionState.value}
+					wrongNetworkMessage={wrongNetworkMessage}
+					zoltarUniverse={zoltarUniverse}
+				/>
+				<AppHeaderShell overview={overviewProps} simulationController={simulationController} subNavigation={routeSubNavigation} tabNavigation={tabNavigationProps} onRefresh={refreshSimulationView} />
 
-			<fieldset className='route-shell' disabled={isRouteContentDisabled}>
-				<AppRouteContent deploy={deployRouteContentProps} market={marketRouteContentProps} openOracle={openOracleRouteContentProps} route={route} securityPools={securityPoolsRouteContentProps} wrongNetworkMessage={wrongNetworkMessage} />
-			</fieldset>
-		</main>
+				<fieldset className='route-shell' disabled={isRouteContentDisabled}>
+					<AppRouteContent deploy={deployRouteContentProps} market={marketRouteContentProps} openOracle={openOracleRouteContentProps} route={route} securityPools={securityPoolsRouteContentProps} wrongNetworkMessage={wrongNetworkMessage} />
+				</fieldset>
+			</main>
+		</ChainTimestampContext.Provider>
 	)
 }

--- a/ui/ts/components/LiquidationModal.tsx
+++ b/ui/ts/components/LiquidationModal.tsx
@@ -10,11 +10,13 @@ import { MetricField } from './MetricField.js'
 import { OpenOraclePriceValue } from './OpenOraclePriceValue.js'
 import { TransactionActionButton } from './TransactionActionButton.js'
 import { sameAddress } from '../lib/address.js'
+import { useChainTimestamp } from '../lib/chainTimestamp.js'
 import { formatCurrencyInputBalance } from '../lib/formatters.js'
 import { getLiquidationFailureReason, simulateLiquidation } from '../lib/liquidation.js'
 import { parseRepAmountInput } from '../lib/marketForm.js'
 import { getRepPriceSourceCopy, renderRepPriceSourceLabel, type RepPriceSource } from '../lib/repPriceSource.js'
 import { getVaultCollateralizationPercent } from '../lib/trading.js'
+import { getCurrentTimestamp as getLocalCurrentTimestamp } from '../lib/time.js'
 import type { ListedSecurityPool, OracleManagerDetails, SecurityPoolOverviewActionResult, SecurityPoolVaultSummary } from '../types/contracts.js'
 
 type LiquidationModalProps = {
@@ -95,6 +97,7 @@ export function LiquidationModal({
 	onLiquidationAmountChange,
 	onQueueLiquidation,
 }: LiquidationModalProps) {
+	const chainCurrentTimestamp = useChainTimestamp()
 	const dialogRef = useRef<HTMLElement | null>(null)
 	const closeButtonRef = useRef<HTMLButtonElement | null>(null)
 	const onCloseRef = useRef(closeLiquidationModal)
@@ -139,7 +142,7 @@ export function LiquidationModal({
 	}, [liquidationModalOpen])
 
 	if (!liquidationModalOpen) return undefined
-	const currentTimestamp = BigInt(Math.floor(Date.now() / 1000))
+	const currentTimestamp = chainCurrentTimestamp ?? getLocalCurrentTimestamp()
 	const liquidationAmountValue = (() => {
 		try {
 			return parseRepAmountInput(liquidationAmount, 'Liquidation amount')

--- a/ui/ts/components/OpenOraclePriceValue.tsx
+++ b/ui/ts/components/OpenOraclePriceValue.tsx
@@ -1,7 +1,9 @@
+import { useChainTimestamp } from '../lib/chainTimestamp.js'
 import { getOracleLastPriceDisplay, getOraclePriceValidityPresentation } from '../lib/securityPoolWorkflow.js'
+import { getCurrentTimestamp } from '../lib/time.js'
 
 type OpenOraclePriceValueProps = {
-	currentTimestamp: bigint
+	currentTimestamp?: bigint
 	lastPrice: bigint | undefined
 	lastSettlementTimestamp: bigint
 	priceValidUntilTimestamp: bigint | undefined
@@ -9,9 +11,11 @@ type OpenOraclePriceValueProps = {
 
 export function OpenOraclePriceValue({ currentTimestamp, lastPrice, lastSettlementTimestamp, priceValidUntilTimestamp }: OpenOraclePriceValueProps) {
 	if (lastPrice === undefined || lastSettlementTimestamp === 0n) return 'Unavailable'
+	const chainCurrentTimestamp = useChainTimestamp()
+	const resolvedCurrentTimestamp = currentTimestamp ?? chainCurrentTimestamp ?? getCurrentTimestamp()
 
 	const validityPresentation = getOraclePriceValidityPresentation({
-		currentTimestamp,
+		currentTimestamp: resolvedCurrentTimestamp,
 		lastSettlementTimestamp,
 		priceValidUntilTimestamp,
 	})

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -31,6 +31,7 @@ import { UniverseLink } from './UniverseLink.js'
 import { VaultMetricGrid } from './VaultMetricGrid.js'
 import { ViewTabs } from './ViewTabs.js'
 import { normalizeAddress, sameAddress } from '../lib/address.js'
+import { useChainTimestamp } from '../lib/chainTimestamp.js'
 import { getSecurityPoolVaultReadinessActions } from '../lib/securityPoolReadiness.js'
 import {
 	getCurrentPoolOracleManagerDetails,
@@ -64,6 +65,7 @@ import {
 	MIN_SECURITY_BOND_ALLOWANCE,
 	MIN_SECURITY_VAULT_REP_DEPOSIT,
 } from '../lib/securityVault.js'
+import { getCurrentTimestamp as getLocalCurrentTimestamp } from '../lib/time.js'
 import { getPoolRegistryPresentation } from '../lib/userCopy.js'
 import { formatUniverseLabel } from '../lib/universe.js'
 import type { OracleManagerDetails, SecurityPoolSystemState } from '../types/contracts.js'
@@ -200,6 +202,7 @@ export function SecurityPoolWorkflowSection({
 	trading,
 }: SecurityPoolWorkflowRouteContentProps & { showHeader?: boolean }) {
 	const view = resolveSelectedPoolView(selectedPoolView)
+	const chainCurrentTimestamp = useChainTimestamp()
 	const [manualPendingOperationId, setManualPendingOperationId] = useState('')
 	const [vaultView, setVaultView] = useState<SelectedVaultView>('selected-vault')
 	const [vaultActionModal, setVaultActionModal] = useState<VaultActionModal>(undefined)
@@ -216,7 +219,7 @@ export function SecurityPoolWorkflowSection({
 	const marketDetails = selectedPool?.marketDetails ?? currentReportingDetails?.marketDetails ?? currentForkAuctionDetails?.marketDetails
 	const selectedPoolState = selectedPool?.systemState ?? currentForkAuctionDetails?.systemState
 	const selectedPoolHasForkActivity = selectedPool !== undefined ? hasForkActivity(selectedPool) : currentForkAuctionDetails !== undefined ? hasForkActivity(currentForkAuctionDetails) : false
-	const currentTimestamp = currentReportingDetails?.currentTime ?? BigInt(Math.floor(Date.now() / 1000))
+	const currentTimestamp = currentReportingDetails?.currentTime ?? chainCurrentTimestamp ?? getLocalCurrentTimestamp()
 	const reportingReady = marketDetails !== undefined && marketDetails.endTime <= currentTimestamp
 	const forkWorkflowDisabled = isForkWorkflowDisabled(selectedPoolState, selectedPoolHasForkActivity)
 	const selectedPoolUniverseMismatch = selectedPool !== undefined && selectedPool.universeId !== activeUniverseId

--- a/ui/ts/components/TimestampValue.tsx
+++ b/ui/ts/components/TimestampValue.tsx
@@ -1,6 +1,8 @@
 import type { ComponentChildren } from 'preact'
 import { useEffect, useState } from 'preact/hooks'
+import { useChainTimestamp } from '../lib/chainTimestamp.js'
 import { formatRelativeTimestamp, formatTimestamp } from '../lib/formatters.js'
+import { getCurrentTimestamp } from '../lib/time.js'
 import { getMetricPlaceholderPresentation } from '../lib/userCopy.js'
 
 type TimestampValueProps = {
@@ -12,26 +14,23 @@ type TimestampValueProps = {
 	zeroText?: ComponentChildren
 }
 
-function getCurrentTimestamp() {
-	return BigInt(Math.floor(Date.now() / 1000))
-}
-
 export function TimestampValue({ className = '', currentTimestamp, loading = false, timestamp, undefinedText = getMetricPlaceholderPresentation(undefined)?.placeholder, zeroText }: TimestampValueProps) {
-	const [now, setNow] = useState(() => currentTimestamp ?? getCurrentTimestamp())
+	const chainCurrentTimestamp = useChainTimestamp()
+	const resolvedCurrentTimestamp = currentTimestamp ?? chainCurrentTimestamp
+	const [fallbackNow, setFallbackNow] = useState(() => getCurrentTimestamp())
+	const now = resolvedCurrentTimestamp ?? fallbackNow
 
 	useEffect(() => {
-		if (loading) return
-		const updateNow = () => {
-			setNow(currentTimestamp ?? getCurrentTimestamp())
-		}
-
-		updateNow()
-		const intervalId = window.setInterval(updateNow, 1000)
+		if (loading || resolvedCurrentTimestamp !== undefined) return
+		setFallbackNow(getCurrentTimestamp())
+		const intervalId = window.setInterval(() => {
+			setFallbackNow(getCurrentTimestamp())
+		}, 1000)
 
 		return () => {
 			window.clearInterval(intervalId)
 		}
-	}, [currentTimestamp, loading])
+	}, [loading, resolvedCurrentTimestamp])
 
 	if (loading) {
 		return <span className={`timestamp-value loading ${className}`}>Loading...</span>

--- a/ui/ts/hooks/useOnchainState.ts
+++ b/ui/ts/hooks/useOnchainState.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'preact/hooks'
 import type { Address } from 'viem'
 import { getDeploymentSteps, loadDeploymentStatusOracleSnapshot, loadErc20Balance } from '../contracts.js'
 import { createConnectedReadClient, normalizeAccount } from '../lib/clients.js'
+import type { ChainBackend } from '../lib/chainBackend.js'
 import { getErrorMessage } from '../lib/errors.js'
 import { getActiveBackend } from '../lib/activeEnvironment.js'
 import { useRequestGuard } from '../lib/requestGuard.js'
@@ -66,6 +67,18 @@ export async function loadWalletState({ chainIdPromise, connectedAddress, ethBal
 	})
 }
 
+async function loadBackendCurrentTimestamp(backend: ChainBackend) {
+	if (backend.currentTimestamp !== undefined) return backend.currentTimestamp
+	if (backend.isBootstrapped === false) return undefined
+
+	try {
+		const block = await backend.createReadClient().getBlock()
+		return typeof block.timestamp === 'bigint' ? block.timestamp : undefined
+	} catch {
+		return undefined
+	}
+}
+
 export function useOnchainState() {
 	const accountState = useSignal<AccountState>({
 		address: undefined,
@@ -84,6 +97,7 @@ export function useOnchainState() {
 	const deploymentStatusLoad = useLoadController()
 	const deploymentStatusesLoaded = useSignal(false)
 	const augurPlaceHolderDeployed = useSignal<boolean | undefined>(undefined)
+	const currentTimestamp = useSignal<bigint | undefined>(getActiveBackend().currentTimestamp)
 	const environmentBootstrapError = useSignal<string | undefined>(undefined)
 	const environmentBootstrapLabel = useSignal(getActiveBackend().bootstrapLabel)
 	const environmentBootstrapProgress = useSignal(getActiveBackend().bootstrapProgress)
@@ -92,11 +106,23 @@ export function useOnchainState() {
 	const walletBootstrapComplete = useSignal(false)
 	const isConnectingWallet = useSignal(false)
 	const nextRefresh = useRequestGuard()
+	const nextTimestampRefresh = useRequestGuard()
 	const errorMessage = useSignal<string | undefined>(undefined)
 	const setDeploymentStatuses = (update: (current: DeploymentStatus[]) => DeploymentStatus[]) => {
 		const updated = update(deploymentStatuses.value)
 		deploymentStatuses.value = updated
 		if (updated.every(step => step.deployed)) augurPlaceHolderDeployed.value = true
+	}
+	const refreshCurrentTimestamp = async (backend: ChainBackend) => {
+		if (backend.currentTimestamp !== undefined) {
+			currentTimestamp.value = backend.currentTimestamp
+			return
+		}
+
+		const isCurrent = nextTimestampRefresh()
+		const nextCurrentTimestamp = await loadBackendCurrentTimestamp(backend)
+		if (!isCurrent() || nextCurrentTimestamp === undefined) return
+		currentTimestamp.value = nextCurrentTimestamp
 	}
 
 	const refreshState = async (options: RefreshStateOptions = {}) => {
@@ -106,6 +132,7 @@ export function useOnchainState() {
 		hasInjectedWallet.value = backend.hasWallet()
 		errorMessage.value = undefined
 		backend.setReadTransportMode?.('rpc')
+		void refreshCurrentTimestamp(backend)
 
 		if (backend.isBootstrapped === false) {
 			deploymentStatusesLoaded.value = false
@@ -245,6 +272,11 @@ export function useOnchainState() {
 			environmentBootstrapLabel.value = backend.bootstrapLabel
 			environmentBootstrapProgress.value = backend.bootstrapProgress
 			environmentReady.value = backend.isBootstrapped ?? true
+			if (backend.currentTimestamp !== undefined) {
+				currentTimestamp.value = backend.currentTimestamp
+				return
+			}
+			void refreshCurrentTimestamp(backend)
 		})
 		const handleWalletChange = () => {
 			void refreshState()
@@ -259,9 +291,29 @@ export function useOnchainState() {
 		}
 	}, [])
 
+	useEffect(() => {
+		const backend = getActiveBackend()
+		if (backend.currentTimestamp !== undefined || backend.isBootstrapped === false) {
+			if (backend.currentTimestamp !== undefined) {
+				currentTimestamp.value = backend.currentTimestamp
+			}
+			return
+		}
+
+		void refreshCurrentTimestamp(backend)
+		const intervalId = window.setInterval(() => {
+			void refreshCurrentTimestamp(backend)
+		}, 1000)
+
+		return () => {
+			window.clearInterval(intervalId)
+		}
+	}, [environmentReady.value])
+
 	return {
 		accountState: accountState.value,
 		connectWallet,
+		currentTimestamp: currentTimestamp.value,
 		deploymentStatuses: deploymentStatuses.value,
 		errorMessage: errorMessage.value,
 		environmentBootstrapError: environmentBootstrapError.value,

--- a/ui/ts/lib/chainBackend.ts
+++ b/ui/ts/lib/chainBackend.ts
@@ -23,6 +23,7 @@ export type ChainBackend = {
 	bootstrapProgress: number | undefined
 	createReadClient(): ReadClient
 	createWriteClient(accountAddress: Address, callbacks?: CreateWriteClientCallbacks): WriteClient
+	currentTimestamp?: bigint
 	getAccounts(): Promise<readonly Address[]>
 	getChainId(): Promise<string>
 	getProvider(): InjectedEthereum | undefined

--- a/ui/ts/lib/chainTimestamp.ts
+++ b/ui/ts/lib/chainTimestamp.ts
@@ -1,0 +1,8 @@
+import { createContext } from 'preact'
+import { useContext } from 'preact/hooks'
+
+export const ChainTimestampContext = createContext<bigint | undefined>(undefined)
+
+export function useChainTimestamp() {
+	return useContext(ChainTimestampContext)
+}

--- a/ui/ts/lib/time.ts
+++ b/ui/ts/lib/time.ts
@@ -1,3 +1,7 @@
+export function getCurrentTimestamp() {
+	return BigInt(Math.floor(Date.now() / 1000))
+}
+
 export function getTimeRemaining(targetTime: bigint | undefined, currentTime: bigint) {
 	if (targetTime === undefined) return undefined
 	return targetTime <= currentTime ? 0n : targetTime - currentTime

--- a/ui/ts/tests/liquidationModal.test.tsx
+++ b/ui/ts/tests/liquidationModal.test.tsx
@@ -7,6 +7,7 @@ import { useState } from 'preact/hooks'
 import { act } from 'preact/test-utils'
 import { getAddress, zeroAddress } from 'viem'
 import { LiquidationModal } from '../components/LiquidationModal.js'
+import { ChainTimestampContext } from '../lib/chainTimestamp.js'
 import type { ListedSecurityPool, MarketDetails, OracleManagerDetails, SecurityPoolVaultSummary } from '../types/contracts.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
@@ -377,6 +378,51 @@ describe('LiquidationModal', () => {
 		expect(button.disabled).toBe(true)
 		expect(documentQueries.getByText('This vault is not undercollateralized at the current Open Oracle price.')).not.toBeNull()
 		expect(documentQueries.getByText(/^Open Oracle Price$/)).not.toBeNull()
+	})
+
+	test('uses the shared chain timestamp context for oracle expiry text', async () => {
+		const originalDateNow = Date.now
+		Date.now = () => 0
+
+		try {
+			const renderedComponent = await renderIntoDocument(
+				<ChainTimestampContext.Provider value={1n + 60n * 60n + 60n}>
+					<LiquidationModal
+						accountAddress={defaultCallerVaultAddress}
+						closeLiquidationModal={() => undefined}
+						currentPoolOracleManagerDetails={undefined}
+						isMainnet
+						liquidationAmount='1'
+						liquidationMaxAmount={5n * 10n ** 18n}
+						liquidationManagerAddress={zeroAddress}
+						liquidationModalOpen
+						liquidationSecurityPoolAddress={zeroAddress}
+						liquidationTargetVault={defaultTargetVaultAddress}
+						loadingPoolOracleManager={false}
+						onLoadPoolOracleManager={() => undefined}
+						onLiquidationAmountChange={() => undefined}
+						onQueueLiquidation={() => undefined}
+						onSelectedPoolViewChange={() => undefined}
+						repPerEthPrice={1n * 10n ** 18n}
+						repPerEthSource='mock'
+						repPerEthSourceUrl={undefined}
+						selectedPool={createSelectedPool({
+							lastOraclePrice: 3n * 10n ** 18n,
+							lastOracleSettlementTimestamp: 1n,
+						})}
+						securityPoolOverviewActiveAction={undefined}
+						securityPoolOverviewResult={undefined}
+						callerVaultSummary={createTargetVaultSummary({ vaultAddress: defaultCallerVaultAddress })}
+						targetVaultSummary={createTargetVaultSummary({ vaultAddress: defaultTargetVaultAddress })}
+					/>
+				</ChainTimestampContext.Provider>,
+			)
+			cleanupRenderedComponent = renderedComponent.cleanup
+
+			expect(document.body.textContent?.includes('(expired 1m ago)')).toBe(true)
+		} finally {
+			Date.now = originalDateNow
+		}
 	})
 
 	test('uses a dedicated top-aligned action row when execute liquidation shows a disabled reason', async () => {

--- a/ui/ts/tests/questionComponent.test.tsx
+++ b/ui/ts/tests/questionComponent.test.tsx
@@ -1,0 +1,59 @@
+/// <reference types="bun-types" />
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { Question } from '../components/Question.js'
+import { ChainTimestampContext } from '../lib/chainTimestamp.js'
+import type { MarketDetails } from '../types/contracts.js'
+import { installDomEnvironment } from './testUtils/domEnvironment.js'
+import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
+
+function createQuestion(overrides: Partial<MarketDetails> = {}): MarketDetails {
+	return {
+		answerUnit: '',
+		createdAt: 120n,
+		description: 'Description',
+		displayValueMax: 1n,
+		displayValueMin: 0n,
+		endTime: 180n,
+		exists: true,
+		marketType: 'binary',
+		numTicks: 1n,
+		outcomeLabels: ['Yes', 'No'],
+		questionId: '0x0000000000000000000000000000000000000000000000000000000000000001',
+		startTime: 0n,
+		title: 'Question title',
+		...overrides,
+	}
+}
+
+describe('Question component', () => {
+	let cleanupRenderedComponent: (() => Promise<void>) | undefined
+	let restoreDomEnvironment: (() => void) | undefined
+	const originalDateNow = Date.now
+
+	beforeEach(() => {
+		const domEnvironment = installDomEnvironment()
+		restoreDomEnvironment = domEnvironment.cleanup
+	})
+
+	afterEach(async () => {
+		Date.now = originalDateNow
+		await cleanupRenderedComponent?.()
+		cleanupRenderedComponent = undefined
+		restoreDomEnvironment?.()
+		restoreDomEnvironment = undefined
+	})
+
+	test('inherits the shared chain timestamp for route-level relative time rendering', async () => {
+		Date.now = () => 0
+		const renderedComponent = await renderIntoDocument(
+			<ChainTimestampContext.Provider value={240n}>
+				<Question question={createQuestion()} showTitle={false} />
+			</ChainTimestampContext.Provider>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(document.body.textContent?.includes('(2m ago)')).toBe(true)
+		expect(document.body.textContent?.includes('(1m ago)')).toBe(true)
+	})
+})

--- a/ui/ts/tests/securityPoolWorkflowSection.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection.test.tsx
@@ -6,6 +6,7 @@ import { render } from 'preact'
 import { act } from 'preact/test-utils'
 import { getAddress, zeroAddress } from 'viem'
 import { SecurityPoolWorkflowSection } from '../components/SecurityPoolWorkflowSection.js'
+import { ChainTimestampContext } from '../lib/chainTimestamp.js'
 import type { AccountState } from '../types/app.js'
 import type { ListedSecurityPool, MarketDetails, OracleManagerDetails, SecurityPoolVaultSummary, SecurityVaultDetails } from '../types/contracts.js'
 import type { ForkAuctionRouteContentProps, ReportingRouteContentProps, SecurityPoolWorkflowRouteContentProps, SecurityVaultRouteContentProps, TradingRouteContentProps } from '../types/components.js'
@@ -1414,6 +1415,66 @@ describe('SecurityPoolWorkflowSection', () => {
 		const reportButton = documentQueries.getByRole('button', { name: 'Report / Contribute On Selected Side' }) as HTMLButtonElement
 		expect(reportButton.disabled).toBe(true)
 		expect(reportButton.title).toBe('Reporting opens after market end.')
+	})
+
+	test('uses the shared chain timestamp context for oracle expiry text', async () => {
+		const originalDateNow = Date.now
+		Date.now = () => 0
+
+		try {
+			const renderedComponent = await renderIntoDocument(
+				<ChainTimestampContext.Provider value={1n + 60n * 60n + 60n}>
+					<SecurityPoolWorkflowSection
+						{...createSecurityPoolWorkflowProps({
+							checkedSecurityPoolAddress: zeroAddress,
+							securityPoolAddress: zeroAddress,
+							securityPools: [
+								createSelectedPool({
+									lastOraclePrice: 3n * 10n ** 18n,
+									lastOracleSettlementTimestamp: 1n,
+								}),
+							],
+							selectedPoolView: 'price-oracle',
+						})}
+						showHeader={false}
+					/>
+				</ChainTimestampContext.Provider>,
+			)
+			cleanupRenderedComponent = renderedComponent.cleanup
+
+			expect(document.body.textContent?.includes('(expired 1m ago)')).toBe(true)
+		} finally {
+			Date.now = originalDateNow
+		}
+	})
+
+	test('uses the shared chain timestamp context to unlock reporting after market end', async () => {
+		const originalDateNow = Date.now
+		Date.now = () => 0
+
+		try {
+			const renderedComponent = await renderIntoDocument(
+				<ChainTimestampContext.Provider value={150n}>
+					<SecurityPoolWorkflowSection
+						{...createSecurityPoolWorkflowProps({
+							checkedSecurityPoolAddress: zeroAddress,
+							securityPoolAddress: zeroAddress,
+							securityPools: [createSelectedPool({ marketDetails: createMarketDetails({ endTime: 100n }) })],
+							selectedPoolView: 'reporting',
+						})}
+						showHeader={false}
+					/>
+				</ChainTimestampContext.Provider>,
+			)
+			cleanupRenderedComponent = renderedComponent.cleanup
+
+			const documentQueries = within(document.body)
+			const reportButton = documentQueries.getByRole('button', { name: 'Report / Contribute On Selected Side' }) as HTMLButtonElement
+			expect(reportButton.disabled).toBe(true)
+			expect(reportButton.title).toBe('Load reporting details before reporting on an outcome.')
+		} finally {
+			Date.now = originalDateNow
+		}
 	})
 
 	test('renders staged operations management inside the staged operations tab instead of a standalone section', async () => {

--- a/ui/ts/tests/testUtils/fakeBackend.ts
+++ b/ui/ts/tests/testUtils/fakeBackend.ts
@@ -4,11 +4,12 @@ import { MAINNET_NETWORK_PROFILE, createSimulationProfile, type NetworkProfile }
 
 type FakeBackendOptions = {
 	accountAddress?: Address
+	currentTimestamp?: bigint
 	hasWallet?: boolean
 	profile?: NetworkProfile
 }
 
-export function createFakeBackend({ accountAddress, hasWallet = true, profile = MAINNET_NETWORK_PROFILE }: FakeBackendOptions = {}): ChainBackend {
+export function createFakeBackend({ accountAddress, currentTimestamp, hasWallet = true, profile = MAINNET_NETWORK_PROFILE }: FakeBackendOptions = {}): ChainBackend {
 	const accounts = accountAddress === undefined ? [] : [accountAddress]
 
 	return {
@@ -21,6 +22,7 @@ export function createFakeBackend({ accountAddress, hasWallet = true, profile = 
 		createWriteClient: () => {
 			throw new Error('Fake backend write client should not be used in this test')
 		},
+		...(currentTimestamp === undefined ? {} : { currentTimestamp }),
 		getAccounts: async () => accounts,
 		getChainId: async () => profile.chainIdHex,
 		getProvider: () => undefined,

--- a/ui/ts/tests/timestampValue.test.tsx
+++ b/ui/ts/tests/timestampValue.test.tsx
@@ -1,0 +1,57 @@
+/// <reference types="bun-types" />
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { TimestampValue } from '../components/TimestampValue.js'
+import { ChainTimestampContext } from '../lib/chainTimestamp.js'
+import { installDomEnvironment } from './testUtils/domEnvironment.js'
+import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
+
+describe('TimestampValue', () => {
+	let cleanupRenderedComponent: (() => Promise<void>) | undefined
+	let restoreDomEnvironment: (() => void) | undefined
+	const originalDateNow = Date.now
+
+	beforeEach(() => {
+		const domEnvironment = installDomEnvironment()
+		restoreDomEnvironment = domEnvironment.cleanup
+	})
+
+	afterEach(async () => {
+		Date.now = originalDateNow
+		await cleanupRenderedComponent?.()
+		cleanupRenderedComponent = undefined
+		restoreDomEnvironment?.()
+		restoreDomEnvironment = undefined
+	})
+
+	test('prefers an explicit current timestamp over the shared chain timestamp context', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<ChainTimestampContext.Provider value={900n}>
+				<TimestampValue currentTimestamp={1_000n} timestamp={1_060n} />
+			</ChainTimestampContext.Provider>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(document.body.textContent?.includes('(in 1m)')).toBe(true)
+		expect(document.body.textContent?.includes('(in 2m)')).toBe(false)
+	})
+
+	test('uses the shared chain timestamp context when no explicit timestamp is provided', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<ChainTimestampContext.Provider value={900n}>
+				<TimestampValue timestamp={1_060n} />
+			</ChainTimestampContext.Provider>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(document.body.textContent?.includes('(in 2m)')).toBe(true)
+	})
+
+	test('falls back to browser time only when no chain timestamp is available', async () => {
+		Date.now = () => 900_000
+		const renderedComponent = await renderIntoDocument(<TimestampValue timestamp={840n} />)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(document.body.textContent?.includes('(1m ago)')).toBe(true)
+	})
+})


### PR DESCRIPTION
## Summary
- Use chain-backed timestamps across UI time displays and simulation flows so notices, modals, and oracle values stay in sync.
- Harden simulation bootstrap, clock reset, and type guards to make the mocked environment more predictable.
- Improve liquidation, trading, and security pool UX with clearer labels, better status notices, and metric styling.
- Add overflow-safe currency rendering and tighten modal/header layout and accessibility.

## Testing
- `bun run tsc`
- `bun run test`
- `bun run format`
- `bun run check`
- `bun run knip`