### PR TITLE
Refine liquidation, security pool, and simulation workflows

### DIFF
--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -507,6 +507,7 @@ export function App() {
 				void loadOracleReport(reportId.toString())
 			},
 			securityPoolOverviewActiveAction,
+			securityPoolOverviewError,
 			securityPoolOverviewResult,
 			poolOracleActiveAction,
 			poolOracleManagerDetails,

--- a/ui/ts/components/LiquidationModal.tsx
+++ b/ui/ts/components/LiquidationModal.tsx
@@ -5,6 +5,7 @@ import { AddressValue } from './AddressValue.js'
 import { CollateralizationMetricField } from './CollateralizationMetricField.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { DataGrid } from './DataGrid.js'
+import { ErrorNotice } from './ErrorNotice.js'
 import { FormInput } from './FormInput.js'
 import { MetricField } from './MetricField.js'
 import { OpenOraclePriceValue } from './OpenOraclePriceValue.js'
@@ -37,6 +38,7 @@ type LiquidationModalProps = {
 	repPerEthSourceUrl: string | undefined
 	selectedPool: ListedSecurityPool | undefined
 	securityPoolOverviewActiveAction: 'queueLiquidation' | undefined
+	securityPoolOverviewError: string | undefined
 	securityPoolOverviewResult: SecurityPoolOverviewActionResult | undefined
 	callerVaultSummary: SecurityPoolVaultSummary | undefined
 	targetVaultSummary: SecurityPoolVaultSummary | undefined
@@ -91,6 +93,7 @@ export function LiquidationModal({
 	repPerEthSourceUrl,
 	selectedPool,
 	securityPoolOverviewActiveAction,
+	securityPoolOverviewError,
 	securityPoolOverviewResult,
 	callerVaultSummary,
 	targetVaultSummary,
@@ -101,19 +104,20 @@ export function LiquidationModal({
 	const dialogRef = useRef<HTMLElement | null>(null)
 	const closeButtonRef = useRef<HTMLButtonElement | null>(null)
 	const onCloseRef = useRef(closeLiquidationModal)
+	const showLiquidationModal = liquidationModalOpen || securityPoolOverviewActiveAction === 'queueLiquidation' || securityPoolOverviewResult?.action === 'queueLiquidation' || securityPoolOverviewError !== undefined
 
 	useEffect(() => {
 		onCloseRef.current = closeLiquidationModal
 	}, [closeLiquidationModal])
 
 	useEffect(() => {
-		if (!liquidationModalOpen) return
+		if (!showLiquidationModal) return
 		if (liquidationManagerAddress === undefined || currentPoolOracleManagerDetails !== undefined || loadingPoolOracleManager) return
 		onLoadPoolOracleManager(liquidationManagerAddress)
-	}, [currentPoolOracleManagerDetails, liquidationManagerAddress, liquidationModalOpen, loadingPoolOracleManager, onLoadPoolOracleManager])
+	}, [currentPoolOracleManagerDetails, liquidationManagerAddress, loadingPoolOracleManager, onLoadPoolOracleManager, showLiquidationModal])
 
 	useEffect(() => {
-		if (!liquidationModalOpen) return
+		if (!showLiquidationModal) return
 		const previouslyFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null
 		closeButtonRef.current?.focus()
 		const handleKeyDown = (event: KeyboardEvent) => {
@@ -139,9 +143,9 @@ export function LiquidationModal({
 			document.removeEventListener('keydown', handleKeyDown)
 			previouslyFocusedElement?.focus()
 		}
-	}, [liquidationModalOpen])
+	}, [showLiquidationModal])
 
-	if (!liquidationModalOpen) return undefined
+	if (!showLiquidationModal) return undefined
 	const currentTimestamp = chainCurrentTimestamp ?? getLocalCurrentTimestamp()
 	const liquidationAmountValue = (() => {
 		try {
@@ -289,6 +293,7 @@ export function LiquidationModal({
 						<p className='detail'>Refreshing the oracle manager to determine whether the liquidation was queued or executed immediately.</p>
 					</section>
 				)}
+				<ErrorNotice message={securityPoolOverviewError} />
 				<DataGrid className='modal-summary-grid' columns={2}>
 					<AddressInfo address={liquidationSecurityPoolAddress} label='Security Pool' />
 					<MetricField label='Security Multiplier'>{selectedPool?.securityMultiplier === undefined ? 'Unavailable' : `${selectedPool.securityMultiplier.toString()}x`}</MetricField>

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -100,6 +100,7 @@ export function SecurityPoolWorkflowSection({
 	reporting,
 	selectedPoolView,
 	securityPoolOverviewActiveAction,
+	securityPoolOverviewError,
 	securityPoolOverviewResult,
 	securityPoolAddress,
 	securityPools,
@@ -688,6 +689,7 @@ export function SecurityPoolWorkflowSection({
 				repPerEthSourceUrl={repPerEthSourceUrl}
 				selectedPool={selectedPool}
 				securityPoolOverviewActiveAction={securityPoolOverviewActiveAction}
+				securityPoolOverviewError={securityPoolOverviewError}
 				securityPoolOverviewResult={securityPoolOverviewResult}
 				callerVaultSummary={accountState.address === undefined ? undefined : selectedPool?.vaults.find(vault => sameAddress(vault.vaultAddress, accountState.address))}
 				targetVaultSummary={selectedPool?.vaults.find(vault => sameAddress(vault.vaultAddress, liquidationTargetVault))}

--- a/ui/ts/components/SecurityPoolsOverviewSection.tsx
+++ b/ui/ts/components/SecurityPoolsOverviewSection.tsx
@@ -202,6 +202,7 @@ export function SecurityPoolsOverviewSection({
 				repPerEthSourceUrl={repPerEthSourceUrl}
 				selectedPool={selectedPool}
 				securityPoolOverviewActiveAction={securityPoolOverviewActiveAction}
+				securityPoolOverviewError={securityPoolOverviewError}
 				securityPoolOverviewResult={securityPoolOverviewResult}
 				callerVaultSummary={callerVaultSummary}
 				targetVaultSummary={targetVaultSummary}

--- a/ui/ts/hooks/useSecurityPoolsOverview.ts
+++ b/ui/ts/hooks/useSecurityPoolsOverview.ts
@@ -59,6 +59,8 @@ export function useSecurityPoolsOverview({ accountAddress, onTransaction, onTran
 	}
 
 	const openLiquidationModal = (managerAddress: Address, securityPoolAddress: Address, vaultAddress: Address, maxAmount: bigint | undefined) => {
+		securityPoolOverviewError.value = undefined
+		securityPoolOverviewResult.value = undefined
 		liquidationManagerAddress.value = managerAddress
 		liquidationMaxAmount.value = maxAmount
 		liquidationSecurityPoolAddress.value = securityPoolAddress
@@ -67,6 +69,8 @@ export function useSecurityPoolsOverview({ accountAddress, onTransaction, onTran
 	}
 
 	const closeLiquidationModal = () => {
+		securityPoolOverviewError.value = undefined
+		securityPoolOverviewResult.value = undefined
 		liquidationModalOpen.value = false
 	}
 

--- a/ui/ts/tests/liquidationModal.test.tsx
+++ b/ui/ts/tests/liquidationModal.test.tsx
@@ -8,7 +8,7 @@ import { act } from 'preact/test-utils'
 import { getAddress, zeroAddress } from 'viem'
 import { LiquidationModal } from '../components/LiquidationModal.js'
 import { ChainTimestampContext } from '../lib/chainTimestamp.js'
-import type { ListedSecurityPool, MarketDetails, OracleManagerDetails, SecurityPoolVaultSummary } from '../types/contracts.js'
+import type { ListedSecurityPool, MarketDetails, OracleManagerDetails, SecurityPoolOverviewActionResult, SecurityPoolVaultSummary } from '../types/contracts.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
 
@@ -132,6 +132,7 @@ describe('LiquidationModal', () => {
 				repPerEthSourceUrl={undefined}
 				selectedPool={createSelectedPool()}
 				securityPoolOverviewActiveAction={undefined}
+				securityPoolOverviewError={undefined}
 				securityPoolOverviewResult={undefined}
 				callerVaultSummary={createTargetVaultSummary({ vaultAddress: defaultCallerVaultAddress })}
 				targetVaultSummary={createTargetVaultSummary({ vaultAddress: defaultTargetVaultAddress })}
@@ -208,6 +209,7 @@ describe('LiquidationModal', () => {
 					repPerEthSourceUrl={undefined}
 					selectedPool={createSelectedPool()}
 					securityPoolOverviewActiveAction={undefined}
+					securityPoolOverviewError={undefined}
 					securityPoolOverviewResult={undefined}
 					callerVaultSummary={createTargetVaultSummary({ vaultAddress: getAddress('0x0000000000000000000000000000000000000001') })}
 					targetVaultSummary={createTargetVaultSummary()}
@@ -335,6 +337,164 @@ describe('LiquidationModal', () => {
 		expect(documentQueries.queryByRole('button', { name: 'View In Staged Operations' })).toBeNull()
 	})
 
+	test('keeps the dialog open and shows execution results when the parent closes it after submit', async () => {
+		function LiquidationExecutionHarness() {
+			const [liquidationModalOpen, setLiquidationModalOpen] = useState(true)
+			const [securityPoolOverviewResult, setSecurityPoolOverviewResult] = useState<SecurityPoolOverviewActionResult | undefined>(undefined)
+
+			return (
+				<LiquidationModal
+					accountAddress={defaultCallerVaultAddress}
+					closeLiquidationModal={() => {
+						setLiquidationModalOpen(false)
+						setSecurityPoolOverviewResult(undefined)
+					}}
+					currentPoolOracleManagerDetails={createOracleManagerDetails({
+						isPriceValid: true,
+						lastPrice: 1n * 10n ** 18n,
+						pendingOperation: undefined,
+						pendingOperationSlotId: 0n,
+					})}
+					isMainnet
+					liquidationAmount='1'
+					liquidationMaxAmount={5n * 10n ** 18n}
+					liquidationManagerAddress={zeroAddress}
+					liquidationModalOpen={liquidationModalOpen}
+					liquidationSecurityPoolAddress={zeroAddress}
+					liquidationTargetVault={defaultTargetVaultAddress}
+					loadingPoolOracleManager={false}
+					onLoadPoolOracleManager={() => undefined}
+					onLiquidationAmountChange={() => undefined}
+					onQueueLiquidation={() => {
+						setLiquidationModalOpen(false)
+						setSecurityPoolOverviewResult({
+							action: 'queueLiquidation',
+							hash: '0x00000000000000000000000000000000000000000000000000000000000000cd',
+							securityPoolAddress: zeroAddress,
+							stagedExecution: {
+								errorMessage: undefined,
+								operation: 'liquidation',
+								operationId: 10n,
+								success: true,
+							},
+						})
+					}}
+					onSelectedPoolViewChange={() => undefined}
+					repPerEthPrice={1n * 10n ** 18n}
+					repPerEthSource='mock'
+					repPerEthSourceUrl={undefined}
+					selectedPool={createSelectedPool({
+						securityMultiplier: 2n,
+					})}
+					securityPoolOverviewActiveAction={undefined}
+					securityPoolOverviewError={undefined}
+					securityPoolOverviewResult={securityPoolOverviewResult}
+					callerVaultSummary={createTargetVaultSummary({
+						repDepositShare: 20n * 10n ** 18n,
+						securityBondAllowance: 1n * 10n ** 18n,
+						vaultAddress: defaultCallerVaultAddress,
+					})}
+					targetVaultSummary={createTargetVaultSummary({
+						repDepositShare: 11n * 10n ** 18n,
+						securityBondAllowance: 11n * 10n ** 18n,
+						vaultAddress: defaultTargetVaultAddress,
+					})}
+				/>
+			)
+		}
+
+		const container = document.createElement('div')
+		document.body.appendChild(container)
+
+		await act(() => {
+			render(<LiquidationExecutionHarness />, container)
+		})
+
+		const documentQueries = within(document.body)
+		await act(() => {
+			fireEvent.click(documentQueries.getByRole('button', { name: 'Execute Liquidation' }))
+		})
+
+		expect(documentQueries.getByRole('dialog', { name: 'Execute Vault Liquidation' })).not.toBeNull()
+		expect(documentQueries.getByRole('heading', { name: 'Liquidation Executed' })).not.toBeNull()
+
+		render(null, container)
+		container.remove()
+	})
+
+	test('keeps the dialog open and shows liquidation errors inside the dialog', async () => {
+		function LiquidationErrorHarness() {
+			const [liquidationModalOpen, setLiquidationModalOpen] = useState(true)
+			const [securityPoolOverviewError, setSecurityPoolOverviewError] = useState<string | undefined>(undefined)
+
+			return (
+				<LiquidationModal
+					accountAddress={defaultCallerVaultAddress}
+					closeLiquidationModal={() => {
+						setLiquidationModalOpen(false)
+						setSecurityPoolOverviewError(undefined)
+					}}
+					currentPoolOracleManagerDetails={createOracleManagerDetails({
+						isPriceValid: true,
+						lastPrice: 1n * 10n ** 18n,
+						pendingOperation: undefined,
+						pendingOperationSlotId: 0n,
+					})}
+					isMainnet
+					liquidationAmount='1'
+					liquidationMaxAmount={5n * 10n ** 18n}
+					liquidationManagerAddress={zeroAddress}
+					liquidationModalOpen={liquidationModalOpen}
+					liquidationSecurityPoolAddress={zeroAddress}
+					liquidationTargetVault={defaultTargetVaultAddress}
+					loadingPoolOracleManager={false}
+					onLoadPoolOracleManager={() => undefined}
+					onLiquidationAmountChange={() => undefined}
+					onQueueLiquidation={() => {
+						setLiquidationModalOpen(false)
+						setSecurityPoolOverviewError('Liquidation execution reverted')
+					}}
+					onSelectedPoolViewChange={() => undefined}
+					repPerEthPrice={1n * 10n ** 18n}
+					repPerEthSource='mock'
+					repPerEthSourceUrl={undefined}
+					selectedPool={createSelectedPool()}
+					securityPoolOverviewActiveAction={undefined}
+					securityPoolOverviewError={securityPoolOverviewError}
+					securityPoolOverviewResult={undefined}
+					callerVaultSummary={createTargetVaultSummary({
+						repDepositShare: 20n * 10n ** 18n,
+						securityBondAllowance: 1n * 10n ** 18n,
+						vaultAddress: defaultCallerVaultAddress,
+					})}
+					targetVaultSummary={createTargetVaultSummary({
+						repDepositShare: 11n * 10n ** 18n,
+						securityBondAllowance: 11n * 10n ** 18n,
+						vaultAddress: defaultTargetVaultAddress,
+					})}
+				/>
+			)
+		}
+
+		const container = document.createElement('div')
+		document.body.appendChild(container)
+
+		await act(() => {
+			render(<LiquidationErrorHarness />, container)
+		})
+
+		const documentQueries = within(document.body)
+		await act(() => {
+			fireEvent.click(documentQueries.getByRole('button', { name: 'Execute Liquidation' }))
+		})
+
+		expect(documentQueries.getByRole('dialog', { name: 'Execute Vault Liquidation' })).not.toBeNull()
+		expect(documentQueries.getByText('Liquidation execution reverted')).not.toBeNull()
+
+		render(null, container)
+		container.remove()
+	})
+
 	test('fills the liquidation amount from the provided Max value', async () => {
 		const amountChanges: string[] = []
 		const renderedComponent = await renderLiquidationModal({
@@ -411,6 +571,7 @@ describe('LiquidationModal', () => {
 							lastOracleSettlementTimestamp: 1n,
 						})}
 						securityPoolOverviewActiveAction={undefined}
+						securityPoolOverviewError={undefined}
 						securityPoolOverviewResult={undefined}
 						callerVaultSummary={createTargetVaultSummary({ vaultAddress: defaultCallerVaultAddress })}
 						targetVaultSummary={createTargetVaultSummary({ vaultAddress: defaultTargetVaultAddress })}
@@ -606,6 +767,7 @@ describe('LiquidationModal', () => {
 						securityMultiplier: 2n,
 					})}
 					securityPoolOverviewActiveAction={undefined}
+					securityPoolOverviewError={undefined}
 					securityPoolOverviewResult={undefined}
 					callerVaultSummary={createTargetVaultSummary({
 						repDepositShare: 12_000n * 10n ** 18n,

--- a/ui/ts/tests/securityPoolWorkflowSection.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection.test.tsx
@@ -292,6 +292,7 @@ function createSecurityPoolWorkflowProps(overrides: Partial<SecurityPoolWorkflow
 		selectedPoolView: '',
 		securityPoolAddress: '',
 		securityPoolOverviewActiveAction: undefined,
+		securityPoolOverviewError: undefined,
 		securityPoolOverviewResult: undefined,
 		securityPools: [],
 		securityVault: createSecurityVaultProps(),
@@ -834,7 +835,8 @@ describe('SecurityPoolWorkflowSection', () => {
 
 		const documentQueries = within(document.body)
 		expect(documentQueries.getByText('Liquidation failed')).not.toBeNull()
-		expect(documentQueries.getByText('Local Security Bond Allowance broken')).not.toBeNull()
+		const liquidationDialog = documentQueries.getByRole('dialog', { name: 'Execute Vault Liquidation' })
+		expect(within(liquidationDialog).getByText('Local Security Bond Allowance broken')).not.toBeNull()
 	})
 
 	test('refreshes the selected pool and loaded vault after an immediate REP withdrawal execution', async () => {

--- a/ui/ts/tests/securityPoolsSection.test.ts
+++ b/ui/ts/tests/securityPoolsSection.test.ts
@@ -262,6 +262,7 @@ function createWorkflowProps(overrides: Partial<SecurityPoolWorkflowRouteContent
 		selectedPoolView: '',
 		securityPoolAddress: '',
 		securityPoolOverviewActiveAction: undefined,
+		securityPoolOverviewError: undefined,
 		securityPoolOverviewResult: undefined,
 		securityPools: [],
 		securityVault: createSecurityVaultProps(),
@@ -662,7 +663,8 @@ void describe('SecurityPoolsSection', () => {
 
 		const documentQueries = within(document.body)
 		expect(documentQueries.getByText('Liquidation failed')).not.toBeNull()
-		expect(documentQueries.getByText('Local Security Bond Allowance broken')).not.toBeNull()
+		const liquidationDialog = documentQueries.getByRole('dialog', { name: 'Execute Vault Liquidation' })
+		expect(within(liquidationDialog).getByText('Local Security Bond Allowance broken')).not.toBeNull()
 	})
 
 	void test('keeps the route summary hidden in operate mode until the selected pool resolves', async () => {

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -347,6 +347,7 @@ type LiquidationControlsProps = {
 	liquidationSecurityPoolAddress: Address | undefined
 	loadingPoolOracleManager: boolean
 	securityPoolOverviewActiveAction: SecurityPoolOverviewActionResult['action'] | undefined
+	securityPoolOverviewError: string | undefined
 	liquidationTargetVault: string
 	onLiquidationAmountChange: (value: string) => void
 	onLoadPoolOracleManager: (managerAddress: Address) => void
@@ -394,6 +395,7 @@ export type SecurityPoolWorkflowRouteContentProps = {
 	onSelectedPoolViewChange: (view: string | undefined) => void
 	onViewPendingReport: (reportId: bigint) => void
 	securityPoolOverviewActiveAction: SecurityPoolOverviewActionResult['action'] | undefined
+	securityPoolOverviewError: string | undefined
 	securityPoolOverviewResult: SecurityPoolOverviewActionResult | undefined
 	poolOracleActiveAction: OpenOracleActionResult['action'] | undefined
 	poolOracleManagerDetails: OracleManagerDetails | undefined


### PR DESCRIPTION
## Summary
- Keep liquidation dialogs open while queue results or errors are still resolving, and surface the outcome notices in-place.
- Rework security pool and child-universe workflows into clearer modal-based flows with updated labels, metrics, and availability checks.
- Standardize timing and REP price presentation across the UI, including chain-timestamp-backed displays and richer price-source labels.
- Improve currency and metric rendering to handle overflow, compact values, and scoped success or danger styling.
- Harden simulation startup, clock/reset behavior, and type guards for more reliable test and QA flows.

## Testing
- Not run (PR content only).
- Existing commit set includes expanded UI and simulation test coverage for liquidation, security pools, timestamps, currency values, and app status notices.