### PR TITLE
Refine warning surfaces, currency display, and security pool flows

### DIFF
--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -49,6 +49,7 @@
 	--warning: #f5c86a;
 	--warning-soft: rgba(245, 200, 106, 0.12);
 	--warning-border: rgba(245, 200, 106, 0.24);
+	--warning-border-strong: rgba(245, 200, 106, 0.52);
 	--danger: #ff708f;
 	--danger-soft: rgba(255, 112, 143, 0.12);
 	--danger-border: rgba(255, 112, 143, 0.28);
@@ -97,6 +98,7 @@
 
 	/* notice error */
 	--danger-text: #ffe5eb;
+	--notice-warning-gradient: linear-gradient(180deg, rgba(99, 77, 18, 0.96) 0%, rgba(66, 48, 11, 0.96) 100%);
 	--notice-error-gradient: linear-gradient(180deg, rgba(87, 18, 33, 0.94) 0%, rgba(59, 11, 22, 0.94) 100%);
 
 	/* elevated surfaces */
@@ -508,10 +510,6 @@ button.destructive:hover:not(:disabled) {
 	overflow-wrap: anywhere;
 	border: 1px solid var(--border-default);
 	background: rgba(9, 18, 31, 0.36);
-}
-
-.notice.warning {
-	border-color: var(--warning-border);
 }
 
 .notice.error {
@@ -2386,11 +2384,6 @@ strong.metric-value-danger {
 	background: var(--notice-error-gradient);
 }
 
-.notice-stack-item.warning {
-	background: linear-gradient(180deg, rgba(92, 72, 20, 0.9) 0%, rgba(61, 44, 13, 0.9) 100%);
-	border-color: var(--warning-border);
-}
-
 .notice-stack-item.pending {
 	background: linear-gradient(180deg, rgba(16, 43, 64, 0.92) 0%, rgba(8, 28, 46, 0.92) 100%);
 	border-color: var(--interactive-border);
@@ -2430,8 +2423,7 @@ strong.metric-value-danger {
 	border-color: var(--danger-border);
 }
 
-.environment-gate.warning,
-.lifecycle-stage-banner.warning {
+.environment-gate.warning {
 	border-color: var(--warning-border);
 }
 
@@ -2567,10 +2559,6 @@ strong.metric-value-danger {
 	border-color: var(--success-border);
 }
 
-.action-launcher-card.warning {
-	border-color: var(--warning-border);
-}
-
 .action-launcher-card.blocked {
 	border-color: var(--danger-border);
 }
@@ -2578,6 +2566,43 @@ strong.metric-value-danger {
 .action-launcher-card-actions {
 	display: flex;
 	justify-content: flex-start;
+}
+
+.warning-surface {
+	position: relative;
+	border: 1px solid var(--warning-border-strong);
+	background: var(--notice-warning-gradient);
+	color: var(--text);
+	line-height: 1.5;
+	overflow-wrap: anywhere;
+	box-shadow:
+		0 0 0 1px rgba(245, 200, 106, 0.16) inset,
+		0 12px 30px rgba(245, 200, 106, 0.08);
+}
+
+.warning-surface::before {
+	content: "";
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	background: linear-gradient(120deg, rgba(255, 243, 204, 0.12), transparent 28%, transparent 72%, rgba(245, 200, 106, 0.14));
+}
+
+.warning-surface > * {
+	position: relative;
+	z-index: 1;
+}
+
+.warning-surface.compact {
+	display: grid;
+	gap: 1rem;
+	padding: 0.85rem 0.9rem;
+	border-radius: var(--radius-record);
+}
+
+.warning-surface a {
+	color: inherit;
+	text-decoration-thickness: 0.08em;
 }
 
 .read-only-detail-accordion {

--- a/ui/dist/css/index.css
+++ b/ui/dist/css/index.css
@@ -49,6 +49,7 @@
 	--warning: #f5c86a;
 	--warning-soft: rgba(245, 200, 106, 0.12);
 	--warning-border: rgba(245, 200, 106, 0.24);
+	--warning-border-strong: rgba(245, 200, 106, 0.52);
 	--danger: #ff708f;
 	--danger-soft: rgba(255, 112, 143, 0.12);
 	--danger-border: rgba(255, 112, 143, 0.28);
@@ -97,6 +98,7 @@
 
 	/* notice error */
 	--danger-text: #ffe5eb;
+	--notice-warning-gradient: linear-gradient(180deg, rgba(99, 77, 18, 0.96) 0%, rgba(66, 48, 11, 0.96) 100%);
 	--notice-error-gradient: linear-gradient(180deg, rgba(87, 18, 33, 0.94) 0%, rgba(59, 11, 22, 0.94) 100%);
 
 	/* elevated surfaces */
@@ -508,10 +510,6 @@ button.destructive:hover:not(:disabled) {
 	overflow-wrap: anywhere;
 	border: 1px solid var(--border-default);
 	background: rgba(9, 18, 31, 0.36);
-}
-
-.notice.warning {
-	border-color: var(--warning-border);
 }
 
 .notice.error {
@@ -2386,11 +2384,6 @@ strong.metric-value-danger {
 	background: var(--notice-error-gradient);
 }
 
-.notice-stack-item.warning {
-	background: linear-gradient(180deg, rgba(92, 72, 20, 0.9) 0%, rgba(61, 44, 13, 0.9) 100%);
-	border-color: var(--warning-border);
-}
-
 .notice-stack-item.pending {
 	background: linear-gradient(180deg, rgba(16, 43, 64, 0.92) 0%, rgba(8, 28, 46, 0.92) 100%);
 	border-color: var(--interactive-border);
@@ -2430,8 +2423,7 @@ strong.metric-value-danger {
 	border-color: var(--danger-border);
 }
 
-.environment-gate.warning,
-.lifecycle-stage-banner.warning {
+.environment-gate.warning {
 	border-color: var(--warning-border);
 }
 
@@ -2567,10 +2559,6 @@ strong.metric-value-danger {
 	border-color: var(--success-border);
 }
 
-.action-launcher-card.warning {
-	border-color: var(--warning-border);
-}
-
 .action-launcher-card.blocked {
 	border-color: var(--danger-border);
 }
@@ -2578,6 +2566,43 @@ strong.metric-value-danger {
 .action-launcher-card-actions {
 	display: flex;
 	justify-content: flex-start;
+}
+
+.warning-surface {
+	position: relative;
+	border: 1px solid var(--warning-border-strong);
+	background: var(--notice-warning-gradient);
+	color: var(--text);
+	line-height: 1.5;
+	overflow-wrap: anywhere;
+	box-shadow:
+		0 0 0 1px rgba(245, 200, 106, 0.16) inset,
+		0 12px 30px rgba(245, 200, 106, 0.08);
+}
+
+.warning-surface::before {
+	content: "";
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	background: linear-gradient(120deg, rgba(255, 243, 204, 0.12), transparent 28%, transparent 72%, rgba(245, 200, 106, 0.14));
+}
+
+.warning-surface > * {
+	position: relative;
+	z-index: 1;
+}
+
+.warning-surface.compact {
+	display: grid;
+	gap: 1rem;
+	padding: 0.85rem 0.9rem;
+	border-radius: var(--radius-record);
+}
+
+.warning-surface a {
+	color: inherit;
+	text-decoration-thickness: 0.08em;
 }
 
 .read-only-detail-accordion {

--- a/ui/ts/components/ActionLauncherCard.tsx
+++ b/ui/ts/components/ActionLauncherCard.tsx
@@ -1,5 +1,6 @@
 import type { ComponentChildren } from 'preact'
 import { TransactionActionButton } from './TransactionActionButton.js'
+import { WarningSurface } from './WarningSurface.js'
 import type { ReadinessAction } from '../types/components.js'
 
 type ActionLauncherCardProps = {
@@ -11,8 +12,8 @@ type ActionLauncherCardProps = {
 }
 
 export function ActionLauncherCard({ action, children, pending = false, pendingLabel = 'Opening...', tone = 'secondary' }: ActionLauncherCardProps) {
-	return (
-		<section className={`action-launcher-card ${action.readiness}`}>
+	const content = (
+		<>
 			<div className='action-launcher-card-copy'>
 				<h4>{action.title}</h4>
 				<p className='detail'>{action.description}</p>
@@ -21,6 +22,12 @@ export function ActionLauncherCard({ action, children, pending = false, pendingL
 			<div className='action-launcher-card-actions'>
 				<TransactionActionButton idleLabel={action.actionLabel} pendingLabel={pendingLabel} onClick={() => action.onAction?.()} pending={pending} tone={tone} availability={{ disabled: action.onAction === undefined || action.blocker !== undefined, reason: action.blocker }} />
 			</div>
-		</section>
+		</>
 	)
+
+	if (action.readiness === 'warning') {
+		return <WarningSurface className='action-launcher-card'>{content}</WarningSurface>
+	}
+
+	return <section className={`action-launcher-card ${action.readiness}`}>{content}</section>
 }

--- a/ui/ts/components/LifecycleStageBanner.tsx
+++ b/ui/ts/components/LifecycleStageBanner.tsx
@@ -1,4 +1,5 @@
 import type { LifecycleStagePresentation } from '../types/components.js'
+import { WarningSurface } from './WarningSurface.js'
 
 type LifecycleStageBannerProps = {
 	stage: LifecycleStagePresentation | undefined
@@ -6,6 +7,16 @@ type LifecycleStageBannerProps = {
 
 export function LifecycleStageBanner({ stage }: LifecycleStageBannerProps) {
 	if (stage === undefined) return undefined
+	if (stage.tone === 'warning') {
+		return (
+			<WarningSurface className='lifecycle-stage-banner'>
+				<div className='lifecycle-stage-banner-main'>
+					<h3>{stage.label}</h3>
+					<p className='detail'>{stage.detail}</p>
+				</div>
+			</WarningSurface>
+		)
+	}
 
 	return (
 		<section className={`lifecycle-stage-banner ${stage.tone}`}>

--- a/ui/ts/components/LiquidationModal.tsx
+++ b/ui/ts/components/LiquidationModal.tsx
@@ -9,6 +9,7 @@ import { FormInput } from './FormInput.js'
 import { MetricField } from './MetricField.js'
 import { OpenOraclePriceValue } from './OpenOraclePriceValue.js'
 import { TransactionActionButton } from './TransactionActionButton.js'
+import { WarningSurface } from './WarningSurface.js'
 import { sameAddress } from '../lib/address.js'
 import { useChainTimestamp } from '../lib/chainTimestamp.js'
 import { formatCurrencyInputBalance } from '../lib/formatters.js'
@@ -228,12 +229,11 @@ export function LiquidationModal({
 				</div>
 				{queuedLiquidationStatus === undefined ? null : queuedLiquidationStatus === 'queued' ? (
 					queuedLiquidationOperation === undefined ? null : (
-						<section className='entity-card compact'>
+						<WarningSurface as='section' variant='compact'>
 							<div className='entity-card-header'>
 								<div>
 									<h4>Liquidation Queued</h4>
 								</div>
-								<span className='badge warn'>Queued</span>
 							</div>
 							<div className='workflow-metric-grid'>
 								<MetricField label='Staged Operation'>#{queuedLiquidationOperation.operationId.toString()}</MetricField>
@@ -246,7 +246,7 @@ export function LiquidationModal({
 									View In Staged Operations
 								</button>
 							</div>
-						</section>
+						</WarningSurface>
 					)
 				) : queuedLiquidationStatus === 'failed' ? (
 					<section className='entity-card compact'>
@@ -269,15 +269,14 @@ export function LiquidationModal({
 						<p className='detail'>A valid oracle price was already available, so the liquidation executed immediately and no staged operation was created.</p>
 					</section>
 				) : queuedLiquidationStatus === 'missing' ? (
-					<section className='entity-card compact'>
+					<WarningSurface as='section' variant='compact'>
 						<div className='entity-card-header'>
 							<div>
 								<h4>Liquidation Submitted</h4>
 							</div>
-							<span className='badge warn'>Check State</span>
 						</div>
 						<p className='detail'>The transaction succeeded, but no matching staged operation is currently visible for this vault. Refresh staged operations to confirm the latest manager state.</p>
-					</section>
+					</WarningSurface>
 				) : (
 					<section className='entity-card compact'>
 						<div className='entity-card-header'>
@@ -339,15 +338,14 @@ export function LiquidationModal({
 					/>
 				</DataGrid>
 				{sameVaultWarning === undefined ? null : (
-					<section className='entity-card compact'>
+					<WarningSurface as='section' variant='compact'>
 						<div className='entity-card-header'>
 							<div>
 								<h4>Invalid Liquidation Pair</h4>
 							</div>
-							<span className='badge warn'>Warning</span>
 						</div>
 						<p className='detail'>{sameVaultWarning}</p>
-					</section>
+					</WarningSurface>
 				)}
 				<div className='form-grid'>
 					<label className='field'>

--- a/ui/ts/components/NoticeStack.tsx
+++ b/ui/ts/components/NoticeStack.tsx
@@ -1,5 +1,6 @@
 import type { NoticeItem } from '../types/components.js'
 import { orderNoticeItems } from '../lib/noticeStack.js'
+import { WarningSurface } from './WarningSurface.js'
 
 type NoticeStackProps = {
 	items: NoticeItem[]
@@ -10,12 +11,19 @@ export function NoticeStack({ items }: NoticeStackProps) {
 
 	return (
 		<div className='page-notices'>
-			{orderNoticeItems(items).map(item => (
-				<div key={item.id} className={`notice notice-stack-item ${item.tone}`}>
-					{item.title === undefined ? undefined : <strong className='notice-title'>{item.title}</strong>}
-					<div>{item.detail}</div>
-				</div>
-			))}
+			{orderNoticeItems(items).map(item =>
+				item.tone === 'warning' ? (
+					<WarningSurface key={item.id} as='div' className='notice notice-stack-item'>
+						{item.title === undefined ? undefined : <strong className='notice-title'>{item.title}</strong>}
+						<div>{item.detail}</div>
+					</WarningSurface>
+				) : (
+					<div key={item.id} className={`notice notice-stack-item ${item.tone}`}>
+						{item.title === undefined ? undefined : <strong className='notice-title'>{item.title}</strong>}
+						<div>{item.detail}</div>
+					</div>
+				),
+			)}
 		</div>
 	)
 }

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { AddressValue } from './AddressValue.js'
 import { CurrencyValue } from './CurrencyValue.js'
-import { EntityCard } from './EntityCard.js'
 import { ErrorNotice } from './ErrorNotice.js'
 import { FormInput } from './FormInput.js'
 import { ForkAuctionSection } from './ForkAuctionSection.js'
@@ -24,6 +23,7 @@ import { TransactionActionButton } from './TransactionActionButton.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { UniverseLink } from './UniverseLink.js'
 import { ViewTabs } from './ViewTabs.js'
+import { WarningSurface } from './WarningSurface.js'
 import { normalizeAddress, sameAddress } from '../lib/address.js'
 import { useChainTimestamp } from '../lib/chainTimestamp.js'
 import {
@@ -573,8 +573,13 @@ export function SecurityPoolWorkflowSection({
 										)}
 										<SectionBlock density='compact' headingLevel={4} title='Staged Operations List' variant='embedded'>
 											{currentPoolOracleManagerDetails?.pendingOperation === undefined ? null : (
-												<EntityCard className='compact' title={getPendingOperationLabel(currentPoolOracleManagerDetails.pendingOperation.operation)} variant='compact' badge={<span className='badge warn'>Queued</span>}>
-													<div className='workflow-metric-grid'>
+												<WarningSurface as='article' className='warning-entity-card' variant='compact'>
+													<div className='entity-card-header'>
+														<div className='entity-card-copy'>
+															<h3>{getPendingOperationLabel(currentPoolOracleManagerDetails.pendingOperation.operation)}</h3>
+														</div>
+													</div>
+													<div className='entity-card-body workflow-metric-grid'>
 														<MetricField label='Operation Id'>{currentPoolOracleManagerDetails.pendingOperation.operationId.toString()}</MetricField>
 														<MetricField label='Initiator'>
 															<AddressValue address={currentPoolOracleManagerDetails.pendingOperation.initiatorVault} />
@@ -586,7 +591,7 @@ export function SecurityPoolWorkflowSection({
 															<CurrencyValue value={currentPoolOracleManagerDetails.pendingOperation.amount} />
 														</MetricField>
 													</div>
-												</EntityCard>
+												</WarningSurface>
 											)}
 											{currentPoolOracleManagerDetails === undefined || currentPoolOracleManagerDetails.pendingOperation !== undefined ? null : <StateHint presentation={{ key: 'empty', badgeLabel: 'None queued', badgeTone: 'muted', detail: 'No staged operations are currently queued for this pool.' }} />}
 										</SectionBlock>

--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -19,6 +19,7 @@ import { TokenApprovalControl } from './TokenApprovalControl.js'
 import { TransactionActionButton } from './TransactionActionButton.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { VaultMetricGrid } from './VaultMetricGrid.js'
+import { WarningSurface } from './WarningSurface.js'
 import { normalizeAddress, sameAddress } from '../lib/address.js'
 import { formatCurrencyBalance, formatCurrencyInputBalance } from '../lib/formatters.js'
 import { balanceShortage } from '../lib/inputs.js'
@@ -155,7 +156,6 @@ function VaultQueuedOperationStatusCard({
 	failedTitle,
 	missingTitle,
 	missingDescription,
-	queuedBadgeLabel = 'Queued',
 	queuedTitle,
 	queuedVaultOperation,
 	refreshingTitle,
@@ -171,7 +171,6 @@ function VaultQueuedOperationStatusCard({
 	missingDescription: string
 	missingTitle: string
 	onViewStagedOperations: (() => void) | undefined
-	queuedBadgeLabel?: string
 	queuedTitle: string
 	queuedVaultOperation: ReturnType<typeof getQueuedVaultOperation>
 	refreshingDescription: string
@@ -183,12 +182,11 @@ function VaultQueuedOperationStatusCard({
 
 	if (status === 'queued') {
 		return (
-			<section className='entity-card compact'>
+			<WarningSurface as='section' variant='compact'>
 				<div className='entity-card-header'>
 					<div>
 						<h4>{queuedTitle}</h4>
 					</div>
-					<span className='badge warn'>{queuedBadgeLabel}</span>
 				</div>
 				<div className='workflow-metric-grid'>
 					<MetricField label='Staged Operation'>{queuedVaultOperation === undefined ? 'Refreshing...' : `#${queuedVaultOperation.operationId.toString()}`}</MetricField>
@@ -201,7 +199,7 @@ function VaultQueuedOperationStatusCard({
 						</button>
 					</div>
 				)}
-			</section>
+			</WarningSurface>
 		)
 	}
 
@@ -235,15 +233,14 @@ function VaultQueuedOperationStatusCard({
 
 	if (status === 'missing') {
 		return (
-			<section className='entity-card compact'>
+			<WarningSurface as='section' variant='compact'>
 				<div className='entity-card-header'>
 					<div>
 						<h4>{missingTitle}</h4>
 					</div>
-					<span className='badge warn'>Check State</span>
 				</div>
 				<p className='detail'>{missingDescription}</p>
-			</section>
+			</WarningSurface>
 		)
 	}
 

--- a/ui/ts/components/WarningSurface.tsx
+++ b/ui/ts/components/WarningSurface.tsx
@@ -1,0 +1,15 @@
+import type { ComponentChildren } from 'preact'
+
+type WarningSurfaceProps = {
+	as?: 'article' | 'div' | 'section'
+	children: ComponentChildren
+	className?: string
+	variant?: 'compact' | 'default'
+}
+
+export function WarningSurface({ as = 'section', children, className = '', variant = 'default' }: WarningSurfaceProps) {
+	const Tag = as
+	const classes = ['warning-surface', variant === 'compact' ? 'compact' : undefined, className].filter(Boolean).join(' ')
+
+	return <Tag className={classes}>{children}</Tag>
+}

--- a/ui/ts/tests/actionLauncherCard.test.tsx
+++ b/ui/ts/tests/actionLauncherCard.test.tsx
@@ -1,0 +1,41 @@
+/// <reference types="bun-types" />
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { within } from '@testing-library/dom'
+import { ActionLauncherCard } from '../components/ActionLauncherCard.js'
+import { installDomEnvironment } from './testUtils/domEnvironment.js'
+import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
+
+describe('ActionLauncherCard', () => {
+	let restoreDomEnvironment: (() => void) | undefined
+	let cleanupRenderedComponent: (() => Promise<void>) | undefined
+
+	beforeEach(() => {
+		const domEnvironment = installDomEnvironment()
+		restoreDomEnvironment = domEnvironment.cleanup
+	})
+
+	afterEach(async () => {
+		await cleanupRenderedComponent?.()
+		cleanupRenderedComponent = undefined
+		restoreDomEnvironment?.()
+		restoreDomEnvironment = undefined
+	})
+
+	test('uses the warning surface only for warning readiness cards', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<div>
+				<ActionLauncherCard action={{ actionLabel: 'Warning Action', description: 'Warning details.', key: 'warning', onAction: () => undefined, readiness: 'warning', title: 'Warning Action' }} />
+				<ActionLauncherCard action={{ actionLabel: 'Ready Action', description: 'Ready details.', key: 'ready', onAction: () => undefined, readiness: 'ready', title: 'Ready Action' }} />
+				<ActionLauncherCard action={{ actionLabel: 'Blocked Action', blocker: 'Blocked.', description: 'Blocked details.', key: 'blocked', readiness: 'blocked', title: 'Blocked Action' }} />
+			</div>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect((documentQueries.getByRole('heading', { name: 'Warning Action' }) as HTMLElement).closest('.warning-surface')).not.toBeNull()
+		expect((documentQueries.getByRole('heading', { name: 'Ready Action' }) as HTMLElement).closest('.warning-surface')).toBeNull()
+		expect((documentQueries.getByRole('heading', { name: 'Blocked Action' }) as HTMLElement).closest('.warning-surface')).toBeNull()
+		expect(document.body.querySelectorAll('.warning-surface.action-launcher-card')).toHaveLength(1)
+	})
+})

--- a/ui/ts/tests/liquidationModal.test.tsx
+++ b/ui/ts/tests/liquidationModal.test.tsx
@@ -268,6 +268,8 @@ describe('LiquidationModal', () => {
 		const documentQueries = within(document.body)
 		expect(documentQueries.getByRole('heading', { name: 'Liquidation Queued' })).not.toBeNull()
 		expect(documentQueries.getByText('#9')).not.toBeNull()
+		expect(document.body.querySelector('.warning-surface')).not.toBeNull()
+		expect(document.body.querySelector('.badge.warn')).toBeNull()
 
 		await act(() => {
 			fireEvent.click(documentQueries.getByRole('button', { name: 'View In Staged Operations' }))
@@ -540,6 +542,8 @@ describe('LiquidationModal', () => {
 		const executeButton = documentQueries.getByRole('button', { name: 'Execute Liquidation' }) as HTMLButtonElement
 		expect(executeButton.disabled).toBe(true)
 		expect(documentQueries.getByRole('heading', { name: 'Invalid Liquidation Pair' })).not.toBeNull()
+		expect(document.body.querySelector('.warning-surface')).not.toBeNull()
+		expect(document.body.querySelector('.badge.warn')).toBeNull()
 		expect(documentQueries.getAllByText('Select a target vault that is different from the caller vault.')).toHaveLength(2)
 	})
 

--- a/ui/ts/tests/noticeStack.test.tsx
+++ b/ui/ts/tests/noticeStack.test.tsx
@@ -1,0 +1,44 @@
+/// <reference types="bun-types" />
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { within } from '@testing-library/dom'
+import { NoticeStack } from '../components/NoticeStack.js'
+import { installDomEnvironment } from './testUtils/domEnvironment.js'
+import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
+
+describe('NoticeStack', () => {
+	let restoreDomEnvironment: (() => void) | undefined
+	let cleanupRenderedComponent: (() => Promise<void>) | undefined
+
+	beforeEach(() => {
+		const domEnvironment = installDomEnvironment()
+		restoreDomEnvironment = domEnvironment.cleanup
+	})
+
+	afterEach(async () => {
+		await cleanupRenderedComponent?.()
+		cleanupRenderedComponent = undefined
+		restoreDomEnvironment?.()
+		restoreDomEnvironment = undefined
+	})
+
+	test('renders warning items inside the shared warning surface', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<NoticeStack
+				items={[
+					{
+						detail: 'Refresh this workflow before continuing.',
+						id: 'warning-item',
+						title: 'Needs attention',
+						tone: 'warning',
+					},
+				]}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByText('Needs attention')).not.toBeNull()
+		expect(document.body.querySelector('.warning-surface.notice-stack-item')).not.toBeNull()
+	})
+})

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -124,6 +124,23 @@ describe('ReportingSection', () => {
 		expect(document.body.textContent?.includes('Selected side has')).toBe(true)
 	})
 
+	test('renders the pre-reporting stage inside the shared warning surface', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					currentTimestamp: 50n,
+					reportingDetails: undefined,
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByRole('heading', { name: 'Pre-Reporting' })).not.toBeNull()
+		expect(document.body.querySelector('.warning-surface.lifecycle-stage-banner')).not.toBeNull()
+	})
+
 	test('disables reporting buttons when deterministic prerequisites are missing', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(

--- a/ui/ts/tests/securityPoolWorkflowSection.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection.test.tsx
@@ -661,6 +661,8 @@ describe('SecurityPoolWorkflowSection', () => {
 		const dialogQueries = within(withdrawDialog)
 		expect(dialogQueries.getByRole('heading', { name: 'REP Withdrawal Queued' })).not.toBeNull()
 		expect(dialogQueries.getByText('#7')).not.toBeNull()
+		expect(withdrawDialog.querySelector('.warning-surface')).not.toBeNull()
+		expect(withdrawDialog.querySelector('.badge.warn')).toBeNull()
 
 		await act(() => {
 			fireEvent.click(dialogQueries.getByRole('button', { name: 'View In Staged Operations' }))


### PR DESCRIPTION
## Summary
- Consolidated warning and blocking states onto a shared warning surface and updated banners, notices, and launcher cards to use it consistently.
- Refactored currency, timestamp, and REP price presentation to improve compact display behavior, chain-time accuracy, and source labeling.
- Reworked security pool and child-universe workflows with new shared modal components, clearer actions, and expanded vault/pool metric views.
- Stabilized simulation timing and reset behavior, tightened guards, and improved simulation controls and scenario setup.
- Expanded UI test coverage across notices, modals, metrics, trading, security pools, and simulation behavior.

## Testing
- Not run
- Expected checks per repo guidance: `bun run tsc`
- Expected checks per repo guidance: `bun run test`
- Expected checks per repo guidance: `bun run format`
- Expected checks per repo guidance: `bun run check`
- Expected checks per repo guidance: `bun run knip`