### PR TITLE
Gate trading ops until deployment and improve question autoloading

### DIFF
--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -195,6 +195,7 @@ export function App() {
 	} = useSecurityPoolsOverview(baseHookConfig)
 	const { createCompleteSet, loadingTradingDetails, loadingTradingForkUniverse, migrateShares, redeemCompleteSet, redeemShares, setTradingForm, tradingActiveAction, tradingDetails, tradingError, tradingForm, tradingForkUniverse, tradingResult } = useTradingOperations({
 		...baseHookConfig,
+		deploymentStatuses,
 		enabled: route === 'security-pools',
 	})
 	const {

--- a/ui/ts/hooks/useTradingOperations.ts
+++ b/ui/ts/hooks/useTradingOperations.ts
@@ -8,16 +8,17 @@ import { getErrorMessage } from '../lib/errors.js'
 import { parseAddressInput, parseBigIntListInput, parseReportingOutcomeInput } from '../lib/inputs.js'
 import { getDefaultTradingFormState, parseTradingAmountInput } from '../lib/marketForm.js'
 import { useRequestGuard } from '../lib/requestGuard.js'
-import { getDefaultShareMigrationTargetOutcomeIndexes } from '../lib/trading.js'
+import { getDefaultShareMigrationTargetOutcomeIndexes, isTradingSystemDeployed } from '../lib/trading.js'
 import { buildWriteActionConfig, runWriteAction } from '../lib/writeAction.js'
 import type { TradingFormState, WriteOperationsParameters } from '../types/app.js'
-import type { TradingActionResult, TradingDetails, ZoltarUniverseSummary } from '../types/contracts.js'
+import type { DeploymentStatus, TradingActionResult, TradingDetails, ZoltarUniverseSummary } from '../types/contracts.js'
 
 type UseTradingOperationsParameters = WriteOperationsParameters & {
+	deploymentStatuses: DeploymentStatus[]
 	enabled: boolean
 }
 
-export function useTradingOperations({ accountAddress, enabled, onTransaction, onTransactionFinished, onTransactionRequested, onTransactionSubmitted, refreshState }: UseTradingOperationsParameters) {
+export function useTradingOperations({ accountAddress, deploymentStatuses, enabled, onTransaction, onTransactionFinished, onTransactionRequested, onTransactionSubmitted, refreshState }: UseTradingOperationsParameters) {
 	const tradingDetailsLoad = useLoadController()
 	const nextTradingDetailsLoad = useRequestGuard()
 	const tradingDetails = useSignal<TradingDetails | undefined>(undefined)
@@ -27,6 +28,7 @@ export function useTradingOperations({ accountAddress, enabled, onTransaction, o
 	const tradingActiveAction = useSignal<TradingActionResult['action'] | undefined>(undefined)
 	const tradingResult = useSignal<TradingActionResult | undefined>(undefined)
 	const targetOutcomeDefaultsKey = useRef<string | undefined>(undefined)
+	const tradingSystemDeployed = isTradingSystemDeployed(deploymentStatuses)
 
 	const resolveTradingPoolAddressInput = (value: string) => {
 		const trimmed = value.trim()
@@ -40,6 +42,13 @@ export function useTradingOperations({ accountAddress, enabled, onTransaction, o
 	}
 
 	const refreshTradingDetails = async (securityPoolAddressInput: string, walletAddress: Address | undefined, isCurrent?: () => boolean) => {
+		if (!tradingSystemDeployed) {
+			tradingDetails.value = undefined
+			tradingForkUniverse.value = undefined
+			tradingError.value = undefined
+			return
+		}
+
 		const securityPoolAddress = resolveTradingPoolAddressInput(securityPoolAddressInput)
 		if (securityPoolAddress === undefined) {
 			tradingDetails.value = undefined
@@ -137,14 +146,20 @@ export function useTradingOperations({ accountAddress, enabled, onTransaction, o
 			tradingError.value = undefined
 			return
 		}
-	}, [enabled, tradingForm.value.securityPoolAddress])
+		if (!tradingSystemDeployed) {
+			tradingDetails.value = undefined
+			tradingForkUniverse.value = undefined
+			tradingError.value = undefined
+		}
+	}, [enabled, tradingForm.value.securityPoolAddress, tradingSystemDeployed])
 
 	useEffect(() => {
 		if (!enabled) return
 		const isCurrent = nextTradingDetailsLoad()
+		if (!tradingSystemDeployed) return
 		if (resolveTradingPoolAddressInput(tradingForm.value.securityPoolAddress) === undefined) return
 		void refreshTradingDetails(tradingForm.value.securityPoolAddress, accountAddress, isCurrent)
-	}, [accountAddress, enabled, tradingForm.value.securityPoolAddress])
+	}, [accountAddress, enabled, tradingForm.value.securityPoolAddress, tradingSystemDeployed])
 
 	useEffect(() => {
 		if (!enabled) return

--- a/ui/ts/lib/trading.ts
+++ b/ui/ts/lib/trading.ts
@@ -4,6 +4,7 @@ import { parseBigIntListInput } from './inputs.js'
 import { parseTradingAmountInput } from './marketForm.js'
 import { getReportingOutcomeLabel } from './reporting.js'
 import { isValidScalarOutcomeIndex } from './scalarOutcome.js'
+import type { DeploymentStatus } from '../types/contracts.js'
 import type { ReportingOutcomeKey, SecurityPoolSystemState, TradingShareBalances, ZoltarUniverseSummary } from '../types/contracts.js'
 
 const PRICE_PRECISION = 10n ** 18n
@@ -97,6 +98,10 @@ export function getDefaultShareMigrationTargetOutcomeIndexes(tradingForkUniverse
 	if (tradingForkUniverse === undefined || !tradingForkUniverse.hasForked) return ''
 	if (tradingForkUniverse.forkQuestionDetails?.marketType === 'scalar') return ''
 	return tradingForkUniverse.childUniverses.map(child => child.outcomeIndex.toString()).join(', ')
+}
+
+export function isTradingSystemDeployed(deploymentStatuses: DeploymentStatus[]) {
+	return deploymentStatuses.length > 0 && deploymentStatuses.every(step => step.deployed)
 }
 
 export function getTradingMintGuardMessage({

--- a/ui/ts/tests/trading.test.ts
+++ b/ui/ts/tests/trading.test.ts
@@ -21,13 +21,25 @@ import {
 	getTradingRedeemSharesGuardMessage,
 	getVaultCollateralizationPercent,
 	hasRepBackedPoolWithNoActiveAllowance,
+	isTradingSystemDeployed,
 } from '../lib/trading.js'
 import { getScalarOutcomeIndex } from '../lib/scalarOutcome.js'
-import type { ZoltarUniverseSummary } from '../types/contracts.js'
+import type { DeploymentStatus, ZoltarUniverseSummary } from '../types/contracts.js'
 
 const TOKEN_PRECISION = 10n ** 18n
 
 void describe('trading helpers', () => {
+	const createDeploymentStep = (id: DeploymentStatus['id'], deployed: boolean): DeploymentStatus => ({
+		address: zeroAddress,
+		dependencies: [],
+		deploy: async () => {
+			throw new Error('Not implemented in test helper')
+		},
+		deployed,
+		id,
+		label: id,
+	})
+
 	const shareBalances = {
 		invalid: 2n * 10n ** 18n,
 		no: 4n * 10n ** 18n,
@@ -119,6 +131,12 @@ void describe('trading helpers', () => {
 		expect(getRemainingMintCapacity(10n, 10n)).toBe(0n)
 		expect(getRemainingMintCapacity(10n, 12n)).toBe(0n)
 		expect(getRemainingMintCapacity(undefined, 12n)).toBeUndefined()
+	})
+
+	void test('treats the trading system as deployed only when every deterministic deployment step is deployed', () => {
+		expect(isTradingSystemDeployed([])).toBe(false)
+		expect(isTradingSystemDeployed([createDeploymentStep('proxyDeployer', true), createDeploymentStep('zoltar', true), createDeploymentStep('securityPoolFactory', true)])).toBe(true)
+		expect(isTradingSystemDeployed([createDeploymentStep('proxyDeployer', true), createDeploymentStep('zoltar', true), createDeploymentStep('securityPoolFactory', false)])).toBe(false)
 	})
 
 	void test('computes pool collateralization as a percentage using the canonical REP/ETH price', () => {


### PR DESCRIPTION
## Summary
- Skip trading detail refreshes and actions until the trading system deployment is complete.
- Improve market question auto-loading by waiting for question counts to resolve, avoiding duplicate loads, and retrying cleanly on failure.
- Update market/trading component contracts and add coverage for deployment gating and auto-load behavior.

## Testing
- `bun run tsc`
- `bun run test`
- `bun run format`
- `bun run check`
- `bun run knip`