### PR TITLE
Fix reporting escalation countdown

### DIFF
--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -75,7 +75,6 @@ export { readOptionalMulticall } from './contracts/core.js'
 
 export { getMulticall3Address, getOpenOracleAddress, getZoltarAddress } from './contracts/deploymentHelpers.js'
 const LIQUIDATION_OPERATION_TYPE = 0
-const ESCALATION_TIME_LENGTH = 4_233_600n
 const MIGRATION_TIME_LENGTH = 4_838_400n
 const TRUTH_AUCTION_TIME_LENGTH = 604_800n
 const QUESTION_OUTCOME_ABI = [parseAbiItem('function getQuestionOutcome(address securityPool) view returns (uint8 outcome)')]
@@ -221,7 +220,7 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 		}
 	}
 
-	const [startBond, nonDecisionThreshold, startingTime, totalCost, bindingCapital, balances, resolution] = await readRequiredMulticall(client, [
+	const [startBond, nonDecisionThreshold, startingTime, totalCost, bindingCapital, balances, resolution, escalationEndTime] = await readRequiredMulticall(client, [
 		{
 			abi: peripherals_EscalationGame_EscalationGame.abi,
 			functionName: 'startBond',
@@ -264,6 +263,12 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 			address: escalationGameAddress,
 			args: [],
 		},
+		{
+			abi: peripherals_EscalationGame_EscalationGame.abi,
+			functionName: 'getEscalationGameEndDate',
+			address: escalationGameAddress,
+			args: [],
+		},
 	])
 	if (!isBigintTriple(balances)) throw new Error('Unexpected escalation balances response')
 	const [invalidDeposits, yesDeposits, noDeposits] = await Promise.all([loadEscalationDeposits(client, escalationGameAddress, 'invalid'), loadEscalationDeposits(client, escalationGameAddress, 'yes'), loadEscalationDeposits(client, escalationGameAddress, 'no')])
@@ -279,7 +284,7 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 		completeSetCollateralAmount,
 		currentRequiredBond: totalCost === 0n ? startBond : totalCost,
 		currentTime: block.timestamp,
-		escalationEndTime: startingTime + ESCALATION_TIME_LENGTH,
+		escalationEndTime,
 		escalationGameAddress,
 		marketDetails,
 		nonDecisionThreshold,

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -5,8 +5,9 @@ import { within } from '@testing-library/dom'
 import { h } from 'preact'
 import { zeroAddress } from 'viem'
 import { ReportingSection } from '../components/ReportingSection.js'
+import { formatDuration } from '../lib/formatters.js'
 import type { AccountState, ReportingFormState } from '../types/app.js'
-import type { MarketDetails, ReportingDetails } from '../types/contracts.js'
+import type { ActiveReportingDetails, MarketDetails, ReportingDetails } from '../types/contracts.js'
 import type { ReportingSectionProps } from '../types/components.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
@@ -40,7 +41,7 @@ function createMarketDetails(): MarketDetails {
 	}
 }
 
-function createReportingDetails(): ReportingDetails {
+function createReportingDetails(): ActiveReportingDetails {
 	return {
 		bindingCapital: 10n,
 		completeSetCollateralAmount: 1n,
@@ -194,6 +195,45 @@ describe('ReportingSection', () => {
 		expect(documentQueries.queryByRole('heading', { name: 'Report Outcome' })).toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Withdraw Escalation Deposits' })).not.toBeNull()
 		expectTransactionButtonEnabled(document.body, 'Withdraw Escalation Deposits')
+	})
+
+	test('renders time left from escalation end time and current chain time', async () => {
+		const reportingDetails = createReportingDetails()
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					reportingDetails: {
+						...reportingDetails,
+						currentTime: 150n,
+						escalationEndTime: 300n,
+					},
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(document.body.textContent?.includes(formatDuration(300n - 150n))).toBe(true)
+	})
+
+	test('shows awaiting resolution with zero time left once the escalation end time has passed', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					reportingDetails: {
+						...createReportingDetails(),
+						currentTime: 300n,
+						escalationEndTime: 300n,
+					},
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getAllByText('Awaiting Resolution').length).toBeGreaterThan(0)
+		expect(document.body.textContent?.includes(formatDuration(0n))).toBe(true)
 	})
 
 	test('shows first-report guidance before the escalation game starts', async () => {


### PR DESCRIPTION
## Summary
- load the escalation countdown end time from `getEscalationGameEndDate()` instead of deriving it from the max window
- keep reporting countdowns based on chain block time
- add reporting section coverage for the corrected countdown and the zero-time boundary

## Testing
- `cd ui && bun x tsc --project tsconfig.json`
- `bun run test`
- `bun run format`
- `bun run check`
- `bun run knip`