### PR TITLE
Add reporting presets and return estimate updates

### DIFF
--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -17,12 +17,12 @@ import { TransactionActionButton } from './TransactionActionButton.js'
 import { TimestampValue } from './TimestampValue.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
 import { UniverseLink } from './UniverseLink.js'
-import { formatDuration } from '../lib/formatters.js'
+import { formatCurrencyInputBalance, formatDuration } from '../lib/formatters.js'
 import { parseOptionalRepAmountInput } from '../lib/marketForm.js'
 import { isMainnetChain } from '../lib/network.js'
 import { getReportingReportGuardMessage, getReportingWithdrawGuardMessage } from '../lib/reportingGuards.js'
 import { REPORTING_OUTCOME_DROPDOWN_OPTIONS, getReportingOutcomeLabel } from '../lib/reporting.js'
-import { calculateEstimatedEscalationReturn, getEscalationPhase, getEscalationTimeRemaining, getLeadingEscalationOutcome } from '../lib/reportingDomain.js'
+import { calculateEstimatedEscalationReturn, getEscalationPhase, getEscalationTimeRemaining, getLeadingEscalationOutcome, getMaxProfitContribution, getMinimumOutcomeChangeContribution } from '../lib/reportingDomain.js'
 import type { LifecycleStagePresentation, ReportingSectionProps, WorkflowOutcomePresentation } from '../types/components.js'
 
 function getReportingStagePresentation({ effectiveCurrentTimestamp, marketDetails, reportingDetails }: { effectiveCurrentTimestamp: bigint | undefined; marketDetails: ReportingSectionProps['previewMarketDetails']; reportingDetails: ReportingSectionProps['reportingDetails'] }): LifecycleStagePresentation | undefined {
@@ -86,10 +86,12 @@ export function ReportingSection({
 	const selectedAmount = parseOptionalRepAmountInput(reportingForm.reportAmount)
 	const showFullReporting = mode === 'full-reporting'
 	const showWithdrawOnly = mode === 'withdraw-only'
-	const totalBalance = activeReportingDetails === undefined ? 0n : activeReportingDetails.sides.reduce((sum, side) => sum + side.balance, 0n)
 	const leadingOutcome = activeReportingDetails === undefined ? undefined : getLeadingEscalationOutcome(activeReportingDetails.sides)
 	const selectedSide = activeReportingDetails?.sides.find(side => side.key === reportingForm.selectedOutcome)
-	const selectedEstimate = selectedSide === undefined || selectedAmount === undefined ? undefined : calculateEstimatedEscalationReturn(selectedSide.balance, totalBalance, selectedAmount)
+	const selectedEstimate = activeReportingDetails === undefined || selectedAmount === undefined ? undefined : calculateEstimatedEscalationReturn(activeReportingDetails, reportingForm.selectedOutcome, selectedAmount)
+	const minimumOutcomeChangeContribution =
+		activeReportingDetails === undefined ? { amount: undefined, reason: reportingStatus === 'not-started' ? 'Escalation game has not started yet.' : 'Load reporting details before using presets.' } : getMinimumOutcomeChangeContribution(activeReportingDetails, reportingForm.selectedOutcome)
+	const maxProfitContribution = activeReportingDetails === undefined ? { amount: undefined, reason: reportingStatus === 'not-started' ? 'Escalation game has not started yet.' : 'Load reporting details before using presets.' } : getMaxProfitContribution(activeReportingDetails, reportingForm.selectedOutcome)
 	const reportAmountError = selectedAmount === undefined && reportingForm.reportAmount.trim() !== '' ? 'Enter a valid report amount to preview profit.' : undefined
 	const reportGuardMessage = getReportingReportGuardMessage({
 		accountAddress: accountState.address,
@@ -216,7 +218,7 @@ export function ReportingSection({
 				<SectionBlock title='Outcome Sides'>
 					<div className='escalation-sides'>
 						{activeReportingDetails.sides.map(side => {
-							const estimate = selectedAmount === undefined ? undefined : calculateEstimatedEscalationReturn(side.balance, totalBalance, selectedAmount)
+							const estimate = selectedAmount === undefined ? undefined : calculateEstimatedEscalationReturn(activeReportingDetails, side.key, selectedAmount)
 							const userStake = side.userDeposits.reduce((sum, deposit) => sum + deposit.amount, 0n)
 							return <EscalationSide key={side.key} estimate={estimate} isLeading={leadingOutcome === side.key} isSelected={reportingForm.selectedOutcome === side.key} side={side} userStake={userStake} />
 						})}
@@ -243,6 +245,35 @@ export function ReportingSection({
 						<FormInput value={reportingForm.reportAmount} onInput={event => onReportingFormChange({ reportAmount: event.currentTarget.value })} disabled={reportingLocked} />
 					</label>
 
+					<div className='actions'>
+						<button
+							className='secondary'
+							type='button'
+							onClick={() => {
+								if (minimumOutcomeChangeContribution.amount === undefined) return
+								onReportingFormChange({ reportAmount: formatCurrencyInputBalance(minimumOutcomeChangeContribution.amount) })
+							}}
+							disabled={reportingLocked || minimumOutcomeChangeContribution.amount === undefined}
+							title={reportingLocked ? lockedReason : minimumOutcomeChangeContribution.reason}
+						>
+							Min to change proposed outcome
+						</button>
+						<button
+							className='secondary'
+							type='button'
+							onClick={() => {
+								if (maxProfitContribution.amount === undefined) return
+								onReportingFormChange({ reportAmount: formatCurrencyInputBalance(maxProfitContribution.amount) })
+							}}
+							disabled={reportingLocked || maxProfitContribution.amount === undefined}
+							title={reportingLocked ? lockedReason : maxProfitContribution.reason}
+						>
+							Max profit
+						</button>
+					</div>
+
+					{minimumOutcomeChangeContribution.reason === undefined ? undefined : <p className='detail'>{minimumOutcomeChangeContribution.reason}</p>}
+					{maxProfitContribution.reason === undefined ? undefined : <p className='detail'>{maxProfitContribution.reason}</p>}
 					{reportAmountError === undefined ? undefined : <p className='detail'>{reportAmountError}</p>}
 
 					{selectedEstimate === undefined ? undefined : (

--- a/ui/ts/lib/reportingDomain.ts
+++ b/ui/ts/lib/reportingDomain.ts
@@ -1,6 +1,18 @@
-import type { ActiveReportingDetails, EscalationSide } from '../types/contracts.js'
-import { getTimeRemaining } from './time.js'
+import type { ActiveReportingDetails, EscalationSide, ReportingOutcomeKey } from '../types/contracts.js'
 import { requireDefined } from './required.js'
+import { getTimeRemaining } from './time.js'
+
+type ReportingAmountSuggestion = {
+	amount: bigint | undefined
+	reason: string | undefined
+}
+
+const REP_UNIT = 10n ** 18n
+
+function roundUpToRepUnit(value: bigint) {
+	if (value <= 0n) return 0n
+	return ((value + REP_UNIT - 1n) / REP_UNIT) * REP_UNIT
+}
 
 export function getEscalationTimeRemaining(details: ActiveReportingDetails) {
 	return requireDefined(getTimeRemaining(details.escalationEndTime, details.currentTime), 'Escalation end time is required')
@@ -25,7 +37,70 @@ export function getLeadingEscalationOutcome(sides: EscalationSide[]) {
 	return leadingSide?.key
 }
 
-export function calculateEstimatedEscalationReturn(sideBalance: bigint, allBalances: bigint, amount: bigint) {
+function getSelectedAndOtherSides(details: ActiveReportingDetails, selectedOutcome: ReportingOutcomeKey) {
+	const selectedSide = details.sides.find(side => side.key === selectedOutcome)
+	const otherSides = details.sides.filter(side => side.key !== selectedOutcome)
+	const largestOtherBalance = otherSides.reduce((maxBalance, side) => (side.balance > maxBalance ? side.balance : maxBalance), 0n)
+
+	return {
+		largestOtherBalance,
+		otherSides,
+		selectedSide,
+	}
+}
+
+function isUniqueWinner(selectedBalance: bigint, largestOtherBalance: bigint) {
+	return selectedBalance > largestOtherBalance
+}
+
+export function getMinimumOutcomeChangeContribution(details: ActiveReportingDetails, selectedOutcome: ReportingOutcomeKey): ReportingAmountSuggestion {
+	const { largestOtherBalance, otherSides, selectedSide } = getSelectedAndOtherSides(details, selectedOutcome)
+	if (selectedSide === undefined) return { amount: undefined, reason: 'Selected side is unavailable.' }
+	if (details.resolution === selectedOutcome) return { amount: 0n, reason: undefined }
+
+	const selectedAlreadyUniqueWinner = isUniqueWinner(selectedSide.balance, largestOtherBalance)
+	const opposingSideOverBond = otherSides.some(side => side.balance >= details.currentRequiredBond)
+	if (opposingSideOverBond && !selectedAlreadyUniqueWinner) {
+		return { amount: undefined, reason: 'Min preset unavailable because another side is already over the current bond.' }
+	}
+
+	const rawAmount = largestOtherBalance + 1n > selectedSide.balance ? largestOtherBalance + 1n - selectedSide.balance : 0n
+	const minimumAllowedAmount = rawAmount > 0n && rawAmount < details.startBond ? details.startBond : rawAmount
+	const amount = roundUpToRepUnit(minimumAllowedAmount)
+	if (selectedSide.balance + amount > details.nonDecisionThreshold) {
+		return { amount: undefined, reason: 'Min preset unavailable because the selected side cannot accept that much REP.' }
+	}
+
+	return { amount, reason: undefined }
+}
+
+export function getMaxProfitContribution(details: ActiveReportingDetails, selectedOutcome: ReportingOutcomeKey): ReportingAmountSuggestion {
+	const minContribution = getMinimumOutcomeChangeContribution(details, selectedOutcome)
+	if (minContribution.amount === undefined) {
+		return { amount: undefined, reason: minContribution.reason ?? 'Max profit preset is unavailable.' }
+	}
+
+	const { largestOtherBalance, selectedSide } = getSelectedAndOtherSides(details, selectedOutcome)
+	if (selectedSide === undefined) return { amount: undefined, reason: 'Selected side is unavailable.' }
+
+	const rewardEligibleCap = largestOtherBalance + largestOtherBalance / 2n
+	const targetFinalBalance = rewardEligibleCap < details.nonDecisionThreshold ? rewardEligibleCap : details.nonDecisionThreshold
+	if (isUniqueWinner(selectedSide.balance, largestOtherBalance) && selectedSide.balance >= targetFinalBalance) {
+		return { amount: undefined, reason: 'Max profit preset unavailable because the reward window is already filled on the selected side.' }
+	}
+
+	const rawAmount = targetFinalBalance > selectedSide.balance ? targetFinalBalance - selectedSide.balance : 0n
+	const targetAmount = rawAmount > minContribution.amount ? rawAmount : minContribution.amount
+	const minimumAllowedAmount = targetAmount > 0n && targetAmount < details.startBond ? details.startBond : targetAmount
+	const amount = roundUpToRepUnit(minimumAllowedAmount)
+	if (selectedSide.balance + amount > details.nonDecisionThreshold) {
+		return { amount: undefined, reason: 'Max profit preset unavailable because the selected side cannot accept that much REP.' }
+	}
+
+	return { amount, reason: undefined }
+}
+
+export function calculateEstimatedEscalationReturn(details: ActiveReportingDetails, selectedOutcome: ReportingOutcomeKey, amount: bigint) {
 	if (amount <= 0n) {
 		return {
 			payout: 0n,
@@ -33,12 +108,44 @@ export function calculateEstimatedEscalationReturn(sideBalance: bigint, allBalan
 		}
 	}
 
-	const projectedWinningStake = sideBalance + amount
-	const projectedTotal = allBalances + amount
-	const payout = projectedWinningStake === 0n ? 0n : (amount * projectedTotal) / projectedWinningStake
+	const { largestOtherBalance, selectedSide } = getSelectedAndOtherSides(details, selectedOutcome)
+	if (selectedSide === undefined) {
+		return {
+			payout: 0n,
+			profit: 0n,
+		}
+	}
+
+	const availableRoom = details.nonDecisionThreshold > selectedSide.balance ? details.nonDecisionThreshold - selectedSide.balance : 0n
+	const effectiveAmount = amount > availableRoom ? availableRoom : amount
+	if (effectiveAmount <= 0n) {
+		return {
+			payout: 0n,
+			profit: 0n,
+		}
+	}
+
+	const projectedWinningStake = selectedSide.balance + effectiveAmount
+	const bindingCapital = largestOtherBalance
+	const rewardEligibleCap = bindingCapital + bindingCapital / 2n
+	const rewardEligiblePrincipal = projectedWinningStake < rewardEligibleCap ? projectedWinningStake : rewardEligibleCap
+	if (rewardEligiblePrincipal === 0n) {
+		return {
+			payout: effectiveAmount,
+			profit: 0n,
+		}
+	}
+
+	const depositStart = selectedSide.balance
+	const depositEnd = selectedSide.balance + effectiveAmount
+	const eligibleEnd = depositEnd < rewardEligibleCap ? depositEnd : rewardEligibleCap
+	const rewardEligibleDepositAmount = eligibleEnd > depositStart ? eligibleEnd - depositStart : 0n
+	const rewardBonusPool = (bindingCapital * 3n) / 5n
+	const bonusShare = (rewardEligibleDepositAmount * rewardBonusPool) / rewardEligiblePrincipal
+	const payout = effectiveAmount + bonusShare
 
 	return {
 		payout,
-		profit: payout - amount,
+		profit: payout - effectiveAmount,
 	}
 }

--- a/ui/ts/tests/reportingDomain.test.ts
+++ b/ui/ts/tests/reportingDomain.test.ts
@@ -1,0 +1,146 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { zeroAddress } from 'viem'
+import { calculateEstimatedEscalationReturn, getMaxProfitContribution, getMinimumOutcomeChangeContribution } from '../lib/reportingDomain.js'
+import type { ActiveReportingDetails, MarketDetails } from '../types/contracts.js'
+
+function rep(value: bigint) {
+	return value * 10n ** 18n
+}
+
+function createMarketDetails(): MarketDetails {
+	return {
+		answerUnit: '',
+		createdAt: 1n,
+		description: 'Question description',
+		displayValueMax: 100n,
+		displayValueMin: 0n,
+		endTime: 100n,
+		exists: true,
+		marketType: 'binary',
+		numTicks: 2n,
+		outcomeLabels: ['Yes', 'No'],
+		questionId: '0x01',
+		startTime: 1n,
+		title: 'Will this resolve?',
+	}
+}
+
+function createReportingDetails(overrides: Partial<ActiveReportingDetails> = {}): ActiveReportingDetails {
+	return {
+		bindingCapital: rep(10n),
+		completeSetCollateralAmount: 1n,
+		currentRequiredBond: rep(20n),
+		currentTime: 150n,
+		escalationEndTime: 300n,
+		escalationGameAddress: zeroAddress,
+		marketDetails: createMarketDetails(),
+		nonDecisionThreshold: rep(100n),
+		resolution: 'none',
+		securityPoolAddress: zeroAddress,
+		sides: [
+			{ balance: rep(5n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+			{ balance: rep(8n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
+			{ balance: rep(2n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+		],
+		startBond: rep(3n),
+		startingTime: 120n,
+		status: 'active',
+		totalCost: rep(20n),
+		universeId: 1n,
+		...overrides,
+	}
+}
+
+describe('reportingDomain', () => {
+	test('getMinimumOutcomeChangeContribution returns the smallest strict lead', () => {
+		expect(getMinimumOutcomeChangeContribution(createReportingDetails(), 'yes')).toEqual({
+			amount: rep(4n),
+			reason: undefined,
+		})
+	})
+
+	test('getMinimumOutcomeChangeContribution returns zero when the selected side already resolves', () => {
+		const details = createReportingDetails({
+			resolution: 'yes',
+			sides: [
+				{ balance: rep(9n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+				{ balance: rep(8n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
+				{ balance: rep(2n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+			],
+		})
+
+		expect(getMinimumOutcomeChangeContribution(details, 'yes')).toEqual({
+			amount: 0n,
+			reason: undefined,
+		})
+	})
+
+	test('getMinimumOutcomeChangeContribution is unavailable when an opposing side is already over bond', () => {
+		const details = createReportingDetails({
+			sides: [
+				{ balance: rep(5n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+				{ balance: rep(20n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
+				{ balance: rep(2n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+			],
+		})
+
+		expect(getMinimumOutcomeChangeContribution(details, 'yes')).toEqual({
+			amount: undefined,
+			reason: 'Min preset unavailable because another side is already over the current bond.',
+		})
+	})
+
+	test('getMaxProfitContribution fills the remaining reward window', () => {
+		expect(getMaxProfitContribution(createReportingDetails(), 'yes')).toEqual({
+			amount: rep(7n),
+			reason: undefined,
+		})
+	})
+
+	test('getMaxProfitContribution is unavailable when the reward window is already filled', () => {
+		const details = createReportingDetails({
+			sides: [
+				{ balance: rep(13n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+				{ balance: rep(8n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
+				{ balance: rep(2n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+			],
+		})
+
+		expect(getMaxProfitContribution(details, 'yes')).toEqual({
+			amount: undefined,
+			reason: 'Max profit preset unavailable because the reward window is already filled on the selected side.',
+		})
+	})
+
+	test('calculateEstimatedEscalationReturn only rewards the eligible slice when a deposit crosses the cap', () => {
+		const details = createReportingDetails({
+			sides: [
+				{ balance: rep(14n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+				{ balance: rep(20n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
+				{ balance: rep(1n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+			],
+		})
+
+		expect(calculateEstimatedEscalationReturn(details, 'yes', rep(14n))).toEqual({
+			payout: rep(20n),
+			profit: rep(6n),
+		})
+	})
+
+	test('calculateEstimatedEscalationReturn matches the pro-rata reward schedule inside the window', () => {
+		const details = createReportingDetails({
+			sides: [
+				{ balance: 0n, deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+				{ balance: rep(20n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
+				{ balance: 0n, deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+			],
+		})
+
+		expect(calculateEstimatedEscalationReturn(details, 'yes', rep(14n))).toEqual({
+			payout: rep(26n),
+			profit: rep(12n),
+		})
+	})
+})

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -1,8 +1,10 @@
 /// <reference types="bun-types" />
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { within } from '@testing-library/dom'
+import { fireEvent, within } from '@testing-library/dom'
 import { h } from 'preact'
+import { useState } from 'preact/hooks'
+import { act } from 'preact/test-utils'
 import { zeroAddress } from 'viem'
 import { ReportingSection } from '../components/ReportingSection.js'
 import { formatDuration } from '../lib/formatters.js'
@@ -12,6 +14,10 @@ import type { ReportingSectionProps } from '../types/components.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
 import { expectTransactionButtonDisabled, expectTransactionButtonEnabled } from './testUtils/transactionActionButton.js'
+
+function rep(value: bigint) {
+	return value * 10n ** 18n
+}
 
 function createAccountState(overrides: Partial<AccountState> = {}): AccountState {
 	return {
@@ -43,25 +49,25 @@ function createMarketDetails(): MarketDetails {
 
 function createReportingDetails(): ActiveReportingDetails {
 	return {
-		bindingCapital: 10n,
+		bindingCapital: rep(10n),
 		completeSetCollateralAmount: 1n,
-		currentRequiredBond: 2n,
+		currentRequiredBond: rep(20n),
 		currentTime: 150n,
 		escalationEndTime: 300n,
 		escalationGameAddress: zeroAddress,
 		marketDetails: createMarketDetails(),
-		nonDecisionThreshold: 20n,
+		nonDecisionThreshold: rep(20n),
 		resolution: 'none',
 		securityPoolAddress: zeroAddress,
 		sides: [
-			{ balance: 5n, deposits: [], key: 'yes', label: 'Yes', userDeposits: [{ amount: 1n, cumulativeAmount: 1n, depositIndex: 0n, depositor: zeroAddress }] },
-			{ balance: 2n, deposits: [], key: 'no', label: 'No', userDeposits: [] },
-			{ balance: 1n, deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+			{ balance: rep(5n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [{ amount: rep(1n), cumulativeAmount: rep(1n), depositIndex: 0n, depositor: zeroAddress }] },
+			{ balance: rep(8n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
+			{ balance: rep(1n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
 		],
-		startBond: 1n,
-		status: 'active',
+		startBond: rep(3n),
 		startingTime: 120n,
-		totalCost: 0n,
+		status: 'active',
+		totalCost: rep(20n),
 		universeId: 1n,
 	}
 }
@@ -109,6 +115,23 @@ function createProps(overrides: Partial<ReportingSectionProps> = {}): ReportingS
 	}
 }
 
+function ReportingSectionHarness({ initialProps }: { initialProps?: Partial<ReportingSectionProps> }) {
+	const [reportingForm, setReportingForm] = useState<ReportingFormState>(createReportingForm())
+
+	return (
+		<ReportingSection
+			{...createProps(initialProps)}
+			reportingForm={reportingForm}
+			onReportingFormChange={changes => {
+				setReportingForm(currentForm => ({
+					...currentForm,
+					...changes,
+				}))
+			}}
+		/>
+	)
+}
+
 describe('ReportingSection', () => {
 	let restoreDomEnvironment: (() => void) | undefined
 	let cleanupRenderedComponent: (() => Promise<void>) | undefined
@@ -138,6 +161,8 @@ describe('ReportingSection', () => {
 		expect(documentQueries.queryByRole('heading', { name: 'Question' })).toBeNull()
 		expect(document.body.textContent?.includes('Selected side currently has')).toBe(true)
 		expect(document.body.textContent?.includes('Selected side has')).toBe(false)
+		expect(documentQueries.getByRole('button', { name: 'Min to change proposed outcome' })).not.toBeNull()
+		expect(documentQueries.getByRole('button', { name: 'Max profit' })).not.toBeNull()
 	})
 
 	test('renders the pre-reporting stage inside the shared warning surface', async () => {
@@ -174,7 +199,7 @@ describe('ReportingSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		expectTransactionButtonDisabled(document.body, 'Report / Contribute On Selected Side', 'Connect a wallet before reporting on a market.')
-		expect(document.body.querySelector('button[title=\"Connect a wallet before withdrawing escalation deposits.\"]')).toBeNull()
+		expect(document.body.querySelector('button[title="Connect a wallet before withdrawing escalation deposits."]')).toBeNull()
 		expect(document.body.querySelector('.disabled-reason')).toBeNull()
 	})
 
@@ -198,13 +223,12 @@ describe('ReportingSection', () => {
 	})
 
 	test('renders time left from escalation end time and current chain time', async () => {
-		const reportingDetails = createReportingDetails()
 		const renderedComponent = await renderIntoDocument(
 			h(
 				ReportingSection,
 				createProps({
 					reportingDetails: {
-						...reportingDetails,
+						...createReportingDetails(),
 						currentTime: 150n,
 						escalationEndTime: 300n,
 					},
@@ -253,7 +277,6 @@ describe('ReportingSection', () => {
 		expect(documentQueries.queryByText('Outcome Sides')).toBeNull()
 		expect(document.body.textContent?.includes('Reporting is open, but the escalation game has not started yet.')).toBe(true)
 		expect(document.body.textContent?.includes('The first report or contribution will deploy and initialize the escalation game for this pool.')).toBe(true)
-
 		expectTransactionButtonEnabled(document.body, 'Report / Contribute On Selected Side')
 		expect(document.body.textContent?.includes('Withdraw Escalation Deposits')).toBe(false)
 	})
@@ -274,5 +297,94 @@ describe('ReportingSection', () => {
 
 		expect(document.body.textContent?.includes('projects roughly')).toBe(true)
 		expect(document.body.textContent?.includes('Enter a valid report amount to preview profit.')).toBe(false)
+	})
+
+	test('autofills the report amount for the minimum outcome change preset', async () => {
+		const renderedComponent = await renderIntoDocument(<ReportingSectionHarness />)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await act(() => {
+			fireEvent.click(within(document.body).getByRole('button', { name: 'Min to change proposed outcome' }))
+		})
+
+		const amountInput = within(document.body).getByRole('textbox', { name: 'Report / Contribution Amount' })
+		expect((amountInput as HTMLInputElement).value).toBe('4')
+	})
+
+	test('autofills the report amount for the max profit preset and updates the preview', async () => {
+		const renderedComponent = await renderIntoDocument(<ReportingSectionHarness />)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const previewBefore = Array.from(document.body.querySelectorAll('p.detail'))
+			.map(element => element.textContent ?? '')
+			.find(text => text.includes('If Yes wins'))
+
+		await act(() => {
+			fireEvent.click(within(document.body).getByRole('button', { name: 'Max profit' }))
+		})
+
+		const amountInput = within(document.body).getByRole('textbox', { name: 'Report / Contribution Amount' })
+		const previewAfter = Array.from(document.body.querySelectorAll('p.detail'))
+			.map(element => element.textContent ?? '')
+			.find(text => text.includes('If Yes wins'))
+		expect((amountInput as HTMLInputElement).value).toBe('7')
+		expect(document.body.textContent?.includes('projects roughly')).toBe(true)
+		expect(previewBefore).not.toBe(previewAfter)
+	})
+
+	test('disables preset buttons when reporting details are missing', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					reportingDetails: undefined,
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		const minButton = documentQueries.getByRole('button', { name: 'Min to change proposed outcome' })
+		const maxButton = documentQueries.getByRole('button', { name: 'Max profit' })
+		expect((minButton as HTMLButtonElement).disabled).toBe(true)
+		expect((maxButton as HTMLButtonElement).disabled).toBe(true)
+		expect(document.body.textContent?.includes('Load reporting details before using presets.')).toBe(true)
+	})
+
+	test('disables preset buttons when reporting is locked', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					lockedReason: 'Reporting is locked.',
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect((documentQueries.getByRole('button', { name: 'Min to change proposed outcome' }) as HTMLButtonElement).disabled).toBe(true)
+		expect((documentQueries.getByRole('button', { name: 'Max profit' }) as HTMLButtonElement).disabled).toBe(true)
+	})
+
+	test('shows unavailable preset reasons for impossible states', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					reportingDetails: {
+						...createReportingDetails(),
+						sides: [
+							{ balance: rep(5n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+							{ balance: rep(20n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
+							{ balance: rep(1n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+						],
+					},
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(document.body.textContent?.includes('Min preset unavailable because another side is already over the current bond.')).toBe(true)
 	})
 })


### PR DESCRIPTION
## Summary
- Added reporting preset autofill actions for minimum outcome-change and max-profit contribution amounts.
- Updated reporting domain math to support side-aware return estimates and preset suggestions.
- Introduced workflow banners for reporting stage and action results in the reporting section.
- Expanded test coverage for preset behavior, estimate calculations, and new reporting UI states.

## Testing
- Not run (PR content only)