### PR TITLE
Remove current bond from escalation metrics

### DIFF
--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -139,9 +139,6 @@ export function ReportingSection({
 			{showFullReporting && activeReportingDetails !== undefined ? (
 				<SectionBlock title='Escalation Metrics'>
 					<div className='escalation-metrics'>
-						<MetricField label='Current Bond'>
-							<CurrencyValue value={activeReportingDetails.currentRequiredBond} suffix='REP' />
-						</MetricField>
 						<MetricField label='Binding Capital'>
 							<CurrencyValue value={activeReportingDetails.bindingCapital} suffix='REP' />
 						</MetricField>

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -197,6 +197,18 @@ describe('ReportingSection', () => {
 		expect(documentQueries.getByRole('heading', { name: 'Latest Reporting Action' })).not.toBeNull()
 	})
 
+	test('shows escalation metrics without the current bond field and keeps start bond copy', async () => {
+		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps()))
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.queryByText('Current Bond')).toBeNull()
+		expect(documentQueries.getByText('Binding Capital')).not.toBeNull()
+		expect(documentQueries.getByText('Threshold')).not.toBeNull()
+		expect(documentQueries.getByText('Time Left')).not.toBeNull()
+		expect(document.body.textContent?.includes('currently uses a start bond of')).toBe(true)
+	})
+
 	test('disables reporting buttons when deterministic prerequisites are missing', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(


### PR DESCRIPTION
## Summary
- Removed the `Current Bond` field from the Escalation Metrics section in `ReportingSection`
- Added coverage to ensure the metric no longer renders while the existing start bond copy remains visible
- Kept the remaining escalation metrics (`Binding Capital`, `Threshold`, `Time Left`) intact

## Testing
- Not run (PR content only)