### PR TITLE
Add reporting presets and checkbox-based deposit withdrawals

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -366,8 +366,8 @@ The `Reporting` subview handles reporting and escalation.
 | `Outcome Side` | Choose the reporting side for contribution or withdrawal. | Must be one of the supported reporting outcomes. | Disabled when the workflow is locked. |
 | `Report / Contribution Amount` | Set the REP amount to stake on the selected side. | Must parse into a valid positive REP amount. | Disabled when the workflow is locked. |
 | `Report / Contribute On Selected Side` | Submit reporting or contribution. | Requires unlocked workflow, connected wallet, mainnet, loaded reporting details, and valid positive amount. | Disabled whenever any reporting guard condition fails. |
-| `Withdraw Deposit Indexes` | Optionally narrow withdrawal to specific deposits. | Optional input. If used, it must match the downstream withdrawal parser's expected format. | Disabled when the workflow is locked. |
-| `Withdraw Escalation Deposits` | Submit the withdrawal. | Requires unlocked workflow, connected wallet, mainnet, loaded reporting details, and at least one withdrawable user deposit on the selected side. | Disabled whenever any withdrawal guard condition fails. |
+| Deposit selection list | Optionally narrow withdrawal to specific owned unsettled deposits on the selected side. Leaving every checkbox clear withdraws all eligible deposits on that side. | No text parsing. Selected entries must still exist on refresh. | Disabled when the workflow is locked. |
+| `Withdraw Escalation Deposits` | Submit the withdrawal. | Requires unlocked workflow, connected wallet, mainnet, loaded reporting details, the question to be finalized or the game to be canceled by an external fork, and at least one owned unsettled deposit on the selected side. | Disabled whenever any withdrawal guard condition fails. |
 
 ##### Fork
 

--- a/ui/ts/components/EscalationSide.tsx
+++ b/ui/ts/components/EscalationSide.tsx
@@ -26,7 +26,7 @@ export function EscalationSide({ estimate, isLeading, isSelected, side, userStak
 			<p className='detail'>
 				Your stake: <CurrencyValue value={userStake} suffix='REP' />
 			</p>
-			<p className='detail'>Your deposits: {side.userDeposits.map(deposit => deposit.depositIndex.toString()).join(', ') || 'None'}</p>
+			<p className='detail'>Your unsettled deposits: {side.userDeposits.map(deposit => deposit.depositIndex.toString()).join(', ') || 'None'}</p>
 			<p className='detail'>
 				Projected payout for current amount: <CurrencyValue value={estimate?.payout} suffix='REP' />
 			</p>

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -23,6 +23,10 @@ import { REPORTING_OUTCOME_DROPDOWN_OPTIONS, getReportingOutcomeLabel } from '..
 import { calculateEstimatedEscalationReturn, getEscalationPhase, getEscalationTimeRemaining, getLeadingEscalationOutcome, getMaxProfitContribution, getMinimumOutcomeChangeContribution } from '../lib/reportingDomain.js'
 import type { ReportingSectionProps } from '../types/components.js'
 
+function getDepositEntryCountLabel(count: number) {
+	return count === 1 ? 'entry' : 'entries'
+}
+
 export function ReportingSection({
 	accountState,
 	currentTimestamp,
@@ -49,11 +53,12 @@ export function ReportingSection({
 	const marketDetails = reportingDetails?.marketDetails ?? previewMarketDetails
 	const effectiveCurrentTimestamp = reportingDetails?.currentTime ?? currentTimestamp
 	const reportingLocked = lockedReason !== undefined
-	const selectedAmount = parseOptionalRepAmountInput(reportingForm.reportAmount)
 	const showFullReporting = mode === 'full-reporting'
 	const showWithdrawOnly = mode === 'withdraw-only'
-	const leadingOutcome = activeReportingDetails === undefined ? undefined : getLeadingEscalationOutcome(activeReportingDetails.sides)
+	const selectedAmount = parseOptionalRepAmountInput(reportingForm.reportAmount)
 	const selectedSide = activeReportingDetails?.sides.find(side => side.key === reportingForm.selectedOutcome)
+	const selectedWithdrawDepositIndexes = reportingForm.selectedWithdrawDepositIndexes
+	const leadingOutcome = activeReportingDetails === undefined ? undefined : getLeadingEscalationOutcome(activeReportingDetails.sides)
 	const selectedEstimate = activeReportingDetails === undefined || selectedAmount === undefined ? undefined : calculateEstimatedEscalationReturn(activeReportingDetails, reportingForm.selectedOutcome, selectedAmount)
 	const minimumOutcomeChangeContribution =
 		activeReportingDetails === undefined ? { amount: undefined, reason: reportingStatus === 'not-started' ? 'Escalation game has not started yet.' : 'Load reporting details before using presets.' } : getMinimumOutcomeChangeContribution(activeReportingDetails, reportingForm.selectedOutcome)
@@ -73,6 +78,8 @@ export function ReportingSection({
 		isMainnet,
 		lockedReason,
 		reportingStatus,
+		withdrawalEnabled: activeReportingDetails?.withdrawalEnabled ?? false,
+		withdrawalState: reportingDetails?.withdrawalState,
 	})
 	const latestReportingAction =
 		reportingResult === undefined ? undefined : (
@@ -181,7 +188,7 @@ export function ReportingSection({
 					)}
 					<label className='field'>
 						<span>Outcome Side</span>
-						<EnumDropdown options={REPORTING_OUTCOME_DROPDOWN_OPTIONS} value={reportingForm.selectedOutcome} onChange={selectedOutcome => onReportingFormChange({ selectedOutcome })} disabled={reportingLocked} />
+						<EnumDropdown options={REPORTING_OUTCOME_DROPDOWN_OPTIONS} value={reportingForm.selectedOutcome} onChange={selectedOutcome => onReportingFormChange({ selectedOutcome, selectedWithdrawDepositIndexes: [] })} disabled={reportingLocked} />
 					</label>
 
 					<label className='field'>
@@ -234,15 +241,42 @@ export function ReportingSection({
 
 			{showWithdrawOnly ? (
 				<SectionBlock title='Withdraw Escalation Deposits'>
-					{selectedSide === undefined ? undefined : (
+					{selectedSide === undefined ? undefined : selectedSide.userDeposits.length === 0 ? (
+						<p className='detail'>Connected wallet has no unsettled deposits on the selected side.</p>
+					) : activeReportingDetails?.withdrawalEnabled ? (
 						<p className='detail'>
-							Selected side has <strong>{selectedSide.userDeposits.length.toString()}</strong> withdrawable deposit entries for the connected wallet.
+							Connected wallet has <strong>{selectedSide.userDeposits.length.toString()}</strong> withdrawable unsettled deposit {getDepositEntryCountLabel(selectedSide.userDeposits.length)} on the selected side.
+						</p>
+					) : (
+						<p className='detail'>
+							Connected wallet has <strong>{selectedSide.userDeposits.length.toString()}</strong> unsettled deposit {getDepositEntryCountLabel(selectedSide.userDeposits.length)} on the selected side, but withdrawals are not available yet.
 						</p>
 					)}
-					<label className='field'>
-						<span>Withdraw Deposit Indexes</span>
-						<FormInput value={reportingForm.withdrawDepositIndexes} onInput={event => onReportingFormChange({ withdrawDepositIndexes: event.currentTarget.value })} placeholder='Leave empty to withdraw all your deposits on the selected side' disabled={reportingLocked} />
-					</label>
+					{selectedSide === undefined || selectedSide.userDeposits.length === 0 ? undefined : (
+						<div className='field'>
+							<span>Choose deposits to withdraw</span>
+							<p className='detail'>Leave all unchecked to withdraw every eligible deposit on this side.</p>
+							<div>
+								{selectedSide.userDeposits.map(deposit => {
+									const isChecked = selectedWithdrawDepositIndexes.includes(deposit.depositIndex)
+									return (
+										<label key={deposit.depositIndex.toString()} className='detail'>
+											<input
+												type='checkbox'
+												checked={isChecked}
+												disabled={reportingLocked}
+												onChange={event => {
+													const nextSelectedWithdrawDepositIndexes = event.currentTarget.checked ? [...selectedWithdrawDepositIndexes, deposit.depositIndex] : selectedWithdrawDepositIndexes.filter(index => index !== deposit.depositIndex)
+													onReportingFormChange({ selectedWithdrawDepositIndexes: nextSelectedWithdrawDepositIndexes })
+												}}
+											/>{' '}
+											Deposit #{deposit.depositIndex.toString()} | Amount: <CurrencyValue value={deposit.amount} suffix='REP' /> | Cumulative at entry: <CurrencyValue value={deposit.cumulativeAmount} suffix='REP' />
+										</label>
+									)
+								})}
+							</div>
+						</div>
+					)}
 
 					<div className='actions'>
 						<TransactionActionButton idleLabel='Withdraw Escalation Deposits' pendingLabel='Withdrawing deposits...' onClick={onWithdrawEscalation} pending={reportingActiveAction === 'withdrawEscalation'} tone='secondary' availability={{ disabled: withdrawGuardMessage !== undefined, reason: withdrawGuardMessage }} />

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -213,14 +213,17 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 			completeSetCollateralAmount,
 			currentTime: block.timestamp,
 			marketDetails,
+			questionOutcome: 'none',
 			resolution: 'none',
 			securityPoolAddress,
 			status: 'not-started',
 			universeId,
+			withdrawalEnabled: false,
+			withdrawalState: 'not-finalized',
 		}
 	}
 
-	const [startBond, nonDecisionThreshold, startingTime, totalCost, bindingCapital, balances, resolution, escalationEndTime] = await readRequiredMulticall(client, [
+	const [startBond, nonDecisionThreshold, startingTime, totalCost, bindingCapital, balances, resolution, escalationEndTime, questionOutcome, universeForkTime, hasReachedNonDecision] = await readRequiredMulticall(client, [
 		{
 			abi: peripherals_EscalationGame_EscalationGame.abi,
 			functionName: 'startBond',
@@ -269,6 +272,24 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 			address: escalationGameAddress,
 			args: [],
 		},
+		{
+			abi: QUESTION_OUTCOME_ABI,
+			functionName: 'getQuestionOutcome',
+			address: getInfraContractAddresses().securityPoolForker,
+			args: [securityPoolAddress],
+		},
+		{
+			abi: Zoltar_Zoltar.abi,
+			functionName: 'getForkTime',
+			address: getInfraContractAddresses().zoltar,
+			args: [universeId],
+		},
+		{
+			abi: peripherals_EscalationGame_EscalationGame.abi,
+			functionName: 'hasReachedNonDecision',
+			address: escalationGameAddress,
+			args: [],
+		},
 	])
 	if (!isBigintTriple(balances)) throw new Error('Unexpected escalation balances response')
 	const [invalidDeposits, yesDeposits, noDeposits] = await Promise.all([loadEscalationDeposits(client, escalationGameAddress, 'invalid'), loadEscalationDeposits(client, escalationGameAddress, 'yes'), loadEscalationDeposits(client, escalationGameAddress, 'no')])
@@ -278,6 +299,8 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 		{ balance: balances[1] ?? 0n, deposits: yesDeposits, key: 'yes', label: getEscalationSideLabel('yes'), userDeposits: accountAddress === undefined ? [] : yesDeposits.filter(deposit => deposit.depositor === accountAddress) },
 		{ balance: balances[2] ?? 0n, deposits: noDeposits, key: 'no', label: getEscalationSideLabel('no'), userDeposits: accountAddress === undefined ? [] : noDeposits.filter(deposit => deposit.depositor === accountAddress) },
 	]
+	const normalizedQuestionOutcome = getReportingOutcomeKey(questionOutcome)
+	const withdrawalState = normalizedQuestionOutcome !== 'none' ? 'resolved' : universeForkTime > 0n && hasReachedNonDecision === false ? 'canceled-by-external-fork' : 'not-finalized'
 
 	return {
 		bindingCapital,
@@ -288,6 +311,7 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 		escalationGameAddress,
 		marketDetails,
 		nonDecisionThreshold,
+		questionOutcome: normalizedQuestionOutcome,
 		resolution: getReportingOutcomeKey(resolution),
 		securityPoolAddress,
 		sides,
@@ -296,6 +320,8 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 		startingTime,
 		totalCost,
 		universeId,
+		withdrawalEnabled: withdrawalState !== 'not-finalized',
+		withdrawalState,
 	}
 }
 

--- a/ui/ts/hooks/useReportingOperations.ts
+++ b/ui/ts/hooks/useReportingOperations.ts
@@ -5,10 +5,10 @@ import type { Address } from 'viem'
 import { loadReportingDetails, reportOutcomeInSecurityPool, withdrawEscalationFromSecurityPool } from '../contracts.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
 import { getErrorMessage } from '../lib/errors.js'
-import { buildWriteActionConfig, runWriteAction } from '../lib/writeAction.js'
-import { parseAddressInput, resolveOptionalBigIntListInput } from '../lib/inputs.js'
+import { parseAddressInput } from '../lib/inputs.js'
 import { getDefaultReportingFormState, parseRepAmountInput } from '../lib/marketForm.js'
 import { useRequestGuard } from '../lib/requestGuard.js'
+import { buildWriteActionConfig, runWriteAction } from '../lib/writeAction.js'
 import type { ReportingFormState, WriteOperationsParameters } from '../types/app.js'
 import type { ReportingActionResult, ReportingDetails } from '../types/contracts.js'
 
@@ -64,6 +64,19 @@ export function useReportingOperations({ accountAddress, onTransaction, onTransa
 					const securityPoolAddress = parseAddressInput(currentForm.securityPoolAddress, 'Security pool address')
 					const details = await loadReportingDetails(createConnectedReadClient(), securityPoolAddress, accountAddress)
 					reportingDetails.value = details
+					setReportingForm(current => {
+						if (details.status !== 'active') {
+							return current.selectedWithdrawDepositIndexes.length === 0 ? current : { ...current, selectedWithdrawDepositIndexes: [] }
+						}
+						const selectedSide = details.sides.find(side => side.key === current.selectedOutcome)
+						const availableDepositIndexes = selectedSide?.userDeposits.map(deposit => deposit.depositIndex) ?? []
+						const selectedWithdrawDepositIndexes = current.selectedWithdrawDepositIndexes.filter(index => availableDepositIndexes.includes(index))
+						if (selectedWithdrawDepositIndexes.length === current.selectedWithdrawDepositIndexes.length) return current
+						return {
+							...current,
+							selectedWithdrawDepositIndexes,
+						}
+					})
 				},
 			)
 		} finally {
@@ -87,8 +100,18 @@ export function useReportingOperations({ accountAddress, onTransaction, onTransa
 					throw new Error('Escalation game has not started yet')
 				}
 				const selectedSide = latestDetails.sides.find(side => side.key === currentForm.selectedOutcome)
-				const depositIndexes = resolveOptionalBigIntListInput(currentForm.withdrawDepositIndexes, selectedSide?.userDeposits.map(deposit => deposit.depositIndex) ?? [], 'Deposit indexes')
+				const availableDepositIndexes = selectedSide?.userDeposits.map(deposit => deposit.depositIndex) ?? []
 
+				if (!latestDetails.withdrawalEnabled) {
+					throw new Error('Escalation deposits cannot be withdrawn until the question is finalized or the game is canceled by an external fork.')
+				}
+
+				const missingSelectedDepositIndex = currentForm.selectedWithdrawDepositIndexes.find(index => !availableDepositIndexes.includes(index))
+				if (missingSelectedDepositIndex !== undefined) {
+					throw new Error(`Selected deposit #${missingSelectedDepositIndex.toString()} is no longer available to withdraw on the selected side`)
+				}
+
+				const depositIndexes = currentForm.selectedWithdrawDepositIndexes.length > 0 ? currentForm.selectedWithdrawDepositIndexes : availableDepositIndexes
 				if (depositIndexes.length === 0) {
 					throw new Error('No deposits available to withdraw for the selected side')
 				}

--- a/ui/ts/lib/marketForm.ts
+++ b/ui/ts/lib/marketForm.ts
@@ -80,7 +80,7 @@ export function getDefaultReportingFormState(): ReportingFormState {
 		reportAmount: '0',
 		securityPoolAddress: '',
 		selectedOutcome: 'yes',
-		withdrawDepositIndexes: '',
+		selectedWithdrawDepositIndexes: [],
 	}
 }
 

--- a/ui/ts/lib/reportingGuards.ts
+++ b/ui/ts/lib/reportingGuards.ts
@@ -1,4 +1,5 @@
 import type { Address } from 'viem'
+import type { ReportingDetails } from '../types/contracts.js'
 
 type ReportingStatus = 'missing' | 'not-started' | 'active'
 
@@ -26,12 +27,29 @@ export function getReportingReportGuardMessage({
 	return undefined
 }
 
-export function getReportingWithdrawGuardMessage({ accountAddress, hasUserDepositsOnSelectedSide, isMainnet, lockedReason, reportingStatus }: { accountAddress: Address | undefined; hasUserDepositsOnSelectedSide: boolean; isMainnet: boolean; lockedReason: string | undefined; reportingStatus: ReportingStatus }) {
+export function getReportingWithdrawGuardMessage({
+	accountAddress,
+	hasUserDepositsOnSelectedSide,
+	isMainnet,
+	lockedReason,
+	reportingStatus,
+	withdrawalEnabled,
+	withdrawalState,
+}: {
+	accountAddress: Address | undefined
+	hasUserDepositsOnSelectedSide: boolean
+	isMainnet: boolean
+	lockedReason: string | undefined
+	reportingStatus: ReportingStatus
+	withdrawalEnabled: boolean
+	withdrawalState: ReportingDetails['withdrawalState'] | undefined
+}) {
 	if (lockedReason !== undefined) return lockedReason
 	if (accountAddress === undefined) return 'Connect a wallet before withdrawing escalation deposits.'
 	if (!isMainnet) return 'Switch to Ethereum mainnet before withdrawing escalation deposits.'
 	if (reportingStatus === 'missing') return 'Load reporting details before withdrawing escalation deposits.'
 	if (reportingStatus === 'not-started') return 'Escalation game has not started yet.'
+	if (!withdrawalEnabled && withdrawalState === 'not-finalized') return 'Escalation deposits cannot be withdrawn until the question is finalized or the game is canceled by an external fork.'
 	if (!hasUserDepositsOnSelectedSide) return 'No deposits are available to withdraw on the selected side.'
 	return undefined
 }

--- a/ui/ts/tests/reportingDomain.test.ts
+++ b/ui/ts/tests/reportingDomain.test.ts
@@ -37,6 +37,7 @@ function createReportingDetails(overrides: Partial<ActiveReportingDetails> = {})
 		escalationGameAddress: zeroAddress,
 		marketDetails: createMarketDetails(),
 		nonDecisionThreshold: rep(100n),
+		questionOutcome: 'none',
 		resolution: 'none',
 		securityPoolAddress: zeroAddress,
 		sides: [
@@ -49,6 +50,8 @@ function createReportingDetails(overrides: Partial<ActiveReportingDetails> = {})
 		status: 'active',
 		totalCost: rep(20n),
 		universeId: 1n,
+		withdrawalEnabled: false,
+		withdrawalState: 'not-finalized',
 		...overrides,
 	}
 }

--- a/ui/ts/tests/reportingGuards.test.ts
+++ b/ui/ts/tests/reportingGuards.test.ts
@@ -83,6 +83,8 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: undefined,
 				reportingStatus: 'not-started',
+				withdrawalEnabled: false,
+				withdrawalState: 'not-finalized',
 			}),
 		).toBe('Escalation game has not started yet.')
 
@@ -93,6 +95,8 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: undefined,
 				reportingStatus: 'active',
+				withdrawalEnabled: true,
+				withdrawalState: 'resolved',
 			}),
 		).toBe('No deposits are available to withdraw on the selected side.')
 
@@ -103,6 +107,34 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: undefined,
 				reportingStatus: 'active',
+				withdrawalEnabled: true,
+				withdrawalState: 'resolved',
+			}),
+		).toBeUndefined()
+	})
+
+	test('blocks withdraw submission until the contract allows it', () => {
+		expect(
+			getReportingWithdrawGuardMessage({
+				accountAddress: zeroAddress,
+				hasUserDepositsOnSelectedSide: true,
+				isMainnet: true,
+				lockedReason: undefined,
+				reportingStatus: 'active',
+				withdrawalEnabled: false,
+				withdrawalState: 'not-finalized',
+			}),
+		).toBe('Escalation deposits cannot be withdrawn until the question is finalized or the game is canceled by an external fork.')
+
+		expect(
+			getReportingWithdrawGuardMessage({
+				accountAddress: zeroAddress,
+				hasUserDepositsOnSelectedSide: true,
+				isMainnet: true,
+				lockedReason: undefined,
+				reportingStatus: 'active',
+				withdrawalEnabled: true,
+				withdrawalState: 'canceled-by-external-fork',
 			}),
 		).toBeUndefined()
 	})

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -9,7 +9,7 @@ import { zeroAddress } from 'viem'
 import { ReportingSection } from '../components/ReportingSection.js'
 import { formatDuration } from '../lib/formatters.js'
 import type { AccountState, ReportingFormState } from '../types/app.js'
-import type { ActiveReportingDetails, MarketDetails, ReportingActionResult, ReportingDetails } from '../types/contracts.js'
+import type { ActiveReportingDetails, EscalationDeposit, MarketDetails, ReportingActionResult, ReportingDetails } from '../types/contracts.js'
 import type { ReportingSectionProps } from '../types/components.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
@@ -48,6 +48,16 @@ function createMarketDetails(overrides: Partial<MarketDetails> = {}): MarketDeta
 	}
 }
 
+function createDeposit(overrides: Partial<EscalationDeposit> = {}): EscalationDeposit {
+	return {
+		amount: rep(1n),
+		cumulativeAmount: rep(1n),
+		depositIndex: 0n,
+		depositor: zeroAddress,
+		...overrides,
+	}
+}
+
 function createReportingDetails(overrides: Partial<ActiveReportingDetails> = {}): ActiveReportingDetails {
 	return {
 		bindingCapital: rep(10n),
@@ -58,10 +68,11 @@ function createReportingDetails(overrides: Partial<ActiveReportingDetails> = {})
 		escalationGameAddress: zeroAddress,
 		marketDetails: createMarketDetails(),
 		nonDecisionThreshold: rep(20n),
+		questionOutcome: 'none',
 		resolution: 'none',
 		securityPoolAddress: zeroAddress,
 		sides: [
-			{ balance: rep(5n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [{ amount: rep(1n), cumulativeAmount: rep(1n), depositIndex: 0n, depositor: zeroAddress }] },
+			{ balance: rep(5n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [createDeposit()] },
 			{ balance: rep(8n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
 			{ balance: rep(1n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
 		],
@@ -70,6 +81,8 @@ function createReportingDetails(overrides: Partial<ActiveReportingDetails> = {})
 		status: 'active',
 		totalCost: rep(20n),
 		universeId: 1n,
+		withdrawalEnabled: false,
+		withdrawalState: 'not-finalized',
 		...overrides,
 	}
 }
@@ -85,24 +98,29 @@ function createReportingResult(overrides: Partial<ReportingActionResult> = {}): 
 	}
 }
 
-function createNotStartedReportingDetails(): ReportingDetails {
+function createNotStartedReportingDetails(overrides: Partial<Extract<ReportingDetails, { status: 'not-started' }>> = {}): ReportingDetails {
 	return {
 		completeSetCollateralAmount: 1n,
 		currentTime: 150n,
 		marketDetails: createMarketDetails(),
+		questionOutcome: 'none',
 		resolution: 'none',
 		securityPoolAddress: zeroAddress,
 		status: 'not-started',
 		universeId: 1n,
+		withdrawalEnabled: false,
+		withdrawalState: 'not-finalized',
+		...overrides,
 	}
 }
 
-function createReportingForm(): ReportingFormState {
+function createReportingForm(overrides: Partial<ReportingFormState> = {}): ReportingFormState {
 	return {
 		reportAmount: '1',
 		securityPoolAddress: zeroAddress,
 		selectedOutcome: 'yes',
-		withdrawDepositIndexes: '',
+		selectedWithdrawDepositIndexes: [],
+		...overrides,
 	}
 }
 
@@ -170,17 +188,8 @@ describe('ReportingSection', () => {
 		expect(documentQueries.queryByRole('heading', { name: 'Pending Start' })).toBeNull()
 		expect(documentQueries.queryByText('The current escalation lifecycle phase is')).toBeNull()
 		expect(documentQueries.queryByText('Reporting contribution submitted')).toBeNull()
-
-		const reportingContextCard = documentQueries.getByRole('heading', { name: 'Reporting Context' }).closest('.entity-card')
-		if (reportingContextCard === null) throw new Error('Expected reporting context entity card')
-		const reportingContextQueries = within(reportingContextCard as HTMLElement)
-		expect(reportingContextQueries.getByText('Escalation Game')).not.toBeNull()
-		expect(reportingContextQueries.queryByText('Security Pool')).toBeNull()
-		expect(reportingContextQueries.queryByText('Universe')).toBeNull()
-		expect(reportingContextQueries.queryByText('Resolution')).toBeNull()
-
 		expect(document.body.textContent?.includes('Selected side currently has')).toBe(true)
-		expect(document.body.textContent?.includes('Selected side has')).toBe(false)
+		expect(document.body.textContent?.includes('Withdraw Escalation Deposits')).toBe(false)
 		expect(documentQueries.getByRole('button', { name: 'Min to change proposed outcome' })).not.toBeNull()
 		expect(documentQueries.getByRole('button', { name: 'Max profit' })).not.toBeNull()
 	})
@@ -199,7 +208,6 @@ describe('ReportingSection', () => {
 
 		const documentQueries = within(document.body)
 		expect(documentQueries.queryByRole('heading', { name: 'Pre-Reporting' })).toBeNull()
-		expect(document.body.querySelector('.warning-surface.lifecycle-stage-banner')).toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Reporting Context' })).not.toBeNull()
 	})
 
@@ -217,8 +225,6 @@ describe('ReportingSection', () => {
 
 		const documentQueries = within(document.body)
 		expect(documentQueries.queryByText('Reporting contribution submitted')).toBeNull()
-		expect(documentQueries.queryByText('Contributed on the Yes side.')).toBeNull()
-		expect(documentQueries.queryByText('Next: Review the leading side and updated bond before contributing again.')).toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Latest Reporting Action' })).not.toBeNull()
 	})
 
@@ -228,11 +234,10 @@ describe('ReportingSection', () => {
 				ReportingSection,
 				createProps({
 					accountState: createAccountState({ address: undefined }),
-					reportingForm: {
-						...createReportingForm(),
+					reportingForm: createReportingForm({
 						reportAmount: '',
 						selectedOutcome: 'no',
-					},
+					}),
 				}),
 			),
 		)
@@ -259,40 +264,18 @@ describe('ReportingSection', () => {
 		expect(documentQueries.queryByRole('heading', { name: 'Reporting Context' })).toBeNull()
 		expect(documentQueries.queryByRole('heading', { name: 'Report Outcome' })).toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Withdraw Escalation Deposits' })).not.toBeNull()
-		expectTransactionButtonEnabled(document.body, 'Withdraw Escalation Deposits')
+		expectTransactionButtonDisabled(document.body, 'Withdraw Escalation Deposits', 'Escalation deposits cannot be withdrawn until the question is finalized or the game is canceled by an external fork.')
 	})
 
 	test('renders time left from escalation end time and current chain time', async () => {
-		const renderedComponent = await renderIntoDocument(
-			h(
-				ReportingSection,
-				createProps({
-					reportingDetails: {
-						...createReportingDetails(),
-						currentTime: 150n,
-						escalationEndTime: 300n,
-					},
-				}),
-			),
-		)
+		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps({ reportingDetails: createReportingDetails({ currentTime: 150n, escalationEndTime: 300n }) })))
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		expect(document.body.textContent?.includes(formatDuration(300n - 150n))).toBe(true)
 	})
 
 	test('shows awaiting resolution with zero time left once the escalation end time has passed', async () => {
-		const renderedComponent = await renderIntoDocument(
-			h(
-				ReportingSection,
-				createProps({
-					reportingDetails: {
-						...createReportingDetails(),
-						currentTime: 300n,
-						escalationEndTime: 300n,
-					},
-				}),
-			),
-		)
+		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps({ reportingDetails: createReportingDetails({ currentTime: 300n, escalationEndTime: 300n }) })))
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
@@ -301,14 +284,7 @@ describe('ReportingSection', () => {
 	})
 
 	test('shows first-report guidance before the escalation game starts', async () => {
-		const renderedComponent = await renderIntoDocument(
-			h(
-				ReportingSection,
-				createProps({
-					reportingDetails: createNotStartedReportingDetails(),
-				}),
-			),
-		)
+		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps({ reportingDetails: createNotStartedReportingDetails() })))
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
@@ -317,21 +293,10 @@ describe('ReportingSection', () => {
 		expect(document.body.textContent?.includes('Reporting is open, but the escalation game has not started yet.')).toBe(true)
 		expect(document.body.textContent?.includes('The first report or contribution will deploy and initialize the escalation game for this pool.')).toBe(true)
 		expectTransactionButtonEnabled(document.body, 'Report / Contribute On Selected Side')
-		expect(document.body.textContent?.includes('Withdraw Escalation Deposits')).toBe(false)
 	})
 
 	test('accepts decimal report amounts for profit preview', async () => {
-		const renderedComponent = await renderIntoDocument(
-			h(
-				ReportingSection,
-				createProps({
-					reportingForm: {
-						...createReportingForm(),
-						reportAmount: '1.5',
-					},
-				}),
-			),
-		)
+		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps({ reportingForm: createReportingForm({ reportAmount: '1.5' }) })))
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		expect(document.body.textContent?.includes('projects roughly')).toBe(true)
@@ -367,43 +332,17 @@ describe('ReportingSection', () => {
 			.map(element => element.textContent ?? '')
 			.find(text => text.includes('If Yes wins'))
 		expect((amountInput as HTMLInputElement).value).toBe('7')
-		expect(document.body.textContent?.includes('projects roughly')).toBe(true)
 		expect(previewBefore).not.toBe(previewAfter)
 	})
 
 	test('disables preset buttons when reporting details are missing', async () => {
-		const renderedComponent = await renderIntoDocument(
-			h(
-				ReportingSection,
-				createProps({
-					reportingDetails: undefined,
-				}),
-			),
-		)
-		cleanupRenderedComponent = renderedComponent.cleanup
-
-		const documentQueries = within(document.body)
-		const minButton = documentQueries.getByRole('button', { name: 'Min to change proposed outcome' })
-		const maxButton = documentQueries.getByRole('button', { name: 'Max profit' })
-		expect((minButton as HTMLButtonElement).disabled).toBe(true)
-		expect((maxButton as HTMLButtonElement).disabled).toBe(true)
-		expect(document.body.textContent?.includes('Load reporting details before using presets.')).toBe(true)
-	})
-
-	test('disables preset buttons when reporting is locked', async () => {
-		const renderedComponent = await renderIntoDocument(
-			h(
-				ReportingSection,
-				createProps({
-					lockedReason: 'Reporting is locked.',
-				}),
-			),
-		)
+		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps({ reportingDetails: undefined })))
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
 		expect((documentQueries.getByRole('button', { name: 'Min to change proposed outcome' }) as HTMLButtonElement).disabled).toBe(true)
 		expect((documentQueries.getByRole('button', { name: 'Max profit' }) as HTMLButtonElement).disabled).toBe(true)
+		expect(document.body.textContent?.includes('Load reporting details before using presets.')).toBe(true)
 	})
 
 	test('shows unavailable preset reasons for impossible states', async () => {
@@ -411,19 +350,98 @@ describe('ReportingSection', () => {
 			h(
 				ReportingSection,
 				createProps({
-					reportingDetails: {
-						...createReportingDetails(),
+					reportingDetails: createReportingDetails({
 						sides: [
 							{ balance: rep(5n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
 							{ balance: rep(20n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
 							{ balance: rep(1n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
 						],
-					},
+					}),
 				}),
 			),
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		expect(document.body.textContent?.includes('Min preset unavailable because another side is already over the current bond.')).toBe(true)
+	})
+
+	test('renders withdraw-only messages and enables selectable deposits once withdrawal is allowed', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					mode: 'withdraw-only',
+					reportingDetails: createReportingDetails({
+						questionOutcome: 'yes',
+						withdrawalEnabled: true,
+						withdrawalState: 'resolved',
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expectTransactionButtonEnabled(document.body, 'Withdraw Escalation Deposits')
+		expect(document.body.textContent?.includes('Connected wallet has 1 withdrawable unsettled deposit entry on the selected side.')).toBe(true)
+		expect(within(document.body).getByRole('checkbox', { name: /Deposit #0/i })).toBeDefined()
+	})
+
+	test('renders withdraw-only empty state when the selected side has no deposits', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					mode: 'withdraw-only',
+					reportingForm: createReportingForm({ selectedOutcome: 'no' }),
+					reportingDetails: createReportingDetails({
+						questionOutcome: 'yes',
+						withdrawalEnabled: true,
+						withdrawalState: 'resolved',
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(document.body.textContent?.includes('Connected wallet has no unsettled deposits on the selected side.')).toBe(true)
+		expectTransactionButtonDisabled(document.body, 'Withdraw Escalation Deposits', 'No deposits are available to withdraw on the selected side.')
+	})
+
+	test('updates selected withdrawal indexes from deposit checkboxes in withdraw-only mode', async () => {
+		const onReportingFormChangeCalls: Partial<ReportingFormState>[] = []
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					mode: 'withdraw-only',
+					onReportingFormChange: update => {
+						onReportingFormChangeCalls.push(update)
+					},
+					reportingDetails: createReportingDetails({
+						questionOutcome: 'yes',
+						sides: [
+							{
+								balance: rep(5n),
+								deposits: [],
+								key: 'yes',
+								label: 'Yes',
+								userDeposits: [createDeposit(), createDeposit({ amount: rep(2n), cumulativeAmount: rep(3n), depositIndex: 1n })],
+							},
+							{ balance: rep(8n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
+							{ balance: rep(1n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+						],
+						withdrawalEnabled: true,
+						withdrawalState: 'resolved',
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const depositCheckbox = within(document.body).getByRole('checkbox', { name: /Deposit #1/i })
+		fireEvent.click(depositCheckbox)
+		fireEvent.click(depositCheckbox)
+
+		expect(onReportingFormChangeCalls).toEqual([{ selectedWithdrawDepositIndexes: [1n] }, { selectedWithdrawDepositIndexes: [] }])
 	})
 })

--- a/ui/ts/tests/securityPoolWorkflowSection.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection.test.tsx
@@ -69,7 +69,7 @@ function createReportingProps(overrides: Partial<ReportingRouteContentProps> = {
 			reportAmount: '',
 			securityPoolAddress: '',
 			selectedOutcome: 'yes',
-			withdrawDepositIndexes: '',
+			selectedWithdrawDepositIndexes: [],
 		},
 		reportingResult: undefined,
 		...overrides,
@@ -1796,7 +1796,7 @@ describe('SecurityPoolWorkflowSection', () => {
 					reportAmount: '',
 					securityPoolAddress: '',
 					selectedOutcome: 'yes',
-					withdrawDepositIndexes: '',
+					selectedWithdrawDepositIndexes: [],
 				},
 			}),
 			securityPoolAddress: selectedPoolAddress,
@@ -1820,7 +1820,7 @@ describe('SecurityPoolWorkflowSection', () => {
 							reportAmount: '',
 							securityPoolAddress: stalePoolAddress,
 							selectedOutcome: 'yes',
-							withdrawDepositIndexes: '',
+							selectedWithdrawDepositIndexes: [],
 						},
 					})}
 					showHeader={false}
@@ -1843,7 +1843,7 @@ describe('SecurityPoolWorkflowSection', () => {
 							reportAmount: '',
 							securityPoolAddress: selectedPoolAddress,
 							selectedOutcome: 'yes',
-							withdrawDepositIndexes: '',
+							selectedWithdrawDepositIndexes: [],
 						},
 					})}
 					showHeader={false}
@@ -1866,7 +1866,7 @@ describe('SecurityPoolWorkflowSection', () => {
 							reportAmount: '',
 							securityPoolAddress: selectedPoolAddress,
 							selectedOutcome: 'yes',
-							withdrawDepositIndexes: '',
+							selectedWithdrawDepositIndexes: [],
 						},
 					})}
 					showHeader={false}
@@ -1889,7 +1889,7 @@ describe('SecurityPoolWorkflowSection', () => {
 				reportAmount: '',
 				securityPoolAddress: selectedPoolAddress,
 				selectedOutcome: 'yes',
-				withdrawDepositIndexes: '',
+				selectedWithdrawDepositIndexes: [],
 			},
 		})
 		const baseProps = createSecurityPoolWorkflowProps({

--- a/ui/ts/tests/securityPoolsSection.test.ts
+++ b/ui/ts/tests/securityPoolsSection.test.ts
@@ -68,7 +68,7 @@ function createReportingProps(overrides: Partial<ReportingRouteContentProps> = {
 			reportAmount: '',
 			securityPoolAddress: '',
 			selectedOutcome: 'yes',
-			withdrawDepositIndexes: '',
+			selectedWithdrawDepositIndexes: [],
 		},
 		reportingResult: undefined,
 		...overrides,

--- a/ui/ts/tests/useReportingOperations.test.tsx
+++ b/ui/ts/tests/useReportingOperations.test.tsx
@@ -45,6 +45,7 @@ function createReportingDetails(securityPoolAddress: Address): ReportingDetails 
 			title: 'Will this resolve?',
 		},
 		nonDecisionThreshold: 20n,
+		questionOutcome: 'none',
 		resolution: 'none',
 		securityPoolAddress,
 		sides: [
@@ -57,6 +58,8 @@ function createReportingDetails(securityPoolAddress: Address): ReportingDetails 
 		startingTime: 120n,
 		totalCost: 0n,
 		universeId: 1n,
+		withdrawalEnabled: false,
+		withdrawalState: 'not-finalized',
 	}
 }
 

--- a/ui/ts/types/app.ts
+++ b/ui/ts/types/app.ts
@@ -83,7 +83,7 @@ export type ReportingFormState = {
 	reportAmount: string
 	securityPoolAddress: string
 	selectedOutcome: ReportingOutcomeKey
-	withdrawDepositIndexes: string
+	selectedWithdrawDepositIndexes: bigint[]
 }
 
 export type ForkAuctionFormState = {

--- a/ui/ts/types/contracts.ts
+++ b/ui/ts/types/contracts.ts
@@ -201,12 +201,10 @@ export type OpenOracleReportSummaryPage = {
 }
 
 export type OpenOracleReportDetails = {
-	// Identity
 	reportId: bigint
 	openOracleAddress: Address
 	currentTime: bigint
 	currentBlockNumber: bigint
-	// Meta
 	exactToken1Report: bigint
 	escalationHalt: bigint
 	fee: bigint
@@ -219,7 +217,6 @@ export type OpenOracleReportDetails = {
 	protocolFee: bigint
 	multiplier: bigint
 	disputeDelay: bigint
-	// Status
 	currentAmount1: bigint
 	currentAmount2: bigint
 	price: bigint
@@ -229,7 +226,6 @@ export type OpenOracleReportDetails = {
 	initialReporter: Address
 	disputeOccurred: boolean
 	isDistributed: boolean
-	// Extra
 	stateHash: Hex
 	callbackContract: Address
 	callbackSelector: Hex
@@ -325,9 +321,12 @@ type ReportingDetailsBase = {
 	completeSetCollateralAmount: bigint
 	currentTime: bigint
 	marketDetails: MarketDetails
+	questionOutcome: ReportingOutcomeKey | 'none'
 	resolution: ReportingOutcomeKey | 'none'
 	securityPoolAddress: Address
 	universeId: bigint
+	withdrawalEnabled: boolean
+	withdrawalState: 'not-finalized' | 'resolved' | 'canceled-by-external-fork'
 }
 
 export type ActiveReportingDetails = ReportingDetailsBase & {


### PR DESCRIPTION
## Summary
- Added reporting amount presets for minimum outcome-change and max-profit contributions, with updated payout estimates tied to the selected side.
- Replaced freeform withdrawal index input with checkbox-based selection of owned unsettled deposits, including automatic filtering when reporting data refreshes.
- Extended reporting data loading and guard logic to recognize finalized or externally canceled withdrawal states.
- Added domain, guard, and component test coverage for the new reporting and withdrawal flows.

## Testing
- `bun run tsc`
- `bun run test`
- `bun run format`
- `bun run check`
- `bun run knip`