### PR TITLE
Add reporting presets and richer escalation side charts

### DIFF
--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -2977,31 +2977,207 @@ button:focus-visible {
 
 .escalation-sides {
 	display: grid;
-	grid-template-columns: repeat(3, minmax(0, 1fr));
-	gap: 1rem;
+	gap: 0;
+	border: 1px solid var(--border-default);
+	border-radius: var(--radius-control);
+	background: linear-gradient(180deg, rgba(10, 20, 36, 0.48) 0%, rgba(8, 16, 28, 0.82) 100%);
+	box-shadow: var(--glow-inset-subtle);
+	overflow: hidden;
+}
+
+.escalation-sides-shell {
+	margin-top: 1rem;
+}
+
+.escalation-sides-legend {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.75rem 1.25rem;
+	padding: 0.9rem 1rem;
+	border: 1px solid var(--border-default);
+	border-radius: var(--radius-control);
+	background: rgba(9, 18, 31, 0.42);
+}
+
+.escalation-sides-legend-item {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.55rem;
+	min-width: 0;
+}
+
+.escalation-sides-legend-item-binding {
+	margin-left: auto;
+}
+
+.escalation-sides-legend-item .currency-value-wrap {
+	min-width: 0;
+}
+
+.escalation-sides-legend-swatch {
+	display: inline-flex;
+	width: 1.6rem;
+	height: 0.5rem;
+	border-radius: 999px;
+	flex-shrink: 0;
+}
+
+.escalation-sides-legend-swatch-total {
+	background: linear-gradient(90deg, color-mix(in srgb, var(--accent) 68%, white 32%), color-mix(in srgb, var(--accent-strong) 60%, white 40%));
+}
+
+.escalation-sides-legend-swatch-user {
+	background: linear-gradient(90deg, color-mix(in srgb, var(--success) 78%, white 22%), color-mix(in srgb, var(--accent) 52%, white 48%));
+}
+
+.escalation-sides-legend-marker {
+	position: relative;
+	display: inline-flex;
+	width: 0.65rem;
+	height: 1rem;
+	flex-shrink: 0;
+}
+
+.escalation-sides-legend-marker::before {
+	content: "";
+	position: absolute;
+	inset: 0.05rem 0.25rem;
+	border-radius: 999px;
+	background: color-mix(in srgb, var(--warning) 70%, white 30%);
 }
 
 .escalation-side {
 	min-width: 0;
-	padding: 0.5rem 0 0.25rem;
+	padding: 1rem;
 	border-top: 1px solid var(--border-default);
 	background: transparent;
 	border-radius: 0;
 }
 
+.escalation-side:first-child {
+	border-top: 0;
+}
+
 .escalation-side.selected {
-	border-top-color: var(--interactive-border-hover);
+	background: linear-gradient(90deg, rgba(56, 213, 255, 0.08) 0%, rgba(56, 213, 255, 0.03) 100%);
+	box-shadow: inset 0 0 0 1px rgba(56, 213, 255, 0.08);
 }
 
 .escalation-side.leading {
-	background: transparent;
+	background: linear-gradient(90deg, rgba(66, 232, 194, 0.09) 0%, rgba(66, 232, 194, 0.03) 100%);
 }
 
-.escalation-side-header {
-	display: flex;
-	justify-content: space-between;
+.escalation-side.leading.selected {
+	background: linear-gradient(90deg, rgba(56, 213, 255, 0.1) 0%, rgba(66, 232, 194, 0.06) 100%);
+}
+
+.escalation-side-row {
+	display: grid;
+	grid-template-columns: minmax(0, 12rem) minmax(0, 1fr) minmax(0, 15rem);
 	align-items: center;
-	gap: 0.75rem;
+	gap: 1rem;
+}
+
+.escalation-side-copy {
+	min-width: 0;
+}
+
+.escalation-side-title-row {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.5rem;
+}
+
+.escalation-side-badges {
+	display: inline-flex;
+	flex-wrap: wrap;
+	gap: 0.45rem;
+}
+
+.escalation-side-selected-badge {
+	border-color: var(--interactive-border-hover);
+	background: var(--interactive-bg);
+	color: var(--text);
+}
+
+.escalation-side-chart {
+	min-width: 0;
+}
+
+.escalation-side-track {
+	position: relative;
+	height: 1.65rem;
+	border: 1px solid var(--border-default);
+	border-radius: 999px;
+	background: linear-gradient(90deg, rgba(56, 213, 255, 0.03), rgba(124, 108, 255, 0.03)), var(--surface-inset);
+	overflow: hidden;
+}
+
+.escalation-side-total-bar,
+.escalation-side-user-bar,
+.escalation-side-binding-marker {
+	position: absolute;
+}
+
+.escalation-side-total-bar {
+	inset: 0 auto 0 0;
+	width: var(--side-ratio, 0%);
+	border-radius: inherit;
+	background: linear-gradient(90deg, color-mix(in srgb, var(--accent) 75%, white 25%), color-mix(in srgb, var(--accent-strong) 58%, white 42%));
+}
+
+.escalation-side-user-bar {
+	top: 50%;
+	left: 0.22rem;
+	height: 0.42rem;
+	width: min(var(--user-ratio, 0%), calc(100% - 0.44rem));
+	transform: translateY(-50%);
+	border-radius: 999px;
+	background: linear-gradient(90deg, color-mix(in srgb, var(--success) 82%, white 18%), color-mix(in srgb, var(--accent) 52%, white 48%));
+	box-shadow: 0 0 0 1px rgba(7, 17, 31, 0.32);
+	z-index: 1;
+}
+
+.escalation-side-binding-marker {
+	top: 0.16rem;
+	bottom: 0.16rem;
+	left: min(var(--binding-ratio, 0%), calc(100% - 0.22rem));
+	width: 0.22rem;
+	transform: translateX(-50%);
+	border-radius: 999px;
+	background: color-mix(in srgb, var(--warning) 72%, white 28%);
+	box-shadow: 0 0 0 1px rgba(7, 17, 31, 0.45);
+	z-index: 2;
+}
+
+.escalation-side-values {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 0.9rem;
+	min-width: 0;
+}
+
+.escalation-side-value {
+	display: grid;
+	gap: 0.2rem;
+	min-width: 0;
+}
+
+.escalation-side-value .currency-value-wrap,
+.escalation-side-value .currency-value {
+	min-width: 0;
+}
+
+.escalation-side-value .currency-value {
+	color: var(--text);
+	font-size: var(--font-value);
+	line-height: 1.35;
+}
+
+.escalation-side-value .currency-value.unavailable {
+	color: var(--muted);
 }
 
 @media (max-width: 800px) {
@@ -3011,7 +3187,6 @@ button:focus-visible {
 
 	.grid,
 	.escalation-metrics,
-	.escalation-sides,
 	.categorical-outcome-row,
 	.fork-summary-grid,
 	.field-row,
@@ -3039,6 +3214,24 @@ button:focus-visible {
 	.overview-inline-metrics > div {
 		flex: 1 1 100%;
 		min-width: 0;
+	}
+
+	.escalation-sides-legend {
+		align-items: flex-start;
+	}
+
+	.escalation-sides-legend-item-binding {
+		margin-left: 0;
+	}
+
+	.escalation-side-row {
+		grid-template-columns: 1fr;
+		gap: 0.85rem;
+	}
+
+	.escalation-side-values {
+		grid-template-columns: 1fr;
+		gap: 0.7rem;
 	}
 
 	.tab-nav {

--- a/ui/dist/css/index.css
+++ b/ui/dist/css/index.css
@@ -2977,31 +2977,207 @@ button:focus-visible {
 
 .escalation-sides {
 	display: grid;
-	grid-template-columns: repeat(3, minmax(0, 1fr));
-	gap: 1rem;
+	gap: 0;
+	border: 1px solid var(--border-default);
+	border-radius: var(--radius-control);
+	background: linear-gradient(180deg, rgba(10, 20, 36, 0.48) 0%, rgba(8, 16, 28, 0.82) 100%);
+	box-shadow: var(--glow-inset-subtle);
+	overflow: hidden;
+}
+
+.escalation-sides-shell {
+	margin-top: 1rem;
+}
+
+.escalation-sides-legend {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.75rem 1.25rem;
+	padding: 0.9rem 1rem;
+	border: 1px solid var(--border-default);
+	border-radius: var(--radius-control);
+	background: rgba(9, 18, 31, 0.42);
+}
+
+.escalation-sides-legend-item {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.55rem;
+	min-width: 0;
+}
+
+.escalation-sides-legend-item-binding {
+	margin-left: auto;
+}
+
+.escalation-sides-legend-item .currency-value-wrap {
+	min-width: 0;
+}
+
+.escalation-sides-legend-swatch {
+	display: inline-flex;
+	width: 1.6rem;
+	height: 0.5rem;
+	border-radius: 999px;
+	flex-shrink: 0;
+}
+
+.escalation-sides-legend-swatch-total {
+	background: linear-gradient(90deg, color-mix(in srgb, var(--accent) 68%, white 32%), color-mix(in srgb, var(--accent-strong) 60%, white 40%));
+}
+
+.escalation-sides-legend-swatch-user {
+	background: linear-gradient(90deg, color-mix(in srgb, var(--success) 78%, white 22%), color-mix(in srgb, var(--accent) 52%, white 48%));
+}
+
+.escalation-sides-legend-marker {
+	position: relative;
+	display: inline-flex;
+	width: 0.65rem;
+	height: 1rem;
+	flex-shrink: 0;
+}
+
+.escalation-sides-legend-marker::before {
+	content: "";
+	position: absolute;
+	inset: 0.05rem 0.25rem;
+	border-radius: 999px;
+	background: color-mix(in srgb, var(--warning) 70%, white 30%);
 }
 
 .escalation-side {
 	min-width: 0;
-	padding: 0.5rem 0 0.25rem;
+	padding: 1rem;
 	border-top: 1px solid var(--border-default);
 	background: transparent;
 	border-radius: 0;
 }
 
+.escalation-side:first-child {
+	border-top: 0;
+}
+
 .escalation-side.selected {
-	border-top-color: var(--interactive-border-hover);
+	background: linear-gradient(90deg, rgba(56, 213, 255, 0.08) 0%, rgba(56, 213, 255, 0.03) 100%);
+	box-shadow: inset 0 0 0 1px rgba(56, 213, 255, 0.08);
 }
 
 .escalation-side.leading {
-	background: transparent;
+	background: linear-gradient(90deg, rgba(66, 232, 194, 0.09) 0%, rgba(66, 232, 194, 0.03) 100%);
 }
 
-.escalation-side-header {
-	display: flex;
-	justify-content: space-between;
+.escalation-side.leading.selected {
+	background: linear-gradient(90deg, rgba(56, 213, 255, 0.1) 0%, rgba(66, 232, 194, 0.06) 100%);
+}
+
+.escalation-side-row {
+	display: grid;
+	grid-template-columns: minmax(0, 12rem) minmax(0, 1fr) minmax(0, 15rem);
 	align-items: center;
-	gap: 0.75rem;
+	gap: 1rem;
+}
+
+.escalation-side-copy {
+	min-width: 0;
+}
+
+.escalation-side-title-row {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.5rem;
+}
+
+.escalation-side-badges {
+	display: inline-flex;
+	flex-wrap: wrap;
+	gap: 0.45rem;
+}
+
+.escalation-side-selected-badge {
+	border-color: var(--interactive-border-hover);
+	background: var(--interactive-bg);
+	color: var(--text);
+}
+
+.escalation-side-chart {
+	min-width: 0;
+}
+
+.escalation-side-track {
+	position: relative;
+	height: 1.65rem;
+	border: 1px solid var(--border-default);
+	border-radius: 999px;
+	background: linear-gradient(90deg, rgba(56, 213, 255, 0.03), rgba(124, 108, 255, 0.03)), var(--surface-inset);
+	overflow: hidden;
+}
+
+.escalation-side-total-bar,
+.escalation-side-user-bar,
+.escalation-side-binding-marker {
+	position: absolute;
+}
+
+.escalation-side-total-bar {
+	inset: 0 auto 0 0;
+	width: var(--side-ratio, 0%);
+	border-radius: inherit;
+	background: linear-gradient(90deg, color-mix(in srgb, var(--accent) 75%, white 25%), color-mix(in srgb, var(--accent-strong) 58%, white 42%));
+}
+
+.escalation-side-user-bar {
+	top: 50%;
+	left: 0.22rem;
+	height: 0.42rem;
+	width: min(var(--user-ratio, 0%), calc(100% - 0.44rem));
+	transform: translateY(-50%);
+	border-radius: 999px;
+	background: linear-gradient(90deg, color-mix(in srgb, var(--success) 82%, white 18%), color-mix(in srgb, var(--accent) 52%, white 48%));
+	box-shadow: 0 0 0 1px rgba(7, 17, 31, 0.32);
+	z-index: 1;
+}
+
+.escalation-side-binding-marker {
+	top: 0.16rem;
+	bottom: 0.16rem;
+	left: min(var(--binding-ratio, 0%), calc(100% - 0.22rem));
+	width: 0.22rem;
+	transform: translateX(-50%);
+	border-radius: 999px;
+	background: color-mix(in srgb, var(--warning) 72%, white 28%);
+	box-shadow: 0 0 0 1px rgba(7, 17, 31, 0.45);
+	z-index: 2;
+}
+
+.escalation-side-values {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 0.9rem;
+	min-width: 0;
+}
+
+.escalation-side-value {
+	display: grid;
+	gap: 0.2rem;
+	min-width: 0;
+}
+
+.escalation-side-value .currency-value-wrap,
+.escalation-side-value .currency-value {
+	min-width: 0;
+}
+
+.escalation-side-value .currency-value {
+	color: var(--text);
+	font-size: var(--font-value);
+	line-height: 1.35;
+}
+
+.escalation-side-value .currency-value.unavailable {
+	color: var(--muted);
 }
 
 @media (max-width: 800px) {
@@ -3011,7 +3187,6 @@ button:focus-visible {
 
 	.grid,
 	.escalation-metrics,
-	.escalation-sides,
 	.categorical-outcome-row,
 	.fork-summary-grid,
 	.field-row,
@@ -3039,6 +3214,24 @@ button:focus-visible {
 	.overview-inline-metrics > div {
 		flex: 1 1 100%;
 		min-width: 0;
+	}
+
+	.escalation-sides-legend {
+		align-items: flex-start;
+	}
+
+	.escalation-sides-legend-item-binding {
+		margin-left: 0;
+	}
+
+	.escalation-side-row {
+		grid-template-columns: 1fr;
+		gap: 0.85rem;
+	}
+
+	.escalation-side-values {
+		grid-template-columns: 1fr;
+		gap: 0.7rem;
 	}
 
 	.tab-nav {

--- a/ui/ts/components/EscalationSide.tsx
+++ b/ui/ts/components/EscalationSide.tsx
@@ -2,37 +2,62 @@ import { CurrencyValue } from './CurrencyValue.js'
 import type { EscalationSide } from '../types/contracts.js'
 
 type EscalationSideProps = {
-	estimate:
-		| {
-				profit: bigint
-				payout: bigint
-		  }
-		| undefined
+	bindingCapital: bigint
+	chartScaleMax: bigint
 	isLeading: boolean
 	isSelected: boolean
 	side: EscalationSide
 	userStake: bigint
 }
 
-export function EscalationSide({ estimate, isLeading, isSelected, side, userStake }: EscalationSideProps) {
+function getChartRatio(value: bigint, maxValue: bigint) {
+	if (value <= 0n || maxValue <= 0n) return '0%'
+
+	const basisPoints = (value * 10000n) / maxValue
+	const wholePercent = basisPoints / 100n
+	const fractionalPercent = (basisPoints % 100n).toString().padStart(2, '0')
+
+	return `${wholePercent.toString()}.${fractionalPercent}%`
+}
+
+export function EscalationSide({ bindingCapital, chartScaleMax, isLeading, isSelected, side, userStake }: EscalationSideProps) {
 	return (
-		<div className={`escalation-side ${isSelected ? 'selected' : ''} ${isLeading ? 'leading' : ''}`}>
-			<div className='escalation-side-header'>
-				<p className='panel-label'>{isLeading ? `${side.label} (Leading)` : side.label}</p>
+		<div
+			className={`escalation-side ${isSelected ? 'selected' : ''} ${isLeading ? 'leading' : ''}`}
+			style={{
+				'--binding-ratio': getChartRatio(bindingCapital, chartScaleMax),
+				'--side-ratio': getChartRatio(side.balance, chartScaleMax),
+				'--user-ratio': getChartRatio(userStake, chartScaleMax),
+			}}
+		>
+			<div className='escalation-side-row'>
+				<div className='escalation-side-copy'>
+					<div className='escalation-side-title-row'>
+						<span className='panel-label'>{side.label}</span>
+						<div className='escalation-side-badges'>
+							{isLeading ? <span className='badge ok'>Leading</span> : undefined}
+							{isSelected ? <span className='badge escalation-side-selected-badge'>Selected</span> : undefined}
+						</div>
+					</div>
+				</div>
+				<div aria-hidden='true' className='escalation-side-chart'>
+					<div className='escalation-side-track'>
+						<div className='escalation-side-total-bar' />
+						<div className='escalation-side-user-bar' />
+						<div className='escalation-side-binding-marker' />
+					</div>
+				</div>
+				<div className='escalation-side-values'>
+					<div className='escalation-side-value'>
+						<span className='metric-label'>Total stake</span>
+						<CurrencyValue copyable={false} value={side.balance} suffix='REP' />
+					</div>
+					<div className='escalation-side-value'>
+						<span className='metric-label'>Your stake</span>
+						<CurrencyValue copyable={false} value={userStake} suffix='REP' />
+					</div>
+				</div>
 			</div>
-			<p className='detail'>
-				Total stake: <CurrencyValue value={side.balance} suffix='REP' />
-			</p>
-			<p className='detail'>
-				Your stake: <CurrencyValue value={userStake} suffix='REP' />
-			</p>
-			<p className='detail'>Your deposits: {side.userDeposits.map(deposit => deposit.depositIndex.toString()).join(', ') || 'None'}</p>
-			<p className='detail'>
-				Projected payout for current amount: <CurrencyValue value={estimate?.payout} suffix='REP' />
-			</p>
-			<p className='detail'>
-				Projected profit if this side wins: <CurrencyValue value={estimate?.profit} suffix='REP' />
-			</p>
 		</div>
 	)
 }

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -52,6 +52,7 @@ export function ReportingSection({
 	const selectedAmount = parseOptionalRepAmountInput(reportingForm.reportAmount)
 	const showFullReporting = mode === 'full-reporting'
 	const showWithdrawOnly = mode === 'withdraw-only'
+	const chartScaleMax = activeReportingDetails === undefined ? 1n : activeReportingDetails.sides.reduce((maxBalance, side) => (side.balance > maxBalance ? side.balance : maxBalance), activeReportingDetails.bindingCapital > 1n ? activeReportingDetails.bindingCapital : 1n)
 	const leadingOutcome = activeReportingDetails === undefined ? undefined : getLeadingEscalationOutcome(activeReportingDetails.sides)
 	const selectedSide = activeReportingDetails?.sides.find(side => side.key === reportingForm.selectedOutcome)
 	const selectedEstimate = activeReportingDetails === undefined || selectedAmount === undefined ? undefined : calculateEstimatedEscalationReturn(activeReportingDetails, reportingForm.selectedOutcome, selectedAmount)
@@ -159,12 +160,29 @@ export function ReportingSection({
 			) : undefined}
 
 			{showFullReporting && activeReportingDetails !== undefined ? (
-				<SectionBlock title='Outcome Sides'>
+				<SectionBlock title='Outcome Sides' description='Bars show total REP on each outcome. The marker shows current binding capital, and the thin inset shows your wallet stake.'>
+					<div className='escalation-sides-shell'>
+						<div className='escalation-sides-legend'>
+							<div className='escalation-sides-legend-item'>
+								<span aria-hidden='true' className='escalation-sides-legend-swatch escalation-sides-legend-swatch-total' />
+								<span className='panel-label'>Total stake</span>
+							</div>
+							<div className='escalation-sides-legend-item'>
+								<span aria-hidden='true' className='escalation-sides-legend-swatch escalation-sides-legend-swatch-user' />
+								<span className='panel-label'>Your stake</span>
+							</div>
+							<div className='escalation-sides-legend-item escalation-sides-legend-item-binding'>
+								<span aria-hidden='true' className='escalation-sides-legend-marker' />
+								<span className='panel-label'>Binding capital</span>
+								<CurrencyValue copyable={false} value={activeReportingDetails.bindingCapital} suffix='REP' />
+							</div>
+						</div>
+					</div>
 					<div className='escalation-sides'>
 						{activeReportingDetails.sides.map(side => {
-							const estimate = selectedAmount === undefined ? undefined : calculateEstimatedEscalationReturn(activeReportingDetails, side.key, selectedAmount)
 							const userStake = side.userDeposits.reduce((sum, deposit) => sum + deposit.amount, 0n)
-							return <EscalationSide key={side.key} estimate={estimate} isLeading={leadingOutcome === side.key} isSelected={reportingForm.selectedOutcome === side.key} side={side} userStake={userStake} />
+
+							return <EscalationSide key={side.key} bindingCapital={activeReportingDetails.bindingCapital} chartScaleMax={chartScaleMax} isLeading={leadingOutcome === side.key} isSelected={reportingForm.selectedOutcome === side.key} side={side} userStake={userStake} />
 						})}
 					</div>
 				</SectionBlock>

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -426,4 +426,34 @@ describe('ReportingSection', () => {
 
 		expect(document.body.textContent?.includes('Min preset unavailable because another side is already over the current bond.')).toBe(true)
 	})
+
+	test('renders the shared outcome chart without per-side projections or deposit details', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					reportingForm: {
+						...createReportingForm(),
+						selectedOutcome: 'no',
+					},
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		const outcomeSection = documentQueries.getByRole('heading', { name: 'Outcome Sides' }).closest('section')
+		if (outcomeSection === null) throw new Error('Expected outcome sides section')
+		const outcomeSectionQueries = within(outcomeSection as HTMLElement)
+
+		expect(outcomeSectionQueries.getByText('Bars show total REP on each outcome. The marker shows current binding capital, and the thin inset shows your wallet stake.')).not.toBeNull()
+		expect(outcomeSectionQueries.getAllByText('Total stake').length).toBeGreaterThan(0)
+		expect(outcomeSectionQueries.getAllByText('Your stake').length).toBeGreaterThan(0)
+		expect(outcomeSectionQueries.getByText('Binding capital')).not.toBeNull()
+		expect(outcomeSectionQueries.getByText('Leading')).not.toBeNull()
+		expect(outcomeSectionQueries.getByText('Selected')).not.toBeNull()
+		expect(outcomeSection.textContent?.includes('Projected payout for current amount')).toBe(false)
+		expect(outcomeSection.textContent?.includes('Projected profit if this side wins')).toBe(false)
+		expect(outcomeSection.textContent?.includes('Your deposits:')).toBe(false)
+	})
 })


### PR DESCRIPTION
## Summary
- Added reporting preset buttons for minimum outcome-change and max-profit contributions, with inline explanations when presets are unavailable.
- Refined escalation side calculations to use active reporting details for projected returns and preset sizing.
- Redesigned the outcome sides panel with a legend, binding-capital marker, stake bars, and selected/leading state badges.
- Expanded domain and UI tests to cover the new contribution helpers, return estimates, and reporting section controls.

## Testing
- Not run (PR summary only).
- Existing coverage added in `ui/ts/tests/reportingDomain.test.ts`.
- Existing coverage expanded in `ui/ts/tests/reportingSection.test.tsx`.