### PR TITLE
Show projected resolution in reporting section

### DIFF
--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -54,8 +54,10 @@ export function ReportingSection({
 	const showWithdrawOnly = mode === 'withdraw-only'
 	const totalBalance = activeReportingDetails === undefined ? 0n : activeReportingDetails.sides.reduce((sum, side) => sum + side.balance, 0n)
 	const leadingOutcome = activeReportingDetails === undefined ? undefined : getLeadingEscalationOutcome(activeReportingDetails.sides)
+	const leadingSide = activeReportingDetails?.sides.find(side => side.key === leadingOutcome)
 	const selectedSide = activeReportingDetails?.sides.find(side => side.key === reportingForm.selectedOutcome)
 	const selectedEstimate = selectedSide === undefined || selectedAmount === undefined ? undefined : calculateEstimatedEscalationReturn(selectedSide.balance, totalBalance, selectedAmount)
+	const escalationTimeRemaining = activeReportingDetails === undefined ? undefined : formatDuration(getEscalationTimeRemaining(activeReportingDetails))
 	const reportAmountError = selectedAmount === undefined && reportingForm.reportAmount.trim() !== '' ? 'Enter a valid report amount to preview profit.' : undefined
 	const reportGuardMessage = getReportingReportGuardMessage({
 		accountAddress: accountState.address,
@@ -148,11 +150,12 @@ export function ReportingSection({
 						<MetricField label='Threshold'>
 							<CurrencyValue value={activeReportingDetails.nonDecisionThreshold} suffix='REP' />
 						</MetricField>
-						<MetricField label='Time Left'>{formatDuration(getEscalationTimeRemaining(activeReportingDetails))}</MetricField>
 					</div>
-					<p className='detail'>
-						Game starts at <TimestampValue {...(effectiveCurrentTimestamp === undefined ? {} : { currentTimestamp: effectiveCurrentTimestamp })} timestamp={activeReportingDetails.startingTime} /> and currently uses a start bond of <CurrencyValue value={activeReportingDetails.startBond} suffix='REP' />.
-					</p>
+					{escalationTimeRemaining === undefined ? undefined : (
+						<p className='detail'>
+							The market resolves as {leadingSide?.label ?? getReportingOutcomeLabel(activeReportingDetails.resolution)} in {escalationTimeRemaining} unless disputed.
+						</p>
+					)}
 				</SectionBlock>
 			) : undefined}
 

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -237,7 +237,7 @@ describe('ReportingSection', () => {
 		expectTransactionButtonEnabled(document.body, 'Withdraw Escalation Deposits')
 	})
 
-	test('renders time left from escalation end time and current chain time', async () => {
+	test('shows the projected resolution outcome with remaining time', async () => {
 		const reportingDetails = createReportingDetails()
 		const renderedComponent = await renderIntoDocument(
 			h(
@@ -253,7 +253,9 @@ describe('ReportingSection', () => {
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		expect(document.body.textContent?.includes(formatDuration(300n - 150n))).toBe(true)
+		expect(document.body.textContent?.includes(`The market resolves as Yes in ${formatDuration(300n - 150n)} unless disputed.`)).toBe(true)
+		expect(document.body.textContent?.includes('Game starts at')).toBe(false)
+		expect(document.body.textContent?.includes('start bond')).toBe(false)
 	})
 
 	test('shows awaiting resolution with zero time left once the escalation end time has passed', async () => {


### PR DESCRIPTION
## Summary
- Replaced the generic reporting detail copy with a projected resolution message in the reporting section.
- Displays the leading outcome label, or falls back to the configured resolution label, alongside the remaining escalation time.
- Updated the reporting section test to assert the new copy and verify the old start-time language is no longer shown.

## Testing
- Not run