### PR TITLE
Improve reporting presets and withdrawal selection

### DIFF
--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -73,9 +73,10 @@ export function ReportingSection({
 	const leadingOutcome = activeReportingDetails === undefined ? undefined : getLeadingEscalationOutcome(activeReportingDetails.sides)
 	const leadingSide = activeReportingDetails?.sides.find(side => side.key === leadingOutcome)
 	const selectedEstimate = activeReportingDetails === undefined || selectedAmount === undefined ? undefined : calculateEstimatedEscalationReturn(activeReportingDetails, reportingForm.selectedOutcome, selectedAmount)
-	const minimumOutcomeChangeContribution =
-		activeReportingDetails === undefined ? { amount: undefined, reason: reportingStatus === 'not-started' ? 'Escalation game has not started yet.' : 'Load reporting details before using presets.' } : getMinimumOutcomeChangeContribution(activeReportingDetails, reportingForm.selectedOutcome)
-	const maxProfitContribution = activeReportingDetails === undefined ? { amount: undefined, reason: reportingStatus === 'not-started' ? 'Escalation game has not started yet.' : 'Load reporting details before using presets.' } : getMaxProfitContribution(activeReportingDetails, reportingForm.selectedOutcome)
+	const presetFallbackReason = reportingStatus === 'not-started' ? 'Escalation game has not started yet.' : 'Load reporting details before using presets.'
+	const minimumOutcomeChangeContribution = activeReportingDetails === undefined ? { amount: undefined, reason: presetFallbackReason } : getMinimumOutcomeChangeContribution(activeReportingDetails, reportingForm.selectedOutcome)
+	const maxProfitContribution = activeReportingDetails === undefined ? { amount: undefined, reason: presetFallbackReason } : getMaxProfitContribution(activeReportingDetails, reportingForm.selectedOutcome)
+	const presetReasons = reportingLocked ? [] : [minimumOutcomeChangeContribution.reason, maxProfitContribution.reason].filter((reason, index, reasons): reason is string => reason !== undefined && reasons.indexOf(reason) === index)
 	const escalationTimeRemaining = activeReportingDetails === undefined ? undefined : formatDuration(getEscalationTimeRemaining(activeReportingDetails))
 	const reportAmountError = selectedAmount === undefined && reportingForm.reportAmount.trim() !== '' ? 'Enter a valid report amount to preview profit.' : undefined
 	const reportGuardMessage = getReportingReportGuardMessage({
@@ -246,8 +247,11 @@ export function ReportingSection({
 						</button>
 					</div>
 
-					{minimumOutcomeChangeContribution.reason === undefined ? undefined : <p className='detail'>{minimumOutcomeChangeContribution.reason}</p>}
-					{maxProfitContribution.reason === undefined ? undefined : <p className='detail'>{maxProfitContribution.reason}</p>}
+					{presetReasons.map(reason => (
+						<p key={reason} className='detail'>
+							{reason}
+						</p>
+					))}
 					{reportAmountError === undefined ? undefined : <p className='detail'>{reportAmountError}</p>}
 
 					{selectedEstimate === undefined ? undefined : (

--- a/ui/ts/lib/reportingDomain.ts
+++ b/ui/ts/lib/reportingDomain.ts
@@ -14,6 +14,24 @@ function roundUpToRepUnit(value: bigint) {
 	return ((value + REP_UNIT - 1n) / REP_UNIT) * REP_UNIT
 }
 
+function getSelectedAndOtherSides(details: ActiveReportingDetails, selectedOutcome: ReportingOutcomeKey) {
+	const selectedSide = details.sides.find(side => side.key === selectedOutcome)
+	const largestOtherBalance = details.sides.filter(side => side.key !== selectedOutcome).reduce((maxBalance, side) => (side.balance > maxBalance ? side.balance : maxBalance), 0n)
+
+	return {
+		largestOtherBalance,
+		selectedSide,
+	}
+}
+
+function getAvailableRoom(details: ActiveReportingDetails, selectedBalance: bigint) {
+	return details.nonDecisionThreshold > selectedBalance ? details.nonDecisionThreshold - selectedBalance : 0n
+}
+
+function isUniqueWinner(selectedBalance: bigint, largestOtherBalance: bigint) {
+	return selectedBalance > largestOtherBalance
+}
+
 export function getEscalationTimeRemaining(details: ActiveReportingDetails) {
 	return requireDefined(getTimeRemaining(details.escalationEndTime, details.currentTime), 'Escalation end time is required')
 }
@@ -37,38 +55,24 @@ export function getLeadingEscalationOutcome(sides: EscalationSide[]) {
 	return leadingSide?.key
 }
 
-function getSelectedAndOtherSides(details: ActiveReportingDetails, selectedOutcome: ReportingOutcomeKey) {
-	const selectedSide = details.sides.find(side => side.key === selectedOutcome)
-	const otherSides = details.sides.filter(side => side.key !== selectedOutcome)
-	const largestOtherBalance = otherSides.reduce((maxBalance, side) => (side.balance > maxBalance ? side.balance : maxBalance), 0n)
-
-	return {
-		largestOtherBalance,
-		otherSides,
-		selectedSide,
-	}
-}
-
-function isUniqueWinner(selectedBalance: bigint, largestOtherBalance: bigint) {
-	return selectedBalance > largestOtherBalance
-}
-
 export function getMinimumOutcomeChangeContribution(details: ActiveReportingDetails, selectedOutcome: ReportingOutcomeKey): ReportingAmountSuggestion {
-	const { largestOtherBalance, otherSides, selectedSide } = getSelectedAndOtherSides(details, selectedOutcome)
+	const { largestOtherBalance, selectedSide } = getSelectedAndOtherSides(details, selectedOutcome)
 	if (selectedSide === undefined) return { amount: undefined, reason: 'Selected side is unavailable.' }
-	if (details.resolution === selectedOutcome) return { amount: 0n, reason: undefined }
-
-	const selectedAlreadyUniqueWinner = isUniqueWinner(selectedSide.balance, largestOtherBalance)
-	const opposingSideOverBond = otherSides.some(side => side.balance >= details.currentRequiredBond)
-	if (opposingSideOverBond && !selectedAlreadyUniqueWinner) {
-		return { amount: undefined, reason: 'Min preset unavailable because another side is already over the current bond.' }
+	if (details.resolution === selectedOutcome || isUniqueWinner(selectedSide.balance, largestOtherBalance)) {
+		return { amount: 0n, reason: undefined }
 	}
 
-	const rawAmount = largestOtherBalance + 1n > selectedSide.balance ? largestOtherBalance + 1n - selectedSide.balance : 0n
-	const minimumAllowedAmount = rawAmount > 0n && rawAmount < details.startBond ? details.startBond : rawAmount
-	const amount = roundUpToRepUnit(minimumAllowedAmount)
-	if (selectedSide.balance + amount > details.nonDecisionThreshold) {
-		return { amount: undefined, reason: 'Min preset unavailable because the selected side cannot accept that much REP.' }
+	const requiredLeadAmount = largestOtherBalance + 1n - selectedSide.balance
+	const enteredAmount = details.startBond > requiredLeadAmount ? details.startBond : requiredLeadAmount
+	const amount = roundUpToRepUnit(enteredAmount)
+	const availableRoom = getAvailableRoom(details, selectedSide.balance)
+	const effectiveAmount = amount > availableRoom ? availableRoom : amount
+
+	if (availableRoom === 0n || selectedSide.balance + effectiveAmount <= largestOtherBalance) {
+		return {
+			amount: undefined,
+			reason: 'Min preset unavailable because the selected side cannot take the lead within the remaining bond capacity.',
+		}
 	}
 
 	return { amount, reason: undefined }
@@ -77,7 +81,10 @@ export function getMinimumOutcomeChangeContribution(details: ActiveReportingDeta
 export function getMaxProfitContribution(details: ActiveReportingDetails, selectedOutcome: ReportingOutcomeKey): ReportingAmountSuggestion {
 	const minContribution = getMinimumOutcomeChangeContribution(details, selectedOutcome)
 	if (minContribution.amount === undefined) {
-		return { amount: undefined, reason: minContribution.reason ?? 'Max profit preset is unavailable.' }
+		return {
+			amount: undefined,
+			reason: minContribution.reason ?? 'Max profit preset is unavailable.',
+		}
 	}
 
 	const { largestOtherBalance, selectedSide } = getSelectedAndOtherSides(details, selectedOutcome)
@@ -86,15 +93,24 @@ export function getMaxProfitContribution(details: ActiveReportingDetails, select
 	const rewardEligibleCap = largestOtherBalance + largestOtherBalance / 2n
 	const targetFinalBalance = rewardEligibleCap < details.nonDecisionThreshold ? rewardEligibleCap : details.nonDecisionThreshold
 	if (isUniqueWinner(selectedSide.balance, largestOtherBalance) && selectedSide.balance >= targetFinalBalance) {
-		return { amount: undefined, reason: 'Max profit preset unavailable because the reward window is already filled on the selected side.' }
+		return {
+			amount: undefined,
+			reason: 'Max profit preset unavailable because the reward window is already filled on the selected side.',
+		}
 	}
 
-	const rawAmount = targetFinalBalance > selectedSide.balance ? targetFinalBalance - selectedSide.balance : 0n
-	const targetAmount = rawAmount > minContribution.amount ? rawAmount : minContribution.amount
-	const minimumAllowedAmount = targetAmount > 0n && targetAmount < details.startBond ? details.startBond : targetAmount
-	const amount = roundUpToRepUnit(minimumAllowedAmount)
-	if (selectedSide.balance + amount > details.nonDecisionThreshold) {
-		return { amount: undefined, reason: 'Max profit preset unavailable because the selected side cannot accept that much REP.' }
+	const requiredWindowAmount = targetFinalBalance > selectedSide.balance ? targetFinalBalance - selectedSide.balance : 0n
+	const minimumEnteredAmount = minContribution.amount > requiredWindowAmount ? minContribution.amount : requiredWindowAmount
+	const enteredAmount = details.startBond > minimumEnteredAmount ? details.startBond : minimumEnteredAmount
+	const amount = roundUpToRepUnit(enteredAmount)
+	const availableRoom = getAvailableRoom(details, selectedSide.balance)
+	const effectiveAmount = amount > availableRoom ? availableRoom : amount
+
+	if (selectedSide.balance + effectiveAmount < targetFinalBalance) {
+		return {
+			amount: undefined,
+			reason: 'Max profit preset unavailable because the selected side cannot fill the reward window within the remaining bond capacity.',
+		}
 	}
 
 	return { amount, reason: undefined }
@@ -116,7 +132,7 @@ export function calculateEstimatedEscalationReturn(details: ActiveReportingDetai
 		}
 	}
 
-	const availableRoom = details.nonDecisionThreshold > selectedSide.balance ? details.nonDecisionThreshold - selectedSide.balance : 0n
+	const availableRoom = getAvailableRoom(details, selectedSide.balance)
 	const effectiveAmount = amount > availableRoom ? availableRoom : amount
 	if (effectiveAmount <= 0n) {
 		return {
@@ -142,10 +158,9 @@ export function calculateEstimatedEscalationReturn(details: ActiveReportingDetai
 	const rewardEligibleDepositAmount = eligibleEnd > depositStart ? eligibleEnd - depositStart : 0n
 	const rewardBonusPool = (bindingCapital * 3n) / 5n
 	const bonusShare = (rewardEligibleDepositAmount * rewardBonusPool) / rewardEligiblePrincipal
-	const payout = effectiveAmount + bonusShare
 
 	return {
-		payout,
-		profit: payout - effectiveAmount,
+		payout: effectiveAmount + bonusShare,
+		profit: bonusShare,
 	}
 }

--- a/ui/ts/tests/reportingDomain.test.ts
+++ b/ui/ts/tests/reportingDomain.test.ts
@@ -5,8 +5,10 @@ import { zeroAddress } from 'viem'
 import { calculateEstimatedEscalationReturn, getMaxProfitContribution, getMinimumOutcomeChangeContribution } from '../lib/reportingDomain.js'
 import type { ActiveReportingDetails, MarketDetails } from '../types/contracts.js'
 
+const REP = 10n ** 18n
+
 function rep(value: bigint) {
-	return value * 10n ** 18n
+	return value * REP
 }
 
 function createMarketDetails(): MarketDetails {
@@ -64,6 +66,40 @@ describe('reportingDomain', () => {
 		})
 	})
 
+	test('getMinimumOutcomeChangeContribution returns 1001 REP for 1000 REP on yes and no selected', () => {
+		const details = createReportingDetails({
+			currentRequiredBond: rep(1_000n),
+			nonDecisionThreshold: rep(2_000n),
+			sides: [
+				{ balance: 0n, deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+				{ balance: rep(1_000n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+				{ balance: 0n, deposits: [], key: 'no', label: 'No', userDeposits: [] },
+			],
+			startBond: rep(1n),
+		})
+
+		expect(getMinimumOutcomeChangeContribution(details, 'no')).toEqual({
+			amount: rep(1_001n),
+			reason: undefined,
+		})
+	})
+
+	test('getMinimumOutcomeChangeContribution respects startBond when the lead delta is smaller than the minimum report', () => {
+		const details = createReportingDetails({
+			sides: [
+				{ balance: 0n, deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+				{ balance: rep(5n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+				{ balance: rep(5n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
+			],
+			startBond: rep(3n),
+		})
+
+		expect(getMinimumOutcomeChangeContribution(details, 'no')).toEqual({
+			amount: rep(3n),
+			reason: undefined,
+		})
+	})
+
 	test('getMinimumOutcomeChangeContribution returns zero when the selected side already resolves', () => {
 		const details = createReportingDetails({
 			resolution: 'yes',
@@ -80,18 +116,20 @@ describe('reportingDomain', () => {
 		})
 	})
 
-	test('getMinimumOutcomeChangeContribution is unavailable when an opposing side is already over bond', () => {
+	test('getMinimumOutcomeChangeContribution is unavailable when the selected side cannot lead within remaining room', () => {
 		const details = createReportingDetails({
+			nonDecisionThreshold: rep(20n),
 			sides: [
-				{ balance: rep(5n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
-				{ balance: rep(20n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
-				{ balance: rep(2n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+				{ balance: 0n, deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+				{ balance: rep(20n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+				{ balance: rep(19n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
 			],
+			startBond: rep(1n),
 		})
 
-		expect(getMinimumOutcomeChangeContribution(details, 'yes')).toEqual({
+		expect(getMinimumOutcomeChangeContribution(details, 'no')).toEqual({
 			amount: undefined,
-			reason: 'Min preset unavailable because another side is already over the current bond.',
+			reason: 'Min preset unavailable because the selected side cannot take the lead within the remaining bond capacity.',
 		})
 	})
 
@@ -102,10 +140,28 @@ describe('reportingDomain', () => {
 		})
 	})
 
+	test('getMaxProfitContribution returns 1500 REP for 1000 REP on yes and no selected', () => {
+		const details = createReportingDetails({
+			currentRequiredBond: rep(1_000n),
+			nonDecisionThreshold: rep(2_000n),
+			sides: [
+				{ balance: 0n, deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+				{ balance: rep(1_000n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+				{ balance: 0n, deposits: [], key: 'no', label: 'No', userDeposits: [] },
+			],
+			startBond: rep(1n),
+		})
+
+		expect(getMaxProfitContribution(details, 'no')).toEqual({
+			amount: rep(1_500n),
+			reason: undefined,
+		})
+	})
+
 	test('getMaxProfitContribution is unavailable when the reward window is already filled', () => {
 		const details = createReportingDetails({
 			sides: [
-				{ balance: rep(13n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+				{ balance: rep(15n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
 				{ balance: rep(8n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
 				{ balance: rep(2n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
 			],
@@ -119,16 +175,17 @@ describe('reportingDomain', () => {
 
 	test('calculateEstimatedEscalationReturn only rewards the eligible slice when a deposit crosses the cap', () => {
 		const details = createReportingDetails({
+			nonDecisionThreshold: rep(40n),
 			sides: [
-				{ balance: rep(14n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+				{ balance: rep(20n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
 				{ balance: rep(20n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
-				{ balance: rep(1n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+				{ balance: 0n, deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
 			],
 		})
 
 		expect(calculateEstimatedEscalationReturn(details, 'yes', rep(14n))).toEqual({
-			payout: rep(20n),
-			profit: rep(6n),
+			payout: rep(18n),
+			profit: rep(4n),
 		})
 	})
 

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -1,10 +1,10 @@
 /// <reference types="bun-types" />
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { act } from 'preact/test-utils'
 import { fireEvent, within } from '@testing-library/dom'
 import { h } from 'preact'
 import { useState } from 'preact/hooks'
-import { act } from 'preact/test-utils'
 import { zeroAddress } from 'viem'
 import { ReportingSection } from '../components/ReportingSection.js'
 import { formatDuration } from '../lib/formatters.js'
@@ -15,8 +15,10 @@ import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
 import { expectTransactionButtonDisabled, expectTransactionButtonEnabled } from './testUtils/transactionActionButton.js'
 
+const REP = 10n ** 18n
+
 function rep(value: bigint) {
-	return value * 10n ** 18n
+	return value * REP
 }
 
 function createAccountState(overrides: Partial<AccountState> = {}): AccountState {
@@ -147,7 +149,7 @@ function createProps(overrides: Partial<ReportingSectionProps> = {}): ReportingS
 }
 
 function ReportingSectionHarness({ initialProps }: { initialProps?: Partial<ReportingSectionProps> }) {
-	const [reportingForm, setReportingForm] = useState<ReportingFormState>(createReportingForm())
+	const [reportingForm, setReportingForm] = useState<ReportingFormState>(createReportingForm(initialProps?.reportingForm))
 
 	return (
 		<ReportingSection
@@ -161,6 +163,12 @@ function ReportingSectionHarness({ initialProps }: { initialProps?: Partial<Repo
 			}}
 		/>
 	)
+}
+
+function findProfitPreview() {
+	return Array.from(document.body.querySelectorAll('p.detail'))
+		.map(element => element.textContent ?? '')
+		.find(text => text.includes('projects roughly'))
 }
 
 describe('ReportingSection', () => {
@@ -390,18 +398,14 @@ describe('ReportingSection', () => {
 		const renderedComponent = await renderIntoDocument(<ReportingSectionHarness />)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		const previewBefore = Array.from(document.body.querySelectorAll('p.detail'))
-			.map(element => element.textContent ?? '')
-			.find(text => text.includes('If Yes wins'))
+		const previewBefore = findProfitPreview()
 
 		await act(() => {
 			fireEvent.click(within(document.body).getByRole('button', { name: 'Max profit' }))
 		})
 
 		const amountInput = within(document.body).getByRole('textbox', { name: 'Report / Contribution Amount' })
-		const previewAfter = Array.from(document.body.querySelectorAll('p.detail'))
-			.map(element => element.textContent ?? '')
-			.find(text => text.includes('If Yes wins'))
+		const previewAfter = findProfitPreview()
 		expect((amountInput as HTMLInputElement).value).toBe('7')
 		expect(previewBefore).not.toBe(previewAfter)
 	})
@@ -422,18 +426,23 @@ describe('ReportingSection', () => {
 				ReportingSection,
 				createProps({
 					reportingDetails: createReportingDetails({
+						nonDecisionThreshold: rep(20n),
 						sides: [
-							{ balance: rep(5n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
-							{ balance: rep(20n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
-							{ balance: rep(1n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+							{ balance: 0n, deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+							{ balance: rep(20n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+							{ balance: rep(19n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
 						],
+						startBond: rep(1n),
+					}),
+					reportingForm: createReportingForm({
+						selectedOutcome: 'no',
 					}),
 				}),
 			),
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		expect(document.body.textContent?.includes('Min preset unavailable because another side is already over the current bond.')).toBe(true)
+		expect(document.body.textContent?.includes('Min preset unavailable because the selected side cannot take the lead within the remaining bond capacity.')).toBe(true)
 	})
 
 	test('renders the shared outcome chart without per-side projections or deposit details', async () => {
@@ -441,10 +450,9 @@ describe('ReportingSection', () => {
 			h(
 				ReportingSection,
 				createProps({
-					reportingForm: {
-						...createReportingForm(),
+					reportingForm: createReportingForm({
 						selectedOutcome: 'no',
-					},
+					}),
 				}),
 			),
 		)
@@ -544,5 +552,108 @@ describe('ReportingSection', () => {
 		fireEvent.click(depositCheckbox)
 
 		expect(onReportingFormChangeCalls).toEqual([{ selectedWithdrawDepositIndexes: [1n] }, { selectedWithdrawDepositIndexes: [] }])
+	})
+
+	test('autofills the report amount for the minimum outcome change preset with 1001 REP when another side has 1000 REP', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(ReportingSectionHarness, {
+				initialProps: {
+					reportingDetails: createReportingDetails({
+						currentRequiredBond: rep(1_000n),
+						nonDecisionThreshold: rep(2_000n),
+						sides: [
+							{ balance: 0n, deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+							{ balance: rep(1_000n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+							{ balance: 0n, deposits: [], key: 'no', label: 'No', userDeposits: [] },
+						],
+						startBond: rep(1n),
+					}),
+					reportingForm: createReportingForm({
+						selectedOutcome: 'no',
+					}),
+				},
+			}),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await act(() => {
+			fireEvent.click(within(document.body).getByRole('button', { name: 'Min to change proposed outcome' }))
+		})
+
+		const amountInput = within(document.body).getByRole('textbox', { name: 'Report / Contribution Amount' })
+		expect((amountInput as HTMLInputElement).value).toBe('1001')
+	})
+
+	test('autofills the report amount for the max profit preset with 1500 REP when another side has 1000 REP', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(ReportingSectionHarness, {
+				initialProps: {
+					reportingDetails: createReportingDetails({
+						currentRequiredBond: rep(1_000n),
+						nonDecisionThreshold: rep(2_000n),
+						sides: [
+							{ balance: 0n, deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+							{ balance: rep(1_000n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+							{ balance: 0n, deposits: [], key: 'no', label: 'No', userDeposits: [] },
+						],
+						startBond: rep(1n),
+					}),
+					reportingForm: createReportingForm({
+						selectedOutcome: 'no',
+					}),
+				},
+			}),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await act(() => {
+			fireEvent.click(within(document.body).getByRole('button', { name: 'Max profit' }))
+		})
+
+		const amountInput = within(document.body).getByRole('textbox', { name: 'Report / Contribution Amount' })
+		expect((amountInput as HTMLInputElement).value).toBe('1500')
+		expect(document.body.textContent?.includes('projects roughly')).toBe(true)
+	})
+
+	test('updates the displayed profit preview after clicking max profit in a partial-depth scenario', async () => {
+		const renderedComponent = await renderIntoDocument(<ReportingSectionHarness />)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const previewBefore = findProfitPreview()
+
+		await act(() => {
+			fireEvent.click(within(document.body).getByRole('button', { name: 'Max profit' }))
+		})
+
+		const previewAfter = findProfitPreview()
+		expect(previewBefore).not.toBe(previewAfter)
+	})
+
+	test('deduplicates identical preset unavailability reasons', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					reportingDetails: createReportingDetails({
+						nonDecisionThreshold: rep(20n),
+						sides: [
+							{ balance: 0n, deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+							{ balance: rep(20n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+							{ balance: rep(19n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
+						],
+						startBond: rep(1n),
+					}),
+					reportingForm: createReportingForm({
+						selectedOutcome: 'no',
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect((documentQueries.getByRole('button', { name: 'Min to change proposed outcome' }) as HTMLButtonElement).disabled).toBe(true)
+		expect((documentQueries.getByRole('button', { name: 'Max profit' }) as HTMLButtonElement).disabled).toBe(true)
+		expect(documentQueries.getAllByText('Min preset unavailable because the selected side cannot take the lead within the remaining bond capacity.')).toHaveLength(1)
 	})
 })


### PR DESCRIPTION
## Summary
- Updated the reporting section to show projected outcome estimates, preset contribution shortcuts, and a clearer escalation metrics layout.
- Reworked outcome side presentation with stake bars, binding capital markers, and clearer selected/leading state styling.
- Replaced free-form withdrawal index input with checkbox-based deposit selection and tightened withdrawal availability handling.
- Added reporting-domain coverage and UI tests for the new preset, estimation, and withdrawal behavior.

## Testing
- Not run