### PR TITLE
Refine reporting workflow and escalation side views

### DIFF
--- a/ui/ts/components/EscalationSide.tsx
+++ b/ui/ts/components/EscalationSide.tsx
@@ -1,17 +1,29 @@
 import { CurrencyValue } from './CurrencyValue.js'
-import type { EscalationSide } from '../types/contracts.js'
+import type { EscalationDeposit } from '../types/contracts.js'
 
-type EscalationSideProps = {
-	bindingCapital: bigint
-	chartScaleMax: bigint
-	isLeading: boolean
-	isSelected: boolean
-	side: EscalationSide
-	userStake: bigint
+type EscalationSideDisplay = {
+	balance: bigint | undefined
+	label: string
+	userDeposits: EscalationDeposit[] | undefined
+	userStake: bigint | undefined
 }
 
-function getChartRatio(value: bigint, maxValue: bigint) {
-	if (value <= 0n || maxValue <= 0n) return '0%'
+type EscalationSideProps = {
+	bindingCapital: bigint | undefined
+	chartScaleMax: bigint
+	estimate:
+		| {
+				profit: bigint
+				payout: bigint
+		  }
+		| undefined
+	isLeading: boolean
+	isSelected: boolean
+	side: EscalationSideDisplay
+}
+
+function getChartRatio(value: bigint | undefined, maxValue: bigint) {
+	if (value === undefined || value <= 0n || maxValue <= 0n) return '0%'
 
 	const basisPoints = (value * 10000n) / maxValue
 	const wholePercent = basisPoints / 100n
@@ -20,14 +32,16 @@ function getChartRatio(value: bigint, maxValue: bigint) {
 	return `${wholePercent.toString()}.${fractionalPercent}%`
 }
 
-export function EscalationSide({ bindingCapital, chartScaleMax, isLeading, isSelected, side, userStake }: EscalationSideProps) {
+export function EscalationSide({ bindingCapital, chartScaleMax, estimate, isLeading, isSelected, side }: EscalationSideProps) {
+	const depositIndexes = side.userDeposits === undefined ? '—' : side.userDeposits.map(deposit => deposit.depositIndex.toString()).join(', ') || 'None'
+
 	return (
 		<div
 			className={`escalation-side ${isSelected ? 'selected' : ''} ${isLeading ? 'leading' : ''}`}
 			style={{
 				'--binding-ratio': getChartRatio(bindingCapital, chartScaleMax),
 				'--side-ratio': getChartRatio(side.balance, chartScaleMax),
-				'--user-ratio': getChartRatio(userStake, chartScaleMax),
+				'--user-ratio': getChartRatio(side.userStake, chartScaleMax),
 			}}
 		>
 			<div className='escalation-side-row'>
@@ -54,10 +68,17 @@ export function EscalationSide({ bindingCapital, chartScaleMax, isLeading, isSel
 					</div>
 					<div className='escalation-side-value'>
 						<span className='metric-label'>Your stake</span>
-						<CurrencyValue copyable={false} value={userStake} suffix='REP' />
+						<CurrencyValue copyable={false} value={side.userStake} suffix='REP' />
 					</div>
 				</div>
 			</div>
+			<p className='detail'>Your deposits: {depositIndexes}</p>
+			<p className='detail'>
+				Projected payout for current amount: <CurrencyValue copyable={false} value={estimate?.payout} suffix='REP' />
+			</p>
+			<p className='detail'>
+				Projected profit if this side wins: <CurrencyValue copyable={false} value={estimate?.profit} suffix='REP' />
+			</p>
 		</div>
 	)
 }

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -42,6 +42,8 @@ type EscalationSideDisplay = {
 	userStake: bigint | undefined
 }
 
+const ZERO_REP = 0n
+
 function getOutcomeSides({ activeReportingDetails, selectedAmount }: { activeReportingDetails: ActiveReportingDetails | undefined; selectedAmount: bigint | undefined }) {
 	if (activeReportingDetails !== undefined) {
 		return activeReportingDetails.sides.map<EscalationSideDisplay>(side => {
@@ -58,23 +60,13 @@ function getOutcomeSides({ activeReportingDetails, selectedAmount }: { activeRep
 	}
 
 	return REPORTING_OUTCOME_DROPDOWN_OPTIONS.map<EscalationSideDisplay>(option => ({
-		balance: undefined,
+		balance: ZERO_REP,
 		estimate: undefined,
 		key: option.value,
 		label: option.label,
-		userDeposits: undefined,
-		userStake: undefined,
+		userDeposits: [],
+		userStake: ZERO_REP,
 	}))
-}
-
-function getOutcomeSidesHint(reportingStatus: ReportingStatus) {
-	if (reportingStatus === 'missing') {
-		return 'Load reporting details to populate live stakes, bond progression, and deposit indexes.'
-	}
-	if (reportingStatus === 'not-started') {
-		return 'Escalation game has not started yet. The first report will populate live stakes, bond progression, and deposit indexes.'
-	}
-	return undefined
 }
 
 function getDepositEntryCountLabel(count: number) {
@@ -128,12 +120,11 @@ export function ReportingSection({
 		activeReportingDetails,
 		selectedAmount,
 	})
-	const outcomeSidesHint = getOutcomeSidesHint(reportingStatus)
 	const presetFallbackReason = reportingStatus === 'not-started' ? 'Escalation game has not started yet.' : 'Load reporting details before using presets.'
 	const minimumOutcomeChangeContribution = activeReportingDetails === undefined ? { amount: undefined, reason: presetFallbackReason } : getMinimumOutcomeChangeContribution(activeReportingDetails, reportingForm.selectedOutcome)
 	const maxProfitContribution = activeReportingDetails === undefined ? { amount: undefined, reason: presetFallbackReason } : getMaxProfitContribution(activeReportingDetails, reportingForm.selectedOutcome)
 	const presetReasons = reportingLocked ? [] : [minimumOutcomeChangeContribution.reason, maxProfitContribution.reason].filter((reason, index, reasons): reason is string => reason !== undefined && reasons.indexOf(reason) === index)
-	const escalationTimeRemaining = activeReportingDetails === undefined ? undefined : formatDuration(getEscalationTimeRemaining(activeReportingDetails))
+	const escalationTimeRemaining = activeReportingDetails === undefined ? formatDuration(ZERO_REP) : formatDuration(getEscalationTimeRemaining(activeReportingDetails))
 	const reportAmountError = selectedAmount === undefined && reportingForm.reportAmount.trim() !== '' ? 'Enter a valid report amount to preview profit.' : undefined
 	const reportGuardMessage = getReportingReportGuardMessage({
 		accountAddress: accountState.address,
@@ -214,23 +205,22 @@ export function ReportingSection({
 				<SectionBlock title='Outcome Sides' {...(activeReportingDetails === undefined ? {} : { description: 'Bars show total REP on each outcome. The marker shows current binding capital, and the thin inset shows your wallet stake.' })}>
 					<div className='escalation-metrics'>
 						<MetricField label='Current Bond'>
-							<CurrencyValue value={activeReportingDetails?.currentRequiredBond} suffix='REP' />
+							<CurrencyValue value={activeReportingDetails?.currentRequiredBond ?? ZERO_REP} suffix='REP' />
 						</MetricField>
 						<MetricField label='Binding Capital'>
-							<CurrencyValue value={activeReportingDetails?.bindingCapital} suffix='REP' />
+							<CurrencyValue value={activeReportingDetails?.bindingCapital ?? ZERO_REP} suffix='REP' />
 						</MetricField>
 						<MetricField label='Threshold'>
-							<CurrencyValue value={activeReportingDetails?.nonDecisionThreshold} suffix='REP' />
+							<CurrencyValue value={activeReportingDetails?.nonDecisionThreshold ?? ZERO_REP} suffix='REP' />
 						</MetricField>
-						<MetricField label='Time Left'>{escalationTimeRemaining ?? '—'}</MetricField>
+						<MetricField label='Time Left'>{escalationTimeRemaining}</MetricField>
 						<MetricField label='Game Start'>
 							<TimestampValue {...(effectiveCurrentTimestamp === undefined ? {} : { currentTimestamp: effectiveCurrentTimestamp })} timestamp={activeReportingDetails?.startingTime} />
 						</MetricField>
 						<MetricField label='Start Bond'>
-							<CurrencyValue value={activeReportingDetails?.startBond} suffix='REP' />
+							<CurrencyValue value={activeReportingDetails?.startBond ?? ZERO_REP} suffix='REP' />
 						</MetricField>
 					</div>
-					{outcomeSidesHint === undefined ? undefined : <p className='detail'>{outcomeSidesHint}</p>}
 					<div className='escalation-sides-shell'>
 						{activeReportingDetails === undefined ? undefined : (
 							<div className='escalation-sides-legend'>

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -24,6 +24,58 @@ import { REPORTING_OUTCOME_DROPDOWN_OPTIONS, getReportingOutcomeLabel } from '..
 import { calculateEstimatedEscalationReturn, getEscalationPhase, getEscalationTimeRemaining, getLeadingEscalationOutcome, getMaxProfitContribution, getMinimumOutcomeChangeContribution } from '../lib/reportingDomain.js'
 import type { UserMessagePresentation } from '../lib/userCopy.js'
 import type { ReportingSectionProps } from '../types/components.js'
+import type { ActiveReportingDetails, EscalationDeposit, ReportingOutcomeKey } from '../types/contracts.js'
+
+type ReportingStatus = 'active' | 'missing' | 'not-started'
+
+type EscalationSideDisplay = {
+	balance: bigint | undefined
+	estimate:
+		| {
+				profit: bigint
+				payout: bigint
+		  }
+		| undefined
+	key: ReportingOutcomeKey
+	label: string
+	userDeposits: EscalationDeposit[] | undefined
+	userStake: bigint | undefined
+}
+
+function getOutcomeSides({ activeReportingDetails, selectedAmount }: { activeReportingDetails: ActiveReportingDetails | undefined; selectedAmount: bigint | undefined }) {
+	if (activeReportingDetails !== undefined) {
+		return activeReportingDetails.sides.map<EscalationSideDisplay>(side => {
+			const userStake = side.userDeposits.reduce((sum, deposit) => sum + deposit.amount, 0n)
+			return {
+				balance: side.balance,
+				estimate: selectedAmount === undefined ? undefined : calculateEstimatedEscalationReturn(activeReportingDetails, side.key, selectedAmount),
+				key: side.key,
+				label: side.label,
+				userDeposits: side.userDeposits,
+				userStake,
+			}
+		})
+	}
+
+	return REPORTING_OUTCOME_DROPDOWN_OPTIONS.map<EscalationSideDisplay>(option => ({
+		balance: undefined,
+		estimate: undefined,
+		key: option.value,
+		label: option.label,
+		userDeposits: undefined,
+		userStake: undefined,
+	}))
+}
+
+function getOutcomeSidesHint(reportingStatus: ReportingStatus) {
+	if (reportingStatus === 'missing') {
+		return 'Load reporting details to populate live stakes, bond progression, and deposit indexes.'
+	}
+	if (reportingStatus === 'not-started') {
+		return 'Escalation game has not started yet. The first report will populate live stakes, bond progression, and deposit indexes.'
+	}
+	return undefined
+}
 
 function getDepositEntryCountLabel(count: number) {
 	return count === 1 ? 'entry' : 'entries'
@@ -60,7 +112,7 @@ export function ReportingSection({
 }: ReportingSectionProps) {
 	const isMainnet = isMainnetChain(accountState.chainId)
 	const activeReportingDetails = reportingDetails?.status === 'active' ? reportingDetails : undefined
-	const reportingStatus = reportingDetails === undefined ? 'missing' : reportingDetails.status
+	const reportingStatus: ReportingStatus = reportingDetails === undefined ? 'missing' : reportingDetails.status
 	const marketDetails = reportingDetails?.marketDetails ?? previewMarketDetails
 	const effectiveCurrentTimestamp = reportingDetails?.currentTime ?? currentTimestamp
 	const reportingLocked = lockedReason !== undefined
@@ -71,12 +123,15 @@ export function ReportingSection({
 	const selectedWithdrawDepositIndexes = reportingForm.selectedWithdrawDepositIndexes
 	const chartScaleMax = activeReportingDetails === undefined ? 1n : activeReportingDetails.sides.reduce((maxBalance, side) => (side.balance > maxBalance ? side.balance : maxBalance), activeReportingDetails.bindingCapital > 1n ? activeReportingDetails.bindingCapital : 1n)
 	const leadingOutcome = activeReportingDetails === undefined ? undefined : getLeadingEscalationOutcome(activeReportingDetails.sides)
-	const leadingSide = activeReportingDetails?.sides.find(side => side.key === leadingOutcome)
 	const selectedEstimate = activeReportingDetails === undefined || selectedAmount === undefined ? undefined : calculateEstimatedEscalationReturn(activeReportingDetails, reportingForm.selectedOutcome, selectedAmount)
+	const outcomeSides = getOutcomeSides({
+		activeReportingDetails,
+		selectedAmount,
+	})
+	const outcomeSidesHint = getOutcomeSidesHint(reportingStatus)
 	const minimumOutcomeChangeContribution =
 		activeReportingDetails === undefined ? { amount: undefined, reason: reportingStatus === 'not-started' ? 'Escalation game has not started yet.' : 'Load reporting details before using presets.' } : getMinimumOutcomeChangeContribution(activeReportingDetails, reportingForm.selectedOutcome)
 	const maxProfitContribution = activeReportingDetails === undefined ? { amount: undefined, reason: reportingStatus === 'not-started' ? 'Escalation game has not started yet.' : 'Load reporting details before using presets.' } : getMaxProfitContribution(activeReportingDetails, reportingForm.selectedOutcome)
-	const escalationTimeRemaining = activeReportingDetails === undefined ? undefined : formatDuration(getEscalationTimeRemaining(activeReportingDetails))
 	const reportAmountError = selectedAmount === undefined && reportingForm.reportAmount.trim() !== '' ? 'Enter a valid report amount to preview profit.' : undefined
 	const reportGuardMessage = getReportingReportGuardMessage({
 		accountAddress: accountState.address,
@@ -153,49 +208,50 @@ export function ReportingSection({
 				</EntityCard>
 			) : undefined}
 
-			{showFullReporting && activeReportingDetails !== undefined ? (
-				<SectionBlock title='Escalation Metrics'>
+			{showFullReporting ? (
+				<SectionBlock title='Outcome Sides' {...(activeReportingDetails === undefined ? {} : { description: 'Bars show total REP on each outcome. The marker shows current binding capital, and the thin inset shows your wallet stake.' })}>
 					<div className='escalation-metrics'>
+						<MetricField label='Current Bond'>
+							<CurrencyValue value={activeReportingDetails?.currentRequiredBond} suffix='REP' />
+						</MetricField>
 						<MetricField label='Binding Capital'>
-							<CurrencyValue value={activeReportingDetails.bindingCapital} suffix='REP' />
+							<CurrencyValue value={activeReportingDetails?.bindingCapital} suffix='REP' />
 						</MetricField>
 						<MetricField label='Threshold'>
-							<CurrencyValue value={activeReportingDetails.nonDecisionThreshold} suffix='REP' />
+							<CurrencyValue value={activeReportingDetails?.nonDecisionThreshold} suffix='REP' />
+						</MetricField>
+						<MetricField label='Time Left'>{activeReportingDetails === undefined ? '—' : formatDuration(getEscalationTimeRemaining(activeReportingDetails))}</MetricField>
+						<MetricField label='Game Start'>
+							<TimestampValue {...(effectiveCurrentTimestamp === undefined ? {} : { currentTimestamp: effectiveCurrentTimestamp })} timestamp={activeReportingDetails?.startingTime} />
+						</MetricField>
+						<MetricField label='Start Bond'>
+							<CurrencyValue value={activeReportingDetails?.startBond} suffix='REP' />
 						</MetricField>
 					</div>
-					{escalationTimeRemaining === undefined ? undefined : (
-						<p className='detail'>
-							The market resolves as {leadingSide?.label ?? getReportingOutcomeLabel(activeReportingDetails.resolution)} in {escalationTimeRemaining} unless disputed.
-						</p>
-					)}
-				</SectionBlock>
-			) : undefined}
-
-			{showFullReporting && activeReportingDetails !== undefined ? (
-				<SectionBlock title='Outcome Sides' description='Bars show total REP on each outcome. The marker shows current binding capital, and the thin inset shows your wallet stake.'>
+					{outcomeSidesHint === undefined ? undefined : <p className='detail'>{outcomeSidesHint}</p>}
 					<div className='escalation-sides-shell'>
-						<div className='escalation-sides-legend'>
-							<div className='escalation-sides-legend-item'>
-								<span aria-hidden='true' className='escalation-sides-legend-swatch escalation-sides-legend-swatch-total' />
-								<span className='panel-label'>Total stake</span>
+						{activeReportingDetails === undefined ? undefined : (
+							<div className='escalation-sides-legend'>
+								<div className='escalation-sides-legend-item'>
+									<span aria-hidden='true' className='escalation-sides-legend-swatch escalation-sides-legend-swatch-total' />
+									<span className='panel-label'>Total stake</span>
+								</div>
+								<div className='escalation-sides-legend-item'>
+									<span aria-hidden='true' className='escalation-sides-legend-swatch escalation-sides-legend-swatch-user' />
+									<span className='panel-label'>Your stake</span>
+								</div>
+								<div className='escalation-sides-legend-item escalation-sides-legend-item-binding'>
+									<span aria-hidden='true' className='escalation-sides-legend-marker' />
+									<span className='panel-label'>Binding capital</span>
+									<CurrencyValue copyable={false} value={activeReportingDetails.bindingCapital} suffix='REP' />
+								</div>
 							</div>
-							<div className='escalation-sides-legend-item'>
-								<span aria-hidden='true' className='escalation-sides-legend-swatch escalation-sides-legend-swatch-user' />
-								<span className='panel-label'>Your stake</span>
-							</div>
-							<div className='escalation-sides-legend-item escalation-sides-legend-item-binding'>
-								<span aria-hidden='true' className='escalation-sides-legend-marker' />
-								<span className='panel-label'>Binding capital</span>
-								<CurrencyValue copyable={false} value={activeReportingDetails.bindingCapital} suffix='REP' />
-							</div>
-						</div>
+						)}
 					</div>
 					<div className='escalation-sides'>
-						{activeReportingDetails.sides.map(side => {
-							const userStake = side.userDeposits.reduce((sum, deposit) => sum + deposit.amount, 0n)
-
-							return <EscalationSide key={side.key} bindingCapital={activeReportingDetails.bindingCapital} chartScaleMax={chartScaleMax} isLeading={leadingOutcome === side.key} isSelected={reportingForm.selectedOutcome === side.key} side={side} userStake={userStake} />
-						})}
+						{outcomeSides.map(side => (
+							<EscalationSide key={side.key} bindingCapital={activeReportingDetails?.bindingCapital} chartScaleMax={chartScaleMax} estimate={side.estimate} isLeading={leadingOutcome === side.key} isSelected={reportingForm.selectedOutcome === side.key} side={side} />
+						))}
 					</div>
 				</SectionBlock>
 			) : undefined}

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -19,6 +19,13 @@ function rep(value: bigint) {
 	return value * 10n ** 18n
 }
 
+function getClosestSection(heading: HTMLElement | null) {
+	if (heading === null) throw new Error('Expected heading to exist')
+	const section = heading.closest('section')
+	if (!(section instanceof HTMLElement)) throw new Error('Expected heading to be inside a section')
+	return section
+}
+
 function createAccountState(overrides: Partial<AccountState> = {}): AccountState {
 	return {
 		address: zeroAddress,
@@ -72,9 +79,9 @@ function createReportingDetails(overrides: Partial<ActiveReportingDetails> = {})
 		resolution: 'none',
 		securityPoolAddress: zeroAddress,
 		sides: [
+			{ balance: rep(1n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
 			{ balance: rep(5n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [createDeposit()] },
 			{ balance: rep(8n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
-			{ balance: rep(1n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
 		],
 		startBond: rep(3n),
 		startingTime: 120n,
@@ -228,17 +235,20 @@ describe('ReportingSection', () => {
 		expect(documentQueries.getByRole('heading', { name: 'Latest Reporting Action' })).not.toBeNull()
 	})
 
-	test('shows escalation metrics without the legacy time-left or start-bond copy', async () => {
+	test('renders escalation metrics inside outcome sides instead of a standalone card', async () => {
 		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps()))
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		expect(documentQueries.queryByText('Current Bond')).toBeNull()
-		expect(documentQueries.getByText('Binding Capital')).not.toBeNull()
-		expect(documentQueries.getByText('Threshold')).not.toBeNull()
-		expect(documentQueries.queryByText('Time Left')).toBeNull()
-		expect(document.body.textContent?.includes('currently uses a start bond of')).toBe(false)
-		expect(document.body.textContent?.includes('The market resolves as No in')).toBe(true)
+		expect(documentQueries.queryByRole('heading', { name: 'Escalation Metrics' })).toBeNull()
+		const outcomeSidesSection = getClosestSection(documentQueries.getByRole('heading', { name: 'Outcome Sides' }))
+		const outcomeSidesQueries = within(outcomeSidesSection)
+		expect(outcomeSidesQueries.getByText('Current Bond')).not.toBeNull()
+		expect(outcomeSidesQueries.getByText('Binding Capital')).not.toBeNull()
+		expect(outcomeSidesQueries.getByText('Threshold')).not.toBeNull()
+		expect(outcomeSidesQueries.getByText('Time Left')).not.toBeNull()
+		expect(outcomeSidesQueries.getByText('Game Start')).not.toBeNull()
+		expect(outcomeSidesQueries.getByText('Start Bond')).not.toBeNull()
 	})
 
 	test('shows a warning dialog instead of locked reporting metrics before the market end time', async () => {
@@ -275,6 +285,32 @@ describe('ReportingSection', () => {
 		const documentQueries = within(document.body)
 		expect(documentQueries.queryByText('Reporting Open')).toBeNull()
 		expect(documentQueries.queryByText(/current escalation lifecycle phase/i)).toBeNull()
+	})
+
+	test('keeps outcome sides visible with placeholder cards before reporting details load', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					reportingDetails: undefined,
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		const outcomeSidesSection = getClosestSection(documentQueries.getByRole('heading', { name: 'Outcome Sides' }))
+		expect(within(outcomeSidesSection).getByText('Load reporting details to populate live stakes, bond progression, and deposit indexes.')).not.toBeNull()
+
+		const sideCards = Array.from(outcomeSidesSection.querySelectorAll('.escalation-side'))
+		expect(sideCards).toHaveLength(3)
+		const sideLabels = sideCards.map(card => {
+			const label = card.querySelector('.panel-label')?.textContent
+			if (label === undefined) throw new Error('Expected side label')
+			return label
+		})
+		expect(sideLabels).toEqual(['Invalid', 'Yes', 'No'])
+		expect(outcomeSidesSection.textContent?.includes('Your deposits: —')).toBe(true)
 	})
 
 	test('disables reporting buttons when deterministic prerequisites are missing', async () => {
@@ -316,7 +352,7 @@ describe('ReportingSection', () => {
 		expectTransactionButtonDisabled(document.body, 'Withdraw Escalation Deposits', 'Escalation deposits cannot be withdrawn until the question is finalized or the game is canceled by an external fork.')
 	})
 
-	test('shows the projected resolution outcome with remaining time', async () => {
+	test('shows the moved time and bond metrics inside outcome sides', async () => {
 		const reportingDetails = createReportingDetails()
 		const renderedComponent = await renderIntoDocument(
 			h(
@@ -332,9 +368,10 @@ describe('ReportingSection', () => {
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		expect(document.body.textContent?.includes(`The market resolves as No in ${formatDuration(300n - 150n)} unless disputed.`)).toBe(true)
-		expect(document.body.textContent?.includes('Game starts at')).toBe(false)
-		expect(document.body.textContent?.includes('start bond')).toBe(false)
+		const outcomeSidesSection = getClosestSection(within(document.body).getByRole('heading', { name: 'Outcome Sides' }))
+		expect(outcomeSidesSection.textContent?.includes(formatDuration(300n - 150n))).toBe(true)
+		expect(outcomeSidesSection.textContent?.includes('The market resolves as')).toBe(false)
+		expect(outcomeSidesSection.textContent?.includes('Game starts at')).toBe(false)
 	})
 
 	test('shows awaiting resolution with zero time left once the escalation end time has passed', async () => {
@@ -346,7 +383,7 @@ describe('ReportingSection', () => {
 		expect(document.body.textContent?.includes(formatDuration(0n))).toBe(true)
 	})
 
-	test('does not show a separate escalation status card before the first report starts the escalation game', async () => {
+	test('shows placeholder outcome sides before the first report starts the escalation game', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(
 				ReportingSection,
@@ -359,10 +396,10 @@ describe('ReportingSection', () => {
 
 		const documentQueries = within(document.body)
 		expect(documentQueries.queryByText('Escalation Metrics')).toBeNull()
-		expect(documentQueries.queryByText('Outcome Sides')).toBeNull()
+		const outcomeSidesSection = getClosestSection(documentQueries.getByRole('heading', { name: 'Outcome Sides' }))
 		expect(documentQueries.queryByRole('heading', { name: 'Escalation Status' })).toBeNull()
-		expect(document.body.textContent?.includes('Reporting is open, but the escalation game has not started yet.')).toBe(false)
-		expect(document.body.textContent?.includes('The first report or contribution will deploy and initialize the escalation game for this pool.')).toBe(false)
+		expect(within(outcomeSidesSection).getByText('Escalation game has not started yet. The first report will populate live stakes, bond progression, and deposit indexes.')).not.toBeNull()
+		expect(outcomeSidesSection.querySelectorAll('.escalation-side')).toHaveLength(3)
 		expectTransactionButtonEnabled(document.body, 'Report / Contribute On Selected Side')
 	})
 
@@ -436,7 +473,7 @@ describe('ReportingSection', () => {
 		expect(document.body.textContent?.includes('Min preset unavailable because another side is already over the current bond.')).toBe(true)
 	})
 
-	test('renders the shared outcome chart without per-side projections or deposit details', async () => {
+	test('renders the shared outcome chart with per-side projections and deposit details', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(
 				ReportingSection,
@@ -451,9 +488,8 @@ describe('ReportingSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		const outcomeSection = documentQueries.getByRole('heading', { name: 'Outcome Sides' }).closest('section')
-		if (outcomeSection === null) throw new Error('Expected outcome sides section')
-		const outcomeSectionQueries = within(outcomeSection as HTMLElement)
+		const outcomeSection = getClosestSection(documentQueries.getByRole('heading', { name: 'Outcome Sides' }))
+		const outcomeSectionQueries = within(outcomeSection)
 
 		expect(outcomeSectionQueries.getByText('Bars show total REP on each outcome. The marker shows current binding capital, and the thin inset shows your wallet stake.')).not.toBeNull()
 		expect(outcomeSectionQueries.getAllByText('Total stake').length).toBeGreaterThan(0)
@@ -461,9 +497,9 @@ describe('ReportingSection', () => {
 		expect(outcomeSectionQueries.getByText('Binding capital')).not.toBeNull()
 		expect(outcomeSectionQueries.getByText('Leading')).not.toBeNull()
 		expect(outcomeSectionQueries.getByText('Selected')).not.toBeNull()
-		expect(outcomeSection.textContent?.includes('Projected payout for current amount')).toBe(false)
-		expect(outcomeSection.textContent?.includes('Projected profit if this side wins')).toBe(false)
-		expect(outcomeSection.textContent?.includes('Your deposits:')).toBe(false)
+		expect(outcomeSection.textContent?.includes('Projected payout for current amount')).toBe(true)
+		expect(outcomeSection.textContent?.includes('Projected profit if this side wins')).toBe(true)
+		expect(outcomeSection.textContent?.includes('Your deposits:')).toBe(true)
 	})
 
 	test('renders withdraw-only messages and enables selectable deposits once withdrawal is allowed', async () => {

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -295,7 +295,7 @@ describe('ReportingSection', () => {
 		expect(documentQueries.queryByText(/current escalation lifecycle phase/i)).toBeNull()
 	})
 
-	test('keeps outcome sides visible with placeholder cards before reporting details load', async () => {
+	test('keeps outcome sides visible with zeroed cards before reporting details load', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(
 				ReportingSection,
@@ -308,7 +308,7 @@ describe('ReportingSection', () => {
 
 		const documentQueries = within(document.body)
 		const outcomeSidesSection = getClosestSection(documentQueries.getByRole('heading', { name: 'Outcome Sides' }))
-		expect(within(outcomeSidesSection).getByText('Load reporting details to populate live stakes, bond progression, and deposit indexes.')).not.toBeNull()
+		expect(within(outcomeSidesSection).queryByText('Load reporting details to populate live stakes, bond progression, and deposit indexes.')).toBeNull()
 
 		const sideCards = Array.from(outcomeSidesSection.querySelectorAll('.escalation-side'))
 		expect(sideCards).toHaveLength(3)
@@ -318,7 +318,8 @@ describe('ReportingSection', () => {
 			return label
 		})
 		expect(sideLabels).toEqual(['Invalid', 'Yes', 'No'])
-		expect(outcomeSidesSection.textContent?.includes('Your deposits: —')).toBe(true)
+		expect(outcomeSidesSection.textContent?.includes('Your deposits: None')).toBe(true)
+		expect(outcomeSidesSection.querySelector('[title="0 REP"]')).not.toBeNull()
 	})
 
 	test('disables reporting buttons when deterministic prerequisites are missing', async () => {
@@ -391,7 +392,7 @@ describe('ReportingSection', () => {
 		expect(document.body.textContent?.includes(formatDuration(0n))).toBe(true)
 	})
 
-	test('shows placeholder outcome sides before the first report starts the escalation game', async () => {
+	test('shows zeroed outcome sides before the first report starts the escalation game', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(
 				ReportingSection,
@@ -406,8 +407,10 @@ describe('ReportingSection', () => {
 		expect(documentQueries.queryByText('Escalation Metrics')).toBeNull()
 		const outcomeSidesSection = getClosestSection(documentQueries.getByRole('heading', { name: 'Outcome Sides' }))
 		expect(documentQueries.queryByRole('heading', { name: 'Escalation Status' })).toBeNull()
-		expect(within(outcomeSidesSection).getByText('Escalation game has not started yet. The first report will populate live stakes, bond progression, and deposit indexes.')).not.toBeNull()
+		expect(within(outcomeSidesSection).queryByText('Escalation game has not started yet. The first report will populate live stakes, bond progression, and deposit indexes.')).toBeNull()
 		expect(outcomeSidesSection.querySelectorAll('.escalation-side')).toHaveLength(3)
+		expect(outcomeSidesSection.textContent?.includes('Your deposits: None')).toBe(true)
+		expect(outcomeSidesSection.querySelector('[title="0 REP"]')).not.toBeNull()
 		expectTransactionButtonEnabled(document.body, 'Report / Contribute On Selected Side')
 	})
 

--- a/ui/ts/tests/securityPoolWorkflowSection.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection.test.tsx
@@ -1517,10 +1517,13 @@ describe('SecurityPoolWorkflowSection', () => {
 		const documentQueries = within(document.body)
 		expect(documentQueries.getAllByRole('heading', { name: 'Question' }).length).toBe(1)
 		expect(documentQueries.getByRole('heading', { name: 'Reporting Context' })).not.toBeNull()
+		expect(documentQueries.getByRole('heading', { name: 'Outcome Sides' })).not.toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Report Outcome' })).not.toBeNull()
 		expect(documentQueries.queryByRole('heading', { name: 'Withdraw Escalation Deposits' })).toBeNull()
+		expect(documentQueries.getByText('Load reporting details to populate live stakes, bond progression, and deposit indexes.')).not.toBeNull()
 		expect(documentQueries.queryByText('Reporting unlocks after the market end timestamp for the selected pool.')).toBeNull()
 		expect(documentQueries.queryByText('Reporting opens after market end.')).toBeNull()
+		expect(document.body.querySelectorAll('.escalation-side')).toHaveLength(3)
 
 		const reportButton = documentQueries.getByRole('button', { name: 'Report / Contribute On Selected Side' }) as HTMLButtonElement
 		expect(reportButton.disabled).toBe(true)

--- a/ui/ts/tests/securityPoolWorkflowSection.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection.test.tsx
@@ -1520,10 +1520,11 @@ describe('SecurityPoolWorkflowSection', () => {
 		expect(documentQueries.getByRole('heading', { name: 'Outcome Sides' })).not.toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Report Outcome' })).not.toBeNull()
 		expect(documentQueries.queryByRole('heading', { name: 'Withdraw Escalation Deposits' })).toBeNull()
-		expect(documentQueries.getByText('Load reporting details to populate live stakes, bond progression, and deposit indexes.')).not.toBeNull()
+		expect(documentQueries.queryByText('Load reporting details to populate live stakes, bond progression, and deposit indexes.')).toBeNull()
 		expect(documentQueries.queryByText('Reporting unlocks after the market end timestamp for the selected pool.')).toBeNull()
 		expect(documentQueries.queryByText('Reporting opens after market end.')).toBeNull()
 		expect(document.body.querySelectorAll('.escalation-side')).toHaveLength(3)
+		expect(document.body.textContent?.includes('Your deposits: None')).toBe(true)
 
 		const reportButton = documentQueries.getByRole('button', { name: 'Report / Contribute On Selected Side' }) as HTMLButtonElement
 		expect(reportButton.disabled).toBe(true)


### PR DESCRIPTION
## Summary
- Redesigned the reporting outcome-side section with richer stake visualization, binding-capital markers, and clearer selected/leading state treatment.
- Replaced free-form withdrawal index input with checkbox-based selection of owned unsettled deposits on the chosen side.
- Added reporting presets for minimum outcome-change and max-profit contributions, plus improved lock/start hints and projected payout messaging.
- Expanded reporting-domain and guard logic to account for withdrawal eligibility, non-decision thresholds, and external fork-finalized resolution state.
- Added and updated UI, domain, guard, and workflow tests to cover the new reporting and withdrawal behavior.

## Testing
- Not run (PR content only).
- The branch diff includes new/updated tests in `ui/ts/tests/reportingDomain.test.ts`, `ui/ts/tests/reportingGuards.test.ts`, `ui/ts/tests/reportingSection.test.tsx`, and related workflow coverage.