### PR TITLE
Refine reporting, escalation, and action feedback UX

### DIFF
--- a/solidity/contracts/peripherals/SecurityPool.sol
+++ b/solidity/contracts/peripherals/SecurityPool.sol
@@ -114,6 +114,10 @@ contract SecurityPool is ISecurityPool {
 		return vaults.length;
 	}
 
+	function initialEscalationGameDeposit() external pure returns (uint256) {
+		return TODO_INITIAL_ESCALATION_GAME_DEPOSIT;
+	}
+
 	function getVaults(uint256 startIndex, uint256 count) external view returns (address[] memory vaultRange) {
 		if (startIndex >= vaults.length || count == 0) return new address[](0);
 

--- a/solidity/contracts/peripherals/interfaces/ISecurityPool.sol
+++ b/solidity/contracts/peripherals/interfaces/ISecurityPool.sol
@@ -64,6 +64,7 @@ interface ISecurityPool {
 	function getAvailableRepBalance() external view returns (uint256);
 	function getTotalRepBalance() external view returns (uint256);
 	function isEscalationResolved() external view returns (bool);
+	function initialEscalationGameDeposit() external pure returns (uint256);
 
 	function setStartingParams(uint256 currentRetentionRate, uint256 completeSetCollateralAmount) external;
 

--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -2532,6 +2532,11 @@ strong.metric-value-danger {
 	gap: 0.9rem;
 }
 
+.reporting-header-stack {
+	display: grid;
+	gap: 1rem;
+}
+
 .stage-list,
 .requirements-checklist {
 	margin: 0;

--- a/ui/dist/css/index.css
+++ b/ui/dist/css/index.css
@@ -2532,6 +2532,11 @@ strong.metric-value-danger {
 	gap: 0.9rem;
 }
 
+.reporting-header-stack {
+	display: grid;
+	gap: 1rem;
+}
+
 .stage-list,
 .requirements-checklist {
 	margin: 0;

--- a/ui/ts/components/EscalationSide.tsx
+++ b/ui/ts/components/EscalationSide.tsx
@@ -11,12 +11,6 @@ type EscalationSideDisplay = {
 type EscalationSideProps = {
 	bindingCapital: bigint | undefined
 	chartScaleMax: bigint
-	estimate:
-		| {
-				profit: bigint
-				payout: bigint
-		  }
-		| undefined
 	isLeading: boolean
 	isSelected: boolean
 	side: EscalationSideDisplay
@@ -32,9 +26,7 @@ function getChartRatio(value: bigint | undefined, maxValue: bigint) {
 	return `${wholePercent.toString()}.${fractionalPercent}%`
 }
 
-export function EscalationSide({ bindingCapital, chartScaleMax, estimate, isLeading, isSelected, side }: EscalationSideProps) {
-	const depositIndexes = side.userDeposits === undefined ? '—' : side.userDeposits.map(deposit => deposit.depositIndex.toString()).join(', ') || 'None'
-
+export function EscalationSide({ bindingCapital, chartScaleMax, isLeading, isSelected, side }: EscalationSideProps) {
 	return (
 		<div
 			className={`escalation-side ${isSelected ? 'selected' : ''} ${isLeading ? 'leading' : ''}`}
@@ -72,13 +64,6 @@ export function EscalationSide({ bindingCapital, chartScaleMax, estimate, isLead
 					</div>
 				</div>
 			</div>
-			<p className='detail'>Your deposits: {depositIndexes}</p>
-			<p className='detail'>
-				Projected payout for current amount: <CurrencyValue copyable={false} value={estimate?.payout} suffix='REP' />
-			</p>
-			<p className='detail'>
-				Projected profit if this side wins: <CurrencyValue copyable={false} value={estimate?.profit} suffix='REP' />
-			</p>
 		</div>
 	)
 }

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -1,10 +1,9 @@
-import { AddressValue } from './AddressValue.js'
 import { CurrencyValue } from './CurrencyValue.js'
-import { EntityCard } from './EntityCard.js'
 import { EnumDropdown } from './EnumDropdown.js'
 import { ErrorNotice } from './ErrorNotice.js'
 import { FormInput } from './FormInput.js'
 import { EscalationSide } from './EscalationSide.js'
+import { LifecycleStageBanner } from './LifecycleStageBanner.js'
 import { LookupFieldRow } from './LookupFieldRow.js'
 import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
@@ -12,56 +11,45 @@ import { RouteWorkflowPanel } from './RouteWorkflowPanel.js'
 import { SectionBlock } from './SectionBlock.js'
 import { TransactionActionButton } from './TransactionActionButton.js'
 import { TimestampValue } from './TimestampValue.js'
-import { WarningSurface } from './WarningSurface.js'
 import { formatCurrencyInputBalance, formatDuration } from '../lib/formatters.js'
 import { parseOptionalRepAmountInput } from '../lib/marketForm.js'
 import { isMainnetChain } from '../lib/network.js'
+import { calculateEstimatedEscalationReturn, getEscalationPhase, getEscalationTimeRemaining, getLeadingEscalationOutcome, getReportingMaxProfitContribution, getReportingMinimumOutcomeChangeContribution, previewReportingContribution } from '../lib/reportingDomain.js'
 import { getReportingReportGuardMessage, getReportingWithdrawGuardMessage } from '../lib/reportingGuards.js'
 import { REPORTING_OUTCOME_DROPDOWN_OPTIONS, getReportingOutcomeLabel } from '../lib/reporting.js'
-import { calculateEstimatedEscalationReturn, getEscalationPhase, getEscalationTimeRemaining, getLeadingEscalationOutcome, getMaxProfitContribution, getMinimumOutcomeChangeContribution, previewReportingContribution } from '../lib/reportingDomain.js'
-import type { ReportingSectionProps } from '../types/components.js'
-import type { ActiveReportingDetails, EscalationDeposit, ReportingOutcomeKey } from '../types/contracts.js'
+import type { LifecycleStagePresentation, ReportingSectionProps } from '../types/components.js'
+import type { ActiveReportingDetails, EscalationDeposit, ReportingDetails, ReportingOutcomeKey } from '../types/contracts.js'
 
 type ReportingStatus = 'active' | 'missing' | 'not-started'
 
 type EscalationSideDisplay = {
 	balance: bigint | undefined
-	estimate:
-		| {
-				profit: bigint
-				payout: bigint
-		  }
-		| undefined
 	key: ReportingOutcomeKey
 	label: string
 	userDeposits: EscalationDeposit[] | undefined
 	userStake: bigint | undefined
 }
 
-const ZERO_REP = 0n
+const MAX_PROFIT_NOT_STARTED_REASON = 'Max profit becomes available after the escalation game starts.'
+const LOAD_REPORTING_PRESETS_REASON = 'Load reporting details before using presets.'
 
-function getOutcomeSides({ activeReportingDetails, selectedAmount }: { activeReportingDetails: ActiveReportingDetails | undefined; selectedAmount: bigint | undefined }) {
+function getOutcomeSides(activeReportingDetails: ActiveReportingDetails | undefined) {
 	if (activeReportingDetails !== undefined) {
-		return activeReportingDetails.sides.map<EscalationSideDisplay>(side => {
-			const userStake = side.userDeposits.reduce((sum, deposit) => sum + deposit.amount, 0n)
-			return {
-				balance: side.balance,
-				estimate: selectedAmount === undefined ? undefined : calculateEstimatedEscalationReturn(activeReportingDetails, side.key, selectedAmount),
-				key: side.key,
-				label: side.label,
-				userDeposits: side.userDeposits,
-				userStake,
-			}
-		})
+		return activeReportingDetails.sides.map<EscalationSideDisplay>(side => ({
+			balance: side.balance,
+			key: side.key,
+			label: side.label,
+			userDeposits: side.userDeposits,
+			userStake: side.userDeposits.reduce((sum, deposit) => sum + deposit.amount, 0n),
+		}))
 	}
 
 	return REPORTING_OUTCOME_DROPDOWN_OPTIONS.map<EscalationSideDisplay>(option => ({
-		balance: ZERO_REP,
-		estimate: undefined,
+		balance: undefined,
 		key: option.value,
 		label: option.label,
-		userDeposits: [],
-		userStake: ZERO_REP,
+		userDeposits: undefined,
+		userStake: undefined,
 	}))
 }
 
@@ -69,27 +57,92 @@ function getDepositEntryCountLabel(count: number) {
 	return count === 1 ? 'entry' : 'entries'
 }
 
-function isPresetLoadReason(reason: string | undefined) {
-	return reason === 'Load reporting details before using presets.'
+function isHiddenPresetReason(reason: string | undefined) {
+	return reason === LOAD_REPORTING_PRESETS_REASON || reason === MAX_PROFIT_NOT_STARTED_REASON
 }
 
-function renderReportingContextStatus(effectiveCurrentTimestamp: bigint | undefined, marketDetails: ReportingSectionProps['previewMarketDetails']) {
+function getReportingStagePresentation({
+	effectiveCurrentTimestamp,
+	marketDetails,
+	reportingDetails,
+}: {
+	effectiveCurrentTimestamp: bigint | undefined
+	marketDetails: ReportingDetails['marketDetails'] | ReportingSectionProps['previewMarketDetails']
+	reportingDetails: ReportingDetails | undefined
+}): LifecycleStagePresentation | undefined {
 	if (effectiveCurrentTimestamp === undefined || marketDetails === undefined) return undefined
+
 	if (marketDetails.endTime > effectiveCurrentTimestamp) {
-		return (
-			<WarningSurface as='div' className='transaction-action-status warning' role='status' variant='compact'>
-				<p className='detail transaction-action-status-detail'>Reporting is not enabled. Opens in {formatDuration(marketDetails.endTime - effectiveCurrentTimestamp)}.</p>
-			</WarningSurface>
-		)
+		return {
+			availableActions: [],
+			blockedActions: ['report'],
+			detail: 'Reporting opens after the market end timestamp for this pool.',
+			key: 'reporting-not-enabled',
+			label: 'Reporting Not Enabled',
+			tone: 'warning',
+		}
 	}
 
-	return (
-		<div className='transaction-action-status success' role='status'>
-			<p className='detail transaction-action-status-detail'>
-				Reporting is open. Market ended at <TimestampValue currentTimestamp={effectiveCurrentTimestamp} timestamp={marketDetails.endTime} /> ({formatDuration(effectiveCurrentTimestamp - marketDetails.endTime)} ago).
-			</p>
-		</div>
-	)
+	if (reportingDetails === undefined) {
+		return {
+			availableActions: [],
+			blockedActions: [],
+			detail: 'Load reporting details to view the escalation state for this pool.',
+			key: 'reporting-open',
+			label: 'Reporting Open',
+			tone: 'default',
+		}
+	}
+
+	if (reportingDetails.status === 'not-started') {
+		return {
+			availableActions: ['first-report'],
+			blockedActions: [],
+			detail: 'This pool does not have an escalation game yet. The first report or contribution will deploy it.',
+			key: 'first-report-starts-escalation',
+			label: 'First Report Starts Escalation',
+			tone: 'default',
+		}
+	}
+
+	switch (getEscalationPhase(reportingDetails)) {
+		case 'Pending Start':
+			return {
+				availableActions: [],
+				blockedActions: [],
+				detail: 'The escalation game has been initialized and will start at the scheduled start time.',
+				key: 'escalation-pending-start',
+				label: 'Pending Start',
+				tone: 'default',
+			}
+		case 'Active':
+			return {
+				availableActions: [],
+				blockedActions: [],
+				detail: 'Escalation is live. Review the bond, side balances, and time remaining before contributing or withdrawing.',
+				key: 'escalation-active',
+				label: 'Active',
+				tone: 'default',
+			}
+		case 'Awaiting Resolution':
+			return {
+				availableActions: [],
+				blockedActions: [],
+				detail: 'Escalation has reached its end time and is waiting for final resolution.',
+				key: 'escalation-awaiting-resolution',
+				label: 'Awaiting Resolution',
+				tone: 'default',
+			}
+		case 'Resolved':
+			return {
+				availableActions: [],
+				blockedActions: [],
+				detail: 'Escalation has resolved. Review the final state and any remaining deposits below.',
+				key: 'escalation-resolved',
+				label: 'Resolved',
+				tone: 'success',
+			}
+	}
 }
 
 export function ReportingSection({
@@ -128,15 +181,10 @@ export function ReportingSection({
 	const reportContributionPreview = reportingDetails === undefined || selectedAmount === undefined ? undefined : previewReportingContribution(reportingDetails, reportingForm.selectedOutcome, selectedAmount)
 	const actualReportDepositAmount = reportContributionPreview?.actualDepositAmount
 	const selectedEstimate = activeReportingDetails === undefined || selectedAmount === undefined ? undefined : calculateEstimatedEscalationReturn(activeReportingDetails, reportingForm.selectedOutcome, selectedAmount)
-	const outcomeSides = getOutcomeSides({
-		activeReportingDetails,
-		selectedAmount,
-	})
-	const presetFallbackReason = reportingStatus === 'not-started' ? 'Escalation game has not started yet.' : 'Load reporting details before using presets.'
-	const minimumOutcomeChangeContribution = activeReportingDetails === undefined ? { amount: undefined, reason: presetFallbackReason } : getMinimumOutcomeChangeContribution(activeReportingDetails, reportingForm.selectedOutcome)
-	const maxProfitContribution = activeReportingDetails === undefined ? { amount: undefined, reason: presetFallbackReason } : getMaxProfitContribution(activeReportingDetails, reportingForm.selectedOutcome)
-	const presetReasons = reportingLocked ? [] : [minimumOutcomeChangeContribution.reason, maxProfitContribution.reason].filter((reason, index, reasons): reason is string => reason !== undefined && reasons.indexOf(reason) === index)
-	const escalationTimeRemaining = activeReportingDetails === undefined ? formatDuration(ZERO_REP) : formatDuration(getEscalationTimeRemaining(activeReportingDetails))
+	const outcomeSides = getOutcomeSides(activeReportingDetails)
+	const minimumOutcomeChangeContribution = getReportingMinimumOutcomeChangeContribution(reportingDetails, reportingForm.selectedOutcome)
+	const maxProfitContribution = getReportingMaxProfitContribution(reportingDetails, reportingForm.selectedOutcome)
+	const presetReasons = reportingLocked ? [] : [minimumOutcomeChangeContribution.reason, maxProfitContribution.reason].filter((reason, index, reasons): reason is string => reason !== undefined && !isHiddenPresetReason(reason) && reasons.indexOf(reason) === index)
 	const reportAmountError = selectedAmount === undefined && reportingForm.reportAmount.trim() !== '' ? 'Enter a valid report amount to preview profit.' : undefined
 	const reportGuardMessage = getReportingReportGuardMessage({
 		actualDepositAmount: actualReportDepositAmount,
@@ -159,12 +207,19 @@ export function ReportingSection({
 		withdrawalEnabled: activeReportingDetails?.withdrawalEnabled ?? false,
 		withdrawalState: reportingDetails?.withdrawalState,
 	})
-	const reportingContextStatus = renderReportingContextStatus(effectiveCurrentTimestamp, marketDetails)
+	const reportingStage = showFullReporting
+		? getReportingStagePresentation({
+				effectiveCurrentTimestamp,
+				marketDetails,
+				reportingDetails,
+			})
+		: undefined
+	const showReportingHeaderStack = showFullReporting && (showSecurityPoolAddressInput || reportingStage !== undefined)
 
 	const sections = (
 		<>
-			{showFullReporting ? (
-				<EntityCard title='Reporting Context' variant='record' badge={activeReportingDetails === undefined ? undefined : <span className='badge ok'>{getEscalationPhase(activeReportingDetails)}</span>}>
+			{showReportingHeaderStack ? (
+				<div className='reporting-header-stack'>
 					{showSecurityPoolAddressInput ? (
 						<LookupFieldRow
 							label='Security Pool Address'
@@ -178,39 +233,28 @@ export function ReportingSection({
 							}
 						/>
 					) : undefined}
-					{reportingContextStatus}
-
-					{activeReportingDetails === undefined ? undefined : (
-						<ul className='status-list hashes'>
-							<li>
-								<span>Escalation Game</span>
-								<strong>
-									<AddressValue address={activeReportingDetails.escalationGameAddress} />
-								</strong>
-							</li>
-						</ul>
-					)}
-				</EntityCard>
+					<LifecycleStageBanner stage={reportingStage} />
+				</div>
 			) : undefined}
 
 			{showFullReporting ? (
 				<SectionBlock title='Outcome Sides' {...(activeReportingDetails === undefined ? {} : { description: 'Bars show total REP on each outcome. The marker shows current binding capital, and the thin inset shows your wallet stake.' })}>
 					<div className='escalation-metrics'>
 						<MetricField label='Current Bond'>
-							<CurrencyValue value={activeReportingDetails?.currentRequiredBond ?? ZERO_REP} suffix='REP' />
+							<CurrencyValue value={activeReportingDetails?.currentRequiredBond} suffix='REP' />
 						</MetricField>
 						<MetricField label='Binding Capital'>
-							<CurrencyValue value={activeReportingDetails?.bindingCapital ?? ZERO_REP} suffix='REP' />
+							<CurrencyValue value={activeReportingDetails?.bindingCapital} suffix='REP' />
 						</MetricField>
 						<MetricField label='Threshold'>
-							<CurrencyValue value={activeReportingDetails?.nonDecisionThreshold ?? ZERO_REP} suffix='REP' />
+							<CurrencyValue value={reportingDetails?.nonDecisionThreshold} suffix='REP' />
 						</MetricField>
-						<MetricField label='Time Left'>{escalationTimeRemaining}</MetricField>
+						<MetricField label='Time Left'>{activeReportingDetails === undefined ? '—' : formatDuration(getEscalationTimeRemaining(activeReportingDetails))}</MetricField>
 						<MetricField label='Game Start'>
 							<TimestampValue {...(effectiveCurrentTimestamp === undefined ? {} : { currentTimestamp: effectiveCurrentTimestamp })} timestamp={activeReportingDetails?.startingTime} />
 						</MetricField>
 						<MetricField label='Start Bond'>
-							<CurrencyValue value={activeReportingDetails?.startBond ?? ZERO_REP} suffix='REP' />
+							<CurrencyValue value={reportingDetails?.startBond} suffix='REP' />
 						</MetricField>
 					</div>
 					<div className='escalation-sides-shell'>
@@ -234,7 +278,7 @@ export function ReportingSection({
 					</div>
 					<div className='escalation-sides'>
 						{outcomeSides.map(side => (
-							<EscalationSide key={side.key} bindingCapital={activeReportingDetails?.bindingCapital} chartScaleMax={chartScaleMax} estimate={side.estimate} isLeading={leadingOutcome === side.key} isSelected={reportingForm.selectedOutcome === side.key} side={side} />
+							<EscalationSide key={side.key} bindingCapital={activeReportingDetails?.bindingCapital} chartScaleMax={chartScaleMax} isLeading={leadingOutcome === side.key} isSelected={reportingForm.selectedOutcome === side.key} side={side} />
 						))}
 					</div>
 				</SectionBlock>
@@ -247,7 +291,6 @@ export function ReportingSection({
 							Selected side currently has <CurrencyValue value={selectedSide.balance} suffix='REP' /> deposited.
 						</p>
 					)}
-					<p className='detail'>Reporting locks REP already deposited in your security vault. It does not spend wallet REP directly or require a wallet approval.</p>
 					{reportingDetails?.viewerVaultAvailableEscalationRep === undefined ? undefined : (
 						<p className='detail'>
 							Available unlocked vault REP for reporting: <CurrencyValue value={reportingDetails.viewerVaultAvailableEscalationRep} suffix='REP' />.
@@ -290,13 +333,11 @@ export function ReportingSection({
 						</button>
 					</div>
 
-					{presetReasons
-						.filter(reason => !isPresetLoadReason(reason))
-						.map(reason => (
-							<p key={reason} className='detail'>
-								{reason}
-							</p>
-						))}
+					{presetReasons.map(reason => (
+						<p key={reason} className='detail'>
+							{reason}
+						</p>
+					))}
 					{reportAmountError === undefined ? undefined : <p className='detail'>{reportAmountError}</p>}
 
 					{selectedEstimate === undefined ? undefined : (

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -222,7 +222,7 @@ async function loadViewerReportingVaultState(client: ReadClient, securityPoolAdd
 }
 
 export async function loadReportingDetails(client: ReadClient, securityPoolAddress: Address, accountAddress: Address | undefined): Promise<ReportingDetails> {
-	const [questionId, escalationGameAddress, completeSetCollateralAmount, universeId] = await readRequiredMulticall(client, [
+	const [questionId, escalationGameAddress, completeSetCollateralAmount, universeId, zoltarAddress, initialEscalationGameDeposit] = await readRequiredMulticall(client, [
 		{
 			abi: peripherals_SecurityPool_SecurityPool.abi,
 			functionName: 'questionId',
@@ -247,12 +247,30 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 			address: securityPoolAddress,
 			args: [],
 		},
+		{
+			abi: peripherals_SecurityPool_SecurityPool.abi,
+			functionName: 'zoltar',
+			address: securityPoolAddress,
+			args: [],
+		},
+		{
+			abi: peripherals_SecurityPool_SecurityPool.abi,
+			functionName: 'initialEscalationGameDeposit',
+			address: securityPoolAddress,
+			args: [],
+		},
 	])
-	const [marketDetails, block, escalationGameCode, viewerVaultState] = await Promise.all([
+	const [marketDetails, block, escalationGameCode, viewerVaultState, forkThreshold] = await Promise.all([
 		loadMarketDetails(client, questionId),
 		client.getBlock(),
 		escalationGameAddress === zeroAddress ? Promise.resolve('0x' as const) : client.getCode({ address: escalationGameAddress }),
 		loadViewerReportingVaultState(client, securityPoolAddress, accountAddress),
+		client.readContract({
+			abi: Zoltar_Zoltar.abi,
+			address: zoltarAddress,
+			functionName: 'getForkThreshold',
+			args: [universeId],
+		}),
 	])
 	if (!hasTimestamp(block)) throw new Error('Unexpected block response')
 	if (escalationGameAddress === zeroAddress || escalationGameCode === undefined || escalationGameCode === '0x') {
@@ -260,9 +278,11 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 			completeSetCollateralAmount,
 			currentTime: block.timestamp,
 			marketDetails,
+			nonDecisionThreshold: forkThreshold / 2n,
 			questionOutcome: 'none',
 			resolution: 'none',
 			securityPoolAddress,
+			startBond: initialEscalationGameDeposit,
 			status: 'not-started',
 			universeId,
 			withdrawalEnabled: false,

--- a/ui/ts/hooks/useReportingOperations.ts
+++ b/ui/ts/hooks/useReportingOperations.ts
@@ -130,7 +130,7 @@ export function useReportingOperations({ accountAddress, onTransaction, onTransa
 			async (walletAddress, securityPoolAddress, currentForm) => {
 				const latestDetails = await loadReportingDetails(createConnectedReadClient(), securityPoolAddress, walletAddress)
 				if (latestDetails.status !== 'active') {
-					throw new Error('Escalation game has not started yet')
+					throw new Error('Withdrawals are unavailable until the first report or contribution deploys the escalation game.')
 				}
 				const selectedSide = latestDetails.sides.find(side => side.key === currentForm.selectedOutcome)
 				const availableDepositIndexes = selectedSide?.userDeposits.map(deposit => deposit.depositIndex) ?? []

--- a/ui/ts/lib/reportingDomain.ts
+++ b/ui/ts/lib/reportingDomain.ts
@@ -9,6 +9,10 @@ type ReportingAmountSuggestion = {
 }
 
 const REP_UNIT = 10n ** 18n
+const LOAD_REPORTING_PRESETS_REASON = 'Load reporting details before using presets.'
+const MAX_PROFIT_NOT_STARTED_REASON = 'Max profit becomes available after the escalation game starts.'
+const SELECTED_SIDE_ALREADY_LEADS_REASON = 'Selected side already leads.'
+const ESCALATION_RESOLVED_REASON = 'Escalation is already resolved.'
 
 function roundUpToRepUnit(value: bigint) {
 	if (value <= 0n) return 0n
@@ -79,6 +83,39 @@ export function getMinimumOutcomeChangeContribution(details: ActiveReportingDeta
 	return { amount, reason: undefined }
 }
 
+export function getReportingMinimumOutcomeChangeContribution(details: ReportingDetails | undefined, selectedOutcome: ReportingOutcomeKey): ReportingAmountSuggestion {
+	if (details === undefined) {
+		return {
+			amount: undefined,
+			reason: LOAD_REPORTING_PRESETS_REASON,
+		}
+	}
+
+	if (details.status === 'not-started') {
+		return {
+			amount: details.startBond,
+			reason: undefined,
+		}
+	}
+
+	if (details.resolution !== 'none') {
+		return {
+			amount: undefined,
+			reason: ESCALATION_RESOLVED_REASON,
+		}
+	}
+
+	const minContribution = getMinimumOutcomeChangeContribution(details, selectedOutcome)
+	if (minContribution.amount === 0n && minContribution.reason === undefined) {
+		return {
+			amount: undefined,
+			reason: SELECTED_SIDE_ALREADY_LEADS_REASON,
+		}
+	}
+
+	return minContribution
+}
+
 export function getMaxProfitContribution(details: ActiveReportingDetails, selectedOutcome: ReportingOutcomeKey): ReportingAmountSuggestion {
 	const minContribution = getMinimumOutcomeChangeContribution(details, selectedOutcome)
 	if (minContribution.amount === undefined) {
@@ -115,6 +152,31 @@ export function getMaxProfitContribution(details: ActiveReportingDetails, select
 	}
 
 	return { amount, reason: undefined }
+}
+
+export function getReportingMaxProfitContribution(details: ReportingDetails | undefined, selectedOutcome: ReportingOutcomeKey): ReportingAmountSuggestion {
+	if (details === undefined) {
+		return {
+			amount: undefined,
+			reason: LOAD_REPORTING_PRESETS_REASON,
+		}
+	}
+
+	if (details.status === 'not-started') {
+		return {
+			amount: undefined,
+			reason: MAX_PROFIT_NOT_STARTED_REASON,
+		}
+	}
+
+	if (details.resolution !== 'none') {
+		return {
+			amount: undefined,
+			reason: ESCALATION_RESOLVED_REASON,
+		}
+	}
+
+	return getMaxProfitContribution(details, selectedOutcome)
 }
 
 export function calculateEstimatedEscalationReturn(details: ActiveReportingDetails, selectedOutcome: ReportingOutcomeKey, amount: bigint) {
@@ -236,6 +298,13 @@ function previewEscalationContribution(details: ActiveReportingDetails, outcome:
 
 export function previewReportingContribution(details: ReportingDetails, outcome: ReportingOutcomeKey, amount: bigint): ReportingContributionPreview {
 	if (details.status === 'not-started') {
+		if (amount < details.startBond) {
+			return {
+				actualDepositAmount: undefined,
+				reason: `Enter at least ${formatCurrencyBalance(details.startBond)} REP to start the escalation game.`,
+			}
+		}
+
 		return {
 			actualDepositAmount: amount,
 			reason: undefined,

--- a/ui/ts/lib/reportingGuards.ts
+++ b/ui/ts/lib/reportingGuards.ts
@@ -64,7 +64,7 @@ export function getReportingWithdrawGuardMessage({
 	if (accountAddress === undefined) return 'Connect a wallet before withdrawing escalation deposits.'
 	if (!isMainnet) return 'Switch to Ethereum mainnet before withdrawing escalation deposits.'
 	if (reportingStatus === 'missing') return 'Load reporting details before withdrawing escalation deposits.'
-	if (reportingStatus === 'not-started') return 'Escalation game has not started yet.'
+	if (reportingStatus === 'not-started') return 'Withdrawals are unavailable until the first report or contribution deploys the escalation game.'
 	if (!withdrawalEnabled && withdrawalState === 'not-finalized') return 'Escalation deposits cannot be withdrawn until the question is finalized or the game is canceled by an external fork.'
 	if (!hasUserDepositsOnSelectedSide) return 'No deposits are available to withdraw on the selected side.'
 	return undefined

--- a/ui/ts/tests/activeEnvironment.test.ts
+++ b/ui/ts/tests/activeEnvironment.test.ts
@@ -505,6 +505,8 @@ void describe('simulation backend', () => {
 
 			expect(reportingDetails.status).toBe('not-started')
 			expect(reportingDetails.marketDetails.endTime < reportingDetails.currentTime).toBe(true)
+			expect(reportingDetails.startBond > 0n).toBe(true)
+			expect(reportingDetails.nonDecisionThreshold > 0n).toBe(true)
 		} finally {
 			await backend.dispose()
 		}

--- a/ui/ts/tests/reportingDomain.test.ts
+++ b/ui/ts/tests/reportingDomain.test.ts
@@ -2,8 +2,8 @@
 
 import { describe, expect, test } from 'bun:test'
 import { zeroAddress } from 'viem'
-import { calculateEstimatedEscalationReturn, getMaxProfitContribution, getMinimumOutcomeChangeContribution } from '../lib/reportingDomain.js'
-import type { ActiveReportingDetails, MarketDetails } from '../types/contracts.js'
+import { calculateEstimatedEscalationReturn, getMaxProfitContribution, getMinimumOutcomeChangeContribution, getReportingMaxProfitContribution, getReportingMinimumOutcomeChangeContribution, previewReportingContribution } from '../lib/reportingDomain.js'
+import type { ActiveReportingDetails, MarketDetails, ReportingDetails } from '../types/contracts.js'
 
 const REP = 10n ** 18n
 
@@ -58,6 +58,28 @@ function createReportingDetails(overrides: Partial<ActiveReportingDetails> = {})
 		viewerVaultExists: true,
 		viewerVaultLockedRepInEscalationGame: 1n * REP,
 		viewerVaultRepDepositShare: 11n * REP,
+		...overrides,
+	}
+}
+
+function createNotStartedReportingDetails(overrides: Partial<Extract<ReportingDetails, { status: 'not-started' }>> = {}): ReportingDetails {
+	return {
+		completeSetCollateralAmount: 1n,
+		currentTime: 150n,
+		marketDetails: createMarketDetails(),
+		nonDecisionThreshold: rep(50n),
+		questionOutcome: 'none',
+		resolution: 'none',
+		securityPoolAddress: zeroAddress,
+		startBond: rep(3n),
+		status: 'not-started',
+		universeId: 1n,
+		withdrawalEnabled: false,
+		withdrawalState: 'not-finalized',
+		viewerVaultAvailableEscalationRep: 10n * REP,
+		viewerVaultExists: true,
+		viewerVaultLockedRepInEscalationGame: 0n,
+		viewerVaultRepDepositShare: 10n * REP,
 		...overrides,
 	}
 }
@@ -120,6 +142,21 @@ describe('reportingDomain', () => {
 		})
 	})
 
+	test('getReportingMinimumOutcomeChangeContribution disables the preset when the selected side already leads', () => {
+		const details = createReportingDetails({
+			sides: [
+				{ balance: rep(9n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+				{ balance: rep(8n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
+				{ balance: rep(2n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+			],
+		})
+
+		expect(getReportingMinimumOutcomeChangeContribution(details, 'yes')).toEqual({
+			amount: undefined,
+			reason: 'Selected side already leads.',
+		})
+	})
+
 	test('getMinimumOutcomeChangeContribution is unavailable when the selected side cannot lead within remaining room', () => {
 		const details = createReportingDetails({
 			nonDecisionThreshold: rep(20n),
@@ -174,6 +211,49 @@ describe('reportingDomain', () => {
 		expect(getMaxProfitContribution(details, 'yes')).toEqual({
 			amount: undefined,
 			reason: 'Max profit preset unavailable because the reward window is already filled on the selected side.',
+		})
+	})
+
+	test('getReportingMinimumOutcomeChangeContribution returns the first-report minimum before the escalation game exists', () => {
+		expect(getReportingMinimumOutcomeChangeContribution(createNotStartedReportingDetails(), 'yes')).toEqual({
+			amount: rep(3n),
+			reason: undefined,
+		})
+	})
+
+	test('getReportingMaxProfitContribution is unavailable before the escalation game exists', () => {
+		expect(getReportingMaxProfitContribution(createNotStartedReportingDetails(), 'yes')).toEqual({
+			amount: undefined,
+			reason: 'Max profit becomes available after the escalation game starts.',
+		})
+	})
+
+	test('reporting preset helpers disable both presets once the escalation game is resolved', () => {
+		const details = createReportingDetails({
+			resolution: 'yes',
+		})
+
+		expect(getReportingMinimumOutcomeChangeContribution(details, 'yes')).toEqual({
+			amount: undefined,
+			reason: 'Escalation is already resolved.',
+		})
+		expect(getReportingMaxProfitContribution(details, 'yes')).toEqual({
+			amount: undefined,
+			reason: 'Escalation is already resolved.',
+		})
+	})
+
+	test('previewReportingContribution rejects a pre-start amount below the first-report minimum', () => {
+		expect(previewReportingContribution(createNotStartedReportingDetails(), 'yes', rep(2n))).toEqual({
+			actualDepositAmount: undefined,
+			reason: 'Enter at least 3 REP to start the escalation game.',
+		})
+	})
+
+	test('previewReportingContribution accepts a valid pre-start amount', () => {
+		expect(previewReportingContribution(createNotStartedReportingDetails(), 'yes', rep(3n))).toEqual({
+			actualDepositAmount: rep(3n),
+			reason: undefined,
 		})
 	})
 

--- a/ui/ts/tests/reportingGuards.test.ts
+++ b/ui/ts/tests/reportingGuards.test.ts
@@ -157,7 +157,7 @@ describe('reporting guards', () => {
 				withdrawalEnabled: false,
 				withdrawalState: 'not-finalized',
 			}),
-		).toBe('Escalation game has not started yet.')
+		).toBe('Withdrawals are unavailable until the first report or contribution deploys the escalation game.')
 
 		expect(
 			getReportingWithdrawGuardMessage({

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -118,9 +118,11 @@ function createNotStartedReportingDetails(overrides: Partial<Extract<ReportingDe
 		completeSetCollateralAmount: 1n * REP,
 		currentTime: 150n,
 		marketDetails: createMarketDetails(),
+		nonDecisionThreshold: rep(50n),
 		questionOutcome: 'none',
 		resolution: 'none',
 		securityPoolAddress: zeroAddress,
+		startBond: rep(3n),
 		status: 'not-started',
 		universeId: 1n,
 		withdrawalEnabled: false,
@@ -205,22 +207,20 @@ describe('ReportingSection', () => {
 		restoreDomEnvironment = undefined
 	})
 
-	test('renders the reporting workflow without banners or duplicate loaded-market metadata', async () => {
+	test('renders active reporting with a lifecycle banner and no reporting context card', async () => {
 		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps()))
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		expect(documentQueries.getByRole('heading', { name: 'Reporting Context' })).not.toBeNull()
-		expect(documentQueries.queryByRole('heading', { name: 'Pending Start' })).toBeNull()
-		expect(documentQueries.queryByText('The current escalation lifecycle phase is')).toBeNull()
-		expect(documentQueries.queryByText('Reporting contribution submitted')).toBeNull()
-		expect(document.body.textContent?.includes('Selected side currently has')).toBe(true)
-		expect(document.body.textContent?.includes('Withdraw Escalation Deposits')).toBe(false)
+		expect(documentQueries.queryByRole('heading', { name: 'Reporting Context' })).toBeNull()
+		expect(documentQueries.getByRole('heading', { name: 'Active' })).not.toBeNull()
 		expect(documentQueries.getByRole('button', { name: 'Min to change proposed outcome' })).not.toBeNull()
 		expect(documentQueries.getByRole('button', { name: 'Max profit' })).not.toBeNull()
+		expect(document.body.textContent?.includes('Selected side currently has')).toBe(true)
+		expect(document.body.textContent?.includes('Withdraw Escalation Deposits')).toBe(false)
 	})
 
-	test('does not render the pre-reporting warning banner before market end', async () => {
+	test('renders Reporting Not Enabled before market end', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(
 				ReportingSection,
@@ -233,11 +233,30 @@ describe('ReportingSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		expect(documentQueries.queryByRole('heading', { name: 'Pre-Reporting' })).toBeNull()
-		expect(documentQueries.getByRole('heading', { name: 'Reporting Context' })).not.toBeNull()
+		expect(documentQueries.getByRole('heading', { name: 'Reporting Not Enabled' })).not.toBeNull()
+		expect(documentQueries.queryByRole('heading', { name: 'Reporting Context' })).toBeNull()
+		expect(documentQueries.queryByText('Opens In')).toBeNull()
+		expect(document.body.textContent?.includes('Reporting opens after the market end timestamp for this pool.')).toBe(true)
 	})
 
-	test('renders button-local reporting feedback instead of the latest action card', async () => {
+	test('renders Reporting Open when the market has ended but details are not loaded', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					currentTimestamp: 150n,
+					reportingDetails: undefined,
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByRole('heading', { name: 'Reporting Open' })).not.toBeNull()
+		expect(document.body.textContent?.includes('Load reporting details to view the escalation state for this pool.')).toBe(true)
+	})
+
+	test('renders button-local reporting feedback instead of a latest action card', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(
 				ReportingSection,
@@ -253,13 +272,11 @@ describe('ReportingSection', () => {
 		expect(documentQueries.queryByRole('heading', { name: 'Latest Reporting Action' })).toBeNull()
 	})
 
-	test('renders escalation metrics inside outcome sides instead of a standalone card', async () => {
+	test('keeps escalation metrics inside Outcome Sides', async () => {
 		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps()))
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		const documentQueries = within(document.body)
-		expect(documentQueries.queryByRole('heading', { name: 'Escalation Metrics' })).toBeNull()
-		const outcomeSidesSection = getClosestSection(documentQueries.getByRole('heading', { name: 'Outcome Sides' }))
+		const outcomeSidesSection = getClosestSection(within(document.body).getByRole('heading', { name: 'Outcome Sides' }))
 		const outcomeSidesQueries = within(outcomeSidesSection)
 		expect(outcomeSidesQueries.getByText('Current Bond')).not.toBeNull()
 		expect(outcomeSidesQueries.getByText('Binding Capital')).not.toBeNull()
@@ -269,69 +286,20 @@ describe('ReportingSection', () => {
 		expect(outcomeSidesQueries.getByText('Start Bond')).not.toBeNull()
 	})
 
-	test('shows a warning dialog instead of locked reporting metrics before the market end time', async () => {
-		const renderedComponent = await renderIntoDocument(
-			h(
-				ReportingSection,
-				createProps({
-					currentTimestamp: 50n,
-					reportingDetails: undefined,
-				}),
-			),
-		)
+	test('keeps placeholder outcome cards visible before reporting details load', async () => {
+		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps({ reportingDetails: undefined })))
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		const documentQueries = within(document.body)
-		expect(documentQueries.getByText('Reporting is not enabled. Opens in less than a minute.')).not.toBeNull()
-		expect(documentQueries.queryByText('Locked')).toBeNull()
-		expect(documentQueries.queryByText('Opens In')).toBeNull()
+		const outcomeSidesSection = getClosestSection(within(document.body).getByRole('heading', { name: 'Outcome Sides' }))
+		expect(outcomeSidesSection.querySelectorAll('.escalation-side')).toHaveLength(3)
+		expect(outcomeSidesSection.textContent?.includes('Your deposits:')).toBe(false)
+		expect(outcomeSidesSection.textContent?.includes('Projected payout for current amount')).toBe(false)
+		expect(outcomeSidesSection.textContent?.includes('Projected profit if this side wins')).toBe(false)
+		expect(outcomeSidesSection.textContent?.includes('Total stake')).toBe(true)
+		expect(outcomeSidesSection.textContent?.includes('Your stake')).toBe(true)
 	})
 
-	test('shows a single reporting-open status line when escalation details are not loaded yet', async () => {
-		const renderedComponent = await renderIntoDocument(
-			h(
-				ReportingSection,
-				createProps({
-					currentTimestamp: 150n,
-					reportingDetails: undefined,
-				}),
-			),
-		)
-		cleanupRenderedComponent = renderedComponent.cleanup
-
-		const documentQueries = within(document.body)
-		expect(document.body.textContent?.includes('Reporting is open. Market ended at')).toBe(true)
-		expect(documentQueries.queryByText(/current escalation lifecycle phase/i)).toBeNull()
-	})
-
-	test('keeps outcome sides visible with zeroed cards before reporting details load', async () => {
-		const renderedComponent = await renderIntoDocument(
-			h(
-				ReportingSection,
-				createProps({
-					reportingDetails: undefined,
-				}),
-			),
-		)
-		cleanupRenderedComponent = renderedComponent.cleanup
-
-		const documentQueries = within(document.body)
-		const outcomeSidesSection = getClosestSection(documentQueries.getByRole('heading', { name: 'Outcome Sides' }))
-		expect(within(outcomeSidesSection).queryByText('Load reporting details to populate live stakes, bond progression, and deposit indexes.')).toBeNull()
-
-		const sideCards = Array.from(outcomeSidesSection.querySelectorAll('.escalation-side'))
-		expect(sideCards).toHaveLength(3)
-		const sideLabels = sideCards.map(card => {
-			const label = card.querySelector('.panel-label')?.textContent
-			if (label === undefined) throw new Error('Expected side label')
-			return label
-		})
-		expect(sideLabels).toEqual(['Invalid', 'Yes', 'No'])
-		expect(outcomeSidesSection.textContent?.includes('Your deposits: None')).toBe(true)
-		expect(outcomeSidesSection.querySelector('[title="0 REP"]')).not.toBeNull()
-	})
-
-	test('disables reporting buttons when deterministic prerequisites are missing', async () => {
+	test('disables reporting when deterministic prerequisites are missing', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(
 				ReportingSection,
@@ -348,27 +316,9 @@ describe('ReportingSection', () => {
 
 		expectTransactionButtonDisabled(document.body, 'Report / Contribute On Selected Side', 'Connect a wallet before reporting on a market.')
 		expect(document.body.querySelector('button[title="Connect a wallet before withdrawing escalation deposits."]')).toBeNull()
-		expect(document.body.querySelector('.disabled-reason')).toBeNull()
 	})
 
-	test('enables reporting action when the selected side can accept reports', async () => {
-		const renderedComponent = await renderIntoDocument(
-			h(
-				ReportingSection,
-				createProps({
-					reportingForm: createReportingForm({
-						reportAmount: '4',
-					}),
-				}),
-			),
-		)
-		cleanupRenderedComponent = renderedComponent.cleanup
-
-		expectTransactionButtonEnabled(document.body, 'Report / Contribute On Selected Side')
-		expect(document.body.textContent?.includes('Withdraw Escalation Deposits')).toBe(false)
-	})
-
-	test('shows vault-collateral copy and blocks reporting when unlocked vault REP is insufficient', async () => {
+	test('removes the approval explainer copy and still blocks when unlocked vault REP is insufficient', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(
 				ReportingSection,
@@ -376,85 +326,94 @@ describe('ReportingSection', () => {
 					reportingDetails: createReportingDetails({
 						viewerVaultAvailableEscalationRep: 2n * REP,
 					}),
-					reportingForm: {
-						...createReportingForm(),
+					reportingForm: createReportingForm({
 						reportAmount: '5',
-					},
+					}),
 				}),
 			),
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		expect(document.body.textContent?.includes('It does not spend wallet REP directly or require a wallet approval.')).toBe(true)
+		expect(document.body.textContent?.includes('It does not spend wallet REP directly or require a wallet approval.')).toBe(false)
 		expect(document.body.textContent?.includes('Available unlocked vault REP for reporting:')).toBe(true)
 		expectTransactionButtonDisabled(document.body, 'Report / Contribute On Selected Side', 'Need 3 more unlocked REP in your vault before reporting.')
 	})
 
-	test('renders a withdraw-only mode without reporting context or report form', async () => {
+	test('renders a compact withdraw-only mode without the reporting banner or report form', async () => {
 		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps({ mode: 'withdraw-only' })))
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
 		expect(documentQueries.queryByRole('heading', { name: 'Reporting Context' })).toBeNull()
 		expect(documentQueries.queryByRole('heading', { name: 'Report Outcome' })).toBeNull()
+		expect(documentQueries.queryByRole('heading', { name: 'Active' })).toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Withdraw Escalation Deposits' })).not.toBeNull()
 		expectTransactionButtonDisabled(document.body, 'Withdraw Escalation Deposits', 'Escalation deposits cannot be withdrawn until the question is finalized or the game is canceled by an external fork.')
 	})
 
-	test('shows the moved time and bond metrics inside outcome sides', async () => {
+	test('shows the time-left metric inside Outcome Sides', async () => {
 		const reportingDetails = createReportingDetails()
-		const renderedComponent = await renderIntoDocument(
-			h(
-				ReportingSection,
-				createProps({
-					reportingDetails: {
-						...reportingDetails,
-						currentTime: 150n,
-						escalationEndTime: 300n,
-					},
-				}),
-			),
-		)
+		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps({ reportingDetails })))
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const outcomeSidesSection = getClosestSection(within(document.body).getByRole('heading', { name: 'Outcome Sides' }))
 		expect(outcomeSidesSection.textContent?.includes(formatDuration(300n - 150n))).toBe(true)
-		expect(outcomeSidesSection.textContent?.includes('The market resolves as')).toBe(false)
-		expect(outcomeSidesSection.textContent?.includes('Game starts at')).toBe(false)
 	})
 
-	test('shows awaiting resolution with zero time left once the escalation end time has passed', async () => {
+	test('shows Awaiting Resolution with zero time left once the escalation end time has passed', async () => {
 		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps({ reportingDetails: createReportingDetails({ currentTime: 300n, escalationEndTime: 300n }) })))
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		expect(documentQueries.getAllByText('Awaiting Resolution').length).toBeGreaterThan(0)
+		expect(documentQueries.getByRole('heading', { name: 'Awaiting Resolution' })).not.toBeNull()
 		expect(document.body.textContent?.includes(formatDuration(0n))).toBe(true)
 	})
 
-	test('shows zeroed outcome sides before the first report starts the escalation game', async () => {
+	test('renders pre-start metrics and placeholders before the first report starts escalation', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(
 				ReportingSection,
 				createProps({
 					reportingDetails: createNotStartedReportingDetails(),
+					reportingForm: createReportingForm({
+						reportAmount: '3',
+					}),
 				}),
 			),
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		expect(documentQueries.queryByText('Escalation Metrics')).toBeNull()
 		const outcomeSidesSection = getClosestSection(documentQueries.getByRole('heading', { name: 'Outcome Sides' }))
-		expect(documentQueries.queryByRole('heading', { name: 'Escalation Status' })).toBeNull()
-		expect(within(outcomeSidesSection).queryByText('Escalation game has not started yet. The first report will populate live stakes, bond progression, and deposit indexes.')).toBeNull()
-		expect(outcomeSidesSection.querySelectorAll('.escalation-side')).toHaveLength(3)
-		expect(outcomeSidesSection.textContent?.includes('Your deposits: None')).toBe(true)
-		expect(outcomeSidesSection.querySelector('[title="0 REP"]')).not.toBeNull()
+		expect(documentQueries.getByRole('heading', { name: 'First Report Starts Escalation' })).not.toBeNull()
+		expect(outcomeSidesSection.textContent?.includes('Your deposits:')).toBe(false)
+		expect(outcomeSidesSection.textContent?.includes('Projected payout for current amount')).toBe(false)
+		expect(outcomeSidesSection.textContent?.includes('Projected profit if this side wins')).toBe(false)
+		expect(outcomeSidesSection.querySelector('[title="50 REP"]')).not.toBeNull()
+		expect(outcomeSidesSection.querySelector('[title="3 REP"]')).not.toBeNull()
+		expect(outcomeSidesSection.querySelectorAll('.currency-value.unavailable').length).toBeGreaterThanOrEqual(2)
+		expect(document.body.textContent?.includes('Load reporting details to populate live stakes')).toBe(false)
 		expectTransactionButtonEnabled(document.body, 'Report / Contribute On Selected Side')
 	})
 
-	test('accepts decimal report amounts for profit preview', async () => {
+	test('disables report submission for a pre-start amount below the first-report minimum', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					reportingDetails: createNotStartedReportingDetails(),
+					reportingForm: createReportingForm({
+						reportAmount: '2',
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expectTransactionButtonDisabled(document.body, 'Report / Contribute On Selected Side', 'Enter at least 3 REP to start the escalation game.')
+	})
+
+	test('accepts decimal report amounts for the profit preview', async () => {
 		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps({ reportingForm: createReportingForm({ reportAmount: '1.5' }) })))
 		cleanupRenderedComponent = renderedComponent.cleanup
 
@@ -462,7 +421,7 @@ describe('ReportingSection', () => {
 		expect(document.body.textContent?.includes('Enter a valid report amount to preview profit.')).toBe(false)
 	})
 
-	test('autofills the report amount for the minimum outcome change preset', async () => {
+	test('autofills the active minimum-outcome-change preset', async () => {
 		const renderedComponent = await renderIntoDocument(<ReportingSectionHarness />)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
@@ -474,7 +433,7 @@ describe('ReportingSection', () => {
 		expect((amountInput as HTMLInputElement).value).toBe('4')
 	})
 
-	test('autofills the report amount for the max profit preset and updates the preview', async () => {
+	test('autofills the active max-profit preset and updates the preview', async () => {
 		const renderedComponent = await renderIntoDocument(<ReportingSectionHarness />)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
@@ -490,7 +449,29 @@ describe('ReportingSection', () => {
 		expect(previewBefore).not.toBe(previewAfter)
 	})
 
-	test('disables preset buttons when reporting details are missing', async () => {
+	test('autofills the pre-start minimum-outcome-change preset from the pool start bond', async () => {
+		const renderedComponent = await renderIntoDocument(<ReportingSectionHarness initialProps={{ reportingDetails: createNotStartedReportingDetails() }} />)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await act(() => {
+			fireEvent.click(within(document.body).getByRole('button', { name: 'Min to change proposed outcome' }))
+		})
+
+		const amountInput = within(document.body).getByRole('textbox', { name: 'Report / Contribution Amount (REP)' })
+		expect((amountInput as HTMLInputElement).value).toBe('3')
+	})
+
+	test('disables Max profit before the escalation game exists', async () => {
+		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps({ reportingDetails: createNotStartedReportingDetails() })))
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const maxProfitButton = within(document.body).getByRole('button', { name: 'Max profit' }) as HTMLButtonElement
+		expect(maxProfitButton.disabled).toBe(true)
+		expect(maxProfitButton.title).toBe('Max profit becomes available after the escalation game starts.')
+		expect(document.body.textContent?.includes('Max profit becomes available after the escalation game starts.')).toBe(false)
+	})
+
+	test('disables preset buttons when reporting details are missing without showing the load reason inline', async () => {
 		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps({ reportingDetails: undefined })))
 		cleanupRenderedComponent = renderedComponent.cleanup
 
@@ -500,7 +481,7 @@ describe('ReportingSection', () => {
 		expect(document.body.textContent?.includes('Load reporting details before using presets.')).toBe(false)
 	})
 
-	test('shows unavailable preset reasons for impossible states', async () => {
+	test('shows unavailable preset reasons for impossible active-game states', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(
 				ReportingSection,
@@ -525,7 +506,7 @@ describe('ReportingSection', () => {
 		expect(document.body.textContent?.includes('Min preset unavailable because the selected side cannot take the lead within the remaining bond capacity.')).toBe(true)
 	})
 
-	test('renders the shared outcome chart with per-side projections and deposit details', async () => {
+	test('removes side-level deposit and projection detail lines from the shared outcome chart', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(
 				ReportingSection,
@@ -538,19 +519,11 @@ describe('ReportingSection', () => {
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		const documentQueries = within(document.body)
-		const outcomeSection = getClosestSection(documentQueries.getByRole('heading', { name: 'Outcome Sides' }))
-		const outcomeSectionQueries = within(outcomeSection)
-
-		expect(outcomeSectionQueries.getByText('Bars show total REP on each outcome. The marker shows current binding capital, and the thin inset shows your wallet stake.')).not.toBeNull()
-		expect(outcomeSectionQueries.getAllByText('Total stake').length).toBeGreaterThan(0)
-		expect(outcomeSectionQueries.getAllByText('Your stake').length).toBeGreaterThan(0)
-		expect(outcomeSectionQueries.getByText('Binding capital')).not.toBeNull()
-		expect(outcomeSectionQueries.getByText('Leading')).not.toBeNull()
-		expect(outcomeSectionQueries.getByText('Selected')).not.toBeNull()
-		expect(outcomeSection.textContent?.includes('Projected payout for current amount')).toBe(true)
-		expect(outcomeSection.textContent?.includes('Projected profit if this side wins')).toBe(true)
-		expect(outcomeSection.textContent?.includes('Your deposits:')).toBe(true)
+		const outcomeSection = getClosestSection(within(document.body).getByRole('heading', { name: 'Outcome Sides' }))
+		expect(outcomeSection.textContent?.includes('Bars show total REP on each outcome. The marker shows current binding capital, and the thin inset shows your wallet stake.')).toBe(true)
+		expect(outcomeSection.textContent?.includes('Projected payout for current amount')).toBe(false)
+		expect(outcomeSection.textContent?.includes('Projected profit if this side wins')).toBe(false)
+		expect(outcomeSection.textContent?.includes('Your deposits:')).toBe(false)
 	})
 
 	test('renders withdraw-only messages and enables selectable deposits once withdrawal is allowed', async () => {
@@ -633,7 +606,7 @@ describe('ReportingSection', () => {
 		expect(onReportingFormChangeCalls).toEqual([{ selectedWithdrawDepositIndexes: [1n] }, { selectedWithdrawDepositIndexes: [] }])
 	})
 
-	test('autofills the report amount for the minimum outcome change preset with 1001 REP when another side has 1000 REP', async () => {
+	test('autofills the minimum-outcome-change preset with 1001 REP when another side has 1000 REP', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(ReportingSectionHarness, {
 				initialProps: {
@@ -663,7 +636,7 @@ describe('ReportingSection', () => {
 		expect((amountInput as HTMLInputElement).value).toBe('1001')
 	})
 
-	test('autofills the report amount for the max profit preset with 1500 REP when another side has 1000 REP', async () => {
+	test('autofills the max-profit preset with 1500 REP when another side has 1000 REP', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(ReportingSectionHarness, {
 				initialProps: {
@@ -694,45 +667,26 @@ describe('ReportingSection', () => {
 		expect(document.body.textContent?.includes('projects roughly')).toBe(true)
 	})
 
-	test('updates the displayed profit preview after clicking max profit in a partial-depth scenario', async () => {
-		const renderedComponent = await renderIntoDocument(<ReportingSectionHarness />)
-		cleanupRenderedComponent = renderedComponent.cleanup
-
-		const previewBefore = findProfitPreview()
-
-		await act(() => {
-			fireEvent.click(within(document.body).getByRole('button', { name: 'Max profit' }))
-		})
-
-		const previewAfter = findProfitPreview()
-		expect(previewBefore).not.toBe(previewAfter)
-	})
-
-	test('deduplicates identical preset unavailability reasons', async () => {
+	test('disables the minimum-outcome-change preset when the selected side already leads', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(
 				ReportingSection,
 				createProps({
 					reportingDetails: createReportingDetails({
-						nonDecisionThreshold: rep(20n),
 						sides: [
-							{ balance: 0n, deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
-							{ balance: rep(20n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
-							{ balance: rep(19n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
+							{ balance: rep(2n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+							{ balance: rep(9n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [createDeposit()] },
+							{ balance: rep(8n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
 						],
-						startBond: rep(1n),
-					}),
-					reportingForm: createReportingForm({
-						selectedOutcome: 'no',
 					}),
 				}),
 			),
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		const documentQueries = within(document.body)
-		expect((documentQueries.getByRole('button', { name: 'Min to change proposed outcome' }) as HTMLButtonElement).disabled).toBe(true)
-		expect((documentQueries.getByRole('button', { name: 'Max profit' }) as HTMLButtonElement).disabled).toBe(true)
-		expect(documentQueries.getAllByText('Min preset unavailable because the selected side cannot take the lead within the remaining bond capacity.')).toHaveLength(1)
+		const minButton = within(document.body).getByRole('button', { name: 'Min to change proposed outcome' }) as HTMLButtonElement
+		expect(minButton.disabled).toBe(true)
+		expect(minButton.title).toBe('Selected side already leads.')
+		expect(document.body.textContent?.includes('Selected side already leads.')).toBe(true)
 	})
 })

--- a/ui/ts/tests/securityPoolWorkflowSection.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection.test.tsx
@@ -1650,7 +1650,8 @@ describe('SecurityPoolWorkflowSection', () => {
 
 		const documentQueries = within(document.body)
 		expect(documentQueries.getAllByRole('heading', { name: 'Question' }).length).toBe(1)
-		expect(documentQueries.getByRole('heading', { name: 'Reporting Context' })).not.toBeNull()
+		expect(documentQueries.queryByRole('heading', { name: 'Reporting Context' })).toBeNull()
+		expect(documentQueries.getByRole('heading', { name: 'Reporting Not Enabled' })).not.toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Outcome Sides' })).not.toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Report Outcome' })).not.toBeNull()
 		expect(documentQueries.queryByRole('heading', { name: 'Withdraw Escalation Deposits' })).toBeNull()
@@ -1658,7 +1659,9 @@ describe('SecurityPoolWorkflowSection', () => {
 		expect(documentQueries.queryByText('Reporting unlocks after the market end timestamp for the selected pool.')).toBeNull()
 		expect(documentQueries.queryByText('Reporting opens after market end.')).toBeNull()
 		expect(document.body.querySelectorAll('.escalation-side')).toHaveLength(3)
-		expect(document.body.textContent?.includes('Your deposits: None')).toBe(true)
+		expect(document.body.textContent?.includes('Your deposits: None')).toBe(false)
+		expect(document.body.textContent?.includes('Projected payout for current amount')).toBe(false)
+		expect(document.body.textContent?.includes('Projected profit if this side wins')).toBe(false)
 
 		const reportButton = documentQueries.getByRole('button', { name: 'Report / Contribute On Selected Side' }) as HTMLButtonElement
 		expect(reportButton.disabled).toBe(true)

--- a/ui/ts/types/contracts.ts
+++ b/ui/ts/types/contracts.ts
@@ -321,9 +321,11 @@ type ReportingDetailsBase = {
 	completeSetCollateralAmount: bigint
 	currentTime: bigint
 	marketDetails: MarketDetails
+	nonDecisionThreshold: bigint
 	questionOutcome: ReportingOutcomeKey | 'none'
 	resolution: ReportingOutcomeKey | 'none'
 	securityPoolAddress: Address
+	startBond: bigint
 	universeId: bigint
 	withdrawalEnabled: boolean
 	withdrawalState: 'not-finalized' | 'resolved' | 'canceled-by-external-fork'
@@ -339,9 +341,7 @@ export type ActiveReportingDetails = ReportingDetailsBase & {
 	currentRequiredBond: bigint
 	escalationEndTime: bigint
 	escalationGameAddress: Address
-	nonDecisionThreshold: bigint
 	sides: EscalationSide[]
-	startBond: bigint
 	startingTime: bigint
 	totalCost: bigint
 }


### PR DESCRIPTION
## Summary
- Refines the reporting lifecycle with clearer presets, projected resolution details, zero-state placeholders, and updated withdrawal selection behavior.
- Adds transaction feedback across deployment, reporting, trading, security pool, and open oracle actions so buttons can reflect pending, success, and error states.
- Reworks escalation and security pool presentation with richer charts, legends, withdrawal controls, and updated copy/guards for fork and vault workflows.
- Extends peripheral and UI contract interfaces to support new escalation deposit metadata and related reporting flow logic.

## Testing
- Not run
- Expected validation per repo guidance: `bun run tsc`
- Expected validation per repo guidance: `bun run test`
- Expected validation per repo guidance: `bun run format`
- Expected validation per repo guidance: `bun run check`
- Expected validation per repo guidance: `bun run knip`