### PR TITLE
Refine reporting, deployment, and transaction feedback UX

### DIFF
--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -32,6 +32,8 @@ type EscalationSideDisplay = {
 
 const MAX_PROFIT_NOT_STARTED_REASON = 'Max profit becomes available after the escalation game starts.'
 const LOAD_REPORTING_PRESETS_REASON = 'Load reporting details before using presets.'
+const SELECTED_SIDE_ALREADY_LEADS_REASON = 'Selected side already leads.'
+const MAX_PROFIT_WINDOW_FILLED_REASON = 'Max profit preset unavailable because the reward window is already filled on the selected side.'
 
 function getOutcomeSides(activeReportingDetails: ActiveReportingDetails | undefined) {
 	if (activeReportingDetails !== undefined) {
@@ -58,7 +60,7 @@ function getDepositEntryCountLabel(count: number) {
 }
 
 function isHiddenPresetReason(reason: string | undefined) {
-	return reason === LOAD_REPORTING_PRESETS_REASON || reason === MAX_PROFIT_NOT_STARTED_REASON
+	return reason === LOAD_REPORTING_PRESETS_REASON || reason === MAX_PROFIT_NOT_STARTED_REASON || reason === SELECTED_SIDE_ALREADY_LEADS_REASON || reason === MAX_PROFIT_WINDOW_FILLED_REASON
 }
 
 function getReportingStagePresentation({
@@ -350,7 +352,6 @@ export function ReportingSection({
 							Based on the current escalation state, this action would lock <CurrencyValue value={actualReportDepositAmount} suffix='REP' /> instead of the full entered amount.
 						</p>
 					)}
-
 					<div className='actions'>
 						<TransactionActionButton
 							idleLabel='Report / Contribute On Selected Side'

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -687,6 +687,29 @@ describe('ReportingSection', () => {
 		const minButton = within(document.body).getByRole('button', { name: 'Min to change proposed outcome' }) as HTMLButtonElement
 		expect(minButton.disabled).toBe(true)
 		expect(minButton.title).toBe('Selected side already leads.')
-		expect(document.body.textContent?.includes('Selected side already leads.')).toBe(true)
+		expect(document.body.textContent?.includes('Selected side already leads.')).toBe(false)
+	})
+
+	test('disables max profit when the reward window is already filled without rendering the inline reason', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					reportingDetails: createReportingDetails({
+						sides: [
+							{ balance: rep(15n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+							{ balance: rep(8n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
+							{ balance: rep(2n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+						],
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const maxProfitButton = within(document.body).getByRole('button', { name: 'Max profit' }) as HTMLButtonElement
+		expect(maxProfitButton.disabled).toBe(true)
+		expect(maxProfitButton.title).toBe('Max profit preset unavailable because the reward window is already filled on the selected side.')
+		expect(document.body.textContent?.includes('Max profit preset unavailable because the reward window is already filled on the selected side.')).toBe(false)
 	})
 })


### PR DESCRIPTION
## Summary
- Reworked reporting and escalation UI to show owned unsettled deposits with checkbox selection, projected resolution details, and a more structured side comparison.
- Added transaction feedback surfaces across deployment, trading, security pools, open oracle, reporting, and Zoltar flows so buttons can show pending/success/error state inline.
- Updated reporting and security pool logic to support the new withdrawal flow and initial escalation deposit handling.
- Expanded docs and tests around the revised reporting lifecycle, guards, and action feedback behavior.

## Testing
- Not run (PR description only).
- Existing coverage updated for reporting, escalation, open oracle, liquidation, trading, transaction action buttons, and security pool workflows.