### PR TITLE
Refine reporting, transaction feedback, and security pool flows

### DIFF
--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -24,6 +24,7 @@ import { ChainTimestampContext } from './lib/chainTimestamp.js'
 import { getDeploymentSections } from './lib/deployment.js'
 import { resolveLoadableValueState } from './lib/loadState.js'
 import { getWrongNetworkMessage, isSupportedAppChain } from './lib/network.js'
+import { applyReportingFormUpdate } from './lib/reportingForm.js'
 import { createLoadSecurityVaultHandler } from './lib/securityVaultHandlers.js'
 import { getUseQuestionForPoolState } from './lib/securityPoolNavigation.js'
 import { createInitialTransactionState, markTransactionFinished, markTransactionRequested, markTransactionSubmitted } from './lib/transactionState.js'
@@ -33,6 +34,7 @@ import { writeOpenOracleViewQueryParam, writeSecurityPoolsViewQueryParam, writeZ
 import { getUniversePresentation } from './lib/userCopy.js'
 import { formatUniverseCollectionLabel } from './lib/universe.js'
 import { resolveEnumValue, resolveFirstMatchingValue } from './lib/viewState.js'
+import type { ReportingFormState } from './types/app.js'
 import type { DeploymentRouteContentProps, MarketRouteContentProps, OpenOracleSectionProps, OpenOracleView, SecurityPoolsSectionProps, SecurityPoolsView, ZoltarView } from './types/components.js'
 
 export function App() {
@@ -195,6 +197,9 @@ export function App() {
 		wrapWethForInitialReport,
 	} = useOpenOracleOperations({ ...baseHookConfig, enabled: route === 'open-oracle' })
 	const { loadingReportingDetails, loadReporting, onReportOutcome, reportingActiveAction, reportingDetails, reportingError, reportingFeedback, reportingForm, reportingResult, setReportingForm, withdrawEscalation } = useReportingOperations(baseHookConfig)
+	const updateReportingForm = (update: Partial<ReportingFormState>) => {
+		setReportingForm(current => applyReportingFormUpdate(current, update))
+	}
 	const { executePendingPoolOperation, loadingPoolOracleManager, loadPoolOracleManager, poolOracleActiveAction, poolOracleFeedback, poolOracleManagerDetails, poolOracleManagerError, poolPriceOracleResult, requestPoolPrice } = usePriceOracleManager(baseHookConfig)
 	const {
 		checkedSecurityPoolAddress,
@@ -353,7 +358,7 @@ export function App() {
 		selectedPoolSecurityPoolAddress: selectedPool?.securityPoolAddress,
 		setForkAuctionFormSecurityPoolAddress: nextSecurityPoolAddress => setForkAuctionForm(current => (current.securityPoolAddress === nextSecurityPoolAddress ? current : { ...current, securityPoolAddress: nextSecurityPoolAddress })),
 		setOpenOracleReport,
-		setReportingFormSecurityPoolAddress: nextSecurityPoolAddress => setReportingForm(current => (current.securityPoolAddress === nextSecurityPoolAddress ? current : { ...current, securityPoolAddress: nextSecurityPoolAddress })),
+		setReportingFormSecurityPoolAddress: nextSecurityPoolAddress => updateReportingForm({ securityPoolAddress: nextSecurityPoolAddress }),
 		setSecurityVaultFormSelectedVaultAddress: nextSelectedVaultAddress => setSecurityVaultForm(current => (current.selectedVaultAddress === nextSelectedVaultAddress ? current : { ...current, selectedVaultAddress: nextSelectedVaultAddress })),
 		setSecurityVaultFormSecurityPoolAddress: nextSecurityPoolAddress => setSecurityVaultForm(current => (current.securityPoolAddress === nextSecurityPoolAddress ? current : { ...current, securityPoolAddress: nextSecurityPoolAddress })),
 		setTradingFormSecurityPoolAddress: nextSecurityPoolAddress => setTradingForm(current => (current.securityPoolAddress === nextSecurityPoolAddress ? current : { ...current, securityPoolAddress: nextSecurityPoolAddress })),
@@ -554,7 +559,7 @@ export function App() {
 				loadingReportingDetails,
 				onLoadReporting: () => void loadReporting(),
 				onReportOutcome: () => void onReportOutcome(),
-				onReportingFormChange: update => setReportingForm(current => ({ ...current, ...update })),
+				onReportingFormChange: update => updateReportingForm(update),
 				onWithdrawEscalation: () => void withdrawEscalation(),
 				reportingActiveAction,
 				reportingDetails,

--- a/ui/ts/components/EnumDropdown.tsx
+++ b/ui/ts/components/EnumDropdown.tsx
@@ -9,13 +9,14 @@ type EnumDropdownProps<T extends string> = {
 	disabled?: boolean
 	onChange: (value: T) => void
 	options: ReadonlyArray<EnumDropdownOption<T>>
-	value: T
+	placeholder?: string
+	value: T | undefined
 }
 
-export function EnumDropdown<T extends string>({ disabled = false, onChange, options, value }: EnumDropdownProps<T>) {
+export function EnumDropdown<T extends string>({ disabled = false, onChange, options, placeholder, value }: EnumDropdownProps<T>) {
 	const [open, setOpen] = useState(false)
 	const rootRef = useRef<HTMLDivElement | null>(null)
-	const selectedOption = options.find(option => option.value === value) ?? options[0]
+	const selectedOption = value === undefined ? undefined : options.find(option => option.value === value)
 
 	useEffect(() => {
 		const handleDocumentMouseDown = (event: MouseEvent) => {
@@ -51,7 +52,7 @@ export function EnumDropdown<T extends string>({ disabled = false, onChange, opt
 					setOpen(current => !current)
 				}}
 			>
-				<span className='enum-dropdown-label'>{selectedOption?.label ?? value}</span>
+				<span className='enum-dropdown-label'>{selectedOption?.label ?? value ?? placeholder ?? ''}</span>
 				<span className='enum-dropdown-chevron' aria-hidden='true' />
 			</button>
 			{open ? (

--- a/ui/ts/components/EscalationSide.tsx
+++ b/ui/ts/components/EscalationSide.tsx
@@ -40,10 +40,7 @@ export function EscalationSide({ bindingCapital, chartScaleMax, isLeading, isSel
 				<div className='escalation-side-copy'>
 					<div className='escalation-side-title-row'>
 						<span className='panel-label'>{side.label}</span>
-						<div className='escalation-side-badges'>
-							{isLeading ? <span className='badge ok'>Leading</span> : undefined}
-							{isSelected ? <span className='badge escalation-side-selected-badge'>Selected</span> : undefined}
-						</div>
+						{isLeading ? <span className='badge ok'>Leading</span> : undefined}
 					</div>
 				</div>
 				<div aria-hidden='true' className='escalation-side-chart'>

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -32,6 +32,7 @@ type EscalationSideDisplay = {
 
 const MAX_PROFIT_NOT_STARTED_REASON = 'Max profit becomes available after the escalation game starts.'
 const LOAD_REPORTING_PRESETS_REASON = 'Load reporting details before using presets.'
+const SELECT_OUTCOME_PRESET_REASON = 'Select an outcome side before using presets.'
 const SELECTED_SIDE_ALREADY_LEADS_REASON = 'Selected side already leads.'
 const MAX_PROFIT_WINDOW_FILLED_REASON = 'Max profit preset unavailable because the reward window is already filled on the selected side.'
 
@@ -60,7 +61,7 @@ function getDepositEntryCountLabel(count: number) {
 }
 
 function isHiddenPresetReason(reason: string | undefined) {
-	return reason === LOAD_REPORTING_PRESETS_REASON || reason === MAX_PROFIT_NOT_STARTED_REASON || reason === SELECTED_SIDE_ALREADY_LEADS_REASON || reason === MAX_PROFIT_WINDOW_FILLED_REASON
+	return reason === LOAD_REPORTING_PRESETS_REASON || reason === MAX_PROFIT_NOT_STARTED_REASON || reason === SELECT_OUTCOME_PRESET_REASON || reason === SELECTED_SIDE_ALREADY_LEADS_REASON || reason === MAX_PROFIT_WINDOW_FILLED_REASON
 }
 
 function getReportingStagePresentation({
@@ -176,16 +177,17 @@ export function ReportingSection({
 	const selectedAmount = parseOptionalRepAmountInput(reportingForm.reportAmount)
 	const showFullReporting = mode === 'full-reporting'
 	const showWithdrawOnly = mode === 'withdraw-only'
-	const selectedSide = activeReportingDetails?.sides.find(side => side.key === reportingForm.selectedOutcome)
+	const selectedOutcome = reportingForm.selectedOutcome
+	const selectedSide = selectedOutcome === undefined ? undefined : activeReportingDetails?.sides.find(side => side.key === selectedOutcome)
 	const selectedWithdrawDepositIndexes = reportingForm.selectedWithdrawDepositIndexes
 	const chartScaleMax = activeReportingDetails === undefined ? 1n : activeReportingDetails.sides.reduce((maxBalance, side) => (side.balance > maxBalance ? side.balance : maxBalance), activeReportingDetails.bindingCapital > 1n ? activeReportingDetails.bindingCapital : 1n)
 	const leadingOutcome = activeReportingDetails === undefined ? undefined : getLeadingEscalationOutcome(activeReportingDetails.sides)
-	const reportContributionPreview = reportingDetails === undefined || selectedAmount === undefined ? undefined : previewReportingContribution(reportingDetails, reportingForm.selectedOutcome, selectedAmount)
+	const reportContributionPreview = reportingDetails === undefined || selectedAmount === undefined || selectedOutcome === undefined ? undefined : previewReportingContribution(reportingDetails, selectedOutcome, selectedAmount)
 	const actualReportDepositAmount = reportContributionPreview?.actualDepositAmount
-	const selectedEstimate = activeReportingDetails === undefined || selectedAmount === undefined ? undefined : calculateEstimatedEscalationReturn(activeReportingDetails, reportingForm.selectedOutcome, selectedAmount)
+	const selectedEstimate = activeReportingDetails === undefined || selectedAmount === undefined || selectedOutcome === undefined ? undefined : calculateEstimatedEscalationReturn(activeReportingDetails, selectedOutcome, selectedAmount)
 	const outcomeSides = getOutcomeSides(activeReportingDetails)
-	const minimumOutcomeChangeContribution = getReportingMinimumOutcomeChangeContribution(reportingDetails, reportingForm.selectedOutcome)
-	const maxProfitContribution = getReportingMaxProfitContribution(reportingDetails, reportingForm.selectedOutcome)
+	const minimumOutcomeChangeContribution = selectedOutcome === undefined ? { amount: undefined, reason: SELECT_OUTCOME_PRESET_REASON } : getReportingMinimumOutcomeChangeContribution(reportingDetails, selectedOutcome)
+	const maxProfitContribution = selectedOutcome === undefined ? { amount: undefined, reason: SELECT_OUTCOME_PRESET_REASON } : getReportingMaxProfitContribution(reportingDetails, selectedOutcome)
 	const presetReasons = reportingLocked ? [] : [minimumOutcomeChangeContribution.reason, maxProfitContribution.reason].filter((reason, index, reasons): reason is string => reason !== undefined && !isHiddenPresetReason(reason) && reasons.indexOf(reason) === index)
 	const reportAmountError = selectedAmount === undefined && reportingForm.reportAmount.trim() !== '' ? 'Enter a valid report amount to preview profit.' : undefined
 	const reportGuardMessage = getReportingReportGuardMessage({
@@ -196,6 +198,7 @@ export function ReportingSection({
 		lockedReason,
 		reportAmount: reportingForm.reportAmount,
 		reportingStatus,
+		selectedOutcome,
 		selectedAmount,
 		viewerVaultAvailableEscalationRep: reportingDetails?.viewerVaultAvailableEscalationRep,
 		viewerVaultExists: reportingDetails?.viewerVaultExists ?? false,
@@ -208,6 +211,7 @@ export function ReportingSection({
 		reportingStatus,
 		withdrawalEnabled: activeReportingDetails?.withdrawalEnabled ?? false,
 		withdrawalState: reportingDetails?.withdrawalState,
+		selectedOutcome,
 	})
 	const reportingStage = showFullReporting
 		? getReportingStagePresentation({
@@ -280,7 +284,7 @@ export function ReportingSection({
 					</div>
 					<div className='escalation-sides'>
 						{outcomeSides.map(side => (
-							<EscalationSide key={side.key} bindingCapital={activeReportingDetails?.bindingCapital} chartScaleMax={chartScaleMax} isLeading={leadingOutcome === side.key} isSelected={reportingForm.selectedOutcome === side.key} side={side} />
+							<EscalationSide key={side.key} bindingCapital={activeReportingDetails?.bindingCapital} chartScaleMax={chartScaleMax} isLeading={leadingOutcome === side.key} isSelected={selectedOutcome !== undefined && selectedOutcome === side.key} side={side} />
 						))}
 					</div>
 				</SectionBlock>
@@ -300,9 +304,8 @@ export function ReportingSection({
 					)}
 					<label className='field'>
 						<span>Outcome Side</span>
-						<EnumDropdown options={REPORTING_OUTCOME_DROPDOWN_OPTIONS} value={reportingForm.selectedOutcome} onChange={selectedOutcome => onReportingFormChange({ selectedOutcome, selectedWithdrawDepositIndexes: [] })} disabled={reportingLocked} />
+						<EnumDropdown options={REPORTING_OUTCOME_DROPDOWN_OPTIONS} value={selectedOutcome} onChange={nextSelectedOutcome => onReportingFormChange({ selectedOutcome: nextSelectedOutcome, selectedWithdrawDepositIndexes: [] })} disabled={reportingLocked} placeholder='Select outcome side' />
 					</label>
-
 					<label className='field'>
 						<span>Report / Contribution Amount (REP)</span>
 						<FormInput value={reportingForm.reportAmount} onInput={event => onReportingFormChange({ reportAmount: event.currentTarget.value })} disabled={reportingLocked} />
@@ -341,10 +344,9 @@ export function ReportingSection({
 						</p>
 					))}
 					{reportAmountError === undefined ? undefined : <p className='detail'>{reportAmountError}</p>}
-
-					{selectedEstimate === undefined ? undefined : (
+					{selectedEstimate === undefined || selectedOutcome === undefined ? undefined : (
 						<p className='detail'>
-							If {getReportingOutcomeLabel(reportingForm.selectedOutcome)} wins and no one else contributes afterward, the current amount projects roughly <CurrencyValue value={selectedEstimate.profit} suffix='REP' /> of profit.
+							If {getReportingOutcomeLabel(selectedOutcome)} wins and no one else contributes afterward, the current amount projects roughly <CurrencyValue value={selectedEstimate.profit} suffix='REP' /> of profit.
 						</p>
 					)}
 					{actualReportDepositAmount === undefined || selectedAmount === undefined || actualReportDepositAmount === selectedAmount ? undefined : (

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -1,6 +1,5 @@
 import { AddressValue } from './AddressValue.js'
 import { CurrencyValue } from './CurrencyValue.js'
-import { EnumDropdown } from './EnumDropdown.js'
 import { ErrorNotice } from './ErrorNotice.js'
 import { FormInput } from './FormInput.js'
 import { EscalationSide } from './EscalationSide.js'
@@ -355,10 +354,6 @@ export function ReportingSection({
 							Available unlocked vault REP for reporting: <CurrencyValue value={reportingDetails.viewerVaultAvailableEscalationRep} suffix='REP' />.
 						</p>
 					)}
-					<label className='field'>
-						<span>Outcome Side</span>
-						<EnumDropdown options={REPORTING_OUTCOME_DROPDOWN_OPTIONS} value={selectedOutcome} onChange={nextSelectedOutcome => onReportingFormChange({ selectedOutcome: nextSelectedOutcome, selectedWithdrawDepositIndexes: [] })} disabled={reportingLocked} placeholder='Select outcome side' />
-					</label>
 					<label className='field'>
 						<span>Report / Contribution Amount (REP)</span>
 						<FormInput value={reportingForm.reportAmount} onInput={event => onReportingFormChange({ reportAmount: event.currentTarget.value })} disabled={reportingLocked} />

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -222,43 +222,43 @@ async function loadViewerReportingVaultState(client: ReadClient, securityPoolAdd
 }
 
 export async function loadReportingDetails(client: ReadClient, securityPoolAddress: Address, accountAddress: Address | undefined): Promise<ReportingDetails> {
-	const [questionId, escalationGameAddress, completeSetCollateralAmount, universeId, zoltarAddress, initialEscalationGameDeposit] = await readRequiredMulticall(client, [
-		{
+	const [questionId, escalationGameAddress, completeSetCollateralAmount, universeId, zoltarAddress, initialEscalationGameDeposit] = await Promise.all([
+		client.readContract({
 			abi: peripherals_SecurityPool_SecurityPool.abi,
 			functionName: 'questionId',
 			address: securityPoolAddress,
 			args: [],
-		},
-		{
+		}),
+		client.readContract({
 			abi: peripherals_SecurityPool_SecurityPool.abi,
 			functionName: 'escalationGame',
 			address: securityPoolAddress,
 			args: [],
-		},
-		{
+		}),
+		client.readContract({
 			abi: peripherals_SecurityPool_SecurityPool.abi,
 			functionName: 'completeSetCollateralAmount',
 			address: securityPoolAddress,
 			args: [],
-		},
-		{
+		}),
+		client.readContract({
 			abi: peripherals_SecurityPool_SecurityPool.abi,
 			functionName: 'universeId',
 			address: securityPoolAddress,
 			args: [],
-		},
-		{
+		}),
+		client.readContract({
 			abi: peripherals_SecurityPool_SecurityPool.abi,
 			functionName: 'zoltar',
 			address: securityPoolAddress,
 			args: [],
-		},
-		{
+		}),
+		client.readContract({
 			abi: peripherals_SecurityPool_SecurityPool.abi,
 			functionName: 'initialEscalationGameDeposit',
 			address: securityPoolAddress,
 			args: [],
-		},
+		}),
 	])
 	const [marketDetails, block, escalationGameCode, viewerVaultState, forkThreshold] = await Promise.all([
 		loadMarketDetails(client, questionId),

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -83,6 +83,7 @@ const CONTRACT_PAGE_SIZE = 30n
 
 type ForkDataTuple = readonly [bigint, Address, bigint, bigint, bigint, boolean, number]
 type AuctionClearingTuple = readonly [boolean, bigint, bigint, bigint]
+type ReportingBootstrapReadResult = readonly [bigint, Address, bigint, bigint, Address, bigint]
 
 type SecurityPoolDeploymentQueryResult = {
 	completeSetCollateralAmount: bigint
@@ -222,44 +223,45 @@ async function loadViewerReportingVaultState(client: ReadClient, securityPoolAdd
 }
 
 export async function loadReportingDetails(client: ReadClient, securityPoolAddress: Address, accountAddress: Address | undefined): Promise<ReportingDetails> {
-	const [questionId, escalationGameAddress, completeSetCollateralAmount, universeId, zoltarAddress, initialEscalationGameDeposit] = await Promise.all([
-		client.readContract({
+	const reportingBootstrapContracts: readonly ContractFunctionParameters[] = [
+		{
 			abi: peripherals_SecurityPool_SecurityPool.abi,
 			functionName: 'questionId',
 			address: securityPoolAddress,
 			args: [],
-		}),
-		client.readContract({
+		},
+		{
 			abi: peripherals_SecurityPool_SecurityPool.abi,
 			functionName: 'escalationGame',
 			address: securityPoolAddress,
 			args: [],
-		}),
-		client.readContract({
+		},
+		{
 			abi: peripherals_SecurityPool_SecurityPool.abi,
 			functionName: 'completeSetCollateralAmount',
 			address: securityPoolAddress,
 			args: [],
-		}),
-		client.readContract({
+		},
+		{
 			abi: peripherals_SecurityPool_SecurityPool.abi,
 			functionName: 'universeId',
 			address: securityPoolAddress,
 			args: [],
-		}),
-		client.readContract({
+		},
+		{
 			abi: peripherals_SecurityPool_SecurityPool.abi,
 			functionName: 'zoltar',
 			address: securityPoolAddress,
 			args: [],
-		}),
-		client.readContract({
+		},
+		{
 			abi: peripherals_SecurityPool_SecurityPool.abi,
 			functionName: 'initialEscalationGameDeposit',
 			address: securityPoolAddress,
 			args: [],
-		}),
-	])
+		},
+	]
+	const [questionId, escalationGameAddress, completeSetCollateralAmount, universeId, zoltarAddress, initialEscalationGameDeposit] = (await readRequiredMulticall(client, reportingBootstrapContracts)) as unknown as ReportingBootstrapReadResult
 	const [marketDetails, block, escalationGameCode, viewerVaultState, forkThreshold] = await Promise.all([
 		loadMarketDetails(client, questionId),
 		client.getBlock(),

--- a/ui/ts/hooks/useReportingOperations.ts
+++ b/ui/ts/hooks/useReportingOperations.ts
@@ -32,6 +32,12 @@ export function useReportingOperations({ accountAddress, onTransaction, onTransa
 	const getSuccessTitle = (actionName: ReportingActionResult['action']) => (actionName === 'reportOutcome' ? 'Report submitted' : 'Escalation deposits withdrawn')
 	const getFailureTitle = (actionName: ReportingActionResult['action']) => (actionName === 'reportOutcome' ? 'Report failed' : 'Withdrawal failed')
 
+	const requireSelectedOutcome = (selectedOutcome: ReportingFormState['selectedOutcome'], action: 'report' | 'withdraw') => {
+		if (selectedOutcome !== undefined) return selectedOutcome
+		if (action === 'report') throw new Error('Select an outcome side before reporting on a market.')
+		throw new Error('Select an outcome side before withdrawing escalation deposits.')
+	}
+
 	const loadReporting = async () => {
 		const isCurrent = nextReportingLoad()
 		await reportingLoad.run({
@@ -105,9 +111,10 @@ export function useReportingOperations({ accountAddress, onTransaction, onTransa
 		await runReportingAction(
 			'reportOutcome',
 			async (walletAddress, securityPoolAddress, currentForm) => {
+				const selectedOutcome = requireSelectedOutcome(currentForm.selectedOutcome, 'report')
 				const reportAmount = parseRepAmountInput(currentForm.reportAmount, 'Report amount')
 				const latestDetails = await loadReportingDetails(createConnectedReadClient(), securityPoolAddress, walletAddress)
-				const contributionPreview = previewReportingContribution(latestDetails, currentForm.selectedOutcome, reportAmount)
+				const contributionPreview = previewReportingContribution(latestDetails, selectedOutcome, reportAmount)
 				if (contributionPreview.actualDepositAmount === undefined) {
 					throw new Error(contributionPreview.reason ?? 'Unable to preview the REP that would be locked for this report.')
 				}
@@ -119,7 +126,7 @@ export function useReportingOperations({ accountAddress, onTransaction, onTransa
 					throw new Error(`Insufficient unlocked REP in your vault. Need ${formatCurrencyBalance(contributionPreview.actualDepositAmount - availableVaultRep)} more REP deposited and unlocked before reporting.`)
 				}
 
-				return await reportOutcomeInSecurityPool(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), securityPoolAddress, currentForm.selectedOutcome, reportAmount)
+				return await reportOutcomeInSecurityPool(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), securityPoolAddress, selectedOutcome, reportAmount)
 			},
 			'Failed to report on outcome',
 		)
@@ -128,11 +135,12 @@ export function useReportingOperations({ accountAddress, onTransaction, onTransa
 		await runReportingAction(
 			'withdrawEscalation',
 			async (walletAddress, securityPoolAddress, currentForm) => {
+				const selectedOutcome = requireSelectedOutcome(currentForm.selectedOutcome, 'withdraw')
 				const latestDetails = await loadReportingDetails(createConnectedReadClient(), securityPoolAddress, walletAddress)
 				if (latestDetails.status !== 'active') {
 					throw new Error('Withdrawals are unavailable until the first report or contribution deploys the escalation game.')
 				}
-				const selectedSide = latestDetails.sides.find(side => side.key === currentForm.selectedOutcome)
+				const selectedSide = latestDetails.sides.find(side => side.key === selectedOutcome)
 				const availableDepositIndexes = selectedSide?.userDeposits.map(deposit => deposit.depositIndex) ?? []
 
 				if (!latestDetails.withdrawalEnabled) {
@@ -149,7 +157,7 @@ export function useReportingOperations({ accountAddress, onTransaction, onTransa
 					throw new Error('No deposits available to withdraw for the selected side')
 				}
 
-				return await withdrawEscalationFromSecurityPool(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), securityPoolAddress, currentForm.selectedOutcome, depositIndexes)
+				return await withdrawEscalationFromSecurityPool(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), securityPoolAddress, selectedOutcome, depositIndexes)
 			},
 			'Failed to withdraw escalation deposits',
 		)

--- a/ui/ts/lib/marketForm.ts
+++ b/ui/ts/lib/marketForm.ts
@@ -79,7 +79,7 @@ export function getDefaultReportingFormState(): ReportingFormState {
 	return {
 		reportAmount: '0',
 		securityPoolAddress: '',
-		selectedOutcome: 'yes',
+		selectedOutcome: undefined,
 		selectedWithdrawDepositIndexes: [],
 	}
 }

--- a/ui/ts/lib/reportingForm.ts
+++ b/ui/ts/lib/reportingForm.ts
@@ -1,0 +1,21 @@
+import { sameCaseInsensitiveText } from './caseInsensitive.js'
+import type { ReportingFormState } from '../types/app.js'
+
+export function applyReportingFormUpdate(current: ReportingFormState, update: Partial<ReportingFormState>): ReportingFormState {
+	const securityPoolAddressChanged = update.securityPoolAddress !== undefined && !sameCaseInsensitiveText(current.securityPoolAddress, update.securityPoolAddress)
+	const nextForm = {
+		...current,
+		...update,
+		...(securityPoolAddressChanged ? { selectedOutcome: undefined } : {}),
+	}
+
+	const hasChanged = (Object.keys(update) as Array<keyof ReportingFormState>).some(key => {
+		if (key === 'securityPoolAddress' && update.securityPoolAddress !== undefined) {
+			return securityPoolAddressChanged || !sameCaseInsensitiveText(current.securityPoolAddress, nextForm.securityPoolAddress)
+		}
+		return current[key] !== nextForm[key]
+	})
+
+	if (!hasChanged && current.selectedOutcome === nextForm.selectedOutcome) return current
+	return nextForm
+}

--- a/ui/ts/lib/reportingGuards.ts
+++ b/ui/ts/lib/reportingGuards.ts
@@ -1,5 +1,6 @@
 import type { Address } from 'viem'
 import type { ReportingDetails } from '../types/contracts.js'
+import type { ReportingOutcomeKey } from '../types/contracts.js'
 import { formatCurrencyBalance } from './formatters.js'
 
 type ReportingStatus = 'missing' | 'not-started' | 'active'
@@ -12,6 +13,7 @@ export function getReportingReportGuardMessage({
 	lockedReason,
 	reportAmount,
 	reportingStatus,
+	selectedOutcome,
 	selectedAmount,
 	viewerVaultAvailableEscalationRep,
 	viewerVaultExists,
@@ -23,6 +25,7 @@ export function getReportingReportGuardMessage({
 	lockedReason: string | undefined
 	reportAmount: string
 	reportingStatus: ReportingStatus
+	selectedOutcome: ReportingOutcomeKey | undefined
 	selectedAmount: bigint | undefined
 	viewerVaultAvailableEscalationRep: bigint | undefined
 	viewerVaultExists: boolean
@@ -31,6 +34,7 @@ export function getReportingReportGuardMessage({
 	if (accountAddress === undefined) return 'Connect a wallet before reporting on a market.'
 	if (!isMainnet) return 'Switch to Ethereum mainnet before reporting on a market.'
 	if (reportingStatus === 'missing') return 'Load reporting details before reporting on an outcome.'
+	if (selectedOutcome === undefined) return 'Select an outcome side before reporting on a market.'
 	if (reportAmount.trim() === '') return 'Enter a report amount greater than zero.'
 	if (selectedAmount === undefined || selectedAmount <= 0n) return 'Enter a valid report amount greater than zero.'
 	if (contributionPreviewReason !== undefined) return contributionPreviewReason
@@ -51,6 +55,7 @@ export function getReportingWithdrawGuardMessage({
 	reportingStatus,
 	withdrawalEnabled,
 	withdrawalState,
+	selectedOutcome,
 }: {
 	accountAddress: Address | undefined
 	hasUserDepositsOnSelectedSide: boolean
@@ -59,6 +64,7 @@ export function getReportingWithdrawGuardMessage({
 	reportingStatus: ReportingStatus
 	withdrawalEnabled: boolean
 	withdrawalState: ReportingDetails['withdrawalState'] | undefined
+	selectedOutcome: ReportingOutcomeKey | undefined
 }) {
 	if (lockedReason !== undefined) return lockedReason
 	if (accountAddress === undefined) return 'Connect a wallet before withdrawing escalation deposits.'
@@ -66,6 +72,7 @@ export function getReportingWithdrawGuardMessage({
 	if (reportingStatus === 'missing') return 'Load reporting details before withdrawing escalation deposits.'
 	if (reportingStatus === 'not-started') return 'Withdrawals are unavailable until the first report or contribution deploys the escalation game.'
 	if (!withdrawalEnabled && withdrawalState === 'not-finalized') return 'Escalation deposits cannot be withdrawn until the question is finalized or the game is canceled by an external fork.'
+	if (selectedOutcome === undefined) return 'Select an outcome side before withdrawing escalation deposits.'
 	if (!hasUserDepositsOnSelectedSide) return 'No deposits are available to withdraw on the selected side.'
 	return undefined
 }

--- a/ui/ts/tests/enumDropdown.test.tsx
+++ b/ui/ts/tests/enumDropdown.test.tsx
@@ -1,0 +1,54 @@
+/// <reference types="bun-types" />
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { fireEvent, within } from '@testing-library/dom'
+import { act } from 'preact/test-utils'
+import { EnumDropdown } from '../components/EnumDropdown.js'
+import { installDomEnvironment } from './testUtils/domEnvironment.js'
+import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
+
+describe('EnumDropdown', () => {
+	let restoreDomEnvironment: (() => void) | undefined
+	let cleanupRenderedComponent: (() => Promise<void>) | undefined
+
+	beforeEach(() => {
+		const domEnvironment = installDomEnvironment()
+		restoreDomEnvironment = domEnvironment.cleanup
+	})
+
+	afterEach(async () => {
+		await cleanupRenderedComponent?.()
+		cleanupRenderedComponent = undefined
+		restoreDomEnvironment?.()
+		restoreDomEnvironment = undefined
+	})
+
+	test('renders an explicit placeholder without silently selecting the first option', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<EnumDropdown
+				options={[
+					{ label: 'Yes', value: 'yes' },
+					{ label: 'No', value: 'no' },
+				]}
+				value={undefined}
+				onChange={() => undefined}
+				placeholder='Select outcome side'
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		const trigger = documentQueries.getByRole('button', { name: 'Select outcome side' })
+		expect(trigger).not.toBeNull()
+
+		await act(() => {
+			fireEvent.click(trigger)
+		})
+
+		const options = documentQueries.getAllByRole('option')
+		expect(document.body.querySelectorAll('.enum-dropdown-option.selected').length).toBe(0)
+		for (const option of options) {
+			expect(option.getAttribute('aria-selected')).toBe('false')
+		}
+	})
+})

--- a/ui/ts/tests/reportingForm.test.ts
+++ b/ui/ts/tests/reportingForm.test.ts
@@ -1,0 +1,52 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { applyReportingFormUpdate } from '../lib/reportingForm.js'
+import type { ReportingFormState } from '../types/app.js'
+
+function createReportingFormState(): ReportingFormState {
+	return {
+		reportAmount: '10',
+		securityPoolAddress: '0x0000000000000000000000000000000000000001',
+		selectedOutcome: 'yes',
+		selectedWithdrawDepositIndexes: [1n, 2n],
+	}
+}
+
+describe('reporting form updates', () => {
+	test('clears the selected outcome when the reporting pool address changes', () => {
+		expect(
+			applyReportingFormUpdate(createReportingFormState(), {
+				securityPoolAddress: '0x0000000000000000000000000000000000000002',
+			}),
+		).toEqual({
+			reportAmount: '10',
+			securityPoolAddress: '0x0000000000000000000000000000000000000002',
+			selectedOutcome: undefined,
+			selectedWithdrawDepositIndexes: [1n, 2n],
+		})
+	})
+
+	test('keeps the selected outcome when the reporting pool address is unchanged', () => {
+		expect(
+			applyReportingFormUpdate(createReportingFormState(), {
+				reportAmount: '12',
+				securityPoolAddress: '0x0000000000000000000000000000000000000001',
+			}),
+		).toEqual({
+			reportAmount: '12',
+			securityPoolAddress: '0x0000000000000000000000000000000000000001',
+			selectedOutcome: 'yes',
+			selectedWithdrawDepositIndexes: [1n, 2n],
+		})
+	})
+
+	test('returns the current form for no-op pool-address sync updates', () => {
+		const current = createReportingFormState()
+		expect(
+			applyReportingFormUpdate(current, {
+				securityPoolAddress: '0x0000000000000000000000000000000000000001',
+			}),
+		).toBe(current)
+	})
+})

--- a/ui/ts/tests/reportingGuards.test.ts
+++ b/ui/ts/tests/reportingGuards.test.ts
@@ -5,7 +5,7 @@ import { zeroAddress } from 'viem'
 import { getReportingReportGuardMessage, getReportingWithdrawGuardMessage } from '../lib/reportingGuards.js'
 
 describe('reporting guards', () => {
-	test('blocks report submission for locked, disconnected, and invalid amount states', () => {
+	test('blocks report submission for locked, disconnected, unselected, and invalid amount states', () => {
 		expect(
 			getReportingReportGuardMessage({
 				actualDepositAmount: 1n,
@@ -18,6 +18,7 @@ describe('reporting guards', () => {
 				selectedAmount: 1n,
 				viewerVaultAvailableEscalationRep: 10n,
 				viewerVaultExists: true,
+				selectedOutcome: 'yes',
 			}),
 		).toBe('Reporting opens after market end.')
 
@@ -33,6 +34,7 @@ describe('reporting guards', () => {
 				selectedAmount: 1n,
 				viewerVaultAvailableEscalationRep: 10n,
 				viewerVaultExists: true,
+				selectedOutcome: 'yes',
 			}),
 		).toBe('Connect a wallet before reporting on a market.')
 
@@ -43,11 +45,28 @@ describe('reporting guards', () => {
 				contributionPreviewReason: undefined,
 				isMainnet: true,
 				lockedReason: undefined,
+				reportAmount: '1',
+				reportingStatus: 'active',
+				selectedAmount: 1n,
+				selectedOutcome: undefined,
+				viewerVaultAvailableEscalationRep: 10n,
+				viewerVaultExists: true,
+			}),
+		).toBe('Select an outcome side before reporting on a market.')
+
+		expect(
+			getReportingReportGuardMessage({
+				actualDepositAmount: 1n,
+				accountAddress: zeroAddress,
+				contributionPreviewReason: undefined,
+				isMainnet: true,
+				lockedReason: undefined,
 				reportAmount: '0',
 				reportingStatus: 'active',
 				selectedAmount: 0n,
 				viewerVaultAvailableEscalationRep: 10n,
 				viewerVaultExists: true,
+				selectedOutcome: 'yes',
 			}),
 		).toBe('Enter a valid report amount greater than zero.')
 	})
@@ -63,6 +82,7 @@ describe('reporting guards', () => {
 				reportAmount: '1',
 				reportingStatus: 'missing',
 				selectedAmount: 1n,
+				selectedOutcome: 'yes',
 				viewerVaultAvailableEscalationRep: 10n,
 				viewerVaultExists: true,
 			}),
@@ -78,6 +98,7 @@ describe('reporting guards', () => {
 				reportAmount: '1',
 				reportingStatus: 'not-started',
 				selectedAmount: 1n,
+				selectedOutcome: 'yes',
 				viewerVaultAvailableEscalationRep: 10n,
 				viewerVaultExists: true,
 			}),
@@ -93,6 +114,7 @@ describe('reporting guards', () => {
 				reportAmount: '1',
 				reportingStatus: 'active',
 				selectedAmount: 1n,
+				selectedOutcome: 'yes',
 				viewerVaultAvailableEscalationRep: 10n,
 				viewerVaultExists: true,
 			}),
@@ -110,6 +132,7 @@ describe('reporting guards', () => {
 				reportAmount: '5',
 				reportingStatus: 'active',
 				selectedAmount: 5n * 10n ** 18n,
+				selectedOutcome: 'yes',
 				viewerVaultAvailableEscalationRep: 2n * 10n ** 18n,
 				viewerVaultExists: true,
 			}),
@@ -125,6 +148,7 @@ describe('reporting guards', () => {
 				reportAmount: '1',
 				reportingStatus: 'active',
 				selectedAmount: 1n * 10n ** 18n,
+				selectedOutcome: 'yes',
 				viewerVaultAvailableEscalationRep: 10n * 10n ** 18n,
 				viewerVaultExists: true,
 			}),
@@ -140,13 +164,14 @@ describe('reporting guards', () => {
 				reportAmount: '1',
 				reportingStatus: 'active',
 				selectedAmount: 1n,
+				selectedOutcome: 'yes',
 				viewerVaultAvailableEscalationRep: 0n,
 				viewerVaultExists: false,
 			}),
 		).toBe('Reporting locks REP already deposited in your security vault. Deposit REP into your vault before reporting.')
 	})
 
-	test('blocks withdraw submission until the escalation game is active and the selected side has deposits', () => {
+	test('blocks withdraw submission until an outcome is selected and that side has deposits', () => {
 		expect(
 			getReportingWithdrawGuardMessage({
 				accountAddress: zeroAddress,
@@ -154,6 +179,7 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: undefined,
 				reportingStatus: 'not-started',
+				selectedOutcome: 'yes',
 				withdrawalEnabled: false,
 				withdrawalState: 'not-finalized',
 			}),
@@ -166,6 +192,20 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: undefined,
 				reportingStatus: 'active',
+				selectedOutcome: undefined,
+				withdrawalEnabled: true,
+				withdrawalState: 'resolved',
+			}),
+		).toBe('Select an outcome side before withdrawing escalation deposits.')
+
+		expect(
+			getReportingWithdrawGuardMessage({
+				accountAddress: zeroAddress,
+				hasUserDepositsOnSelectedSide: false,
+				isMainnet: true,
+				lockedReason: undefined,
+				reportingStatus: 'active',
+				selectedOutcome: 'yes',
 				withdrawalEnabled: true,
 				withdrawalState: 'resolved',
 			}),
@@ -180,6 +220,7 @@ describe('reporting guards', () => {
 				reportingStatus: 'active',
 				withdrawalEnabled: true,
 				withdrawalState: 'resolved',
+				selectedOutcome: 'yes',
 			}),
 		).toBeUndefined()
 	})
@@ -192,6 +233,7 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: undefined,
 				reportingStatus: 'active',
+				selectedOutcome: 'yes',
 				withdrawalEnabled: false,
 				withdrawalState: 'not-finalized',
 			}),
@@ -204,6 +246,7 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: undefined,
 				reportingStatus: 'active',
+				selectedOutcome: 'yes',
 				withdrawalEnabled: true,
 				withdrawalState: 'canceled-by-external-fork',
 			}),

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -139,7 +139,7 @@ function createReportingForm(overrides: Partial<ReportingFormState> = {}): Repor
 	return {
 		reportAmount: '1',
 		securityPoolAddress: zeroAddress,
-		selectedOutcome: 'yes',
+		selectedOutcome: undefined,
 		selectedWithdrawDepositIndexes: [],
 		...overrides,
 	}
@@ -207,8 +207,31 @@ describe('ReportingSection', () => {
 		restoreDomEnvironment = undefined
 	})
 
-	test('renders active reporting with a lifecycle banner and no reporting context card', async () => {
+	test('starts unselected until the user explicitly chooses an outcome side', async () => {
 		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps()))
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getAllByText('Active').length).toBeGreaterThan(0)
+		expect(documentQueries.queryByText('Available')).toBeNull()
+		expect(documentQueries.queryByText('Blocked')).toBeNull()
+		expect(documentQueries.queryByText('Reporting Workflow')).toBeNull()
+		expect(document.body.textContent?.includes('Selected side currently has')).toBe(false)
+		expect(documentQueries.getByText('Select outcome side')).not.toBeNull()
+		expect(document.body.querySelectorAll('.escalation-side.selected').length).toBe(0)
+	})
+
+	test('renders active reporting with a lifecycle banner and no reporting context card', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					reportingForm: createReportingForm({
+						selectedOutcome: 'yes',
+					}),
+				}),
+			),
+		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
@@ -218,6 +241,25 @@ describe('ReportingSection', () => {
 		expect(documentQueries.getByRole('button', { name: 'Max profit' })).not.toBeNull()
 		expect(document.body.textContent?.includes('Selected side currently has')).toBe(true)
 		expect(document.body.textContent?.includes('Withdraw Escalation Deposits')).toBe(false)
+	})
+
+	test('keeps the outcome dropdown unselected when reporting is locked', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					lockedReason: 'Reporting opens after market end.',
+					reportingDetails: undefined,
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByText('Select outcome side')).not.toBeNull()
+		const outcomeButton = documentQueries.getByRole('button', { name: 'Outcome Side' }) as HTMLButtonElement
+		expect(outcomeButton.disabled).toBe(true)
+		expect(document.body.querySelectorAll('.escalation-side.selected').length).toBe(0)
 	})
 
 	test('renders Reporting Not Enabled before market end', async () => {
@@ -318,6 +360,25 @@ describe('ReportingSection', () => {
 		expect(document.body.querySelector('button[title="Connect a wallet before withdrawing escalation deposits."]')).toBeNull()
 	})
 
+	test('shows the selected side details after an explicit outcome choice', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					reportingForm: createReportingForm({
+						selectedOutcome: 'yes',
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(document.body.querySelectorAll('.escalation-side.selected').length).toBe(1)
+		expect(document.body.textContent?.includes('Selected side currently has')).toBe(true)
+		expect(documentQueries.getByText(/If Yes wins and no one else contributes afterward/)).not.toBeNull()
+	})
+
 	test('removes the approval explainer copy and still blocks when unlocked vault REP is insufficient', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(
@@ -328,6 +389,7 @@ describe('ReportingSection', () => {
 					}),
 					reportingForm: createReportingForm({
 						reportAmount: '5',
+						selectedOutcome: 'yes',
 					}),
 				}),
 			),
@@ -340,7 +402,17 @@ describe('ReportingSection', () => {
 	})
 
 	test('renders a compact withdraw-only mode without the reporting banner or report form', async () => {
-		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps({ mode: 'withdraw-only' })))
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					mode: 'withdraw-only',
+					reportingForm: createReportingForm({
+						selectedOutcome: 'yes',
+					}),
+				}),
+			),
+		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
@@ -377,6 +449,7 @@ describe('ReportingSection', () => {
 					reportingDetails: createNotStartedReportingDetails(),
 					reportingForm: createReportingForm({
 						reportAmount: '3',
+						selectedOutcome: 'yes',
 					}),
 				}),
 			),
@@ -404,6 +477,7 @@ describe('ReportingSection', () => {
 					reportingDetails: createNotStartedReportingDetails(),
 					reportingForm: createReportingForm({
 						reportAmount: '2',
+						selectedOutcome: 'yes',
 					}),
 				}),
 			),
@@ -414,7 +488,17 @@ describe('ReportingSection', () => {
 	})
 
 	test('accepts decimal report amounts for the profit preview', async () => {
-		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps({ reportingForm: createReportingForm({ reportAmount: '1.5' }) })))
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					reportingForm: createReportingForm({
+						reportAmount: '1.5',
+						selectedOutcome: 'yes',
+					}),
+				}),
+			),
+		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		expect(document.body.textContent?.includes('projects roughly')).toBe(true)
@@ -422,7 +506,7 @@ describe('ReportingSection', () => {
 	})
 
 	test('autofills the active minimum-outcome-change preset', async () => {
-		const renderedComponent = await renderIntoDocument(<ReportingSectionHarness />)
+		const renderedComponent = await renderIntoDocument(<ReportingSectionHarness initialProps={{ reportingForm: createReportingForm({ selectedOutcome: 'yes' }) }} />)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		await act(() => {
@@ -434,7 +518,7 @@ describe('ReportingSection', () => {
 	})
 
 	test('autofills the active max-profit preset and updates the preview', async () => {
-		const renderedComponent = await renderIntoDocument(<ReportingSectionHarness />)
+		const renderedComponent = await renderIntoDocument(<ReportingSectionHarness initialProps={{ reportingForm: createReportingForm({ selectedOutcome: 'yes' }) }} />)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const previewBefore = findProfitPreview()
@@ -450,7 +534,7 @@ describe('ReportingSection', () => {
 	})
 
 	test('autofills the pre-start minimum-outcome-change preset from the pool start bond', async () => {
-		const renderedComponent = await renderIntoDocument(<ReportingSectionHarness initialProps={{ reportingDetails: createNotStartedReportingDetails() }} />)
+		const renderedComponent = await renderIntoDocument(<ReportingSectionHarness initialProps={{ reportingDetails: createNotStartedReportingDetails(), reportingForm: createReportingForm({ selectedOutcome: 'yes' }) }} />)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		await act(() => {
@@ -462,7 +546,17 @@ describe('ReportingSection', () => {
 	})
 
 	test('disables Max profit before the escalation game exists', async () => {
-		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps({ reportingDetails: createNotStartedReportingDetails() })))
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					reportingDetails: createNotStartedReportingDetails(),
+					reportingForm: createReportingForm({
+						selectedOutcome: 'yes',
+					}),
+				}),
+			),
+		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const maxProfitButton = within(document.body).getByRole('button', { name: 'Max profit' }) as HTMLButtonElement
@@ -472,7 +566,17 @@ describe('ReportingSection', () => {
 	})
 
 	test('disables preset buttons when reporting details are missing without showing the load reason inline', async () => {
-		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps({ reportingDetails: undefined })))
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					reportingDetails: undefined,
+					reportingForm: createReportingForm({
+						selectedOutcome: 'yes',
+					}),
+				}),
+			),
+		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
@@ -532,6 +636,9 @@ describe('ReportingSection', () => {
 				ReportingSection,
 				createProps({
 					mode: 'withdraw-only',
+					reportingForm: createReportingForm({
+						selectedOutcome: 'yes',
+					}),
 					reportingDetails: createReportingDetails({
 						questionOutcome: 'yes',
 						withdrawalEnabled: true,
@@ -578,6 +685,9 @@ describe('ReportingSection', () => {
 					onReportingFormChange: update => {
 						onReportingFormChangeCalls.push(update)
 					},
+					reportingForm: createReportingForm({
+						selectedOutcome: 'yes',
+					}),
 					reportingDetails: createReportingDetails({
 						questionOutcome: 'yes',
 						sides: [
@@ -679,6 +789,9 @@ describe('ReportingSection', () => {
 							{ balance: rep(8n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
 						],
 					}),
+					reportingForm: createReportingForm({
+						selectedOutcome: 'yes',
+					}),
 				}),
 			),
 		)
@@ -701,6 +814,9 @@ describe('ReportingSection', () => {
 							{ balance: rep(8n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
 							{ balance: rep(2n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
 						],
+					}),
+					reportingForm: createReportingForm({
+						selectedOutcome: 'yes',
 					}),
 				}),
 			),

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -270,7 +270,7 @@ describe('ReportingSection', () => {
 		expect(documentQueries.queryByText('Blocked')).toBeNull()
 		expect(documentQueries.queryByText('Reporting Workflow')).toBeNull()
 		expect(document.body.textContent?.includes('Selected side currently has')).toBe(false)
-		expect(documentQueries.getByText('Select outcome side')).not.toBeNull()
+		expect(documentQueries.queryByRole('button', { name: 'Outcome Side' })).toBeNull()
 		expect(document.body.querySelectorAll('.escalation-side.selected').length).toBe(0)
 	})
 
@@ -296,7 +296,7 @@ describe('ReportingSection', () => {
 		expect(document.body.textContent?.includes('Withdraw Escalation Deposits')).toBe(false)
 	})
 
-	test('keeps the outcome dropdown unselected when reporting is locked', async () => {
+	test('keeps the outcome cards unselected when reporting is locked', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(
 				ReportingSection,
@@ -309,9 +309,7 @@ describe('ReportingSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		expect(documentQueries.getByText('Select outcome side')).not.toBeNull()
-		const outcomeButton = documentQueries.getByRole('button', { name: 'Outcome Side' }) as HTMLButtonElement
-		expect(outcomeButton.disabled).toBe(true)
+		expect(documentQueries.queryByRole('button', { name: 'Outcome Side' })).toBeNull()
 		expect(document.body.querySelectorAll('.escalation-side.selected').length).toBe(0)
 	})
 

--- a/ui/ts/tests/securityPoolWorkflowSection.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection.test.tsx
@@ -68,7 +68,7 @@ function createReportingProps(overrides: Partial<ReportingRouteContentProps> = {
 		reportingForm: {
 			reportAmount: '',
 			securityPoolAddress: '',
-			selectedOutcome: 'yes',
+			selectedOutcome: undefined,
 			selectedWithdrawDepositIndexes: [],
 		},
 		reportingResult: undefined,

--- a/ui/ts/tests/securityPoolsSection.test.ts
+++ b/ui/ts/tests/securityPoolsSection.test.ts
@@ -67,7 +67,7 @@ function createReportingProps(overrides: Partial<ReportingRouteContentProps> = {
 		reportingForm: {
 			reportAmount: '',
 			securityPoolAddress: '',
-			selectedOutcome: 'yes',
+			selectedOutcome: undefined,
 			selectedWithdrawDepositIndexes: [],
 		},
 		reportingResult: undefined,

--- a/ui/ts/types/app.ts
+++ b/ui/ts/types/app.ts
@@ -82,7 +82,7 @@ export type TradingFormState = {
 export type ReportingFormState = {
 	reportAmount: string
 	securityPoolAddress: string
-	selectedOutcome: ReportingOutcomeKey
+	selectedOutcome: ReportingOutcomeKey | undefined
 	selectedWithdrawDepositIndexes: bigint[]
 }
 


### PR DESCRIPTION
## Summary
- Tightened the reporting flow with explicit outcome selection, clearer withdrawal eligibility, and checkbox-based deposit selection.
- Added richer transaction feedback across deployment, reporting, trading, open oracle, fork auction, security vault, and security pool actions.
- Updated reporting, escalation, and security pool UI to show more contextual status, metrics, and lock/state guidance.
- Extended security pool contracts and UI types to support the new escalation deposit behavior.
- Added and expanded tests around reporting, open oracle, fork auction, security vault, transaction actions, and related guards.

## Testing
- Not run