### PR TITLE
Refine reporting, escalation, and transaction feedback UX

### DIFF
--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -20,7 +20,7 @@ import { useSecurityVaultOperations } from './hooks/useSecurityVaultOperations.j
 import { useTradingOperations } from './hooks/useTradingOperations.js'
 import { useUrlState } from './hooks/useUrlState.js'
 import { getActiveSimulationController } from './lib/activeEnvironment.js'
-import { ChainTimestampContext } from './lib/chainTimestamp.js'
+import { ChainBlockNumberContext, ChainTimestampContext } from './lib/chainTimestamp.js'
 import { getDeploymentSections } from './lib/deployment.js'
 import { resolveLoadableValueState } from './lib/loadState.js'
 import { getWrongNetworkMessage, isSupportedAppChain } from './lib/network.js'
@@ -60,6 +60,7 @@ export function App() {
 		accountState,
 		augurPlaceHolderDeployed,
 		connectWallet,
+		currentBlockNumber,
 		currentTimestamp,
 		deploymentStatuses,
 		environmentBootstrapError,
@@ -689,22 +690,24 @@ export function App() {
 		) : undefined
 
 	return (
-		<ChainTimestampContext.Provider value={currentTimestamp}>
-			<main>
-				<AppStatusNotices
-					errorMessage={errorMessage}
-					simulationBootstrapError={environmentBootstrapError}
-					showAugurPlaceHolderDeploymentWarning={showAugurPlaceHolderDeploymentWarning}
-					showZoltarUniverseForkedWarning={showZoltarUniverseForkedWarning}
-					wrongNetworkMessage={wrongNetworkMessage}
-					zoltarUniverse={zoltarUniverse}
-				/>
-				<AppHeaderShell overview={overviewProps} simulationController={simulationController} subNavigation={routeSubNavigation} tabNavigation={tabNavigationProps} onRefresh={refreshSimulationView} />
+		<ChainBlockNumberContext.Provider value={currentBlockNumber}>
+			<ChainTimestampContext.Provider value={currentTimestamp}>
+				<main>
+					<AppStatusNotices
+						errorMessage={errorMessage}
+						simulationBootstrapError={environmentBootstrapError}
+						showAugurPlaceHolderDeploymentWarning={showAugurPlaceHolderDeploymentWarning}
+						showZoltarUniverseForkedWarning={showZoltarUniverseForkedWarning}
+						wrongNetworkMessage={wrongNetworkMessage}
+						zoltarUniverse={zoltarUniverse}
+					/>
+					<AppHeaderShell overview={overviewProps} simulationController={simulationController} subNavigation={routeSubNavigation} tabNavigation={tabNavigationProps} onRefresh={refreshSimulationView} />
 
-				<fieldset className='route-shell' disabled={isRouteContentDisabled}>
-					<AppRouteContent deploy={deployRouteContentProps} market={marketRouteContentProps} openOracle={openOracleRouteContentProps} route={route} securityPools={securityPoolsRouteContentProps} wrongNetworkMessage={wrongNetworkMessage} />
-				</fieldset>
-			</main>
-		</ChainTimestampContext.Provider>
+					<fieldset className='route-shell' disabled={isRouteContentDisabled}>
+						<AppRouteContent deploy={deployRouteContentProps} market={marketRouteContentProps} openOracle={openOracleRouteContentProps} route={route} securityPools={securityPoolsRouteContentProps} wrongNetworkMessage={wrongNetworkMessage} />
+					</fieldset>
+				</main>
+			</ChainTimestampContext.Provider>
+		</ChainBlockNumberContext.Provider>
 	)
 }

--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -77,9 +77,9 @@ function renderAddress(address: string | undefined) {
 	return <AddressValue address={address} />
 }
 
-function renderTimestamp(timestamp: bigint | undefined, fallbackText: string, currentTimestamp?: bigint) {
-	if (timestamp === undefined) return fallbackText
-	return <TimestampValue {...(currentTimestamp === undefined ? {} : { currentTimestamp })} timestamp={timestamp} />
+function renderTimestamp({ chainCurrentTimestamp, fallbackText, valueTimestamp }: { chainCurrentTimestamp: bigint | undefined; fallbackText: string; valueTimestamp: bigint | undefined }) {
+	if (valueTimestamp === undefined) return fallbackText
+	return <TimestampValue {...(chainCurrentTimestamp === undefined ? {} : { currentTimestamp: chainCurrentTimestamp })} timestamp={valueTimestamp} />
 }
 
 function getForkOnlyFallbackText(hasPreviewForkActivity: boolean) {
@@ -226,10 +226,18 @@ export function ForkAuctionSection({
 		forkAuctionDetails === undefined
 			? previewPool?.truthAuctionStartedAt === undefined || previewPool.truthAuctionStartedAt === 0n
 				? 'Not started'
-				: renderTimestamp(previewPool.truthAuctionStartedAt, 'Not started', effectiveCurrentTimestamp)
+				: renderTimestamp({
+						chainCurrentTimestamp: effectiveCurrentTimestamp,
+						fallbackText: 'Not started',
+						valueTimestamp: previewPool.truthAuctionStartedAt,
+					})
 			: forkAuctionDetails.truthAuctionStartedAt === 0n
 				? 'Not started'
-				: renderTimestamp(forkAuctionDetails.truthAuctionStartedAt, 'Not started', effectiveCurrentTimestamp)
+				: renderTimestamp({
+						chainCurrentTimestamp: effectiveCurrentTimestamp,
+						fallbackText: 'Not started',
+						valueTimestamp: forkAuctionDetails.truthAuctionStartedAt,
+					})
 	const endsDisplay = auctionWindow === undefined ? 'Not started' : <TimestampValue {...(effectiveCurrentTimestamp === undefined ? {} : { currentTimestamp: effectiveCurrentTimestamp })} timestamp={auctionWindow.endsAt} />
 	const truthAuctionTimeRemaining = truthAuctionEndsAt === undefined || effectiveCurrentTimestamp === undefined ? forkAuctionDetails?.truthAuction?.timeRemaining : getTimeRemaining(truthAuctionEndsAt, effectiveCurrentTimestamp)
 	const timeLeftDisplay = forkAuctionDetails?.truthAuction === undefined ? forkOnlyFallbackText : truthAuctionTimeRemaining === undefined ? formatDuration(AUCTION_TIME_SECONDS) : formatDuration(truthAuctionTimeRemaining)

--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -79,9 +79,9 @@ function renderAddress(address: string | undefined) {
 	return <AddressValue address={address} />
 }
 
-function renderTimestamp({ displayTimestamp, fallbackText, relativeToTimestamp }: { displayTimestamp: bigint | undefined; fallbackText: string; relativeToTimestamp: bigint | undefined }) {
+function renderTimestamp({ displayTimestamp, fallbackText }: { displayTimestamp: bigint | undefined; fallbackText: string }) {
 	if (displayTimestamp === undefined) return fallbackText
-	return <TimestampValue {...(relativeToTimestamp === undefined ? {} : { currentTimestamp: relativeToTimestamp })} timestamp={displayTimestamp} />
+	return <TimestampValue timestamp={displayTimestamp} />
 }
 
 function getForkOnlyFallbackText(hasPreviewForkActivity: boolean) {
@@ -231,14 +231,12 @@ export function ForkAuctionSection({
 				: renderTimestamp({
 						displayTimestamp: previewPool.truthAuctionStartedAt,
 						fallbackText: 'Not started',
-						relativeToTimestamp: effectiveCurrentTimestamp,
 					})
 			: forkAuctionDetails.truthAuctionStartedAt === 0n
 				? 'Not started'
 				: renderTimestamp({
 						displayTimestamp: forkAuctionDetails.truthAuctionStartedAt,
 						fallbackText: 'Not started',
-						relativeToTimestamp: effectiveCurrentTimestamp,
 					})
 	const endsDisplay = auctionWindow === undefined ? 'Not started' : <TimestampValue {...(effectiveCurrentTimestamp === undefined ? {} : { currentTimestamp: effectiveCurrentTimestamp })} timestamp={auctionWindow.endsAt} />
 	const truthAuctionTimeRemaining = truthAuctionEndsAt === undefined || effectiveCurrentTimestamp === undefined ? forkAuctionDetails?.truthAuction?.timeRemaining : getTimeRemaining(truthAuctionEndsAt, effectiveCurrentTimestamp)

--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -79,9 +79,9 @@ function renderAddress(address: string | undefined) {
 	return <AddressValue address={address} />
 }
 
-function renderTimestamp({ chainCurrentTimestamp, fallbackText, valueTimestamp }: { chainCurrentTimestamp: bigint | undefined; fallbackText: string; valueTimestamp: bigint | undefined }) {
-	if (valueTimestamp === undefined) return fallbackText
-	return <TimestampValue {...(chainCurrentTimestamp === undefined ? {} : { currentTimestamp: chainCurrentTimestamp })} timestamp={valueTimestamp} />
+function renderTimestamp({ displayTimestamp, fallbackText, relativeToTimestamp }: { displayTimestamp: bigint | undefined; fallbackText: string; relativeToTimestamp: bigint | undefined }) {
+	if (displayTimestamp === undefined) return fallbackText
+	return <TimestampValue {...(relativeToTimestamp === undefined ? {} : { currentTimestamp: relativeToTimestamp })} timestamp={displayTimestamp} />
 }
 
 function getForkOnlyFallbackText(hasPreviewForkActivity: boolean) {
@@ -229,16 +229,16 @@ export function ForkAuctionSection({
 			? previewPool?.truthAuctionStartedAt === undefined || previewPool.truthAuctionStartedAt === 0n
 				? 'Not started'
 				: renderTimestamp({
-						chainCurrentTimestamp: effectiveCurrentTimestamp,
+						displayTimestamp: previewPool.truthAuctionStartedAt,
 						fallbackText: 'Not started',
-						valueTimestamp: previewPool.truthAuctionStartedAt,
+						relativeToTimestamp: effectiveCurrentTimestamp,
 					})
 			: forkAuctionDetails.truthAuctionStartedAt === 0n
 				? 'Not started'
 				: renderTimestamp({
-						chainCurrentTimestamp: effectiveCurrentTimestamp,
+						displayTimestamp: forkAuctionDetails.truthAuctionStartedAt,
 						fallbackText: 'Not started',
-						valueTimestamp: forkAuctionDetails.truthAuctionStartedAt,
+						relativeToTimestamp: effectiveCurrentTimestamp,
 					})
 	const endsDisplay = auctionWindow === undefined ? 'Not started' : <TimestampValue {...(effectiveCurrentTimestamp === undefined ? {} : { currentTimestamp: effectiveCurrentTimestamp })} timestamp={auctionWindow.endsAt} />
 	const truthAuctionTimeRemaining = truthAuctionEndsAt === undefined || effectiveCurrentTimestamp === undefined ? forkAuctionDetails?.truthAuction?.timeRemaining : getTimeRemaining(truthAuctionEndsAt, effectiveCurrentTimestamp)

--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -77,9 +77,9 @@ function renderAddress(address: string | undefined) {
 	return <AddressValue address={address} />
 }
 
-function renderTimestamp(timestamp: bigint | undefined, fallbackText: string) {
+function renderTimestamp(timestamp: bigint | undefined, fallbackText: string, currentTimestamp?: bigint) {
 	if (timestamp === undefined) return fallbackText
-	return <TimestampValue timestamp={timestamp} />
+	return <TimestampValue {...(currentTimestamp === undefined ? {} : { currentTimestamp })} timestamp={timestamp} />
 }
 
 function getForkOnlyFallbackText(hasPreviewForkActivity: boolean) {
@@ -156,6 +156,7 @@ function estimateBidRep(bidAmount: string, selectedAuctionPrice: bigint | undefi
 
 export function ForkAuctionSection({
 	accountState,
+	currentTimestamp,
 	disabled = false,
 	disabledMessage,
 	embedInCard = false,
@@ -187,9 +188,11 @@ export function ForkAuctionSection({
 	const isMainnet = isMainnetChain(accountState.chainId)
 	const selectedAuctionPrice = forkAuctionDetails?.truthAuction?.clearingPrice
 	const estimatedRep = estimateBidRep(forkAuctionForm.submitBidAmount, selectedAuctionPrice)
-	const migrationTimeRemaining = forkAuctionDetails === undefined ? undefined : getTimeRemaining(forkAuctionDetails.migrationEndsAt, forkAuctionDetails.currentTime)
+	const effectiveCurrentTimestamp = currentTimestamp ?? forkAuctionDetails?.currentTime
+	const migrationTimeRemaining = forkAuctionDetails === undefined ? undefined : getTimeRemaining(forkAuctionDetails.migrationEndsAt, effectiveCurrentTimestamp ?? forkAuctionDetails.currentTime)
 	const previewAuctionWindow = getTruthAuctionWindow(previewPool?.truthAuctionStartedAt)
 	const auctionWindow = forkAuctionDetails === undefined ? previewAuctionWindow : getTruthAuctionWindow(forkAuctionDetails.truthAuctionStartedAt)
+	const truthAuctionEndsAt = forkAuctionDetails?.truthAuction?.auctionEndsAt ?? auctionWindow?.endsAt
 	const securityPoolAddress = forkAuctionDetails?.securityPoolAddress ?? previewPool?.securityPoolAddress
 	const universeId = forkAuctionDetails?.universeId ?? previewPool?.universeId
 	const parentSecurityPoolAddress = forkAuctionDetails?.parentSecurityPoolAddress ?? previewPool?.parent
@@ -223,12 +226,13 @@ export function ForkAuctionSection({
 		forkAuctionDetails === undefined
 			? previewPool?.truthAuctionStartedAt === undefined || previewPool.truthAuctionStartedAt === 0n
 				? 'Not started'
-				: renderTimestamp(previewPool.truthAuctionStartedAt, 'Not started')
+				: renderTimestamp(previewPool.truthAuctionStartedAt, 'Not started', effectiveCurrentTimestamp)
 			: forkAuctionDetails.truthAuctionStartedAt === 0n
 				? 'Not started'
-				: renderTimestamp(forkAuctionDetails.truthAuctionStartedAt, 'Not started')
-	const endsDisplay = auctionWindow === undefined ? 'Not started' : <TimestampValue timestamp={auctionWindow.endsAt} />
-	const timeLeftDisplay = forkAuctionDetails?.truthAuction?.timeRemaining === undefined ? (forkAuctionDetails?.truthAuction === undefined ? forkOnlyFallbackText : formatDuration(AUCTION_TIME_SECONDS)) : formatDuration(forkAuctionDetails.truthAuction.timeRemaining)
+				: renderTimestamp(forkAuctionDetails.truthAuctionStartedAt, 'Not started', effectiveCurrentTimestamp)
+	const endsDisplay = auctionWindow === undefined ? 'Not started' : <TimestampValue {...(effectiveCurrentTimestamp === undefined ? {} : { currentTimestamp: effectiveCurrentTimestamp })} timestamp={auctionWindow.endsAt} />
+	const truthAuctionTimeRemaining = truthAuctionEndsAt === undefined || effectiveCurrentTimestamp === undefined ? forkAuctionDetails?.truthAuction?.timeRemaining : getTimeRemaining(truthAuctionEndsAt, effectiveCurrentTimestamp)
+	const timeLeftDisplay = forkAuctionDetails?.truthAuction === undefined ? forkOnlyFallbackText : truthAuctionTimeRemaining === undefined ? formatDuration(AUCTION_TIME_SECONDS) : formatDuration(truthAuctionTimeRemaining)
 	const ethRaisedCapDisplay =
 		forkAuctionDetails?.truthAuction === undefined ? (
 			forkOnlyFallbackText
@@ -326,7 +330,10 @@ export function ForkAuctionSection({
 				? [
 						{ label: 'REP At Fork', value: forkAuctionDetails === undefined ? forkOnlyFallbackText : <CurrencyValue value={forkAuctionDetails.repAtFork} suffix='REP' /> },
 						{ label: 'Migrated REP', value: renderMetricValue(forkAuctionDetails?.migratedRep ?? previewPool?.migratedRep, 'REP', UNKNOWN_VALUE) },
-						{ label: 'Migration Ends', value: forkAuctionDetails === undefined ? migrationSummaryText : forkAuctionDetails.migrationEndsAt === undefined ? 'Started/finished' : <TimestampValue timestamp={forkAuctionDetails.migrationEndsAt} /> },
+						{
+							label: 'Migration Ends',
+							value: forkAuctionDetails === undefined ? migrationSummaryText : forkAuctionDetails.migrationEndsAt === undefined ? 'Started/finished' : <TimestampValue {...(effectiveCurrentTimestamp === undefined ? {} : { currentTimestamp: effectiveCurrentTimestamp })} timestamp={forkAuctionDetails.migrationEndsAt} />,
+						},
 						{ label: 'Time Left', value: forkAuctionDetails === undefined ? forkOnlyFallbackText : migrationTimeRemaining === undefined ? formatDuration(MIGRATION_TIME_SECONDS) : formatDuration(migrationTimeRemaining) },
 					]
 				: selectedStage === 'auction'
@@ -354,7 +361,10 @@ export function ForkAuctionSection({
 		{ label: 'REP At Fork', value: forkAuctionDetails === undefined ? forkOnlyFallbackText : <CurrencyValue value={forkAuctionDetails.repAtFork} suffix='REP' /> },
 		{ label: 'Migrated REP', value: renderMetricValue(forkAuctionDetails?.migratedRep ?? previewPool?.migratedRep, 'REP', UNKNOWN_VALUE) },
 		{ label: 'Collateral', value: renderMetricValue(forkAuctionDetails?.completeSetCollateralAmount ?? previewPool?.completeSetCollateralAmount, 'ETH', UNKNOWN_VALUE) },
-		{ label: 'Migration Ends', value: forkAuctionDetails === undefined ? migrationSummaryText : forkAuctionDetails.migrationEndsAt === undefined ? 'Started/finished' : <TimestampValue timestamp={forkAuctionDetails.migrationEndsAt} /> },
+		{
+			label: 'Migration Ends',
+			value: forkAuctionDetails === undefined ? migrationSummaryText : forkAuctionDetails.migrationEndsAt === undefined ? 'Started/finished' : <TimestampValue {...(effectiveCurrentTimestamp === undefined ? {} : { currentTimestamp: effectiveCurrentTimestamp })} timestamp={forkAuctionDetails.migrationEndsAt} />,
+		},
 		{ label: 'Time Left', value: forkAuctionDetails === undefined ? forkOnlyFallbackText : migrationTimeRemaining === undefined ? formatDuration(MIGRATION_TIME_SECONDS) : formatDuration(migrationTimeRemaining) },
 		{ label: 'Fork Type', value: forkAuctionDetails === undefined ? getPreviewForkType(previewPool, hasPreviewForkActivity) : forkAuctionDetails.forkOwnSecurityPool ? 'Own escalation fork' : 'Parent/Zoltar fork' },
 	]

--- a/ui/ts/components/OpenOracleSection.tsx
+++ b/ui/ts/components/OpenOracleSection.tsx
@@ -23,6 +23,7 @@ import { TransactionActionButton } from './TransactionActionButton.js'
 import { TimestampValue } from './TimestampValue.js'
 import { useLoadController } from '../hooks/useLoadController.js'
 import { createConnectedReadClient } from '../lib/clients.js'
+import { useChainBlockNumber, useChainTimestamp } from '../lib/chainTimestamp.js'
 import {
 	getOpenOracleCreateGuardMessage,
 	formatOpenOracleFeePercentage,
@@ -48,6 +49,19 @@ import type { OpenOracleSectionProps } from '../types/components.js'
 const BROWSE_PAGE_SIZE = 10
 type SelectedReportModal = 'dispute' | 'initial-report' | 'settle' | undefined
 type BrowseStatusFilter = 'all' | 'Awaiting Initial Report' | 'Pending' | 'Disputed' | 'Settled'
+
+function getEffectiveOpenOracleReportDetails(report: OpenOracleReportDetails | undefined, currentTimestamp: bigint | undefined, currentBlockNumber: bigint | undefined) {
+	if (report === undefined) return undefined
+	if ((currentTimestamp === undefined || report.currentTime === currentTimestamp) && (currentBlockNumber === undefined || report.currentBlockNumber === currentBlockNumber)) {
+		return report
+	}
+
+	return {
+		...report,
+		currentBlockNumber: currentBlockNumber ?? report.currentBlockNumber,
+		currentTime: currentTimestamp ?? report.currentTime,
+	}
+}
 
 function resolveBrowseStatusFilter(value: string): BrowseStatusFilter {
 	switch (value) {
@@ -755,6 +769,8 @@ export function OpenOracleSection({
 	onActiveViewChange,
 }: OpenOracleSectionProps) {
 	const view = activeView
+	const chainCurrentTimestamp = useChainTimestamp()
+	const chainCurrentBlockNumber = useChainBlockNumber()
 	const [browsePage, setBrowsePage] = useState<OpenOracleReportSummaryPage | undefined>(undefined)
 	const [browseError, setBrowseError] = useState<string | undefined>(undefined)
 	const [browsePageIndex, setBrowsePageIndex] = useState(0)
@@ -771,6 +787,7 @@ export function OpenOracleSection({
 		walletConnected: isConnected,
 		walletEthBalance: accountState.ethBalance,
 	})
+	const effectiveOpenOracleReportDetails = getEffectiveOpenOracleReportDetails(openOracleReportDetails, chainCurrentTimestamp, chainCurrentBlockNumber)
 
 	useEffect(() => {
 		let cancelled = false
@@ -977,7 +994,7 @@ export function OpenOracleSection({
 			{view === 'selected-report' ? (
 				<div className='workflow-stack route-workflow-stack'>
 					{renderReportDetailsCard(
-						openOracleReportDetails,
+						effectiveOpenOracleReportDetails,
 						openOracleForm,
 						openOracleInitialReportState,
 						openOracleDisputeSubmission,

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -147,6 +147,17 @@ function getReportingStagePresentation({
 	}
 }
 
+function getEffectiveReportingDetails(reportingDetails: ReportingDetails | undefined, currentTimestamp: bigint | undefined) {
+	if (reportingDetails === undefined || currentTimestamp === undefined || reportingDetails.currentTime === currentTimestamp) {
+		return reportingDetails
+	}
+
+	return {
+		...reportingDetails,
+		currentTime: currentTimestamp,
+	}
+}
+
 export function ReportingSection({
 	accountState,
 	currentTimestamp,
@@ -168,10 +179,11 @@ export function ReportingSection({
 	mode = 'full-reporting',
 }: ReportingSectionProps) {
 	const isMainnet = isMainnetChain(accountState.chainId)
-	const activeReportingDetails = reportingDetails?.status === 'active' ? reportingDetails : undefined
-	const reportingStatus: ReportingStatus = reportingDetails === undefined ? 'missing' : reportingDetails.status
-	const marketDetails = reportingDetails?.marketDetails ?? previewMarketDetails
-	const effectiveCurrentTimestamp = reportingDetails?.currentTime ?? currentTimestamp
+	const effectiveCurrentTimestamp = currentTimestamp ?? reportingDetails?.currentTime
+	const effectiveReportingDetails = getEffectiveReportingDetails(reportingDetails, effectiveCurrentTimestamp)
+	const activeReportingDetails = effectiveReportingDetails?.status === 'active' ? effectiveReportingDetails : undefined
+	const reportingStatus: ReportingStatus = effectiveReportingDetails === undefined ? 'missing' : effectiveReportingDetails.status
+	const marketDetails = effectiveReportingDetails?.marketDetails ?? previewMarketDetails
 	const reportingLocked = lockedReason !== undefined
 	const selectedAmount = parseOptionalRepAmountInput(reportingForm.reportAmount)
 	const showFullReporting = mode === 'full-reporting'
@@ -180,12 +192,12 @@ export function ReportingSection({
 	const selectedWithdrawDepositIndexes = reportingForm.selectedWithdrawDepositIndexes
 	const chartScaleMax = activeReportingDetails === undefined ? 1n : activeReportingDetails.sides.reduce((maxBalance, side) => (side.balance > maxBalance ? side.balance : maxBalance), activeReportingDetails.bindingCapital > 1n ? activeReportingDetails.bindingCapital : 1n)
 	const leadingOutcome = activeReportingDetails === undefined ? undefined : getLeadingEscalationOutcome(activeReportingDetails.sides)
-	const reportContributionPreview = reportingDetails === undefined || selectedAmount === undefined ? undefined : previewReportingContribution(reportingDetails, reportingForm.selectedOutcome, selectedAmount)
+	const reportContributionPreview = effectiveReportingDetails === undefined || selectedAmount === undefined ? undefined : previewReportingContribution(effectiveReportingDetails, reportingForm.selectedOutcome, selectedAmount)
 	const actualReportDepositAmount = reportContributionPreview?.actualDepositAmount
 	const selectedEstimate = activeReportingDetails === undefined || selectedAmount === undefined ? undefined : calculateEstimatedEscalationReturn(activeReportingDetails, reportingForm.selectedOutcome, selectedAmount)
 	const outcomeSides = getOutcomeSides(activeReportingDetails)
-	const minimumOutcomeChangeContribution = getReportingMinimumOutcomeChangeContribution(reportingDetails, reportingForm.selectedOutcome)
-	const maxProfitContribution = getReportingMaxProfitContribution(reportingDetails, reportingForm.selectedOutcome)
+	const minimumOutcomeChangeContribution = getReportingMinimumOutcomeChangeContribution(effectiveReportingDetails, reportingForm.selectedOutcome)
+	const maxProfitContribution = getReportingMaxProfitContribution(effectiveReportingDetails, reportingForm.selectedOutcome)
 	const presetReasons = reportingLocked ? [] : [minimumOutcomeChangeContribution.reason, maxProfitContribution.reason].filter((reason, index, reasons): reason is string => reason !== undefined && !isHiddenPresetReason(reason) && reasons.indexOf(reason) === index)
 	const reportAmountError = selectedAmount === undefined && reportingForm.reportAmount.trim() !== '' ? 'Enter a valid report amount to preview profit.' : undefined
 	const reportGuardMessage = getReportingReportGuardMessage({
@@ -197,8 +209,8 @@ export function ReportingSection({
 		reportAmount: reportingForm.reportAmount,
 		reportingStatus,
 		selectedAmount,
-		viewerVaultAvailableEscalationRep: reportingDetails?.viewerVaultAvailableEscalationRep,
-		viewerVaultExists: reportingDetails?.viewerVaultExists ?? false,
+		viewerVaultAvailableEscalationRep: effectiveReportingDetails?.viewerVaultAvailableEscalationRep,
+		viewerVaultExists: effectiveReportingDetails?.viewerVaultExists ?? false,
 	})
 	const withdrawGuardMessage = getReportingWithdrawGuardMessage({
 		accountAddress: accountState.address,
@@ -207,13 +219,13 @@ export function ReportingSection({
 		lockedReason,
 		reportingStatus,
 		withdrawalEnabled: activeReportingDetails?.withdrawalEnabled ?? false,
-		withdrawalState: reportingDetails?.withdrawalState,
+		withdrawalState: effectiveReportingDetails?.withdrawalState,
 	})
 	const reportingStage = showFullReporting
 		? getReportingStagePresentation({
 				effectiveCurrentTimestamp,
 				marketDetails,
-				reportingDetails,
+				reportingDetails: effectiveReportingDetails,
 			})
 		: undefined
 	const showReportingHeaderStack = showFullReporting && (showSecurityPoolAddressInput || reportingStage !== undefined)
@@ -249,14 +261,14 @@ export function ReportingSection({
 							<CurrencyValue value={activeReportingDetails?.bindingCapital} suffix='REP' />
 						</MetricField>
 						<MetricField label='Threshold'>
-							<CurrencyValue value={reportingDetails?.nonDecisionThreshold} suffix='REP' />
+							<CurrencyValue value={effectiveReportingDetails?.nonDecisionThreshold} suffix='REP' />
 						</MetricField>
 						<MetricField label='Time Left'>{activeReportingDetails === undefined ? '—' : formatDuration(getEscalationTimeRemaining(activeReportingDetails))}</MetricField>
 						<MetricField label='Game Start'>
 							<TimestampValue {...(effectiveCurrentTimestamp === undefined ? {} : { currentTimestamp: effectiveCurrentTimestamp })} timestamp={activeReportingDetails?.startingTime} />
 						</MetricField>
 						<MetricField label='Start Bond'>
-							<CurrencyValue value={reportingDetails?.startBond} suffix='REP' />
+							<CurrencyValue value={effectiveReportingDetails?.startBond} suffix='REP' />
 						</MetricField>
 					</div>
 					<div className='escalation-sides-shell'>
@@ -293,9 +305,9 @@ export function ReportingSection({
 							Selected side currently has <CurrencyValue value={selectedSide.balance} suffix='REP' /> deposited.
 						</p>
 					)}
-					{reportingDetails?.viewerVaultAvailableEscalationRep === undefined ? undefined : (
+					{effectiveReportingDetails?.viewerVaultAvailableEscalationRep === undefined ? undefined : (
 						<p className='detail'>
-							Available unlocked vault REP for reporting: <CurrencyValue value={reportingDetails.viewerVaultAvailableEscalationRep} suffix='REP' />.
+							Available unlocked vault REP for reporting: <CurrencyValue value={effectiveReportingDetails.viewerVaultAvailableEscalationRep} suffix='REP' />.
 						</p>
 					)}
 					<label className='field'>

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -129,7 +129,7 @@ export function SecurityPoolWorkflowSection({
 	const marketDetails = selectedPool?.marketDetails ?? currentReportingDetails?.marketDetails ?? currentForkAuctionDetails?.marketDetails
 	const selectedPoolState = selectedPool?.systemState ?? currentForkAuctionDetails?.systemState
 	const selectedPoolHasForkActivity = selectedPool !== undefined ? hasForkActivity(selectedPool) : currentForkAuctionDetails !== undefined ? hasForkActivity(currentForkAuctionDetails) : false
-	const currentTimestamp = currentReportingDetails?.currentTime ?? chainCurrentTimestamp ?? getLocalCurrentTimestamp()
+	const currentTimestamp = chainCurrentTimestamp ?? currentReportingDetails?.currentTime ?? getLocalCurrentTimestamp()
 	const reportingReady = marketDetails !== undefined && marketDetails.endTime <= currentTimestamp
 	const forkWorkflowDisabled = isForkWorkflowDisabled(selectedPoolState, selectedPoolHasForkActivity)
 	const selectedPoolUniverseMismatch = selectedPool !== undefined && selectedPool.universeId !== activeUniverseId
@@ -576,6 +576,7 @@ export function SecurityPoolWorkflowSection({
 								{view === 'fork' ? (
 									<ForkAuctionSection
 										{...forkAuction}
+										currentTimestamp={currentTimestamp}
 										disabled={forkWorkflowDisabled}
 										disabledMessage={forkWorkflowDisabled ? 'This pool is currently operational, so fork and truth auction actions are read only.' : undefined}
 										embedInCard

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -1,4 +1,4 @@
-import { decodeEventLog, parseAbiItem, zeroAddress, type Address, type ContractFunctionParameters, type Hash, type Hex, type TransactionReceipt } from 'viem'
+import { decodeEventLog, getAddress, isHex, parseAbiItem, zeroAddress, type Address, type ContractFunctionParameters, type Hash, type Hex, type TransactionReceipt } from 'viem'
 import { ABIS } from './abis.js'
 import { sortBigIntsAscending } from './shared/bigInt.js'
 import { assertNever } from './lib/assert.js'
@@ -222,7 +222,7 @@ async function loadViewerReportingVaultState(client: ReadClient, securityPoolAdd
 }
 
 export async function loadReportingDetails(client: ReadClient, securityPoolAddress: Address, accountAddress: Address | undefined): Promise<ReportingDetails> {
-	const [questionId, escalationGameAddress, completeSetCollateralAmount, universeId, zoltarAddress, initialEscalationGameDeposit] = await readRequiredMulticall(client, [
+	const reportingContracts: readonly ContractFunctionParameters[] = [
 		{
 			abi: peripherals_SecurityPool_SecurityPool.abi,
 			functionName: 'questionId',
@@ -259,7 +259,17 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 			address: securityPoolAddress,
 			args: [],
 		},
-	])
+	]
+	const [rawQuestionId, rawEscalationGameAddress, rawCompleteSetCollateralAmount, rawUniverseId, rawZoltarAddress, rawInitialEscalationGameDeposit] = await readRequiredMulticall(client, reportingContracts)
+	if (typeof rawQuestionId !== 'bigint' || !isHex(rawEscalationGameAddress) || typeof rawCompleteSetCollateralAmount !== 'bigint' || typeof rawUniverseId !== 'bigint' || !isHex(rawZoltarAddress) || typeof rawInitialEscalationGameDeposit !== 'bigint') {
+		throw new Error('Unexpected reporting details response')
+	}
+	const questionId = rawQuestionId
+	const escalationGameAddress = getAddress(rawEscalationGameAddress)
+	const completeSetCollateralAmount = rawCompleteSetCollateralAmount
+	const universeId = rawUniverseId
+	const zoltarAddress = getAddress(rawZoltarAddress)
+	const initialEscalationGameDeposit = rawInitialEscalationGameDeposit
 	const [marketDetails, block, escalationGameCode, viewerVaultState, forkThreshold] = await Promise.all([
 		loadMarketDetails(client, questionId),
 		client.getBlock(),

--- a/ui/ts/hooks/useOnchainState.ts
+++ b/ui/ts/hooks/useOnchainState.ts
@@ -16,6 +16,11 @@ type RefreshStateOptions = {
 	loadWalletState?: boolean
 }
 
+type ChainClock = {
+	currentBlockNumber: bigint | undefined
+	currentTimestamp: bigint | undefined
+}
+
 type LoadWalletStateParameters = {
 	chainIdPromise: Promise<string> | undefined
 	connectedAddress: Address | undefined
@@ -67,15 +72,27 @@ export async function loadWalletState({ chainIdPromise, connectedAddress, ethBal
 	})
 }
 
-async function loadBackendCurrentTimestamp(backend: ChainBackend) {
-	if (backend.currentTimestamp !== undefined) return backend.currentTimestamp
-	if (backend.isBootstrapped === false) return undefined
+const CHAIN_CLOCK_POLL_INTERVAL_MILLISECONDS = 12_000
+
+async function loadBackendChainClock(backend: ChainBackend): Promise<ChainClock> {
+	if (backend.isBootstrapped === false) {
+		return {
+			currentBlockNumber: undefined,
+			currentTimestamp: undefined,
+		}
+	}
 
 	try {
 		const block = await backend.createReadClient().getBlock()
-		return typeof block.timestamp === 'bigint' ? block.timestamp : undefined
+		return {
+			currentBlockNumber: typeof block.number === 'bigint' ? block.number : undefined,
+			currentTimestamp: typeof block.timestamp === 'bigint' ? block.timestamp : undefined,
+		}
 	} catch {
-		return undefined
+		return {
+			currentBlockNumber: undefined,
+			currentTimestamp: undefined,
+		}
 	}
 }
 
@@ -98,6 +115,7 @@ export function useOnchainState() {
 	const deploymentStatusesLoaded = useSignal(false)
 	const augurPlaceHolderDeployed = useSignal<boolean | undefined>(undefined)
 	const currentTimestamp = useSignal<bigint | undefined>(getActiveBackend().currentTimestamp)
+	const currentBlockNumber = useSignal<bigint | undefined>(undefined)
 	const environmentBootstrapError = useSignal<string | undefined>(undefined)
 	const environmentBootstrapLabel = useSignal(getActiveBackend().bootstrapLabel)
 	const environmentBootstrapProgress = useSignal(getActiveBackend().bootstrapProgress)
@@ -106,23 +124,23 @@ export function useOnchainState() {
 	const walletBootstrapComplete = useSignal(false)
 	const isConnectingWallet = useSignal(false)
 	const nextRefresh = useRequestGuard()
-	const nextTimestampRefresh = useRequestGuard()
+	const nextChainClockRefresh = useRequestGuard()
 	const errorMessage = useSignal<string | undefined>(undefined)
 	const setDeploymentStatuses = (update: (current: DeploymentStatus[]) => DeploymentStatus[]) => {
 		const updated = update(deploymentStatuses.value)
 		deploymentStatuses.value = updated
 		if (updated.every(step => step.deployed)) augurPlaceHolderDeployed.value = true
 	}
-	const refreshCurrentTimestamp = async (backend: ChainBackend) => {
-		if (backend.currentTimestamp !== undefined) {
-			currentTimestamp.value = backend.currentTimestamp
-			return
+	const refreshChainClock = async (backend: ChainBackend) => {
+		const isCurrent = nextChainClockRefresh()
+		const nextChainClock = await loadBackendChainClock(backend)
+		if (!isCurrent()) return
+		if (nextChainClock.currentTimestamp !== undefined) {
+			currentTimestamp.value = nextChainClock.currentTimestamp
 		}
-
-		const isCurrent = nextTimestampRefresh()
-		const nextCurrentTimestamp = await loadBackendCurrentTimestamp(backend)
-		if (!isCurrent() || nextCurrentTimestamp === undefined) return
-		currentTimestamp.value = nextCurrentTimestamp
+		if (nextChainClock.currentBlockNumber !== undefined) {
+			currentBlockNumber.value = nextChainClock.currentBlockNumber
+		}
 	}
 
 	const refreshState = async (options: RefreshStateOptions = {}) => {
@@ -132,7 +150,7 @@ export function useOnchainState() {
 		hasInjectedWallet.value = backend.hasWallet()
 		errorMessage.value = undefined
 		backend.setReadTransportMode?.('rpc')
-		void refreshCurrentTimestamp(backend)
+		void refreshChainClock(backend)
 
 		if (backend.isBootstrapped === false) {
 			deploymentStatusesLoaded.value = false
@@ -272,11 +290,7 @@ export function useOnchainState() {
 			environmentBootstrapLabel.value = backend.bootstrapLabel
 			environmentBootstrapProgress.value = backend.bootstrapProgress
 			environmentReady.value = backend.isBootstrapped ?? true
-			if (backend.currentTimestamp !== undefined) {
-				currentTimestamp.value = backend.currentTimestamp
-				return
-			}
-			void refreshCurrentTimestamp(backend)
+			void refreshChainClock(backend)
 		})
 		const handleWalletChange = () => {
 			void refreshState()
@@ -293,17 +307,14 @@ export function useOnchainState() {
 
 	useEffect(() => {
 		const backend = getActiveBackend()
-		if (backend.currentTimestamp !== undefined || backend.isBootstrapped === false) {
-			if (backend.currentTimestamp !== undefined) {
-				currentTimestamp.value = backend.currentTimestamp
-			}
+		if (backend.isBootstrapped === false) {
 			return
 		}
 
-		void refreshCurrentTimestamp(backend)
+		void refreshChainClock(backend)
 		const intervalId = window.setInterval(() => {
-			void refreshCurrentTimestamp(backend)
-		}, 1000)
+			void refreshChainClock(backend)
+		}, CHAIN_CLOCK_POLL_INTERVAL_MILLISECONDS)
 
 		return () => {
 			window.clearInterval(intervalId)
@@ -313,6 +324,7 @@ export function useOnchainState() {
 	return {
 		accountState: accountState.value,
 		connectWallet,
+		currentBlockNumber: currentBlockNumber.value,
 		currentTimestamp: currentTimestamp.value,
 		deploymentStatuses: deploymentStatuses.value,
 		errorMessage: errorMessage.value,

--- a/ui/ts/hooks/useOpenOracleOperations.ts
+++ b/ui/ts/hooks/useOpenOracleOperations.ts
@@ -738,42 +738,6 @@ export function useOpenOracleOperations({ accountAddress, enabled, onTransaction
 		void refreshOpenOracleInitialReportTokenAccess(openOracleReportDetails.value)
 	}, [accountAddress, enabled, openOracleReportDetails.value?.reportId, openOracleReportDetails.value?.token1, openOracleReportDetails.value?.token2, openOracleReportDetails.value?.exactToken1Report])
 
-	useEffect(() => {
-		if (!enabled) return
-		const loadedReport = openOracleReportDetails.value
-		if (loadedReport === undefined) return
-
-		let cancelled = false
-		const trackedReportId = loadedReport.reportId
-		const refreshChainClock = async () => {
-			try {
-				const block = await createConnectedReadClient().getBlock()
-				if (cancelled || typeof block.timestamp !== 'bigint' || typeof block.number !== 'bigint') return
-
-				const currentReport = openOracleReportDetails.value
-				if (currentReport === undefined || currentReport.reportId !== trackedReportId) return
-
-				openOracleReportDetails.value = {
-					...currentReport,
-					currentTime: block.timestamp,
-					currentBlockNumber: block.number,
-				}
-			} catch {
-				return
-			}
-		}
-
-		void refreshChainClock()
-		const intervalId = window.setInterval(() => {
-			void refreshChainClock()
-		}, 1000)
-
-		return () => {
-			cancelled = true
-			window.clearInterval(intervalId)
-		}
-	}, [enabled, openOracleReportDetails.value?.reportId])
-
 	const openOracleInitialReportSubmission = openOracleReportDetails.value === undefined ? undefined : getInitialReportSubmission(openOracleReportDetails.value)
 	const openOracleDisputeSubmission = openOracleReportDetails.value === undefined ? undefined : getDisputeSubmission(openOracleReportDetails.value)
 

--- a/ui/ts/lib/chainTimestamp.ts
+++ b/ui/ts/lib/chainTimestamp.ts
@@ -2,7 +2,12 @@ import { createContext } from 'preact'
 import { useContext } from 'preact/hooks'
 
 export const ChainTimestampContext = createContext<bigint | undefined>(undefined)
+export const ChainBlockNumberContext = createContext<bigint | undefined>(undefined)
 
 export function useChainTimestamp() {
 	return useContext(ChainTimestampContext)
+}
+
+export function useChainBlockNumber() {
+	return useContext(ChainBlockNumberContext)
 }

--- a/ui/ts/tests/forkAuctionSection.test.tsx
+++ b/ui/ts/tests/forkAuctionSection.test.tsx
@@ -5,6 +5,8 @@ import { fireEvent, within } from '@testing-library/dom'
 import { h } from 'preact'
 import { zeroAddress } from 'viem'
 import { ForkAuctionSection } from '../components/ForkAuctionSection.js'
+import { AUCTION_TIME_SECONDS } from '../lib/forkAuction.js'
+import { formatDuration } from '../lib/formatters.js'
 import type { AccountState, ForkAuctionFormState } from '../types/app.js'
 import type { ForkAuctionDetails, MarketDetails } from '../types/contracts.js'
 import type { ForkAuctionSectionProps } from '../types/components.js'
@@ -192,6 +194,61 @@ describe('ForkAuctionSection', () => {
 		fireEvent.click(modalQueries.getByRole('button', { name: 'Create Yes Child Universe' }))
 
 		expect(createChildUniverseCallCount).toBe(1)
+	})
+
+	test('prefers the live chain timestamp over the loaded snapshot for migration time left', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					currentTimestamp: 150n,
+					forkAuctionDetails: createForkAuctionDetails(),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(document.body.textContent?.includes(formatDuration(200n - 100n))).toBe(false)
+		expect(document.body.textContent?.includes(formatDuration(200n - 150n))).toBe(true)
+	})
+
+	test('recomputes truth auction time left from the live chain timestamp', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					currentTimestamp: 150n,
+					forkAuctionDetails: {
+						...createForkAuctionDetails(),
+						currentTime: 100n,
+						systemState: 'forkTruthAuction',
+						truthAuction: {
+							accumulatedEth: 0n,
+							auctionEndsAt: 200n,
+							clearingPrice: undefined,
+							clearingTick: undefined,
+							ethAtClearingTick: 0n,
+							ethRaiseCap: 10n,
+							ethRaised: 0n,
+							finalized: false,
+							hitCap: false,
+							maxRepBeingSold: 10n,
+							minBidSize: 1n,
+							repPurchasableAtBid: undefined,
+							timeRemaining: 100n,
+							totalRepPurchased: 0n,
+							underfunded: false,
+						},
+						truthAuctionAddress: '0x0000000000000000000000000000000000000001',
+						truthAuctionStartedAt: 200n - AUCTION_TIME_SECONDS,
+					},
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(document.body.textContent?.includes(formatDuration(100n))).toBe(false)
+		expect(document.body.textContent?.includes(formatDuration(50n))).toBe(true)
 	})
 
 	test('blocks truth auction bids below the minimum bid size', async () => {

--- a/ui/ts/tests/openOracleRouteSection.test.tsx
+++ b/ui/ts/tests/openOracleRouteSection.test.tsx
@@ -5,6 +5,7 @@ import { within } from '@testing-library/dom'
 import { h } from 'preact'
 import { zeroAddress } from 'viem'
 import { OpenOracleSection } from '../components/OpenOracleSection.js'
+import { ChainBlockNumberContext, ChainTimestampContext } from '../lib/chainTimestamp.js'
 import { getDefaultOpenOracleCreateFormState, getDefaultOpenOracleFormState } from '../lib/marketForm.js'
 import { deriveOpenOracleDisputeSubmissionDetails, deriveOpenOracleInitialReportSubmissionDetails } from '../lib/openOracle.js'
 import type { AccountState } from '../types/app.js'
@@ -252,5 +253,57 @@ describe('OpenOracleSection route create view', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		expectTransactionButtonDisabled(document.body, 'Create Open Oracle Game', 'Need 100 more ETH in this wallet to create the selected Open Oracle game.')
+	})
+
+	test('uses the shared live chain timestamp to switch a selected report into settle mode', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<ChainTimestampContext.Provider value={161n}>
+				<OpenOracleSection
+					{...createOpenOracleSectionProps({
+						activeView: 'selected-report',
+						openOracleReportDetails: createOpenOracleReportDetails({
+							currentBlockNumber: 100n,
+							currentReporter: '0x3000000000000000000000000000000000000000',
+							currentTime: 100n,
+							disputeDelay: 10n,
+							reportTimestamp: 100n,
+							settlementTime: 60n,
+							timeType: true,
+						}),
+					})}
+				/>
+			</ChainTimestampContext.Provider>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.queryByRole('button', { name: 'Dispute & Swap' })).toBeNull()
+		expect(documentQueries.getByRole('button', { name: 'Settle Report' })).not.toBeNull()
+	})
+
+	test('uses the shared live block number to switch a selected report into settle mode', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<ChainBlockNumberContext.Provider value={161n}>
+				<OpenOracleSection
+					{...createOpenOracleSectionProps({
+						activeView: 'selected-report',
+						openOracleReportDetails: createOpenOracleReportDetails({
+							currentBlockNumber: 100n,
+							currentReporter: '0x3000000000000000000000000000000000000000',
+							currentTime: 100n,
+							disputeDelay: 10n,
+							reportTimestamp: 100n,
+							settlementTime: 60n,
+							timeType: false,
+						}),
+					})}
+				/>
+			</ChainBlockNumberContext.Provider>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.queryByRole('button', { name: 'Dispute & Swap' })).toBeNull()
+		expect(documentQueries.getByRole('button', { name: 'Settle Report' })).not.toBeNull()
 	})
 })

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -360,12 +360,66 @@ describe('ReportingSection', () => {
 		expect(outcomeSidesSection.textContent?.includes(formatDuration(300n - 150n))).toBe(true)
 	})
 
+	test('prefers the live chain timestamp over the loaded reporting snapshot for time left', async () => {
+		const reportingDetails = createReportingDetails()
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					currentTimestamp: 200n,
+					reportingDetails: {
+						...reportingDetails,
+						currentTime: 150n,
+						escalationEndTime: 300n,
+					},
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(document.body.textContent?.includes(formatDuration(300n - 100n))).toBe(false)
+		expect(document.body.textContent?.includes(formatDuration(300n - 200n))).toBe(true)
+	})
+
 	test('shows Awaiting Resolution with zero time left once the escalation end time has passed', async () => {
-		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps({ reportingDetails: createReportingDetails({ currentTime: 300n, escalationEndTime: 300n }) })))
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					currentTimestamp: undefined,
+					reportingDetails: {
+						...createReportingDetails(),
+						currentTime: 300n,
+						escalationEndTime: 300n,
+					},
+				}),
+			),
+		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
 		expect(documentQueries.getByRole('heading', { name: 'Awaiting Resolution' })).not.toBeNull()
+		expect(document.body.textContent?.includes(formatDuration(0n))).toBe(true)
+	})
+
+	test('uses the live chain timestamp to flip the escalation phase once the end time passes', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					currentTimestamp: 300n,
+					reportingDetails: {
+						...createReportingDetails(),
+						currentTime: 150n,
+						escalationEndTime: 300n,
+					},
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getAllByText('Awaiting Resolution').length).toBeGreaterThan(0)
 		expect(document.body.textContent?.includes(formatDuration(0n))).toBe(true)
 	})
 

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -618,6 +618,7 @@ export type ForkAuctionRouteContentProps = {
 }
 
 export type ForkAuctionSectionProps = ForkAuctionRouteContentProps & {
+	currentTimestamp?: bigint | undefined
 	disabled?: boolean
 	disabledMessage?: string | undefined
 	embedInCard?: boolean


### PR DESCRIPTION
## Summary
- Reworked the reporting and escalation UI to use clearer side-by-side metrics, checkbox-based withdrawal selection, and updated guard logic for finalized or canceled outcomes
- Added transaction action status feedback across deployment, reporting, trading, oracle, vault, fork, and security pool workflows
- Synced UI timing to the live chain block clock and tightened simulation/status notice behavior
- Extended security pool contracts and related hooks/utilities to support the new escalation deposit flow
- Updated and expanded tests across reporting, oracle, fork auction, trading, vault, and transaction action surfaces

## Testing
- Not run
- Expected checks from repo guidelines: `bun run tsc`, `bun run test`, `bun run format`, `bun run check`, `bun run knip`