### PR TITLE
Refine reporting workflow and action feedback

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -363,9 +363,9 @@ The `Reporting` subview handles reporting and escalation.
 | --- | --- | --- | --- |
 | `Security Pool Address` | Select the target pool when reporting is used standalone. | Free-form address interpreted by the reporting loader. | Hidden in embedded pool workflows. |
 | `Refresh reporting` | Load or reload escalation/reporting state. | No field input. | Disabled while reporting details are loading or when the workflow is locked by pool state. |
-| `Outcome Side` | Choose the reporting side for contribution or withdrawal. | Must be one of the supported reporting outcomes. | Disabled when the workflow is locked. |
+| `Outcome Sides` | Choose the reporting side for contribution or withdrawal by selecting one of the visible outcome cards. | Must be one of the supported reporting outcomes. | Disabled when the workflow is locked. |
 | `Report / Contribution Amount` | Set the REP amount to stake on the selected side. | Must parse into a valid positive REP amount. | Disabled when the workflow is locked. |
-| `Report / Contribute On Selected Side` | Submit reporting or contribution. | Requires unlocked workflow, connected wallet, mainnet, loaded reporting details, and valid positive amount. | Disabled whenever any reporting guard condition fails. |
+| `Report / Contribute {Selected Side}` | Submit reporting or contribution on the currently selected outcome card. | Requires unlocked workflow, connected wallet, mainnet, loaded reporting details, and valid positive amount. | Disabled whenever any reporting guard condition fails. |
 | Deposit selection list | Optionally narrow withdrawal to specific owned unsettled deposits on the selected side. Leaving every checkbox clear withdraws all eligible deposits on that side. | No text parsing. Selected entries must still exist on refresh. | Disabled when the workflow is locked. |
 | `Withdraw Escalation Deposits` | Submit the withdrawal. | Requires unlocked workflow, connected wallet, mainnet, loaded reporting details, the question to be finalized or the game to be canceled by an external fork, and at least one owned unsettled deposit on the selected side. | Disabled whenever any withdrawal guard condition fails. |
 

--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -3053,11 +3053,19 @@ button:focus-visible {
 }
 
 .escalation-side {
+	display: block;
+	width: 100%;
 	min-width: 0;
 	padding: 1rem;
+	border: 0;
 	border-top: 1px solid var(--border-default);
 	background: transparent;
 	border-radius: 0;
+	appearance: none;
+	cursor: pointer;
+	color: inherit;
+	font: inherit;
+	text-align: left;
 }
 
 .escalation-side:first-child {
@@ -3075,6 +3083,16 @@ button:focus-visible {
 
 .escalation-side.leading.selected {
 	background: linear-gradient(90deg, rgba(56, 213, 255, 0.1) 0%, rgba(66, 232, 194, 0.06) 100%);
+}
+
+.escalation-side:focus-visible {
+	outline: 2px solid var(--interactive-border-hover);
+	outline-offset: 0.25rem;
+}
+
+.escalation-side:disabled {
+	cursor: not-allowed;
+	opacity: 0.6;
 }
 
 .escalation-side-row {

--- a/ui/dist/css/index.css
+++ b/ui/dist/css/index.css
@@ -3053,11 +3053,19 @@ button:focus-visible {
 }
 
 .escalation-side {
+	display: block;
+	width: 100%;
 	min-width: 0;
 	padding: 1rem;
+	border: 0;
 	border-top: 1px solid var(--border-default);
 	background: transparent;
 	border-radius: 0;
+	appearance: none;
+	cursor: pointer;
+	color: inherit;
+	font: inherit;
+	text-align: left;
 }
 
 .escalation-side:first-child {
@@ -3075,6 +3083,16 @@ button:focus-visible {
 
 .escalation-side.leading.selected {
 	background: linear-gradient(90deg, rgba(56, 213, 255, 0.1) 0%, rgba(66, 232, 194, 0.06) 100%);
+}
+
+.escalation-side:focus-visible {
+	outline: 2px solid var(--interactive-border-hover);
+	outline-offset: 0.25rem;
+}
+
+.escalation-side:disabled {
+	cursor: not-allowed;
+	opacity: 0.6;
 }
 
 .escalation-side-row {

--- a/ui/ts/components/EscalationSide.tsx
+++ b/ui/ts/components/EscalationSide.tsx
@@ -11,8 +11,10 @@ type EscalationSideDisplay = {
 type EscalationSideProps = {
 	bindingCapital: bigint | undefined
 	chartScaleMax: bigint
+	disabled?: boolean
 	isLeading: boolean
 	isSelected: boolean
+	onSelect: () => void
 	side: EscalationSideDisplay
 }
 
@@ -26,15 +28,19 @@ function getChartRatio(value: bigint | undefined, maxValue: bigint) {
 	return `${wholePercent.toString()}.${fractionalPercent}%`
 }
 
-export function EscalationSide({ bindingCapital, chartScaleMax, isLeading, isSelected, side }: EscalationSideProps) {
+export function EscalationSide({ bindingCapital, chartScaleMax, disabled = false, isLeading, isSelected, onSelect, side }: EscalationSideProps) {
 	return (
-		<div
+		<button
+			aria-pressed={isSelected}
 			className={`escalation-side ${isSelected ? 'selected' : ''} ${isLeading ? 'leading' : ''}`}
+			disabled={disabled}
+			onClick={onSelect}
 			style={{
 				'--binding-ratio': getChartRatio(bindingCapital, chartScaleMax),
 				'--side-ratio': getChartRatio(side.balance, chartScaleMax),
 				'--user-ratio': getChartRatio(side.userStake, chartScaleMax),
 			}}
+			type='button'
 		>
 			<div className='escalation-side-row'>
 				<div className='escalation-side-copy'>
@@ -64,6 +70,6 @@ export function EscalationSide({ bindingCapital, chartScaleMax, isLeading, isSel
 					</div>
 				</div>
 			</div>
-		</div>
+		</button>
 	)
 }

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -1,5 +1,4 @@
 import { CurrencyValue } from './CurrencyValue.js'
-import { EnumDropdown } from './EnumDropdown.js'
 import { ErrorNotice } from './ErrorNotice.js'
 import { FormInput } from './FormInput.js'
 import { EscalationSide } from './EscalationSide.js'
@@ -184,6 +183,7 @@ export function ReportingSection({
 	const actualReportDepositAmount = reportContributionPreview?.actualDepositAmount
 	const selectedEstimate = activeReportingDetails === undefined || selectedAmount === undefined ? undefined : calculateEstimatedEscalationReturn(activeReportingDetails, reportingForm.selectedOutcome, selectedAmount)
 	const outcomeSides = getOutcomeSides(activeReportingDetails)
+	const selectedOutcomeLabel = outcomeSides.find(side => side.key === reportingForm.selectedOutcome)?.label ?? getReportingOutcomeLabel(reportingForm.selectedOutcome)
 	const minimumOutcomeChangeContribution = getReportingMinimumOutcomeChangeContribution(reportingDetails, reportingForm.selectedOutcome)
 	const maxProfitContribution = getReportingMaxProfitContribution(reportingDetails, reportingForm.selectedOutcome)
 	const presetReasons = reportingLocked ? [] : [minimumOutcomeChangeContribution.reason, maxProfitContribution.reason].filter((reason, index, reasons): reason is string => reason !== undefined && !isHiddenPresetReason(reason) && reasons.indexOf(reason) === index)
@@ -280,7 +280,16 @@ export function ReportingSection({
 					</div>
 					<div className='escalation-sides'>
 						{outcomeSides.map(side => (
-							<EscalationSide key={side.key} bindingCapital={activeReportingDetails?.bindingCapital} chartScaleMax={chartScaleMax} isLeading={leadingOutcome === side.key} isSelected={reportingForm.selectedOutcome === side.key} side={side} />
+							<EscalationSide
+								key={side.key}
+								bindingCapital={activeReportingDetails?.bindingCapital}
+								chartScaleMax={chartScaleMax}
+								disabled={reportingLocked}
+								isLeading={leadingOutcome === side.key}
+								isSelected={reportingForm.selectedOutcome === side.key}
+								onSelect={() => onReportingFormChange({ selectedOutcome: side.key, selectedWithdrawDepositIndexes: [] })}
+								side={side}
+							/>
 						))}
 					</div>
 				</SectionBlock>
@@ -298,10 +307,6 @@ export function ReportingSection({
 							Available unlocked vault REP for reporting: <CurrencyValue value={reportingDetails.viewerVaultAvailableEscalationRep} suffix='REP' />.
 						</p>
 					)}
-					<label className='field'>
-						<span>Outcome Side</span>
-						<EnumDropdown options={REPORTING_OUTCOME_DROPDOWN_OPTIONS} value={reportingForm.selectedOutcome} onChange={selectedOutcome => onReportingFormChange({ selectedOutcome, selectedWithdrawDepositIndexes: [] })} disabled={reportingLocked} />
-					</label>
 
 					<label className='field'>
 						<span>Report / Contribution Amount (REP)</span>
@@ -344,7 +349,7 @@ export function ReportingSection({
 
 					{selectedEstimate === undefined ? undefined : (
 						<p className='detail'>
-							If {getReportingOutcomeLabel(reportingForm.selectedOutcome)} wins and no one else contributes afterward, the current amount projects roughly <CurrencyValue value={selectedEstimate.profit} suffix='REP' /> of profit.
+							If {selectedOutcomeLabel} wins and no one else contributes afterward, the current amount projects roughly <CurrencyValue value={selectedEstimate.profit} suffix='REP' /> of profit.
 						</p>
 					)}
 					{actualReportDepositAmount === undefined || selectedAmount === undefined || actualReportDepositAmount === selectedAmount ? undefined : (
@@ -354,7 +359,7 @@ export function ReportingSection({
 					)}
 					<div className='actions'>
 						<TransactionActionButton
-							idleLabel='Report / Contribute On Selected Side'
+							idleLabel={`Report / Contribute ${selectedOutcomeLabel}`}
 							pendingLabel='Submitting report...'
 							onClick={onReportOutcome}
 							pending={reportingActiveAction === 'reportOutcome'}

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -176,6 +176,7 @@ function ReportingSectionHarness({ initialProps }: { initialProps?: Partial<Repo
 			{...createProps(initialProps)}
 			reportingForm={reportingForm}
 			onReportingFormChange={changes => {
+				initialProps?.onReportingFormChange?.(changes)
 				setReportingForm(currentForm => ({
 					...currentForm,
 					...changes,
@@ -190,7 +191,6 @@ function findProfitPreview() {
 		.map(element => element.textContent ?? '')
 		.find(text => text.includes('projects roughly'))
 }
-
 describe('ReportingSection', () => {
 	let restoreDomEnvironment: (() => void) | undefined
 	let cleanupRenderedComponent: (() => Promise<void>) | undefined
@@ -314,7 +314,7 @@ describe('ReportingSection', () => {
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		expectTransactionButtonDisabled(document.body, 'Report / Contribute On Selected Side', 'Connect a wallet before reporting on a market.')
+		expectTransactionButtonDisabled(document.body, 'Report / Contribute No', 'Connect a wallet before reporting on a market.')
 		expect(document.body.querySelector('button[title="Connect a wallet before withdrawing escalation deposits."]')).toBeNull()
 	})
 
@@ -333,10 +333,9 @@ describe('ReportingSection', () => {
 			),
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
-
 		expect(document.body.textContent?.includes('It does not spend wallet REP directly or require a wallet approval.')).toBe(false)
 		expect(document.body.textContent?.includes('Available unlocked vault REP for reporting:')).toBe(true)
-		expectTransactionButtonDisabled(document.body, 'Report / Contribute On Selected Side', 'Need 3 more unlocked REP in your vault before reporting.')
+		expectTransactionButtonDisabled(document.body, 'Report / Contribute Yes', 'Need 3 more unlocked REP in your vault before reporting.')
 	})
 
 	test('renders a compact withdraw-only mode without the reporting banner or report form', async () => {
@@ -393,7 +392,7 @@ describe('ReportingSection', () => {
 		expect(outcomeSidesSection.querySelector('[title="3 REP"]')).not.toBeNull()
 		expect(outcomeSidesSection.querySelectorAll('.currency-value.unavailable').length).toBeGreaterThanOrEqual(2)
 		expect(document.body.textContent?.includes('Load reporting details to populate live stakes')).toBe(false)
-		expectTransactionButtonEnabled(document.body, 'Report / Contribute On Selected Side')
+		expectTransactionButtonEnabled(document.body, 'Report / Contribute Yes')
 	})
 
 	test('disables report submission for a pre-start amount below the first-report minimum', async () => {
@@ -410,7 +409,7 @@ describe('ReportingSection', () => {
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		expectTransactionButtonDisabled(document.body, 'Report / Contribute On Selected Side', 'Enter at least 3 REP to start the escalation game.')
+		expectTransactionButtonDisabled(document.body, 'Report / Contribute Yes', 'Enter at least 3 REP to start the escalation game.')
 	})
 
 	test('accepts decimal report amounts for the profit preview', async () => {
@@ -541,7 +540,6 @@ describe('ReportingSection', () => {
 			),
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
-
 		expectTransactionButtonEnabled(document.body, 'Withdraw Escalation Deposits')
 		expect(document.body.textContent?.includes('Connected wallet has 1 withdrawable unsettled deposit entry on the selected side.')).toBe(true)
 		expect(within(document.body).getByRole('checkbox', { name: /Deposit #0/i })).toBeDefined()
@@ -711,5 +709,53 @@ describe('ReportingSection', () => {
 		expect(maxProfitButton.disabled).toBe(true)
 		expect(maxProfitButton.title).toBe('Max profit preset unavailable because the reward window is already filled on the selected side.')
 		expect(document.body.textContent?.includes('Max profit preset unavailable because the reward window is already filled on the selected side.')).toBe(false)
+	})
+
+	test('lets users select an outcome side from the outcome cards and updates the report button label', async () => {
+		const updates: Partial<ReportingFormState>[] = []
+		const renderedComponent = await renderIntoDocument(
+			<ReportingSectionHarness
+				initialProps={{
+					onReportingFormChange: update => {
+						updates.push(update)
+					},
+				}}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		const yesButton = documentQueries.getByRole('button', { name: /^Yes/ }) as HTMLButtonElement
+		const noButton = documentQueries.getByRole('button', { name: /^No/ }) as HTMLButtonElement
+
+		expect(yesButton.getAttribute('aria-pressed')).toBe('true')
+		expect(noButton.getAttribute('aria-pressed')).toBe('false')
+		expect(documentQueries.getByRole('button', { name: 'Report / Contribute Yes' })).not.toBeNull()
+
+		await act(() => {
+			fireEvent.click(noButton)
+		})
+
+		expect(updates).toEqual([{ selectedOutcome: 'no', selectedWithdrawDepositIndexes: [] }])
+		expect((documentQueries.getByRole('button', { name: /^Yes/ }) as HTMLButtonElement).getAttribute('aria-pressed')).toBe('false')
+		expect((documentQueries.getByRole('button', { name: /^No/ }) as HTMLButtonElement).getAttribute('aria-pressed')).toBe('true')
+		expect(documentQueries.getByRole('button', { name: 'Report / Contribute No' })).not.toBeNull()
+	})
+
+	test('disables outcome side selection when the reporting workflow is locked', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					lockedReason: 'Reporting opens after market end.',
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect((documentQueries.getByRole('button', { name: /^Yes/ }) as HTMLButtonElement).disabled).toBe(true)
+		expect((documentQueries.getByRole('button', { name: /^No/ }) as HTMLButtonElement).disabled).toBe(true)
+		expect((documentQueries.getByRole('button', { name: /^Invalid/ }) as HTMLButtonElement).disabled).toBe(true)
 	})
 })

--- a/ui/ts/tests/securityPoolWorkflowSection.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection.test.tsx
@@ -1663,7 +1663,7 @@ describe('SecurityPoolWorkflowSection', () => {
 		expect(document.body.textContent?.includes('Projected payout for current amount')).toBe(false)
 		expect(document.body.textContent?.includes('Projected profit if this side wins')).toBe(false)
 
-		const reportButton = documentQueries.getByRole('button', { name: 'Report / Contribute On Selected Side' }) as HTMLButtonElement
+		const reportButton = documentQueries.getByRole('button', { name: 'Report / Contribute Yes' }) as HTMLButtonElement
 		expect(reportButton.disabled).toBe(true)
 		expect(reportButton.title).toBe('Reporting opens after market end.')
 	})
@@ -1720,7 +1720,7 @@ describe('SecurityPoolWorkflowSection', () => {
 			cleanupRenderedComponent = renderedComponent.cleanup
 
 			const documentQueries = within(document.body)
-			const reportButton = documentQueries.getByRole('button', { name: 'Report / Contribute On Selected Side' }) as HTMLButtonElement
+			const reportButton = documentQueries.getByRole('button', { name: 'Report / Contribute Yes' }) as HTMLButtonElement
 			expect(reportButton.disabled).toBe(true)
 			expect(reportButton.title).toBe('Load reporting details before reporting on an outcome.')
 		} finally {


### PR DESCRIPTION
## Summary
- Reworked the reporting UI so outcome cards are selectable controls with clearer balance, deposit, and binding visuals.
- Added deposit-level withdrawal selection, preset handling refinements, and clearer reporting lifecycle states.
- Surfaced transaction feedback across deployment, reporting, security pool, trading, fork, and oracle actions.
- Added security pool contract support for reading the initial escalation game deposit and updated related types, guards, and docs.
- Expanded and updated UI tests for reporting, open oracle, security vault, transaction actions, and related workflows.

## Testing
- Not run (PR content only).
- The branch includes updated coverage for the changed reporting, feedback, and security pool flows in `ui/ts/tests/`.