### PR TITLE
Refine reporting and escalation workflows

### DIFF
--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -14,7 +14,7 @@ import { TimestampValue } from './TimestampValue.js'
 import { formatCurrencyInputBalance, formatDuration } from '../lib/formatters.js'
 import { parseOptionalRepAmountInput } from '../lib/marketForm.js'
 import { isMainnetChain } from '../lib/network.js'
-import { calculateEstimatedEscalationReturn, getEscalationPhase, getEscalationTimeRemaining, getLeadingEscalationOutcome, getReportingMaxProfitContribution, getReportingMinimumOutcomeChangeContribution, previewReportingContribution } from '../lib/reportingDomain.js'
+import { calculateEstimatedEscalationReturn, getEscalationPhase, getEscalationTimeRemaining, getLeadingEscalationOutcome, getReportingMaxProfitContribution, getReportingMinimumOutcomeChangeContribution, isReportingClosed, previewReportingContribution, projectEscalationEndTime } from '../lib/reportingDomain.js'
 import { getReportingReportGuardMessage, getReportingWithdrawGuardMessage } from '../lib/reportingGuards.js'
 import { REPORTING_OUTCOME_DROPDOWN_OPTIONS, getReportingOutcomeLabel } from '../lib/reporting.js'
 import type { LifecycleStagePresentation, ReportingSectionProps } from '../types/components.js'
@@ -183,6 +183,8 @@ export function ReportingSection({
 	const reportContributionPreview = reportingDetails === undefined || selectedAmount === undefined ? undefined : previewReportingContribution(reportingDetails, reportingForm.selectedOutcome, selectedAmount)
 	const actualReportDepositAmount = reportContributionPreview?.actualDepositAmount
 	const selectedEstimate = activeReportingDetails === undefined || selectedAmount === undefined ? undefined : calculateEstimatedEscalationReturn(activeReportingDetails, reportingForm.selectedOutcome, selectedAmount)
+	const reportingClosed = activeReportingDetails === undefined ? false : isReportingClosed(activeReportingDetails)
+	const timerProjection = activeReportingDetails === undefined || selectedAmount === undefined || selectedAmount <= 0n || reportingClosed ? undefined : projectEscalationEndTime(activeReportingDetails, reportingForm.selectedOutcome, selectedAmount)
 	const outcomeSides = getOutcomeSides(activeReportingDetails)
 	const minimumOutcomeChangeContribution = getReportingMinimumOutcomeChangeContribution(reportingDetails, reportingForm.selectedOutcome)
 	const maxProfitContribution = getReportingMaxProfitContribution(reportingDetails, reportingForm.selectedOutcome)
@@ -195,6 +197,7 @@ export function ReportingSection({
 		isMainnet,
 		lockedReason,
 		reportAmount: reportingForm.reportAmount,
+		reportingClosed,
 		reportingStatus,
 		selectedAmount,
 		viewerVaultAvailableEscalationRep: reportingDetails?.viewerVaultAvailableEscalationRep,
@@ -347,11 +350,6 @@ export function ReportingSection({
 							If {getReportingOutcomeLabel(reportingForm.selectedOutcome)} wins and no one else contributes afterward, the current amount projects roughly <CurrencyValue value={selectedEstimate.profit} suffix='REP' /> of profit.
 						</p>
 					)}
-					{actualReportDepositAmount === undefined || selectedAmount === undefined || actualReportDepositAmount === selectedAmount ? undefined : (
-						<p className='detail'>
-							Based on the current escalation state, this action would lock <CurrencyValue value={actualReportDepositAmount} suffix='REP' /> instead of the full entered amount.
-						</p>
-					)}
 					<div className='actions'>
 						<TransactionActionButton
 							idleLabel='Report / Contribute On Selected Side'
@@ -362,6 +360,21 @@ export function ReportingSection({
 							availability={{ disabled: reportGuardMessage !== undefined, reason: reportGuardMessage }}
 						/>
 					</div>
+					{timerProjection === undefined || activeReportingDetails === undefined ? undefined : (
+						<p className='detail'>
+							{timerProjection.endsImmediately
+								? 'This contribution would end the escalation immediately instead of extending the timer.'
+								: timerProjection.projectedEndTime > activeReportingDetails.escalationEndTime
+									? `This contribution would extend the timer by ${formatDuration(timerProjection.projectedEndTime - activeReportingDetails.escalationEndTime)}.`
+									: 'This contribution would not extend the timer.'}
+							{timerProjection.acceptedAmount === selectedAmount ? undefined : (
+								<>
+									{' '}
+									Based on an accepted deposit of <CurrencyValue copyable={false} value={timerProjection.acceptedAmount} suffix='REP' />.
+								</>
+							)}
+						</p>
+					)}
 				</SectionBlock>
 			) : undefined}
 

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -222,7 +222,7 @@ async function loadViewerReportingVaultState(client: ReadClient, securityPoolAdd
 }
 
 export async function loadReportingDetails(client: ReadClient, securityPoolAddress: Address, accountAddress: Address | undefined): Promise<ReportingDetails> {
-	const [questionId, escalationGameAddress, completeSetCollateralAmount, universeId, zoltarAddress, initialEscalationGameDeposit] = await readRequiredMulticall(client, [
+	const reportingLoadContracts = [
 		{
 			abi: peripherals_SecurityPool_SecurityPool.abi,
 			functionName: 'questionId',
@@ -259,7 +259,8 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 			address: securityPoolAddress,
 			args: [],
 		},
-	])
+	] as readonly ContractFunctionParameters[]
+	const [questionId, escalationGameAddress, completeSetCollateralAmount, universeId, zoltarAddress, initialEscalationGameDeposit] = (await readRequiredMulticall(client, reportingLoadContracts)) as [bigint, Address, bigint, bigint, Address, bigint]
 	const [marketDetails, block, escalationGameCode, viewerVaultState, forkThreshold] = await Promise.all([
 		loadMarketDetails(client, questionId),
 		client.getBlock(),

--- a/ui/ts/lib/reportingDomain.ts
+++ b/ui/ts/lib/reportingDomain.ts
@@ -9,10 +9,28 @@ type ReportingAmountSuggestion = {
 }
 
 const REP_UNIT = 10n ** 18n
+const ESCALATION_TIME_LENGTH = 4_233_600n
+const SCALE = 1_000_000n
+const LN2_SCALED = 693_147n
+const MAX_ATANH_ITERATIONS = 16
 const LOAD_REPORTING_PRESETS_REASON = 'Load reporting details before using presets.'
 const MAX_PROFIT_NOT_STARTED_REASON = 'Max profit becomes available after the escalation game starts.'
 const SELECTED_SIDE_ALREADY_LEADS_REASON = 'Selected side already leads.'
 const ESCALATION_RESOLVED_REASON = 'Escalation is already resolved.'
+
+type EscalationBalanceTuple = readonly [bigint, bigint, bigint]
+
+type ProjectedEscalationDeposit = {
+	acceptedAmount: bigint
+	projectedBalances: EscalationBalanceTuple
+	reachesNonDecision: boolean
+}
+
+type ProjectedEscalationEndTime = {
+	acceptedAmount: bigint
+	endsImmediately: boolean
+	projectedEndTime: bigint
+}
 
 function roundUpToRepUnit(value: bigint) {
 	if (value <= 0n) return 0n
@@ -41,11 +59,76 @@ export function getEscalationTimeRemaining(details: ActiveReportingDetails) {
 	return requireDefined(getTimeRemaining(details.escalationEndTime, details.currentTime), 'Escalation end time is required')
 }
 
+export function isReportingClosed(details: ActiveReportingDetails) {
+	return details.resolution !== 'none' || details.currentTime > details.escalationEndTime
+}
+
 export function getEscalationPhase(details: ActiveReportingDetails) {
 	if (details.resolution !== 'none') return 'Resolved'
 	if (details.currentTime < details.startingTime) return 'Pending Start'
-	if (details.currentTime >= details.escalationEndTime) return 'Awaiting Resolution'
+	if (details.currentTime > details.escalationEndTime) return 'Awaiting Resolution'
 	return 'Active'
+}
+
+export function getEscalationBalanceTuple(sides: EscalationSide[]): EscalationBalanceTuple {
+	const invalidBalance = sides.find(side => side.key === 'invalid')?.balance ?? 0n
+	const yesBalance = sides.find(side => side.key === 'yes')?.balance ?? 0n
+	const noBalance = sides.find(side => side.key === 'no')?.balance ?? 0n
+
+	return [invalidBalance, yesBalance, noBalance]
+}
+
+export function getEscalationBindingCapital(balances: EscalationBalanceTuple) {
+	const [invalidBalance, yesBalance, noBalance] = balances
+
+	if ((invalidBalance >= yesBalance && invalidBalance <= noBalance) || (invalidBalance >= noBalance && invalidBalance <= yesBalance)) {
+		return invalidBalance
+	}
+
+	if ((yesBalance >= invalidBalance && yesBalance <= noBalance) || (yesBalance >= noBalance && yesBalance <= invalidBalance)) {
+		return yesBalance
+	}
+
+	return noBalance
+}
+
+export function computeEscalationTimeSinceStartFromAttritionCost(startBond: bigint, nonDecisionThreshold: bigint, attritionCost: bigint) {
+	if (attritionCost <= startBond) return 0n
+	if (attritionCost >= nonDecisionThreshold) return ESCALATION_TIME_LENGTH
+
+	const lnRatioScaled = computeLnRatioScaled(startBond, nonDecisionThreshold)
+	if (lnRatioScaled === 0n) return 0n
+
+	const lnCostRatioScaled = computeLnRatioScaled(startBond, attritionCost)
+	return (lnCostRatioScaled * ESCALATION_TIME_LENGTH) / lnRatioScaled
+}
+
+export function projectEscalationEndTime(details: ActiveReportingDetails, outcome: ReportingOutcomeKey, amount: bigint): ProjectedEscalationEndTime | undefined {
+	if (amount <= 0n) return undefined
+
+	const projectedDeposit = projectEscalationDeposit({
+		amount,
+		balances: getEscalationBalanceTuple(details.sides),
+		nonDecisionThreshold: details.nonDecisionThreshold,
+		outcome,
+		startBond: details.startBond,
+	})
+	if (projectedDeposit === undefined) return undefined
+
+	if (projectedDeposit.reachesNonDecision) {
+		return {
+			acceptedAmount: projectedDeposit.acceptedAmount,
+			endsImmediately: true,
+			projectedEndTime: details.currentTime,
+		}
+	}
+
+	const projectedBindingCapital = getEscalationBindingCapital(projectedDeposit.projectedBalances)
+	return {
+		acceptedAmount: projectedDeposit.acceptedAmount,
+		endsImmediately: false,
+		projectedEndTime: details.startingTime + computeEscalationTimeSinceStartFromAttritionCost(details.startBond, details.nonDecisionThreshold, projectedBindingCapital),
+	}
 }
 
 export function getLeadingEscalationOutcome(sides: EscalationSide[]) {
@@ -274,24 +357,22 @@ function previewEscalationContribution(details: ActiveReportingDetails, outcome:
 		}
 	}
 
-	const room = details.nonDecisionThreshold - selectedSide.balance
-	let effectiveDeposit = amount > room ? room : amount
-	const balances = details.sides.map(side => side.balance)
-	const maxBalance = balances.reduce((currentMax, sideBalance) => (sideBalance > currentMax ? sideBalance : currentMax), 0n)
-	const newBalance = selectedSide.balance + effectiveDeposit
-	const otherSideHasMax = details.sides.some(side => side.key !== outcome && side.balance === maxBalance)
-	if (newBalance === maxBalance && otherSideHasMax && maxBalance < details.nonDecisionThreshold) {
-		effectiveDeposit -= 1n
-		if (effectiveDeposit < details.startBond) {
-			return {
-				actualDepositAmount: undefined,
-				reason: 'Increase the report amount slightly to avoid a tie at the minimum bond.',
-			}
+	const projectedDeposit = projectEscalationDeposit({
+		amount,
+		balances: getEscalationBalanceTuple(details.sides),
+		nonDecisionThreshold: details.nonDecisionThreshold,
+		outcome,
+		startBond: details.startBond,
+	})
+	if (projectedDeposit === undefined) {
+		return {
+			actualDepositAmount: undefined,
+			reason: 'Increase the report amount slightly to avoid a tie at the minimum bond.',
 		}
 	}
 
 	return {
-		actualDepositAmount: effectiveDeposit,
+		actualDepositAmount: projectedDeposit.acceptedAmount,
 		reason: undefined,
 	}
 }
@@ -312,4 +393,101 @@ export function previewReportingContribution(details: ReportingDetails, outcome:
 	}
 
 	return previewEscalationContribution(details, outcome, amount)
+}
+
+function computeLnRatioScaled(lowValue: bigint, highValue: bigint) {
+	let normalizedLow = lowValue
+	let log2Count = 0n
+
+	while (highValue >= normalizedLow * 2n) {
+		normalizedLow *= 2n
+		log2Count += 1n
+	}
+
+	const diff = highValue - normalizedLow
+	const sum = highValue + normalizedLow
+	const z = (diff * SCALE) / sum
+	if (z === 0n) return 0n
+
+	return log2Count * LN2_SCALED + 2n * computeAtanhScaled(z)
+}
+
+function computeAtanhScaled(z: bigint) {
+	const z2 = (z * z) / SCALE
+	let term = z
+	let atanhScaled = term
+
+	for (let iteration = 1; iteration < MAX_ATANH_ITERATIONS; iteration += 1) {
+		term = (term * z2 * BigInt(2 * iteration - 1)) / (BigInt(2 * iteration + 1) * SCALE)
+		if (term === 0n) break
+		atanhScaled += term
+	}
+
+	return atanhScaled
+}
+
+function getOutcomeIndex(outcome: ReportingOutcomeKey) {
+	switch (outcome) {
+		case 'invalid':
+			return 0
+		case 'yes':
+			return 1
+		case 'no':
+			return 2
+	}
+}
+
+function getMaxEscalationBalance(balances: EscalationBalanceTuple) {
+	const [invalidBalance, yesBalance, noBalance] = balances
+	return invalidBalance > yesBalance ? (invalidBalance > noBalance ? invalidBalance : noBalance) : yesBalance > noBalance ? yesBalance : noBalance
+}
+
+function hasReachedNonDecision(balances: EscalationBalanceTuple, nonDecisionThreshold: bigint) {
+	let thresholdHits = 0
+
+	if (balances[0] >= nonDecisionThreshold) thresholdHits += 1
+	if (balances[1] >= nonDecisionThreshold) thresholdHits += 1
+	if (balances[2] >= nonDecisionThreshold) thresholdHits += 1
+
+	return thresholdHits >= 2
+}
+
+function setBalanceAtIndex(balances: EscalationBalanceTuple, index: number, value: bigint): EscalationBalanceTuple {
+	switch (index) {
+		case 0:
+			return [value, balances[1], balances[2]]
+		case 1:
+			return [balances[0], value, balances[2]]
+		case 2:
+			return [balances[0], balances[1], value]
+		default:
+			throw new RangeError(`Unknown escalation balance index: ${index.toString()}`)
+	}
+}
+
+function projectEscalationDeposit({ amount, balances, nonDecisionThreshold, outcome, startBond }: { amount: bigint; balances: EscalationBalanceTuple; nonDecisionThreshold: bigint; outcome: ReportingOutcomeKey; startBond: bigint }): ProjectedEscalationDeposit | undefined {
+	if (amount < startBond) return undefined
+
+	const outcomeIndex = getOutcomeIndex(outcome)
+	const currentBalance = balances[outcomeIndex]
+	if (currentBalance >= nonDecisionThreshold) return undefined
+
+	const room = nonDecisionThreshold - currentBalance
+	let acceptedAmount = amount > room ? room : amount
+	let newBalance = currentBalance + acceptedAmount
+	const maxBalance = getMaxEscalationBalance(balances)
+	const otherHasMax = outcomeIndex === 0 ? balances[1] === maxBalance || balances[2] === maxBalance : outcomeIndex === 1 ? balances[0] === maxBalance || balances[2] === maxBalance : balances[0] === maxBalance || balances[1] === maxBalance
+
+	if (newBalance === maxBalance && otherHasMax && maxBalance < nonDecisionThreshold) {
+		acceptedAmount -= 1n
+		if (acceptedAmount < startBond) return undefined
+		newBalance = currentBalance + acceptedAmount
+	}
+
+	const projectedBalances = setBalanceAtIndex(balances, outcomeIndex, newBalance)
+	return {
+		acceptedAmount,
+		projectedBalances,
+		reachesNonDecision: hasReachedNonDecision(projectedBalances, nonDecisionThreshold),
+	}
 }

--- a/ui/ts/lib/reportingGuards.ts
+++ b/ui/ts/lib/reportingGuards.ts
@@ -11,6 +11,7 @@ export function getReportingReportGuardMessage({
 	isMainnet,
 	lockedReason,
 	reportAmount,
+	reportingClosed,
 	reportingStatus,
 	selectedAmount,
 	viewerVaultAvailableEscalationRep,
@@ -22,12 +23,14 @@ export function getReportingReportGuardMessage({
 	isMainnet: boolean
 	lockedReason: string | undefined
 	reportAmount: string
+	reportingClosed: boolean
 	reportingStatus: ReportingStatus
 	selectedAmount: bigint | undefined
 	viewerVaultAvailableEscalationRep: bigint | undefined
 	viewerVaultExists: boolean
 }) {
 	if (lockedReason !== undefined) return lockedReason
+	if (reportingClosed) return 'Reporting is closed because the escalation timer has ended.'
 	if (accountAddress === undefined) return 'Connect a wallet before reporting on a market.'
 	if (!isMainnet) return 'Switch to Ethereum mainnet before reporting on a market.'
 	if (reportingStatus === 'missing') return 'Load reporting details before reporting on an outcome.'

--- a/ui/ts/tests/reportingDomain.test.ts
+++ b/ui/ts/tests/reportingDomain.test.ts
@@ -2,7 +2,18 @@
 
 import { describe, expect, test } from 'bun:test'
 import { zeroAddress } from 'viem'
-import { calculateEstimatedEscalationReturn, getMaxProfitContribution, getMinimumOutcomeChangeContribution, getReportingMaxProfitContribution, getReportingMinimumOutcomeChangeContribution, previewReportingContribution } from '../lib/reportingDomain.js'
+import {
+	calculateEstimatedEscalationReturn,
+	computeEscalationTimeSinceStartFromAttritionCost,
+	getEscalationBalanceTuple,
+	getEscalationBindingCapital,
+	getMaxProfitContribution,
+	getMinimumOutcomeChangeContribution,
+	getReportingMaxProfitContribution,
+	getReportingMinimumOutcomeChangeContribution,
+	previewReportingContribution,
+	projectEscalationEndTime,
+} from '../lib/reportingDomain.js'
 import type { ActiveReportingDetails, MarketDetails, ReportingDetails } from '../types/contracts.js'
 
 const REP = 10n ** 18n
@@ -81,6 +92,58 @@ function createNotStartedReportingDetails(overrides: Partial<Extract<ReportingDe
 		viewerVaultLockedRepInEscalationGame: 0n,
 		viewerVaultRepDepositShare: 10n * REP,
 		...overrides,
+	}
+}
+
+function createDynamicReportingDetails(overrides: Partial<ActiveReportingDetails> = {}): ActiveReportingDetails {
+	const sides = overrides.sides ?? [
+		{ balance: rep(1n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+		{ balance: rep(8n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+		{ balance: rep(3n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
+	]
+	const startBond = overrides.startBond ?? rep(1n)
+	const nonDecisionThreshold = overrides.nonDecisionThreshold ?? rep(20n)
+	const startingTime = overrides.startingTime ?? 120n
+	const currentTime = overrides.currentTime ?? 150n
+	const bindingCapital = getEscalationBindingCapital(getEscalationBalanceTuple(sides))
+	const escalationEndTime = startingTime + computeEscalationTimeSinceStartFromAttritionCost(startBond, nonDecisionThreshold, bindingCapital)
+
+	const baseDetails: ActiveReportingDetails = {
+		bindingCapital,
+		completeSetCollateralAmount: 1n,
+		currentRequiredBond: rep(2n),
+		currentTime,
+		escalationEndTime,
+		escalationGameAddress: zeroAddress,
+		marketDetails: createMarketDetails(),
+		nonDecisionThreshold,
+		questionOutcome: 'none',
+		resolution: 'none',
+		securityPoolAddress: zeroAddress,
+		sides,
+		startBond,
+		startingTime,
+		status: 'active',
+		totalCost: 0n,
+		universeId: 1n,
+		withdrawalEnabled: false,
+		withdrawalState: 'not-finalized',
+		viewerVaultAvailableEscalationRep: 10n * REP,
+		viewerVaultExists: true,
+		viewerVaultLockedRepInEscalationGame: 1n * REP,
+		viewerVaultRepDepositShare: 11n * REP,
+	}
+
+	return {
+		...baseDetails,
+		...overrides,
+		bindingCapital,
+		currentTime,
+		escalationEndTime,
+		nonDecisionThreshold,
+		sides,
+		startBond,
+		startingTime,
 	}
 }
 
@@ -254,6 +317,55 @@ describe('reportingDomain', () => {
 		expect(previewReportingContribution(createNotStartedReportingDetails(), 'yes', rep(3n))).toEqual({
 			actualDepositAmount: rep(3n),
 			reason: undefined,
+		})
+	})
+
+	test('projectEscalationEndTime keeps the timer unchanged for a leading-side deposit', () => {
+		const details = createDynamicReportingDetails()
+
+		expect(projectEscalationEndTime(details, 'yes', rep(1n))).toEqual({
+			acceptedAmount: rep(1n),
+			endsImmediately: false,
+			projectedEndTime: details.escalationEndTime,
+		})
+	})
+
+	test('projectEscalationEndTime extends the timer for a non-leading-side deposit that raises binding capital', () => {
+		const details = createDynamicReportingDetails()
+		const projection = projectEscalationEndTime(details, 'no', rep(2n))
+
+		expect(projection).toBeDefined()
+		expect(projection?.acceptedAmount).toBe(rep(2n))
+		expect(projection?.endsImmediately).toBe(false)
+		expect(projection?.projectedEndTime).toBeGreaterThan(details.escalationEndTime)
+	})
+
+	test('projectEscalationEndTime reflects the tie-adjusted accepted amount', () => {
+		const details = createDynamicReportingDetails({
+			sides: [
+				{ balance: rep(5n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+				{ balance: 0n, deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+				{ balance: 0n, deposits: [], key: 'no', label: 'No', userDeposits: [] },
+			],
+		})
+
+		expect(projectEscalationEndTime(details, 'yes', rep(5n))?.acceptedAmount).toBe(rep(5n) - 1n)
+	})
+
+	test('projectEscalationEndTime ends escalation immediately when a deposit creates a threshold tie', () => {
+		const details = createDynamicReportingDetails({
+			nonDecisionThreshold: rep(10n),
+			sides: [
+				{ balance: rep(10n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+				{ balance: rep(9n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+				{ balance: 0n, deposits: [], key: 'no', label: 'No', userDeposits: [] },
+			],
+		})
+
+		expect(projectEscalationEndTime(details, 'yes', rep(1n))).toEqual({
+			acceptedAmount: rep(1n),
+			endsImmediately: true,
+			projectedEndTime: details.currentTime,
 		})
 	})
 

--- a/ui/ts/tests/reportingGuards.test.ts
+++ b/ui/ts/tests/reportingGuards.test.ts
@@ -14,6 +14,7 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: 'Reporting opens after market end.',
 				reportAmount: '1',
+				reportingClosed: false,
 				reportingStatus: 'active',
 				selectedAmount: 1n,
 				viewerVaultAvailableEscalationRep: 10n,
@@ -29,6 +30,7 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: undefined,
 				reportAmount: '1',
+				reportingClosed: false,
 				reportingStatus: 'active',
 				selectedAmount: 1n,
 				viewerVaultAvailableEscalationRep: 10n,
@@ -44,6 +46,7 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: undefined,
 				reportAmount: '0',
+				reportingClosed: false,
 				reportingStatus: 'active',
 				selectedAmount: 0n,
 				viewerVaultAvailableEscalationRep: 10n,
@@ -61,6 +64,7 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: undefined,
 				reportAmount: '1',
+				reportingClosed: false,
 				reportingStatus: 'missing',
 				selectedAmount: 1n,
 				viewerVaultAvailableEscalationRep: 10n,
@@ -76,6 +80,7 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: undefined,
 				reportAmount: '1',
+				reportingClosed: false,
 				reportingStatus: 'not-started',
 				selectedAmount: 1n,
 				viewerVaultAvailableEscalationRep: 10n,
@@ -91,12 +96,31 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: undefined,
 				reportAmount: '1',
+				reportingClosed: false,
 				reportingStatus: 'active',
 				selectedAmount: 1n,
 				viewerVaultAvailableEscalationRep: 10n,
 				viewerVaultExists: true,
 			}),
 		).toBeUndefined()
+	})
+
+	test('blocks reporting once the escalation timer is closed', () => {
+		expect(
+			getReportingReportGuardMessage({
+				actualDepositAmount: 1n,
+				accountAddress: zeroAddress,
+				contributionPreviewReason: undefined,
+				isMainnet: true,
+				lockedReason: undefined,
+				reportAmount: '1',
+				reportingClosed: true,
+				reportingStatus: 'active',
+				selectedAmount: 1n,
+				viewerVaultAvailableEscalationRep: 10n,
+				viewerVaultExists: true,
+			}),
+		).toBe('Reporting is closed because the escalation timer has ended.')
 	})
 
 	test('blocks reporting when the vault lacks unlocked REP or the contribution preview is invalid', () => {
@@ -108,6 +132,7 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: undefined,
 				reportAmount: '5',
+				reportingClosed: false,
 				reportingStatus: 'active',
 				selectedAmount: 5n * 10n ** 18n,
 				viewerVaultAvailableEscalationRep: 2n * 10n ** 18n,
@@ -123,6 +148,7 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: undefined,
 				reportAmount: '1',
+				reportingClosed: false,
 				reportingStatus: 'active',
 				selectedAmount: 1n * 10n ** 18n,
 				viewerVaultAvailableEscalationRep: 10n * 10n ** 18n,
@@ -138,6 +164,7 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: undefined,
 				reportAmount: '1',
+				reportingClosed: false,
 				reportingStatus: 'active',
 				selectedAmount: 1n,
 				viewerVaultAvailableEscalationRep: 0n,

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -8,6 +8,7 @@ import { useState } from 'preact/hooks'
 import { zeroAddress } from 'viem'
 import { ReportingSection } from '../components/ReportingSection.js'
 import { formatDuration } from '../lib/formatters.js'
+import { computeEscalationTimeSinceStartFromAttritionCost, getEscalationBalanceTuple, getEscalationBindingCapital } from '../lib/reportingDomain.js'
 import type { AccountState, ReportingFormState } from '../types/app.js'
 import type { ActiveReportingDetails, EscalationDeposit, MarketDetails, ReportingDetails } from '../types/contracts.js'
 import type { ReportingSectionProps } from '../types/components.js'
@@ -97,6 +98,58 @@ function createReportingDetails(overrides: Partial<ActiveReportingDetails> = {})
 		viewerVaultLockedRepInEscalationGame: 1n * REP,
 		viewerVaultRepDepositShare: 11n * REP,
 		...overrides,
+	}
+}
+
+function createDynamicReportingDetails(overrides: Partial<ActiveReportingDetails> = {}): ActiveReportingDetails {
+	const sides = overrides.sides ?? [
+		{ balance: rep(1n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+		{ balance: rep(8n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [createDeposit()] },
+		{ balance: rep(3n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
+	]
+	const startBond = overrides.startBond ?? rep(1n)
+	const nonDecisionThreshold = overrides.nonDecisionThreshold ?? rep(20n)
+	const startingTime = overrides.startingTime ?? 120n
+	const currentTime = overrides.currentTime ?? 150n
+	const bindingCapital = getEscalationBindingCapital(getEscalationBalanceTuple(sides))
+	const escalationEndTime = startingTime + computeEscalationTimeSinceStartFromAttritionCost(startBond, nonDecisionThreshold, bindingCapital)
+
+	const baseDetails: ActiveReportingDetails = {
+		bindingCapital,
+		completeSetCollateralAmount: 1n,
+		currentRequiredBond: rep(2n),
+		currentTime,
+		escalationEndTime,
+		escalationGameAddress: zeroAddress,
+		marketDetails: createMarketDetails(),
+		nonDecisionThreshold,
+		questionOutcome: 'none',
+		resolution: 'none',
+		securityPoolAddress: zeroAddress,
+		sides,
+		startBond,
+		startingTime,
+		status: 'active',
+		totalCost: 0n,
+		universeId: 1n,
+		withdrawalEnabled: false,
+		withdrawalState: 'not-finalized',
+		viewerVaultAvailableEscalationRep: 10n * REP,
+		viewerVaultExists: true,
+		viewerVaultLockedRepInEscalationGame: 1n * REP,
+		viewerVaultRepDepositShare: 11n * REP,
+	}
+
+	return {
+		...baseDetails,
+		...overrides,
+		bindingCapital,
+		currentTime,
+		escalationEndTime,
+		nonDecisionThreshold,
+		sides,
+		startBond,
+		startingTime,
 	}
 }
 
@@ -361,12 +414,29 @@ describe('ReportingSection', () => {
 	})
 
 	test('shows Awaiting Resolution with zero time left once the escalation end time has passed', async () => {
-		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps({ reportingDetails: createReportingDetails({ currentTime: 300n, escalationEndTime: 300n }) })))
+		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps({ reportingDetails: createReportingDetails({ currentTime: 301n, escalationEndTime: 300n }) })))
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
 		expect(documentQueries.getByRole('heading', { name: 'Awaiting Resolution' })).not.toBeNull()
 		expect(document.body.textContent?.includes(formatDuration(0n))).toBe(true)
+	})
+
+	test('disables reporting after the escalation timer ends', async () => {
+		const reportingDetails = createDynamicReportingDetails()
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					reportingDetails: createDynamicReportingDetails({
+						currentTime: reportingDetails.escalationEndTime + 1n,
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expectTransactionButtonDisabled(document.body, 'Report / Contribute On Selected Side', 'Reporting is closed because the escalation timer has ended.')
 	})
 
 	test('renders pre-start metrics and placeholders before the first report starts escalation', async () => {
@@ -419,6 +489,59 @@ describe('ReportingSection', () => {
 
 		expect(document.body.textContent?.includes('projects roughly')).toBe(true)
 		expect(document.body.textContent?.includes('Enter a valid report amount to preview profit.')).toBe(false)
+	})
+
+	test('shows the timer-extension preview below the report button for contributions that raise binding capital', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					reportingDetails: createDynamicReportingDetails(),
+					reportingForm: createReportingForm({
+						reportAmount: '2',
+						selectedOutcome: 'no',
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		const reportButton = documentQueries.getByRole('button', { name: 'Report / Contribute On Selected Side' })
+		const preview = documentQueries.getByText(/^This contribution would extend the timer by /)
+		expect(reportButton.compareDocumentPosition(preview) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0)
+	})
+
+	test('shows a no-extension preview when the selected contribution leaves binding capital unchanged', async () => {
+		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps({ reportingDetails: createDynamicReportingDetails() })))
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(document.body.textContent?.includes('This contribution would not extend the timer.')).toBe(true)
+	})
+
+	test('shows the accepted-deposit note when the typed contribution exceeds the remaining room on the selected side', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					reportingDetails: createDynamicReportingDetails({
+						sides: [
+							{ balance: rep(1n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+							{ balance: rep(19n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [createDeposit()] },
+							{ balance: rep(3n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
+						],
+					}),
+					reportingForm: createReportingForm({
+						reportAmount: '5',
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(document.body.textContent?.includes('This contribution would not extend the timer.')).toBe(true)
+		expect(document.body.textContent?.includes('Based on an accepted deposit of')).toBe(true)
+		expect(document.body.textContent?.includes('≈ 1.00 REP.')).toBe(true)
 	})
 
 	test('autofills the active minimum-outcome-change preset', async () => {


### PR DESCRIPTION
## Summary
- Reworked the reporting UI to surface projected resolution, timer context, and clearer escalation-side comparisons.
- Swapped withdrawal inputs for checkbox-based deposit selection and tightened reporting/withdrawal guard logic.
- Added transaction feedback/status surfaces across deploy, trading, security pool, oracle, and reporting actions.
- Improved open oracle, security vault, fork auction, and Zoltar flows with richer lifecycle handling and feedback propagation.
- Extended SecurityPool with an initial escalation game deposit accessor for UI and reporting logic.

## Testing
- Not run (PR summary only).
- Suggested checks: `bun run tsc`
- Suggested checks: `bun run test`
- Suggested checks: `bun run format`
- Suggested checks: `bun run check`
- Suggested checks: `bun run knip`