### PR TITLE
Handle non-decision and timeout reporting states

### DIFF
--- a/solidity/ts/tests/escalationGame.test.ts
+++ b/solidity/ts/tests/escalationGame.test.ts
@@ -47,6 +47,14 @@ describe('Escalation Game Test Suite', () => {
 			args: [],
 		})
 
+	const readHasReachedNonDecision = async (escalationGame: Address) =>
+		await client.readContract({
+			abi: peripherals_EscalationGame_EscalationGame.abi,
+			functionName: 'hasReachedNonDecision',
+			address: escalationGame,
+			args: [],
+		})
+
 	const deployEscalationGameTestSecurityPool = async () => {
 		const zoltarAddress = getZoltarAddress()
 		const deploymentHash = await client.sendTransaction({
@@ -155,6 +163,19 @@ describe('Escalation Game Test Suite', () => {
 		const startingTime = await getStartingTime(client, escalationGame)
 		await mockWindow.setTime(startingTime + ESCALATION_TIME_LENGTH + 1n)
 		assert.strictEqual(await getQuestionResolution(client, escalationGame), QuestionOutcome.Invalid, 'empty game should resolve as invalid')
+	})
+
+	test('non-decision keeps question resolution at None even after the nominal timeout window', async () => {
+		const escalationGame = await deployEscalationGame(client, reportBond, nonDecisionThreshold)
+		await depositOnOutcome(client, escalationGame, client.account.address, QuestionOutcome.Yes, nonDecisionThreshold)
+		await depositOnOutcome(client, escalationGame, client.account.address, QuestionOutcome.No, nonDecisionThreshold)
+		assert.strictEqual(await readHasReachedNonDecision(escalationGame), true, 'two threshold-reaching outcomes should trigger non-decision')
+		assert.strictEqual(await getQuestionResolution(client, escalationGame), QuestionOutcome.None, 'non-decision should leave the question unresolved')
+
+		const startingTime = await getStartingTime(client, escalationGame)
+		await mockWindow.setTime(startingTime + ESCALATION_TIME_LENGTH + 1n)
+		assert.strictEqual(await readHasReachedNonDecision(escalationGame), true, 'non-decision should stay active after time advances')
+		assert.strictEqual(await getQuestionResolution(client, escalationGame), QuestionOutcome.None, 'non-decision should still take precedence after time advances')
 	})
 
 	test('depositOnOutcome reverts when outcome is None', async () => {

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'preact/hooks'
 import { AddressValue } from './AddressValue.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { ErrorNotice } from './ErrorNotice.js'
@@ -17,7 +18,7 @@ import { WorkflowTransactionStatus } from './WorkflowTransactionStatus.js'
 import { formatCurrencyInputBalance, formatDuration } from '../lib/formatters.js'
 import { parseOptionalRepAmountInput } from '../lib/marketForm.js'
 import { isMainnetChain } from '../lib/network.js'
-import { calculateEstimatedEscalationReturn, getEscalationPhase, getEscalationTimeRemaining, getLeadingEscalationOutcome, getReportingMaxProfitContribution, getReportingMinimumOutcomeChangeContribution, getReportingTimerPreview, isReportingClosed, previewReportingContribution } from '../lib/reportingDomain.js'
+import { calculateEstimatedEscalationReturn, getEscalationPhase, getEscalationTimeRemaining, getLeadingEscalationOutcome, getReportingMaxProfitContribution, getReportingMinimumOutcomeChangeContribution, getReportingTimerPreview, previewReportingContribution } from '../lib/reportingDomain.js'
 import { getReportingReportGuardMessage, getReportingWithdrawGuardMessage } from '../lib/reportingGuards.js'
 import { REPORTING_OUTCOME_DROPDOWN_OPTIONS, getReportingOutcomeLabel } from '../lib/reporting.js'
 import type { LifecycleStagePresentation, ReportingSectionProps, WorkflowOutcomePresentation } from '../types/components.js'
@@ -126,13 +127,22 @@ function getReportingStagePresentation({
 				label: 'Active',
 				tone: 'default',
 			}
-		case 'Awaiting Resolution':
+		case 'Fork Triggered':
 			return {
 				availableActions: [],
 				blockedActions: [],
-				detail: 'Escalation has reached its end time and is waiting for final resolution.',
-				key: 'escalation-awaiting-resolution',
-				label: 'Awaiting Resolution',
+				detail: 'Escalation reached non-decision. Continue in the Fork workflow; this panel does not have a final-resolution action.',
+				key: 'escalation-fork-triggered',
+				label: 'Fork Triggered',
+				tone: 'default',
+			}
+		case 'Timed Out':
+			return {
+				availableActions: [],
+				blockedActions: [],
+				detail: 'Escalation ended by timeout. The winner is computed from the current stakes; refresh reporting if the resolved outcome is not loaded yet.',
+				key: 'escalation-timed-out',
+				label: 'Timed Out',
 				tone: 'default',
 			}
 		case 'Resolved':
@@ -193,10 +203,12 @@ export function ReportingSection({
 	showSecurityPoolAddressInput = true,
 	mode = 'full-reporting',
 }: ReportingSectionProps) {
+	const lastTimedOutRefreshBoundaryKey = useRef<string | undefined>(undefined)
 	const isMainnet = isMainnetChain(accountState.chainId)
 	const effectiveCurrentTimestamp = currentTimestamp ?? reportingDetails?.currentTime
 	const effectiveReportingDetails = getEffectiveReportingDetails(reportingDetails, effectiveCurrentTimestamp)
 	const activeReportingDetails = effectiveReportingDetails?.status === 'active' ? effectiveReportingDetails : undefined
+	const escalationPhase = activeReportingDetails === undefined ? undefined : getEscalationPhase(activeReportingDetails)
 	const reportingStatus: ReportingStatus = effectiveReportingDetails === undefined ? 'missing' : effectiveReportingDetails.status
 	const marketDetails = effectiveReportingDetails?.marketDetails ?? previewMarketDetails
 	const reportingLocked = lockedReason !== undefined
@@ -219,7 +231,6 @@ export function ReportingSection({
 	const reportContributionPreview = effectiveReportingDetails === undefined || selectedAmount === undefined || selectedOutcome === undefined ? undefined : previewReportingContribution(effectiveReportingDetails, selectedOutcome, selectedAmount)
 	const actualReportDepositAmount = reportContributionPreview?.actualDepositAmount
 	const selectedEstimate = activeReportingDetails === undefined || selectedAmount === undefined || selectedOutcome === undefined ? undefined : calculateEstimatedEscalationReturn(activeReportingDetails, selectedOutcome, selectedAmount)
-	const reportingClosed = activeReportingDetails === undefined ? false : isReportingClosed(activeReportingDetails)
 	const timerPreview = effectiveReportingDetails === undefined || selectedAmount === undefined || selectedOutcome === undefined ? undefined : getReportingTimerPreview(effectiveReportingDetails, selectedOutcome, selectedAmount, effectiveCurrentTimestamp)
 	const selectedOutcomeLabel = selectedOutcome === undefined ? 'Selected Side' : (outcomeSides.find(side => side.key === selectedOutcome)?.label ?? getReportingOutcomeLabel(selectedOutcome))
 	const reportButtonLabel = selectedOutcome === undefined ? 'Report / Contribute On Selected Side' : `Report / Contribute ${selectedOutcomeLabel}`
@@ -234,12 +245,12 @@ export function ReportingSection({
 		isMainnet,
 		lockedReason,
 		reportAmount: reportingForm.reportAmount,
-		reportingClosed,
 		reportingStatus,
 		selectedOutcome,
 		selectedAmount,
 		viewerVaultAvailableEscalationRep: effectiveReportingDetails?.viewerVaultAvailableEscalationRep,
 		viewerVaultExists: effectiveReportingDetails?.viewerVaultExists ?? false,
+		...(activeReportingDetails === undefined ? {} : { activeReportingDetails }),
 	})
 	const withdrawGuardMessage = getReportingWithdrawGuardMessage({
 		accountAddress: accountState.address,
@@ -250,8 +261,22 @@ export function ReportingSection({
 		withdrawalEnabled: activeReportingDetails?.withdrawalEnabled ?? false,
 		withdrawalState: effectiveReportingDetails?.withdrawalState,
 		selectedOutcome,
+		...(activeReportingDetails === undefined ? {} : { activeReportingDetails }),
 	})
 	const reportingOpenNotice = showFullReporting && reportingStatus === 'not-started' ? 'Reporting is open.' : undefined
+
+	useEffect(() => {
+		if (activeReportingDetails === undefined) return
+		if (escalationPhase !== 'Timed Out') return
+		if (loadingReportingDetails) return
+		if (activeReportingDetails.resolution !== 'none' || activeReportingDetails.hasReachedNonDecision) return
+
+		const refreshBoundaryKey = `${activeReportingDetails.securityPoolAddress}:${activeReportingDetails.escalationEndTime.toString()}`
+		if (lastTimedOutRefreshBoundaryKey.current === refreshBoundaryKey) return
+
+		lastTimedOutRefreshBoundaryKey.current = refreshBoundaryKey
+		void onLoadReporting()
+	}, [activeReportingDetails, escalationPhase, loadingReportingDetails, onLoadReporting])
 	const reportingStage = showFullReporting
 		? getReportingStagePresentation({
 				effectiveCurrentTimestamp,

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -379,6 +379,7 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 		currentTime: block.timestamp,
 		escalationEndTime,
 		escalationGameAddress,
+		hasReachedNonDecision,
 		marketDetails,
 		nonDecisionThreshold,
 		questionOutcome: normalizedQuestionOutcome,

--- a/ui/ts/lib/reportingDomain.ts
+++ b/ui/ts/lib/reportingDomain.ts
@@ -46,6 +46,8 @@ type ReportingTimerPreview =
 			timerIncrease?: bigint
 	  }
 
+type EscalationPhase = 'Resolved' | 'Fork Triggered' | 'Pending Start' | 'Timed Out' | 'Active'
+
 function roundUpToRepUnit(value: bigint) {
 	if (value <= 0n) return 0n
 	return ((value + REP_UNIT - 1n) / REP_UNIT) * REP_UNIT
@@ -73,14 +75,19 @@ export function getEscalationTimeRemaining(details: ActiveReportingDetails) {
 	return requireDefined(getTimeRemaining(details.escalationEndTime, details.currentTime), 'Escalation end time is required')
 }
 
-export function isReportingClosed(details: ActiveReportingDetails) {
-	return details.resolution !== 'none' || details.currentTime > details.escalationEndTime
+function hasEscalationTimedOut(details: ActiveReportingDetails) {
+	return details.currentTime >= details.escalationEndTime
 }
 
-export function getEscalationPhase(details: ActiveReportingDetails) {
+export function isReportingClosed(details: ActiveReportingDetails) {
+	return details.resolution !== 'none' || details.hasReachedNonDecision || hasEscalationTimedOut(details)
+}
+
+export function getEscalationPhase(details: ActiveReportingDetails): EscalationPhase {
 	if (details.resolution !== 'none') return 'Resolved'
+	if (details.hasReachedNonDecision) return 'Fork Triggered'
 	if (details.currentTime < details.startingTime) return 'Pending Start'
-	if (details.currentTime > details.escalationEndTime) return 'Awaiting Resolution'
+	if (hasEscalationTimedOut(details)) return 'Timed Out'
 	return 'Active'
 }
 

--- a/ui/ts/lib/reportingGuards.ts
+++ b/ui/ts/lib/reportingGuards.ts
@@ -1,18 +1,18 @@
 import type { Address } from 'viem'
-import type { ReportingDetails } from '../types/contracts.js'
-import type { ReportingOutcomeKey } from '../types/contracts.js'
+import type { ActiveReportingDetails, ReportingDetails, ReportingOutcomeKey } from '../types/contracts.js'
 import { formatCurrencyBalance } from './formatters.js'
+import { getEscalationPhase } from './reportingDomain.js'
 
 type ReportingStatus = 'missing' | 'not-started' | 'active'
 
 export function getReportingReportGuardMessage({
 	actualDepositAmount,
+	activeReportingDetails,
 	accountAddress,
 	contributionPreviewReason,
 	isMainnet,
 	lockedReason,
 	reportAmount,
-	reportingClosed,
 	reportingStatus,
 	selectedOutcome,
 	selectedAmount,
@@ -20,12 +20,12 @@ export function getReportingReportGuardMessage({
 	viewerVaultExists,
 }: {
 	actualDepositAmount: bigint | undefined
+	activeReportingDetails?: ActiveReportingDetails
 	accountAddress: Address | undefined
 	contributionPreviewReason: string | undefined
 	isMainnet: boolean
 	lockedReason: string | undefined
 	reportAmount: string
-	reportingClosed: boolean
 	reportingStatus: ReportingStatus
 	selectedOutcome: ReportingOutcomeKey | undefined
 	selectedAmount: bigint | undefined
@@ -33,7 +33,19 @@ export function getReportingReportGuardMessage({
 	viewerVaultExists: boolean
 }) {
 	if (lockedReason !== undefined) return lockedReason
-	if (reportingClosed) return 'Reporting is closed because the escalation timer has ended.'
+	if (activeReportingDetails !== undefined) {
+		switch (getEscalationPhase(activeReportingDetails)) {
+			case 'Resolved':
+				return 'Reporting is closed because escalation has resolved.'
+			case 'Fork Triggered':
+				return 'Reporting is closed because escalation reached non-decision and moved into the fork workflow.'
+			case 'Timed Out':
+				return 'Reporting is closed because the escalation timeout has been reached.'
+			case 'Pending Start':
+			case 'Active':
+				break
+		}
+	}
 	if (accountAddress === undefined) return 'Connect a wallet before reporting on a market.'
 	if (!isMainnet) return 'Switch to Ethereum mainnet before reporting on a market.'
 	if (reportingStatus === 'missing') return 'Load reporting details before reporting on an outcome.'
@@ -51,6 +63,7 @@ export function getReportingReportGuardMessage({
 }
 
 export function getReportingWithdrawGuardMessage({
+	activeReportingDetails,
 	accountAddress,
 	hasUserDepositsOnSelectedSide,
 	isMainnet,
@@ -60,6 +73,7 @@ export function getReportingWithdrawGuardMessage({
 	withdrawalState,
 	selectedOutcome,
 }: {
+	activeReportingDetails?: ActiveReportingDetails
 	accountAddress: Address | undefined
 	hasUserDepositsOnSelectedSide: boolean
 	isMainnet: boolean
@@ -74,6 +88,7 @@ export function getReportingWithdrawGuardMessage({
 	if (!isMainnet) return 'Switch to Ethereum mainnet before withdrawing escalation deposits.'
 	if (reportingStatus === 'missing') return 'Load reporting details before withdrawing escalation deposits.'
 	if (reportingStatus === 'not-started') return 'Withdrawals are unavailable until the first report or contribution deploys the escalation game.'
+	if (!withdrawalEnabled && activeReportingDetails?.hasReachedNonDecision === true) return 'Escalation deposits move through the Fork workflow after non-decision; they cannot be withdrawn from this panel.'
 	if (!withdrawalEnabled && withdrawalState === 'not-finalized') return 'Escalation deposits cannot be withdrawn until the question is finalized or the game is canceled by an external fork.'
 	if (selectedOutcome === undefined) return 'Select an outcome side before withdrawing escalation deposits.'
 	if (!hasUserDepositsOnSelectedSide) return 'No deposits are available to withdraw on the selected side.'

--- a/ui/ts/tests/reportingDomain.test.ts
+++ b/ui/ts/tests/reportingDomain.test.ts
@@ -7,11 +7,13 @@ import {
 	computeEscalationTimeSinceStartFromAttritionCost,
 	getEscalationBalanceTuple,
 	getEscalationBindingCapital,
+	getEscalationPhase,
 	getMaxProfitContribution,
 	getMinimumOutcomeChangeContribution,
 	getReportingMaxProfitContribution,
 	getReportingMinimumOutcomeChangeContribution,
 	getReportingTimerPreview,
+	isReportingClosed,
 	previewReportingContribution,
 	projectEscalationEndTime,
 } from '../lib/reportingDomain.js'
@@ -49,6 +51,7 @@ function createReportingDetails(overrides: Partial<ActiveReportingDetails> = {})
 		currentTime: 150n,
 		escalationEndTime: 300n,
 		escalationGameAddress: zeroAddress,
+		hasReachedNonDecision: false,
 		marketDetails: createMarketDetails(),
 		nonDecisionThreshold: rep(100n),
 		questionOutcome: 'none',
@@ -116,6 +119,7 @@ function createDynamicReportingDetails(overrides: Partial<ActiveReportingDetails
 		currentTime,
 		escalationEndTime,
 		escalationGameAddress: zeroAddress,
+		hasReachedNonDecision: false,
 		marketDetails: createMarketDetails(),
 		nonDecisionThreshold,
 		questionOutcome: 'none',
@@ -149,6 +153,46 @@ function createDynamicReportingDetails(overrides: Partial<ActiveReportingDetails
 }
 
 describe('reportingDomain', () => {
+	test('getEscalationPhase prioritizes non-decision before timeout', () => {
+		const details = createReportingDetails({
+			currentTime: 300n,
+			escalationEndTime: 300n,
+			hasReachedNonDecision: true,
+		})
+
+		expect(getEscalationPhase(details)).toBe('Fork Triggered')
+	})
+
+	test('getEscalationPhase treats the exact timeout boundary as Timed Out', () => {
+		const details = createReportingDetails({
+			currentTime: 300n,
+			escalationEndTime: 300n,
+		})
+
+		expect(getEscalationPhase(details)).toBe('Timed Out')
+	})
+
+	test('isReportingClosed treats non-decision and the exact timeout boundary as closed', () => {
+		expect(
+			isReportingClosed(
+				createReportingDetails({
+					currentTime: 200n,
+					escalationEndTime: 300n,
+					hasReachedNonDecision: true,
+				}),
+			),
+		).toBe(true)
+
+		expect(
+			isReportingClosed(
+				createReportingDetails({
+					currentTime: 300n,
+					escalationEndTime: 300n,
+				}),
+			),
+		).toBe(true)
+	})
+
 	test('getMinimumOutcomeChangeContribution returns the smallest strict lead', () => {
 		expect(getMinimumOutcomeChangeContribution(createReportingDetails(), 'yes')).toEqual({
 			amount: rep(4n),

--- a/ui/ts/tests/reportingGuards.test.ts
+++ b/ui/ts/tests/reportingGuards.test.ts
@@ -3,6 +3,55 @@
 import { describe, expect, test } from 'bun:test'
 import { zeroAddress } from 'viem'
 import { getReportingReportGuardMessage, getReportingWithdrawGuardMessage } from '../lib/reportingGuards.js'
+import type { ActiveReportingDetails } from '../types/contracts.js'
+
+function createActiveReportingDetails(overrides: Partial<ActiveReportingDetails> = {}): ActiveReportingDetails {
+	return {
+		bindingCapital: 10n,
+		completeSetCollateralAmount: 1n,
+		currentRequiredBond: 2n,
+		currentTime: 150n,
+		escalationEndTime: 300n,
+		escalationGameAddress: zeroAddress,
+		hasReachedNonDecision: false,
+		marketDetails: {
+			answerUnit: '',
+			createdAt: 1n,
+			description: 'Question description',
+			displayValueMax: 100n,
+			displayValueMin: 0n,
+			endTime: 100n,
+			exists: true,
+			marketType: 'binary',
+			numTicks: 2n,
+			outcomeLabels: ['Yes', 'No'],
+			questionId: '0x01',
+			startTime: 1n,
+			title: 'Will this resolve?',
+		},
+		nonDecisionThreshold: 20n,
+		questionOutcome: 'none',
+		resolution: 'none',
+		securityPoolAddress: zeroAddress,
+		sides: [
+			{ balance: 1n, deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+			{ balance: 5n, deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+			{ balance: 2n, deposits: [], key: 'no', label: 'No', userDeposits: [] },
+		],
+		startBond: 1n,
+		startingTime: 120n,
+		status: 'active',
+		totalCost: 2n,
+		universeId: 1n,
+		withdrawalEnabled: false,
+		withdrawalState: 'not-finalized',
+		viewerVaultAvailableEscalationRep: 10n,
+		viewerVaultExists: true,
+		viewerVaultLockedRepInEscalationGame: 0n,
+		viewerVaultRepDepositShare: 10n,
+		...overrides,
+	}
+}
 
 describe('reporting guards', () => {
 	test('blocks report submission for locked, disconnected, unselected, and invalid amount states', () => {
@@ -14,7 +63,6 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: 'Reporting opens after market end.',
 				reportAmount: '1',
-				reportingClosed: false,
 				reportingStatus: 'active',
 				selectedAmount: 1n,
 				viewerVaultAvailableEscalationRep: 10n,
@@ -31,7 +79,6 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: undefined,
 				reportAmount: '1',
-				reportingClosed: false,
 				reportingStatus: 'active',
 				selectedAmount: 1n,
 				viewerVaultAvailableEscalationRep: 10n,
@@ -48,7 +95,6 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: undefined,
 				reportAmount: '1',
-				reportingClosed: false,
 				reportingStatus: 'active',
 				selectedAmount: 1n,
 				selectedOutcome: undefined,
@@ -65,7 +111,6 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: undefined,
 				reportAmount: '0',
-				reportingClosed: false,
 				reportingStatus: 'active',
 				selectedAmount: 0n,
 				viewerVaultAvailableEscalationRep: 10n,
@@ -84,7 +129,6 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: undefined,
 				reportAmount: '1',
-				reportingClosed: false,
 				reportingStatus: 'missing',
 				selectedAmount: 1n,
 				selectedOutcome: 'yes',
@@ -101,7 +145,6 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: undefined,
 				reportAmount: '1',
-				reportingClosed: false,
 				reportingStatus: 'not-started',
 				selectedAmount: 1n,
 				selectedOutcome: 'yes',
@@ -118,7 +161,6 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: undefined,
 				reportAmount: '1',
-				reportingClosed: false,
 				reportingStatus: 'active',
 				selectedAmount: 1n,
 				selectedOutcome: 'yes',
@@ -128,23 +170,49 @@ describe('reporting guards', () => {
 		).toBeUndefined()
 	})
 
-	test('blocks reporting once the escalation timer is closed', () => {
+	test('blocks reporting once the escalation timeout is reached', () => {
 		expect(
 			getReportingReportGuardMessage({
 				actualDepositAmount: 1n,
+				activeReportingDetails: createActiveReportingDetails({
+					currentTime: 300n,
+					escalationEndTime: 300n,
+				}),
 				accountAddress: zeroAddress,
 				contributionPreviewReason: undefined,
 				isMainnet: true,
 				lockedReason: undefined,
 				reportAmount: '1',
-				reportingClosed: true,
 				reportingStatus: 'active',
 				selectedAmount: 1n,
 				selectedOutcome: 'yes',
 				viewerVaultAvailableEscalationRep: 10n,
 				viewerVaultExists: true,
 			}),
-		).toBe('Reporting is closed because the escalation timer has ended.')
+		).toBe('Reporting is closed because the escalation timeout has been reached.')
+	})
+
+	test('blocks reporting once non-decision moves escalation into the fork workflow', () => {
+		expect(
+			getReportingReportGuardMessage({
+				actualDepositAmount: 1n,
+				activeReportingDetails: createActiveReportingDetails({
+					currentTime: 300n,
+					escalationEndTime: 300n,
+					hasReachedNonDecision: true,
+				}),
+				accountAddress: zeroAddress,
+				contributionPreviewReason: undefined,
+				isMainnet: true,
+				lockedReason: undefined,
+				reportAmount: '1',
+				reportingStatus: 'active',
+				selectedAmount: 1n,
+				selectedOutcome: 'yes',
+				viewerVaultAvailableEscalationRep: 10n,
+				viewerVaultExists: true,
+			}),
+		).toBe('Reporting is closed because escalation reached non-decision and moved into the fork workflow.')
 	})
 
 	test('blocks reporting when the vault lacks unlocked REP or the contribution preview is invalid', () => {
@@ -156,7 +224,6 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: undefined,
 				reportAmount: '5',
-				reportingClosed: false,
 				reportingStatus: 'active',
 				selectedAmount: 5n * 10n ** 18n,
 				selectedOutcome: 'yes',
@@ -173,7 +240,6 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: undefined,
 				reportAmount: '1',
-				reportingClosed: false,
 				reportingStatus: 'active',
 				selectedAmount: 1n * 10n ** 18n,
 				selectedOutcome: 'yes',
@@ -190,7 +256,6 @@ describe('reporting guards', () => {
 				isMainnet: true,
 				lockedReason: undefined,
 				reportAmount: '1',
-				reportingClosed: false,
 				reportingStatus: 'active',
 				selectedAmount: 1n,
 				selectedOutcome: 'yes',
@@ -255,6 +320,22 @@ describe('reporting guards', () => {
 	})
 
 	test('blocks withdraw submission until the contract allows it', () => {
+		expect(
+			getReportingWithdrawGuardMessage({
+				activeReportingDetails: createActiveReportingDetails({
+					hasReachedNonDecision: true,
+				}),
+				accountAddress: zeroAddress,
+				hasUserDepositsOnSelectedSide: true,
+				isMainnet: true,
+				lockedReason: undefined,
+				reportingStatus: 'active',
+				selectedOutcome: 'yes',
+				withdrawalEnabled: false,
+				withdrawalState: 'not-finalized',
+			}),
+		).toBe('Escalation deposits move through the Fork workflow after non-decision; they cannot be withdrawn from this panel.')
+
 		expect(
 			getReportingWithdrawGuardMessage({
 				accountAddress: zeroAddress,

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -3,7 +3,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { act } from 'preact/test-utils'
 import { fireEvent, within } from '@testing-library/dom'
-import { h } from 'preact'
+import { h, render } from 'preact'
 import { useState } from 'preact/hooks'
 import { zeroAddress } from 'viem'
 import { ReportingSection } from '../components/ReportingSection.js'
@@ -84,6 +84,7 @@ function createReportingDetails(overrides: Partial<ActiveReportingDetails> = {})
 		currentTime: 150n,
 		escalationEndTime: 300n,
 		escalationGameAddress: zeroAddress,
+		hasReachedNonDecision: false,
 		marketDetails: createMarketDetails(),
 		nonDecisionThreshold: rep(20n),
 		questionOutcome: 'none',
@@ -129,6 +130,7 @@ function createDynamicReportingDetails(overrides: Partial<ActiveReportingDetails
 		currentTime,
 		escalationEndTime,
 		escalationGameAddress: zeroAddress,
+		hasReachedNonDecision: false,
 		marketDetails: createMarketDetails(),
 		nonDecisionThreshold,
 		questionOutcome: 'none',
@@ -541,7 +543,7 @@ describe('ReportingSection', () => {
 		expect(document.body.textContent?.includes(formatDuration(300n - 200n))).toBe(true)
 	})
 
-	test('shows Awaiting Resolution with zero time left once the escalation end time has passed', async () => {
+	test('shows Timed Out with zero time left once the escalation end time is reached', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(
 				ReportingSection,
@@ -549,7 +551,7 @@ describe('ReportingSection', () => {
 					currentTimestamp: undefined,
 					reportingDetails: {
 						...createReportingDetails(),
-						currentTime: 301n,
+						currentTime: 300n,
 						escalationEndTime: 300n,
 					},
 				}),
@@ -558,16 +560,17 @@ describe('ReportingSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		expect(documentQueries.getByRole('heading', { name: 'Awaiting Resolution' })).not.toBeNull()
+		expect(documentQueries.getByRole('heading', { name: 'Timed Out' })).not.toBeNull()
+		expect(document.body.textContent?.includes('Escalation ended by timeout. The winner is computed from the current stakes; refresh reporting if the resolved outcome is not loaded yet.')).toBe(true)
 		expect(document.body.textContent?.includes(formatDuration(0n))).toBe(true)
 	})
 
-	test('uses the live chain timestamp to flip the escalation phase once the end time passes', async () => {
+	test('uses the live chain timestamp to flip the escalation phase once the end time is reached', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(
 				ReportingSection,
 				createProps({
-					currentTimestamp: 301n,
+					currentTimestamp: 300n,
 					reportingDetails: {
 						...createReportingDetails(),
 						currentTime: 150n,
@@ -579,7 +582,7 @@ describe('ReportingSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		expect(documentQueries.getAllByText('Awaiting Resolution').length).toBeGreaterThan(0)
+		expect(documentQueries.getAllByText('Timed Out').length).toBeGreaterThan(0)
 		expect(document.body.textContent?.includes(formatDuration(0n))).toBe(true)
 	})
 
@@ -601,7 +604,97 @@ describe('ReportingSection', () => {
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		expectTransactionButtonDisabled(document.body, 'Report / Contribute Yes', 'Reporting is closed because the escalation timer has ended.')
+		expectTransactionButtonDisabled(document.body, 'Report / Contribute Yes', 'Reporting is closed because the escalation timeout has been reached.')
+	})
+
+	test('shows Fork Triggered instead of timeout when non-decision is reached first', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					currentTimestamp: 300n,
+					reportingDetails: createReportingDetails({
+						currentTime: 300n,
+						escalationEndTime: 300n,
+						hasReachedNonDecision: true,
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByRole('heading', { name: 'Fork Triggered' })).not.toBeNull()
+		expect(document.body.textContent?.includes('Escalation reached non-decision. Continue in the Fork workflow; this panel does not have a final-resolution action.')).toBe(true)
+	})
+
+	test('auto-refreshes reporting once when the live timestamp reaches an unresolved timeout boundary', async () => {
+		const onLoadReportingCalls: string[] = []
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					currentTimestamp: 300n,
+					onLoadReporting: () => {
+						onLoadReportingCalls.push('refresh')
+					},
+					reportingDetails: createReportingDetails({
+						currentTime: 150n,
+						escalationEndTime: 300n,
+						securityPoolAddress: '0x00000000000000000000000000000000000000c1',
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(onLoadReportingCalls).toEqual(['refresh'])
+
+		await act(() => {
+			render(
+				h(
+					ReportingSection,
+					createProps({
+						currentTimestamp: 300n,
+						onLoadReporting: () => {
+							onLoadReportingCalls.push('rerender')
+						},
+						reportingDetails: createReportingDetails({
+							currentTime: 150n,
+							escalationEndTime: 300n,
+							securityPoolAddress: '0x00000000000000000000000000000000000000c1',
+						}),
+					}),
+				),
+				renderedComponent.container,
+			)
+		})
+
+		expect(onLoadReportingCalls).toEqual(['refresh'])
+	})
+
+	test('does not auto-refresh reporting when non-decision closes escalation before timeout handling', async () => {
+		const onLoadReportingCalls: string[] = []
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					currentTimestamp: 300n,
+					onLoadReporting: () => {
+						onLoadReportingCalls.push('refresh')
+					},
+					reportingDetails: createReportingDetails({
+						currentTime: 150n,
+						escalationEndTime: 300n,
+						hasReachedNonDecision: true,
+						securityPoolAddress: '0x00000000000000000000000000000000000000c2',
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(onLoadReportingCalls).toEqual([])
 	})
 
 	test('renders a reporting-open notice with zeroed pre-start diagram values before the first report', async () => {

--- a/ui/ts/tests/useReportingOperations.test.tsx
+++ b/ui/ts/tests/useReportingOperations.test.tsx
@@ -29,6 +29,7 @@ function createReportingDetails(securityPoolAddress: Address): ReportingDetails 
 		currentTime: 150n,
 		escalationEndTime: 300n,
 		escalationGameAddress: zeroAddress,
+		hasReachedNonDecision: false,
 		marketDetails: {
 			answerUnit: '',
 			createdAt: 1n,

--- a/ui/ts/types/contracts.ts
+++ b/ui/ts/types/contracts.ts
@@ -341,6 +341,7 @@ export type ActiveReportingDetails = ReportingDetailsBase & {
 	currentRequiredBond: bigint
 	escalationEndTime: bigint
 	escalationGameAddress: Address
+	hasReachedNonDecision: boolean
 	sides: EscalationSide[]
 	startingTime: bigint
 	totalCost: bigint


### PR DESCRIPTION
## Summary
- Add explicit reporting and escalation handling for non-decision and exact-timeout states, including updated phase classification and guard messages.
- Refine the reporting UI to show clearer escalation metrics, timer previews, and status messaging for not-started, active, timed-out, and fork-triggered flows.
- Update escalation side presentation and styling to highlight selection and leading status more clearly.
- Extend Solidity and UI tests to cover non-decision precedence, timer preview behavior, and reporting guard edge cases.

## Testing
- `bun run tsc`
- `bun run test`
- `bun run format`
- `bun run check`
- `bun run knip`