### PR TITLE
Add selectable escalation withdrawals and activation timing

### DIFF
--- a/solidity/contracts/peripherals/EscalationGame.sol
+++ b/solidity/contracts/peripherals/EscalationGame.sol
@@ -20,7 +20,9 @@ uint256 constant MAX_EXP_ITERATIONS = 16;
 uint256 constant EXCESS_REWARD_WINDOW_DIVISOR = 2;
 
 contract EscalationGame {
-	uint256 public startingTime;
+	uint256 public constant activationDelay = 3 days;
+	uint256 public activationTime;
+	uint256 public createdAt;
 	uint256[3] public balances; // outcome -> amount
 	mapping(uint8 => Deposit[]) public deposits; // make a fixed array with dynamic
 	ISecurityPool public securityPool;
@@ -30,7 +32,7 @@ contract EscalationGame {
 	address public owner;
 	uint256 public nonDecisionTimestamp;
 
-	event GameStarted(uint256 startingTime, uint256 startBond, uint256 nonDecisionThreshold);
+	event GameStarted(uint256 createdAt, uint256 activationTime, uint256 startBond, uint256 nonDecisionThreshold);
 	event DepositOnOutcome(address depositor, BinaryOutcomes.BinaryOutcome outcome, uint256 amount, uint256 depositIndex, uint256 cumulativeAmount);
 	event WithdrawDeposit(address depositor, BinaryOutcomes.BinaryOutcome outcome, uint256 amountToWithdraw, uint256 depositIndex);
 	event ClaimDeposit(uint256 amountToWithdraw, uint256 burnAmount);
@@ -42,16 +44,17 @@ contract EscalationGame {
 
 	function start(uint256 _startBond, uint256 _nonDecisionThreshold) public {
 		require(owner == msg.sender, 'only owner can start');
-		require(startingTime == 0, 'already started');
+		require(activationTime == 0, 'already started');
 		require(_nonDecisionThreshold > _startBond, 'threshold must exceed start bond');
 		require(_startBond > 0, 'start bond must be positive');
 		require(_startBond >= 1e18, 'start bond must be at least 1 ether');
 		require(_nonDecisionThreshold >= 1e18, 'threshold must be at least 1 ether');
-		startingTime = block.timestamp + 3 days;
+		createdAt = block.timestamp;
+		activationTime = block.timestamp + activationDelay;
 		nonDecisionThreshold = _nonDecisionThreshold;
 		startBond = _startBond;
 		lnRatioScaled = _computeLnRatioScaled(_startBond, _nonDecisionThreshold);
-		emit GameStarted(startingTime, startBond, nonDecisionThreshold);
+		emit GameStarted(createdAt, activationTime, startBond, nonDecisionThreshold);
 	}
 
 	function getBalances() public view returns (uint256[3] memory) {
@@ -141,12 +144,12 @@ contract EscalationGame {
 
 	function getEscalationGameEndDate() public view returns (uint256 endTime) {
 		if (nonDecisionTimestamp > 0) return nonDecisionTimestamp;
-		return startingTime + computeTimeSinceStartFromAttritionCost(getBindingCapital());
+		return activationTime + computeTimeSinceStartFromAttritionCost(getBindingCapital());
 	}
 
 	function totalCost() public view returns (uint256) {
-		if (startingTime >= block.timestamp) return 0;
-		uint256 timeFromStart = block.timestamp - startingTime;
+		if (activationTime >= block.timestamp) return 0;
+		uint256 timeFromStart = block.timestamp - activationTime;
 		if (timeFromStart >= escalationTimeLength) return nonDecisionThreshold;
 		return computeIterativeAttritionCost(timeFromStart);
 	}

--- a/solidity/contracts/peripherals/EscalationGame.sol
+++ b/solidity/contracts/peripherals/EscalationGame.sol
@@ -22,7 +22,6 @@ uint256 constant EXCESS_REWARD_WINDOW_DIVISOR = 2;
 contract EscalationGame {
 	uint256 public constant activationDelay = 3 days;
 	uint256 public activationTime;
-	uint256 public createdAt;
 	uint256[3] public balances; // outcome -> amount
 	mapping(uint8 => Deposit[]) public deposits; // make a fixed array with dynamic
 	ISecurityPool public securityPool;
@@ -32,7 +31,7 @@ contract EscalationGame {
 	address public owner;
 	uint256 public nonDecisionTimestamp;
 
-	event GameStarted(uint256 createdAt, uint256 activationTime, uint256 startBond, uint256 nonDecisionThreshold);
+	event GameStarted(uint256 activationTime, uint256 startBond, uint256 nonDecisionThreshold);
 	event DepositOnOutcome(address depositor, BinaryOutcomes.BinaryOutcome outcome, uint256 amount, uint256 depositIndex, uint256 cumulativeAmount);
 	event WithdrawDeposit(address depositor, BinaryOutcomes.BinaryOutcome outcome, uint256 amountToWithdraw, uint256 depositIndex);
 	event ClaimDeposit(uint256 amountToWithdraw, uint256 burnAmount);
@@ -49,12 +48,11 @@ contract EscalationGame {
 		require(_startBond > 0, 'start bond must be positive');
 		require(_startBond >= 1e18, 'start bond must be at least 1 ether');
 		require(_nonDecisionThreshold >= 1e18, 'threshold must be at least 1 ether');
-		createdAt = block.timestamp;
 		activationTime = block.timestamp + activationDelay;
 		nonDecisionThreshold = _nonDecisionThreshold;
 		startBond = _startBond;
 		lnRatioScaled = _computeLnRatioScaled(_startBond, _nonDecisionThreshold);
-		emit GameStarted(createdAt, activationTime, startBond, nonDecisionThreshold);
+		emit GameStarted(activationTime, startBond, nonDecisionThreshold);
 	}
 
 	function getBalances() public view returns (uint256[3] memory) {

--- a/solidity/ts/tests/escalationGame.test.ts
+++ b/solidity/ts/tests/escalationGame.test.ts
@@ -7,7 +7,7 @@ import { TEST_ADDRESSES } from '../testsuite/simulator/utils/constants'
 import { contractExists, setupTestAccounts } from '../testsuite/simulator/utils/utilities'
 import { QuestionOutcome } from '../testsuite/simulator/types/types'
 import assert from 'node:assert'
-import { deployEscalationGame, depositOnOutcome, getBalances, getEscalationGameDeposits, getStartingTime, getQuestionResolution } from '../testsuite/simulator/utils/contracts/escalationGame'
+import { deployEscalationGame, depositOnOutcome, getActivationTime, getBalances, getEscalationGameDeposits, getQuestionResolution } from '../testsuite/simulator/utils/contracts/escalationGame'
 import { ensureZoltarDeployed, getZoltarAddress } from '../testsuite/simulator/utils/contracts/zoltar'
 import { ensureInfraDeployed } from '../testsuite/simulator/utils/contracts/deployPeripherals'
 import { peripherals_EscalationGame_EscalationGame, peripherals_test_EscalationGameTestSecurityPool_EscalationGameTestSecurityPool } from '../types/contractArtifact'
@@ -149,8 +149,8 @@ describe('Escalation Game Test Suite', () => {
 		assert.strictEqual(outcomeBalances.no, 0n, 'no stake')
 		assert.strictEqual(outcomeBalances.invalid, 0n, 'invalid stake')
 
-		const startingTime = await getStartingTime(client, escalationGame)
-		assert.strictEqual(startingTime !== 0n, true, 'game was started')
+		const activationTime = await getActivationTime(client, escalationGame)
+		assert.strictEqual(activationTime !== 0n, true, 'game was started')
 		await depositOnOutcome(client, escalationGame, client.account.address, QuestionOutcome.No, reportBond)
 		const outcomeBalancesAfterDeposit = await getBalances(client, escalationGame)
 		assert.strictEqual(outcomeBalancesAfterDeposit.yes, 0n, 'yes stake')
@@ -160,8 +160,8 @@ describe('Escalation Game Test Suite', () => {
 
 	test('empty started game resolves to invalid after timeout', async () => {
 		const escalationGame = await deployEscalationGame(client, reportBond, nonDecisionThreshold)
-		const startingTime = await getStartingTime(client, escalationGame)
-		await mockWindow.setTime(startingTime + ESCALATION_TIME_LENGTH + 1n)
+		const activationTime = await getActivationTime(client, escalationGame)
+		await mockWindow.setTime(activationTime + ESCALATION_TIME_LENGTH + 1n)
 		assert.strictEqual(await getQuestionResolution(client, escalationGame), QuestionOutcome.Invalid, 'empty game should resolve as invalid')
 	})
 
@@ -172,8 +172,8 @@ describe('Escalation Game Test Suite', () => {
 		assert.strictEqual(await readHasReachedNonDecision(escalationGame), true, 'two threshold-reaching outcomes should trigger non-decision')
 		assert.strictEqual(await getQuestionResolution(client, escalationGame), QuestionOutcome.None, 'non-decision should leave the question unresolved')
 
-		const startingTime = await getStartingTime(client, escalationGame)
-		await mockWindow.setTime(startingTime + ESCALATION_TIME_LENGTH + 1n)
+		const activationTime = await getActivationTime(client, escalationGame)
+		await mockWindow.setTime(activationTime + ESCALATION_TIME_LENGTH + 1n)
 		assert.strictEqual(await readHasReachedNonDecision(escalationGame), true, 'non-decision should stay active after time advances')
 		assert.strictEqual(await getQuestionResolution(client, escalationGame), QuestionOutcome.None, 'non-decision should still take precedence after time advances')
 	})
@@ -346,7 +346,7 @@ describe('Escalation Game Test Suite', () => {
 	test('totalCost: returns 0 before game starts and nonDecisionThreshold after timeout', async () => {
 		const escalationGame = await deployEscalationGame(client, reportBond, nonDecisionThreshold)
 
-		// totalCost before game starts (startingTime is 3 days in future) returns 0
+		// totalCost before activationTime (3 days in the future) returns 0
 		const costBeforeStart = await client.readContract({
 			abi: peripherals_EscalationGame_EscalationGame.abi,
 			functionName: 'totalCost',
@@ -356,8 +356,8 @@ describe('Escalation Game Test Suite', () => {
 		assert.strictEqual(costBeforeStart, 0n, 'totalCost returns 0 before game starts')
 
 		// Advance time past the escalation period to test after-timeout behavior
-		const startTime = await getStartingTime(client, escalationGame)
-		await mockWindow.setTime(startTime + ESCALATION_TIME_LENGTH + 1n)
+		const activationTime = await getActivationTime(client, escalationGame)
+		await mockWindow.setTime(activationTime + ESCALATION_TIME_LENGTH + 1n)
 		const costAfterTimeout = await client.readContract({
 			abi: peripherals_EscalationGame_EscalationGame.abi,
 			functionName: 'totalCost',
@@ -468,8 +468,8 @@ describe('Escalation Game Test Suite', () => {
 		assert.strictEqual(balances.invalid, depositAmount - 1n, 'Invalid balance reduced by 1 wei')
 		assert.strictEqual(balances.no, 0n, 'No balance remains zero')
 		// Advance time past game end
-		const startTime = await getStartingTime(client, escalationGame)
-		await mockWindow.setTime(startTime + ESCALATION_TIME_LENGTH + 1n)
+		const activationTime = await getActivationTime(client, escalationGame)
+		await mockWindow.setTime(activationTime + ESCALATION_TIME_LENGTH + 1n)
 		const resolution = await getQuestionResolution(client, escalationGame)
 		assert.strictEqual(resolution, QuestionOutcome.Yes, 'Winner should be Yes')
 	})
@@ -484,8 +484,8 @@ describe('Escalation Game Test Suite', () => {
 		assert.strictEqual(balances.yes, amount1 + amount2, 'Yes balance increased without adjustment')
 		assert.strictEqual(balances.invalid, 0n, 'Invalid balance zero')
 		assert.strictEqual(balances.no, 0n, 'No balance zero')
-		const startTime = await getStartingTime(client, escalationGame)
-		await mockWindow.setTime(startTime + ESCALATION_TIME_LENGTH + 1n)
+		const activationTime = await getActivationTime(client, escalationGame)
+		await mockWindow.setTime(activationTime + ESCALATION_TIME_LENGTH + 1n)
 		const resolution = await getQuestionResolution(client, escalationGame)
 		assert.strictEqual(resolution, QuestionOutcome.Yes, 'Resolution should be Yes')
 	})
@@ -506,8 +506,8 @@ describe('Escalation Game Test Suite', () => {
 		await depositOnOutcomeViaTestSecurityPool(testSecurityPoolAddress, winningDepositorAddress, QuestionOutcome.Yes, excessWinningDeposit)
 		await depositOnOutcomeViaTestSecurityPool(testSecurityPoolAddress, losingDepositorAddress, QuestionOutcome.No, losingDeposit)
 
-		const startTime = await getStartingTime(client, escalationGameAddress)
-		await mockWindow.setTime(startTime + ESCALATION_TIME_LENGTH + 1n)
+		const activationTime = await getActivationTime(client, escalationGameAddress)
+		await mockWindow.setTime(activationTime + ESCALATION_TIME_LENGTH + 1n)
 
 		assert.strictEqual(await getQuestionResolution(client, escalationGameAddress), QuestionOutcome.Yes, 'Resolution should be Yes')
 		const claimLog = await claimWinningDepositAndReadClaimLog(testSecurityPoolAddress, 0n, QuestionOutcome.Yes)
@@ -528,8 +528,8 @@ describe('Escalation Game Test Suite', () => {
 		await depositOnOutcomeViaTestSecurityPool(testSecurityPoolAddress, secondWinningDepositorAddress, QuestionOutcome.Yes, secondWinningDeposit)
 		await depositOnOutcomeViaTestSecurityPool(testSecurityPoolAddress, losingDepositorAddress, QuestionOutcome.No, losingDeposit)
 
-		const startTime = await getStartingTime(client, escalationGameAddress)
-		await mockWindow.setTime(startTime + ESCALATION_TIME_LENGTH + 1n)
+		const activationTime = await getActivationTime(client, escalationGameAddress)
+		await mockWindow.setTime(activationTime + ESCALATION_TIME_LENGTH + 1n)
 
 		assert.strictEqual(await getQuestionResolution(client, escalationGameAddress), QuestionOutcome.Yes, 'Resolution should be Yes')
 		const claimLog = await claimWinningDepositAndReadClaimLog(testSecurityPoolAddress, 1n, QuestionOutcome.Yes)
@@ -550,8 +550,8 @@ describe('Escalation Game Test Suite', () => {
 		await depositOnOutcomeViaTestSecurityPool(testSecurityPoolAddress, secondWinningDepositorAddress, QuestionOutcome.Yes, secondWinningDeposit)
 		await depositOnOutcomeViaTestSecurityPool(testSecurityPoolAddress, losingDepositorAddress, QuestionOutcome.No, losingDeposit)
 
-		const startTime = await getStartingTime(client, escalationGameAddress)
-		await mockWindow.setTime(startTime + ESCALATION_TIME_LENGTH + 1n)
+		const activationTime = await getActivationTime(client, escalationGameAddress)
+		await mockWindow.setTime(activationTime + ESCALATION_TIME_LENGTH + 1n)
 
 		assert.strictEqual(await getQuestionResolution(client, escalationGameAddress), QuestionOutcome.Yes, 'Resolution should be Yes')
 		const firstClaimLog = await claimWinningDepositAndReadClaimLog(testSecurityPoolAddress, 0n, QuestionOutcome.Yes)

--- a/solidity/ts/testsuite/simulator/utils/contracts/escalationGame.ts
+++ b/solidity/ts/testsuite/simulator/utils/contracts/escalationGame.ts
@@ -63,7 +63,7 @@ export const getEscalationGameDeposits = async (client: ReadClient, escalationGa
 		).map((deposit, index) => ({ ...deposit, depositIndex: currentIndex + BigInt(index) }))
 		const newDeposits = returnedDeposits.filter(deposit => BigInt(deposit.depositor) !== 0n || deposit.amount !== 0n || deposit.cumulativeAmount !== 0n)
 		pages.push(...newDeposits)
-		if (BigInt(returnedDeposits.length) !== CONTRACT_PAGE_SIZE || BigInt(newDeposits.length) !== CONTRACT_PAGE_SIZE) break
+		if (BigInt(returnedDeposits.length) !== CONTRACT_PAGE_SIZE) break
 		currentIndex += CONTRACT_PAGE_SIZE
 	} while (true)
 	return pages
@@ -107,10 +107,10 @@ export const getBalances = async (client: ReadClient, escalationGame: AccountAdd
 	return { invalid, yes, no }
 }
 
-export const getStartingTime = async (client: ReadClient, escalationGame: AccountAddress) =>
+export const getActivationTime = async (client: ReadClient, escalationGame: AccountAddress) =>
 	await client.readContract({
 		abi: peripherals_EscalationGame_EscalationGame.abi,
-		functionName: 'startingTime',
+		functionName: 'activationTime',
 		address: escalationGame,
 		args: [],
 	})

--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -2486,6 +2486,30 @@ strong.metric-value-danger {
 	gap: var(--space-3);
 }
 
+.workflow-status-item {
+	position: relative;
+}
+
+.workflow-status-item > .entity-card,
+.workflow-status-item > .transaction-action-status,
+.workflow-status-item > .warning-surface {
+	padding-right: 3.4rem;
+}
+
+.workflow-status-close {
+	position: absolute;
+	top: 0.8rem;
+	right: 0.8rem;
+	z-index: 2;
+	width: 2rem;
+	min-width: 2rem;
+	min-height: 2rem;
+	padding: 0;
+	border-radius: 999px;
+	font-size: 1.2rem;
+	line-height: 1;
+}
+
 .sticky-object-context-body {
 	display: grid;
 	gap: 0.9rem;
@@ -2540,6 +2564,36 @@ strong.metric-value-danger {
 .reporting-header-stack {
 	display: grid;
 	gap: 1rem;
+}
+
+.withdraw-deposit-list {
+	display: grid;
+	gap: 0.8rem;
+}
+
+.withdraw-deposit-option {
+	display: grid;
+	grid-template-columns: auto minmax(0, 1fr);
+	align-items: start;
+	gap: 0.8rem;
+	padding: 0.9rem 1rem;
+	border: 1px solid var(--border-subtle);
+	border-radius: var(--radius-control);
+	background: var(--surface-inset);
+}
+
+.withdraw-deposit-option input {
+	margin: 0.2rem 0 0;
+}
+
+.withdraw-deposit-copy {
+	display: grid;
+	gap: 0.2rem;
+	min-width: 0;
+}
+
+.withdraw-deposit-copy strong {
+	font-size: var(--font-body);
 }
 
 .stage-list,

--- a/ui/dist/css/index.css
+++ b/ui/dist/css/index.css
@@ -2486,6 +2486,30 @@ strong.metric-value-danger {
 	gap: var(--space-3);
 }
 
+.workflow-status-item {
+	position: relative;
+}
+
+.workflow-status-item > .entity-card,
+.workflow-status-item > .transaction-action-status,
+.workflow-status-item > .warning-surface {
+	padding-right: 3.4rem;
+}
+
+.workflow-status-close {
+	position: absolute;
+	top: 0.8rem;
+	right: 0.8rem;
+	z-index: 2;
+	width: 2rem;
+	min-width: 2rem;
+	min-height: 2rem;
+	padding: 0;
+	border-radius: 999px;
+	font-size: 1.2rem;
+	line-height: 1;
+}
+
 .sticky-object-context-body {
 	display: grid;
 	gap: 0.9rem;
@@ -2540,6 +2564,36 @@ strong.metric-value-danger {
 .reporting-header-stack {
 	display: grid;
 	gap: 1rem;
+}
+
+.withdraw-deposit-list {
+	display: grid;
+	gap: 0.8rem;
+}
+
+.withdraw-deposit-option {
+	display: grid;
+	grid-template-columns: auto minmax(0, 1fr);
+	align-items: start;
+	gap: 0.8rem;
+	padding: 0.9rem 1rem;
+	border: 1px solid var(--border-subtle);
+	border-radius: var(--radius-control);
+	background: var(--surface-inset);
+}
+
+.withdraw-deposit-option input {
+	margin: 0.2rem 0 0;
+}
+
+.withdraw-deposit-copy {
+	display: grid;
+	gap: 0.2rem;
+	min-width: 0;
+}
+
+.withdraw-deposit-copy strong {
+	font-size: var(--font-body);
 }
 
 .stage-list,

--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -561,7 +561,7 @@ export function App() {
 				onLoadReporting: () => void loadReporting(),
 				onReportOutcome: () => void onReportOutcome(),
 				onReportingFormChange: update => updateReportingForm(update),
-				onWithdrawEscalation: () => void withdrawEscalation(),
+				onWithdrawEscalation: depositIndexes => void withdrawEscalation(depositIndexes),
 				reportingActiveAction,
 				reportingDetails,
 				reportingError,

--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -322,6 +322,7 @@ export function ForkAuctionSection({
 		forkAuctionResult === undefined
 			? undefined
 			: {
+					dismissKey: forkAuctionResult.hash,
 					title: 'Latest Fork / Auction Action',
 					embedInCard,
 					rows: [

--- a/ui/ts/components/LiquidationModal.tsx
+++ b/ui/ts/components/LiquidationModal.tsx
@@ -20,7 +20,6 @@ import { parseRepAmountInput } from '../lib/marketForm.js'
 import { getOracleRequestEthGuardMessage } from '../lib/oracleRequestEth.js'
 import { getRepPriceSourceCopy, renderRepPriceSourceLabel, type RepPriceSource } from '../lib/repPriceSource.js'
 import { getVaultCollateralizationPercent } from '../lib/trading.js'
-import { getCurrentTimestamp as getLocalCurrentTimestamp } from '../lib/time.js'
 import type { ActionFeedback } from '../types/components.js'
 import type { ListedSecurityPool, OracleManagerDetails, SecurityPoolOverviewActionResult, SecurityPoolVaultSummary } from '../types/contracts.js'
 
@@ -204,7 +203,7 @@ export function LiquidationModal({
 	}, [showLiquidationModal])
 
 	if (!showLiquidationModal) return undefined
-	const currentTimestamp = chainCurrentTimestamp ?? getLocalCurrentTimestamp()
+	const currentTimestamp = chainCurrentTimestamp
 	const liquidationAmountValue = (() => {
 		try {
 			return parseRepAmountInput(liquidationAmount, 'Liquidation amount')

--- a/ui/ts/components/OpenOraclePriceValue.tsx
+++ b/ui/ts/components/OpenOraclePriceValue.tsx
@@ -1,9 +1,8 @@
 import { useChainTimestamp } from '../lib/chainTimestamp.js'
 import { getOracleLastPriceDisplay, getOraclePriceValidityPresentation } from '../lib/securityPoolWorkflow.js'
-import { getCurrentTimestamp } from '../lib/time.js'
 
 type OpenOraclePriceValueProps = {
-	currentTimestamp?: bigint
+	currentTimestamp?: bigint | undefined
 	lastPrice: bigint | undefined
 	lastSettlementTimestamp: bigint
 	priceValidUntilTimestamp: bigint | undefined
@@ -12,13 +11,16 @@ type OpenOraclePriceValueProps = {
 export function OpenOraclePriceValue({ currentTimestamp, lastPrice, lastSettlementTimestamp, priceValidUntilTimestamp }: OpenOraclePriceValueProps) {
 	if (lastPrice === undefined || lastSettlementTimestamp === 0n) return 'Unavailable'
 	const chainCurrentTimestamp = useChainTimestamp()
-	const resolvedCurrentTimestamp = currentTimestamp ?? chainCurrentTimestamp ?? getCurrentTimestamp()
+	const resolvedCurrentTimestamp = currentTimestamp ?? chainCurrentTimestamp
 
-	const validityPresentation = getOraclePriceValidityPresentation({
-		currentTimestamp: resolvedCurrentTimestamp,
-		lastSettlementTimestamp,
-		priceValidUntilTimestamp,
-	})
+	const validityPresentation =
+		resolvedCurrentTimestamp === undefined
+			? undefined
+			: getOraclePriceValidityPresentation({
+					currentTimestamp: resolvedCurrentTimestamp,
+					lastSettlementTimestamp,
+					priceValidUntilTimestamp,
+				})
 
 	return (
 		<span className='oracle-price-value'>

--- a/ui/ts/components/OpenOracleSection.tsx
+++ b/ui/ts/components/OpenOracleSection.tsx
@@ -742,6 +742,7 @@ function getLatestActionPresentation(action: OpenOracleSectionProps['openOracleR
 	if (action === undefined) return undefined
 
 	return {
+		dismissKey: action.hash,
 		title: 'Latest Oracle Action',
 		rows: [
 			{ label: 'Action', value: action.action },
@@ -757,42 +758,49 @@ function getOpenOracleOutcomePresentation(action: OpenOracleSectionProps['openOr
 		case 'approveToken1':
 			return {
 				detail: 'Token1 approval was updated for the selected report workflow.',
+				dismissKey: `${action.action}:${action.hash}:outcome`,
 				nextStep: 'Return to the report modal and complete the report submission.',
 				title: 'Token1 Approved',
 			}
 		case 'approveToken2':
 			return {
 				detail: 'Token2 approval was updated for the selected report workflow.',
+				dismissKey: `${action.action}:${action.hash}:outcome`,
 				nextStep: 'Return to the report modal and complete the report submission.',
 				title: 'Token2 Approved',
 			}
 		case 'wrapWeth':
 			return {
 				detail: 'ETH was wrapped to WETH for the selected report flow.',
+				dismissKey: `${action.action}:${action.hash}:outcome`,
 				nextStep: 'Submit the initial report once all requirements are ready.',
 				title: 'WETH Wrapped',
 			}
 		case 'submitInitialReport':
 			return {
 				detail: 'The selected report now has an initial report on-chain.',
+				dismissKey: `${action.action}:${action.hash}:outcome`,
 				nextStep: 'Monitor the dispute window and settle once the report is ready.',
 				title: 'Initial Report Submitted',
 			}
 		case 'dispute':
 			return {
 				detail: 'The selected report was disputed with the replacement swap amounts.',
+				dismissKey: `${action.action}:${action.hash}:outcome`,
 				nextStep: 'Monitor the updated report state and settle when the dispute window closes.',
 				title: 'Report Disputed',
 			}
 		case 'settle':
 			return {
 				detail: 'The selected report was settled on-chain.',
+				dismissKey: `${action.action}:${action.hash}:outcome`,
 				nextStep: 'No further write actions are expected for this report.',
 				title: 'Report Settled',
 			}
 		case 'createReportInstance':
 			return {
 				detail: 'A new Open Oracle game was created.',
+				dismissKey: `${action.action}:${action.hash}:outcome`,
 				nextStep: 'Open the new report to continue its lifecycle.',
 				title: 'Open Oracle Game Created',
 			}

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -505,17 +505,17 @@ export function ReportingSection({
 											/>
 											<span className='withdraw-deposit-copy'>
 												<strong>Deposit #{deposit.depositIndex.toString()}</strong>
-												{claimLabel === undefined ? undefined : <span>{claimLabel}</span>}
+												<span>
+													Initially deposited: <CurrencyValue value={deposit.amount} suffix='REP' />
+												</span>
 												{claimAmount === undefined ? (
-													<span>Available after finalization</span>
+													<span>Worth after finalization: Pending finalization</span>
 												) : (
 													<span>
-														Available now: <CurrencyValue value={claimAmount} suffix='REP' />
+														Worth now: <CurrencyValue value={claimAmount} suffix='REP' />
 													</span>
 												)}
-												<span>
-													Amount deposited: <CurrencyValue value={deposit.amount} suffix='REP' />
-												</span>
+												<span>Current claim type: {claimLabel ?? 'Pending finalization'}</span>
 												<span>
 													Entry depth: <CurrencyValue value={deposit.cumulativeAmount} suffix='REP' />
 												</span>

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -355,7 +355,7 @@ export function ReportingSection({
 						</MetricField>
 						<MetricField label='Time Left'>{activeReportingDetails === undefined ? '—' : formatDuration(getEscalationTimeRemaining(activeReportingDetails))}</MetricField>
 						<MetricField label='Game Start'>
-							<TimestampValue {...(effectiveCurrentTimestamp === undefined ? {} : { currentTimestamp: effectiveCurrentTimestamp })} timestamp={activeReportingDetails?.gameCreatedAt} />
+							<TimestampValue {...(effectiveCurrentTimestamp === undefined ? {} : { currentTimestamp: effectiveCurrentTimestamp })} timestamp={activeReportingDetails?.activationTime} />
 						</MetricField>
 						<MetricField label='Start Bond'>
 							<CurrencyValue value={effectiveReportingDetails?.startBond} suffix='REP' />

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -18,9 +18,19 @@ import { WorkflowTransactionStatus } from './WorkflowTransactionStatus.js'
 import { formatCurrencyInputBalance, formatDuration } from '../lib/formatters.js'
 import { parseOptionalRepAmountInput } from '../lib/marketForm.js'
 import { isMainnetChain } from '../lib/network.js'
-import { calculateEstimatedEscalationReturn, getEscalationPhase, getEscalationTimeRemaining, getLeadingEscalationOutcome, getReportingMaxProfitContribution, getReportingMinimumOutcomeChangeContribution, getReportingTimerPreview, previewReportingContribution } from '../lib/reportingDomain.js'
+import {
+	calculateEstimatedEscalationReturn,
+	getEscalationDepositClaimAmount,
+	getEscalationPhase,
+	getEscalationTimeRemaining,
+	getLeadingEscalationOutcome,
+	getReportingMaxProfitContribution,
+	getReportingMinimumOutcomeChangeContribution,
+	getReportingTimerPreview,
+	previewReportingContribution,
+} from '../lib/reportingDomain.js'
 import { getReportingReportGuardMessage, getReportingWithdrawGuardMessage } from '../lib/reportingGuards.js'
-import { REPORTING_OUTCOME_DROPDOWN_OPTIONS, getReportingOutcomeLabel } from '../lib/reporting.js'
+import { REPORTING_OUTCOME_DROPDOWN_OPTIONS, getReportingLockedUntilMessage, getReportingOutcomeLabel } from '../lib/reporting.js'
 import type { LifecycleStagePresentation, ReportingSectionProps, WorkflowOutcomePresentation } from '../types/components.js'
 import type { EscalationDeposit, ReportingDetails, ReportingOutcomeKey } from '../types/contracts.js'
 
@@ -70,12 +80,22 @@ function getOutcomeSides(reportingDetails: ReportingDetails | undefined) {
 	}))
 }
 
-function getDepositEntryCountLabel(count: number) {
-	return count === 1 ? 'entry' : 'entries'
-}
-
 function isHiddenPresetReason(reason: string | undefined) {
 	return reason === LOAD_REPORTING_PRESETS_REASON || reason === MAX_PROFIT_NOT_STARTED_REASON || reason === SELECT_OUTCOME_PRESET_REASON || reason === SELECTED_SIDE_ALREADY_LEADS_REASON || reason === MAX_PROFIT_WINDOW_FILLED_REASON
+}
+
+function getResolvedReportingOutcomeLabel(reportingDetails: ReportingDetails) {
+	const resolvedOutcome = reportingDetails.questionOutcome !== 'none' ? reportingDetails.questionOutcome : reportingDetails.resolution
+	return getReportingOutcomeLabel(resolvedOutcome)
+}
+
+function getWithdrawDepositClaimLabel(details: ReportingDetails | undefined, selectedOutcome: ReportingOutcomeKey) {
+	if (details === undefined || details.status !== 'active') return undefined
+	if (details.withdrawalState === 'canceled-by-external-fork') return 'External fork refund'
+
+	const resolvedOutcome = details.questionOutcome !== 'none' ? details.questionOutcome : details.resolution
+	if (resolvedOutcome === 'none') return undefined
+	return resolvedOutcome === selectedOutcome ? 'Winning payout' : 'Losing deposit settlement'
 }
 
 function getReportingStagePresentation({
@@ -93,7 +113,7 @@ function getReportingStagePresentation({
 		return {
 			availableActions: [],
 			blockedActions: ['report'],
-			detail: 'Reporting opens after the market end timestamp for this pool.',
+			detail: getReportingLockedUntilMessage(marketDetails.endTime, effectiveCurrentTimestamp),
 			key: 'reporting-not-enabled',
 			label: 'Reporting Not Enabled',
 			tone: 'warning',
@@ -149,7 +169,7 @@ function getReportingStagePresentation({
 			return {
 				availableActions: [],
 				blockedActions: [],
-				detail: 'Escalation has resolved. Review the final state and any remaining deposits below.',
+				detail: `Market finalized as ${getResolvedReportingOutcomeLabel(reportingDetails)}. Review any remaining deposits below.`,
 				key: 'escalation-resolved',
 				label: 'Resolved',
 				tone: 'success',
@@ -166,6 +186,7 @@ function getReportingOutcomePresentation(action: ReportingSectionProps['reportin
 		case 'withdrawEscalation':
 			return {
 				detail: 'Eligible escalation deposits were withdrawn for the selected outcome side.',
+				dismissKey: `${action.action}:${action.hash}:outcome`,
 				nextStep: 'Review the updated escalation balances before taking another reporting action.',
 				title: 'Escalation Deposits Withdrawn',
 			}
@@ -218,6 +239,7 @@ export function ReportingSection({
 	const selectedOutcome = reportingForm.selectedOutcome
 	const selectedSide = selectedOutcome === undefined ? undefined : activeReportingDetails?.sides.find(side => side.key === selectedOutcome)
 	const selectedWithdrawDepositIndexes = reportingForm.selectedWithdrawDepositIndexes
+	const allWithdrawDepositIndexes = selectedSide?.userDeposits.map(deposit => deposit.depositIndex) ?? []
 	const displayBindingCapital = effectiveReportingDetails === undefined ? undefined : effectiveReportingDetails.status === 'not-started' ? 0n : effectiveReportingDetails.bindingCapital
 	const outcomeSides = getOutcomeSides(effectiveReportingDetails)
 	const chartScaleMax = outcomeSides.reduce(
@@ -231,7 +253,7 @@ export function ReportingSection({
 	const reportContributionPreview = effectiveReportingDetails === undefined || selectedAmount === undefined || selectedOutcome === undefined ? undefined : previewReportingContribution(effectiveReportingDetails, selectedOutcome, selectedAmount)
 	const actualReportDepositAmount = reportContributionPreview?.actualDepositAmount
 	const selectedEstimate = activeReportingDetails === undefined || selectedAmount === undefined || selectedOutcome === undefined ? undefined : calculateEstimatedEscalationReturn(activeReportingDetails, selectedOutcome, selectedAmount)
-	const timerPreview = effectiveReportingDetails === undefined || selectedAmount === undefined || selectedOutcome === undefined ? undefined : getReportingTimerPreview(effectiveReportingDetails, selectedOutcome, selectedAmount, effectiveCurrentTimestamp)
+	const timerPreview = effectiveReportingDetails === undefined || selectedAmount === undefined || selectedOutcome === undefined ? undefined : getReportingTimerPreview(effectiveReportingDetails, selectedOutcome, selectedAmount)
 	const selectedOutcomeLabel = selectedOutcome === undefined ? 'Selected Side' : (outcomeSides.find(side => side.key === selectedOutcome)?.label ?? getReportingOutcomeLabel(selectedOutcome))
 	const reportButtonLabel = selectedOutcome === undefined ? 'Report / Contribute On Selected Side' : `Report / Contribute ${selectedOutcomeLabel}`
 	const minimumOutcomeChangeContribution = selectedOutcome === undefined ? { amount: undefined, reason: SELECT_OUTCOME_PRESET_REASON } : getReportingMinimumOutcomeChangeContribution(effectiveReportingDetails, selectedOutcome)
@@ -263,6 +285,7 @@ export function ReportingSection({
 		selectedOutcome,
 		...(activeReportingDetails === undefined ? {} : { activeReportingDetails }),
 	})
+	const withdrawSelectedGuardMessage = withdrawGuardMessage ?? (selectedSide !== undefined && selectedSide.userDeposits.length > 0 && selectedWithdrawDepositIndexes.length === 0 ? 'Select at least one deposit to withdraw or use Withdraw all.' : undefined)
 	const reportingOpenNotice = showFullReporting && reportingStatus === 'not-started' ? 'Reporting is open.' : undefined
 
 	useEffect(() => {
@@ -289,6 +312,7 @@ export function ReportingSection({
 		reportingResult === undefined
 			? undefined
 			: {
+					dismissKey: reportingResult.hash,
 					title: 'Latest Reporting Action',
 					embedInCard,
 					rows: [
@@ -326,15 +350,12 @@ export function ReportingSection({
 			{showFullReporting ? (
 				<SectionBlock title='Escalation Metrics'>
 					<div className='escalation-metrics'>
-						<MetricField label='Binding Capital'>
-							<CurrencyValue value={displayBindingCapital} suffix='REP' />
-						</MetricField>
 						<MetricField label='Threshold'>
 							<CurrencyValue value={effectiveReportingDetails?.nonDecisionThreshold} suffix='REP' />
 						</MetricField>
 						<MetricField label='Time Left'>{activeReportingDetails === undefined ? '—' : formatDuration(getEscalationTimeRemaining(activeReportingDetails))}</MetricField>
 						<MetricField label='Game Start'>
-							<TimestampValue {...(effectiveCurrentTimestamp === undefined ? {} : { currentTimestamp: effectiveCurrentTimestamp })} timestamp={activeReportingDetails?.startingTime} />
+							<TimestampValue {...(effectiveCurrentTimestamp === undefined ? {} : { currentTimestamp: effectiveCurrentTimestamp })} timestamp={activeReportingDetails?.gameCreatedAt} />
 						</MetricField>
 						<MetricField label='Start Bond'>
 							<CurrencyValue value={effectiveReportingDetails?.startBond} suffix='REP' />
@@ -434,10 +455,14 @@ export function ReportingSection({
 					</div>
 					{timerPreview === undefined ? undefined : timerPreview.kind === 'not-started' ? (
 						<>
-							<p className='detail'>This contribution would start the escalation timer at {timerPreview.startsAt === undefined ? 'immediately' : <TimestampValue currentTimestamp={timerPreview.startsAt} timestamp={timerPreview.startsAt} />}.</p>
-							<p className='detail'>
-								If <CurrencyValue copyable={false} value={selectedAmount} suffix='REP' /> became binding capital, the dispute window would last {formatDuration(timerPreview.hypotheticalDuration)} from game start.
-							</p>
+							<p className='detail'>This contribution would start the escalation timer in {formatDuration(timerPreview.timeUntilStart)}.</p>
+							{timerPreview.hypotheticalDuration === 0n ? (
+								<p className='detail'>At that binding capital, the dispute timer would expire as soon as it activates, so reporting would close in {formatDuration(timerPreview.timeUntilEnd)}.</p>
+							) : (
+								<p className='detail'>
+									If <CurrencyValue copyable={false} value={selectedAmount} suffix='REP' /> became binding capital, the dispute window would run for {formatDuration(timerPreview.hypotheticalDuration)} after activation and end in {formatDuration(timerPreview.timeUntilEnd)}.
+								</p>
+							)}
 						</>
 					) : (
 						<>
@@ -458,26 +483,17 @@ export function ReportingSection({
 
 			{showWithdrawOnly ? (
 				<SectionBlock title='Withdraw Escalation Deposits'>
-					{selectedSide === undefined ? undefined : selectedSide.userDeposits.length === 0 ? (
-						<p className='detail'>Connected wallet has no unsettled deposits on the selected side.</p>
-					) : activeReportingDetails?.withdrawalEnabled ? (
-						<p className='detail'>
-							Connected wallet has <strong>{selectedSide.userDeposits.length.toString()}</strong> withdrawable unsettled deposit {getDepositEntryCountLabel(selectedSide.userDeposits.length)} on the selected side.
-						</p>
-					) : (
-						<p className='detail'>
-							Connected wallet has <strong>{selectedSide.userDeposits.length.toString()}</strong> unsettled deposit {getDepositEntryCountLabel(selectedSide.userDeposits.length)} on the selected side, but withdrawals are not available yet.
-						</p>
-					)}
+					{selectedSide === undefined ? undefined : selectedSide.userDeposits.length === 0 ? <p className='detail'>Connected wallet has no unsettled deposits on the selected side.</p> : undefined}
 					{selectedSide === undefined || selectedSide.userDeposits.length === 0 ? undefined : (
 						<div className='field'>
 							<span>Choose deposits to withdraw</span>
-							<p className='detail'>Leave all unchecked to withdraw every eligible deposit on this side.</p>
-							<div>
+							<div className='withdraw-deposit-list'>
 								{selectedSide.userDeposits.map(deposit => {
 									const isChecked = selectedWithdrawDepositIndexes.includes(deposit.depositIndex)
+									const claimLabel = getWithdrawDepositClaimLabel(effectiveReportingDetails, selectedSide.key)
+									const claimAmount = getEscalationDepositClaimAmount(effectiveReportingDetails, selectedSide.key, deposit)
 									return (
-										<label key={deposit.depositIndex.toString()} className='detail'>
+										<label key={deposit.depositIndex.toString()} className='withdraw-deposit-option'>
 											<input
 												type='checkbox'
 												checked={isChecked}
@@ -486,8 +502,24 @@ export function ReportingSection({
 													const nextSelectedWithdrawDepositIndexes = event.currentTarget.checked ? [...selectedWithdrawDepositIndexes, deposit.depositIndex] : selectedWithdrawDepositIndexes.filter(index => index !== deposit.depositIndex)
 													onReportingFormChange({ selectedWithdrawDepositIndexes: nextSelectedWithdrawDepositIndexes })
 												}}
-											/>{' '}
-											Deposit #{deposit.depositIndex.toString()} | Amount: <CurrencyValue value={deposit.amount} suffix='REP' /> | Cumulative at entry: <CurrencyValue value={deposit.cumulativeAmount} suffix='REP' />
+											/>
+											<span className='withdraw-deposit-copy'>
+												<strong>Deposit #{deposit.depositIndex.toString()}</strong>
+												{claimLabel === undefined ? undefined : <span>{claimLabel}</span>}
+												{claimAmount === undefined ? (
+													<span>Available after finalization</span>
+												) : (
+													<span>
+														Available now: <CurrencyValue value={claimAmount} suffix='REP' />
+													</span>
+												)}
+												<span>
+													Amount deposited: <CurrencyValue value={deposit.amount} suffix='REP' />
+												</span>
+												<span>
+													Entry depth: <CurrencyValue value={deposit.cumulativeAmount} suffix='REP' />
+												</span>
+											</span>
 										</label>
 									)
 								})}
@@ -496,7 +528,22 @@ export function ReportingSection({
 					)}
 
 					<div className='actions'>
-						<TransactionActionButton idleLabel='Withdraw Escalation Deposits' pendingLabel='Withdrawing deposits...' onClick={onWithdrawEscalation} pending={reportingActiveAction === 'withdrawEscalation'} tone='secondary' availability={{ disabled: withdrawGuardMessage !== undefined, reason: withdrawGuardMessage }} />
+						<TransactionActionButton
+							idleLabel='Withdraw Selected Deposits'
+							pendingLabel='Withdrawing deposits...'
+							onClick={() => onWithdrawEscalation(selectedWithdrawDepositIndexes)}
+							pending={reportingActiveAction === 'withdrawEscalation'}
+							tone='secondary'
+							availability={{ disabled: withdrawSelectedGuardMessage !== undefined, reason: withdrawSelectedGuardMessage }}
+						/>
+						<TransactionActionButton
+							idleLabel='Withdraw All'
+							pendingLabel='Withdrawing deposits...'
+							onClick={() => onWithdrawEscalation(allWithdrawDepositIndexes)}
+							pending={reportingActiveAction === 'withdrawEscalation'}
+							tone='secondary'
+							availability={{ disabled: withdrawGuardMessage !== undefined, reason: withdrawGuardMessage }}
+						/>
 					</div>
 				</SectionBlock>
 			) : undefined}

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -41,9 +41,9 @@ import { hasForkActivity } from '../lib/forkAuction.js'
 import { getLiquidationNoticeState } from '../lib/liquidationStatus.js'
 import { resolveRequestedLoadableValueState } from '../lib/loadState.js'
 import { isMainnetChain } from '../lib/network.js'
+import { getReportingLockedUntilMessage } from '../lib/reporting.js'
 import { getVaultExecutePendingOperationGuardMessage, getVaultRequestPriceGuardMessage } from '../lib/securityVaultGuards.js'
 import { doesLoadedSecurityVaultMatchSelection, getSelectedVaultAddress, isSelectedVaultOwnedByAccount as isSelectedVaultOwnedByAccountHelper } from '../lib/securityVault.js'
-import { getCurrentTimestamp as getLocalCurrentTimestamp } from '../lib/time.js'
 import { getPoolRegistryPresentation } from '../lib/userCopy.js'
 import { formatUniverseLabel } from '../lib/universe.js'
 import type { SecurityPoolSystemState } from '../types/contracts.js'
@@ -127,8 +127,9 @@ export function SecurityPoolWorkflowSection({
 	const marketDetails = selectedPool?.marketDetails ?? currentReportingDetails?.marketDetails ?? currentForkAuctionDetails?.marketDetails
 	const selectedPoolState = selectedPool?.systemState ?? currentForkAuctionDetails?.systemState
 	const selectedPoolHasForkActivity = selectedPool !== undefined ? hasForkActivity(selectedPool) : currentForkAuctionDetails !== undefined ? hasForkActivity(currentForkAuctionDetails) : false
-	const currentTimestamp = chainCurrentTimestamp ?? currentReportingDetails?.currentTime ?? getLocalCurrentTimestamp()
-	const reportingReady = marketDetails !== undefined && marketDetails.endTime <= currentTimestamp
+	const currentTimestamp = chainCurrentTimestamp ?? currentReportingDetails?.currentTime ?? currentForkAuctionDetails?.currentTime
+	const reportingReady = marketDetails !== undefined && currentTimestamp !== undefined && marketDetails.endTime <= currentTimestamp
+	const reportingLockedReason = reportingReady ? undefined : marketDetails === undefined ? 'Reporting opens after market end.' : getReportingLockedUntilMessage(marketDetails.endTime, currentTimestamp)
 	const forkWorkflowDisabled = isForkWorkflowDisabled(selectedPoolState, selectedPoolHasForkActivity)
 	const selectedPoolUniverseMismatch = selectedPool !== undefined && selectedPool.universeId !== activeUniverseId
 	const hasSelectedPoolAddress = securityPoolAddress.trim() !== ''
@@ -548,7 +549,7 @@ export function SecurityPoolWorkflowSection({
 										{...reporting}
 										currentTimestamp={currentTimestamp}
 										embedInCard
-										lockedReason={reportingReady ? undefined : 'Reporting opens after market end.'}
+										lockedReason={reportingLockedReason}
 										mode='full-reporting'
 										previewMarketDetails={currentReportingDetails === undefined ? marketDetails : undefined}
 										reportingDetails={currentReportingDetails}
@@ -562,7 +563,7 @@ export function SecurityPoolWorkflowSection({
 										{...reporting}
 										currentTimestamp={currentTimestamp}
 										embedInCard
-										lockedReason={reportingReady ? undefined : 'Reporting opens after market end.'}
+										lockedReason={reportingLockedReason}
 										mode='withdraw-only'
 										previewMarketDetails={currentReportingDetails === undefined ? marketDetails : undefined}
 										reportingDetails={currentReportingDetails}

--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -384,6 +384,7 @@ export function SecurityVaultSection({
 		securityVaultResult === undefined
 			? undefined
 			: {
+					dismissKey: securityVaultResult.hash,
 					title: 'Latest Vault Action',
 					embedInCard: compactLayout,
 					rows: [

--- a/ui/ts/components/TimestampValue.tsx
+++ b/ui/ts/components/TimestampValue.tsx
@@ -1,8 +1,6 @@
 import type { ComponentChildren } from 'preact'
-import { useEffect, useState } from 'preact/hooks'
 import { useChainTimestamp } from '../lib/chainTimestamp.js'
 import { formatRelativeTimestamp, formatTimestamp } from '../lib/formatters.js'
-import { getCurrentTimestamp } from '../lib/time.js'
 import { getMetricPlaceholderPresentation } from '../lib/userCopy.js'
 
 type TimestampValueProps = {
@@ -17,20 +15,6 @@ type TimestampValueProps = {
 export function TimestampValue({ className = '', currentTimestamp, loading = false, timestamp, undefinedText = getMetricPlaceholderPresentation(undefined)?.placeholder, zeroText }: TimestampValueProps) {
 	const chainCurrentTimestamp = useChainTimestamp()
 	const resolvedCurrentTimestamp = currentTimestamp ?? chainCurrentTimestamp
-	const [fallbackNow, setFallbackNow] = useState(() => getCurrentTimestamp())
-	const now = resolvedCurrentTimestamp ?? fallbackNow
-
-	useEffect(() => {
-		if (loading || resolvedCurrentTimestamp !== undefined) return
-		setFallbackNow(getCurrentTimestamp())
-		const intervalId = window.setInterval(() => {
-			setFallbackNow(getCurrentTimestamp())
-		}, 1000)
-
-		return () => {
-			window.clearInterval(intervalId)
-		}
-	}, [loading, resolvedCurrentTimestamp])
 
 	if (loading) {
 		return <span className={`timestamp-value loading ${className}`}>Loading...</span>
@@ -49,11 +33,17 @@ export function TimestampValue({ className = '', currentTimestamp, loading = fal
 	}
 
 	const absoluteTimestamp = formatTimestamp(timestamp)
-	const relativeTimestamp = formatRelativeTimestamp(timestamp, now)
+	const relativeTimestamp = resolvedCurrentTimestamp === undefined ? undefined : formatRelativeTimestamp(timestamp, resolvedCurrentTimestamp)
 
 	return (
 		<time className={`timestamp-value ${className}`} dateTime={new Date(Number(timestamp) * 1000).toISOString()} title={absoluteTimestamp}>
-			{absoluteTimestamp} <span className='timestamp-value-relative'>({relativeTimestamp})</span>
+			{absoluteTimestamp}
+			{relativeTimestamp === undefined ? null : (
+				<>
+					{' '}
+					<span className='timestamp-value-relative'>({relativeTimestamp})</span>
+				</>
+			)}
 		</time>
 	)
 }

--- a/ui/ts/components/TradingSection.tsx
+++ b/ui/ts/components/TradingSection.tsx
@@ -42,24 +42,28 @@ function getTradingOutcomePresentation(action: TradingSectionProps['tradingResul
 		case 'createCompleteSet':
 			return {
 				detail: 'Complete sets were minted for the selected pool.',
+				dismissKey: `${action.action}:${action.hash}:outcome`,
 				nextStep: 'Review the updated share balances before your next trading action.',
 				title: 'Complete Sets Minted',
 			}
 		case 'redeemCompleteSet':
 			return {
 				detail: 'Matching complete sets were redeemed back into collateral.',
+				dismissKey: `${action.action}:${action.hash}:outcome`,
 				nextStep: 'Review the updated share balances and wallet collateral balance.',
 				title: 'Complete Sets Redeemed',
 			}
 		case 'migrateShares':
 			return {
 				detail: 'Forked shares were migrated into the selected child universes.',
+				dismissKey: `${action.action}:${action.hash}:outcome`,
 				nextStep: 'Open the target universe or pool views to inspect the migrated balances.',
 				title: 'Shares Migrated',
 			}
 		case 'redeemShares':
 			return {
 				detail: 'Resolved shares were redeemed for the selected pool.',
+				dismissKey: `${action.action}:${action.hash}:outcome`,
 				nextStep: 'Review the updated balances and proceed with any remaining resolved positions.',
 				title: 'Resolved Shares Redeemed',
 			}
@@ -226,6 +230,7 @@ export function TradingSection({
 		tradingResult === undefined
 			? undefined
 			: {
+					dismissKey: tradingResult.hash,
 					title: 'Latest Trading Action',
 					embedInCard,
 					rows: [

--- a/ui/ts/components/WorkflowTransactionStatus.tsx
+++ b/ui/ts/components/WorkflowTransactionStatus.tsx
@@ -1,39 +1,78 @@
+import { useEffect, useRef, useState } from 'preact/hooks'
 import { EntityCard } from './EntityCard.js'
 import { TransactionActionStatus } from './TransactionActionStatus.js'
 import type { WorkflowTransactionStatusProps } from '../types/components.js'
 
 export function WorkflowTransactionStatus({ latestAction, outcome }: WorkflowTransactionStatusProps) {
-	if (latestAction === undefined && outcome === undefined) return undefined
+	const [dismissedLatestActionKey, setDismissedLatestActionKey] = useState<string | undefined>(undefined)
+	const [dismissedOutcomeKey, setDismissedOutcomeKey] = useState<string | undefined>(undefined)
+	const latestActionKeyRef = useRef(latestAction?.dismissKey)
+	const outcomeKeyRef = useRef(outcome?.dismissKey)
+
+	useEffect(() => {
+		if (latestAction?.dismissKey === latestActionKeyRef.current) return
+		latestActionKeyRef.current = latestAction?.dismissKey
+		if (dismissedLatestActionKey !== undefined) {
+			setDismissedLatestActionKey(undefined)
+		}
+	}, [dismissedLatestActionKey, latestAction?.dismissKey])
+
+	useEffect(() => {
+		if (outcome?.dismissKey === outcomeKeyRef.current) return
+		outcomeKeyRef.current = outcome?.dismissKey
+		if (dismissedOutcomeKey !== undefined) {
+			setDismissedOutcomeKey(undefined)
+		}
+	}, [dismissedOutcomeKey, outcome?.dismissKey])
+
+	const showOutcome = outcome !== undefined && (outcome.dismissKey === undefined || outcome.dismissKey !== dismissedOutcomeKey)
+	const showLatestAction = latestAction !== undefined && (latestAction.dismissKey === undefined || latestAction.dismissKey !== dismissedLatestActionKey)
+
+	if (!showLatestAction && !showOutcome) return undefined
 
 	return (
 		<div className='workflow-transaction-status'>
-			{outcome === undefined ? undefined : (
-				<TransactionActionStatus
-					status={{
-						detail:
-							outcome.nextStep === undefined ? (
-								outcome.detail
-							) : (
-								<>
-									{outcome.detail} Next: {outcome.nextStep}
-								</>
-							),
-						title: outcome.title,
-						tone: 'success',
-					}}
-				/>
+			{!showOutcome || outcome === undefined ? undefined : (
+				<div className='workflow-status-item'>
+					{outcome.dismissKey === undefined ? undefined : (
+						<button className='quiet modal-close-button workflow-status-close' type='button' aria-label='Dismiss workflow outcome' title='Close' onClick={() => setDismissedOutcomeKey(outcome.dismissKey)}>
+							&times;
+						</button>
+					)}
+					<TransactionActionStatus
+						status={{
+							detail:
+								outcome.nextStep === undefined ? (
+									outcome.detail
+								) : (
+									<>
+										{outcome.detail} Next: {outcome.nextStep}
+									</>
+								),
+							title: outcome.title,
+							tone: 'success',
+						}}
+					/>
+				</div>
 			)}
-			{latestAction === undefined ? undefined : (
-				<EntityCard className={latestAction.embedInCard === true ? 'transaction-status-card embedded' : 'transaction-status-card'} title={latestAction.title} variant='compact'>
-					<ul className='status-list hashes'>
-						{latestAction.rows.map(row => (
-							<li key={row.label}>
-								<span>{row.label}</span>
-								<strong>{row.value}</strong>
-							</li>
-						))}
-					</ul>
-				</EntityCard>
+			{!showLatestAction || latestAction === undefined ? undefined : (
+				<div className='workflow-status-item'>
+					{latestAction.dismissKey === undefined ? undefined : (
+						<button className='quiet modal-close-button workflow-status-close' type='button' aria-label='Dismiss latest action' title='Close' onClick={() => setDismissedLatestActionKey(latestAction.dismissKey)}>
+							&times;
+						</button>
+					)}
+					<EntityCard className={latestAction.embedInCard === true ? 'transaction-status-card embedded' : 'transaction-status-card'} title={latestAction.title} variant='compact'>
+						<ul className='status-list hashes'>
+							{latestAction.rows.map(row => (
+								<li key={row.label}>
+									<span>{row.label}</span>
+									<strong>{row.value}</strong>
+								</li>
+							))}
+						</ul>
+					</EntityCard>
+				</div>
 			)}
 		</div>
 	)

--- a/ui/ts/components/ZoltarMigrationSection.tsx
+++ b/ui/ts/components/ZoltarMigrationSection.tsx
@@ -200,6 +200,7 @@ export function ZoltarMigrationSection({
 		zoltarMigrationResult === undefined
 			? undefined
 			: {
+					dismissKey: zoltarMigrationResult.hash,
 					title: 'Latest Migration Action',
 					rows: [
 						{ label: 'Action', value: zoltarMigrationResult.action },

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -1,4 +1,4 @@
-import { decodeEventLog, parseAbiItem, zeroAddress, type Address, type ContractFunctionParameters, type Hash, type Hex, type TransactionReceipt } from 'viem'
+import { decodeEventLog, getAddress, parseAbiItem, zeroAddress, type Address, type ContractFunctionParameters, type Hash, type Hex, type TransactionReceipt } from 'viem'
 import { ABIS } from './abis.js'
 import { sortBigIntsAscending } from './shared/bigInt.js'
 import { assertNever } from './lib/assert.js'
@@ -64,7 +64,7 @@ import {
 	requireSecurityVaultTupleArray,
 	toUint8Array,
 } from './contracts/helpers.js'
-import { type ContractRevertReasonParams, readRequiredMulticall, writeContractAndWait, writeContractAndWaitForReceipt } from './contracts/core.js'
+import { type ContractRevertReasonParams, type WriteContractClient, readRequiredMulticall, writeContractAndWait, writeContractAndWaitForReceipt } from './contracts/core.js'
 import { getInfraContractAddresses, getOpenOracleAddress } from './contracts/deploymentHelpers.js'
 export { getDeploymentSteps, loadDeploymentStatusOracleSnapshot, loadErc20Allowance, loadErc20Balance } from './contracts/deployment.js'
 import { getDeploymentSteps } from './contracts/deployment.js'
@@ -80,6 +80,12 @@ const TRUTH_AUCTION_TIME_LENGTH = 604_800n
 const QUESTION_OUTCOME_ABI = [parseAbiItem('function getQuestionOutcome(address securityPool) view returns (uint8 outcome)')]
 
 const CONTRACT_PAGE_SIZE = 30n
+
+type ContractReadClient = {
+	readContract: (params: ContractFunctionParameters) => Promise<unknown>
+}
+
+type ReadWriteContractClient<TReceipt extends Pick<TransactionReceipt, 'status'> = TransactionReceipt> = ContractReadClient & WriteContractClient<TReceipt>
 
 type ForkDataTuple = readonly [bigint, Address, bigint, bigint, bigint, boolean, number]
 type AuctionClearingTuple = readonly [boolean, bigint, bigint, bigint]
@@ -135,13 +141,15 @@ function getStagedOracleExecutionResult(receipt: TransactionReceipt, expectedOpe
 	}
 	return undefined
 }
-async function readSecurityPoolUniverseId(client: Pick<ReadClient, 'readContract'>, securityPoolAddress: Address) {
-	return await client.readContract({
+async function readSecurityPoolUniverseId(client: ContractReadClient, securityPoolAddress: Address) {
+	const universeId = await client.readContract({
 		address: securityPoolAddress,
 		abi: peripherals_SecurityPool_SecurityPool.abi,
 		functionName: 'universeId',
 		args: [],
 	})
+	if (typeof universeId !== 'bigint') throw new Error('Unexpected security pool universe id response')
+	return universeId
 }
 
 function getDeploymentStep(id: DeploymentStepId) {
@@ -150,7 +158,7 @@ function getDeploymentStep(id: DeploymentStepId) {
 	return step
 }
 
-export async function loadEscalationDeposits(client: ReadClient, escalationGameAddress: Address, outcome: ReportingOutcomeKey): Promise<EscalationDeposit[]> {
+export async function loadEscalationDeposits(client: ContractReadClient, escalationGameAddress: Address, outcome: ReportingOutcomeKey): Promise<EscalationDeposit[]> {
 	let currentIndex = 0n
 	const deposits: EscalationDeposit[] = []
 
@@ -997,7 +1005,7 @@ export async function submitInitialOracleReport(client: WriteClient, openOracleA
 	} satisfies OpenOracleActionResult
 }
 
-export async function settleOracleReport(client: WriteClient, openOracleAddress: Address, reportId: bigint) {
+export async function settleOracleReport<TReceipt extends Pick<TransactionReceipt, 'status'>>(client: WriteContractClient<TReceipt>, openOracleAddress: Address, reportId: bigint) {
 	const hash = await writeContractAndWait(client, () => ({
 		address: openOracleAddress,
 		abi: peripherals_openOracle_OpenOracle_OpenOracle.abi,
@@ -1674,7 +1682,7 @@ export async function redeemSharesInSecurityPool(client: WriteClient, securityPo
 	} satisfies TradingActionResult
 }
 
-export async function migrateSharesFromUniverse(client: WriteClient, securityPoolAddress: Address, shareOutcome: ReportingOutcomeKey, targetOutcomeIndexes: bigint[]) {
+export async function migrateSharesFromUniverse<TReceipt extends Pick<TransactionReceipt, 'status'>>(client: ReadWriteContractClient<TReceipt>, securityPoolAddress: Address, shareOutcome: ReportingOutcomeKey, targetOutcomeIndexes: bigint[]) {
 	const sortedTargetOutcomeIndexes = sortBigIntsAscending(targetOutcomeIndexes)
 	const [universeId, shareTokenAddress] = await Promise.all([
 		readSecurityPoolUniverseId(client, securityPoolAddress),
@@ -1685,8 +1693,9 @@ export async function migrateSharesFromUniverse(client: WriteClient, securityPoo
 			args: [],
 		}),
 	])
+	if (typeof shareTokenAddress !== 'string') throw new Error('Unexpected share token address response')
 	const hash = await writeContractAndWait(client, () => ({
-		address: shareTokenAddress,
+		address: getAddress(shareTokenAddress),
 		abi: peripherals_tokens_ShareToken_ShareToken.abi,
 		functionName: 'migrate',
 		args: [getShareTokenId(universeId, shareOutcome), sortedTargetOutcomeIndexes],

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -150,7 +150,7 @@ function getDeploymentStep(id: DeploymentStepId) {
 	return step
 }
 
-async function loadEscalationDeposits(client: ReadClient, escalationGameAddress: Address, outcome: ReportingOutcomeKey): Promise<EscalationDeposit[]> {
+export async function loadEscalationDeposits(client: ReadClient, escalationGameAddress: Address, outcome: ReportingOutcomeKey): Promise<EscalationDeposit[]> {
 	let currentIndex = 0n
 	const deposits: EscalationDeposit[] = []
 
@@ -170,10 +170,10 @@ async function loadEscalationDeposits(client: ReadClient, escalationGameAddress:
 				depositIndex: currentIndex + BigInt(index),
 				depositor: deposit.depositor,
 			}))
-			.filter(deposit => deposit.depositor !== zeroAddress)
+			.filter(deposit => deposit.depositor !== zeroAddress && deposit.amount > 0n)
 
 		deposits.push(...normalizedPage)
-		if (BigInt(normalizedPage.length) !== CONTRACT_PAGE_SIZE) break
+		if (BigInt(page.length) !== CONTRACT_PAGE_SIZE) break
 		currentIndex += CONTRACT_PAGE_SIZE
 	}
 
@@ -279,6 +279,7 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 		return {
 			completeSetCollateralAmount,
 			currentTime: block.timestamp,
+			forkThreshold,
 			marketDetails,
 			nonDecisionThreshold: forkThreshold / 2n,
 			questionOutcome: 'none',
@@ -293,7 +294,7 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 		}
 	}
 
-	const [startBond, nonDecisionThreshold, startingTime, totalCost, bindingCapital, balances, resolution, escalationEndTime, questionOutcome, universeForkTime, hasReachedNonDecision] = await readRequiredMulticall(client, [
+	const [startBond, nonDecisionThreshold, gameCreatedAt, activationTime, totalCost, bindingCapital, balances, resolution, escalationEndTime, questionOutcome, universeForkTime, hasReachedNonDecision] = await readRequiredMulticall(client, [
 		{
 			abi: peripherals_EscalationGame_EscalationGame.abi,
 			functionName: 'startBond',
@@ -308,7 +309,13 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 		},
 		{
 			abi: peripherals_EscalationGame_EscalationGame.abi,
-			functionName: 'startingTime',
+			functionName: 'createdAt',
+			address: escalationGameAddress,
+			args: [],
+		},
+		{
+			abi: peripherals_EscalationGame_EscalationGame.abi,
+			functionName: 'activationTime',
 			address: escalationGameAddress,
 			args: [],
 		},
@@ -379,6 +386,8 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 		currentTime: block.timestamp,
 		escalationEndTime,
 		escalationGameAddress,
+		forkThreshold,
+		gameCreatedAt,
 		hasReachedNonDecision,
 		marketDetails,
 		nonDecisionThreshold,
@@ -388,7 +397,7 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 		sides,
 		startBond,
 		status: 'active',
-		startingTime,
+		activationTime,
 		totalCost,
 		universeId,
 		withdrawalEnabled: withdrawalState !== 'not-finalized',

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -1,4 +1,4 @@
-import { decodeEventLog, getAddress, parseAbiItem, zeroAddress, type Address, type ContractFunctionParameters, type Hash, type Hex, type TransactionReceipt } from 'viem'
+import { decodeEventLog, parseAbiItem, zeroAddress, type Address, type ContractFunctionParameters, type Hash, type Hex, type TransactionReceipt } from 'viem'
 import { ABIS } from './abis.js'
 import { sortBigIntsAscending } from './shared/bigInt.js'
 import { assertNever } from './lib/assert.js'
@@ -55,7 +55,6 @@ import {
 	hasTimestamp,
 	hasTimestampAndNumber,
 	isBigintTriple,
-	isEscalationDepositPage,
 	requireOpenOracleExtraDataTuple,
 	requireOpenOracleReportMetaTuple,
 	requireOpenOracleReportMetaTupleArray,
@@ -81,11 +80,7 @@ const QUESTION_OUTCOME_ABI = [parseAbiItem('function getQuestionOutcome(address 
 
 const CONTRACT_PAGE_SIZE = 30n
 
-type ContractReadClient = {
-	readContract: (params: ContractFunctionParameters) => Promise<unknown>
-}
-
-type ReadWriteContractClient<TReceipt extends Pick<TransactionReceipt, 'status'> = TransactionReceipt> = ContractReadClient & WriteContractClient<TReceipt>
+type ReadWriteContractClient<TReceipt extends Pick<TransactionReceipt, 'status'> = TransactionReceipt> = Pick<ReadClient, 'readContract'> & WriteContractClient<TReceipt>
 
 type ForkDataTuple = readonly [bigint, Address, bigint, bigint, bigint, boolean, number]
 type AuctionClearingTuple = readonly [boolean, bigint, bigint, bigint]
@@ -141,15 +136,13 @@ function getStagedOracleExecutionResult(receipt: TransactionReceipt, expectedOpe
 	}
 	return undefined
 }
-async function readSecurityPoolUniverseId(client: ContractReadClient, securityPoolAddress: Address) {
-	const universeId = await client.readContract({
+async function readSecurityPoolUniverseId(client: Pick<ReadClient, 'readContract'>, securityPoolAddress: Address) {
+	return await client.readContract({
 		address: securityPoolAddress,
 		abi: peripherals_SecurityPool_SecurityPool.abi,
 		functionName: 'universeId',
 		args: [],
 	})
-	if (typeof universeId !== 'bigint') throw new Error('Unexpected security pool universe id response')
-	return universeId
 }
 
 function getDeploymentStep(id: DeploymentStepId) {
@@ -158,7 +151,7 @@ function getDeploymentStep(id: DeploymentStepId) {
 	return step
 }
 
-export async function loadEscalationDeposits(client: ContractReadClient, escalationGameAddress: Address, outcome: ReportingOutcomeKey): Promise<EscalationDeposit[]> {
+export async function loadEscalationDeposits(client: Pick<ReadClient, 'readContract'>, escalationGameAddress: Address, outcome: ReportingOutcomeKey): Promise<EscalationDeposit[]> {
 	let currentIndex = 0n
 	const deposits: EscalationDeposit[] = []
 
@@ -169,7 +162,6 @@ export async function loadEscalationDeposits(client: ContractReadClient, escalat
 			functionName: 'getDepositsByOutcome',
 			args: [getReportingOutcomeValue(outcome), currentIndex, CONTRACT_PAGE_SIZE],
 		})
-		if (!isEscalationDepositPage(page)) throw new Error('Unexpected escalation deposits response')
 
 		const normalizedPage = page
 			.map((deposit, index) => ({
@@ -1693,9 +1685,8 @@ export async function migrateSharesFromUniverse<TReceipt extends Pick<Transactio
 			args: [],
 		}),
 	])
-	if (typeof shareTokenAddress !== 'string') throw new Error('Unexpected share token address response')
 	const hash = await writeContractAndWait(client, () => ({
-		address: getAddress(shareTokenAddress),
+		address: shareTokenAddress,
 		abi: peripherals_tokens_ShareToken_ShareToken.abi,
 		functionName: 'migrate',
 		args: [getShareTokenId(universeId, shareOutcome), sortedTargetOutcomeIndexes],

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -294,7 +294,7 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 		}
 	}
 
-	const [startBond, nonDecisionThreshold, gameCreatedAt, activationTime, totalCost, bindingCapital, balances, resolution, escalationEndTime, questionOutcome, universeForkTime, hasReachedNonDecision] = await readRequiredMulticall(client, [
+	const [startBond, nonDecisionThreshold, activationTime, totalCost, bindingCapital, balances, resolution, escalationEndTime, questionOutcome, universeForkTime, hasReachedNonDecision] = await readRequiredMulticall(client, [
 		{
 			abi: peripherals_EscalationGame_EscalationGame.abi,
 			functionName: 'startBond',
@@ -304,12 +304,6 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 		{
 			abi: peripherals_EscalationGame_EscalationGame.abi,
 			functionName: 'nonDecisionThreshold',
-			address: escalationGameAddress,
-			args: [],
-		},
-		{
-			abi: peripherals_EscalationGame_EscalationGame.abi,
-			functionName: 'createdAt',
 			address: escalationGameAddress,
 			args: [],
 		},
@@ -387,7 +381,6 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 		escalationEndTime,
 		escalationGameAddress,
 		forkThreshold,
-		gameCreatedAt,
 		hasReachedNonDecision,
 		marketDetails,
 		nonDecisionThreshold,

--- a/ui/ts/contracts/core.ts
+++ b/ui/ts/contracts/core.ts
@@ -1,6 +1,6 @@
 import { encodeFunctionData, RpcError, type Abi, type Account, type Address, type ContractFunctionParameters, type Hash, type MulticallReturnType, type TransactionReceipt } from 'viem'
 import { getMulticall3Address } from './deploymentHelpers.js'
-import type { ReadClient } from '../types/contracts.js'
+import type { ReadClient, WriteClient } from '../types/contracts.js'
 
 export type ContractRevertReasonParams = {
 	account?: Account | Address | undefined | null
@@ -13,13 +13,13 @@ export type ContractRevertReasonParams = {
 }
 
 type ContractCallClient = {
-	call?: (params: { account?: Account | Address | undefined; data: `0x${string}`; gas?: bigint | undefined; to: Address; value?: bigint | undefined }) => Promise<unknown>
+	call?: WriteClient['call']
 }
 
-export type WriteContractClient<TReceipt extends Pick<TransactionReceipt, 'status'> = TransactionReceipt> = ContractCallClient & {
-	sendTransaction: (params: { account?: Account | Address | undefined; data: `0x${string}`; gas?: bigint | undefined; to: Address; value?: bigint | undefined }) => Promise<Hash>
-	waitForTransactionReceipt: (params: { hash: Hash }) => Promise<TReceipt>
-}
+export type WriteContractClient<TReceipt extends Pick<TransactionReceipt, 'status'> = TransactionReceipt> = Pick<WriteClient, 'sendTransaction'> &
+	ContractCallClient & {
+		waitForTransactionReceipt: (...args: Parameters<WriteClient['waitForTransactionReceipt']>) => Promise<TReceipt>
+	}
 
 export async function readRequiredMulticall<const TContracts extends readonly unknown[]>(client: Pick<ReadClient, 'multicall'>, contracts: TContracts): Promise<MulticallReturnType<TContracts, false>> {
 	return (await client.multicall({

--- a/ui/ts/contracts/core.ts
+++ b/ui/ts/contracts/core.ts
@@ -1,6 +1,6 @@
 import { encodeFunctionData, RpcError, type Abi, type Account, type Address, type ContractFunctionParameters, type Hash, type MulticallReturnType, type TransactionReceipt } from 'viem'
 import { getMulticall3Address } from './deploymentHelpers.js'
-import type { ReadClient, WriteClient } from '../types/contracts.js'
+import type { ReadClient } from '../types/contracts.js'
 
 export type ContractRevertReasonParams = {
 	account?: Account | Address | undefined | null
@@ -10,6 +10,15 @@ export type ContractRevertReasonParams = {
 	functionName: string
 	gas?: bigint
 	value?: bigint
+}
+
+type ContractCallClient = {
+	call?: (params: { account?: Account | Address | undefined; data: `0x${string}`; gas?: bigint | undefined; to: Address; value?: bigint | undefined }) => Promise<unknown>
+}
+
+export type WriteContractClient<TReceipt extends Pick<TransactionReceipt, 'status'> = TransactionReceipt> = ContractCallClient & {
+	sendTransaction: (params: { account?: Account | Address | undefined; data: `0x${string}`; gas?: bigint | undefined; to: Address; value?: bigint | undefined }) => Promise<Hash>
+	waitForTransactionReceipt: (params: { hash: Hash }) => Promise<TReceipt>
 }
 
 export async function readRequiredMulticall<const TContracts extends readonly unknown[]>(client: Pick<ReadClient, 'multicall'>, contracts: TContracts): Promise<MulticallReturnType<TContracts, false>> {
@@ -28,7 +37,8 @@ export async function readOptionalMulticall<const TContracts extends readonly un
 	})) as MulticallReturnType<TContracts, true>
 }
 
-async function getContractRevertReason<TCallParams extends ContractRevertReasonParams>(client: ReadClient | WriteClient, params: TCallParams) {
+async function getContractRevertReason<TCallParams extends ContractRevertReasonParams>(client: ContractCallClient, params: TCallParams) {
+	if (client.call === undefined) return undefined
 	try {
 		const data = encodeFunctionData({
 			abi: params.abi,
@@ -61,12 +71,12 @@ function getOriginalErrorMessage(error: unknown) {
 	return undefined
 }
 
-export async function writeContractAndWait<TCallParams extends ContractRevertReasonParams>(client: WriteClient, getCallParams: () => TCallParams) {
+export async function writeContractAndWait<TCallParams extends ContractRevertReasonParams, TReceipt extends Pick<TransactionReceipt, 'status'>>(client: WriteContractClient<TReceipt>, getCallParams: () => TCallParams) {
 	const { hash } = await writeContractAndWaitForReceipt(client, getCallParams)
 	return hash
 }
 
-export async function writeContractAndWaitForReceipt<TCallParams extends ContractRevertReasonParams>(client: WriteClient, getCallParams: () => TCallParams): Promise<{ hash: Hash; receipt: TransactionReceipt }> {
+export async function writeContractAndWaitForReceipt<TCallParams extends ContractRevertReasonParams, TReceipt extends Pick<TransactionReceipt, 'status'>>(client: WriteContractClient<TReceipt>, getCallParams: () => TCallParams): Promise<{ hash: Hash; receipt: TReceipt }> {
 	const callParams = getCallParams()
 	const data = encodeFunctionData({
 		abi: callParams.abi,

--- a/ui/ts/contracts/helpers.ts
+++ b/ui/ts/contracts/helpers.ts
@@ -25,10 +25,6 @@ export function isStringArray(value: unknown): value is string[] {
 	return Array.isArray(value) && value.every(item => typeof item === 'string')
 }
 
-export function isEscalationDepositPage(value: unknown): value is readonly { amount: bigint; cumulativeAmount: bigint; depositor: Address }[] {
-	return Array.isArray(value) && value.every(item => isObjectRecord(item) && typeof item['amount'] === 'bigint' && typeof item['cumulativeAmount'] === 'bigint' && typeof item['depositor'] === 'string')
-}
-
 export function isBigintTriple(value: unknown): value is [bigint, bigint, bigint] {
 	return Array.isArray(value) && value.length === 3 && value.every(item => typeof item === 'bigint')
 }

--- a/ui/ts/hooks/useReportingOperations.ts
+++ b/ui/ts/hooks/useReportingOperations.ts
@@ -131,7 +131,7 @@ export function useReportingOperations({ accountAddress, onTransaction, onTransa
 			'Failed to report on outcome',
 		)
 
-	const withdrawEscalation = async () =>
+	const withdrawEscalation = async (depositIndexesOverride?: bigint[]) =>
 		await runReportingAction(
 			'withdrawEscalation',
 			async (walletAddress, securityPoolAddress, currentForm) => {
@@ -147,14 +147,15 @@ export function useReportingOperations({ accountAddress, onTransaction, onTransa
 					throw new Error('Escalation deposits cannot be withdrawn until the question is finalized or the game is canceled by an external fork.')
 				}
 
-				const missingSelectedDepositIndex = currentForm.selectedWithdrawDepositIndexes.find(index => !availableDepositIndexes.includes(index))
+				const requestedDepositIndexes = depositIndexesOverride ?? currentForm.selectedWithdrawDepositIndexes
+				const missingSelectedDepositIndex = requestedDepositIndexes.find(index => !availableDepositIndexes.includes(index))
 				if (missingSelectedDepositIndex !== undefined) {
 					throw new Error(`Selected deposit #${missingSelectedDepositIndex.toString()} is no longer available to withdraw on the selected side`)
 				}
 
-				const depositIndexes = currentForm.selectedWithdrawDepositIndexes.length > 0 ? currentForm.selectedWithdrawDepositIndexes : availableDepositIndexes
+				const depositIndexes = requestedDepositIndexes
 				if (depositIndexes.length === 0) {
-					throw new Error('No deposits available to withdraw for the selected side')
+					throw new Error('Select at least one deposit to withdraw or use Withdraw all.')
 				}
 
 				return await withdrawEscalationFromSecurityPool(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), securityPoolAddress, selectedOutcome, depositIndexes)

--- a/ui/ts/lib/formatters.ts
+++ b/ui/ts/lib/formatters.ts
@@ -166,7 +166,7 @@ function formatRelativeDuration(seconds: bigint) {
 	return `${minutes}m`
 }
 
-export function formatRelativeTimestamp(timestamp: bigint, currentTimestamp: bigint = BigInt(Math.floor(Date.now() / MILLISECONDS_PER_SECOND))) {
+export function formatRelativeTimestamp(timestamp: bigint, currentTimestamp: bigint) {
 	const delta = timestamp - currentTimestamp
 	if (delta === 0n) return 'now'
 	if (delta > 0n) return `in ${formatRelativeDuration(delta)}`

--- a/ui/ts/lib/reporting.ts
+++ b/ui/ts/lib/reporting.ts
@@ -1,5 +1,6 @@
 import type { ReportingOutcomeKey } from '../types/contracts.js'
 import { assertNever } from './assert.js'
+import { formatRelativeTimestamp, formatTimestamp } from './formatters.js'
 
 const REPORTING_OUTCOME_OPTIONS: { key: ReportingOutcomeKey; label: string }[] = [
 	{ key: 'invalid', label: 'Invalid' },
@@ -25,4 +26,12 @@ export function getReportingOutcomeLabel(outcome: ReportingOutcomeKey | 'none') 
 		default:
 			return assertNever(outcome)
 	}
+}
+
+export function getReportingLockedUntilMessage(endTime: bigint, currentTimestamp: bigint | undefined) {
+	if (currentTimestamp === undefined) {
+		return `Reporting opens at this pool's market end timestamp: ${formatTimestamp(endTime)}.`
+	}
+
+	return `Reporting opens at this pool's market end timestamp: ${formatTimestamp(endTime)} (${formatRelativeTimestamp(endTime, currentTimestamp)}).`
 }

--- a/ui/ts/lib/reporting.ts
+++ b/ui/ts/lib/reporting.ts
@@ -30,8 +30,8 @@ export function getReportingOutcomeLabel(outcome: ReportingOutcomeKey | 'none') 
 
 export function getReportingLockedUntilMessage(endTime: bigint, currentTimestamp: bigint | undefined) {
 	if (currentTimestamp === undefined) {
-		return `Reporting opens at this pool's market end timestamp: ${formatTimestamp(endTime)}.`
+		return `Reporting opens when this pool's market ends: ${formatTimestamp(endTime)}.`
 	}
 
-	return `Reporting opens at this pool's market end timestamp: ${formatTimestamp(endTime)} (${formatRelativeTimestamp(endTime, currentTimestamp)}).`
+	return `Reporting opens when this pool's market ends: ${formatTimestamp(endTime)} (${formatRelativeTimestamp(endTime, currentTimestamp)}).`
 }

--- a/ui/ts/lib/reportingDomain.ts
+++ b/ui/ts/lib/reportingDomain.ts
@@ -1,4 +1,4 @@
-import type { ActiveReportingDetails, EscalationSide, ReportingDetails, ReportingOutcomeKey } from '../types/contracts.js'
+import type { ActiveReportingDetails, EscalationDeposit, EscalationSide, ReportingDetails, ReportingOutcomeKey } from '../types/contracts.js'
 import { formatCurrencyBalance } from './formatters.js'
 import { requireDefined } from './required.js'
 import { getTimeRemaining } from './time.js'
@@ -10,6 +10,7 @@ type ReportingAmountSuggestion = {
 
 const REP_UNIT = 10n ** 18n
 const ESCALATION_TIME_LENGTH = 4_233_600n
+export const ESCALATION_GAME_ACTIVATION_DELAY = 3n * 24n * 60n * 60n
 const SCALE = 1_000_000n
 const LN2_SCALED = 693_147n
 const MAX_ATANH_ITERATIONS = 16
@@ -36,7 +37,8 @@ type ReportingTimerPreview =
 	| {
 			hypotheticalDuration: bigint
 			kind: 'not-started'
-			startsAt: bigint | undefined
+			timeUntilEnd: bigint
+			timeUntilStart: bigint
 	  }
 	| {
 			acceptedAmount: bigint
@@ -86,7 +88,7 @@ export function isReportingClosed(details: ActiveReportingDetails) {
 export function getEscalationPhase(details: ActiveReportingDetails): EscalationPhase {
 	if (details.resolution !== 'none') return 'Resolved'
 	if (details.hasReachedNonDecision) return 'Fork Triggered'
-	if (details.currentTime < details.startingTime) return 'Pending Start'
+	if (details.currentTime < details.activationTime) return 'Pending Start'
 	if (hasEscalationTimedOut(details)) return 'Timed Out'
 	return 'Active'
 }
@@ -153,11 +155,50 @@ export function projectEscalationEndTime(details: ActiveReportingDetails, outcom
 	return {
 		acceptedAmount: projectedDeposit.acceptedAmount,
 		endsImmediately: false,
-		projectedEndTime: details.startingTime + computeEscalationTimeSinceStartFromAttritionCost(details.startBond, details.nonDecisionThreshold, projectedBindingCapital),
+		projectedEndTime: details.activationTime + computeEscalationTimeSinceStartFromAttritionCost(details.startBond, details.nonDecisionThreshold, projectedBindingCapital),
 	}
 }
 
-export function getReportingTimerPreview(details: ReportingDetails, outcome: ReportingOutcomeKey, amount: bigint, currentTimestamp: bigint | undefined): ReportingTimerPreview | undefined {
+function getWinningEscalationDepositClaimAmount(details: ActiveReportingDetails, outcome: ReportingOutcomeKey, deposit: EscalationDeposit) {
+	const winningOutcomeBalance = details.sides.find(side => side.key === outcome)?.balance
+	if (winningOutcomeBalance === undefined) return undefined
+
+	const bindingCapitalAmount = details.bindingCapital
+	const rewardEligibleCapAmount = bindingCapitalAmount + bindingCapitalAmount / 2n
+	const rewardEligiblePrincipalAmount = winningOutcomeBalance < rewardEligibleCapAmount ? winningOutcomeBalance : rewardEligibleCapAmount
+	const rewardBonusPoolAmount = (bindingCapitalAmount * 3n) / 5n
+
+	let amountToWithdraw: bigint
+	if (rewardEligiblePrincipalAmount === 0n) {
+		amountToWithdraw = deposit.amount
+	} else {
+		const depositStart = deposit.cumulativeAmount - deposit.amount
+		const eligibleEndAmount = deposit.cumulativeAmount < rewardEligibleCapAmount ? deposit.cumulativeAmount : rewardEligibleCapAmount
+		const rewardEligibleDepositAmount = eligibleEndAmount > depositStart ? eligibleEndAmount - depositStart : 0n
+		const cappedRewardEligibleDepositAmount = rewardEligibleDepositAmount > deposit.amount ? deposit.amount : rewardEligibleDepositAmount
+		const bonusShare = (cappedRewardEligibleDepositAmount * rewardBonusPoolAmount) / rewardEligiblePrincipalAmount
+		amountToWithdraw = deposit.amount + bonusShare
+	}
+
+	if (details.forkThreshold < details.nonDecisionThreshold) {
+		return (amountToWithdraw * details.forkThreshold) / details.nonDecisionThreshold
+	}
+
+	return amountToWithdraw
+}
+
+export function getEscalationDepositClaimAmount(details: ReportingDetails | undefined, outcome: ReportingOutcomeKey, deposit: EscalationDeposit) {
+	if (details === undefined || details.status !== 'active' || !details.withdrawalEnabled) return undefined
+	if (details.withdrawalState === 'canceled-by-external-fork') return deposit.amount
+
+	const resolvedOutcome = details.questionOutcome !== 'none' ? details.questionOutcome : details.resolution
+	if (resolvedOutcome === 'none') return undefined
+	if (resolvedOutcome !== outcome) return 0n
+
+	return getWinningEscalationDepositClaimAmount(details, outcome, deposit)
+}
+
+export function getReportingTimerPreview(details: ReportingDetails, outcome: ReportingOutcomeKey, amount: bigint): ReportingTimerPreview | undefined {
 	if (amount <= 0n) return undefined
 
 	const hypotheticalDuration = computeHypotheticalBindingDuration(details.startBond, details.nonDecisionThreshold, amount)
@@ -169,7 +210,8 @@ export function getReportingTimerPreview(details: ReportingDetails, outcome: Rep
 		return {
 			hypotheticalDuration,
 			kind: 'not-started',
-			startsAt: currentTimestamp,
+			timeUntilEnd: ESCALATION_GAME_ACTIVATION_DELAY + hypotheticalDuration,
+			timeUntilStart: ESCALATION_GAME_ACTIVATION_DELAY,
 		}
 	}
 

--- a/ui/ts/lib/time.ts
+++ b/ui/ts/lib/time.ts
@@ -1,7 +1,3 @@
-export function getCurrentTimestamp() {
-	return BigInt(Math.floor(Date.now() / 1000))
-}
-
 export function getTimeRemaining(targetTime: bigint | undefined, currentTime: bigint) {
 	if (targetTime === undefined) return undefined
 	return targetTime <= currentTime ? 0n : targetTime - currentTime

--- a/ui/ts/tests/activeEnvironment.test.ts
+++ b/ui/ts/tests/activeEnvironment.test.ts
@@ -316,9 +316,9 @@ void describe('simulation backend', () => {
 				to: getAddress(toAccount),
 				value: 1n,
 			})
-			const startTime = Date.now()
+			const startTime = performance.now()
 			await writeClient.waitForTransactionReceipt({ hash })
-			const elapsedMilliseconds = Date.now() - startTime
+			const elapsedMilliseconds = performance.now() - startTime
 
 			expect(elapsedMilliseconds >= 200).toBe(true)
 		} finally {

--- a/ui/ts/tests/contracts.test.ts
+++ b/ui/ts/tests/contracts.test.ts
@@ -2,9 +2,9 @@
 
 import { describe, expect, test } from 'bun:test'
 import { decodeFunctionData, getAddress, type Address, type Hash, type Hex } from 'viem'
-import { getOpenOracleAddress, migrateSharesFromUniverse, settleOracleReport } from '../contracts.js'
+import { getOpenOracleAddress, loadEscalationDeposits, migrateSharesFromUniverse, settleOracleReport } from '../contracts.js'
 import { peripherals_openOracle_OpenOracle_OpenOracle, peripherals_tokens_ShareToken_ShareToken } from '../contractArtifact.js'
-import type { WriteClient } from '../types/contracts.js'
+import type { ReadClient, WriteClient } from '../types/contracts.js'
 
 const securityPoolAddress = getAddress('0x00000000000000000000000000000000000000a1')
 const shareTokenAddress = getAddress('0x00000000000000000000000000000000000000b2')
@@ -26,6 +26,12 @@ function createMockWriteClient(onSendTransaction: (request: { data?: Hex | undef
 	client.sendTransaction = sendTransaction
 	client.waitForTransactionReceipt = waitForTransactionReceipt
 
+	return client
+}
+
+function createMockReadClient(readContract: ReadClient['readContract']): ReadClient {
+	const client = {} as ReadClient
+	client.readContract = readContract
 	return client
 }
 
@@ -72,5 +78,40 @@ describe('contracts helpers', () => {
 		})
 		expect(decodedCall.functionName).toBe('settle')
 		expect(decodedCall.args).toEqual([7n])
+	})
+
+	test('loadEscalationDeposits continues paging past settled entries on a full page', async () => {
+		const escalationGameAddress = getAddress('0x00000000000000000000000000000000000000d4')
+		const depositor = getAddress('0x00000000000000000000000000000000000000e5')
+		const readCalls: bigint[] = []
+		const firstPage = Array.from({ length: 30 }, (_, index) => ({
+			amount: index === 29 ? 0n : BigInt(index + 1),
+			cumulativeAmount: BigInt(index + 1),
+			depositor,
+		}))
+		const secondPage = [
+			{
+				amount: 31n,
+				cumulativeAmount: 31n,
+				depositor,
+			},
+		]
+		const client = createMockReadClient(async request => {
+			const args = Reflect.get(request, 'args')
+			const startIndex = Array.isArray(args) ? args[1] : undefined
+			if (typeof startIndex !== 'bigint') throw new Error('Expected pagination start index')
+			readCalls.push(startIndex)
+			if (startIndex === 0n) return firstPage as never
+			if (startIndex === 30n) return secondPage as never
+			throw new Error(`Unexpected start index: ${startIndex.toString()}`)
+		})
+
+		const deposits = await loadEscalationDeposits(client, escalationGameAddress, 'yes')
+
+		expect(readCalls).toEqual([0n, 30n])
+		expect(deposits).toHaveLength(30)
+		expect(deposits.some(deposit => deposit.amount === 0n)).toBe(false)
+		expect(deposits[28]?.depositIndex).toBe(28n)
+		expect(deposits[29]?.depositIndex).toBe(30n)
 	})
 })

--- a/ui/ts/tests/contracts.test.ts
+++ b/ui/ts/tests/contracts.test.ts
@@ -4,35 +4,33 @@ import { describe, expect, test } from 'bun:test'
 import { decodeFunctionData, getAddress, type Address, type Hash, type Hex } from 'viem'
 import { getOpenOracleAddress, loadEscalationDeposits, migrateSharesFromUniverse, settleOracleReport } from '../contracts.js'
 import { peripherals_openOracle_OpenOracle_OpenOracle, peripherals_tokens_ShareToken_ShareToken } from '../contractArtifact.js'
-import type { ReadClient, WriteClient } from '../types/contracts.js'
 
 const securityPoolAddress = getAddress('0x00000000000000000000000000000000000000a1')
 const shareTokenAddress = getAddress('0x00000000000000000000000000000000000000b2')
 const transactionHash = '0x00000000000000000000000000000000000000000000000000000000000000c3' satisfies Hash
 
-function createMockWriteClient(onSendTransaction: (request: { data?: Hex | undefined; gas?: bigint | undefined; to?: Address | null | undefined }) => void): WriteClient {
-	const client = {} as WriteClient
-	const readContract: WriteClient['readContract'] = async ({ functionName }) => {
-		if (functionName === 'universeId') return 12n as never
-		if (functionName === 'shareToken') return shareTokenAddress as never
-		throw new Error(`Unexpected readContract function: ${functionName}`)
-	}
-	const sendTransaction: WriteClient['sendTransaction'] = async request => {
-		onSendTransaction(request)
-		return transactionHash
-	}
-	const waitForTransactionReceipt: WriteClient['waitForTransactionReceipt'] = async () => ({ status: 'success' }) as never
-	client.readContract = readContract
-	client.sendTransaction = sendTransaction
-	client.waitForTransactionReceipt = waitForTransactionReceipt
+type MockWriteClient = Parameters<typeof migrateSharesFromUniverse>[0]
+type MockReadClient = Parameters<typeof loadEscalationDeposits>[0]
 
-	return client
+function createMockWriteClient(onSendTransaction: (request: { data?: Hex | undefined; gas?: bigint | undefined; to?: Address | undefined }) => void): MockWriteClient {
+	return {
+		readContract: async request => {
+			if (request.functionName === 'universeId') return 12n
+			if (request.functionName === 'shareToken') return shareTokenAddress
+			throw new Error(`Unexpected readContract function: ${request.functionName}`)
+		},
+		sendTransaction: async request => {
+			onSendTransaction(request)
+			return transactionHash
+		},
+		waitForTransactionReceipt: async () => ({ status: 'success' }),
+	} satisfies MockWriteClient
 }
 
-function createMockReadClient(readContract: ReadClient['readContract']): ReadClient {
-	const client = {} as ReadClient
-	client.readContract = readContract
-	return client
+function createMockReadClient(readContract: MockReadClient['readContract']): MockReadClient {
+	return {
+		readContract,
+	}
 }
 
 describe('contracts helpers', () => {
@@ -101,8 +99,8 @@ describe('contracts helpers', () => {
 			const startIndex = Array.isArray(args) ? args[1] : undefined
 			if (typeof startIndex !== 'bigint') throw new Error('Expected pagination start index')
 			readCalls.push(startIndex)
-			if (startIndex === 0n) return firstPage as never
-			if (startIndex === 30n) return secondPage as never
+			if (startIndex === 0n) return firstPage
+			if (startIndex === 30n) return secondPage
 			throw new Error(`Unexpected start index: ${startIndex.toString()}`)
 		})
 

--- a/ui/ts/tests/contracts.test.ts
+++ b/ui/ts/tests/contracts.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from 'bun:test'
 import { decodeFunctionData, getAddress, type Address, type Hash, type Hex } from 'viem'
 import { getOpenOracleAddress, loadEscalationDeposits, migrateSharesFromUniverse, settleOracleReport } from '../contracts.js'
 import { peripherals_openOracle_OpenOracle_OpenOracle, peripherals_tokens_ShareToken_ShareToken } from '../contractArtifact.js'
+import type { ReadClient } from '../types/contracts.js'
 
 const securityPoolAddress = getAddress('0x00000000000000000000000000000000000000a1')
 const shareTokenAddress = getAddress('0x00000000000000000000000000000000000000b2')
@@ -12,13 +13,15 @@ const transactionHash = '0x00000000000000000000000000000000000000000000000000000
 type MockWriteClient = Parameters<typeof migrateSharesFromUniverse>[0]
 type MockReadClient = Parameters<typeof loadEscalationDeposits>[0]
 
-function createMockWriteClient(onSendTransaction: (request: { data?: Hex | undefined; gas?: bigint | undefined; to?: Address | undefined }) => void): MockWriteClient {
+function createMockWriteClient(onSendTransaction: (request: { data?: Hex | undefined; gas?: bigint | undefined; to?: Address | null | undefined }) => void): MockWriteClient {
+	const readContract: ReadClient['readContract'] = async request => {
+		if (request.functionName === 'universeId') return 12n as never
+		if (request.functionName === 'shareToken') return shareTokenAddress as never
+		throw new Error(`Unexpected readContract function: ${request.functionName}`)
+	}
+
 	return {
-		readContract: async request => {
-			if (request.functionName === 'universeId') return 12n
-			if (request.functionName === 'shareToken') return shareTokenAddress
-			throw new Error(`Unexpected readContract function: ${request.functionName}`)
-		},
+		readContract,
 		sendTransaction: async request => {
 			onSendTransaction(request)
 			return transactionHash
@@ -94,14 +97,17 @@ describe('contracts helpers', () => {
 				depositor,
 			},
 		]
-		const client = createMockReadClient(async request => {
+		const readContract: ReadClient['readContract'] = async request => {
 			const args = Reflect.get(request, 'args')
 			const startIndex = Array.isArray(args) ? args[1] : undefined
 			if (typeof startIndex !== 'bigint') throw new Error('Expected pagination start index')
 			readCalls.push(startIndex)
-			if (startIndex === 0n) return firstPage
-			if (startIndex === 30n) return secondPage
+			if (startIndex === 0n) return firstPage as never
+			if (startIndex === 30n) return secondPage as never
 			throw new Error(`Unexpected start index: ${startIndex.toString()}`)
+		}
+		const client = createMockReadClient(async request => {
+			return await readContract(request)
 		})
 
 		const deposits = await loadEscalationDeposits(client, escalationGameAddress, 'yes')

--- a/ui/ts/tests/liquidationModal.test.tsx
+++ b/ui/ts/tests/liquidationModal.test.tsx
@@ -595,49 +595,42 @@ describe('LiquidationModal', () => {
 	})
 
 	test('uses the shared chain timestamp context for oracle expiry text', async () => {
-		const originalDateNow = Date.now
-		Date.now = () => 0
+		const renderedComponent = await renderIntoDocument(
+			<ChainTimestampContext.Provider value={1n + 60n * 60n + 60n}>
+				<LiquidationModal
+					accountAddress={defaultCallerVaultAddress}
+					closeLiquidationModal={() => undefined}
+					currentPoolOracleManagerDetails={undefined}
+					isMainnet
+					liquidationAmount='1'
+					liquidationMaxAmount={5n * 10n ** 18n}
+					liquidationManagerAddress={zeroAddress}
+					liquidationModalOpen
+					liquidationSecurityPoolAddress={zeroAddress}
+					liquidationTargetVault={defaultTargetVaultAddress}
+					loadingPoolOracleManager={false}
+					onLoadPoolOracleManager={() => undefined}
+					onLiquidationAmountChange={() => undefined}
+					onQueueLiquidation={() => undefined}
+					onSelectedPoolViewChange={() => undefined}
+					repPerEthPrice={1n * 10n ** 18n}
+					repPerEthSource='mock'
+					repPerEthSourceUrl={undefined}
+					selectedPool={createSelectedPool({
+						lastOraclePrice: 3n * 10n ** 18n,
+						lastOracleSettlementTimestamp: 1n,
+					})}
+					securityPoolOverviewActiveAction={undefined}
+					securityPoolOverviewError={undefined}
+					securityPoolOverviewResult={undefined}
+					callerVaultSummary={createTargetVaultSummary({ vaultAddress: defaultCallerVaultAddress })}
+					targetVaultSummary={createTargetVaultSummary({ vaultAddress: defaultTargetVaultAddress })}
+				/>
+			</ChainTimestampContext.Provider>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
 
-		try {
-			const renderedComponent = await renderIntoDocument(
-				<ChainTimestampContext.Provider value={1n + 60n * 60n + 60n}>
-					<LiquidationModal
-						accountAddress={defaultCallerVaultAddress}
-						closeLiquidationModal={() => undefined}
-						currentPoolOracleManagerDetails={undefined}
-						isMainnet
-						liquidationAmount='1'
-						liquidationMaxAmount={5n * 10n ** 18n}
-						liquidationManagerAddress={zeroAddress}
-						liquidationModalOpen
-						liquidationSecurityPoolAddress={zeroAddress}
-						liquidationTargetVault={defaultTargetVaultAddress}
-						loadingPoolOracleManager={false}
-						onLoadPoolOracleManager={() => undefined}
-						onLiquidationAmountChange={() => undefined}
-						onQueueLiquidation={() => undefined}
-						onSelectedPoolViewChange={() => undefined}
-						repPerEthPrice={1n * 10n ** 18n}
-						repPerEthSource='mock'
-						repPerEthSourceUrl={undefined}
-						selectedPool={createSelectedPool({
-							lastOraclePrice: 3n * 10n ** 18n,
-							lastOracleSettlementTimestamp: 1n,
-						})}
-						securityPoolOverviewActiveAction={undefined}
-						securityPoolOverviewError={undefined}
-						securityPoolOverviewResult={undefined}
-						callerVaultSummary={createTargetVaultSummary({ vaultAddress: defaultCallerVaultAddress })}
-						targetVaultSummary={createTargetVaultSummary({ vaultAddress: defaultTargetVaultAddress })}
-					/>
-				</ChainTimestampContext.Provider>,
-			)
-			cleanupRenderedComponent = renderedComponent.cleanup
-
-			expect(document.body.textContent?.includes('(expired 1m ago)')).toBe(true)
-		} finally {
-			Date.now = originalDateNow
-		}
+		expect(document.body.textContent?.includes('(expired 1m ago)')).toBe(true)
 	})
 
 	test('uses a dedicated top-aligned action row when execute liquidation shows a disabled reason', async () => {

--- a/ui/ts/tests/questionComponent.test.tsx
+++ b/ui/ts/tests/questionComponent.test.tsx
@@ -29,7 +29,6 @@ function createQuestion(overrides: Partial<MarketDetails> = {}): MarketDetails {
 describe('Question component', () => {
 	let cleanupRenderedComponent: (() => Promise<void>) | undefined
 	let restoreDomEnvironment: (() => void) | undefined
-	const originalDateNow = Date.now
 
 	beforeEach(() => {
 		const domEnvironment = installDomEnvironment()
@@ -37,7 +36,6 @@ describe('Question component', () => {
 	})
 
 	afterEach(async () => {
-		Date.now = originalDateNow
 		await cleanupRenderedComponent?.()
 		cleanupRenderedComponent = undefined
 		restoreDomEnvironment?.()
@@ -45,7 +43,6 @@ describe('Question component', () => {
 	})
 
 	test('inherits the shared chain timestamp for route-level relative time rendering', async () => {
-		Date.now = () => 0
 		const renderedComponent = await renderIntoDocument(
 			<ChainTimestampContext.Provider value={240n}>
 				<Question question={createQuestion()} showTitle={false} />

--- a/ui/ts/tests/reportingDomain.test.ts
+++ b/ui/ts/tests/reportingDomain.test.ts
@@ -53,7 +53,6 @@ function createReportingDetails(overrides: Partial<ActiveReportingDetails> = {})
 		escalationEndTime: 300n,
 		escalationGameAddress: zeroAddress,
 		forkThreshold: rep(200n),
-		gameCreatedAt: 90n,
 		hasReachedNonDecision: false,
 		marketDetails: createMarketDetails(),
 		nonDecisionThreshold: rep(100n),
@@ -114,7 +113,6 @@ function createDynamicReportingDetails(overrides: Partial<ActiveReportingDetails
 	const forkThreshold = overrides.forkThreshold ?? nonDecisionThreshold * 2n
 	const activationTime = overrides.activationTime ?? 120n
 	const currentTime = overrides.currentTime ?? 150n
-	const gameCreatedAt = overrides.gameCreatedAt ?? 90n
 	const bindingCapital = getEscalationBindingCapital(getEscalationBalanceTuple(sides))
 	const escalationEndTime = activationTime + computeEscalationTimeSinceStartFromAttritionCost(startBond, nonDecisionThreshold, bindingCapital)
 
@@ -126,7 +124,6 @@ function createDynamicReportingDetails(overrides: Partial<ActiveReportingDetails
 		escalationEndTime,
 		escalationGameAddress: zeroAddress,
 		forkThreshold,
-		gameCreatedAt,
 		hasReachedNonDecision: false,
 		marketDetails: createMarketDetails(),
 		nonDecisionThreshold,
@@ -154,7 +151,6 @@ function createDynamicReportingDetails(overrides: Partial<ActiveReportingDetails
 		currentTime,
 		escalationEndTime,
 		forkThreshold,
-		gameCreatedAt,
 		nonDecisionThreshold,
 		sides,
 		startBond,

--- a/ui/ts/tests/reportingDomain.test.ts
+++ b/ui/ts/tests/reportingDomain.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, test } from 'bun:test'
 import { zeroAddress } from 'viem'
 import {
+	ESCALATION_GAME_ACTIVATION_DELAY,
 	calculateEstimatedEscalationReturn,
 	computeEscalationTimeSinceStartFromAttritionCost,
 	getEscalationBalanceTuple,
@@ -51,6 +52,8 @@ function createReportingDetails(overrides: Partial<ActiveReportingDetails> = {})
 		currentTime: 150n,
 		escalationEndTime: 300n,
 		escalationGameAddress: zeroAddress,
+		forkThreshold: rep(200n),
+		gameCreatedAt: 90n,
 		hasReachedNonDecision: false,
 		marketDetails: createMarketDetails(),
 		nonDecisionThreshold: rep(100n),
@@ -62,8 +65,8 @@ function createReportingDetails(overrides: Partial<ActiveReportingDetails> = {})
 			{ balance: rep(8n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
 			{ balance: rep(2n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
 		],
+		activationTime: 120n,
 		startBond: rep(3n),
-		startingTime: 120n,
 		status: 'active',
 		totalCost: rep(20n),
 		universeId: 1n,
@@ -81,6 +84,7 @@ function createNotStartedReportingDetails(overrides: Partial<Extract<ReportingDe
 	return {
 		completeSetCollateralAmount: 1n,
 		currentTime: 150n,
+		forkThreshold: rep(100n),
 		marketDetails: createMarketDetails(),
 		nonDecisionThreshold: rep(50n),
 		questionOutcome: 'none',
@@ -107,10 +111,12 @@ function createDynamicReportingDetails(overrides: Partial<ActiveReportingDetails
 	]
 	const startBond = overrides.startBond ?? rep(1n)
 	const nonDecisionThreshold = overrides.nonDecisionThreshold ?? rep(20n)
-	const startingTime = overrides.startingTime ?? 120n
+	const forkThreshold = overrides.forkThreshold ?? nonDecisionThreshold * 2n
+	const activationTime = overrides.activationTime ?? 120n
 	const currentTime = overrides.currentTime ?? 150n
+	const gameCreatedAt = overrides.gameCreatedAt ?? 90n
 	const bindingCapital = getEscalationBindingCapital(getEscalationBalanceTuple(sides))
-	const escalationEndTime = startingTime + computeEscalationTimeSinceStartFromAttritionCost(startBond, nonDecisionThreshold, bindingCapital)
+	const escalationEndTime = activationTime + computeEscalationTimeSinceStartFromAttritionCost(startBond, nonDecisionThreshold, bindingCapital)
 
 	const baseDetails: ActiveReportingDetails = {
 		bindingCapital,
@@ -119,6 +125,8 @@ function createDynamicReportingDetails(overrides: Partial<ActiveReportingDetails
 		currentTime,
 		escalationEndTime,
 		escalationGameAddress: zeroAddress,
+		forkThreshold,
+		gameCreatedAt,
 		hasReachedNonDecision: false,
 		marketDetails: createMarketDetails(),
 		nonDecisionThreshold,
@@ -127,7 +135,7 @@ function createDynamicReportingDetails(overrides: Partial<ActiveReportingDetails
 		securityPoolAddress: zeroAddress,
 		sides,
 		startBond,
-		startingTime,
+		activationTime,
 		status: 'active',
 		totalCost: 0n,
 		universeId: 1n,
@@ -145,10 +153,12 @@ function createDynamicReportingDetails(overrides: Partial<ActiveReportingDetails
 		bindingCapital,
 		currentTime,
 		escalationEndTime,
+		forkThreshold,
+		gameCreatedAt,
 		nonDecisionThreshold,
 		sides,
 		startBond,
-		startingTime,
+		activationTime,
 	}
 }
 
@@ -366,15 +376,18 @@ describe('reportingDomain', () => {
 	})
 
 	test('getReportingTimerPreview returns a pre-start timer preview for a valid first report', () => {
-		expect(getReportingTimerPreview(createNotStartedReportingDetails(), 'yes', rep(10n), 150n)).toEqual({
+		const hypotheticalDuration = computeEscalationTimeSinceStartFromAttritionCost(rep(3n), rep(50n), rep(10n))
+
+		expect(getReportingTimerPreview(createNotStartedReportingDetails(), 'yes', rep(10n))).toEqual({
 			hypotheticalDuration: computeEscalationTimeSinceStartFromAttritionCost(rep(3n), rep(50n), rep(10n)),
 			kind: 'not-started',
-			startsAt: 150n,
+			timeUntilEnd: ESCALATION_GAME_ACTIVATION_DELAY + hypotheticalDuration,
+			timeUntilStart: ESCALATION_GAME_ACTIVATION_DELAY,
 		})
 	})
 
 	test('getReportingTimerPreview returns undefined for an invalid pre-start amount', () => {
-		expect(getReportingTimerPreview(createNotStartedReportingDetails(), 'yes', rep(2n), 150n)).toBeUndefined()
+		expect(getReportingTimerPreview(createNotStartedReportingDetails(), 'yes', rep(2n))).toBeUndefined()
 	})
 
 	test('projectEscalationEndTime keeps the timer unchanged for a leading-side deposit', () => {
@@ -400,7 +413,7 @@ describe('reportingDomain', () => {
 	test('getReportingTimerPreview reports timer extensions for active escalation contributions', () => {
 		const details = createDynamicReportingDetails()
 
-		expect(getReportingTimerPreview(details, 'no', rep(2n), details.currentTime)).toEqual({
+		expect(getReportingTimerPreview(details, 'no', rep(2n))).toEqual({
 			acceptedAmount: rep(2n),
 			actualState: 'extends',
 			hypotheticalDuration: computeEscalationTimeSinceStartFromAttritionCost(details.startBond, details.nonDecisionThreshold, rep(2n)),
@@ -412,7 +425,7 @@ describe('reportingDomain', () => {
 	test('getReportingTimerPreview reports unchanged timers while still using the standalone amount for hypothetical duration', () => {
 		const details = createDynamicReportingDetails()
 
-		expect(getReportingTimerPreview(details, 'yes', rep(5n), details.currentTime)).toEqual({
+		expect(getReportingTimerPreview(details, 'yes', rep(5n))).toEqual({
 			acceptedAmount: rep(5n),
 			actualState: 'unchanged',
 			hypotheticalDuration: computeEscalationTimeSinceStartFromAttritionCost(details.startBond, details.nonDecisionThreshold, rep(5n)),

--- a/ui/ts/tests/reportingGuards.test.ts
+++ b/ui/ts/tests/reportingGuards.test.ts
@@ -13,6 +13,8 @@ function createActiveReportingDetails(overrides: Partial<ActiveReportingDetails>
 		currentTime: 150n,
 		escalationEndTime: 300n,
 		escalationGameAddress: zeroAddress,
+		forkThreshold: 40n,
+		gameCreatedAt: 90n,
 		hasReachedNonDecision: false,
 		marketDetails: {
 			answerUnit: '',
@@ -38,8 +40,8 @@ function createActiveReportingDetails(overrides: Partial<ActiveReportingDetails>
 			{ balance: 5n, deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
 			{ balance: 2n, deposits: [], key: 'no', label: 'No', userDeposits: [] },
 		],
+		activationTime: 120n,
 		startBond: 1n,
-		startingTime: 120n,
 		status: 'active',
 		totalCost: 2n,
 		universeId: 1n,

--- a/ui/ts/tests/reportingGuards.test.ts
+++ b/ui/ts/tests/reportingGuards.test.ts
@@ -14,7 +14,6 @@ function createActiveReportingDetails(overrides: Partial<ActiveReportingDetails>
 		escalationEndTime: 300n,
 		escalationGameAddress: zeroAddress,
 		forkThreshold: 40n,
-		gameCreatedAt: 90n,
 		hasReachedNonDecision: false,
 		marketDetails: {
 			answerUnit: '',

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -86,7 +86,6 @@ function createReportingDetails(overrides: Partial<ActiveReportingDetails> = {})
 		escalationEndTime: 300n,
 		escalationGameAddress: zeroAddress,
 		forkThreshold: rep(40n),
-		gameCreatedAt: 90n,
 		hasReachedNonDecision: false,
 		marketDetails: createMarketDetails(),
 		nonDecisionThreshold: rep(20n),
@@ -124,7 +123,6 @@ function createDynamicReportingDetails(overrides: Partial<ActiveReportingDetails
 	const forkThreshold = overrides.forkThreshold ?? nonDecisionThreshold * 2n
 	const activationTime = overrides.activationTime ?? 120n
 	const currentTime = overrides.currentTime ?? 150n
-	const gameCreatedAt = overrides.gameCreatedAt ?? 90n
 	const bindingCapital = getEscalationBindingCapital(getEscalationBalanceTuple(sides))
 	const escalationEndTime = activationTime + computeEscalationTimeSinceStartFromAttritionCost(startBond, nonDecisionThreshold, bindingCapital)
 
@@ -136,7 +134,6 @@ function createDynamicReportingDetails(overrides: Partial<ActiveReportingDetails
 		escalationEndTime,
 		escalationGameAddress: zeroAddress,
 		forkThreshold,
-		gameCreatedAt,
 		hasReachedNonDecision: false,
 		marketDetails: createMarketDetails(),
 		nonDecisionThreshold,
@@ -164,7 +161,6 @@ function createDynamicReportingDetails(overrides: Partial<ActiveReportingDetails
 		currentTime,
 		escalationEndTime,
 		forkThreshold,
-		gameCreatedAt,
 		nonDecisionThreshold,
 		sides,
 		startBond,

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -8,6 +8,7 @@ import { useState } from 'preact/hooks'
 import { zeroAddress } from 'viem'
 import { ReportingSection } from '../components/ReportingSection.js'
 import { formatDuration } from '../lib/formatters.js'
+import { getReportingLockedUntilMessage } from '../lib/reporting.js'
 import { computeEscalationTimeSinceStartFromAttritionCost, getEscalationBalanceTuple, getEscalationBindingCapital } from '../lib/reportingDomain.js'
 import type { AccountState, ReportingFormState } from '../types/app.js'
 import type { ActiveReportingDetails, EscalationDeposit, MarketDetails, ReportingDetails } from '../types/contracts.js'
@@ -84,6 +85,8 @@ function createReportingDetails(overrides: Partial<ActiveReportingDetails> = {})
 		currentTime: 150n,
 		escalationEndTime: 300n,
 		escalationGameAddress: zeroAddress,
+		forkThreshold: rep(40n),
+		gameCreatedAt: 90n,
 		hasReachedNonDecision: false,
 		marketDetails: createMarketDetails(),
 		nonDecisionThreshold: rep(20n),
@@ -95,8 +98,8 @@ function createReportingDetails(overrides: Partial<ActiveReportingDetails> = {})
 			{ balance: rep(5n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [createDeposit()] },
 			{ balance: rep(8n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
 		],
+		activationTime: 120n,
 		startBond: rep(3n),
-		startingTime: 120n,
 		status: 'active',
 		totalCost: rep(20n),
 		universeId: 1n,
@@ -118,10 +121,12 @@ function createDynamicReportingDetails(overrides: Partial<ActiveReportingDetails
 	]
 	const startBond = overrides.startBond ?? rep(1n)
 	const nonDecisionThreshold = overrides.nonDecisionThreshold ?? rep(20n)
-	const startingTime = overrides.startingTime ?? 120n
+	const forkThreshold = overrides.forkThreshold ?? nonDecisionThreshold * 2n
+	const activationTime = overrides.activationTime ?? 120n
 	const currentTime = overrides.currentTime ?? 150n
+	const gameCreatedAt = overrides.gameCreatedAt ?? 90n
 	const bindingCapital = getEscalationBindingCapital(getEscalationBalanceTuple(sides))
-	const escalationEndTime = startingTime + computeEscalationTimeSinceStartFromAttritionCost(startBond, nonDecisionThreshold, bindingCapital)
+	const escalationEndTime = activationTime + computeEscalationTimeSinceStartFromAttritionCost(startBond, nonDecisionThreshold, bindingCapital)
 
 	const baseDetails: ActiveReportingDetails = {
 		bindingCapital,
@@ -130,6 +135,8 @@ function createDynamicReportingDetails(overrides: Partial<ActiveReportingDetails
 		currentTime,
 		escalationEndTime,
 		escalationGameAddress: zeroAddress,
+		forkThreshold,
+		gameCreatedAt,
 		hasReachedNonDecision: false,
 		marketDetails: createMarketDetails(),
 		nonDecisionThreshold,
@@ -138,7 +145,7 @@ function createDynamicReportingDetails(overrides: Partial<ActiveReportingDetails
 		securityPoolAddress: zeroAddress,
 		sides,
 		startBond,
-		startingTime,
+		activationTime,
 		status: 'active',
 		totalCost: 0n,
 		universeId: 1n,
@@ -156,10 +163,12 @@ function createDynamicReportingDetails(overrides: Partial<ActiveReportingDetails
 		bindingCapital,
 		currentTime,
 		escalationEndTime,
+		forkThreshold,
+		gameCreatedAt,
 		nonDecisionThreshold,
 		sides,
 		startBond,
-		startingTime,
+		activationTime,
 	}
 }
 
@@ -180,6 +189,7 @@ function createNotStartedReportingDetails(overrides: Partial<Extract<ReportingDe
 	return {
 		completeSetCollateralAmount: 1n * REP,
 		currentTime: 150n,
+		forkThreshold: rep(100n),
 		marketDetails: createMarketDetails(),
 		nonDecisionThreshold: rep(50n),
 		questionOutcome: 'none',
@@ -315,7 +325,7 @@ describe('ReportingSection', () => {
 					currentTimestamp: 110n,
 					reportingDetails: createDynamicReportingDetails({
 						currentTime: 110n,
-						startingTime: 120n,
+						activationTime: 120n,
 					}),
 					reportingForm: createReportingForm({
 						selectedOutcome: 'yes',
@@ -363,7 +373,7 @@ describe('ReportingSection', () => {
 		expect(documentQueries.getByRole('heading', { name: 'Reporting Not Enabled' })).not.toBeNull()
 		expect(documentQueries.queryByRole('heading', { name: 'Reporting Context' })).toBeNull()
 		expect(documentQueries.queryByText('Opens In')).toBeNull()
-		expect(document.body.textContent?.includes('Reporting opens after the market end timestamp for this pool.')).toBe(true)
+		expect(document.body.textContent?.includes(getReportingLockedUntilMessage(100n, 50n))).toBe(true)
 	})
 
 	test('renders Reporting Open when the market has ended but details are not loaded', async () => {
@@ -406,7 +416,6 @@ describe('ReportingSection', () => {
 		const metricsSection = getEscalationMetricsSection()
 		const metricsQueries = within(metricsSection)
 		expect(metricsQueries.queryByText('Current Bond')).toBeNull()
-		expect(metricsQueries.getByText('Binding Capital')).not.toBeNull()
 		expect(metricsQueries.getByText('Threshold')).not.toBeNull()
 		expect(metricsQueries.getByText('Time Left')).not.toBeNull()
 		expect(metricsQueries.getByText('Game Start')).not.toBeNull()
@@ -510,7 +519,8 @@ describe('ReportingSection', () => {
 		expect(documentQueries.queryByRole('heading', { name: 'Report Outcome' })).toBeNull()
 		expect(documentQueries.queryByRole('heading', { name: 'Active' })).toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Withdraw Escalation Deposits' })).not.toBeNull()
-		expectTransactionButtonDisabled(document.body, 'Withdraw Escalation Deposits', 'Escalation deposits cannot be withdrawn until the question is finalized or the game is canceled by an external fork.')
+		expectTransactionButtonDisabled(document.body, 'Withdraw Selected Deposits', 'Escalation deposits cannot be withdrawn until the question is finalized or the game is canceled by an external fork.')
+		expectTransactionButtonDisabled(document.body, 'Withdraw All', 'Escalation deposits cannot be withdrawn until the question is finalized or the game is canceled by an external fork.')
 	})
 
 	test('shows the time-left metric inside Escalation Metrics', async () => {
@@ -584,6 +594,25 @@ describe('ReportingSection', () => {
 		const documentQueries = within(document.body)
 		expect(documentQueries.getAllByText('Timed Out').length).toBeGreaterThan(0)
 		expect(document.body.textContent?.includes(formatDuration(0n))).toBe(true)
+	})
+
+	test('shows the finalized outcome in the resolved banner', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					reportingDetails: createReportingDetails({
+						questionOutcome: 'yes',
+						resolution: 'yes',
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByRole('heading', { name: 'Resolved' })).not.toBeNull()
+		expect(document.body.textContent?.includes('Market finalized as Yes. Review any remaining deposits below.')).toBe(true)
 	})
 
 	test('disables reporting after the escalation timer ends', async () => {
@@ -720,15 +749,13 @@ describe('ReportingSection', () => {
 		expect(reportOutcomeSection.textContent?.includes('Your deposits:')).toBe(false)
 		expect(reportOutcomeSection.textContent?.includes('Projected payout for current amount')).toBe(false)
 		expect(reportOutcomeSection.textContent?.includes('Projected profit if this side wins')).toBe(false)
-		expect(metricsSection.querySelector('[title="0 REP"]')).not.toBeNull()
 		expect(metricsSection.querySelector('[title="50 REP"]')).not.toBeNull()
 		expect(metricsSection.querySelector('[title="3 REP"]')).not.toBeNull()
 		expect(reportOutcomeSection.querySelectorAll('.currency-value.unavailable')).toHaveLength(0)
 		expect(document.body.textContent?.includes('Load reporting details to populate live stakes')).toBe(false)
 		expectTransactionButtonEnabled(document.body, 'Report / Contribute Yes')
-		expect(document.body.textContent?.includes('This contribution would start the escalation timer at')).toBe(true)
-		expect(document.body.textContent?.includes('If')).toBe(true)
-		expect(document.body.textContent?.includes('became binding capital')).toBe(true)
+		expect(document.body.textContent?.includes('This contribution would start the escalation timer in 3d 0h 0m.')).toBe(true)
+		expect(document.body.textContent?.includes('the dispute timer would expire as soon as it activates, so reporting would close in 3d 0h 0m.')).toBe(true)
 	})
 
 	test('disables report submission for a pre-start amount below the first-report minimum', async () => {
@@ -976,9 +1003,11 @@ describe('ReportingSection', () => {
 			),
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
-		expectTransactionButtonEnabled(document.body, 'Withdraw Escalation Deposits')
-		expect(document.body.textContent?.includes('Connected wallet has 1 withdrawable unsettled deposit entry on the selected side.')).toBe(true)
+		expectTransactionButtonDisabled(document.body, 'Withdraw Selected Deposits', 'Select at least one deposit to withdraw or use Withdraw all.')
+		expectTransactionButtonEnabled(document.body, 'Withdraw All')
 		expect(within(document.body).getByRole('checkbox', { name: /Deposit #0/i })).toBeDefined()
+		expect(document.body.textContent?.includes('Winning payout')).toBe(true)
+		expect(document.body.textContent?.includes('Available now:')).toBe(true)
 	})
 
 	test('renders withdraw-only empty state when the selected side has no deposits', async () => {
@@ -999,7 +1028,8 @@ describe('ReportingSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		expect(document.body.textContent?.includes('Connected wallet has no unsettled deposits on the selected side.')).toBe(true)
-		expectTransactionButtonDisabled(document.body, 'Withdraw Escalation Deposits', 'No deposits are available to withdraw on the selected side.')
+		expectTransactionButtonDisabled(document.body, 'Withdraw Selected Deposits', 'No deposits are available to withdraw on the selected side.')
+		expectTransactionButtonDisabled(document.body, 'Withdraw All', 'No deposits are available to withdraw on the selected side.')
 	})
 
 	test('updates selected withdrawal indexes from deposit checkboxes in withdraw-only mode', async () => {

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -1002,8 +1002,9 @@ describe('ReportingSection', () => {
 		expectTransactionButtonDisabled(document.body, 'Withdraw Selected Deposits', 'Select at least one deposit to withdraw or use Withdraw all.')
 		expectTransactionButtonEnabled(document.body, 'Withdraw All')
 		expect(within(document.body).getByRole('checkbox', { name: /Deposit #0/i })).toBeDefined()
-		expect(document.body.textContent?.includes('Winning payout')).toBe(true)
-		expect(document.body.textContent?.includes('Available now:')).toBe(true)
+		expect(document.body.textContent?.includes('Current claim type: Winning payout')).toBe(true)
+		expect(document.body.textContent?.includes('Initially deposited:')).toBe(true)
+		expect(document.body.textContent?.includes('Worth now:')).toBe(true)
 	})
 
 	test('renders withdraw-only empty state when the selected side has no deposits', async () => {

--- a/ui/ts/tests/securityPoolWorkflowSection.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection.test.tsx
@@ -7,6 +7,7 @@ import { act } from 'preact/test-utils'
 import { getAddress, zeroAddress } from 'viem'
 import { SecurityPoolWorkflowSection } from '../components/SecurityPoolWorkflowSection.js'
 import { ChainTimestampContext } from '../lib/chainTimestamp.js'
+import { getReportingLockedUntilMessage } from '../lib/reporting.js'
 import type { AccountState } from '../types/app.js'
 import type { ListedSecurityPool, MarketDetails, OracleManagerDetails, SecurityPoolVaultSummary, SecurityVaultDetails } from '../types/contracts.js'
 import type { ForkAuctionRouteContentProps, ReportingRouteContentProps, SecurityPoolWorkflowRouteContentProps, SecurityVaultRouteContentProps, TradingRouteContentProps } from '../types/components.js'
@@ -1635,17 +1636,20 @@ describe('SecurityPoolWorkflowSection', () => {
 	})
 
 	test('shows disabled reporting actions before market end instead of a placeholder message', async () => {
-		const futureMarket = createMarketDetails({ endTime: BigInt(Math.floor(Date.now() / 1000) + 3600) })
+		const futureMarket = createMarketDetails({ endTime: 1_700_003_600n })
+		const expectedLockedReason = getReportingLockedUntilMessage(futureMarket.endTime, 1_700_000_000n)
 		const renderedComponent = await renderIntoDocument(
-			<SecurityPoolWorkflowSection
-				{...createSecurityPoolWorkflowProps({
-					checkedSecurityPoolAddress: zeroAddress,
-					securityPoolAddress: zeroAddress,
-					securityPools: [createSelectedPool({ marketDetails: futureMarket })],
-					selectedPoolView: 'reporting',
-				})}
-				showHeader={false}
-			/>,
+			<ChainTimestampContext.Provider value={1_700_000_000n}>
+				<SecurityPoolWorkflowSection
+					{...createSecurityPoolWorkflowProps({
+						checkedSecurityPoolAddress: zeroAddress,
+						securityPoolAddress: zeroAddress,
+						securityPools: [createSelectedPool({ marketDetails: futureMarket })],
+						selectedPoolView: 'reporting',
+					})}
+					showHeader={false}
+				/>
+			</ChainTimestampContext.Provider>,
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
@@ -1659,7 +1663,7 @@ describe('SecurityPoolWorkflowSection', () => {
 		expect(documentQueries.queryByRole('heading', { name: 'Withdraw Escalation Deposits' })).toBeNull()
 		expect(documentQueries.queryByText('Load reporting details to populate live stakes, bond progression, and deposit indexes.')).toBeNull()
 		expect(documentQueries.queryByText('Reporting unlocks after the market end timestamp for the selected pool.')).toBeNull()
-		expect(documentQueries.queryByText('Reporting opens after market end.')).toBeNull()
+		expect(documentQueries.queryByText(expectedLockedReason)).not.toBeNull()
 		expect(document.body.querySelectorAll('.escalation-side')).toHaveLength(3)
 		expect(document.body.textContent?.includes('Your deposits: None')).toBe(false)
 		expect(document.body.textContent?.includes('Projected payout for current amount')).toBe(false)
@@ -1667,67 +1671,53 @@ describe('SecurityPoolWorkflowSection', () => {
 
 		const reportButton = documentQueries.getByRole('button', { name: 'Report / Contribute On Selected Side' }) as HTMLButtonElement
 		expect(reportButton.disabled).toBe(true)
-		expect(reportButton.title).toBe('Reporting opens after market end.')
+		expect(reportButton.title).toBe(expectedLockedReason)
 	})
 
 	test('uses the shared chain timestamp context for oracle expiry text', async () => {
-		const originalDateNow = Date.now
-		Date.now = () => 0
+		const renderedComponent = await renderIntoDocument(
+			<ChainTimestampContext.Provider value={1n + 60n * 60n + 60n}>
+				<SecurityPoolWorkflowSection
+					{...createSecurityPoolWorkflowProps({
+						checkedSecurityPoolAddress: zeroAddress,
+						securityPoolAddress: zeroAddress,
+						securityPools: [
+							createSelectedPool({
+								lastOraclePrice: 3n * 10n ** 18n,
+								lastOracleSettlementTimestamp: 1n,
+							}),
+						],
+						selectedPoolView: 'price-oracle',
+					})}
+					showHeader={false}
+				/>
+			</ChainTimestampContext.Provider>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
 
-		try {
-			const renderedComponent = await renderIntoDocument(
-				<ChainTimestampContext.Provider value={1n + 60n * 60n + 60n}>
-					<SecurityPoolWorkflowSection
-						{...createSecurityPoolWorkflowProps({
-							checkedSecurityPoolAddress: zeroAddress,
-							securityPoolAddress: zeroAddress,
-							securityPools: [
-								createSelectedPool({
-									lastOraclePrice: 3n * 10n ** 18n,
-									lastOracleSettlementTimestamp: 1n,
-								}),
-							],
-							selectedPoolView: 'price-oracle',
-						})}
-						showHeader={false}
-					/>
-				</ChainTimestampContext.Provider>,
-			)
-			cleanupRenderedComponent = renderedComponent.cleanup
-
-			expect(document.body.textContent?.includes('(expired 1m ago)')).toBe(true)
-		} finally {
-			Date.now = originalDateNow
-		}
+		expect(document.body.textContent?.includes('(expired 1m ago)')).toBe(true)
 	})
 
 	test('uses the shared chain timestamp context to unlock reporting after market end', async () => {
-		const originalDateNow = Date.now
-		Date.now = () => 0
+		const renderedComponent = await renderIntoDocument(
+			<ChainTimestampContext.Provider value={150n}>
+				<SecurityPoolWorkflowSection
+					{...createSecurityPoolWorkflowProps({
+						checkedSecurityPoolAddress: zeroAddress,
+						securityPoolAddress: zeroAddress,
+						securityPools: [createSelectedPool({ marketDetails: createMarketDetails({ endTime: 100n }) })],
+						selectedPoolView: 'reporting',
+					})}
+					showHeader={false}
+				/>
+			</ChainTimestampContext.Provider>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
 
-		try {
-			const renderedComponent = await renderIntoDocument(
-				<ChainTimestampContext.Provider value={150n}>
-					<SecurityPoolWorkflowSection
-						{...createSecurityPoolWorkflowProps({
-							checkedSecurityPoolAddress: zeroAddress,
-							securityPoolAddress: zeroAddress,
-							securityPools: [createSelectedPool({ marketDetails: createMarketDetails({ endTime: 100n }) })],
-							selectedPoolView: 'reporting',
-						})}
-						showHeader={false}
-					/>
-				</ChainTimestampContext.Provider>,
-			)
-			cleanupRenderedComponent = renderedComponent.cleanup
-
-			const documentQueries = within(document.body)
-			const reportButton = documentQueries.getByRole('button', { name: 'Report / Contribute On Selected Side' }) as HTMLButtonElement
-			expect(reportButton.disabled).toBe(true)
-			expect(reportButton.title).toBe('Load reporting details before reporting on an outcome.')
-		} finally {
-			Date.now = originalDateNow
-		}
+		const documentQueries = within(document.body)
+		const reportButton = documentQueries.getByRole('button', { name: 'Report / Contribute On Selected Side' }) as HTMLButtonElement
+		expect(reportButton.disabled).toBe(true)
+		expect(reportButton.title).toBe('Load reporting details before reporting on an outcome.')
 	})
 
 	test('renders staged operations management inside the staged operations tab instead of a standalone section', async () => {
@@ -1969,27 +1959,33 @@ describe('SecurityPoolWorkflowSection', () => {
 			selectedPoolView: 'reporting',
 		})
 
-		const renderedComponent = await renderIntoDocument(<SecurityPoolWorkflowSection {...baseProps} showHeader={false} />)
+		const renderedComponent = await renderIntoDocument(
+			<ChainTimestampContext.Provider value={1n}>
+				<SecurityPoolWorkflowSection {...baseProps} showHeader={false} />
+			</ChainTimestampContext.Provider>,
+		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 		expect(reportingLoadCalls).toBe(0)
 
 		await act(async () => {
 			render(
-				<SecurityPoolWorkflowSection
-					{...baseProps}
-					reporting={createReportingProps({
-						onLoadReporting: () => {
-							reportingLoadCalls += 1
-						},
-						reportingForm: {
-							reportAmount: '',
-							securityPoolAddress: stalePoolAddress,
-							selectedOutcome: 'yes',
-							selectedWithdrawDepositIndexes: [],
-						},
-					})}
-					showHeader={false}
-				/>,
+				<ChainTimestampContext.Provider value={1n}>
+					<SecurityPoolWorkflowSection
+						{...baseProps}
+						reporting={createReportingProps({
+							onLoadReporting: () => {
+								reportingLoadCalls += 1
+							},
+							reportingForm: {
+								reportAmount: '',
+								securityPoolAddress: stalePoolAddress,
+								selectedOutcome: 'yes',
+								selectedWithdrawDepositIndexes: [],
+							},
+						})}
+						showHeader={false}
+					/>
+				</ChainTimestampContext.Provider>,
 				renderedComponent.container,
 			)
 		})
@@ -1998,21 +1994,23 @@ describe('SecurityPoolWorkflowSection', () => {
 
 		await act(async () => {
 			render(
-				<SecurityPoolWorkflowSection
-					{...baseProps}
-					reporting={createReportingProps({
-						onLoadReporting: () => {
-							reportingLoadCalls += 1
-						},
-						reportingForm: {
-							reportAmount: '',
-							securityPoolAddress: selectedPoolAddress,
-							selectedOutcome: 'yes',
-							selectedWithdrawDepositIndexes: [],
-						},
-					})}
-					showHeader={false}
-				/>,
+				<ChainTimestampContext.Provider value={1n}>
+					<SecurityPoolWorkflowSection
+						{...baseProps}
+						reporting={createReportingProps({
+							onLoadReporting: () => {
+								reportingLoadCalls += 1
+							},
+							reportingForm: {
+								reportAmount: '',
+								securityPoolAddress: selectedPoolAddress,
+								selectedOutcome: 'yes',
+								selectedWithdrawDepositIndexes: [],
+							},
+						})}
+						showHeader={false}
+					/>
+				</ChainTimestampContext.Provider>,
 				renderedComponent.container,
 			)
 		})
@@ -2021,21 +2019,23 @@ describe('SecurityPoolWorkflowSection', () => {
 
 		await act(async () => {
 			render(
-				<SecurityPoolWorkflowSection
-					{...baseProps}
-					reporting={createReportingProps({
-						onLoadReporting: () => {
-							reportingLoadCalls += 1
-						},
-						reportingForm: {
-							reportAmount: '',
-							securityPoolAddress: selectedPoolAddress,
-							selectedOutcome: 'yes',
-							selectedWithdrawDepositIndexes: [],
-						},
-					})}
-					showHeader={false}
-				/>,
+				<ChainTimestampContext.Provider value={1n}>
+					<SecurityPoolWorkflowSection
+						{...baseProps}
+						reporting={createReportingProps({
+							onLoadReporting: () => {
+								reportingLoadCalls += 1
+							},
+							reportingForm: {
+								reportAmount: '',
+								securityPoolAddress: selectedPoolAddress,
+								selectedOutcome: 'yes',
+								selectedWithdrawDepositIndexes: [],
+							},
+						})}
+						showHeader={false}
+					/>
+				</ChainTimestampContext.Provider>,
 				renderedComponent.container,
 			)
 		})
@@ -2064,18 +2064,32 @@ describe('SecurityPoolWorkflowSection', () => {
 			securityPools: [createSelectedPool({ marketDetails: createMarketDetails({ endTime: 0n }), securityPoolAddress: selectedPoolAddress })],
 		})
 
-		const renderedComponent = await renderIntoDocument(<SecurityPoolWorkflowSection {...baseProps} selectedPoolView='reporting' showHeader={false} />)
+		const renderedComponent = await renderIntoDocument(
+			<ChainTimestampContext.Provider value={1n}>
+				<SecurityPoolWorkflowSection {...baseProps} selectedPoolView='reporting' showHeader={false} />
+			</ChainTimestampContext.Provider>,
+		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 		expect(reportingLoadCalls).toBe(1)
 
 		await act(async () => {
-			render(<SecurityPoolWorkflowSection {...baseProps} selectedPoolView='vaults' showHeader={false} />, renderedComponent.container)
+			render(
+				<ChainTimestampContext.Provider value={1n}>
+					<SecurityPoolWorkflowSection {...baseProps} selectedPoolView='vaults' showHeader={false} />
+				</ChainTimestampContext.Provider>,
+				renderedComponent.container,
+			)
 		})
 
 		expect(reportingLoadCalls).toBe(1)
 
 		await act(async () => {
-			render(<SecurityPoolWorkflowSection {...baseProps} selectedPoolView='reporting' showHeader={false} />, renderedComponent.container)
+			render(
+				<ChainTimestampContext.Provider value={1n}>
+					<SecurityPoolWorkflowSection {...baseProps} selectedPoolView='reporting' showHeader={false} />
+				</ChainTimestampContext.Provider>,
+				renderedComponent.container,
+			)
 		})
 
 		expect(reportingLoadCalls).toBe(2)

--- a/ui/ts/tests/timestampValue.test.tsx
+++ b/ui/ts/tests/timestampValue.test.tsx
@@ -3,13 +3,13 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { TimestampValue } from '../components/TimestampValue.js'
 import { ChainTimestampContext } from '../lib/chainTimestamp.js'
+import { formatTimestamp } from '../lib/formatters.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
 
 describe('TimestampValue', () => {
 	let cleanupRenderedComponent: (() => Promise<void>) | undefined
 	let restoreDomEnvironment: (() => void) | undefined
-	const originalDateNow = Date.now
 
 	beforeEach(() => {
 		const domEnvironment = installDomEnvironment()
@@ -17,7 +17,6 @@ describe('TimestampValue', () => {
 	})
 
 	afterEach(async () => {
-		Date.now = originalDateNow
 		await cleanupRenderedComponent?.()
 		cleanupRenderedComponent = undefined
 		restoreDomEnvironment?.()
@@ -47,11 +46,11 @@ describe('TimestampValue', () => {
 		expect(document.body.textContent?.includes('(in 2m)')).toBe(true)
 	})
 
-	test('falls back to browser time only when no chain timestamp is available', async () => {
-		Date.now = () => 900_000
+	test('omits relative time when no chain timestamp is available', async () => {
 		const renderedComponent = await renderIntoDocument(<TimestampValue timestamp={840n} />)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		expect(document.body.textContent?.includes('(1m ago)')).toBe(true)
+		expect(document.body.textContent?.includes(formatTimestamp(840n))).toBe(true)
+		expect(document.body.querySelector('.timestamp-value-relative')).toBeNull()
 	})
 })

--- a/ui/ts/tests/useReportingOperations.test.tsx
+++ b/ui/ts/tests/useReportingOperations.test.tsx
@@ -29,6 +29,8 @@ function createReportingDetails(securityPoolAddress: Address): ReportingDetails 
 		currentTime: 150n,
 		escalationEndTime: 300n,
 		escalationGameAddress: zeroAddress,
+		forkThreshold: 40n,
+		gameCreatedAt: 90n,
 		hasReachedNonDecision: false,
 		marketDetails: {
 			answerUnit: '',
@@ -54,9 +56,9 @@ function createReportingDetails(securityPoolAddress: Address): ReportingDetails 
 			{ balance: 2n, deposits: [], key: 'no', label: 'No', userDeposits: [] },
 			{ balance: 1n, deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
 		],
+		activationTime: 120n,
 		startBond: 1n,
 		status: 'active',
-		startingTime: 120n,
 		totalCost: 0n,
 		universeId: 1n,
 		withdrawalEnabled: false,
@@ -134,7 +136,7 @@ describe('useReportingOperations', () => {
 			createWalletWriteClient: mock(() => ({ kind: 'write-client' })),
 		}))
 
-		const { useReportingOperations } = await import(`../hooks/useReportingOperations.js?case=${Date.now().toString()}`)
+		const { useReportingOperations } = await import(`../hooks/useReportingOperations.js?case=${crypto.randomUUID()}`)
 		let hookState: UseReportingOperationsState | undefined
 		const Harness = createHarness(useReportingOperations, state => {
 			hookState = state

--- a/ui/ts/tests/useReportingOperations.test.tsx
+++ b/ui/ts/tests/useReportingOperations.test.tsx
@@ -30,7 +30,6 @@ function createReportingDetails(securityPoolAddress: Address): ReportingDetails 
 		escalationEndTime: 300n,
 		escalationGameAddress: zeroAddress,
 		forkThreshold: 40n,
-		gameCreatedAt: 90n,
 		hasReachedNonDecision: false,
 		marketDetails: {
 			answerUnit: '',

--- a/ui/ts/tests/workflowTransactionStatus.test.tsx
+++ b/ui/ts/tests/workflowTransactionStatus.test.tsx
@@ -1,8 +1,10 @@
 /// <reference types="bun-types" />
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { fireEvent } from '@testing-library/dom'
 import { within } from '@testing-library/dom'
 import { render } from 'preact'
+import { act } from 'preact/test-utils'
 import { WorkflowTransactionStatus } from '../components/WorkflowTransactionStatus.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 
@@ -64,10 +66,11 @@ describe('WorkflowTransactionStatus', () => {
 		render(
 			<WorkflowTransactionStatus
 				latestAction={{
+					dismissKey: 'latest-vault-action',
 					rows: [{ label: 'Action', value: 'queueWithdrawRep' }],
 					title: 'Latest Vault Action',
 				}}
-				outcome={{ detail: 'Queued successfully', title: 'Vault Action Queued' }}
+				outcome={{ detail: 'Queued successfully', dismissKey: 'vault-action-queued', title: 'Vault Action Queued' }}
 			/>,
 			container as HTMLDivElement,
 		)
@@ -77,5 +80,35 @@ describe('WorkflowTransactionStatus', () => {
 		expect(statusStack.children).toHaveLength(2)
 		expect(statusStack.children[0]?.textContent?.includes('Vault Action Queued')).toBe(true)
 		expect(statusStack.children[1]?.textContent?.includes('Latest Vault Action')).toBe(true)
+	})
+
+	test('dismisses the latest action and outcome independently when close buttons are clicked', async () => {
+		render(
+			<WorkflowTransactionStatus
+				latestAction={{
+					dismissKey: 'latest-action',
+					rows: [{ label: 'Action', value: 'queueWithdrawRep' }],
+					title: 'Latest Vault Action',
+				}}
+				outcome={{ detail: 'Queued successfully', dismissKey: 'queued-outcome', title: 'Vault Action Queued' }}
+			/>,
+			container as HTMLDivElement,
+		)
+
+		const containerQueries = within(container as HTMLDivElement)
+		await act(async () => {
+			fireEvent.click(containerQueries.getByRole('button', { name: 'Dismiss workflow outcome' }))
+			await Promise.resolve()
+		})
+		const statusStackAfterOutcomeDismiss = (container as HTMLDivElement).querySelector('.workflow-transaction-status')
+		if (!(statusStackAfterOutcomeDismiss instanceof HTMLElement)) throw new Error('Expected status stack to remain after dismissing the outcome')
+		expect(statusStackAfterOutcomeDismiss.children).toHaveLength(1)
+		expect(statusStackAfterOutcomeDismiss.textContent?.includes('Latest Vault Action')).toBe(true)
+
+		await act(async () => {
+			fireEvent.click(containerQueries.getByRole('button', { name: 'Dismiss latest action' }))
+			await Promise.resolve()
+		})
+		expect((container as HTMLDivElement).textContent).toBe('')
 	})
 })

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -85,6 +85,7 @@ export type ReadinessAction = {
 
 export type WorkflowOutcomePresentation = {
 	detail: ComponentChildren
+	dismissKey?: string
 	nextStep?: string
 	title: string
 }
@@ -95,6 +96,7 @@ type WorkflowLatestActionRow = {
 }
 
 export type WorkflowLatestActionPresentation = {
+	dismissKey?: string
 	embedInCard?: boolean
 	rows: WorkflowLatestActionRow[]
 	title: string
@@ -574,7 +576,7 @@ export type ReportingRouteContentProps = {
 	onLoadReporting: () => void
 	onReportOutcome: () => void
 	onReportingFormChange: (update: Partial<ReportingFormState>) => void
-	onWithdrawEscalation: () => void
+	onWithdrawEscalation: (depositIndexes?: bigint[]) => void
 	reportingActiveAction: ReportingActionResult['action'] | undefined
 	reportingDetails: ReportingDetails | undefined
 	reportingError: string | undefined

--- a/ui/ts/types/contracts.ts
+++ b/ui/ts/types/contracts.ts
@@ -320,6 +320,7 @@ export type EscalationSide = {
 type ReportingDetailsBase = {
 	completeSetCollateralAmount: bigint
 	currentTime: bigint
+	forkThreshold: bigint
 	marketDetails: MarketDetails
 	nonDecisionThreshold: bigint
 	questionOutcome: ReportingOutcomeKey | 'none'
@@ -341,9 +342,10 @@ export type ActiveReportingDetails = ReportingDetailsBase & {
 	currentRequiredBond: bigint
 	escalationEndTime: bigint
 	escalationGameAddress: Address
+	gameCreatedAt: bigint
 	hasReachedNonDecision: boolean
 	sides: EscalationSide[]
-	startingTime: bigint
+	activationTime: bigint
 	totalCost: bigint
 }
 

--- a/ui/ts/types/contracts.ts
+++ b/ui/ts/types/contracts.ts
@@ -342,7 +342,6 @@ export type ActiveReportingDetails = ReportingDetailsBase & {
 	currentRequiredBond: bigint
 	escalationEndTime: bigint
 	escalationGameAddress: Address
-	gameCreatedAt: bigint
 	hasReachedNonDecision: boolean
 	sides: EscalationSide[]
 	activationTime: bigint


### PR DESCRIPTION
## Summary
- Added selectable escalation deposit withdrawals, including separate actions for withdrawing chosen deposits or all eligible deposits.
- Updated escalation timing to distinguish game creation time from activation time, and refreshed contract tests and simulator helpers accordingly.
- Improved reporting and workflow UI copy, status cards, dismiss behavior, and timestamp handling to reflect the new timing model.
- Added UI styling for selectable withdrawal options and closable workflow status cards.

## Testing
- Not run (PR content prepared from the provided diff/stat and commit summary only).