### PR TITLE
Surface finalized market and workflow status states

### DIFF
--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -539,6 +539,7 @@ button.destructive:hover:not(:disabled) {
 
 .notice.success {
 	border-color: var(--success-border);
+	background: linear-gradient(180deg, rgba(11, 51, 43, 0.92) 0%, rgba(8, 34, 29, 0.92) 100%);
 }
 
 .notice a {

--- a/ui/dist/css/index.css
+++ b/ui/dist/css/index.css
@@ -539,6 +539,7 @@ button.destructive:hover:not(:disabled) {
 
 .notice.success {
 	border-color: var(--success-border);
+	background: linear-gradient(180deg, rgba(11, 51, 43, 0.92) 0%, rgba(8, 34, 29, 0.92) 100%);
 }
 
 .notice a {

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -20,6 +20,7 @@ import { parseOptionalRepAmountInput } from '../lib/marketForm.js'
 import { isMainnetChain } from '../lib/network.js'
 import {
 	calculateEstimatedEscalationReturn,
+	ESCALATION_GAME_ACTIVATION_DELAY,
 	getEscalationDepositClaimAmount,
 	getEscalationPhase,
 	getEscalationTimeRemaining,
@@ -31,7 +32,7 @@ import {
 } from '../lib/reportingDomain.js'
 import { getReportingReportGuardMessage, getReportingWithdrawGuardMessage } from '../lib/reportingGuards.js'
 import { REPORTING_OUTCOME_DROPDOWN_OPTIONS, getReportingLockedUntilMessage, getReportingOutcomeLabel } from '../lib/reporting.js'
-import type { LifecycleStagePresentation, ReportingSectionProps, WorkflowOutcomePresentation } from '../types/components.js'
+import type { LifecycleStagePresentation, ReportingSectionProps } from '../types/components.js'
 import type { EscalationDeposit, ReportingDetails, ReportingOutcomeKey } from '../types/contracts.js'
 
 type ReportingStatus = 'active' | 'missing' | 'not-started'
@@ -169,7 +170,7 @@ function getReportingStagePresentation({
 			return {
 				availableActions: [],
 				blockedActions: [],
-				detail: `Market finalized as ${getResolvedReportingOutcomeLabel(reportingDetails)}. Review any remaining deposits below.`,
+				detail: `Market finalized as ${getResolvedReportingOutcomeLabel(reportingDetails)}.`,
 				key: 'escalation-resolved',
 				label: 'Resolved',
 				tone: 'success',
@@ -177,20 +178,9 @@ function getReportingStagePresentation({
 	}
 }
 
-function getReportingOutcomePresentation(action: ReportingSectionProps['reportingResult']): WorkflowOutcomePresentation | undefined {
-	if (action === undefined) return undefined
-
-	switch (action.action) {
-		case 'reportOutcome':
-			return undefined
-		case 'withdrawEscalation':
-			return {
-				detail: 'Eligible escalation deposits were withdrawn for the selected outcome side.',
-				dismissKey: `${action.action}:${action.hash}:outcome`,
-				nextStep: 'Review the updated escalation balances before taking another reporting action.',
-				title: 'Escalation Deposits Withdrawn',
-			}
-	}
+function getEscalationGameStartTimestamp(activationTime: bigint | undefined) {
+	if (activationTime === undefined) return undefined
+	return activationTime > ESCALATION_GAME_ACTIVATION_DELAY ? activationTime - ESCALATION_GAME_ACTIVATION_DELAY : 0n
 }
 
 function getEffectiveReportingDetails(reportingDetails: ReportingDetails | undefined, currentTimestamp: bigint | undefined) {
@@ -230,6 +220,7 @@ export function ReportingSection({
 	const effectiveReportingDetails = getEffectiveReportingDetails(reportingDetails, effectiveCurrentTimestamp)
 	const activeReportingDetails = effectiveReportingDetails?.status === 'active' ? effectiveReportingDetails : undefined
 	const escalationPhase = activeReportingDetails === undefined ? undefined : getEscalationPhase(activeReportingDetails)
+	const escalationGameStartTimestamp = getEscalationGameStartTimestamp(activeReportingDetails?.activationTime)
 	const reportingStatus: ReportingStatus = effectiveReportingDetails === undefined ? 'missing' : effectiveReportingDetails.status
 	const marketDetails = effectiveReportingDetails?.marketDetails ?? previewMarketDetails
 	const reportingLocked = lockedReason !== undefined
@@ -254,6 +245,16 @@ export function ReportingSection({
 	const actualReportDepositAmount = reportContributionPreview?.actualDepositAmount
 	const selectedEstimate = activeReportingDetails === undefined || selectedAmount === undefined || selectedOutcome === undefined ? undefined : calculateEstimatedEscalationReturn(activeReportingDetails, selectedOutcome, selectedAmount)
 	const timerPreview = effectiveReportingDetails === undefined || selectedAmount === undefined || selectedOutcome === undefined ? undefined : getReportingTimerPreview(effectiveReportingDetails, selectedOutcome, selectedAmount)
+	const projectedFinalizationNotice =
+		timerPreview === undefined
+			? undefined
+			: timerPreview.kind === 'not-started'
+				? `If no one disputes after this report, the market would finalize in ${formatDuration(timerPreview.timeUntilEnd)}.`
+				: activeReportingDetails === undefined
+					? undefined
+					: timerPreview.actualState === 'ends-immediately'
+						? 'If no one disputes after this contribution, the market would finalize immediately.'
+						: `If no one disputes after this contribution, the market would finalize in ${formatDuration(getEscalationTimeRemaining(activeReportingDetails) + (timerPreview.timerIncrease ?? 0n))}.`
 	const selectedOutcomeLabel = selectedOutcome === undefined ? 'Selected Side' : (outcomeSides.find(side => side.key === selectedOutcome)?.label ?? getReportingOutcomeLabel(selectedOutcome))
 	const reportButtonLabel = selectedOutcome === undefined ? 'Report / Contribute On Selected Side' : `Report / Contribute ${selectedOutcomeLabel}`
 	const minimumOutcomeChangeContribution = selectedOutcome === undefined ? { amount: undefined, reason: SELECT_OUTCOME_PRESET_REASON } : getReportingMinimumOutcomeChangeContribution(effectiveReportingDetails, selectedOutcome)
@@ -323,11 +324,9 @@ export function ReportingSection({
 						{ label: 'Transaction', value: <TransactionHashLink hash={reportingResult.hash} /> },
 					],
 				}
-	const reportingOutcome = getReportingOutcomePresentation(reportingResult)
-
 	const sections = (
 		<>
-			<WorkflowTransactionStatus latestAction={latestReportingAction} outcome={reportingOutcome} />
+			<WorkflowTransactionStatus latestAction={latestReportingAction} outcome={undefined} />
 			{showReportingHeaderStack ? (
 				<div className='reporting-header-stack'>
 					{showSecurityPoolAddressInput ? (
@@ -343,7 +342,7 @@ export function ReportingSection({
 							}
 						/>
 					) : undefined}
-					{reportingOpenNotice === undefined ? <LifecycleStageBanner stage={reportingStage} /> : <p className='notice'>{reportingOpenNotice}</p>}
+					{reportingOpenNotice === undefined ? <LifecycleStageBanner stage={reportingStage} /> : <p className='notice success'>{reportingOpenNotice}</p>}
 				</div>
 			) : undefined}
 
@@ -355,7 +354,7 @@ export function ReportingSection({
 						</MetricField>
 						<MetricField label='Time Left'>{activeReportingDetails === undefined ? '—' : formatDuration(getEscalationTimeRemaining(activeReportingDetails))}</MetricField>
 						<MetricField label='Game Start'>
-							<TimestampValue {...(effectiveCurrentTimestamp === undefined ? {} : { currentTimestamp: effectiveCurrentTimestamp })} timestamp={activeReportingDetails?.activationTime} />
+							<TimestampValue {...(effectiveCurrentTimestamp === undefined ? {} : { currentTimestamp: effectiveCurrentTimestamp })} timestamp={escalationGameStartTimestamp} />
 						</MetricField>
 						<MetricField label='Start Bond'>
 							<CurrencyValue value={effectiveReportingDetails?.startBond} suffix='REP' />
@@ -454,16 +453,7 @@ export function ReportingSection({
 						<TransactionActionButton idleLabel={reportButtonLabel} pendingLabel='Submitting report...' onClick={onReportOutcome} pending={reportingActiveAction === 'reportOutcome'} availability={{ disabled: reportGuardMessage !== undefined, reason: reportGuardMessage }} />
 					</div>
 					{timerPreview === undefined ? undefined : timerPreview.kind === 'not-started' ? (
-						<>
-							<p className='detail'>This contribution would start the escalation timer in {formatDuration(timerPreview.timeUntilStart)}.</p>
-							{timerPreview.hypotheticalDuration === 0n ? (
-								<p className='detail'>At that binding capital, the dispute timer would expire as soon as it activates, so reporting would close in {formatDuration(timerPreview.timeUntilEnd)}.</p>
-							) : (
-								<p className='detail'>
-									If <CurrencyValue copyable={false} value={selectedAmount} suffix='REP' /> became binding capital, the dispute window would run for {formatDuration(timerPreview.hypotheticalDuration)} after activation and end in {formatDuration(timerPreview.timeUntilEnd)}.
-								</p>
-							)}
-						</>
+						<p className='detail'>{projectedFinalizationNotice}</p>
 					) : (
 						<>
 							<p className='detail'>
@@ -473,9 +463,7 @@ export function ReportingSection({
 										? `This contribution would extend the timer by ${formatDuration(timerPreview.timerIncrease ?? 0n)}.`
 										: 'This contribution would not extend the timer.'}
 							</p>
-							<p className='detail'>
-								If <CurrencyValue copyable={false} value={selectedAmount} suffix='REP' /> became binding capital, the dispute window would last {formatDuration(timerPreview.hypotheticalDuration)} from game start.
-							</p>
+							{projectedFinalizationNotice === undefined ? undefined : <p className='detail'>{projectedFinalizationNotice}</p>}
 						</>
 					)}
 				</SectionBlock>

--- a/ui/ts/components/TradingSection.tsx
+++ b/ui/ts/components/TradingSection.tsx
@@ -19,6 +19,7 @@ import { isMainnetChain } from '../lib/network.js'
 import { getReportingOutcomeLabel, REPORTING_OUTCOME_DROPDOWN_OPTIONS } from '../lib/reporting.js'
 import {
 	getDefaultShareMigrationTargetOutcomeIndexes,
+	MARKET_ALREADY_FINALIZED_MESSAGE,
 	getRemainingMintCapacity,
 	getSelectedOutcomeShareBalance,
 	getTradingMigrateSharesGuardMessage,
@@ -83,6 +84,7 @@ export function TradingSection({
 	tradingDetails,
 	selectedPool,
 	tradingActiveAction,
+	tradingFeedback,
 	tradingError,
 	tradingForm,
 	tradingForkUniverse,
@@ -114,6 +116,7 @@ export function TradingSection({
 		hasSelectedPool,
 		isMainnet,
 		mintAmountInput: tradingForm.completeSetAmount,
+		questionOutcome: selectedPool?.questionOutcome,
 		systemState: selectedPool?.systemState,
 		totalRepDeposit: selectedPool?.totalRepDeposit,
 		totalSecurityBondAllowance: selectedPool?.totalSecurityBondAllowance,
@@ -159,15 +162,17 @@ export function TradingSection({
 				? 'Switch to Ethereum mainnet before minting complete sets.'
 				: poolUniverseHasForked === true
 					? 'Minting is unavailable after this universe has forked.'
-					: selectedPool?.systemState !== undefined && selectedPool.systemState !== 'operational'
-						? 'Minting is only available while the pool is operational.'
-						: remainingMintCapacity === undefined
-							? 'Loading mint capacity.'
-							: remainingMintCapacity === 0n
-								? hasRepBackedPoolWithNoActiveAllowance(selectedPool?.totalRepDeposit, selectedPool?.totalSecurityBondAllowance)
-									? NO_MINT_CAPACITY_NO_ACTIVE_ALLOWANCE_MESSAGE
-									: 'No mint capacity remaining.'
-								: undefined
+					: selectedPool?.questionOutcome !== undefined && selectedPool.questionOutcome !== 'none'
+						? MARKET_ALREADY_FINALIZED_MESSAGE
+						: selectedPool?.systemState !== undefined && selectedPool.systemState !== 'operational'
+							? 'Minting is only available while the pool is operational.'
+							: remainingMintCapacity === undefined
+								? 'Loading mint capacity.'
+								: remainingMintCapacity === 0n
+									? hasRepBackedPoolWithNoActiveAllowance(selectedPool?.totalRepDeposit, selectedPool?.totalSecurityBondAllowance)
+										? NO_MINT_CAPACITY_NO_ACTIVE_ALLOWANCE_MESSAGE
+										: 'No mint capacity remaining.'
+									: undefined
 	const redeemCompleteSetsLauncherBlocker = !hasSelectedPool
 		? 'Load a pool before redeeming complete sets.'
 		: accountState.address === undefined
@@ -226,6 +231,10 @@ export function TradingSection({
 		})
 	}
 	const renderShareMetricValue = (value: bigint | undefined) => <CurrencyValue loading={loadingTradingDetails} value={value} />
+	const getTradingActionStatus = (actionName: NonNullable<TradingSectionProps['tradingFeedback']>['action']) => {
+		if (tradingFeedback?.action !== actionName) return undefined
+		return tradingFeedback.status.tone === 'success' ? undefined : tradingFeedback.status
+	}
 	const latestTradingAction =
 		tradingResult === undefined
 			? undefined
@@ -328,7 +337,14 @@ export function TradingSection({
 				</label>
 				{mintGuardMessage === undefined ? undefined : <p className='detail'>{mintGuardMessage}</p>}
 				<div className='actions'>
-					<TransactionActionButton idleLabel='Mint Complete Sets' pendingLabel='Minting complete sets...' onClick={onCreateCompleteSet} pending={tradingActiveAction === 'createCompleteSet'} availability={{ disabled: mintGuardMessage !== undefined, reason: mintGuardMessage }} />
+					<TransactionActionButton
+						idleLabel='Mint Complete Sets'
+						pendingLabel='Minting complete sets...'
+						onClick={onCreateCompleteSet}
+						pending={tradingActiveAction === 'createCompleteSet'}
+						status={getTradingActionStatus('createCompleteSet')}
+						availability={{ disabled: mintGuardMessage !== undefined, reason: mintGuardMessage }}
+					/>
 				</div>
 			</OperationModal>
 
@@ -357,6 +373,7 @@ export function TradingSection({
 						pendingLabel='Redeeming complete sets...'
 						onClick={onRedeemCompleteSet}
 						pending={tradingActiveAction === 'redeemCompleteSet'}
+						status={getTradingActionStatus('redeemCompleteSet')}
 						tone='secondary'
 						availability={{ disabled: redeemCompleteSetGuardMessage !== undefined, reason: redeemCompleteSetGuardMessage }}
 					/>
@@ -379,14 +396,30 @@ export function TradingSection({
 				/>
 				{migrateSharesGuardMessage === undefined ? undefined : <p className='detail'>{migrateSharesGuardMessage}</p>}
 				<div className='actions'>
-					<TransactionActionButton idleLabel='Migrate Shares' pendingLabel='Migrating shares...' onClick={onMigrateShares} pending={tradingActiveAction === 'migrateShares'} tone='secondary' availability={{ disabled: migrateSharesGuardMessage !== undefined, reason: migrateSharesGuardMessage }} />
+					<TransactionActionButton
+						idleLabel='Migrate Shares'
+						pendingLabel='Migrating shares...'
+						onClick={onMigrateShares}
+						pending={tradingActiveAction === 'migrateShares'}
+						status={getTradingActionStatus('migrateShares')}
+						tone='secondary'
+						availability={{ disabled: migrateSharesGuardMessage !== undefined, reason: migrateSharesGuardMessage }}
+					/>
 				</div>
 			</OperationModal>
 
 			<OperationModal description='Redeem finalized winning shares once the selected pool has resolved.' isOpen={activeModal === 'redeem-shares'} onClose={() => setActiveModal(undefined)} title='Redeem Resolved Shares'>
 				{redeemSharesGuardMessage === undefined ? undefined : <p className='detail'>{redeemSharesGuardMessage}</p>}
 				<div className='actions'>
-					<TransactionActionButton idleLabel='Redeem Shares' pendingLabel='Redeeming shares...' onClick={onRedeemShares} pending={tradingActiveAction === 'redeemShares'} tone='secondary' availability={{ disabled: redeemSharesGuardMessage !== undefined, reason: redeemSharesGuardMessage }} />
+					<TransactionActionButton
+						idleLabel='Redeem Shares'
+						pendingLabel='Redeeming shares...'
+						onClick={onRedeemShares}
+						pending={tradingActiveAction === 'redeemShares'}
+						status={getTradingActionStatus('redeemShares')}
+						tone='secondary'
+						availability={{ disabled: redeemSharesGuardMessage !== undefined, reason: redeemSharesGuardMessage }}
+					/>
 				</div>
 			</OperationModal>
 		</>

--- a/ui/ts/components/WorkflowTransactionStatus.tsx
+++ b/ui/ts/components/WorkflowTransactionStatus.tsx
@@ -3,26 +3,34 @@ import { EntityCard } from './EntityCard.js'
 import { TransactionActionStatus } from './TransactionActionStatus.js'
 import type { WorkflowTransactionStatusProps } from '../types/components.js'
 
+const dismissedLatestActionKeys = new Set<string>()
+const dismissedOutcomeKeys = new Set<string>()
+
+function getPersistedDismissedKey(dismissedKeys: Set<string>, dismissKey: string | undefined) {
+	if (dismissKey === undefined || !dismissedKeys.has(dismissKey)) return undefined
+	return dismissKey
+}
+
 export function WorkflowTransactionStatus({ latestAction, outcome }: WorkflowTransactionStatusProps) {
-	const [dismissedLatestActionKey, setDismissedLatestActionKey] = useState<string | undefined>(undefined)
-	const [dismissedOutcomeKey, setDismissedOutcomeKey] = useState<string | undefined>(undefined)
+	const [dismissedLatestActionKey, setDismissedLatestActionKey] = useState<string | undefined>(() => getPersistedDismissedKey(dismissedLatestActionKeys, latestAction?.dismissKey))
+	const [dismissedOutcomeKey, setDismissedOutcomeKey] = useState<string | undefined>(() => getPersistedDismissedKey(dismissedOutcomeKeys, outcome?.dismissKey))
 	const latestActionKeyRef = useRef(latestAction?.dismissKey)
 	const outcomeKeyRef = useRef(outcome?.dismissKey)
 
 	useEffect(() => {
 		if (latestAction?.dismissKey === latestActionKeyRef.current) return
 		latestActionKeyRef.current = latestAction?.dismissKey
-		if (dismissedLatestActionKey !== undefined) {
-			setDismissedLatestActionKey(undefined)
-		}
+		const nextDismissedLatestActionKey = getPersistedDismissedKey(dismissedLatestActionKeys, latestAction?.dismissKey)
+		if (dismissedLatestActionKey === nextDismissedLatestActionKey) return
+		setDismissedLatestActionKey(nextDismissedLatestActionKey)
 	}, [dismissedLatestActionKey, latestAction?.dismissKey])
 
 	useEffect(() => {
 		if (outcome?.dismissKey === outcomeKeyRef.current) return
 		outcomeKeyRef.current = outcome?.dismissKey
-		if (dismissedOutcomeKey !== undefined) {
-			setDismissedOutcomeKey(undefined)
-		}
+		const nextDismissedOutcomeKey = getPersistedDismissedKey(dismissedOutcomeKeys, outcome?.dismissKey)
+		if (dismissedOutcomeKey === nextDismissedOutcomeKey) return
+		setDismissedOutcomeKey(nextDismissedOutcomeKey)
 	}, [dismissedOutcomeKey, outcome?.dismissKey])
 
 	const showOutcome = outcome !== undefined && (outcome.dismissKey === undefined || outcome.dismissKey !== dismissedOutcomeKey)
@@ -35,7 +43,17 @@ export function WorkflowTransactionStatus({ latestAction, outcome }: WorkflowTra
 			{!showOutcome || outcome === undefined ? undefined : (
 				<div className='workflow-status-item'>
 					{outcome.dismissKey === undefined ? undefined : (
-						<button className='quiet modal-close-button workflow-status-close' type='button' aria-label='Dismiss workflow outcome' title='Close' onClick={() => setDismissedOutcomeKey(outcome.dismissKey)}>
+						<button
+							className='quiet modal-close-button workflow-status-close'
+							type='button'
+							aria-label='Dismiss workflow outcome'
+							title='Close'
+							onClick={() => {
+								if (outcome.dismissKey === undefined) return
+								dismissedOutcomeKeys.add(outcome.dismissKey)
+								setDismissedOutcomeKey(outcome.dismissKey)
+							}}
+						>
 							&times;
 						</button>
 					)}
@@ -58,7 +76,17 @@ export function WorkflowTransactionStatus({ latestAction, outcome }: WorkflowTra
 			{!showLatestAction || latestAction === undefined ? undefined : (
 				<div className='workflow-status-item'>
 					{latestAction.dismissKey === undefined ? undefined : (
-						<button className='quiet modal-close-button workflow-status-close' type='button' aria-label='Dismiss latest action' title='Close' onClick={() => setDismissedLatestActionKey(latestAction.dismissKey)}>
+						<button
+							className='quiet modal-close-button workflow-status-close'
+							type='button'
+							aria-label='Dismiss latest action'
+							title='Close'
+							onClick={() => {
+								if (latestAction.dismissKey === undefined) return
+								dismissedLatestActionKeys.add(latestAction.dismissKey)
+								setDismissedLatestActionKey(latestAction.dismissKey)
+							}}
+						>
 							&times;
 						</button>
 					)}

--- a/ui/ts/lib/securityPoolWorkflow.ts
+++ b/ui/ts/lib/securityPoolWorkflow.ts
@@ -58,11 +58,20 @@ export function getSelectedPoolWorkflowLockedPresentation({ hasSelectedPoolAddre
 		}
 	}
 
+	if (hasSelectedPoolAddress) {
+		return {
+			actionHint: 'Refresh this address after the pool is deployed.',
+			badgeLabel: 'Not found',
+			badgeTone: 'blocked',
+			detail: 'Pool not found.',
+			key: 'not_found',
+		}
+	}
+
 	return {
-		badgeLabel: hasSelectedPoolAddress ? 'Waiting for pool' : 'No pool selected',
+		badgeLabel: 'No pool selected',
 		badgeTone: 'muted',
-		detail: hasSelectedPoolAddress ? 'Pool not available yet.' : 'No pool selected.',
-		...(hasSelectedPoolAddress ? { actionHint: 'Refresh this address after the pool is deployed.' } : {}),
+		detail: 'No pool selected.',
 		key: 'action_needed',
 	}
 }

--- a/ui/ts/lib/trading.ts
+++ b/ui/ts/lib/trading.ts
@@ -17,6 +17,7 @@ export const NO_MINT_CAPACITY_NO_ACTIVE_ALLOWANCE_MESSAGE = 'No mint capacity. N
 export const NEED_MATCHING_COMPLETE_SET_SHARES_MESSAGE = 'Need matching Invalid, Yes, and No shares to redeem complete sets.'
 export const SHARE_MIGRATION_AFTER_FORK_MESSAGE = 'Share migration is only available after this universe has forked.'
 export const MARKET_NOT_FINALIZED_MESSAGE = 'This market has not finalized yet.'
+export const MARKET_ALREADY_FINALIZED_MESSAGE = 'This market has already finalized.'
 
 const HIDDEN_TRADING_GUARD_MESSAGES = [NO_MINT_CAPACITY_NO_ACTIVE_ALLOWANCE_MESSAGE, NEED_MATCHING_COMPLETE_SET_SHARES_MESSAGE, SHARE_MIGRATION_AFTER_FORK_MESSAGE, MARKET_NOT_FINALIZED_MESSAGE]
 
@@ -111,6 +112,7 @@ export function getTradingMintGuardMessage({
 	hasSelectedPool,
 	isMainnet,
 	mintAmountInput,
+	questionOutcome,
 	systemState,
 	totalRepDeposit,
 	totalSecurityBondAllowance,
@@ -122,6 +124,7 @@ export function getTradingMintGuardMessage({
 	hasSelectedPool: boolean
 	isMainnet: boolean
 	mintAmountInput: string
+	questionOutcome?: ReportingOutcomeKey | 'none' | undefined
 	systemState: SecurityPoolSystemState | undefined
 	totalRepDeposit: bigint | undefined
 	totalSecurityBondAllowance: bigint | undefined
@@ -131,6 +134,7 @@ export function getTradingMintGuardMessage({
 	if (accountAddress === undefined) return 'Connect a wallet before minting complete sets.'
 	if (!isMainnet) return 'Switch to Ethereum mainnet before minting complete sets.'
 	if (universeHasForked === true) return 'Minting is unavailable after this universe has forked.'
+	if (questionOutcome !== undefined && questionOutcome !== 'none') return MARKET_ALREADY_FINALIZED_MESSAGE
 	if (systemState !== undefined && systemState !== 'operational') return 'Minting is only available while the pool is operational.'
 
 	const remainingCapacity = getRemainingMintCapacity(totalSecurityBondAllowance, completeSetCollateralAmount)

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -7,9 +7,9 @@ import { h, render } from 'preact'
 import { useState } from 'preact/hooks'
 import { zeroAddress } from 'viem'
 import { ReportingSection } from '../components/ReportingSection.js'
-import { formatDuration } from '../lib/formatters.js'
+import { formatDuration, formatTimestamp } from '../lib/formatters.js'
 import { getReportingLockedUntilMessage } from '../lib/reporting.js'
-import { computeEscalationTimeSinceStartFromAttritionCost, getEscalationBalanceTuple, getEscalationBindingCapital } from '../lib/reportingDomain.js'
+import { computeEscalationTimeSinceStartFromAttritionCost, ESCALATION_GAME_ACTIVATION_DELAY, getEscalationBalanceTuple, getEscalationBindingCapital } from '../lib/reportingDomain.js'
 import type { AccountState, ReportingFormState } from '../types/app.js'
 import type { ActiveReportingDetails, EscalationDeposit, MarketDetails, ReportingDetails } from '../types/contracts.js'
 import type { ReportingSectionProps } from '../types/components.js'
@@ -418,6 +418,28 @@ describe('ReportingSection', () => {
 		expect(metricsQueries.getByText('Start Bond')).not.toBeNull()
 	})
 
+	test('shows Game Start as activation time minus the initial delay', async () => {
+		const gameStartTimestamp = 120n
+		const activationTime = ESCALATION_GAME_ACTIVATION_DELAY + gameStartTimestamp
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					currentTimestamp: gameStartTimestamp,
+					reportingDetails: createDynamicReportingDetails({
+						activationTime,
+						currentTime: gameStartTimestamp,
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const metricsSection = getEscalationMetricsSection()
+		expect(metricsSection.textContent?.includes(formatTimestamp(gameStartTimestamp))).toBe(true)
+		expect(metricsSection.textContent?.includes(formatTimestamp(activationTime))).toBe(false)
+	})
+
 	test('keeps placeholder outcome cards visible inside Report Outcome before reporting details load', async () => {
 		const renderedComponent = await renderIntoDocument(h(ReportingSection, createProps({ reportingDetails: undefined })))
 		cleanupRenderedComponent = renderedComponent.cleanup
@@ -608,7 +630,8 @@ describe('ReportingSection', () => {
 
 		const documentQueries = within(document.body)
 		expect(documentQueries.getByRole('heading', { name: 'Resolved' })).not.toBeNull()
-		expect(document.body.textContent?.includes('Market finalized as Yes. Review any remaining deposits below.')).toBe(true)
+		expect(document.body.textContent?.includes('Market finalized as Yes.')).toBe(true)
+		expect(document.body.textContent?.includes('Review any remaining deposits below.')).toBe(false)
 	})
 
 	test('disables reporting after the escalation timer ends', async () => {
@@ -742,6 +765,7 @@ describe('ReportingSection', () => {
 		const reportOutcomeSection = getReportOutcomeSection()
 		expect(documentQueries.queryByRole('heading', { name: 'First Report Starts Escalation' })).toBeNull()
 		expect(document.body.textContent?.includes('Reporting is open.')).toBe(true)
+		expect(document.body.querySelector('.notice.success')?.textContent).toContain('Reporting is open.')
 		expect(reportOutcomeSection.textContent?.includes('Your deposits:')).toBe(false)
 		expect(reportOutcomeSection.textContent?.includes('Projected payout for current amount')).toBe(false)
 		expect(reportOutcomeSection.textContent?.includes('Projected profit if this side wins')).toBe(false)
@@ -750,8 +774,7 @@ describe('ReportingSection', () => {
 		expect(reportOutcomeSection.querySelectorAll('.currency-value.unavailable')).toHaveLength(0)
 		expect(document.body.textContent?.includes('Load reporting details to populate live stakes')).toBe(false)
 		expectTransactionButtonEnabled(document.body, 'Report / Contribute Yes')
-		expect(document.body.textContent?.includes('This contribution would start the escalation timer in 3d 0h 0m.')).toBe(true)
-		expect(document.body.textContent?.includes('the dispute timer would expire as soon as it activates, so reporting would close in 3d 0h 0m.')).toBe(true)
+		expect(document.body.textContent?.includes('If no one disputes after this report, the market would finalize in 3d 0h 0m.')).toBe(true)
 	})
 
 	test('disables report submission for a pre-start amount below the first-report minimum', async () => {
@@ -809,7 +832,8 @@ describe('ReportingSection', () => {
 		const reportButton = documentQueries.getByRole('button', { name: 'Report / Contribute No' })
 		const preview = documentQueries.getByText(/^This contribution would extend the timer by /)
 		expect(reportButton.compareDocumentPosition(preview) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0)
-		expect(document.body.textContent?.includes('became binding capital')).toBe(true)
+		expect(document.body.textContent?.includes('If no one disputes after this contribution, the market would finalize in')).toBe(true)
+		expect(document.body.textContent?.includes('became binding capital')).toBe(false)
 	})
 
 	test('shows a no-extension preview when the selected contribution leaves binding capital unchanged', async () => {
@@ -827,7 +851,8 @@ describe('ReportingSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		expect(document.body.textContent?.includes('This contribution would not extend the timer.')).toBe(true)
-		expect(document.body.textContent?.includes('became binding capital')).toBe(true)
+		expect(document.body.textContent?.includes('If no one disputes after this contribution, the market would finalize in')).toBe(true)
+		expect(document.body.textContent?.includes('became binding capital')).toBe(false)
 	})
 
 	test('shows the accepted-deposit note when the typed contribution exceeds the remaining room on the selected side', async () => {
@@ -1254,5 +1279,28 @@ describe('ReportingSection', () => {
 		expect(statusStack.textContent?.includes('Reporting Contribution Submitted')).toBe(false)
 		expect(documentQueries.getByRole('heading', { name: 'Latest Reporting Action' })).not.toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Latest Reporting Action' }).closest('.actions')).toBeNull()
+	})
+
+	test('uses only the latest action card after withdrawing escalation deposits', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					reportingResult: {
+						action: 'withdrawEscalation',
+						hash: '0x5678000000000000000000000000000000000000000000000000000000000000',
+						outcome: 'yes',
+						securityPoolAddress: zeroAddress,
+						universeId: 1n,
+					},
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByRole('heading', { name: 'Latest Reporting Action' })).not.toBeNull()
+		expect(documentQueries.queryByText('Escalation Deposits Withdrawn')).toBeNull()
+		expect(documentQueries.queryByText('Eligible escalation deposits were withdrawn for the selected outcome side.')).toBeNull()
 	})
 })

--- a/ui/ts/tests/securityPoolWorkflow.test.ts
+++ b/ui/ts/tests/securityPoolWorkflow.test.ts
@@ -130,6 +130,20 @@ void describe('selected pool workflow visibility', () => {
 		expect(
 			getSelectedPoolWorkflowLockedPresentation({
 				hasSelectedPoolAddress: true,
+				selectedPoolLookupState: 'unknown',
+				selectedPoolUniverseMismatch: false,
+			}),
+		).toEqual({
+			actionHint: 'Refresh this address after the pool is deployed.',
+			badgeLabel: 'Not found',
+			badgeTone: 'blocked',
+			detail: 'Pool not found.',
+			key: 'not_found',
+		})
+
+		expect(
+			getSelectedPoolWorkflowLockedPresentation({
+				hasSelectedPoolAddress: true,
 				selectedPoolLookupState: 'loading',
 				selectedPoolUniverseMismatch: false,
 			}),

--- a/ui/ts/tests/securityPoolWorkflowSection.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection.test.tsx
@@ -337,6 +337,24 @@ describe('SecurityPoolWorkflowSection', () => {
 		expect(documentQueries.queryByText('Locked')).toBeNull()
 	})
 
+	test('shows a pool not found warning while an entered address is still unresolved', async () => {
+		const unresolvedAddress = '0x00000000000000000000000000000000000000ab'
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					securityPoolAddress: unresolvedAddress,
+				})}
+				showHeader={false}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByRole('heading', { name: 'Pool Workflows' })).not.toBeNull()
+		expect(documentQueries.getByText('Pool not found.')).not.toBeNull()
+		expect(documentQueries.getByText('Refresh this address after the pool is deployed.')).not.toBeNull()
+	})
+
 	test('shows a pool not found card when the selected address does not resolve', async () => {
 		const missingAddress = '0x00000000000000000000000000000000000000ab'
 		const renderedComponent = await renderIntoDocument(

--- a/ui/ts/tests/trading.test.ts
+++ b/ui/ts/tests/trading.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, test } from 'bun:test'
 import { zeroAddress } from 'viem'
 import {
+	MARKET_ALREADY_FINALIZED_MESSAGE,
 	MARKET_NOT_FINALIZED_MESSAGE,
 	NEED_MATCHING_COMPLETE_SET_SHARES_MESSAGE,
 	NO_MINT_CAPACITY_NO_ACTIVE_ALLOWANCE_MESSAGE,
@@ -241,6 +242,22 @@ void describe('trading helpers', () => {
 	})
 
 	void test('surfaces the main mint block reasons before the transaction is sent', () => {
+		expect(
+			getTradingMintGuardMessage({
+				accountAddress: '0x1234567890123456789012345678901234567890',
+				completeSetCollateralAmount: 1n,
+				ethBalance: 10n ** 18n,
+				hasSelectedPool: true,
+				isMainnet: true,
+				mintAmountInput: '100',
+				questionOutcome: 'yes',
+				systemState: 'operational',
+				totalRepDeposit: 0n,
+				totalSecurityBondAllowance: 10n,
+				universeHasForked: false,
+			}),
+		).toBe(MARKET_ALREADY_FINALIZED_MESSAGE)
+
 		expect(
 			getTradingMintGuardMessage({
 				accountAddress: '0x1234567890123456789012345678901234567890',

--- a/ui/ts/tests/tradingSection.test.tsx
+++ b/ui/ts/tests/tradingSection.test.tsx
@@ -6,7 +6,7 @@ import { useState } from 'preact/hooks'
 import { act } from 'preact/test-utils'
 import { zeroAddress, zeroHash } from 'viem'
 import { TradingSection } from '../components/TradingSection.js'
-import { MARKET_NOT_FINALIZED_MESSAGE, NEED_MATCHING_COMPLETE_SET_SHARES_MESSAGE, NO_MINT_CAPACITY_NO_ACTIVE_ALLOWANCE_MESSAGE, SHARE_MIGRATION_AFTER_FORK_MESSAGE } from '../lib/trading.js'
+import { MARKET_ALREADY_FINALIZED_MESSAGE, MARKET_NOT_FINALIZED_MESSAGE, NEED_MATCHING_COMPLETE_SET_SHARES_MESSAGE, NO_MINT_CAPACITY_NO_ACTIVE_ALLOWANCE_MESSAGE, SHARE_MIGRATION_AFTER_FORK_MESSAGE } from '../lib/trading.js'
 import type { AccountState, TradingFormState } from '../types/app.js'
 import type { ListedSecurityPool, MarketDetails, TradingDetails, TradingShareBalances, ZoltarUniverseSummary } from '../types/contracts.js'
 import type { TradingSectionProps } from '../types/components.js'
@@ -43,7 +43,7 @@ function createSelectedPool(overrides: Partial<ListedSecurityPool> = {}): Listed
 		marketDetails: createMarketDetails(),
 		migratedRep: 0n,
 		parent: zeroAddress,
-		questionOutcome: 'yes',
+		questionOutcome: 'none',
 		questionId: '0x01',
 		securityMultiplier: 2n,
 		securityPoolAddress: zeroAddress,
@@ -370,6 +370,49 @@ void describe('TradingSection', () => {
 		const redeemSharesButton = documentQueries.getByRole('button', { name: 'Redeem resolved shares' }) as HTMLButtonElement
 		expect(redeemSharesButton.disabled).toBe(true)
 		expect(redeemSharesButton.title).toBe(MARKET_NOT_FINALIZED_MESSAGE)
+	})
+
+	void test('blocks minting once the selected market has finalized', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<TradingSection
+				{...createTradingSectionProps({
+					selectedPool: createSelectedPool({ questionOutcome: 'yes' }),
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		const mintButton = documentQueries.getByRole('button', { name: 'Mint complete sets' }) as HTMLButtonElement
+		expect(mintButton.disabled).toBe(true)
+		expect(mintButton.title).toBe(MARKET_ALREADY_FINALIZED_MESSAGE)
+	})
+
+	void test('shows mint write failures inline in the modal', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<TradingSection
+				{...createTradingSectionProps({
+					tradingFeedback: {
+						action: 'createCompleteSet',
+						status: {
+							detail: 'Transaction failed. Reason: question already resolved.',
+							title: 'Mint failed',
+							tone: 'error',
+						},
+					},
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		await act(() => {
+			fireEvent.click(documentQueries.getByRole('button', { name: 'Mint complete sets' }))
+		})
+
+		const modalQueries = within(documentQueries.getByRole('dialog'))
+		expect(modalQueries.getByText('Mint failed')).not.toBeNull()
+		expect(modalQueries.getByText('Transaction failed. Reason: question already resolved.')).not.toBeNull()
 	})
 
 	void test('keeps non-suppressed trading guard messages visible in the redeem modal', async () => {

--- a/ui/ts/tests/workflowTransactionStatus.test.tsx
+++ b/ui/ts/tests/workflowTransactionStatus.test.tsx
@@ -111,4 +111,26 @@ describe('WorkflowTransactionStatus', () => {
 		})
 		expect((container as HTMLDivElement).textContent).toBe('')
 	})
+
+	test('keeps a dismissed latest action hidden after unmounting and remounting the same dismiss key', async () => {
+		const latestAction = {
+			dismissKey: 'workflow-status-remount-latest-action',
+			rows: [{ label: 'Action', value: 'reportOutcome' }],
+			title: 'Latest Reporting Action',
+		}
+
+		render(<WorkflowTransactionStatus latestAction={latestAction} outcome={undefined} />, container as HTMLDivElement)
+
+		const containerQueries = within(container as HTMLDivElement)
+		await act(async () => {
+			fireEvent.click(containerQueries.getByRole('button', { name: 'Dismiss latest action' }))
+			await Promise.resolve()
+		})
+		expect((container as HTMLDivElement).textContent).toBe('')
+
+		render(null, container as HTMLDivElement)
+		render(<WorkflowTransactionStatus latestAction={latestAction} outcome={undefined} />, container as HTMLDivElement)
+
+		expect((container as HTMLDivElement).textContent).toBe('')
+	})
 })


### PR DESCRIPTION
## Summary
- Update reporting and trading flows to recognize finalized markets and surface clearer guard/status messaging.
- Improve reporting previews with a unified finalization notice, adjusted resolved-market messaging, and corrected game start timestamps.
- Persist dismissed workflow status cards across remounts and refine pool-not-found handling for unresolved addresses.
- Add styling and test coverage for the new finalized-state and status-dismissal behavior.

## Testing
- Not run (PR summary only).
- Added/updated tests covering reporting finalization copy, trading mint guards, inline trading failure status, pool-not-found workflow states, and workflow status dismissal persistence.