### PR TITLE
Handle ended security pools across the workflow UI

### DIFF
--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -20,23 +20,11 @@ import { UniverseLink } from './UniverseLink.js'
 import { TimestampValue } from './TimestampValue.js'
 import { ViewTabs } from './ViewTabs.js'
 import { WorkflowTransactionStatus } from './WorkflowTransactionStatus.js'
-import {
-	AUCTION_TIME_SECONDS,
-	type ForkAuctionStageView,
-	estimateRepPurchased,
-	getForkAuctionStageView,
-	getForkStageDescription,
-	getForkStageDescriptionForState,
-	getOutcomeActionLabel,
-	getSystemStateLabel,
-	getTimeRemaining,
-	getTruthAuctionBidGuardMessage,
-	hasForkActivity,
-	MIGRATION_TIME_SECONDS,
-} from '../lib/forkAuction.js'
+import { AUCTION_TIME_SECONDS, type ForkAuctionStageView, estimateRepPurchased, getForkAuctionStageView, getForkStageDescription, getForkStageDescriptionForState, getOutcomeActionLabel, getTimeRemaining, getTruthAuctionBidGuardMessage, hasForkActivity, MIGRATION_TIME_SECONDS } from '../lib/forkAuction.js'
 import { formatDuration } from '../lib/formatters.js'
 import { isMainnetChain } from '../lib/network.js'
 import { REPORTING_OUTCOME_DROPDOWN_OPTIONS, getReportingOutcomeLabel } from '../lib/reporting.js'
+import { getSecurityPoolDisplayState, getSecurityPoolDisplayStateLabel } from '../lib/securityPoolState.js'
 import type { ListedSecurityPool } from '../types/contracts.js'
 import type { ForkAuctionSectionProps, ReadinessAction } from '../types/components.js'
 
@@ -204,6 +192,10 @@ export function ForkAuctionSection({
 	const truthAuctionAddress = forkAuctionDetails?.truthAuctionAddress ?? previewPool?.truthAuctionAddress
 	const hasPreviewForkActivity = previewPool === undefined ? false : hasForkActivity(previewPool)
 	const forkOnlyFallbackText = getForkOnlyFallbackText(hasPreviewForkActivity)
+	const displaySystemState = getSecurityPoolDisplayState({
+		questionOutcome,
+		systemState,
+	})
 	const forkStageDescription = forkAuctionDetails === undefined ? (systemState === undefined ? undefined : getForkStageDescriptionForState(systemState)) : getForkStageDescription(forkAuctionDetails)
 	const migrationSummaryText = forkAuctionDetails === undefined ? getPreviewMigrationSummary(previewPool, hasPreviewForkActivity) : undefined
 	const hasLoadedPoolContext = securityPoolAddress !== undefined && systemState !== undefined
@@ -336,7 +328,7 @@ export function ForkAuctionSection({
 		{ label: 'Security Pool', value: renderAddress(securityPoolAddress) },
 		{ label: 'Universe', value: universeId === undefined ? UNKNOWN_VALUE : <UniverseLink universeId={universeId} /> },
 		{ label: 'Parent Pool', value: renderAddress(parentSecurityPoolAddress) },
-		{ label: 'System State', value: systemState === undefined ? UNKNOWN_VALUE : getSystemStateLabel(systemState) },
+		{ label: 'System State', value: displaySystemState === undefined ? UNKNOWN_VALUE : getSecurityPoolDisplayStateLabel(displaySystemState) },
 		{ label: 'Fork Type', value: forkAuctionDetails === undefined ? getPreviewForkType(previewPool, hasPreviewForkActivity) : forkAuctionDetails.forkOwnSecurityPool ? 'Own escalation fork' : 'Parent/Zoltar fork' },
 		{ label: 'Question Outcome', value: questionOutcome === undefined ? UNKNOWN_VALUE : getReportingOutcomeLabel(questionOutcome) },
 		{ label: 'Fork Outcome', value: forkOutcome === undefined ? UNKNOWN_VALUE : getReportingOutcomeLabel(forkOutcome) },

--- a/ui/ts/components/LiquidationModal.tsx
+++ b/ui/ts/components/LiquidationModal.tsx
@@ -19,9 +19,12 @@ import { getLiquidationFailureReason, simulateLiquidation } from '../lib/liquida
 import { parseRepAmountInput } from '../lib/marketForm.js'
 import { getOracleRequestEthGuardMessage } from '../lib/oracleRequestEth.js'
 import { getRepPriceSourceCopy, renderRepPriceSourceLabel, type RepPriceSource } from '../lib/repPriceSource.js'
+import { isSecurityPoolEnded } from '../lib/securityPoolState.js'
 import { getVaultCollateralizationPercent } from '../lib/trading.js'
 import type { ActionFeedback } from '../types/components.js'
 import type { ListedSecurityPool, OracleManagerDetails, SecurityPoolOverviewActionResult, SecurityPoolVaultSummary } from '../types/contracts.js'
+
+const LIQUIDATION_ENDED_REASON = 'Liquidation is unavailable after this pool has ended.'
 
 type LiquidationModalProps = {
 	accountAddress: Address | undefined
@@ -220,6 +223,10 @@ export function LiquidationModal({
 	const liquidationExecutionMode = getLiquidationExecutionMode(currentPoolOracleManagerDetails)
 	const buttonLabels = getLiquidationButtonLabels(currentPoolOracleManagerDetails)
 	const trimmedLiquidationTargetVault = liquidationTargetVault.trim()
+	const selectedPoolEnded = isSecurityPoolEnded({
+		questionOutcome: selectedPool?.questionOutcome,
+		systemState: selectedPool?.systemState,
+	})
 	const sameVaultWarning = accountAddress === undefined || trimmedLiquidationTargetVault === '' || !sameAddress(accountAddress, trimmedLiquidationTargetVault) ? undefined : 'Select a target vault that is different from the caller vault.'
 	const liquidationSimulation =
 		targetVaultSummary === undefined || poolOraclePrice === undefined || selectedPool?.securityMultiplier === undefined || liquidationAmountValue === undefined
@@ -255,17 +262,19 @@ export function LiquidationModal({
 			? 'Connect a wallet before liquidating.'
 			: !isMainnet
 				? 'Switch to Ethereum mainnet before liquidating.'
-				: liquidationExecutionMode === 'refreshing'
-					? 'Refreshing Open Oracle validity before liquidation.'
-					: liquidationManagerAddress === undefined || liquidationSecurityPoolAddress === undefined
-						? 'Reload the selected pool before liquidating.'
-						: trimmedLiquidationTargetVault === ''
-							? 'Select a target vault first.'
-							: sameVaultWarning !== undefined
-								? sameVaultWarning
-								: liquidationAmount.trim() === ''
-									? 'Enter a liquidation amount.'
-									: (directLiquidationReason ?? queueLiquidationEthGuardMessage)
+				: selectedPoolEnded
+					? LIQUIDATION_ENDED_REASON
+					: liquidationExecutionMode === 'refreshing'
+						? 'Refreshing Open Oracle validity before liquidation.'
+						: liquidationManagerAddress === undefined || liquidationSecurityPoolAddress === undefined
+							? 'Reload the selected pool before liquidating.'
+							: trimmedLiquidationTargetVault === ''
+								? 'Select a target vault first.'
+								: sameVaultWarning !== undefined
+									? sameVaultWarning
+									: liquidationAmount.trim() === ''
+										? 'Enter a liquidation amount.'
+										: (directLiquidationReason ?? queueLiquidationEthGuardMessage)
 
 	const queuedLiquidationOperation =
 		securityPoolOverviewResult?.action !== 'queueLiquidation' || currentPoolOracleManagerDetails?.pendingOperation?.operation !== 'liquidation' || currentPoolOracleManagerDetails.pendingOperation.targetVault !== liquidationTargetVault ? undefined : currentPoolOracleManagerDetails.pendingOperation

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -27,6 +27,7 @@ import {
 	getLeadingEscalationOutcome,
 	getReportingMaxProfitContribution,
 	getReportingMinimumOutcomeChangeContribution,
+	getSelectedOutcomeRewardWindowFillTimestamp,
 	getReportingTimerPreview,
 	isReportingClosed,
 	previewReportingContribution,
@@ -199,6 +200,30 @@ function getClosedReportingLockReason(escalationPhase: ReturnType<typeof getEsca
 	}
 }
 
+function getLatestOutcomeReminder({ currentTimestamp, projectedFinalizationTimestamp, rewardWindowFillTimestamp, selectedOutcomeLabel }: { currentTimestamp: bigint | undefined; projectedFinalizationTimestamp: bigint | undefined; rewardWindowFillTimestamp: bigint | undefined; selectedOutcomeLabel: string }) {
+	if (projectedFinalizationTimestamp !== undefined && currentTimestamp !== undefined && projectedFinalizationTimestamp <= currentTimestamp) {
+		return <>Check back immediately to confirm the market finalized as {selectedOutcomeLabel}.</>
+	}
+
+	if (rewardWindowFillTimestamp !== undefined && currentTimestamp !== undefined && rewardWindowFillTimestamp > currentTimestamp) {
+		return (
+			<>
+				Check back no later than <TimestampValue {...(currentTimestamp === undefined ? {} : { currentTimestamp })} timestamp={rewardWindowFillTimestamp} /> to confirm {selectedOutcomeLabel} is the leading outcome before the remaining reward-eligible REP on {selectedOutcomeLabel} is filled.
+			</>
+		)
+	}
+
+	if (projectedFinalizationTimestamp !== undefined) {
+		return (
+			<>
+				Check back no later than <TimestampValue {...(currentTimestamp === undefined ? {} : { currentTimestamp })} timestamp={projectedFinalizationTimestamp} /> to confirm {selectedOutcomeLabel} is the leading outcome before finalization.
+			</>
+		)
+	}
+
+	return <>Check back later to confirm {selectedOutcomeLabel} is the leading outcome.</>
+}
+
 function getEffectiveReportingDetails(reportingDetails: ReportingDetails | undefined, currentTimestamp: bigint | undefined) {
 	if (reportingDetails === undefined || currentTimestamp === undefined || reportingDetails.currentTime === currentTimestamp) {
 		return reportingDetails
@@ -267,10 +292,26 @@ export function ReportingSection({
 	const selectedEstimate = activeReportingDetails === undefined || selectedAmount === undefined || selectedOutcome === undefined ? undefined : calculateEstimatedEscalationReturn(activeReportingDetails, selectedOutcome, selectedAmount)
 	const timerPreview = effectiveReportingDetails === undefined || selectedAmount === undefined || selectedOutcome === undefined ? undefined : getReportingTimerPreview(effectiveReportingDetails, selectedOutcome, selectedAmount)
 	const selectedOutcomeLabel = selectedOutcome === undefined ? 'Selected Side' : (outcomeSides.find(side => side.key === selectedOutcome)?.label ?? getReportingOutcomeLabel(selectedOutcome))
+	const projectedFinalizationTimestamp =
+		timerPreview === undefined || effectiveCurrentTimestamp === undefined
+			? undefined
+			: timerPreview.kind === 'not-started'
+				? effectiveCurrentTimestamp + timerPreview.timeUntilEnd
+				: timerPreview.actualState === 'ends-immediately'
+					? effectiveCurrentTimestamp
+					: activeReportingDetails === undefined
+						? undefined
+						: effectiveCurrentTimestamp + getEscalationTimeRemaining(activeReportingDetails) + (timerPreview.timerIncrease ?? 0n)
+	const rewardWindowFillTimestamp = activeReportingDetails === undefined || selectedOutcome === undefined || actualReportDepositAmount === undefined ? undefined : getSelectedOutcomeRewardWindowFillTimestamp(activeReportingDetails, selectedOutcome, actualReportDepositAmount)
 	const getProjectedReportingPreview = () => {
 		if (activeReportingDetails !== undefined && isReportingClosed(activeReportingDetails)) return undefined
 
-		const finalizationReminder = `Check back later to confirm ${selectedOutcomeLabel} is still the leading outcome as finalization approaches.`
+		const finalizationReminder = getLatestOutcomeReminder({
+			currentTimestamp: effectiveCurrentTimestamp,
+			projectedFinalizationTimestamp,
+			rewardWindowFillTimestamp,
+			selectedOutcomeLabel,
+		})
 		if (timerPreview === undefined) {
 			if (selectedEstimate === undefined) return undefined
 

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -28,6 +28,7 @@ import {
 	getReportingMaxProfitContribution,
 	getReportingMinimumOutcomeChangeContribution,
 	getReportingTimerPreview,
+	isReportingClosed,
 	previewReportingContribution,
 } from '../lib/reportingDomain.js'
 import { getReportingReportGuardMessage, getReportingWithdrawGuardMessage } from '../lib/reportingGuards.js'
@@ -183,6 +184,21 @@ function getEscalationGameStartTimestamp(activationTime: bigint | undefined) {
 	return activationTime > ESCALATION_GAME_ACTIVATION_DELAY ? activationTime - ESCALATION_GAME_ACTIVATION_DELAY : 0n
 }
 
+function getClosedReportingLockReason(escalationPhase: ReturnType<typeof getEscalationPhase> | undefined) {
+	switch (escalationPhase) {
+		case 'Resolved':
+			return 'Reporting is closed because escalation has resolved.'
+		case 'Fork Triggered':
+			return 'Reporting is closed because escalation reached non-decision and moved into the fork workflow.'
+		case 'Timed Out':
+			return 'Reporting is closed because the escalation timeout has been reached.'
+		case 'Pending Start':
+		case 'Active':
+		case undefined:
+			return undefined
+	}
+}
+
 function getEffectiveReportingDetails(reportingDetails: ReportingDetails | undefined, currentTimestamp: bigint | undefined) {
 	if (reportingDetails === undefined || currentTimestamp === undefined || reportingDetails.currentTime === currentTimestamp) {
 		return reportingDetails
@@ -223,10 +239,15 @@ export function ReportingSection({
 	const escalationGameStartTimestamp = getEscalationGameStartTimestamp(activeReportingDetails?.activationTime)
 	const reportingStatus: ReportingStatus = effectiveReportingDetails === undefined ? 'missing' : effectiveReportingDetails.status
 	const marketDetails = effectiveReportingDetails?.marketDetails ?? previewMarketDetails
-	const reportingLocked = lockedReason !== undefined
-	const selectedAmount = parseOptionalRepAmountInput(reportingForm.reportAmount)
 	const showFullReporting = mode === 'full-reporting'
 	const showWithdrawOnly = mode === 'withdraw-only'
+	const preOpenLockedReason = lockedReason
+	const closedReportingLockReason = activeReportingDetails !== undefined && isReportingClosed(activeReportingDetails) ? getClosedReportingLockReason(escalationPhase) : undefined
+	const reportControlsLockedReason = showFullReporting ? (preOpenLockedReason ?? closedReportingLockReason) : preOpenLockedReason
+	const reportControlsLocked = reportControlsLockedReason !== undefined
+	const withdrawControlsLockedReason = showWithdrawOnly && loadingReportingDetails ? 'Loading escalation deposits.' : preOpenLockedReason
+	const withdrawControlsLocked = withdrawControlsLockedReason !== undefined
+	const selectedAmount = parseOptionalRepAmountInput(reportingForm.reportAmount)
 	const selectedOutcome = reportingForm.selectedOutcome
 	const selectedSide = selectedOutcome === undefined ? undefined : activeReportingDetails?.sides.find(side => side.key === selectedOutcome)
 	const selectedWithdrawDepositIndexes = reportingForm.selectedWithdrawDepositIndexes
@@ -245,28 +266,68 @@ export function ReportingSection({
 	const actualReportDepositAmount = reportContributionPreview?.actualDepositAmount
 	const selectedEstimate = activeReportingDetails === undefined || selectedAmount === undefined || selectedOutcome === undefined ? undefined : calculateEstimatedEscalationReturn(activeReportingDetails, selectedOutcome, selectedAmount)
 	const timerPreview = effectiveReportingDetails === undefined || selectedAmount === undefined || selectedOutcome === undefined ? undefined : getReportingTimerPreview(effectiveReportingDetails, selectedOutcome, selectedAmount)
-	const projectedFinalizationNotice =
-		timerPreview === undefined
-			? undefined
-			: timerPreview.kind === 'not-started'
-				? `If no one disputes after this report, the market would finalize in ${formatDuration(timerPreview.timeUntilEnd)}.`
-				: activeReportingDetails === undefined
-					? undefined
-					: timerPreview.actualState === 'ends-immediately'
-						? 'If no one disputes after this contribution, the market would finalize immediately.'
-						: `If no one disputes after this contribution, the market would finalize in ${formatDuration(getEscalationTimeRemaining(activeReportingDetails) + (timerPreview.timerIncrease ?? 0n))}.`
 	const selectedOutcomeLabel = selectedOutcome === undefined ? 'Selected Side' : (outcomeSides.find(side => side.key === selectedOutcome)?.label ?? getReportingOutcomeLabel(selectedOutcome))
+	const getProjectedReportingPreview = () => {
+		if (activeReportingDetails !== undefined && isReportingClosed(activeReportingDetails)) return undefined
+
+		const finalizationReminder = `Check back later to confirm ${selectedOutcomeLabel} is still the leading outcome as finalization approaches.`
+		if (timerPreview === undefined) {
+			if (selectedEstimate === undefined) return undefined
+
+			return (
+				<>
+					If {selectedOutcomeLabel} wins and no one else contributes afterward, this amount projects roughly <CurrencyValue value={selectedEstimate.profit} suffix='REP' /> of profit. {finalizationReminder}
+				</>
+			)
+		}
+
+		if (timerPreview.kind === 'not-started') {
+			return (
+				<>
+					If no one disputes after this report, the market would finalize in {formatDuration(timerPreview.timeUntilEnd)}. {finalizationReminder}
+				</>
+			)
+		}
+
+		if (selectedEstimate === undefined || activeReportingDetails === undefined) return undefined
+
+		if (timerPreview.actualState === 'ends-immediately') {
+			return (
+				<>
+					If {selectedOutcomeLabel} wins and no one else contributes afterward, this amount projects roughly <CurrencyValue value={selectedEstimate.profit} suffix='REP' /> of profit. This contribution would end the escalation and finalize the market immediately. {finalizationReminder}
+				</>
+			)
+		}
+
+		const projectedFinalizationDuration = formatDuration(getEscalationTimeRemaining(activeReportingDetails) + (timerPreview.timerIncrease ?? 0n))
+		if (timerPreview.actualState === 'extends') {
+			return (
+				<>
+					If {selectedOutcomeLabel} wins and no one else contributes afterward, this amount projects roughly <CurrencyValue value={selectedEstimate.profit} suffix='REP' /> of profit. This contribution would extend the timer by {formatDuration(timerPreview.timerIncrease ?? 0n)}, and if no one disputes after it, the
+					market would finalize in {projectedFinalizationDuration}. {finalizationReminder}
+				</>
+			)
+		}
+
+		return (
+			<>
+				If {selectedOutcomeLabel} wins and no one else contributes afterward, this amount projects roughly <CurrencyValue value={selectedEstimate.profit} suffix='REP' /> of profit. This contribution would not extend the timer, and if no one disputes after it, the market would finalize in {projectedFinalizationDuration}
+				. {finalizationReminder}
+			</>
+		)
+	}
+	const projectedReportingPreview = getProjectedReportingPreview()
 	const reportButtonLabel = selectedOutcome === undefined ? 'Report / Contribute On Selected Side' : `Report / Contribute ${selectedOutcomeLabel}`
 	const minimumOutcomeChangeContribution = selectedOutcome === undefined ? { amount: undefined, reason: SELECT_OUTCOME_PRESET_REASON } : getReportingMinimumOutcomeChangeContribution(effectiveReportingDetails, selectedOutcome)
 	const maxProfitContribution = selectedOutcome === undefined ? { amount: undefined, reason: SELECT_OUTCOME_PRESET_REASON } : getReportingMaxProfitContribution(effectiveReportingDetails, selectedOutcome)
-	const presetReasons = reportingLocked ? [] : [minimumOutcomeChangeContribution.reason, maxProfitContribution.reason].filter((reason, index, reasons): reason is string => reason !== undefined && !isHiddenPresetReason(reason) && reasons.indexOf(reason) === index)
+	const presetReasons = reportControlsLocked ? [] : [minimumOutcomeChangeContribution.reason, maxProfitContribution.reason].filter((reason, index, reasons): reason is string => reason !== undefined && !isHiddenPresetReason(reason) && reasons.indexOf(reason) === index)
 	const reportAmountError = selectedAmount === undefined && reportingForm.reportAmount.trim() !== '' ? 'Enter a valid report amount to preview profit.' : undefined
 	const reportGuardMessage = getReportingReportGuardMessage({
 		actualDepositAmount: actualReportDepositAmount,
 		accountAddress: accountState.address,
 		contributionPreviewReason: reportContributionPreview?.reason,
 		isMainnet,
-		lockedReason,
+		lockedReason: preOpenLockedReason,
 		reportAmount: reportingForm.reportAmount,
 		reportingStatus,
 		selectedOutcome,
@@ -279,7 +340,7 @@ export function ReportingSection({
 		accountAddress: accountState.address,
 		hasUserDepositsOnSelectedSide: (selectedSide?.userDeposits.length ?? 0) > 0,
 		isMainnet,
-		lockedReason,
+		lockedReason: withdrawControlsLockedReason,
 		reportingStatus,
 		withdrawalEnabled: activeReportingDetails?.withdrawalEnabled ?? false,
 		withdrawalState: effectiveReportingDetails?.withdrawalState,
@@ -336,7 +397,7 @@ export function ReportingSection({
 							onInput={securityPoolAddress => onReportingFormChange({ securityPoolAddress })}
 							placeholder='0x...'
 							action={
-								<button className='secondary' onClick={onLoadReporting} disabled={loadingReportingDetails || reportingLocked} title={reportingLocked ? lockedReason : undefined}>
+								<button className='secondary' onClick={onLoadReporting} disabled={loadingReportingDetails || preOpenLockedReason !== undefined} title={preOpenLockedReason}>
 									{loadingReportingDetails ? <LoadingText>Loading escalation...</LoadingText> : 'Refresh reporting'}
 								</button>
 							}
@@ -387,7 +448,7 @@ export function ReportingSection({
 									key={side.key}
 									bindingCapital={displayBindingCapital}
 									chartScaleMax={chartScaleMax}
-									disabled={reportingLocked}
+									disabled={showWithdrawOnly ? withdrawControlsLocked : reportControlsLocked}
 									isLeading={leadingOutcome === side.key}
 									isSelected={selectedOutcome !== undefined && selectedOutcome === side.key}
 									onSelect={() => onReportingFormChange({ selectedOutcome: side.key, selectedWithdrawDepositIndexes: [] })}
@@ -403,7 +464,7 @@ export function ReportingSection({
 					)}
 					<label className='field'>
 						<span>Report / Contribution Amount (REP)</span>
-						<FormInput value={reportingForm.reportAmount} onInput={event => onReportingFormChange({ reportAmount: event.currentTarget.value })} disabled={reportingLocked} />
+						<FormInput value={reportingForm.reportAmount} onInput={event => onReportingFormChange({ reportAmount: event.currentTarget.value })} disabled={reportControlsLocked} />
 					</label>
 
 					<div className='actions'>
@@ -414,8 +475,8 @@ export function ReportingSection({
 								if (minimumOutcomeChangeContribution.amount === undefined) return
 								onReportingFormChange({ reportAmount: formatCurrencyInputBalance(minimumOutcomeChangeContribution.amount) })
 							}}
-							disabled={reportingLocked || minimumOutcomeChangeContribution.amount === undefined}
-							title={reportingLocked ? lockedReason : minimumOutcomeChangeContribution.reason}
+							disabled={reportControlsLocked || minimumOutcomeChangeContribution.amount === undefined}
+							title={reportControlsLocked ? reportControlsLockedReason : minimumOutcomeChangeContribution.reason}
 						>
 							Min to change proposed outcome
 						</button>
@@ -426,8 +487,8 @@ export function ReportingSection({
 								if (maxProfitContribution.amount === undefined) return
 								onReportingFormChange({ reportAmount: formatCurrencyInputBalance(maxProfitContribution.amount) })
 							}}
-							disabled={reportingLocked || maxProfitContribution.amount === undefined}
-							title={reportingLocked ? lockedReason : maxProfitContribution.reason}
+							disabled={reportControlsLocked || maxProfitContribution.amount === undefined}
+							title={reportControlsLocked ? reportControlsLockedReason : maxProfitContribution.reason}
 						>
 							Max profit
 						</button>
@@ -439,11 +500,6 @@ export function ReportingSection({
 						</p>
 					))}
 					{reportAmountError === undefined ? undefined : <p className='detail'>{reportAmountError}</p>}
-					{selectedEstimate === undefined || selectedOutcome === undefined ? undefined : (
-						<p className='detail'>
-							If {selectedOutcomeLabel} wins and no one else contributes afterward, the current amount projects roughly <CurrencyValue value={selectedEstimate.profit} suffix='REP' /> of profit.
-						</p>
-					)}
 					{actualReportDepositAmount === undefined || selectedAmount === undefined || actualReportDepositAmount === selectedAmount ? undefined : (
 						<p className='detail'>
 							Based on the current escalation state, this action would lock <CurrencyValue value={actualReportDepositAmount} suffix='REP' /> instead of the full entered amount.
@@ -452,25 +508,17 @@ export function ReportingSection({
 					<div className='actions'>
 						<TransactionActionButton idleLabel={reportButtonLabel} pendingLabel='Submitting report...' onClick={onReportOutcome} pending={reportingActiveAction === 'reportOutcome'} availability={{ disabled: reportGuardMessage !== undefined, reason: reportGuardMessage }} />
 					</div>
-					{timerPreview === undefined ? undefined : timerPreview.kind === 'not-started' ? (
-						<p className='detail'>{projectedFinalizationNotice}</p>
-					) : (
-						<>
-							<p className='detail'>
-								{timerPreview.actualState === 'ends-immediately'
-									? 'This contribution would end the escalation immediately instead of extending the timer.'
-									: timerPreview.actualState === 'extends'
-										? `This contribution would extend the timer by ${formatDuration(timerPreview.timerIncrease ?? 0n)}.`
-										: 'This contribution would not extend the timer.'}
-							</p>
-							{projectedFinalizationNotice === undefined ? undefined : <p className='detail'>{projectedFinalizationNotice}</p>}
-						</>
-					)}
+					{projectedReportingPreview === undefined ? undefined : <p className='detail'>{projectedReportingPreview}</p>}
 				</SectionBlock>
 			) : undefined}
 
 			{showWithdrawOnly ? (
 				<SectionBlock title='Withdraw Escalation Deposits'>
+					{loadingReportingDetails ? (
+						<p className='detail'>
+							<LoadingText>Loading escalation deposits...</LoadingText>
+						</p>
+					) : undefined}
 					{selectedSide === undefined ? undefined : selectedSide.userDeposits.length === 0 ? <p className='detail'>Connected wallet has no unsettled deposits on the selected side.</p> : undefined}
 					{selectedSide === undefined || selectedSide.userDeposits.length === 0 ? undefined : (
 						<div className='field'>
@@ -485,7 +533,7 @@ export function ReportingSection({
 											<input
 												type='checkbox'
 												checked={isChecked}
-												disabled={reportingLocked}
+												disabled={withdrawControlsLocked}
 												onChange={event => {
 													const nextSelectedWithdrawDepositIndexes = event.currentTarget.checked ? [...selectedWithdrawDepositIndexes, deposit.depositIndex] : selectedWithdrawDepositIndexes.filter(index => index !== deposit.depositIndex)
 													onReportingFormChange({ selectedWithdrawDepositIndexes: nextSelectedWithdrawDepositIndexes })

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -42,14 +42,17 @@ import { getLiquidationNoticeState } from '../lib/liquidationStatus.js'
 import { resolveRequestedLoadableValueState } from '../lib/loadState.js'
 import { isMainnetChain } from '../lib/network.js'
 import { getReportingLockedUntilMessage } from '../lib/reporting.js'
+import { getSecurityPoolDisplayState, getSecurityPoolDisplayStateLabel, isSecurityPoolEnded, type SecurityPoolDisplayState } from '../lib/securityPoolState.js'
 import { getVaultExecutePendingOperationGuardMessage, getVaultRequestPriceGuardMessage } from '../lib/securityVaultGuards.js'
 import { doesLoadedSecurityVaultMatchSelection, getSelectedVaultAddress, isSelectedVaultOwnedByAccount as isSelectedVaultOwnedByAccountHelper } from '../lib/securityVault.js'
 import { getPoolRegistryPresentation } from '../lib/userCopy.js'
 import { formatUniverseLabel } from '../lib/universe.js'
-import type { SecurityPoolSystemState } from '../types/contracts.js'
 import type { SecurityPoolWorkflowRouteContentProps, ViewTabOption } from '../types/components.js'
 
 type SelectedVaultView = 'browse-vaults' | 'selected-vault'
+
+const POOL_ACTION_LOCK_REASON = 'Vault collateral operations are unavailable after this pool has ended.'
+const LIQUIDATION_ENDED_REASON = 'Liquidation is unavailable after this pool has ended.'
 
 function getPendingOperationLabel(operation: 'liquidation' | 'setSecurityBondsAllowance' | 'withdrawRep') {
 	switch (operation) {
@@ -62,7 +65,7 @@ function getPendingOperationLabel(operation: 'liquidation' | 'setSecurityBondsAl
 	}
 }
 
-function getSecurityPoolStatusBadgeTone(systemState: SecurityPoolSystemState) {
+function getSecurityPoolStatusBadgeTone(systemState: SecurityPoolDisplayState) {
 	return systemState === 'operational' ? 'ok' : 'warn'
 }
 export function SecurityPoolWorkflowSection({
@@ -125,7 +128,16 @@ export function SecurityPoolWorkflowSection({
 		value: selectedPool,
 	})
 	const marketDetails = selectedPool?.marketDetails ?? currentReportingDetails?.marketDetails ?? currentForkAuctionDetails?.marketDetails
-	const selectedPoolState = selectedPool?.systemState ?? currentForkAuctionDetails?.systemState
+	const selectedPoolState = currentForkAuctionDetails?.systemState ?? selectedPool?.systemState
+	const selectedPoolQuestionOutcome = currentForkAuctionDetails?.questionOutcome ?? currentReportingDetails?.questionOutcome ?? selectedPool?.questionOutcome
+	const selectedPoolDisplayState = getSecurityPoolDisplayState({
+		questionOutcome: selectedPoolQuestionOutcome,
+		systemState: selectedPoolState,
+	})
+	const selectedPoolEnded = isSecurityPoolEnded({
+		questionOutcome: selectedPoolQuestionOutcome,
+		systemState: selectedPoolState,
+	})
 	const selectedPoolHasForkActivity = selectedPool !== undefined ? hasForkActivity(selectedPool) : currentForkAuctionDetails !== undefined ? hasForkActivity(currentForkAuctionDetails) : false
 	const currentTimestamp = chainCurrentTimestamp ?? currentReportingDetails?.currentTime ?? currentForkAuctionDetails?.currentTime
 	const reportingReady = marketDetails !== undefined && currentTimestamp !== undefined && marketDetails.endTime <= currentTimestamp
@@ -222,6 +234,8 @@ export function SecurityPoolWorkflowSection({
 		walletEthBalance: accountState.ethBalance,
 	})
 	const selectedPendingOperationId = currentPoolOracleManagerDetails?.pendingOperationSlotId ?? 0n
+	const selectedPoolActionLockReason = selectedPoolEnded ? POOL_ACTION_LOCK_REASON : undefined
+	const liquidationDisabledReason = selectedPoolEnded ? LIQUIDATION_ENDED_REASON : undefined
 	const pendingOperationInput = manualPendingOperationId.trim() !== '' ? manualPendingOperationId.trim() : selectedPendingOperationId > 0n ? selectedPendingOperationId.toString() : ''
 	const resolvedPendingOperationId =
 		pendingOperationInput === ''
@@ -364,7 +378,16 @@ export function SecurityPoolWorkflowSection({
 
 	return (
 		<RouteWorkflowPanel showHeader={showHeader} title='Selected Pool'>
-			<StickyObjectContext {...(loadedSelectedPool === undefined ? {} : { badge: <span className={`badge ${getSecurityPoolStatusBadgeTone(loadedSelectedPool.systemState)}`}>{loadedSelectedPool.systemState}</span> })} sticky={false} title={getSelectedPoolCardTitle()} items={[]}>
+			<StickyObjectContext
+				{...(loadedSelectedPool === undefined || selectedPoolDisplayState === undefined
+					? {}
+					: {
+							badge: <span className={`badge ${getSecurityPoolStatusBadgeTone(selectedPoolDisplayState)}`}>{getSecurityPoolDisplayStateLabel(selectedPoolDisplayState)}</span>,
+						})}
+				sticky={false}
+				title={getSelectedPoolCardTitle()}
+				items={[]}
+			>
 				<div className='selected-pool-context-controls'>
 					<div className='selected-pool-context-lookup'>
 						<LookupFieldRow
@@ -496,7 +519,8 @@ export function SecurityPoolWorkflowSection({
 																<button
 																	className='destructive'
 																	onClick={() => onOpenLiquidationModal(selectedPool.managerAddress, selectedPool.securityPoolAddress, vault.vaultAddress, vault.securityBondAllowance)}
-																	disabled={accountState.address === undefined || !isMainnet || currentPoolOracleManagerDetails?.isPriceValid === false}
+																	disabled={accountState.address === undefined || !isMainnet || currentPoolOracleManagerDetails?.isPriceValid === false || liquidationDisabledReason !== undefined}
+																	title={liquidationDisabledReason}
 																>
 																	Liquidate Vault
 																</button>
@@ -518,8 +542,9 @@ export function SecurityPoolWorkflowSection({
 														actionLabel: 'Liquidate Vault',
 														description: 'Queue a high-risk liquidation against the selected vault.',
 														key: 'liquidate-vault',
-														readiness: 'ready',
+														readiness: liquidationDisabledReason === undefined ? 'ready' : 'blocked',
 														title: 'Liquidate Vault',
+														...(liquidationDisabledReason === undefined ? {} : { blocker: liquidationDisabledReason }),
 														...(selectedPool === undefined || selectedVaultDetails === undefined ? { blocker: 'Refresh the selected vault first.' } : selectedVaultAddress === '' ? { blocker: 'Select a pool and vault first.' } : {}),
 														...(selectedPool === undefined || selectedVaultDetails === undefined || selectedVaultAddress === ''
 															? {}
@@ -531,6 +556,7 @@ export function SecurityPoolWorkflowSection({
 												modalFirst
 												onViewStagedOperations={() => onSelectedPoolViewChange('staged-operations')}
 												oracleManagerDetails={currentPoolOracleManagerDetails}
+												poolActionLockReason={selectedPoolActionLockReason}
 												selectedPoolTotalRepDeposit={selectedPool?.totalRepDeposit}
 												selectedPoolTotalSecurityBondAllowance={selectedPool?.totalSecurityBondAllowance}
 												showHeader={false}
@@ -633,7 +659,7 @@ export function SecurityPoolWorkflowSection({
 													}}
 													pending={poolOracleActiveAction === 'executeStagedOperation'}
 													tone='secondary'
-													availability={{ disabled: executePendingOperationGuardMessage !== undefined, reason: executePendingOperationGuardMessage }}
+													availability={{ disabled: executePendingOperationGuardMessage !== undefined || selectedPoolActionLockReason !== undefined, reason: executePendingOperationGuardMessage ?? selectedPoolActionLockReason }}
 												/>
 											)}
 										</div>

--- a/ui/ts/components/SecurityPoolsOverviewSection.tsx
+++ b/ui/ts/components/SecurityPoolsOverviewSection.tsx
@@ -16,9 +16,11 @@ import { TransactionStatusCard } from './TransactionStatusCard.js'
 import { WorkflowSubsection } from './WorkflowSubsection.js'
 import { sameAddress } from '../lib/address.js'
 import { isMainnetChain } from '../lib/network.js'
+import { getSecurityPoolDisplayState, getSecurityPoolDisplayStateLabel, type SecurityPoolDisplayState, isSecurityPoolEnded } from '../lib/securityPoolState.js'
 import { getPoolRegistryPresentation } from '../lib/userCopy.js'
-import type { ListedSecurityPool } from '../types/contracts.js'
 import type { SecurityPoolsOverviewSectionProps } from '../types/components.js'
+
+const LIQUIDATION_ENDED_REASON = 'Liquidation is unavailable after this pool has ended.'
 
 export function SecurityPoolsOverviewSection({
 	accountState,
@@ -50,7 +52,7 @@ export function SecurityPoolsOverviewSection({
 }: SecurityPoolsOverviewSectionProps) {
 	const isMainnet = isMainnetChain(accountState.chainId)
 	const [searchText, setSearchText] = useState('')
-	const [systemStateFilter, setSystemStateFilter] = useState<'all' | ListedSecurityPool['systemState']>('all')
+	const [systemStateFilter, setSystemStateFilter] = useState<'all' | SecurityPoolDisplayState>('all')
 	const [vaultFilter, setVaultFilter] = useState<'all' | 'has-vaults' | 'empty'>('all')
 	const registryPresentation = getPoolRegistryPresentation({
 		hasLoaded: hasLoadedSecurityPools,
@@ -64,7 +66,11 @@ export function SecurityPoolsOverviewSection({
 	const callerVaultSummary = accountState.address === undefined ? undefined : selectedPool?.vaults.find(vault => sameAddress(vault.vaultAddress, accountState.address))
 	const normalizedSearchText = searchText.trim().toLowerCase()
 	const filteredSecurityPools = securityPools.filter(pool => {
-		if (systemStateFilter !== 'all' && pool.systemState !== systemStateFilter) return false
+		const displayState = getSecurityPoolDisplayState({
+			questionOutcome: pool.questionOutcome,
+			systemState: pool.systemState,
+		})
+		if (systemStateFilter !== 'all' && displayState !== systemStateFilter) return false
 		if (vaultFilter === 'has-vaults' && pool.vaults.length === 0) return false
 		if (vaultFilter === 'empty' && pool.vaults.length > 0) return false
 		if (normalizedSearchText === '') return true
@@ -103,9 +109,10 @@ export function SecurityPoolsOverviewSection({
 					</label>
 					<label className='field'>
 						<span>System State</span>
-						<select value={systemStateFilter} onChange={event => setSystemStateFilter(event.currentTarget.value as 'all' | ListedSecurityPool['systemState'])}>
+						<select value={systemStateFilter} onChange={event => setSystemStateFilter(event.currentTarget.value as 'all' | SecurityPoolDisplayState)}>
 							<option value='all'>All states</option>
 							<option value='operational'>Operational</option>
+							<option value='ended'>Ended</option>
 							<option value='poolForked'>Pool Forked</option>
 							<option value='forkMigration'>Fork Migration</option>
 							<option value='forkTruthAuction'>Truth Auction</option>
@@ -134,44 +141,61 @@ export function SecurityPoolsOverviewSection({
 					<StateHint presentation={{ key: 'empty', badgeLabel: 'No matches', badgeTone: 'muted', detail: 'No pools match the current search and filter settings.' }} />
 				) : (
 					<div className='entity-card-list'>
-						{filteredSecurityPools.map(pool => (
-							<EntityCard
-								key={pool.securityPoolAddress}
-								title={getQuestionTitle(pool.marketDetails)}
-								variant='record'
-								badge={<span className={`badge ${pool.systemState === 'operational' ? 'ok' : 'warning'}`}>{pool.systemState}</span>}
-								actions={
-									onSelectSecurityPool === undefined ? undefined : (
-										<button className='primary' onClick={() => onSelectSecurityPool(pool.securityPoolAddress)}>
-											Open Pool
-										</button>
-									)
-								}
-							>
-								<WorkflowSubsection title='Question'>
-									<Question question={pool.marketDetails} />
-								</WorkflowSubsection>
-
-								<WorkflowSubsection title='Pool'>
-									<SecurityPoolSummaryMetrics pool={pool} repPerEthPrice={repPerEthPrice} repPerEthSource={repPerEthSource} repPerEthSourceUrl={repPerEthSourceUrl} showPoolAddress showUniverse />
-								</WorkflowSubsection>
-
-								<WorkflowSubsection title='Vaults'>
-									<SecurityPoolVaultDirectory
-										emptyState={<StateHint presentation={{ key: 'empty', badgeLabel: 'None yet', badgeTone: 'muted', detail: 'No vaults in this pool yet.' }} />}
-										pool={pool}
-										renderActions={vault => (
-											<button className='destructive' onClick={() => onOpenLiquidationModal(pool.managerAddress, pool.securityPoolAddress, vault.vaultAddress, vault.securityBondAllowance)} disabled={accountState.address === undefined || !isMainnet}>
-												Liquidate Vault
+						{filteredSecurityPools.map(pool => {
+							const displayState = getSecurityPoolDisplayState({
+								questionOutcome: pool.questionOutcome,
+								systemState: pool.systemState,
+							})
+							const liquidationDisabledReason = isSecurityPoolEnded({
+								questionOutcome: pool.questionOutcome,
+								systemState: pool.systemState,
+							})
+								? LIQUIDATION_ENDED_REASON
+								: undefined
+							return (
+								<EntityCard
+									key={pool.securityPoolAddress}
+									title={getQuestionTitle(pool.marketDetails)}
+									variant='record'
+									badge={<span className={`badge ${displayState === 'operational' ? 'ok' : 'warning'}`}>{displayState === undefined ? 'Unknown' : getSecurityPoolDisplayStateLabel(displayState)}</span>}
+									actions={
+										onSelectSecurityPool === undefined ? undefined : (
+											<button className='primary' onClick={() => onSelectSecurityPool(pool.securityPoolAddress)}>
+												Open Pool
 											</button>
-										)}
-										repPerEthPrice={repPerEthPrice}
-										repPerEthSource={repPerEthSource}
-										repPerEthSourceUrl={repPerEthSourceUrl}
-									/>
-								</WorkflowSubsection>
-							</EntityCard>
-						))}
+										)
+									}
+								>
+									<WorkflowSubsection title='Question'>
+										<Question question={pool.marketDetails} />
+									</WorkflowSubsection>
+
+									<WorkflowSubsection title='Pool'>
+										<SecurityPoolSummaryMetrics pool={pool} repPerEthPrice={repPerEthPrice} repPerEthSource={repPerEthSource} repPerEthSourceUrl={repPerEthSourceUrl} showPoolAddress showUniverse />
+									</WorkflowSubsection>
+
+									<WorkflowSubsection title='Vaults'>
+										<SecurityPoolVaultDirectory
+											emptyState={<StateHint presentation={{ key: 'empty', badgeLabel: 'None yet', badgeTone: 'muted', detail: 'No vaults in this pool yet.' }} />}
+											pool={pool}
+											renderActions={vault => (
+												<button
+													className='destructive'
+													onClick={() => onOpenLiquidationModal(pool.managerAddress, pool.securityPoolAddress, vault.vaultAddress, vault.securityBondAllowance)}
+													disabled={accountState.address === undefined || !isMainnet || liquidationDisabledReason !== undefined}
+													title={liquidationDisabledReason}
+												>
+													Liquidate Vault
+												</button>
+											)}
+											repPerEthPrice={repPerEthPrice}
+											repPerEthSource={repPerEthSource}
+											repPerEthSourceUrl={repPerEthSourceUrl}
+										/>
+									</WorkflowSubsection>
+								</EntityCard>
+							)
+						})}
 					</div>
 				)}
 			</SectionBlock>

--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -231,6 +231,7 @@ export function SecurityVaultSection({
 	oracleManagerDetails,
 	onViewStagedOperations,
 	onWithdrawRep,
+	poolActionLockReason,
 	repPerEthPrice,
 	repPerEthSource,
 	repPerEthSourceUrl,
@@ -317,47 +318,55 @@ export function SecurityVaultSection({
 	const canClaimFees = selectedVaultIsOwnedByAccount && isMainnet && hasClaimableFees
 	const hasSufficientDepositAllowance = selectedVaultIsOwnedByAccount && depositAmount !== undefined && depositAmount > 0n && approvalRequirement.hasSufficientApproval
 	const hasInsufficientRepBalance = repBalanceGap !== undefined && repBalanceGap > 0n
-	const canWithdrawRep = selectedVaultIsOwnedByAccount && accountState.address !== undefined && isMainnet && hasValidOraclePrice && hasWithdrawAmount && withdrawableRepAmount !== undefined && withdrawableRepAmount > 0n
+	const canWithdrawRep = poolActionLockReason === undefined && selectedVaultIsOwnedByAccount && accountState.address !== undefined && isMainnet && hasValidOraclePrice && hasWithdrawAmount && withdrawableRepAmount !== undefined && withdrawableRepAmount > 0n
 	const claimFeesGuardMessage = getVaultClaimFeesGuardMessage({
 		hasClaimableFees,
 		isMainnet,
 		selectedVaultIsOwnedByAccount,
 	})
-	const setSecurityBondAllowanceGuardMessage = getVaultSetSecurityBondAllowanceGuardMessage({
-		hasValidOraclePrice,
-		isMainnet,
-		maxSecurityBondAllowanceAmount,
-		requestPriceEthCost: oracleManagerDetails?.requestPriceEthCost,
-		securityBondAllowanceAmount,
-		selectedVaultDetailsLoaded: currentSelectedVaultDetails !== undefined,
-		selectedVaultIsOwnedByAccount,
-		walletEthBalance: accountState.ethBalance,
-	})
-	const depositGuardMessage = getVaultDepositGuardMessage({
-		accountAddress: accountState.address,
-		approvalSatisfied: hasSufficientDepositAllowance,
-		isDepositBelowMinimum,
-		isMainnet,
-		repBalanceGap: hasInsufficientRepBalance ? repBalanceGap : undefined,
-		selectedVaultDetailsLoaded: currentSelectedVaultDetails !== undefined,
-		selectedVaultIsOwnedByAccount,
-	})
-	const withdrawRepGuardMessage = getVaultWithdrawGuardMessage({
-		accountAddress: accountState.address,
-		hasValidOraclePrice,
-		isMainnet,
-		requestPriceEthCost: oracleManagerDetails?.requestPriceEthCost,
-		selectedVaultIsOwnedByAccount,
-		withdrawAmount: hasWithdrawAmount ? withdrawAmount : undefined,
-		withdrawableRepAmount,
-		walletEthBalance: accountState.ethBalance,
-	})
-	const approvalGuardMessage = getVaultApprovalGuardMessage({
-		accountAddress: accountState.address,
-		isMainnet,
-		selectedVaultDetailsLoaded: !securityVaultMissing && currentSelectedVaultDetails !== undefined,
-		selectedVaultIsOwnedByAccount,
-	})
+	const setSecurityBondAllowanceGuardMessage =
+		poolActionLockReason ??
+		getVaultSetSecurityBondAllowanceGuardMessage({
+			hasValidOraclePrice,
+			isMainnet,
+			maxSecurityBondAllowanceAmount,
+			requestPriceEthCost: oracleManagerDetails?.requestPriceEthCost,
+			securityBondAllowanceAmount,
+			selectedVaultDetailsLoaded: currentSelectedVaultDetails !== undefined,
+			selectedVaultIsOwnedByAccount,
+			walletEthBalance: accountState.ethBalance,
+		})
+	const depositGuardMessage =
+		poolActionLockReason ??
+		getVaultDepositGuardMessage({
+			accountAddress: accountState.address,
+			approvalSatisfied: hasSufficientDepositAllowance,
+			isDepositBelowMinimum,
+			isMainnet,
+			repBalanceGap: hasInsufficientRepBalance ? repBalanceGap : undefined,
+			selectedVaultDetailsLoaded: currentSelectedVaultDetails !== undefined,
+			selectedVaultIsOwnedByAccount,
+		})
+	const withdrawRepGuardMessage =
+		poolActionLockReason ??
+		getVaultWithdrawGuardMessage({
+			accountAddress: accountState.address,
+			hasValidOraclePrice,
+			isMainnet,
+			requestPriceEthCost: oracleManagerDetails?.requestPriceEthCost,
+			selectedVaultIsOwnedByAccount,
+			withdrawAmount: hasWithdrawAmount ? withdrawAmount : undefined,
+			withdrawableRepAmount,
+			walletEthBalance: accountState.ethBalance,
+		})
+	const approvalGuardMessage =
+		poolActionLockReason ??
+		getVaultApprovalGuardMessage({
+			accountAddress: accountState.address,
+			isMainnet,
+			selectedVaultDetailsLoaded: !securityVaultMissing && currentSelectedVaultDetails !== undefined,
+			selectedVaultIsOwnedByAccount,
+		})
 	const autoLoadKey = `${normalizeAddress(selectedVaultAddress) ?? ''}:${normalizeAddress(normalizedSecurityVaultForm.securityPoolAddress) ?? ''}`
 	const hasLoadedCurrentVault = currentSelectedVaultDetails !== undefined && sameAddress(currentSelectedVaultDetails.vaultAddress, selectedVaultAddress) && sameAddress(currentSelectedVaultDetails.securityPoolAddress, normalizedSecurityVaultForm.securityPoolAddress)
 	const lastAutoLoadKey = useRef<string | undefined>(undefined)
@@ -409,24 +418,27 @@ export function SecurityVaultSection({
 			description: 'Add REP to the selected vault.',
 			key: 'deposit-rep',
 			onAction: () => setVaultActionModal('deposit-rep'),
-			readiness: 'ready',
+			readiness: poolActionLockReason === undefined ? 'ready' : 'blocked',
 			title: 'Deposit REP',
+			...(poolActionLockReason === undefined ? {} : { blocker: poolActionLockReason }),
 		},
 		{
 			actionLabel: 'Withdraw REP',
 			description: 'Queue a REP withdrawal once a valid oracle price exists.',
 			key: 'withdraw-rep',
 			onAction: () => setVaultActionModal('withdraw-rep'),
-			readiness: 'ready',
+			readiness: poolActionLockReason === undefined ? 'ready' : 'blocked',
 			title: 'Withdraw REP',
+			...(poolActionLockReason === undefined ? {} : { blocker: poolActionLockReason }),
 		},
 		{
 			actionLabel: 'Set Bond Allowance',
 			description: 'Queue a new security bond allowance using the current oracle price context.',
 			key: 'set-bond-allowance',
 			onAction: () => setVaultActionModal('set-bond-allowance'),
-			readiness: 'ready',
+			readiness: poolActionLockReason === undefined ? 'ready' : 'blocked',
 			title: 'Set Security Bond Allowance',
+			...(poolActionLockReason === undefined ? {} : { blocker: poolActionLockReason }),
 		},
 		{
 			actionLabel: 'Claim Fees',
@@ -467,7 +479,7 @@ export function SecurityVaultSection({
 						<label className='field'>
 							<span>REP Collateral Amount</span>
 							<div className='field-inline'>
-								<FormInput className='field-inline-input' value={normalizedSecurityVaultForm.depositAmount} onInput={event => onSecurityVaultFormChange({ depositAmount: event.currentTarget.value })} />
+								<FormInput className='field-inline-input' value={normalizedSecurityVaultForm.depositAmount} onInput={event => onSecurityVaultFormChange({ depositAmount: event.currentTarget.value })} disabled={poolActionLockReason !== undefined} />
 								<button
 									className='quiet field-inline-action'
 									type='button'
@@ -475,7 +487,7 @@ export function SecurityVaultSection({
 										if (securityVaultRepBalance === undefined) return
 										onSecurityVaultFormChange({ depositAmount: formatCurrencyInputBalance(securityVaultRepBalance) })
 									}}
-									disabled={securityVaultRepBalance === undefined}
+									disabled={securityVaultRepBalance === undefined || poolActionLockReason !== undefined}
 								>
 									Max
 								</button>
@@ -552,7 +564,7 @@ export function SecurityVaultSection({
 						<label className='field'>
 							<span>REP Withdraw Amount</span>
 							<div className='field-inline'>
-								<FormInput className='field-inline-input' value={normalizedSecurityVaultForm.repWithdrawAmount} onInput={event => onSecurityVaultFormChange({ repWithdrawAmount: event.currentTarget.value })} />
+								<FormInput className='field-inline-input' value={normalizedSecurityVaultForm.repWithdrawAmount} onInput={event => onSecurityVaultFormChange({ repWithdrawAmount: event.currentTarget.value })} disabled={poolActionLockReason !== undefined} />
 								<button
 									className='quiet field-inline-action'
 									type='button'
@@ -560,7 +572,7 @@ export function SecurityVaultSection({
 										if (withdrawableRepAmount === undefined) return
 										onSecurityVaultFormChange({ repWithdrawAmount: formatCurrencyInputBalance(withdrawableRepAmount) })
 									}}
-									disabled={withdrawableRepAmount === undefined}
+									disabled={withdrawableRepAmount === undefined || poolActionLockReason !== undefined}
 								>
 									Max
 								</button>
@@ -610,8 +622,8 @@ export function SecurityVaultSection({
 						<label className='field'>
 							<span>Security Bond Allowance Amount</span>
 							<div className='field-inline'>
-								<FormInput className='field-inline-input' value={normalizedSecurityVaultForm.securityBondAllowanceAmount} onInput={event => onSecurityVaultFormChange({ securityBondAllowanceAmount: event.currentTarget.value })} />
-								<button className='quiet field-inline-action' type='button' onClick={() => onSecurityVaultFormChange({ securityBondAllowanceAmount: formatCurrencyInputBalance(maxSecurityBondAllowanceAmount) })} disabled={maxSecurityBondAllowanceAmount <= 0n}>
+								<FormInput className='field-inline-input' value={normalizedSecurityVaultForm.securityBondAllowanceAmount} onInput={event => onSecurityVaultFormChange({ securityBondAllowanceAmount: event.currentTarget.value })} disabled={poolActionLockReason !== undefined} />
+								<button className='quiet field-inline-action' type='button' onClick={() => onSecurityVaultFormChange({ securityBondAllowanceAmount: formatCurrencyInputBalance(maxSecurityBondAllowanceAmount) })} disabled={maxSecurityBondAllowanceAmount <= 0n || poolActionLockReason !== undefined}>
 									Max
 								</button>
 							</div>
@@ -681,7 +693,7 @@ export function SecurityVaultSection({
 				<label className='field'>
 					<span>REP Collateral Amount</span>
 					<div className='field-inline'>
-						<FormInput className='field-inline-input' value={normalizedSecurityVaultForm.depositAmount} onInput={event => onSecurityVaultFormChange({ depositAmount: event.currentTarget.value })} />
+						<FormInput className='field-inline-input' value={normalizedSecurityVaultForm.depositAmount} onInput={event => onSecurityVaultFormChange({ depositAmount: event.currentTarget.value })} disabled={poolActionLockReason !== undefined} />
 						<button
 							className='quiet field-inline-action'
 							type='button'
@@ -689,7 +701,7 @@ export function SecurityVaultSection({
 								if (securityVaultRepBalance === undefined) return
 								onSecurityVaultFormChange({ depositAmount: formatCurrencyInputBalance(securityVaultRepBalance) })
 							}}
-							disabled={securityVaultRepBalance === undefined}
+							disabled={securityVaultRepBalance === undefined || poolActionLockReason !== undefined}
 						>
 							Max
 						</button>
@@ -739,8 +751,8 @@ export function SecurityVaultSection({
 						<label className='field'>
 							<span>Security Bond Allowance Amount</span>
 							<div className='field-inline'>
-								<FormInput className='field-inline-input' value={normalizedSecurityVaultForm.securityBondAllowanceAmount} onInput={event => onSecurityVaultFormChange({ securityBondAllowanceAmount: event.currentTarget.value })} />
-								<button className='quiet field-inline-action' type='button' onClick={() => onSecurityVaultFormChange({ securityBondAllowanceAmount: formatCurrencyInputBalance(maxSecurityBondAllowanceAmount) })} disabled={maxSecurityBondAllowanceAmount <= 0n}>
+								<FormInput className='field-inline-input' value={normalizedSecurityVaultForm.securityBondAllowanceAmount} onInput={event => onSecurityVaultFormChange({ securityBondAllowanceAmount: event.currentTarget.value })} disabled={poolActionLockReason !== undefined} />
+								<button className='quiet field-inline-action' type='button' onClick={() => onSecurityVaultFormChange({ securityBondAllowanceAmount: formatCurrencyInputBalance(maxSecurityBondAllowanceAmount) })} disabled={maxSecurityBondAllowanceAmount <= 0n || poolActionLockReason !== undefined}>
 									Max
 								</button>
 							</div>
@@ -777,7 +789,7 @@ export function SecurityVaultSection({
 				<label className='field'>
 					<span>REP Withdraw Amount</span>
 					<div className='field-inline'>
-						<FormInput className='field-inline-input' value={normalizedSecurityVaultForm.repWithdrawAmount} onInput={event => onSecurityVaultFormChange({ repWithdrawAmount: event.currentTarget.value })} />
+						<FormInput className='field-inline-input' value={normalizedSecurityVaultForm.repWithdrawAmount} onInput={event => onSecurityVaultFormChange({ repWithdrawAmount: event.currentTarget.value })} disabled={poolActionLockReason !== undefined} />
 						<button
 							className='quiet field-inline-action'
 							type='button'
@@ -785,7 +797,7 @@ export function SecurityVaultSection({
 								if (withdrawableRepAmount === undefined) return
 								onSecurityVaultFormChange({ repWithdrawAmount: formatCurrencyInputBalance(withdrawableRepAmount) })
 							}}
-							disabled={withdrawableRepAmount === undefined}
+							disabled={withdrawableRepAmount === undefined || poolActionLockReason !== undefined}
 						>
 							Max
 						</button>

--- a/ui/ts/lib/forkAuction.ts
+++ b/ui/ts/lib/forkAuction.ts
@@ -23,21 +23,6 @@ type ForkAuctionStageSource = {
 	truthAuctionStartedAt: bigint
 }
 
-export function getSystemStateLabel(state: SecurityPoolSystemState) {
-	switch (state) {
-		case 'operational':
-			return 'Operational'
-		case 'poolForked':
-			return 'Pool Forked'
-		case 'forkMigration':
-			return 'Fork Migration'
-		case 'forkTruthAuction':
-			return 'Truth Auction'
-		default:
-			return assertNever(state)
-	}
-}
-
 export function getOutcomeActionLabel(outcome: ReportingOutcomeKey) {
 	return getReportingOutcomeLabel(outcome)
 }

--- a/ui/ts/lib/reportingDomain.ts
+++ b/ui/ts/lib/reportingDomain.ts
@@ -378,6 +378,24 @@ export function getReportingMaxProfitContribution(details: ReportingDetails | un
 	return getMaxProfitContribution(details, selectedOutcome)
 }
 
+export function getSelectedOutcomeRewardWindowFillTimestamp(details: ActiveReportingDetails, selectedOutcome: ReportingOutcomeKey, acceptedAmount: bigint) {
+	if (acceptedAmount <= 0n) return undefined
+
+	const { largestOtherBalance, selectedSide } = getSelectedAndOtherSides(details, selectedOutcome)
+	if (selectedSide === undefined) return undefined
+
+	const availableRoom = getAvailableRoom(details, selectedSide.balance)
+	const effectiveAmount = acceptedAmount > availableRoom ? availableRoom : acceptedAmount
+	const projectedSelectedBalance = selectedSide.balance + effectiveAmount
+	const rewardEligibleCap = largestOtherBalance + largestOtherBalance / 2n
+	if (rewardEligibleCap <= 0n) return undefined
+
+	const targetFinalBalance = rewardEligibleCap < details.nonDecisionThreshold ? rewardEligibleCap : details.nonDecisionThreshold
+	if (projectedSelectedBalance >= targetFinalBalance) return undefined
+
+	return details.activationTime + computeEscalationTimeSinceStartFromAttritionCost(details.startBond, details.nonDecisionThreshold, targetFinalBalance)
+}
+
 export function calculateEstimatedEscalationReturn(details: ActiveReportingDetails, selectedOutcome: ReportingOutcomeKey, amount: bigint) {
 	if (amount <= 0n) {
 		return {

--- a/ui/ts/lib/securityPoolState.ts
+++ b/ui/ts/lib/securityPoolState.ts
@@ -1,0 +1,31 @@
+import { assertNever } from './assert.js'
+import type { ReportingOutcomeKey, SecurityPoolSystemState } from '../types/contracts.js'
+
+export type SecurityPoolDisplayState = SecurityPoolSystemState | 'ended'
+
+export function isSecurityPoolEnded({ questionOutcome, systemState }: { questionOutcome: ReportingOutcomeKey | 'none' | undefined; systemState: SecurityPoolSystemState | undefined }) {
+	return systemState === 'operational' && questionOutcome !== undefined && questionOutcome !== 'none'
+}
+
+export function getSecurityPoolDisplayState({ questionOutcome, systemState }: { questionOutcome: ReportingOutcomeKey | 'none' | undefined; systemState: SecurityPoolSystemState | undefined }): SecurityPoolDisplayState | undefined {
+	if (systemState === undefined) return undefined
+	if (isSecurityPoolEnded({ questionOutcome, systemState })) return 'ended'
+	return systemState
+}
+
+export function getSecurityPoolDisplayStateLabel(state: SecurityPoolDisplayState) {
+	switch (state) {
+		case 'operational':
+			return 'Operational'
+		case 'ended':
+			return 'Ended'
+		case 'poolForked':
+			return 'Pool Forked'
+		case 'forkMigration':
+			return 'Fork Migration'
+		case 'forkTruthAuction':
+			return 'Truth Auction'
+		default:
+			return assertNever(state)
+	}
+}

--- a/ui/ts/lib/securityPoolWorkflow.ts
+++ b/ui/ts/lib/securityPoolWorkflow.ts
@@ -60,7 +60,6 @@ export function getSelectedPoolWorkflowLockedPresentation({ hasSelectedPoolAddre
 
 	if (hasSelectedPoolAddress) {
 		return {
-			actionHint: 'Refresh this address after the pool is deployed.',
 			badgeLabel: 'Not found',
 			badgeTone: 'blocked',
 			detail: 'Pool not found.',

--- a/ui/ts/tests/liquidationModal.test.tsx
+++ b/ui/ts/tests/liquidationModal.test.tsx
@@ -77,7 +77,7 @@ function createSelectedPool(overrides: Partial<ListedSecurityPool> = {}): Listed
 		marketDetails: createMarketDetails(),
 		migratedRep: 0n,
 		parent: zeroAddress,
-		questionOutcome: 'yes',
+		questionOutcome: 'none',
 		questionId: '0x01',
 		securityMultiplier: 2n,
 		securityPoolAddress: zeroAddress,
@@ -143,6 +143,34 @@ describe('LiquidationModal', () => {
 			/>,
 		)
 	}
+
+	test('disables execute liquidation when the selected pool has ended', async () => {
+		const renderedComponent = await renderLiquidationModal({
+			currentPoolOracleManagerDetails: createOracleManagerDetails({
+				isPriceValid: true,
+			}),
+			selectedPool: createSelectedPool({
+				questionOutcome: 'yes',
+			}),
+		})
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expectTransactionButtonDisabled(document.body, 'Execute Liquidation', 'Liquidation is unavailable after this pool has ended.')
+	})
+
+	test('disables queued liquidation when the selected pool has ended', async () => {
+		const renderedComponent = await renderLiquidationModal({
+			currentPoolOracleManagerDetails: createOracleManagerDetails({
+				isPriceValid: false,
+			}),
+			selectedPool: createSelectedPool({
+				questionOutcome: 'yes',
+			}),
+		})
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expectTransactionButtonDisabled(document.body, 'Queue Liquidation', 'Liquidation is unavailable after this pool has ended.')
+	})
 
 	test('traps focus while open and restores it when closed', async () => {
 		let open = true

--- a/ui/ts/tests/reportingDomain.test.ts
+++ b/ui/ts/tests/reportingDomain.test.ts
@@ -14,6 +14,7 @@ import {
 	getReportingMaxProfitContribution,
 	getReportingMinimumOutcomeChangeContribution,
 	getReportingTimerPreview,
+	getSelectedOutcomeRewardWindowFillTimestamp,
 	isReportingClosed,
 	previewReportingContribution,
 	projectEscalationEndTime,
@@ -326,6 +327,18 @@ describe('reportingDomain', () => {
 			amount: undefined,
 			reason: 'Max profit preset unavailable because the reward window is already filled on the selected side.',
 		})
+	})
+
+	test('getSelectedOutcomeRewardWindowFillTimestamp returns the future reward-window fill time when room remains', () => {
+		const details = createDynamicReportingDetails()
+
+		expect(getSelectedOutcomeRewardWindowFillTimestamp(details, 'no', rep(2n))).toBe(details.activationTime + computeEscalationTimeSinceStartFromAttritionCost(details.startBond, details.nonDecisionThreshold, rep(12n)))
+	})
+
+	test('getSelectedOutcomeRewardWindowFillTimestamp returns undefined when the reward window is already filled', () => {
+		const details = createDynamicReportingDetails()
+
+		expect(getSelectedOutcomeRewardWindowFillTimestamp(details, 'yes', rep(1n))).toBeUndefined()
 	})
 
 	test('getReportingMinimumOutcomeChangeContribution returns the first-report minimum before the escalation game exists', () => {

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -9,7 +9,7 @@ import { zeroAddress } from 'viem'
 import { ReportingSection } from '../components/ReportingSection.js'
 import { formatDuration, formatTimestamp } from '../lib/formatters.js'
 import { getReportingLockedUntilMessage } from '../lib/reporting.js'
-import { computeEscalationTimeSinceStartFromAttritionCost, ESCALATION_GAME_ACTIVATION_DELAY, getEscalationBalanceTuple, getEscalationBindingCapital } from '../lib/reportingDomain.js'
+import { computeEscalationTimeSinceStartFromAttritionCost, ESCALATION_GAME_ACTIVATION_DELAY, getEscalationBalanceTuple, getEscalationBindingCapital, getSelectedOutcomeRewardWindowFillTimestamp } from '../lib/reportingDomain.js'
 import type { AccountState, ReportingFormState } from '../types/app.js'
 import type { ActiveReportingDetails, EscalationDeposit, MarketDetails, ReportingDetails } from '../types/contracts.js'
 import type { ReportingSectionProps } from '../types/components.js'
@@ -256,7 +256,10 @@ function ReportingSectionHarness({ initialProps }: { initialProps?: Partial<Repo
 }
 
 function findProjectionPreviewElement() {
-	return Array.from(document.body.querySelectorAll('p.detail')).find(element => (element.textContent ?? '').includes('Check back later to confirm'))
+	return Array.from(document.body.querySelectorAll('p.detail')).find(element => {
+		const text = element.textContent ?? ''
+		return text.includes('Check back no later than') || text.includes('Check back immediately')
+	})
 }
 
 function findProjectionPreviewText() {
@@ -298,6 +301,7 @@ describe('ReportingSection', () => {
 				ReportingSection,
 				createProps({
 					reportingForm: createReportingForm({
+						reportAmount: '3',
 						selectedOutcome: 'yes',
 					}),
 				}),
@@ -496,7 +500,7 @@ describe('ReportingSection', () => {
 		expect(document.body.querySelectorAll('.escalation-side.selected').length).toBe(1)
 		expect(document.body.textContent?.includes('Selected side currently has')).toBe(false)
 		expect(selectedButton.textContent?.includes('Selected')).toBe(true)
-		expect(findProjectionPreviewText().includes('If Yes wins and no one else contributes afterward')).toBe(true)
+		expect(document.body.textContent?.includes('If Yes wins and no one else contributes afterward')).toBe(true)
 	})
 
 	test('removes the approval explainer copy and still blocks when unlocked vault REP is insufficient', async () => {
@@ -838,7 +842,8 @@ describe('ReportingSection', () => {
 		expect(reportOutcomeSection.querySelectorAll('.currency-value.unavailable')).toHaveLength(0)
 		expect(document.body.textContent?.includes('Load reporting details to populate live stakes')).toBe(false)
 		expectTransactionButtonEnabled(document.body, 'Report / Contribute Yes')
-		expect(document.body.textContent?.includes('If no one disputes after this report, the market would finalize in 3d 0h 0m. Check back later to confirm Yes is still the leading outcome as finalization approaches.')).toBe(true)
+		expect(document.body.textContent?.includes('If no one disputes after this report, the market would finalize in 3d 0h 0m.')).toBe(true)
+		expect(document.body.textContent?.includes(`Check back no later than ${formatTimestamp(150n + ESCALATION_GAME_ACTIVATION_DELAY)} (in 3d 0h 0m) to confirm Yes is the leading outcome before finalization.`)).toBe(true)
 	})
 
 	test('disables report submission for a pre-start amount below the first-report minimum', async () => {
@@ -865,7 +870,7 @@ describe('ReportingSection', () => {
 				ReportingSection,
 				createProps({
 					reportingForm: createReportingForm({
-						reportAmount: '1.5',
+						reportAmount: '3.5',
 						selectedOutcome: 'yes',
 					}),
 				}),
@@ -896,20 +901,24 @@ describe('ReportingSection', () => {
 		const reportButton = documentQueries.getByRole('button', { name: 'Report / Contribute No' })
 		const preview = findProjectionPreviewElement()
 		if (preview === undefined) throw new Error('Expected projection preview to render')
+		const expectedCheckBackTimestamp = getSelectedOutcomeRewardWindowFillTimestamp(createDynamicReportingDetails(), 'no', rep(2n))
 		expect(reportButton.compareDocumentPosition(preview) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0)
 		expect(preview.textContent?.includes('projects roughly')).toBe(true)
 		expect(preview.textContent?.includes('This contribution would extend the timer by')).toBe(true)
 		expect(preview.textContent?.includes('the market would finalize in')).toBe(true)
-		expect(preview.textContent?.includes('Check back later to confirm No is still the leading outcome as finalization approaches.')).toBe(true)
+		expect(preview.textContent?.includes('Check back no later than')).toBe(true)
+		expect(expectedCheckBackTimestamp === undefined ? false : preview.textContent?.includes(formatTimestamp(expectedCheckBackTimestamp))).toBe(true)
+		expect(preview.textContent?.includes('to confirm No is the leading outcome before the remaining reward-eligible REP on No is filled.')).toBe(true)
 		expect(document.body.textContent?.includes('became binding capital')).toBe(false)
 	})
 
 	test('shows a no-extension preview when the selected contribution leaves binding capital unchanged', async () => {
+		const reportingDetails = createDynamicReportingDetails()
 		const renderedComponent = await renderIntoDocument(
 			h(
 				ReportingSection,
 				createProps({
-					reportingDetails: createDynamicReportingDetails(),
+					reportingDetails,
 					reportingForm: createReportingForm({
 						selectedOutcome: 'yes',
 					}),
@@ -921,7 +930,7 @@ describe('ReportingSection', () => {
 		const previewText = findProjectionPreviewText()
 		expect(previewText.includes('projects roughly')).toBe(true)
 		expect(previewText.includes('This contribution would not extend the timer, and if no one disputes after it, the market would finalize in')).toBe(true)
-		expect(previewText.includes('Check back later to confirm Yes is still the leading outcome as finalization approaches.')).toBe(true)
+		expect(previewText.includes(`Check back no later than ${formatTimestamp(reportingDetails.escalationEndTime)} (in ${formatDuration(reportingDetails.escalationEndTime - reportingDetails.currentTime)}) to confirm Yes is the leading outcome before finalization.`)).toBe(true)
 		expect(document.body.textContent?.includes('became binding capital')).toBe(false)
 	})
 
@@ -949,7 +958,7 @@ describe('ReportingSection', () => {
 
 		const previewText = findProjectionPreviewText()
 		expect(previewText.includes('This contribution would end the escalation and finalize the market immediately.')).toBe(true)
-		expect(previewText.includes('Check back later to confirm Yes is still the leading outcome as finalization approaches.')).toBe(true)
+		expect(previewText.includes('Check back immediately to confirm the market finalized as Yes.')).toBe(true)
 	})
 
 	test('shows the accepted-deposit note when the typed contribution exceeds the remaining room on the selected side', async () => {

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -255,10 +255,12 @@ function ReportingSectionHarness({ initialProps }: { initialProps?: Partial<Repo
 	)
 }
 
-function findProfitPreview() {
-	return Array.from(document.body.querySelectorAll('p.detail'))
-		.map(element => element.textContent ?? '')
-		.find(text => text.includes('projects roughly'))
+function findProjectionPreviewElement() {
+	return Array.from(document.body.querySelectorAll('p.detail')).find(element => (element.textContent ?? '').includes('Check back later to confirm'))
+}
+
+function findProjectionPreviewText() {
+	return findProjectionPreviewElement()?.textContent ?? ''
 }
 describe('ReportingSection', () => {
 	let restoreDomEnvironment: (() => void) | undefined
@@ -494,7 +496,7 @@ describe('ReportingSection', () => {
 		expect(document.body.querySelectorAll('.escalation-side.selected').length).toBe(1)
 		expect(document.body.textContent?.includes('Selected side currently has')).toBe(false)
 		expect(selectedButton.textContent?.includes('Selected')).toBe(true)
-		expect(documentQueries.getByText(/If Yes wins and no one else contributes afterward/)).not.toBeNull()
+		expect(findProjectionPreviewText().includes('If Yes wins and no one else contributes afterward')).toBe(true)
 	})
 
 	test('removes the approval explainer copy and still blocks when unlocked vault REP is insufficient', async () => {
@@ -539,6 +541,63 @@ describe('ReportingSection', () => {
 		expect(documentQueries.getByRole('heading', { name: 'Withdraw Escalation Deposits' })).not.toBeNull()
 		expectTransactionButtonDisabled(document.body, 'Withdraw Selected Deposits', 'Escalation deposits cannot be withdrawn until the question is finalized or the game is canceled by an external fork.')
 		expectTransactionButtonDisabled(document.body, 'Withdraw All', 'Escalation deposits cannot be withdrawn until the question is finalized or the game is canceled by an external fork.')
+	})
+
+	test('keeps finalized withdrawals enabled in withdraw-only mode after escalation closes', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					mode: 'withdraw-only',
+					reportingDetails: createReportingDetails({
+						questionOutcome: 'yes',
+						resolution: 'yes',
+						withdrawalEnabled: true,
+						withdrawalState: 'resolved',
+					}),
+					reportingForm: createReportingForm({
+						selectedOutcome: 'yes',
+						selectedWithdrawDepositIndexes: [0n],
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const withdrawCheckbox = document.body.querySelector("input[type='checkbox']") as HTMLInputElement | null
+		if (!(withdrawCheckbox instanceof HTMLInputElement)) throw new Error('Expected withdraw checkbox')
+		expect(withdrawCheckbox.disabled).toBe(false)
+		expectTransactionButtonEnabled(document.body, 'Withdraw Selected Deposits')
+		expectTransactionButtonEnabled(document.body, 'Withdraw All')
+	})
+
+	test('shows a loading notice and disables withdraw-only controls while deposits refresh', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					loadingReportingDetails: true,
+					mode: 'withdraw-only',
+					reportingDetails: createReportingDetails({
+						questionOutcome: 'yes',
+						resolution: 'yes',
+						withdrawalEnabled: true,
+						withdrawalState: 'resolved',
+					}),
+					reportingForm: createReportingForm({
+						selectedOutcome: 'yes',
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(document.body.textContent?.includes('Loading escalation deposits...')).toBe(true)
+		const withdrawCheckbox = document.body.querySelector("input[type='checkbox']") as HTMLInputElement | null
+		if (!(withdrawCheckbox instanceof HTMLInputElement)) throw new Error('Expected withdraw checkbox')
+		expect(withdrawCheckbox.disabled).toBe(true)
+		expectTransactionButtonDisabled(document.body, 'Withdraw Selected Deposits', 'Loading escalation deposits.')
+		expectTransactionButtonDisabled(document.body, 'Withdraw All', 'Loading escalation deposits.')
 	})
 
 	test('shows the time-left metric inside Escalation Metrics', async () => {
@@ -652,6 +711,11 @@ describe('ReportingSection', () => {
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
+		const documentQueries = within(document.body)
+		expect((documentQueries.getByRole('button', { name: /^Yes/ }) as HTMLButtonElement).disabled).toBe(true)
+		expect((documentQueries.getByRole('textbox', { name: 'Report / Contribution Amount (REP)' }) as HTMLInputElement).disabled).toBe(true)
+		expect((documentQueries.getByRole('button', { name: 'Min to change proposed outcome' }) as HTMLButtonElement).disabled).toBe(true)
+		expect((documentQueries.getByRole('button', { name: 'Max profit' }) as HTMLButtonElement).disabled).toBe(true)
 		expectTransactionButtonDisabled(document.body, 'Report / Contribute Yes', 'Reporting is closed because the escalation timeout has been reached.')
 	})
 
@@ -774,7 +838,7 @@ describe('ReportingSection', () => {
 		expect(reportOutcomeSection.querySelectorAll('.currency-value.unavailable')).toHaveLength(0)
 		expect(document.body.textContent?.includes('Load reporting details to populate live stakes')).toBe(false)
 		expectTransactionButtonEnabled(document.body, 'Report / Contribute Yes')
-		expect(document.body.textContent?.includes('If no one disputes after this report, the market would finalize in 3d 0h 0m.')).toBe(true)
+		expect(document.body.textContent?.includes('If no one disputes after this report, the market would finalize in 3d 0h 0m. Check back later to confirm Yes is still the leading outcome as finalization approaches.')).toBe(true)
 	})
 
 	test('disables report submission for a pre-start amount below the first-report minimum', async () => {
@@ -809,7 +873,7 @@ describe('ReportingSection', () => {
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		expect(document.body.textContent?.includes('projects roughly')).toBe(true)
+		expect(findProjectionPreviewText().includes('projects roughly')).toBe(true)
 		expect(document.body.textContent?.includes('Enter a valid report amount to preview profit.')).toBe(false)
 	})
 
@@ -830,9 +894,13 @@ describe('ReportingSection', () => {
 
 		const documentQueries = within(document.body)
 		const reportButton = documentQueries.getByRole('button', { name: 'Report / Contribute No' })
-		const preview = documentQueries.getByText(/^This contribution would extend the timer by /)
+		const preview = findProjectionPreviewElement()
+		if (preview === undefined) throw new Error('Expected projection preview to render')
 		expect(reportButton.compareDocumentPosition(preview) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0)
-		expect(document.body.textContent?.includes('If no one disputes after this contribution, the market would finalize in')).toBe(true)
+		expect(preview.textContent?.includes('projects roughly')).toBe(true)
+		expect(preview.textContent?.includes('This contribution would extend the timer by')).toBe(true)
+		expect(preview.textContent?.includes('the market would finalize in')).toBe(true)
+		expect(preview.textContent?.includes('Check back later to confirm No is still the leading outcome as finalization approaches.')).toBe(true)
 		expect(document.body.textContent?.includes('became binding capital')).toBe(false)
 	})
 
@@ -850,9 +918,38 @@ describe('ReportingSection', () => {
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		expect(document.body.textContent?.includes('This contribution would not extend the timer.')).toBe(true)
-		expect(document.body.textContent?.includes('If no one disputes after this contribution, the market would finalize in')).toBe(true)
+		const previewText = findProjectionPreviewText()
+		expect(previewText.includes('projects roughly')).toBe(true)
+		expect(previewText.includes('This contribution would not extend the timer, and if no one disputes after it, the market would finalize in')).toBe(true)
+		expect(previewText.includes('Check back later to confirm Yes is still the leading outcome as finalization approaches.')).toBe(true)
 		expect(document.body.textContent?.includes('became binding capital')).toBe(false)
+	})
+
+	test('shows an immediate-finalization preview when the contribution creates a threshold tie', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					reportingDetails: createDynamicReportingDetails({
+						nonDecisionThreshold: rep(10n),
+						sides: [
+							{ balance: rep(10n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+							{ balance: rep(9n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+							{ balance: 0n, deposits: [], key: 'no', label: 'No', userDeposits: [] },
+						],
+					}),
+					reportingForm: createReportingForm({
+						reportAmount: '1',
+						selectedOutcome: 'yes',
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const previewText = findProjectionPreviewText()
+		expect(previewText.includes('This contribution would end the escalation and finalize the market immediately.')).toBe(true)
+		expect(previewText.includes('Check back later to confirm Yes is still the leading outcome as finalization approaches.')).toBe(true)
 	})
 
 	test('shows the accepted-deposit note when the typed contribution exceeds the remaining room on the selected side', async () => {
@@ -876,7 +973,7 @@ describe('ReportingSection', () => {
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		expect(document.body.textContent?.includes('This contribution would not extend the timer.')).toBe(true)
+		expect(findProjectionPreviewText().includes('This contribution would not extend the timer, and if no one disputes after it, the market would finalize in')).toBe(true)
 		expect(document.body.textContent?.includes('this action would lock')).toBe(true)
 		expect(document.body.textContent?.includes('instead of the full entered amount.')).toBe(true)
 	})
@@ -897,14 +994,14 @@ describe('ReportingSection', () => {
 		const renderedComponent = await renderIntoDocument(<ReportingSectionHarness initialProps={{ reportingForm: createReportingForm({ selectedOutcome: 'yes' }) }} />)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		const previewBefore = findProfitPreview()
+		const previewBefore = findProjectionPreviewText()
 
 		await act(() => {
 			fireEvent.click(within(document.body).getByRole('button', { name: 'Max profit' }))
 		})
 
 		const amountInput = within(document.body).getByRole('textbox', { name: 'Report / Contribution Amount (REP)' })
-		const previewAfter = findProfitPreview()
+		const previewAfter = findProjectionPreviewText()
 		expect((amountInput as HTMLInputElement).value).toBe('7')
 		expect(previewBefore).not.toBe(previewAfter)
 	})

--- a/ui/ts/tests/securityPoolState.test.ts
+++ b/ui/ts/tests/securityPoolState.test.ts
@@ -1,0 +1,58 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { getSecurityPoolDisplayState, getSecurityPoolDisplayStateLabel, isSecurityPoolEnded } from '../lib/securityPoolState.js'
+
+describe('security pool display state helpers', () => {
+	test('keeps unresolved operational pools in the operational display state', () => {
+		expect(
+			getSecurityPoolDisplayState({
+				questionOutcome: 'none',
+				systemState: 'operational',
+			}),
+		).toBe('operational')
+		expect(
+			isSecurityPoolEnded({
+				questionOutcome: 'none',
+				systemState: 'operational',
+			}),
+		).toBe(false)
+	})
+
+	test('maps resolved operational pools to the ended display state', () => {
+		expect(
+			getSecurityPoolDisplayState({
+				questionOutcome: 'yes',
+				systemState: 'operational',
+			}),
+		).toBe('ended')
+		expect(
+			isSecurityPoolEnded({
+				questionOutcome: 'yes',
+				systemState: 'operational',
+			}),
+		).toBe(true)
+		expect(getSecurityPoolDisplayStateLabel('ended')).toBe('Ended')
+	})
+
+	test('keeps non-operational raw states unchanged', () => {
+		expect(
+			getSecurityPoolDisplayState({
+				questionOutcome: 'yes',
+				systemState: 'poolForked',
+			}),
+		).toBe('poolForked')
+		expect(
+			getSecurityPoolDisplayState({
+				questionOutcome: 'yes',
+				systemState: 'forkMigration',
+			}),
+		).toBe('forkMigration')
+		expect(
+			getSecurityPoolDisplayState({
+				questionOutcome: 'yes',
+				systemState: 'forkTruthAuction',
+			}),
+		).toBe('forkTruthAuction')
+	})
+})

--- a/ui/ts/tests/securityPoolWorkflow.test.ts
+++ b/ui/ts/tests/securityPoolWorkflow.test.ts
@@ -134,7 +134,6 @@ void describe('selected pool workflow visibility', () => {
 				selectedPoolUniverseMismatch: false,
 			}),
 		).toEqual({
-			actionHint: 'Refresh this address after the pool is deployed.',
 			badgeLabel: 'Not found',
 			badgeTone: 'blocked',
 			detail: 'Pool not found.',

--- a/ui/ts/tests/securityPoolWorkflowSection.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection.test.tsx
@@ -240,7 +240,7 @@ function createSelectedPool(overrides: Partial<ListedSecurityPool> = {}): Listed
 		marketDetails: createMarketDetails(),
 		migratedRep: 0n,
 		parent: zeroAddress,
-		questionOutcome: 'yes',
+		questionOutcome: 'none',
 		questionId: '0x01',
 		securityMultiplier: 2n,
 		securityPoolAddress: zeroAddress,
@@ -352,7 +352,7 @@ describe('SecurityPoolWorkflowSection', () => {
 		const documentQueries = within(document.body)
 		expect(documentQueries.getByRole('heading', { name: 'Pool Workflows' })).not.toBeNull()
 		expect(documentQueries.getByText('Pool not found.')).not.toBeNull()
-		expect(documentQueries.getByText('Refresh this address after the pool is deployed.')).not.toBeNull()
+		expect(documentQueries.queryByText('Refresh this address after the pool is deployed.')).toBeNull()
 	})
 
 	test('shows a pool not found card when the selected address does not resolve', async () => {
@@ -632,6 +632,51 @@ describe('SecurityPoolWorkflowSection', () => {
 		expectTransactionButtonEnabled(document.body, 'Withdraw REP')
 		expectTransactionButtonEnabled(document.body, 'Set Bond Allowance')
 		expectTransactionButtonEnabled(document.body, 'Claim Fees')
+	})
+
+	test('shows an Ended badge and blocks ended-pool collateral actions in the vault workflow', async () => {
+		const selectedPoolAddress = getAddress('0x00000000000000000000000000000000000000b1')
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					checkedSecurityPoolAddress: selectedPoolAddress,
+					poolOracleManagerDetails: createOracleManagerDetails({
+						isPriceValid: true,
+					}),
+					securityPoolAddress: selectedPoolAddress,
+					securityPools: [
+						createSelectedPool({
+							questionOutcome: 'yes',
+							securityPoolAddress: selectedPoolAddress,
+						}),
+					],
+					securityVault: createSecurityVaultProps({
+						securityVaultDetails: createSecurityVaultDetails({
+							securityPoolAddress: selectedPoolAddress,
+						}),
+						securityVaultForm: {
+							depositAmount: '1',
+							repWithdrawAmount: '1',
+							securityBondAllowanceAmount: '1',
+							securityPoolAddress: selectedPoolAddress,
+							selectedVaultAddress: zeroAddress,
+						},
+						securityVaultRepBalance: 10n * 10n ** 18n,
+					}),
+					selectedPoolView: 'vaults',
+				})}
+				showHeader={false}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByText('Ended')).not.toBeNull()
+		expectTransactionButtonDisabled(document.body, 'Deposit REP', 'Vault collateral operations are unavailable after this pool has ended.')
+		expectTransactionButtonDisabled(document.body, 'Withdraw REP', 'Vault collateral operations are unavailable after this pool has ended.')
+		expectTransactionButtonDisabled(document.body, 'Set Bond Allowance', 'Vault collateral operations are unavailable after this pool has ended.')
+		expectTransactionButtonEnabled(document.body, 'Claim Fees')
+		expectTransactionButtonDisabled(document.body, 'Liquidate Vault', 'Liquidation is unavailable after this pool has ended.')
 	})
 
 	test('allows selecting a vault from the directory within the current pool', async () => {
@@ -1817,6 +1862,49 @@ describe('SecurityPoolWorkflowSection', () => {
 		expect(documentQueries.getByText('Withdraw REP')).not.toBeNull()
 		expect(documentQueries.getByText('7')).not.toBeNull()
 		expect(documentQueries.queryByText('Pending Price Request')).toBeNull()
+	})
+
+	test('blocks staged-operation execution after the selected pool has ended', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					checkedSecurityPoolAddress: zeroAddress,
+					poolOracleManagerDetails: {
+						callbackStateHash: undefined,
+						exactToken1Report: undefined,
+						isPriceValid: true,
+						lastPrice: 2n * 10n ** 18n,
+						lastSettlementTimestamp: 100n,
+						managerAddress: zeroAddress,
+						openOracleAddress: zeroAddress,
+						pendingOperation: {
+							amount: 5n * 10n ** 18n,
+							initiatorVault: zeroAddress,
+							operation: 'withdrawRep',
+							operationId: 7n,
+							targetVault: zeroAddress,
+						},
+						pendingOperationSlotId: 7n,
+						pendingReportId: 0n,
+						priceValidUntilTimestamp: 1000n,
+						requestPriceEthCost: 1n,
+						token1: zeroAddress,
+						token2: zeroAddress,
+					},
+					securityPoolAddress: zeroAddress,
+					securityPools: [
+						createSelectedPool({
+							questionOutcome: 'yes',
+						}),
+					],
+					selectedPoolView: 'staged-operations',
+				})}
+				showHeader={false}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expectTransactionButtonDisabled(document.body, 'Execute Staged Operation', 'Vault collateral operations are unavailable after this pool has ended.')
 	})
 
 	test('renders price oracle details and request controls in the price oracle tab', async () => {

--- a/ui/ts/tests/securityPoolsOverviewSection.test.tsx
+++ b/ui/ts/tests/securityPoolsOverviewSection.test.tsx
@@ -8,6 +8,7 @@ import type { ListedSecurityPool, MarketDetails } from '../types/contracts.js'
 import type { SecurityPoolsOverviewSectionProps } from '../types/components.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
+import { act } from 'preact/test-utils'
 import { zeroAddress } from 'viem'
 
 function createAccountState(overrides: Partial<AccountState> = {}): AccountState {
@@ -51,7 +52,7 @@ function createSecurityPool(overrides: Partial<ListedSecurityPool> = {}): Listed
 		marketDetails: createMarketDetails(),
 		migratedRep: 0n,
 		parent: zeroAddress,
-		questionOutcome: 'yes',
+		questionOutcome: 'none',
 		questionId: '0x01',
 		securityMultiplier: 2n,
 		securityPoolAddress: zeroAddress,
@@ -135,5 +136,56 @@ describe('SecurityPoolsOverviewSection', () => {
 		expect(documentQueries.getByText('Check State')).not.toBeNull()
 		expect(documentQueries.getByText('0x1234000000000000000000000000000000000000000000000000000000000000')).not.toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Liquidation Submitted' }).closest('.actions')).toBeNull()
+	})
+
+	test('shows Ended for resolved operational pools', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolsOverviewSection
+				{...createProps({
+					securityPools: [
+						createSecurityPool({
+							questionOutcome: 'yes',
+						}),
+					],
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const badgeTexts = Array.from(document.body.querySelectorAll('.entity-card .badge')).map(element => element.textContent?.trim() ?? '')
+		expect(badgeTexts).toContain('Ended')
+	})
+
+	test('filters the registry by the derived Ended state', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolsOverviewSection
+				{...createProps({
+					securityPools: [
+						createSecurityPool({
+							marketDetails: createMarketDetails({ title: 'Operational pool' }),
+							questionOutcome: 'none',
+							securityPoolAddress: '0x0000000000000000000000000000000000000001',
+						}),
+						createSecurityPool({
+							marketDetails: createMarketDetails({ title: 'Ended pool' }),
+							questionOutcome: 'yes',
+							securityPoolAddress: '0x0000000000000000000000000000000000000002',
+						}),
+					],
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		const systemStateSelect = documentQueries.getByLabelText('System State')
+		if (!(systemStateSelect instanceof window.HTMLSelectElement)) throw new Error('Expected system state filter')
+		systemStateSelect.value = 'ended'
+		await act(() => {
+			systemStateSelect.dispatchEvent(new window.Event('change', { bubbles: true }))
+		})
+
+		expect(documentQueries.queryByText('Operational pool')).toBeNull()
+		expect(documentQueries.getAllByText('Ended pool').length).toBeGreaterThan(0)
 	})
 })

--- a/ui/ts/tests/securityPoolsSection.test.ts
+++ b/ui/ts/tests/securityPoolsSection.test.ts
@@ -189,7 +189,7 @@ function createSelectedPool(overrides: Partial<ListedSecurityPool> = {}): Listed
 		marketDetails: createMarketDetails(),
 		migratedRep: 0n,
 		parent: zeroAddress,
-		questionOutcome: 'yes',
+		questionOutcome: 'none',
 		questionId: '0x01',
 		securityMultiplier: 2n,
 		securityPoolAddress: zeroAddress,
@@ -724,18 +724,20 @@ void describe('SecurityPoolsSection', () => {
 		expect(metricLabels.includes('Truth Auction')).toBe(false)
 	})
 
-	void test('filters the browse registry by search text and system state', async () => {
+	void test('filters the browse registry by search text and the derived ended state', async () => {
 		const operationalPool = createSelectedPool({
 			marketDetails: createMarketDetails({ title: 'First pool question' }),
+			questionOutcome: 'none',
 			questionId: '0x01',
 			securityPoolAddress: '0x0000000000000000000000000000000000000001',
 			systemState: 'operational',
 		})
-		const forkedPool = createSelectedPool({
+		const endedPool = createSelectedPool({
 			marketDetails: createMarketDetails({ title: 'Second pool question' }),
+			questionOutcome: 'yes',
 			questionId: '0x02',
 			securityPoolAddress: '0x0000000000000000000000000000000000000002',
-			systemState: 'poolForked',
+			systemState: 'operational',
 		})
 		const renderedComponent = await renderIntoDocument(
 			h(
@@ -743,7 +745,7 @@ void describe('SecurityPoolsSection', () => {
 				createSecurityPoolsSectionProps({
 					overview: createOverviewProps({
 						hasLoadedSecurityPools: true,
-						securityPools: [operationalPool, forkedPool],
+						securityPools: [operationalPool, endedPool],
 					}),
 				}),
 			),
@@ -760,13 +762,18 @@ void describe('SecurityPoolsSection', () => {
 		expect(documentQueries.queryByText('First pool question')).toBeNull()
 		expect(documentQueries.getAllByText('Second pool question').length).toBeGreaterThan(0)
 
+		searchInput.value = ''
+		await act(() => {
+			searchInput.dispatchEvent(new window.Event('input', { bubbles: true }))
+		})
+
 		const systemStateSelect = documentQueries.getByLabelText('System State')
 		if (!(systemStateSelect instanceof window.HTMLSelectElement)) throw new Error('Expected system state filter')
-		systemStateSelect.value = 'operational'
+		systemStateSelect.value = 'ended'
 		await act(() => {
 			systemStateSelect.dispatchEvent(new window.Event('change', { bubbles: true }))
 		})
-		expect(documentQueries.queryByText('Second pool question')).toBeNull()
-		expect(documentQueries.getByText('No pools match the current search and filter settings.')).not.toBeNull()
+		expect(documentQueries.queryByText('First pool question')).toBeNull()
+		expect(documentQueries.getAllByText('Second pool question').length).toBeGreaterThan(0)
 	})
 })

--- a/ui/ts/tests/securityVaultSection.test.tsx
+++ b/ui/ts/tests/securityVaultSection.test.tsx
@@ -238,4 +238,29 @@ describe('SecurityVaultSection', () => {
 		expect(documentQueries.getByRole('heading', { name: 'Latest Vault Action' })).not.toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Latest Vault Action' }).closest('.actions')).toBeNull()
 	})
+
+	test('blocks collateral actions when the selected pool has ended but still allows fee claims', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<SecurityVaultSection
+				{...createSecurityVaultSectionProps({
+					oracleManagerDetails: createOracleManagerDetails(),
+					poolActionLockReason: 'Vault collateral operations are unavailable after this pool has ended.',
+					securityVaultForm: {
+						depositAmount: '1',
+						repWithdrawAmount: '1',
+						securityBondAllowanceAmount: '1',
+						securityPoolAddress: zeroAddress,
+						selectedVaultAddress: zeroAddress,
+					},
+					securityVaultRepBalance: 10n * 10n ** 18n,
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expectTransactionButtonDisabled(document.body, 'Create / Deposit REP', 'Vault collateral operations are unavailable after this pool has ended.')
+		expectTransactionButtonDisabled(document.body, 'Withdraw REP', 'Vault collateral operations are unavailable after this pool has ended.')
+		expectTransactionButtonDisabled(document.body, 'Set Security Bond Allowance', 'Vault collateral operations are unavailable after this pool has ended.')
+		expectTransactionButtonEnabled(document.body, 'Claim Fees')
+	})
 })

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -506,6 +506,7 @@ export type SecurityVaultSectionProps = SecurityVaultRouteContentProps & {
 	modalFirst?: boolean
 	onViewStagedOperations?: () => void
 	oracleManagerDetails?: OracleManagerDetails | undefined
+	poolActionLockReason?: string | undefined
 	selectedPoolTotalRepDeposit?: bigint | undefined
 	selectedPoolTotalSecurityBondAllowance?: bigint | undefined
 	autoLoadVault?: boolean


### PR DESCRIPTION
## Summary
- Adds shared security-pool display state helpers so the UI can distinguish ended pools from operational and fork states.
- Disables liquidation and other vault actions once a pool has ended, with explicit guard messaging in workflow, overview, and modal surfaces.
- Updates reporting UX to better reflect closed escalation states, loading state, and projected report outcomes/finalization timing.
- Expands coverage with new and updated UI tests for pool state handling, reporting, liquidation, workflow, overview, and vault sections.

## Testing
- Not run (PR content only)
- Intended verification per repo guidance: `bun run tsc`
- Intended verification per repo guidance: `bun run test`
- Intended verification per repo guidance: `bun run format`
- Intended verification per repo guidance: `bun run check`
- Intended verification per repo guidance: `bun run knip`