### PR TITLE
Refine fork workflow and finalized truth-auction settlement

### DIFF
--- a/solidity/contracts/peripherals/SecurityPoolForker.sol
+++ b/solidity/contracts/peripherals/SecurityPoolForker.sol
@@ -157,6 +157,7 @@ contract SecurityPoolForker is ISecurityPoolForker {
 		uint248 universe = securityPool.universeId();
 		EscalationGame escalationGame = securityPool.escalationGame();
 		require(zoltar.getForkTime(universe) > 0, 'Zoltar needs to have forked before Security Pool can do so');
+		require(securityPool.systemState() != SystemState.PoolForked, 'Security pool fork already initiated');
 		require(securityPool.systemState() == SystemState.Operational, 'System is not operational');
 		require(address(escalationGame) == address(0x0) || escalationGame.getQuestionResolution() == BinaryOutcomes.BinaryOutcome.None, 'question has been finalized already');
 		ReputationToken rep = securityPool.repToken();
@@ -329,6 +330,7 @@ contract SecurityPoolForker is ISecurityPoolForker {
 		uint256 repToFork = repBalanceAfter - repBalanceBefore;
 		if (repToFork > 0) rep.transfer(address(migrationProxy), repToFork);
 		migrationProxy.forkUniverse(securityPool.questionId());
+		initiateSecurityPoolFork(securityPool);
 	}
 
 	// Settles finalized truth-auction bids through the forker-owned auction.

--- a/solidity/ts/tests/peripherals.test.ts
+++ b/solidity/ts/tests/peripherals.test.ts
@@ -172,7 +172,6 @@ describe('Peripherals Contract Test Suite', () => {
 		await createCompleteSet(openInterestHolder, securityPoolAddresses.securityPool, openInterestAmount)
 
 		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
-		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
 		await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
 
@@ -852,7 +851,6 @@ describe('Peripherals Contract Test Suite', () => {
 		const forkThreshold = (await getTotalTheoreticalSupply(client, await getRepToken(client, securityPoolAddresses.securityPool))) / 20n
 		await depositRep(client, securityPoolAddresses.securityPool, 2n * forkThreshold)
 		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
-		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Invalid, QuestionOutcome.Yes, QuestionOutcome.No])
 		await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
 		await migrateVault(attackerClient, securityPoolAddresses.securityPool, QuestionOutcome.No)
@@ -905,7 +903,7 @@ describe('Peripherals Contract Test Suite', () => {
 		strictEqualTypeSafe(await getLastPrice(client, childManagerAddress), await getLastPrice(client, securityPoolAddresses.priceOracleManagerAndOperatorQueuer), 'child manager should inherit the parent price')
 	})
 
-	test('forkZoltarWithOwnEscalationGame ignores stray REP already sitting on the forker', async () => {
+	test('forkZoltarWithOwnEscalationGame auto-initiates the pool fork and ignores stray REP already sitting on the forker', async () => {
 		const endTime = await getQuestionEndDate(client, questionId)
 		const strayRep = 7n * 10n ** 18n
 		const forkThreshold = (await getTotalTheoreticalSupply(client, await getRepToken(client, securityPoolAddresses.securityPool))) / 20n / securityMultiplier
@@ -917,13 +915,13 @@ describe('Peripherals Contract Test Suite', () => {
 		const repBalance = await getERC20Balance(client, getRepTokenAddress(genesisUniverse), securityPoolAddresses.securityPool)
 		await transferRepToAddress(client, getInfraContractAddresses().securityPoolForker, strayRep)
 		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
-		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
 
 		const forkData = await getSecurityPoolForkerForkData(client, securityPoolAddresses.securityPool)
+		strictEqualTypeSafe(await getSystemState(client, securityPoolAddresses.securityPool), SystemState.PoolForked, 'forkWithOwnEscalationGame should auto-initiate the parent pool fork')
 		strictEqualTypeSafe(forkData.repAtFork, repBalance - burnAmount, 'repAtFork should only track the parent pool REP after the own-game fork')
 	})
 
-	test('initiateSecurityPoolFork ignores stray REP transferred to the forker after the own-game fork', async () => {
+	test('initiateSecurityPoolFork reverts after the own-game fork and ignores stray REP transferred to the forker', async () => {
 		const endTime = await getQuestionEndDate(client, questionId)
 		const strayRep = 9n * 10n ** 18n
 		const forkThreshold = (await getTotalTheoreticalSupply(client, await getRepToken(client, securityPoolAddresses.securityPool))) / 20n / securityMultiplier
@@ -935,9 +933,10 @@ describe('Peripherals Contract Test Suite', () => {
 		const repBalance = await getERC20Balance(client, getRepTokenAddress(genesisUniverse), securityPoolAddresses.securityPool)
 		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
 		await transferRepToAddress(client, getInfraContractAddresses().securityPoolForker, strayRep)
-		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
+		await assert.rejects(initiateSecurityPoolFork(client, securityPoolAddresses.securityPool), /Security pool fork already initiated/)
 
 		const forkData = await getSecurityPoolForkerForkData(client, securityPoolAddresses.securityPool)
+		strictEqualTypeSafe(await getSystemState(client, securityPoolAddresses.securityPool), SystemState.PoolForked, 're-initiating after the own-game fork should leave the parent pool in PoolForked')
 		strictEqualTypeSafe(forkData.repAtFork, repBalance - burnAmount, 'repAtFork should ignore unrelated REP transferred to the forker after the own-game fork')
 	})
 
@@ -1183,8 +1182,6 @@ describe('Peripherals Contract Test Suite', () => {
 		const zoltarForkThreshold = await getZoltarForkThreshold(client, genesisUniverse)
 		const burnAmount = zoltarForkThreshold / 5n
 		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
-
-		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
 
 		const forkData = await getSecurityPoolForkerForkData(client, securityPoolAddresses.securityPool)
@@ -1335,7 +1332,6 @@ describe('Peripherals Contract Test Suite', () => {
 		await createCompleteSet(openInterestHolder, securityPoolAddresses.securityPool, openInterestAmount)
 		assert.deepStrictEqual(await balanceOfSharesInCash(client, securityPoolAddresses.securityPool, securityPoolAddresses.shareToken, genesisUniverse, addressString(TEST_ADDRESSES[2])), openInterestArray, 'Did not create enough complete sets')
 		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
-		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Invalid, QuestionOutcome.Yes, QuestionOutcome.No])
 		const yesUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
 		const yesSecurityPool = getSecurityPoolAddresses(securityPoolAddresses.securityPool, yesUniverse, questionId, securityMultiplier)
@@ -1647,7 +1643,6 @@ describe('Peripherals Contract Test Suite', () => {
 		await depositRep(client, securityPoolAddresses.securityPool, 2n * forkThreshold)
 
 		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
-		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
 		await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
 		await migrateVault(attackerClient, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
@@ -1684,7 +1679,6 @@ describe('Peripherals Contract Test Suite', () => {
 		await createCompleteSet(openInterestHolder, securityPoolAddresses.securityPool, openInterestAmount)
 
 		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
-		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
 
 		strictEqualTypeSafe(await getSystemState(client, securityPoolAddresses.securityPool), SystemState.PoolForked, 'parent pool should enter PoolForked after the universe fork is activated')
 		await assert.rejects(createCompleteSet(client, securityPoolAddresses.securityPool, 1n), /Zoltar has forked/)
@@ -1722,7 +1716,6 @@ describe('Peripherals Contract Test Suite', () => {
 		await depositRep(client, securityPoolAddresses.securityPool, 2n * forkThreshold)
 
 		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
-		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
 		const parentVaultBeforeEscalationMigration = await getSecurityVault(client, securityPoolAddresses.securityPool, client.account.address)
 		await migrateFromEscalationGame(client, securityPoolAddresses.securityPool, client.account.address, QuestionOutcome.Yes, [0n])
@@ -1748,7 +1741,6 @@ describe('Peripherals Contract Test Suite', () => {
 		await depositRep(client, securityPoolAddresses.securityPool, 2n * forkThreshold)
 
 		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
-		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
 		await createChildUniverse(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
 
 		const yesUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
@@ -1774,7 +1766,6 @@ describe('Peripherals Contract Test Suite', () => {
 		await depositRep(client, securityPoolAddresses.securityPool, 2n * forkThreshold)
 
 		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
-		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
 
 		const yesUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
@@ -1824,7 +1815,6 @@ describe('Peripherals Contract Test Suite', () => {
 		await depositToEscalationGame(attackerClient, securityPoolAddresses.securityPool, QuestionOutcome.No, winningDeposit)
 
 		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
-		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
 
 		const yesUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
@@ -2100,7 +2090,6 @@ describe('Peripherals Contract Test Suite', () => {
 		await depositRep(client, securityPoolAddresses.securityPool, 2n * forkThreshold)
 
 		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
-		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
 		await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
 
@@ -2131,7 +2120,6 @@ describe('Peripherals Contract Test Suite', () => {
 
 		// Fork the security pool
 		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
-		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
 
 		const yesUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
@@ -2190,7 +2178,6 @@ describe('Peripherals Contract Test Suite', () => {
 		await createCompleteSet(openInterestHolder, securityPoolAddresses.securityPool, openInterestAmount)
 
 		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
-		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
 		await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
 
@@ -2248,7 +2235,6 @@ describe('Peripherals Contract Test Suite', () => {
 		await createCompleteSet(openInterestHolder, securityPoolAddresses.securityPool, openInterestAmount)
 
 		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
-		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
 		await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
 
@@ -2375,7 +2361,6 @@ describe('Peripherals Contract Test Suite', () => {
 		await createCompleteSet(openInterestHolder, securityPoolAddresses.securityPool, openInterestAmount)
 
 		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
-		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
 		await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
 
@@ -2422,7 +2407,6 @@ describe('Peripherals Contract Test Suite', () => {
 		await createCompleteSet(openInterestHolder, securityPoolAddresses.securityPool, openInterestAmount)
 
 		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
-		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
 		await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
 
@@ -2464,7 +2448,6 @@ describe('Peripherals Contract Test Suite', () => {
 		await createCompleteSet(openInterestHolder, securityPoolAddresses.securityPool, openInterestAmount)
 
 		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
-		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
 		await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
 
@@ -2515,7 +2498,6 @@ describe('Peripherals Contract Test Suite', () => {
 		await createCompleteSet(openInterestHolder, securityPoolAddresses.securityPool, openInterestAmount)
 
 		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
-		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
 		await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
 
@@ -2613,10 +2595,7 @@ describe('Peripherals Contract Test Suite', () => {
 		const repBalanceInGenesisPool = await getERC20Balance(client, getRepTokenAddress(genesisUniverse), securityPoolAddresses.securityPool)
 		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
 
-		// Step 1: Initiate the security pool fork separately
-		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
-
-		// Verify fork state
+		// Verify the own-game fork left the parent pool fully initialized for migration
 		strictEqualTypeSafe(await getSystemState(client, securityPoolAddresses.securityPool), SystemState.PoolForked, 'Parent is forked')
 		const forkData = await getSecurityPoolForkerForkData(client, securityPoolAddresses.securityPool)
 		strictEqualTypeSafe(forkData.repAtFork, repBalanceInGenesisPool - burnAmount, 'rep at fork does not match')
@@ -2687,7 +2666,6 @@ describe('Peripherals Contract Test Suite', () => {
 
 		// Fork and migrate
 		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
-		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
 		await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
 
@@ -2735,7 +2713,6 @@ describe('Peripherals Contract Test Suite', () => {
 		await createCompleteSet(openInterestHolder, securityPoolAddresses.securityPool, openInterestAmount)
 
 		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
-		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
 		await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
 

--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -1,5 +1,6 @@
 import { useSignal } from '@preact/signals'
 import type { ComponentChildren } from 'preact'
+import { useEffect, useRef } from 'preact/hooks'
 import type { Address, Hash } from 'viem'
 import { AppHeaderShell } from './components/AppHeaderShell.js'
 import { AppRouteContent } from './components/AppRouteContent.js'
@@ -91,6 +92,7 @@ export function App() {
 		createMarket,
 		forkZoltar,
 		hasLoadedZoltarQuestions,
+		loadZoltarForkAccess,
 		loadingZoltarForkAccess,
 		loadingZoltarQuestionCount,
 		loadingZoltarQuestions,
@@ -251,7 +253,6 @@ export function App() {
 		setForkAuctionForm,
 		startTruthAuction,
 		submitBid,
-		withdrawBids,
 	} = useForkAuctionOperations(baseHookConfig)
 	const { repPerEthPrice, repPerEthSource, repPerEthSourceUrl, repUsdcPrice, repUsdcSource, repUsdcSourceUrl, isLoadingRepPrices, refreshRepPrices } = useRepPrices()
 	const simulationController = getActiveSimulationController()
@@ -259,6 +260,8 @@ export function App() {
 		await refreshState()
 		refreshRepPrices()
 	}
+	const lastSecurityVaultRepRefreshHash = useRef<string | undefined>(undefined)
+	const lastStagedVaultRepRefreshHash = useRef<string | undefined>(undefined)
 	const deploymentSections = getDeploymentSections(deploymentStatuses)
 	const errorMessage = deploymentErrorMessage ?? walletErrorMessage
 	const isMainnet = isSupportedAppChain(accountState.chainId)
@@ -291,6 +294,8 @@ export function App() {
 		repUsdcPrice,
 		repUsdcSource,
 		repUsdcSourceUrl,
+		universeForkTime: zoltarUniverse?.forkTime,
+		universeHasForked: zoltarUniverse?.hasForked,
 		universePresentation,
 		universeLabel,
 		universeRepBalance: zoltarForkRepBalance,
@@ -343,6 +348,26 @@ export function App() {
 		setSecurityPoolAddress(securityPoolAddress)
 		navigate('security-pools')
 	}
+	useEffect(() => {
+		const securityVaultRepRefreshHash = securityVaultResult?.action === 'depositRep' || securityVaultResult?.action === 'redeemRep' || (securityVaultResult?.action === 'queueWithdrawRep' && securityVaultResult.stagedExecution?.success === true) ? securityVaultResult.hash : undefined
+		if (securityVaultRepRefreshHash === undefined) {
+			lastSecurityVaultRepRefreshHash.current = undefined
+			return
+		}
+		if (lastSecurityVaultRepRefreshHash.current === securityVaultRepRefreshHash) return
+		lastSecurityVaultRepRefreshHash.current = securityVaultRepRefreshHash
+		void loadZoltarForkAccess()
+	}, [loadZoltarForkAccess, securityVaultResult])
+	useEffect(() => {
+		const stagedVaultRepRefreshHash = poolPriceOracleResult?.action === 'executeStagedOperation' && poolPriceOracleResult.stagedExecution?.success === true && poolPriceOracleResult.stagedExecution.operation === 'withdrawRep' ? poolPriceOracleResult.hash : undefined
+		if (stagedVaultRepRefreshHash === undefined) {
+			lastStagedVaultRepRefreshHash.current = undefined
+			return
+		}
+		if (lastStagedVaultRepRefreshHash.current === stagedVaultRepRefreshHash) return
+		lastStagedVaultRepRefreshHash.current = stagedVaultRepRefreshHash
+		void loadZoltarForkAccess()
+	}, [loadZoltarForkAccess, poolPriceOracleResult])
 	useAppRouteEffects({
 		accountAddress: accountState.address,
 		augurPlaceHolderDeploymentMissing,
@@ -511,7 +536,6 @@ export function App() {
 				onRefundLosingBids: () => void refundLosingBids(),
 				onStartTruthAuction: () => void startTruthAuction(),
 				onSubmitBid: () => void submitBid(),
-				onWithdrawBids: () => void withdrawBids(),
 			},
 			liquidationAmount,
 			liquidationMaxAmount,

--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -27,13 +27,13 @@ import { createActionAvailability } from '../lib/actionAvailability.js'
 import { sameAddress } from '../lib/address.js'
 import { createConnectedReadClient } from '../lib/clients.js'
 import { getErrorMessage } from '../lib/errors.js'
-import { AUCTION_TIME_SECONDS, type ForkAuctionStageView, estimateRepPurchased, getForkAuctionStageView, getForkStageDescription, getForkStageDescriptionForState, getOutcomeActionLabel, getTimeRemaining, getTruthAuctionBidGuardMessage, hasForkActivity, MIGRATION_TIME_SECONDS } from '../lib/forkAuction.js'
+import { AUCTION_TIME_SECONDS, type ForkAuctionStageView, estimateRepPurchased, getForkAuctionStageView, getForkStageDescription, getForkStageDescriptionForState, getOutcomeActionLabel, getTimeRemaining, getTruthAuctionBidGuardMessage, MIGRATION_TIME_SECONDS } from '../lib/forkAuction.js'
 import { formatDuration } from '../lib/formatters.js'
 import { isMainnetChain } from '../lib/network.js'
 import { REPORTING_OUTCOME_DROPDOWN_OPTIONS, getReportingOutcomeLabel } from '../lib/reporting.js'
 import { getSecurityPoolLifecycleLabel } from '../lib/securityPoolLabels.js'
 import { deriveSecurityPoolForkStage, deriveSecurityPoolLifecycleState, evaluateSecurityPoolState } from '../lib/securityPoolState.js'
-import type { ListedSecurityPool, ReadClient, TruthAuctionBidView, TruthAuctionMetrics, TruthAuctionTickSummary } from '../types/contracts.js'
+import type { ForkAuctionActionResult, ForkOutcomeKey, ListedSecurityPool, ReadClient, TruthAuctionBidView, TruthAuctionMetrics, TruthAuctionTickSummary } from '../types/contracts.js'
 import type { ForkAuctionSectionProps, ReadinessAction } from '../types/components.js'
 const UNKNOWN_VALUE = '—'
 const UNAVAILABLE_UNTIL_FORK = 'Unavailable until fork'
@@ -84,11 +84,14 @@ type TruthAuctionDisposition = {
 	tone: 'default' | 'danger' | 'success' | 'warning'
 }
 
-type TruthAuctionBidSummaryKind = 'claimed' | 'losing' | 'neutral' | 'partial' | 'refunded' | 'winning'
+type TruthAuctionFinalizedSettlementKind = 'ethRefund' | 'none' | 'repClaim'
+
+type TruthAuctionBidSummaryKind = 'losing' | 'neutral' | 'partial' | 'refundable' | 'refunded' | 'repClaimable' | 'winning'
 
 type TruthAuctionBidDisposition = TruthAuctionDisposition & {
-	canPrefillClaim: boolean
 	canPrefillRefund: boolean
+	canPrefillSettle: boolean
+	settlementKind: TruthAuctionFinalizedSettlementKind
 	summaryKind: TruthAuctionBidSummaryKind
 }
 
@@ -100,10 +103,10 @@ type TruthAuctionBookData = {
 }
 
 type TruthAuctionViewerBidSummary = {
-	claimableCount: number
-	losingCount: number
+	refundableCount: number
 	partialCount: number
 	refundedCount: number
+	repClaimableCount: number
 	winningCount: number
 }
 
@@ -129,10 +132,24 @@ function renderTimestamp({ displayTimestamp, fallbackText }: { displayTimestamp:
 function getForkOnlyFallbackText(hasPreviewForkActivity: boolean) {
 	return hasPreviewForkActivity ? UNKNOWN_VALUE : UNAVAILABLE_UNTIL_FORK
 }
-function getPreviewForkType(previewPool: ListedSecurityPool | undefined, hasPreviewForkActivity: boolean) {
-	if (previewPool === undefined) return UNKNOWN_VALUE
-	if (!hasPreviewForkActivity) return UNAVAILABLE_UNTIL_FORK
-	return previewPool.forkOwnSecurityPool ? 'Own escalation fork' : 'Parent/Zoltar fork'
+
+function getForkTypeLabel(forkOwnSecurityPool: boolean) {
+	return forkOwnSecurityPool ? 'Own escalation fork' : 'Parent/Zoltar fork'
+}
+
+function getForkOutcomeLabel(forkOutcome: ForkOutcomeKey | undefined) {
+	if (forkOutcome === undefined) return UNKNOWN_VALUE
+	return getReportingOutcomeLabel(forkOutcome)
+}
+
+function getPreviewForkSummary({ hasPreviewForkActivity, isSyntheticForkTriggerPreview, previewPool }: { hasPreviewForkActivity: boolean; isSyntheticForkTriggerPreview: boolean; previewPool: ListedSecurityPool | undefined }) {
+	if (previewPool === undefined) return { outcomeLabel: UNKNOWN_VALUE, typeLabel: UNKNOWN_VALUE }
+	if (!hasPreviewForkActivity) return { outcomeLabel: UNAVAILABLE_UNTIL_FORK, typeLabel: UNAVAILABLE_UNTIL_FORK }
+	if (isSyntheticForkTriggerPreview) return { outcomeLabel: 'Not chosen yet', typeLabel: 'Not chosen yet' }
+	return {
+		outcomeLabel: getForkOutcomeLabel(previewPool.forkOutcome),
+		typeLabel: getForkTypeLabel(previewPool.forkOwnSecurityPool),
+	}
 }
 function getPreviewMigrationSummary(previewPool: ListedSecurityPool | undefined, hasPreviewForkActivity: boolean) {
 	if (previewPool === undefined) return UNKNOWN_VALUE
@@ -143,6 +160,15 @@ function getPreviewMigrationSummary(previewPool: ListedSecurityPool | undefined,
 function getStageLabel(stage: ForkAuctionStageView) {
 	return STAGE_LABELS[stage]
 }
+function humanizeForkAuctionAction(actionName: ForkAuctionActionResult['action']) {
+	return actionName.replace(/([A-Z])/g, ' $1').replace(/^./, value => value.toUpperCase())
+}
+
+function getForkAuctionActionLabel(actionName: ForkAuctionActionResult['action']) {
+	if (actionName === 'claimAuctionProceeds') return 'Settle Finalized Bid'
+	return humanizeForkAuctionAction(actionName)
+}
+
 function getStageAheadMessage(stage: ForkAuctionStageView, currentStage: ForkAuctionStageView) {
 	if (STAGE_ORDER[stage] <= STAGE_ORDER[currentStage]) return undefined
 	switch (stage) {
@@ -223,14 +249,26 @@ function getRefundTruthAuctionBidGuardMessage({ refundBidIndexInput, refundTickI
 	return undefined
 }
 
-function getClaimAuctionProceedsGuardMessage({ claimBidIndexInput, claimBidTickInput, claimingAvailable, truthAuction, vaultAddressInput }: { claimBidIndexInput: string; claimBidTickInput: string; claimingAvailable: boolean; truthAuction: TruthAuctionMetrics | undefined; vaultAddressInput: string }) {
-	if (truthAuction === undefined) return 'Load the truth auction before claiming proceeds.'
-	if (!truthAuction.finalized) return 'Claiming becomes available after the truth auction is finalized.'
-	if (!claimingAvailable) return 'Claiming is not yet available for this pool.'
-	if (parseOptionalBigInt(claimBidTickInput) === undefined) return 'Enter a valid claim bid tick.'
-	if (parseOptionalBigInt(claimBidIndexInput) === undefined) return 'Enter a valid claim bid index.'
-	const trimmedVaultAddress = vaultAddressInput.trim()
-	if (trimmedVaultAddress !== '' && !isAddress(trimmedVaultAddress)) return 'Enter a valid vault address.'
+function getSettleFinalizedTruthAuctionBidGuardMessage({
+	claimBidIndexInput,
+	claimBidTickInput,
+	claimingAvailable,
+	settlementAddressInput,
+	truthAuction,
+}: {
+	claimBidIndexInput: string
+	claimBidTickInput: string
+	claimingAvailable: boolean
+	settlementAddressInput: string
+	truthAuction: TruthAuctionMetrics | undefined
+}) {
+	if (truthAuction === undefined) return 'Load the truth auction before settling finalized bids.'
+	if (!truthAuction.finalized) return 'Finalized settlement becomes available after the truth auction is finalized.'
+	if (!claimingAvailable) return 'Finalized settlement is not yet available for this pool.'
+	if (parseOptionalBigInt(claimBidTickInput) === undefined) return 'Enter a valid settlement bid tick.'
+	if (parseOptionalBigInt(claimBidIndexInput) === undefined) return 'Enter a valid settlement bid index.'
+	const trimmedSettlementAddress = settlementAddressInput.trim()
+	if (trimmedSettlementAddress !== '' && !isAddress(trimmedSettlementAddress)) return 'Enter a valid bidder address.'
 	return undefined
 }
 
@@ -269,55 +307,82 @@ function getTickDisposition(tickSummary: TruthAuctionTickSummary, truthAuction: 
 }
 
 function getBidDisposition(bid: TruthAuctionBidView, truthAuction: TruthAuctionMetrics | undefined): TruthAuctionBidDisposition {
-	if (bid.refunded) return { label: 'Refunded', tone: 'default', canPrefillClaim: false, canPrefillRefund: false, summaryKind: 'refunded' }
-	if (bid.claimed) return { label: 'Claimed', tone: 'success', canPrefillClaim: false, canPrefillRefund: false, summaryKind: 'claimed' }
-	if (truthAuction === undefined) return { label: 'Pending', tone: 'default', canPrefillClaim: false, canPrefillRefund: false, summaryKind: 'neutral' }
+	if (bid.refunded) return { label: 'Refunded', tone: 'default', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'ethRefund', summaryKind: 'refunded' }
+	if (truthAuction === undefined) {
+		if (bid.claimed) return { label: 'Claimed', tone: 'success', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'none', summaryKind: 'neutral' }
+		return { label: 'Pending', tone: 'default', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'none', summaryKind: 'neutral' }
+	}
 
 	const winningThresholdPrice = getTruthAuctionWinningThresholdPrice(truthAuction)
 	if (winningThresholdPrice !== undefined) {
 		if (getTruthAuctionPriceAtTick(bid.tick) >= winningThresholdPrice) {
+			if (truthAuction.finalized) {
+				if (bid.claimed) return { label: 'Claimed', tone: 'success', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'repClaim', summaryKind: 'neutral' }
+				return { label: 'Winning', tone: 'success', canPrefillRefund: false, canPrefillSettle: true, settlementKind: 'repClaim', summaryKind: 'winning' }
+			}
 			return {
-				label: truthAuction.finalized ? 'Winning' : 'Provisional',
-				tone: truthAuction.finalized ? 'success' : 'warning',
-				canPrefillClaim: truthAuction.finalized,
+				label: 'Provisional',
+				tone: 'warning',
 				canPrefillRefund: false,
-				summaryKind: truthAuction.finalized ? 'winning' : 'neutral',
+				canPrefillSettle: false,
+				settlementKind: 'none',
+				summaryKind: 'neutral',
 			}
 		}
+		if (truthAuction.finalized) {
+			if (bid.claimed) return { label: 'Refunded', tone: 'default', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'ethRefund', summaryKind: 'refunded' }
+			return { label: 'Refundable', tone: 'danger', canPrefillRefund: false, canPrefillSettle: true, settlementKind: 'ethRefund', summaryKind: 'refundable' }
+		}
 		return {
-			label: truthAuction.finalized ? 'Owner Withdrawal' : 'In Book',
-			tone: truthAuction.finalized ? 'danger' : 'default',
-			canPrefillClaim: false,
+			label: 'In Book',
+			tone: 'default',
 			canPrefillRefund: false,
-			summaryKind: truthAuction.finalized ? 'losing' : 'neutral',
+			canPrefillSettle: false,
+			settlementKind: 'none',
+			summaryKind: 'neutral',
 		}
 	}
 
 	if (!truthAuction.hitCap || truthAuction.clearingTick === undefined || truthAuction.clearingPrice === undefined) {
+		if (truthAuction.finalized) {
+			if (bid.claimed) return { label: 'Claimed', tone: 'success', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'repClaim', summaryKind: 'neutral' }
+			return { label: 'Winning', tone: 'success', canPrefillRefund: false, canPrefillSettle: true, settlementKind: 'repClaim', summaryKind: 'winning' }
+		}
 		return {
-			label: truthAuction.finalized ? 'Winning' : 'In Book',
-			tone: truthAuction.finalized ? 'success' : 'default',
-			canPrefillClaim: truthAuction.finalized,
+			label: 'In Book',
+			tone: 'default',
 			canPrefillRefund: false,
-			summaryKind: truthAuction.finalized ? 'winning' : 'neutral',
+			canPrefillSettle: false,
+			settlementKind: 'none',
+			summaryKind: 'neutral',
 		}
 	}
 
 	if (bid.tick > truthAuction.clearingTick) {
+		if (truthAuction.finalized) {
+			if (bid.claimed) return { label: 'Claimed', tone: 'success', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'repClaim', summaryKind: 'neutral' }
+			return { label: 'Winning', tone: 'success', canPrefillRefund: false, canPrefillSettle: true, settlementKind: 'repClaim', summaryKind: 'winning' }
+		}
 		return {
-			label: truthAuction.finalized ? 'Winning' : 'Above Clearing',
-			tone: truthAuction.finalized ? 'success' : 'warning',
-			canPrefillClaim: truthAuction.finalized,
+			label: 'Above Clearing',
+			tone: 'warning',
 			canPrefillRefund: false,
-			summaryKind: truthAuction.finalized ? 'winning' : 'neutral',
+			canPrefillSettle: false,
+			settlementKind: 'none',
+			summaryKind: 'neutral',
 		}
 	}
 	if (bid.tick < truthAuction.clearingTick) {
+		if (truthAuction.finalized) {
+			if (bid.claimed) return { label: 'Refunded', tone: 'default', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'ethRefund', summaryKind: 'refunded' }
+			return { label: 'Refundable', tone: 'danger', canPrefillRefund: false, canPrefillSettle: true, settlementKind: 'ethRefund', summaryKind: 'refundable' }
+		}
 		return {
-			label: truthAuction.finalized ? 'Owner Withdrawal' : 'Below Clearing',
+			label: 'Below Clearing',
 			tone: 'danger',
-			canPrefillClaim: false,
 			canPrefillRefund: !truthAuction.finalized,
+			canPrefillSettle: false,
+			settlementKind: 'none',
 			summaryKind: 'losing',
 		}
 	}
@@ -325,29 +390,44 @@ function getBidDisposition(bid: TruthAuctionBidView, truthAuction: TruthAuctionM
 	const previousCumulativeEth = bid.activeCumulativeEthBeforeBid
 	const activeCumulativeEth = previousCumulativeEth + bid.ethAmount
 	if (truthAuction.ethAtClearingTick <= previousCumulativeEth) {
+		if (truthAuction.finalized) {
+			if (bid.claimed) return { label: 'Refunded', tone: 'default', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'ethRefund', summaryKind: 'refunded' }
+			return { label: 'Refundable', tone: 'danger', canPrefillRefund: false, canPrefillSettle: true, settlementKind: 'ethRefund', summaryKind: 'refundable' }
+		}
 		return {
-			label: truthAuction.finalized ? 'Owner Withdrawal' : 'Below Clearing',
+			label: 'Below Clearing',
 			tone: 'danger',
-			canPrefillClaim: false,
-			canPrefillRefund: !truthAuction.finalized,
+			canPrefillRefund: true,
+			canPrefillSettle: false,
+			settlementKind: 'none',
 			summaryKind: 'losing',
 		}
 	}
 	if (truthAuction.ethAtClearingTick >= activeCumulativeEth) {
+		if (truthAuction.finalized) {
+			if (bid.claimed) return { label: 'Claimed', tone: 'success', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'repClaim', summaryKind: 'neutral' }
+			return { label: 'Winning', tone: 'success', canPrefillRefund: false, canPrefillSettle: true, settlementKind: 'repClaim', summaryKind: 'winning' }
+		}
 		return {
-			label: truthAuction.finalized ? 'Winning' : 'At Clearing',
-			tone: truthAuction.finalized ? 'success' : 'warning',
-			canPrefillClaim: truthAuction.finalized,
+			label: 'At Clearing',
+			tone: 'warning',
 			canPrefillRefund: false,
-			summaryKind: truthAuction.finalized ? 'winning' : 'neutral',
+			canPrefillSettle: false,
+			settlementKind: 'none',
+			summaryKind: 'neutral',
 		}
 	}
+	if (truthAuction.finalized) {
+		if (bid.claimed) return { label: 'Claimed', tone: 'success', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'repClaim', summaryKind: 'neutral' }
+		return { label: 'Partial', tone: 'warning', canPrefillRefund: false, canPrefillSettle: true, settlementKind: 'repClaim', summaryKind: 'partial' }
+	}
 	return {
-		label: truthAuction.finalized ? 'Partial' : 'At Clearing',
+		label: 'At Clearing',
 		tone: 'warning',
-		canPrefillClaim: truthAuction.finalized,
 		canPrefillRefund: false,
-		summaryKind: truthAuction.finalized ? 'partial' : 'neutral',
+		canPrefillSettle: false,
+		settlementKind: 'none',
+		summaryKind: 'neutral',
 	}
 }
 
@@ -405,18 +485,18 @@ function summarizeViewerTruthAuctionBids(viewerBids: TruthAuctionBidView[], trut
 				summary.winningCount += 1
 			} else if (disposition.summaryKind === 'partial') {
 				summary.partialCount += 1
-			} else if (disposition.summaryKind === 'losing') {
-				summary.losingCount += 1
+			} else if (disposition.summaryKind === 'losing' || disposition.summaryKind === 'refundable') {
+				summary.refundableCount += 1
 			}
-			if (disposition.canPrefillClaim) summary.claimableCount += 1
+			if (disposition.canPrefillSettle && disposition.settlementKind === 'repClaim') summary.repClaimableCount += 1
 
 			return summary
 		},
 		{
-			claimableCount: 0,
-			losingCount: 0,
 			partialCount: 0,
+			refundableCount: 0,
 			refundedCount: 0,
+			repClaimableCount: 0,
 			winningCount: 0,
 		},
 	)
@@ -477,13 +557,13 @@ export function ForkAuctionSection({
 	forkAuctionError,
 	forkAuctionForm,
 	forkAuctionResult,
+	lifecycleStateOverride,
 	loadingForkAuctionDetails,
 	onClaimAuctionProceeds,
 	onCreateChildUniverse,
 	onFinalizeTruthAuction,
 	onForkAuctionFormChange,
 	onForkUniverse,
-	onForkWithOwnEscalation,
 	onInitiateFork,
 	onLoadForkAuction,
 	onMigrateEscalationDeposits,
@@ -512,10 +592,21 @@ export function ForkAuctionSection({
 	const forkOutcome = forkAuctionDetails?.forkOutcome ?? previewPool?.forkOutcome
 	const questionOutcome = forkAuctionDetails?.questionOutcome ?? previewPool?.questionOutcome
 	const truthAuctionAddress = forkAuctionDetails?.truthAuctionAddress ?? previewPool?.truthAuctionAddress
-	const hasPreviewForkActivity = previewPool === undefined ? false : hasForkActivity(previewPool)
+	const previewPoolHasActualForkActivity = previewPool?.hasForkActivity === true
+	const isSyntheticForkTriggerPreview = lifecycleStateOverride === 'poolForked' && !previewPoolHasActualForkActivity
+	const hasPreviewForkActivity = previewPoolHasActualForkActivity || lifecycleStateOverride === 'poolForked'
+	const previewForkSummary = getPreviewForkSummary({
+		hasPreviewForkActivity,
+		isSyntheticForkTriggerPreview,
+		previewPool,
+	})
+	const syntheticForkTriggerNextStep = !isSyntheticForkTriggerPreview ? undefined : 'If this pool is triggering a Zoltar fork from its own escalation game, use Trigger Zoltar Fork from Reporting first. Otherwise activate fork mode here, then move to Migration and run Migrate Escalation Deposits.'
+	const resolvedForkTypeLabel = forkAuctionDetails === undefined ? previewForkSummary.typeLabel : getForkTypeLabel(forkAuctionDetails.forkOwnSecurityPool)
+	const resolvedForkOutcomeLabel = forkAuctionDetails === undefined ? previewForkSummary.outcomeLabel : getForkOutcomeLabel(forkOutcome)
 	const forkOnlyFallbackText = getForkOnlyFallbackText(hasPreviewForkActivity)
 	const forkStageDescription = (() => {
 		if (forkAuctionDetails === undefined) {
+			if (lifecycleStateOverride === 'poolForked' && systemState === 'operational') return 'This pool reached non-decision in its escalation game. Trigger the Zoltar fork from Reporting if this pool should fork the universe, or use the initiate action below once Zoltar is already forked.'
 			if (systemState === undefined) return undefined
 
 			return getForkStageDescriptionForState(systemState)
@@ -642,7 +733,7 @@ export function ForkAuctionSection({
 
 		return 'No'
 	})()
-	const claimingAvailableDisplay = (() => {
+	const settlementAvailableDisplay = (() => {
 		if (forkAuctionDetails === undefined) {
 			if (hasPreviewForkActivity) return UNKNOWN_VALUE
 
@@ -652,6 +743,7 @@ export function ForkAuctionSection({
 
 		return 'No'
 	})()
+	const viewerRefundMetricLabel = truthAuctionStatus?.finalized ? 'Refundable' : 'Below Clearing'
 	const interactionDisabledReason = (() => {
 		if (accountState.address === undefined) return 'Connect a wallet before using fork and auction actions.'
 		if (!isMainnet) return 'Switch to Ethereum mainnet before using fork and auction actions.'
@@ -663,10 +755,12 @@ export function ForkAuctionSection({
 			currentStage,
 			workflowDisabled: disabled,
 		}),
-		lifecycleState: deriveSecurityPoolLifecycleState({
-			questionOutcome,
-			systemState,
-		}),
+		lifecycleState:
+			lifecycleStateOverride ??
+			deriveSecurityPoolLifecycleState({
+				questionOutcome,
+				systemState,
+			}),
 		universeHasForked: previewPool?.universeHasForked === true,
 	})
 	const truthAuctionBidGuardMessage = getTruthAuctionBidGuardMessage({
@@ -691,13 +785,20 @@ export function ForkAuctionSection({
 		refundTickInput: forkAuctionForm.refundTick,
 		truthAuction: truthAuctionStatus,
 	})
-	const claimAuctionProceedsGuardMessage = getClaimAuctionProceedsGuardMessage({
+	const settleFinalizedTruthAuctionBidGuardMessage = getSettleFinalizedTruthAuctionBidGuardMessage({
 		claimBidIndexInput: forkAuctionForm.claimBidIndex,
 		claimBidTickInput: forkAuctionForm.claimBidTick,
 		claimingAvailable: forkAuctionDetails?.claimingAvailable ?? false,
+		settlementAddressInput: forkAuctionForm.settlementAddress,
 		truthAuction: truthAuctionStatus,
-		vaultAddressInput: forkAuctionForm.vaultAddress,
 	})
+	const prefillSettleBid = (bid: TruthAuctionBidView) => {
+		onForkAuctionFormChange({
+			claimBidIndex: bid.bidIndex.toString(),
+			claimBidTick: bid.tick.toString(),
+			settlementAddress: bid.bidder,
+		})
+	}
 	const createChildUniverseEnabled = forkPoolState.actions.createChildUniverse.enabled
 	const childUniverseRequirements = [
 		{ key: 'pool', label: 'Forked pool loaded', resolved: hasLoadedPoolContext, ...(hasLoadedPoolContext ? {} : { detail: 'Load a forked pool before creating a child universe.' }) },
@@ -873,7 +974,7 @@ export function ForkAuctionSection({
 					title: 'Latest Fork / Auction Action',
 					embedInCard,
 					rows: [
-						{ label: 'Action', value: forkAuctionResult.action },
+						{ label: 'Action', value: getForkAuctionActionLabel(forkAuctionResult.action) },
 						{ label: 'Pool', value: <AddressValue address={forkAuctionResult.securityPoolAddress} /> },
 						{ label: 'Universe', value: <UniverseLink universeId={forkAuctionResult.universeId} /> },
 						{ label: 'Transaction', value: <TransactionHashLink hash={forkAuctionResult.hash} /> },
@@ -886,15 +987,13 @@ export function ForkAuctionSection({
 		{ label: 'System State', value: getSecurityPoolLifecycleLabel(forkPoolState.lifecycleState) },
 		{
 			label: 'Fork Type',
-			value: (() => {
-				if (forkAuctionDetails === undefined) return getPreviewForkType(previewPool, hasPreviewForkActivity)
-				if (forkAuctionDetails.forkOwnSecurityPool) return 'Own escalation fork'
-
-				return 'Parent/Zoltar fork'
-			})(),
+			value: resolvedForkTypeLabel,
 		},
 		{ label: 'Question Outcome', value: questionOutcome === undefined ? UNKNOWN_VALUE : getReportingOutcomeLabel(questionOutcome) },
-		{ label: 'Fork Outcome', value: forkOutcome === undefined ? UNKNOWN_VALUE : getReportingOutcomeLabel(forkOutcome) },
+		{
+			label: 'Fork Outcome',
+			value: resolvedForkOutcomeLabel,
+		},
 		{ label: 'Collateral', value: renderMetricValue(forkAuctionDetails?.completeSetCollateralAmount ?? previewPool?.completeSetCollateralAmount, 'ETH', UNKNOWN_VALUE) },
 	]
 	const initiateStatusMetrics: DisplayMetric[] = [
@@ -902,12 +1001,7 @@ export function ForkAuctionSection({
 		{ label: 'REP At Fork', value: forkAuctionDetails === undefined ? forkOnlyFallbackText : <CurrencyValue value={forkAuctionDetails.repAtFork} suffix='REP' /> },
 		{
 			label: 'Fork Type',
-			value: (() => {
-				if (forkAuctionDetails === undefined) return getPreviewForkType(previewPool, hasPreviewForkActivity)
-				if (forkAuctionDetails.forkOwnSecurityPool) return 'Own escalation fork'
-
-				return 'Parent/Zoltar fork'
-			})(),
+			value: resolvedForkTypeLabel,
 		},
 		{ label: 'Migration Window', value: formatDuration(MIGRATION_TIME_SECONDS) },
 	]
@@ -935,12 +1029,7 @@ export function ForkAuctionSection({
 		},
 		{
 			label: 'Fork Type',
-			value: (() => {
-				if (forkAuctionDetails === undefined) return getPreviewForkType(previewPool, hasPreviewForkActivity)
-				if (forkAuctionDetails.forkOwnSecurityPool) return 'Own escalation fork'
-
-				return 'Parent/Zoltar fork'
-			})(),
+			value: resolvedForkTypeLabel,
 		},
 	]
 	const auctionStatusMetrics: DisplayMetric[] = [
@@ -961,7 +1050,7 @@ export function ForkAuctionSection({
 		{ label: 'Finalized', value: finalizedDisplay },
 		{ label: 'Underfunded', value: underfundedDisplay },
 		{ label: 'Auctioned Allowance', value: forkAuctionDetails === undefined ? forkOnlyFallbackText : <CurrencyValue value={forkAuctionDetails.auctionedSecurityBondAllowance} suffix='ETH' /> },
-		{ label: 'Claiming Available', value: claimingAvailableDisplay },
+		{ label: 'Settlement Available', value: settlementAvailableDisplay },
 		{ label: 'ETH Raised / Cap', value: ethRaisedCapDisplay },
 		{ label: 'REP Purchased', value: truthAuctionStatus === undefined ? forkOnlyFallbackText : <CurrencyValue value={truthAuctionStatus.totalRepPurchased} suffix='REP' /> },
 	]
@@ -971,12 +1060,7 @@ export function ForkAuctionSection({
 				{ label: 'REP At Fork', value: forkAuctionDetails === undefined ? forkOnlyFallbackText : <CurrencyValue value={forkAuctionDetails.repAtFork} suffix='REP' /> },
 				{
 					label: 'Fork Type',
-					value: (() => {
-						if (forkAuctionDetails === undefined) return getPreviewForkType(previewPool, hasPreviewForkActivity)
-						if (forkAuctionDetails.forkOwnSecurityPool) return 'Own escalation fork'
-
-						return 'Parent/Zoltar fork'
-					})(),
+					value: resolvedForkTypeLabel,
 				},
 				{ label: 'Parent Pool', value: renderAddress(parentSecurityPoolAddress) },
 				{ label: 'Migration Window', value: formatDuration(MIGRATION_TIME_SECONDS) },
@@ -1018,7 +1102,7 @@ export function ForkAuctionSection({
 					{ label: 'Finalized', value: finalizedDisplay },
 					{ label: 'Underfunded', value: underfundedDisplay },
 					{ label: 'Auctioned Allowance', value: forkAuctionDetails === undefined ? forkOnlyFallbackText : <CurrencyValue value={forkAuctionDetails.auctionedSecurityBondAllowance} suffix='ETH' /> },
-					{ label: 'Claiming Available', value: claimingAvailableDisplay },
+					{ label: 'Settlement Available', value: settlementAvailableDisplay },
 				]
 
 			return initiateStatusMetrics
@@ -1186,6 +1270,7 @@ export function ForkAuctionSection({
 										{resolvedSelectedTickBids.map(bid => {
 											const disposition = getBidDisposition(bid, truthAuctionStatus)
 											const isViewerBid = sameAddress(bid.bidder, accountState.address)
+											const hasRowAction = isViewerBid && (disposition.canPrefillRefund || disposition.canPrefillSettle)
 											return (
 												<div className='truth-auction-bid-row' key={`${bid.tick.toString()}:${bid.bidIndex.toString()}`}>
 													<span className='truth-auction-bid-row-label'>Bid #{bid.bidIndex.toString()}</span>
@@ -1202,8 +1287,8 @@ export function ForkAuctionSection({
 														<span className={`truth-auction-status-pill ${getTruthAuctionDispositionClassName(disposition.tone)}`}>{disposition.label}</span>
 													</span>
 													<div className='truth-auction-bid-row-actions'>
-														{!isViewerBid ? <span className='truth-auction-row-empty'>—</span> : undefined}
-														{disposition.canPrefillRefund ? (
+														{!hasRowAction ? <span className='truth-auction-row-empty'>—</span> : undefined}
+														{isViewerBid && disposition.canPrefillRefund ? (
 															<button
 																className='secondary'
 																onClick={() =>
@@ -1217,18 +1302,9 @@ export function ForkAuctionSection({
 																Prefill Refund
 															</button>
 														) : undefined}
-														{disposition.canPrefillClaim ? (
-															<button
-																className='secondary'
-																onClick={() =>
-																	onForkAuctionFormChange({
-																		claimBidIndex: bid.bidIndex.toString(),
-																		claimBidTick: bid.tick.toString(),
-																	})
-																}
-																type='button'
-															>
-																Prefill Claim
+														{isViewerBid && disposition.canPrefillSettle ? (
+															<button className='secondary' onClick={() => prefillSettleBid(bid)} type='button'>
+																Prefill Settle
 															</button>
 														) : undefined}
 													</div>
@@ -1261,8 +1337,8 @@ export function ForkAuctionSection({
 					<div className='truth-auction-wallet-summary'>
 						<MetricField label='Winning'>{viewerBidSummary.winningCount.toString()}</MetricField>
 						<MetricField label='Partial'>{viewerBidSummary.partialCount.toString()}</MetricField>
-						<MetricField label='Losing'>{viewerBidSummary.losingCount.toString()}</MetricField>
-						<MetricField label='Claimable'>{viewerBidSummary.claimableCount.toString()}</MetricField>
+						<MetricField label={viewerRefundMetricLabel}>{viewerBidSummary.refundableCount.toString()}</MetricField>
+						<MetricField label='REP Claimable'>{viewerBidSummary.repClaimableCount.toString()}</MetricField>
 						<MetricField label='Refunded'>{viewerBidSummary.refundedCount.toString()}</MetricField>
 					</div>
 				) : undefined}
@@ -1312,18 +1388,9 @@ export function ForkAuctionSection({
 												Prefill Refund
 											</button>
 										) : undefined}
-										{disposition.canPrefillClaim ? (
-											<button
-												className='secondary'
-												onClick={() =>
-													onForkAuctionFormChange({
-														claimBidIndex: bid.bidIndex.toString(),
-														claimBidTick: bid.tick.toString(),
-													})
-												}
-												type='button'
-											>
-												Prefill Claim
+										{disposition.canPrefillSettle ? (
+											<button className='secondary' onClick={() => prefillSettleBid(bid)} type='button'>
+												Prefill Settle
 											</button>
 										) : undefined}
 									</div>
@@ -1342,56 +1409,50 @@ export function ForkAuctionSection({
 			</SectionBlock>
 		)
 	})()
-	const truthAuctionSettlementSection = (() => {
-		if (!shouldShowTruthAuctionVisualization || truthAuctionStatus === undefined) return undefined
+	const truthAuctionRefundSection = (() => {
+		if (!shouldShowTruthAuctionVisualization || truthAuctionStatus === undefined || truthAuctionStatus.finalized) return undefined
 		return (
-			<SectionBlock title='Settle Selected Bid' description='Use My Bids or the selected price level to prefill a claim or refund, then settle it here.'>
-				<div className='truth-auction-settlement-grid'>
-					<div className='truth-auction-panel truth-auction-settlement-panel'>
-						<div className='truth-auction-panel-header'>
-							<div>
-								<h4>Refund Losing Bid</h4>
-								<p className='detail'>Refund a losing bid before finalization when the selected row indicates it is below clearing.</p>
-							</div>
-						</div>
-						<div className='form-grid'>
-							<div className='field-row'>
-								<label className='field'>
-									<span>Refund Tick</span>
-									<FormInput value={forkAuctionForm.refundTick} onInput={event => onForkAuctionFormChange({ refundTick: event.currentTarget.value })} />
-								</label>
-								<label className='field'>
-									<span>Refund Bid Index</span>
-									<FormInput value={forkAuctionForm.refundBidIndex} onInput={event => onForkAuctionFormChange({ refundBidIndex: event.currentTarget.value })} />
-								</label>
-							</div>
-							<div className='actions'>{renderStageActionButton({ action: 'refundLosingBids', availability: createActionAvailability(refundTruthAuctionBidGuardMessage), idleLabel: 'Refund Losing Bid', onClick: onRefundLosingBids, pendingLabel: 'Refunding losing bid...', tone: 'primary' })}</div>
-						</div>
-					</div>
-					<div className='truth-auction-panel truth-auction-settlement-panel'>
-						<div className='truth-auction-panel-header'>
-							<div>
-								<h4>Claim Auction Proceeds</h4>
-								<p className='detail'>Claim proceeds for a finalized winning or partial bid. Leave vault blank to use the connected wallet.</p>
-							</div>
-						</div>
-						<div className='form-grid'>
+			<SectionBlock title='Refund Losing Bid' description='Refund a losing bid before finalization when the selected row indicates it is below clearing.'>
+				<div className='truth-auction-panel truth-auction-settlement-panel'>
+					<div className='form-grid'>
+						<div className='field-row'>
 							<label className='field'>
-								<span>Vault Address</span>
-								<FormInput value={forkAuctionForm.vaultAddress} onInput={event => onForkAuctionFormChange({ vaultAddress: event.currentTarget.value })} placeholder='Leave empty to use connected wallet' />
+								<span>Refund Tick</span>
+								<FormInput value={forkAuctionForm.refundTick} onInput={event => onForkAuctionFormChange({ refundTick: event.currentTarget.value })} />
 							</label>
-							<div className='field-row'>
-								<label className='field'>
-									<span>Claim Bid Tick</span>
-									<FormInput value={forkAuctionForm.claimBidTick} onInput={event => onForkAuctionFormChange({ claimBidTick: event.currentTarget.value })} />
-								</label>
-								<label className='field'>
-									<span>Claim Bid Index</span>
-									<FormInput value={forkAuctionForm.claimBidIndex} onInput={event => onForkAuctionFormChange({ claimBidIndex: event.currentTarget.value })} />
-								</label>
-							</div>
-							<div className='actions'>{renderStageActionButton({ action: 'claimAuctionProceeds', availability: createActionAvailability(claimAuctionProceedsGuardMessage), idleLabel: 'Claim Auction Proceeds', onClick: onClaimAuctionProceeds, pendingLabel: 'Claiming auction proceeds...', tone: 'primary' })}</div>
+							<label className='field'>
+								<span>Refund Bid Index</span>
+								<FormInput value={forkAuctionForm.refundBidIndex} onInput={event => onForkAuctionFormChange({ refundBidIndex: event.currentTarget.value })} />
+							</label>
 						</div>
+						<div className='actions'>{renderStageActionButton({ action: 'refundLosingBids', availability: createActionAvailability(refundTruthAuctionBidGuardMessage), idleLabel: 'Refund Losing Bid', onClick: onRefundLosingBids, pendingLabel: 'Refunding losing bid...', tone: 'primary' })}</div>
+					</div>
+				</div>
+			</SectionBlock>
+		)
+	})()
+	const truthAuctionFinalizedSettlementSection = (() => {
+		if (!shouldShowTruthAuctionVisualization || truthAuctionStatus === undefined || !truthAuctionStatus.finalized) return undefined
+		return (
+			<SectionBlock title='Settle Finalized Bid' description='Settle a finalized truth-auction bid. The bidder address must match the wallet that submitted the bid.'>
+				<div className='truth-auction-panel truth-auction-settlement-panel'>
+					<div className='form-grid'>
+						<label className='field'>
+							<span>Bidder Address</span>
+							<FormInput value={forkAuctionForm.settlementAddress} onInput={event => onForkAuctionFormChange({ settlementAddress: event.currentTarget.value })} placeholder='Leave empty to use connected wallet' />
+						</label>
+						<p className='detail'>This must match the address that submitted the bid. Leave empty to use the connected wallet when settling your own bids. Winning and partial bids credit REP into that vault, while losing finalized bids refund ETH to the same address.</p>
+						<div className='field-row'>
+							<label className='field'>
+								<span>Settlement Bid Tick</span>
+								<FormInput value={forkAuctionForm.claimBidTick} onInput={event => onForkAuctionFormChange({ claimBidTick: event.currentTarget.value })} />
+							</label>
+							<label className='field'>
+								<span>Settlement Bid Index</span>
+								<FormInput value={forkAuctionForm.claimBidIndex} onInput={event => onForkAuctionFormChange({ claimBidIndex: event.currentTarget.value })} />
+							</label>
+						</div>
+						<div className='actions'>{renderStageActionButton({ action: 'claimAuctionProceeds', availability: createActionAvailability(settleFinalizedTruthAuctionBidGuardMessage), idleLabel: 'Settle Finalized Bid', onClick: onClaimAuctionProceeds, pendingLabel: 'Settling finalized bid...', tone: 'primary' })}</div>
 					</div>
 				</div>
 			</SectionBlock>
@@ -1402,41 +1463,49 @@ export function ForkAuctionSection({
 		return (
 			<ReadOnlyDetailAccordion defaultOpen={false} title='Operator Tools'>
 				<div className='truth-auction-manual-tools'>
-					<p className='detail'>Keep these raw fallback controls for operator workflows. End-user claim flows should go through the forker-mediated claim action rather than calling auction-owner withdrawals directly.</p>
-					<SectionBlock density='compact' headingLevel={4} title='Raw Refund Fallback' variant='embedded'>
-						<div className='form-grid'>
-							<div className='field-row'>
-								<label className='field'>
-									<span>Refund Tick</span>
-									<FormInput value={forkAuctionForm.refundTick} onInput={event => onForkAuctionFormChange({ refundTick: event.currentTarget.value })} />
-								</label>
-								<label className='field'>
-									<span>Refund Bid Index</span>
-									<FormInput value={forkAuctionForm.refundBidIndex} onInput={event => onForkAuctionFormChange({ refundBidIndex: event.currentTarget.value })} />
-								</label>
+					<p className='detail'>
+						{truthAuctionStatus.finalized
+							? 'Use this fallback to settle finalized truth-auction bids through the forker. The bidder address must match the wallet that submitted the bid. Winning and partial bids credit REP into that vault, while losing finalized bids refund ETH to the same address.'
+							: 'Before finalization, losing bids can still use this raw refund fallback when they are below clearing.'}
+					</p>
+					{truthAuctionStatus.finalized ? undefined : (
+						<SectionBlock density='compact' headingLevel={4} title='Raw Refund Fallback' variant='embedded'>
+							<div className='form-grid'>
+								<div className='field-row'>
+									<label className='field'>
+										<span>Refund Tick</span>
+										<FormInput value={forkAuctionForm.refundTick} onInput={event => onForkAuctionFormChange({ refundTick: event.currentTarget.value })} />
+									</label>
+									<label className='field'>
+										<span>Refund Bid Index</span>
+										<FormInput value={forkAuctionForm.refundBidIndex} onInput={event => onForkAuctionFormChange({ refundBidIndex: event.currentTarget.value })} />
+									</label>
+								</div>
+								<div className='actions'>{renderStageActionButton({ action: 'refundLosingBids', availability: createActionAvailability(refundTruthAuctionBidGuardMessage), idleLabel: 'Run Raw Refund', onClick: onRefundLosingBids, pendingLabel: 'Refunding losing bid...' })}</div>
 							</div>
-							<div className='actions'>{renderStageActionButton({ action: 'refundLosingBids', availability: createActionAvailability(refundTruthAuctionBidGuardMessage), idleLabel: 'Run Raw Refund', onClick: onRefundLosingBids, pendingLabel: 'Refunding losing bid...' })}</div>
-						</div>
-					</SectionBlock>
-					<SectionBlock density='compact' headingLevel={4} title='Raw Claim Fallback' variant='embedded'>
-						<div className='form-grid'>
-							<label className='field'>
-								<span>Vault Address</span>
-								<FormInput value={forkAuctionForm.vaultAddress} onInput={event => onForkAuctionFormChange({ vaultAddress: event.currentTarget.value })} placeholder='Leave empty to use connected wallet' />
-							</label>
-							<div className='field-row'>
+						</SectionBlock>
+					)}
+					{!truthAuctionStatus.finalized ? undefined : (
+						<SectionBlock density='compact' headingLevel={4} title='Raw Finalized Settlement' variant='embedded'>
+							<div className='form-grid'>
 								<label className='field'>
-									<span>Claim Bid Tick</span>
-									<FormInput value={forkAuctionForm.claimBidTick} onInput={event => onForkAuctionFormChange({ claimBidTick: event.currentTarget.value })} />
+									<span>Bidder Address</span>
+									<FormInput value={forkAuctionForm.settlementAddress} onInput={event => onForkAuctionFormChange({ settlementAddress: event.currentTarget.value })} placeholder='Leave empty to use connected wallet' />
 								</label>
-								<label className='field'>
-									<span>Claim Bid Index</span>
-									<FormInput value={forkAuctionForm.claimBidIndex} onInput={event => onForkAuctionFormChange({ claimBidIndex: event.currentTarget.value })} />
-								</label>
+								<div className='field-row'>
+									<label className='field'>
+										<span>Settlement Bid Tick</span>
+										<FormInput value={forkAuctionForm.claimBidTick} onInput={event => onForkAuctionFormChange({ claimBidTick: event.currentTarget.value })} />
+									</label>
+									<label className='field'>
+										<span>Settlement Bid Index</span>
+										<FormInput value={forkAuctionForm.claimBidIndex} onInput={event => onForkAuctionFormChange({ claimBidIndex: event.currentTarget.value })} />
+									</label>
+								</div>
+								<div className='actions'>{renderStageActionButton({ action: 'claimAuctionProceeds', availability: createActionAvailability(settleFinalizedTruthAuctionBidGuardMessage), idleLabel: 'Run Raw Finalized Settlement', onClick: onClaimAuctionProceeds, pendingLabel: 'Settling finalized bid...' })}</div>
 							</div>
-							<div className='actions'>{renderStageActionButton({ action: 'claimAuctionProceeds', availability: createActionAvailability(claimAuctionProceedsGuardMessage), idleLabel: 'Run Raw Claim', onClick: onClaimAuctionProceeds, pendingLabel: 'Claiming auction proceeds...' })}</div>
-						</div>
-					</SectionBlock>
+						</SectionBlock>
+					)}
 				</div>
 			</ReadOnlyDetailAccordion>
 		)
@@ -1445,10 +1514,8 @@ export function ForkAuctionSection({
 		if (selectedStage === 'initiate')
 			return (
 				<fieldset className='fork-stage-panel' disabled={disabled}>
-					<SectionBlock title='Fork Trigger'>{renderWorkflowMetricGrid(initiateStatusMetrics)}</SectionBlock>
-
-					<SectionBlock title='Fork With Own Escalation'>
-						<div className='actions'>{renderStageActionButton({ action: 'forkWithOwnEscalation', idleLabel: 'Fork With Own Escalation', onClick: onForkWithOwnEscalation, pendingLabel: 'Forking with own escalation...', tone: 'primary' })}</div>
+					<SectionBlock description={syntheticForkTriggerNextStep} title='Fork Trigger'>
+						{renderWorkflowMetricGrid(initiateStatusMetrics)}
 					</SectionBlock>
 
 					<SectionBlock title='Initiate Pool Fork'>
@@ -1610,11 +1677,12 @@ export function ForkAuctionSection({
 							{truthAuctionHero}
 							{viewerTruthAuctionBidsSection}
 							{truthAuctionStatus?.finalized ? undefined : (
-								<SectionBlock title='Finalize Truth Auction' description='Finalize the auction once bidding has closed so vault claims can settle against the final clearing result.'>
+								<SectionBlock title='Finalize Truth Auction' description='Finalize the auction once bidding has closed so finalized settlements can settle against the final clearing result.'>
 									<div className='actions'>{renderStageActionButton({ action: 'finalizeTruthAuction', availability: createActionAvailability(finalizeTruthAuctionGuardMessage), idleLabel: 'Finalize Truth Auction', onClick: onFinalizeTruthAuction, pendingLabel: 'Finalizing truth auction...' })}</div>
 								</SectionBlock>
 							)}
-							{truthAuctionSettlementSection}
+							{truthAuctionRefundSection}
+							{truthAuctionFinalizedSettlementSection}
 							{truthAuctionMarketViewSection}
 							{truthAuctionOperatorToolsSection}
 						</fieldset>
@@ -1623,43 +1691,52 @@ export function ForkAuctionSection({
 					<fieldset className='fork-stage-panel' disabled={disabled}>
 						<SectionBlock title='Settlement Status'>{renderWorkflowMetricGrid(settlementStatusMetrics)}</SectionBlock>
 
-						<SectionBlock title='Finalize Truth Auction'>
-							<div className='actions'>{renderStageActionButton({ action: 'finalizeTruthAuction', availability: createActionAvailability(finalizeTruthAuctionGuardMessage), idleLabel: 'Finalize Truth Auction', onClick: onFinalizeTruthAuction, pendingLabel: 'Finalizing truth auction...' })}</div>
-						</SectionBlock>
+						{truthAuctionStatus?.finalized ? undefined : (
+							<SectionBlock title='Finalize Truth Auction'>
+								<div className='actions'>{renderStageActionButton({ action: 'finalizeTruthAuction', availability: createActionAvailability(finalizeTruthAuctionGuardMessage), idleLabel: 'Finalize Truth Auction', onClick: onFinalizeTruthAuction, pendingLabel: 'Finalizing truth auction...' })}</div>
+							</SectionBlock>
+						)}
 
-						<SectionBlock title='Refund Losing Bid'>
-							<div className='form-grid'>
-								<label className='field'>
-									<span>Refund Tick</span>
-									<FormInput value={forkAuctionForm.refundTick} onInput={event => onForkAuctionFormChange({ refundTick: event.currentTarget.value })} />
-								</label>
-								<label className='field'>
-									<span>Refund Bid Index</span>
-									<FormInput value={forkAuctionForm.refundBidIndex} onInput={event => onForkAuctionFormChange({ refundBidIndex: event.currentTarget.value })} />
-								</label>
-								<div className='actions'>{renderStageActionButton({ action: 'refundLosingBids', availability: createActionAvailability(refundTruthAuctionBidGuardMessage), idleLabel: 'Refund Losing Bid', onClick: onRefundLosingBids, pendingLabel: 'Refunding losing bid...', tone: 'primary' })}</div>
-							</div>
-						</SectionBlock>
-
-						<SectionBlock title='Claim Auction Proceeds'>
-							<div className='form-grid'>
-								<label className='field'>
-									<span>Vault Address</span>
-									<FormInput value={forkAuctionForm.vaultAddress} onInput={event => onForkAuctionFormChange({ vaultAddress: event.currentTarget.value })} placeholder='Leave empty to use connected wallet' />
-								</label>
-								<div className='field-row'>
+						{truthAuctionStatus?.finalized ? undefined : (
+							<SectionBlock title='Refund Losing Bid'>
+								<div className='form-grid'>
 									<label className='field'>
-										<span>Claim Bid Tick</span>
-										<FormInput value={forkAuctionForm.claimBidTick} onInput={event => onForkAuctionFormChange({ claimBidTick: event.currentTarget.value })} />
+										<span>Refund Tick</span>
+										<FormInput value={forkAuctionForm.refundTick} onInput={event => onForkAuctionFormChange({ refundTick: event.currentTarget.value })} />
 									</label>
 									<label className='field'>
-										<span>Claim Bid Index</span>
-										<FormInput value={forkAuctionForm.claimBidIndex} onInput={event => onForkAuctionFormChange({ claimBidIndex: event.currentTarget.value })} />
+										<span>Refund Bid Index</span>
+										<FormInput value={forkAuctionForm.refundBidIndex} onInput={event => onForkAuctionFormChange({ refundBidIndex: event.currentTarget.value })} />
 									</label>
+									<div className='actions'>{renderStageActionButton({ action: 'refundLosingBids', availability: createActionAvailability(refundTruthAuctionBidGuardMessage), idleLabel: 'Refund Losing Bid', onClick: onRefundLosingBids, pendingLabel: 'Refunding losing bid...', tone: 'primary' })}</div>
 								</div>
-								<div className='actions'>{renderStageActionButton({ action: 'claimAuctionProceeds', availability: createActionAvailability(claimAuctionProceedsGuardMessage), idleLabel: 'Claim Auction Proceeds', onClick: onClaimAuctionProceeds, pendingLabel: 'Claiming auction proceeds...', tone: 'primary' })}</div>
-							</div>
-						</SectionBlock>
+							</SectionBlock>
+						)}
+
+						{!truthAuctionStatus?.finalized ? undefined : (
+							<SectionBlock title='Settle Finalized Bid' description='Settle a finalized truth-auction bid. The bidder address must match the wallet that submitted the bid.'>
+								<div className='form-grid'>
+									<label className='field'>
+										<span>Bidder Address</span>
+										<FormInput value={forkAuctionForm.settlementAddress} onInput={event => onForkAuctionFormChange({ settlementAddress: event.currentTarget.value })} placeholder='Leave empty to use connected wallet' />
+									</label>
+									<p className='detail'>This must match the address that submitted the bid. Leave empty to use the connected wallet when settling your own bids. Winning and partial bids credit REP into that vault, while losing finalized bids refund ETH to the same address.</p>
+									<div className='field-row'>
+										<label className='field'>
+											<span>Settlement Bid Tick</span>
+											<FormInput value={forkAuctionForm.claimBidTick} onInput={event => onForkAuctionFormChange({ claimBidTick: event.currentTarget.value })} />
+										</label>
+										<label className='field'>
+											<span>Settlement Bid Index</span>
+											<FormInput value={forkAuctionForm.claimBidIndex} onInput={event => onForkAuctionFormChange({ claimBidIndex: event.currentTarget.value })} />
+										</label>
+									</div>
+									<div className='actions'>
+										{renderStageActionButton({ action: 'claimAuctionProceeds', availability: createActionAvailability(settleFinalizedTruthAuctionBidGuardMessage), idleLabel: 'Settle Finalized Bid', onClick: onClaimAuctionProceeds, pendingLabel: 'Settling finalized bid...', tone: 'primary' })}
+									</div>
+								</div>
+							</SectionBlock>
+						)}
 					</fieldset>
 				)
 			}

--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -600,13 +600,12 @@ export function ForkAuctionSection({
 		isSyntheticForkTriggerPreview,
 		previewPool,
 	})
-	const syntheticForkTriggerNextStep = !isSyntheticForkTriggerPreview ? undefined : 'If this pool is triggering a Zoltar fork from its own escalation game, use Trigger Zoltar Fork from Reporting first. Otherwise activate fork mode here, then move to Migration and run Migrate Escalation Deposits.'
 	const resolvedForkTypeLabel = forkAuctionDetails === undefined ? previewForkSummary.typeLabel : getForkTypeLabel(forkAuctionDetails.forkOwnSecurityPool)
 	const resolvedForkOutcomeLabel = forkAuctionDetails === undefined ? previewForkSummary.outcomeLabel : getForkOutcomeLabel(forkOutcome)
 	const forkOnlyFallbackText = getForkOnlyFallbackText(hasPreviewForkActivity)
 	const forkStageDescription = (() => {
 		if (forkAuctionDetails === undefined) {
-			if (lifecycleStateOverride === 'poolForked' && systemState === 'operational') return 'This pool reached non-decision in its escalation game. Trigger the Zoltar fork from Reporting if this pool should fork the universe, or use the initiate action below once Zoltar is already forked.'
+			if (lifecycleStateOverride === 'poolForked' && systemState === 'operational') return undefined
 			if (systemState === undefined) return undefined
 
 			return getForkStageDescriptionForState(systemState)
@@ -1434,14 +1433,13 @@ export function ForkAuctionSection({
 	const truthAuctionFinalizedSettlementSection = (() => {
 		if (!shouldShowTruthAuctionVisualization || truthAuctionStatus === undefined || !truthAuctionStatus.finalized) return undefined
 		return (
-			<SectionBlock title='Settle Finalized Bid' description='Settle a finalized truth-auction bid. The bidder address must match the wallet that submitted the bid.'>
+			<SectionBlock title='Settle Finalized Bid'>
 				<div className='truth-auction-panel truth-auction-settlement-panel'>
 					<div className='form-grid'>
 						<label className='field'>
 							<span>Bidder Address</span>
 							<FormInput value={forkAuctionForm.settlementAddress} onInput={event => onForkAuctionFormChange({ settlementAddress: event.currentTarget.value })} placeholder='Leave empty to use connected wallet' />
 						</label>
-						<p className='detail'>This must match the address that submitted the bid. Leave empty to use the connected wallet when settling your own bids. Winning and partial bids credit REP into that vault, while losing finalized bids refund ETH to the same address.</p>
 						<div className='field-row'>
 							<label className='field'>
 								<span>Settlement Bid Tick</span>
@@ -1463,11 +1461,6 @@ export function ForkAuctionSection({
 		return (
 			<ReadOnlyDetailAccordion defaultOpen={false} title='Operator Tools'>
 				<div className='truth-auction-manual-tools'>
-					<p className='detail'>
-						{truthAuctionStatus.finalized
-							? 'Use this fallback to settle finalized truth-auction bids through the forker. The bidder address must match the wallet that submitted the bid. Winning and partial bids credit REP into that vault, while losing finalized bids refund ETH to the same address.'
-							: 'Before finalization, losing bids can still use this raw refund fallback when they are below clearing.'}
-					</p>
 					{truthAuctionStatus.finalized ? undefined : (
 						<SectionBlock density='compact' headingLevel={4} title='Raw Refund Fallback' variant='embedded'>
 							<div className='form-grid'>
@@ -1514,9 +1507,7 @@ export function ForkAuctionSection({
 		if (selectedStage === 'initiate')
 			return (
 				<fieldset className='fork-stage-panel' disabled={disabled}>
-					<SectionBlock description={syntheticForkTriggerNextStep} title='Fork Trigger'>
-						{renderWorkflowMetricGrid(initiateStatusMetrics)}
-					</SectionBlock>
+					<SectionBlock title='Fork Trigger'>{renderWorkflowMetricGrid(initiateStatusMetrics)}</SectionBlock>
 
 					<SectionBlock title='Initiate Pool Fork'>
 						<div className='actions'>{renderStageActionButton({ action: 'initiateFork', idleLabel: 'Initiate Pool Fork', onClick: onInitiateFork, pendingLabel: 'Initiating pool fork...' })}</div>
@@ -1714,13 +1705,12 @@ export function ForkAuctionSection({
 						)}
 
 						{!truthAuctionStatus?.finalized ? undefined : (
-							<SectionBlock title='Settle Finalized Bid' description='Settle a finalized truth-auction bid. The bidder address must match the wallet that submitted the bid.'>
+							<SectionBlock title='Settle Finalized Bid'>
 								<div className='form-grid'>
 									<label className='field'>
 										<span>Bidder Address</span>
 										<FormInput value={forkAuctionForm.settlementAddress} onInput={event => onForkAuctionFormChange({ settlementAddress: event.currentTarget.value })} placeholder='Leave empty to use connected wallet' />
 									</label>
-									<p className='detail'>This must match the address that submitted the bid. Leave empty to use the connected wallet when settling your own bids. Winning and partial bids credit REP into that vault, while losing finalized bids refund ETH to the same address.</p>
 									<div className='field-row'>
 										<label className='field'>
 											<span>Settlement Bid Tick</span>

--- a/ui/ts/components/OverviewPanels.tsx
+++ b/ui/ts/components/OverviewPanels.tsx
@@ -4,6 +4,7 @@ import { CurrencyValue } from './CurrencyValue.js'
 import { DataGrid } from './DataGrid.js'
 import { MetricField } from './MetricField.js'
 import { StateHint } from './StateHint.js'
+import { TimestampValue } from './TimestampValue.js'
 import { TransactionActionButton } from './TransactionActionButton.js'
 import { renderRepPriceSourceLabel } from '../lib/repPriceSource.js'
 import type { OverviewPanelsProps } from '../types/components.js'
@@ -21,6 +22,8 @@ export function OverviewPanels({
 	repUsdcPrice,
 	repUsdcSource,
 	repUsdcSourceUrl,
+	universeForkTime,
+	universeHasForked,
 	universePresentation,
 	universeLabel,
 	universeRepBalance,
@@ -30,10 +33,25 @@ export function OverviewPanels({
 	const isWalletBootstrapLoading = !walletBootstrapComplete && accountState.address === undefined
 	const isWalletAddressLoading = isConnectingWallet || isWalletBootstrapLoading
 	const showAccountBalances = walletBootstrapComplete && accountState.address !== undefined
+	const operationsHeaderDescription = (() => {
+		if (!universeHasForked) return undefined
+		if (universeForkTime === undefined) return 'Zoltar has forked.'
+		return (
+			<>
+				Zoltar forked on <TimestampValue timestamp={universeForkTime} />.
+			</>
+		)
+	})()
 	return (
 		<section className='overview-shell'>
 			<article className='overview-panel overview-wallet-panel'>
-				<RouteHeader eyebrow='Operations' title='Augur PLACEHOLDER' actions={accountState.address === undefined ? <TransactionActionButton idleLabel='Connect wallet' pendingLabel='Connecting...' onClick={onConnect} pending={isConnectingWallet} /> : undefined} />
+				<RouteHeader
+					actions={accountState.address === undefined ? <TransactionActionButton idleLabel='Connect wallet' pendingLabel='Connecting...' onClick={onConnect} pending={isConnectingWallet} /> : undefined}
+					badge={universeHasForked ? <span className='badge warn'>Forked</span> : undefined}
+					description={operationsHeaderDescription}
+					eyebrow='Operations'
+					title='Augur PLACEHOLDER'
+				/>
 				<DataGrid className='overview-inline-metrics' columns='auto'>
 					<MetricField className='overview-address-metric' label='Address'>
 						{(() => {

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -29,6 +29,7 @@ import {
 	getLeadingEscalationOutcome,
 	getReportingMaxProfitContribution,
 	getReportingMinimumOutcomeChangeContribution,
+	getRemainingSelectedOutcomeContributionCapacity,
 	getSelectedOutcomeRewardWindowFillTimestamp,
 	getReportingTimerPreview,
 	isReportingClosed,
@@ -53,6 +54,12 @@ const SELECT_OUTCOME_PRESET_REASON = 'Select an outcome side before using preset
 const SELECTED_SIDE_ALREADY_LEADS_REASON = 'Selected side already leads.'
 const MAX_PROFIT_WINDOW_FILLED_REASON = 'Max profit preset unavailable because the reward window is already filled on the selected side.'
 const SELECT_OUTCOME_TO_ENABLE_REPORTING_MESSAGE = 'Select an outcome side above to enable reporting.'
+const NO_SELECTED_SIDE_CAPACITY_REASON = 'No remaining contribution capacity is available on the selected side.'
+const BELOW_MINIMUM_SELECTED_SIDE_CAPACITY_REASON = 'Remaining selected-side capacity is below the minimum report bond.'
+const FORK_TRIGGERED_REPORT_REASON = 'Escalation reached non-decision. Trigger Zoltar Fork here if this pool should fork the universe, or open the Fork workflow if Zoltar is already forked.'
+const FORK_TRIGGERED_WITHDRAW_REASON = 'Escalation deposits remain locked after non-decision. Trigger Zoltar Fork here if this pool should fork the universe, or continue in the Fork workflow once Zoltar is already forked.'
+const FORK_ALREADY_TRIGGERED_REPORT_REASON = 'Escalation reached non-decision and Zoltar fork has already been triggered for this pool. Continue in the Fork workflow.'
+const FORK_ALREADY_TRIGGERED_WITHDRAW_REASON = 'Escalation deposits remain locked after non-decision. Zoltar fork has already been triggered for this pool, so continue in the Fork workflow.'
 function getOutcomeSides(reportingDetails: ReportingDetails | undefined) {
 	if (reportingDetails?.status === 'active')
 		return reportingDetails.sides.map<EscalationSideDisplay>(side => ({
@@ -151,7 +158,7 @@ function getReportingStagePresentation({
 			return {
 				availableActions: [],
 				blockedActions: [],
-				detail: 'Escalation reached non-decision. Continue in the Fork workflow; this panel does not have a final-resolution action.',
+				detail: FORK_TRIGGERED_REPORT_REASON,
 				key: 'escalation-fork-triggered',
 				label: 'Fork Triggered',
 				tone: 'default',
@@ -209,9 +216,12 @@ export function ReportingSection({
 	accountState,
 	currentTimestamp,
 	embedInCard = false,
+	forkAlreadyTriggered = false,
 	loadingReportingDetails,
 	lockedReason,
 	onLoadReporting,
+	onOpenForkWorkflow,
+	onTriggerZoltarFork,
 	onReportOutcome,
 	onReportingFormChange,
 	onWithdrawEscalation,
@@ -224,6 +234,8 @@ export function ReportingSection({
 	showHeader = true,
 	showSecurityPoolAddressInput = true,
 	mode = 'full-reporting',
+	triggerZoltarForkAvailability,
+	triggerZoltarForkPending = false,
 }: ReportingSectionProps) {
 	const lastTimedOutRefreshBoundaryKey = useRef<string | undefined>(undefined)
 	const [pendingWithdrawOutcome, setPendingWithdrawOutcome] = useState<ReportingOutcomeKey | undefined>(undefined)
@@ -239,18 +251,33 @@ export function ReportingSection({
 	const showWithdrawOnly = mode === 'withdraw-only'
 	const reportingReady = marketDetails !== undefined && effectiveCurrentTimestamp !== undefined ? marketDetails.endTime <= effectiveCurrentTimestamp : undefined
 	const preOpenLockedReason = lockedReason ?? (reportingReady === false && marketDetails !== undefined && effectiveCurrentTimestamp !== undefined ? getReportingLockedUntilMessage(marketDetails.endTime, effectiveCurrentTimestamp) : undefined)
+	const reportingStageKey = deriveSecurityPoolReportingStage({
+		reportingDetails: effectiveReportingDetails,
+		reportingReady,
+	})
 	const reportingState = evaluateSecurityPoolState({
-		reportingStage: deriveSecurityPoolReportingStage({
-			reportingDetails: effectiveReportingDetails,
-			reportingReady,
-		}),
+		reportingStage: reportingStageKey,
 		universeHasForked: false,
 	})
 	const reportOutcomeEnabled = reportingState.actions.reportOutcome.enabled
 	const withdrawEscalationEnabled = reportingState.actions.withdrawEscalation.enabled
-	const reportControlsLockedReason = showFullReporting ? pickFirstReason(lockedReason, reportingState.reportingStage === 'preOpen' ? preOpenLockedReason : undefined) : preOpenLockedReason
+	let reportLifecycleReason: string | undefined
+	if (reportingStageKey === 'forkTriggered') {
+		reportLifecycleReason = forkAlreadyTriggered ? FORK_ALREADY_TRIGGERED_REPORT_REASON : FORK_TRIGGERED_REPORT_REASON
+	} else if (reportingStageKey === 'timedOut') {
+		reportLifecycleReason = 'Escalation has ended. Refresh reporting to view the finalized outcome before withdrawing deposits.'
+	} else if (reportingStageKey === 'resolved') {
+		reportLifecycleReason = 'Escalation is already resolved.'
+	}
+	const reportControlsLockedReason = showFullReporting ? pickFirstReason(lockedReason, reportingState.reportingStage === 'preOpen' ? preOpenLockedReason : undefined, reportLifecycleReason) : preOpenLockedReason
 	const reportControlsLocked = !reportOutcomeEnabled || reportControlsLockedReason !== undefined
-	const withdrawControlsLockedReason = showWithdrawOnly && loadingReportingDetails ? 'Loading escalation deposits.' : pickFirstReason(lockedReason, reportingState.reportingStage === 'preOpen' ? preOpenLockedReason : undefined)
+	let withdrawLifecycleReason: string | undefined
+	if (reportingStageKey === 'forkTriggered') {
+		withdrawLifecycleReason = forkAlreadyTriggered ? FORK_ALREADY_TRIGGERED_WITHDRAW_REASON : FORK_TRIGGERED_WITHDRAW_REASON
+	} else if (reportingStageKey === 'activeLocked') {
+		withdrawLifecycleReason = 'Escalation deposits cannot be withdrawn until the question is finalized or the game is canceled by an external fork.'
+	}
+	const withdrawControlsLockedReason = showWithdrawOnly && loadingReportingDetails ? 'Loading escalation deposits.' : pickFirstReason(lockedReason, reportingState.reportingStage === 'preOpen' ? preOpenLockedReason : undefined, withdrawLifecycleReason)
 	const withdrawControlsLocked = !withdrawEscalationEnabled || withdrawControlsLockedReason !== undefined
 	const selectedAmount = parseOptionalRepAmountInput(reportingForm.reportAmount)
 	const selectedOutcome = reportingForm.selectedOutcome
@@ -338,9 +365,37 @@ export function ReportingSection({
 		)
 	}
 	const projectedReportingPreview = getProjectedReportingPreview()
-	const reportButtonLabel = selectedOutcome === undefined ? 'Report / Contribute On Selected Side' : `Report / Contribute ${selectedOutcomeLabel}`
+	const reportButtonLabel = selectedOutcome === undefined ? 'Report On Selected Side' : `Report ${selectedOutcomeLabel}`
 	const minimumOutcomeChangeContribution = selectedOutcome === undefined ? { amount: undefined, reason: SELECT_OUTCOME_PRESET_REASON } : getReportingMinimumOutcomeChangeContribution(effectiveReportingDetails, selectedOutcome)
 	const maxProfitContribution = selectedOutcome === undefined ? { amount: undefined, reason: SELECT_OUTCOME_PRESET_REASON } : getReportingMaxProfitContribution(effectiveReportingDetails, selectedOutcome)
+	const remainingSelectedOutcomeCapacity = effectiveReportingDetails === undefined || selectedOutcome === undefined ? undefined : getRemainingSelectedOutcomeContributionCapacity(effectiveReportingDetails, selectedOutcome)
+	const maxContributionAmount = (() => {
+		if (selectedOutcome === undefined) return { amount: undefined, reason: SELECT_OUTCOME_PRESET_REASON }
+		if (effectiveReportingDetails === undefined) return { amount: undefined, reason: LOAD_REPORTING_PRESETS_REASON }
+		if (effectiveReportingDetails.viewerVaultAvailableEscalationRep === undefined) return { amount: undefined, reason: 'Loading available vault REP.' }
+		if (effectiveReportingDetails.viewerVaultAvailableEscalationRep <= 0n) return { amount: undefined, reason: 'No unlocked vault REP available for reporting.' }
+		if (remainingSelectedOutcomeCapacity !== undefined && remainingSelectedOutcomeCapacity <= 0n) return { amount: undefined, reason: NO_SELECTED_SIDE_CAPACITY_REASON }
+		if (effectiveReportingDetails.status === 'not-started') {
+			const cappedAmount = remainingSelectedOutcomeCapacity === undefined || effectiveReportingDetails.viewerVaultAvailableEscalationRep < remainingSelectedOutcomeCapacity ? effectiveReportingDetails.viewerVaultAvailableEscalationRep : remainingSelectedOutcomeCapacity
+			if (cappedAmount < effectiveReportingDetails.startBond) return { amount: undefined, reason: BELOW_MINIMUM_SELECTED_SIDE_CAPACITY_REASON }
+			return {
+				amount: cappedAmount,
+				reason: undefined,
+			}
+		}
+		const selectedSide = effectiveReportingDetails.sides.find(side => side.key === selectedOutcome)
+		if (selectedSide === undefined) return { amount: undefined, reason: 'Selected side is unavailable.' }
+		const maxContributionPreview = previewReportingContribution(effectiveReportingDetails, selectedOutcome, effectiveReportingDetails.nonDecisionThreshold - selectedSide.balance)
+		if (maxContributionPreview.actualDepositAmount === undefined) return { amount: undefined, reason: maxContributionPreview.reason }
+		let cappedAmount = maxContributionPreview.actualDepositAmount
+		if (cappedAmount > effectiveReportingDetails.viewerVaultAvailableEscalationRep) cappedAmount = effectiveReportingDetails.viewerVaultAvailableEscalationRep
+		if (remainingSelectedOutcomeCapacity !== undefined && cappedAmount > remainingSelectedOutcomeCapacity) cappedAmount = remainingSelectedOutcomeCapacity
+		if (cappedAmount < effectiveReportingDetails.startBond) return { amount: undefined, reason: BELOW_MINIMUM_SELECTED_SIDE_CAPACITY_REASON }
+		return {
+			amount: cappedAmount,
+			reason: undefined,
+		}
+	})()
 	const presetReasons = reportControlsLocked ? [] : [minimumOutcomeChangeContribution.reason, maxProfitContribution.reason].filter((reason, index, reasons): reason is string => reason !== undefined && !isHiddenPresetReason(reason) && reasons.indexOf(reason) === index)
 	const reportAmountError = selectedAmount === undefined && reportingForm.reportAmount.trim() !== '' ? 'Enter a valid report amount to preview profit.' : undefined
 	const reportGuardMessage =
@@ -350,6 +405,7 @@ export function ReportingSection({
 			accountAddress: accountState.address,
 			contributionPreviewReason: reportContributionPreview?.reason,
 			isMainnet,
+			remainingSelectedOutcomeCapacity,
 			reportAmount: reportingForm.reportAmount,
 			reportingStatus,
 			selectedOutcome,
@@ -371,6 +427,20 @@ export function ReportingSection({
 	}
 	const withdrawActionPending = reportingActiveAction === 'withdrawEscalation'
 	const shouldShowWithdrawEmptyState = !loadingReportingDetails && reportingStatus !== 'missing' && withdrawableSides.length === 0
+	const showForkWorkflowAction = reportingStageKey === 'forkTriggered' && onOpenForkWorkflow !== undefined
+	const showTriggerZoltarForkAction = reportingStageKey === 'forkTriggered' && !forkAlreadyTriggered && onTriggerZoltarFork !== undefined
+	const resolvedTriggerZoltarForkAvailability = triggerZoltarForkAvailability ?? { disabled: false, reason: undefined }
+	const forkTriggeredActions =
+		reportingStageKey !== 'forkTriggered' || (!showForkWorkflowAction && !showTriggerZoltarForkAction) ? undefined : (
+			<div className='actions'>
+				{showTriggerZoltarForkAction ? <TransactionActionButton idleLabel='Trigger Zoltar Fork' pendingLabel='Triggering Zoltar fork...' onClick={onTriggerZoltarFork} pending={triggerZoltarForkPending} tone='primary' availability={resolvedTriggerZoltarForkAvailability} /> : undefined}
+				{showForkWorkflowAction ? (
+					<button className='secondary' type='button' onClick={onOpenForkWorkflow}>
+						Open Fork Workflow
+					</button>
+				) : undefined}
+			</div>
+		)
 
 	const handleWithdrawEscalation = (outcome: ReportingOutcomeKey, depositIndexes?: bigint[]) => {
 		setPendingWithdrawOutcome(outcome)
@@ -398,6 +468,13 @@ export function ReportingSection({
 				reportingDetails: effectiveReportingDetails,
 			})
 		: undefined
+	const resolvedReportingStage =
+		reportingStage?.key === 'escalation-fork-triggered' && forkAlreadyTriggered
+			? {
+					...reportingStage,
+					detail: FORK_ALREADY_TRIGGERED_REPORT_REASON,
+				}
+			: reportingStage
 	const showReportingHeaderStack = showFullReporting && (showSecurityPoolAddressInput || reportingStage !== undefined || reportingOpenNotice !== undefined)
 	const latestReportingAction =
 		reportingResult === undefined
@@ -432,7 +509,7 @@ export function ReportingSection({
 							}
 						/>
 					) : undefined}
-					{reportingOpenNotice === undefined ? <LifecycleStageBanner stage={reportingStage} /> : <p className='notice success'>{reportingOpenNotice}</p>}
+					{reportingOpenNotice === undefined ? <LifecycleStageBanner stage={resolvedReportingStage} /> : <p className='notice success'>{reportingOpenNotice}</p>}
 				</div>
 			) : undefined}
 
@@ -492,10 +569,26 @@ export function ReportingSection({
 							Available unlocked vault REP for reporting: <CurrencyValue value={effectiveReportingDetails.viewerVaultAvailableEscalationRep} suffix='REP' />.
 						</p>
 					)}
-					<label className='field'>
-						<span>Report / Contribution Amount (REP)</span>
-						<FormInput value={reportingForm.reportAmount} onInput={event => onReportingFormChange({ reportAmount: event.currentTarget.value })} disabled={reportControlsLocked} />
-					</label>
+					<div className='field'>
+						<label htmlFor='reporting-contribution-amount'>
+							<span>Contribution Amount (REP)</span>
+						</label>
+						<div className='field-inline'>
+							<FormInput id='reporting-contribution-amount' className='field-inline-input' value={reportingForm.reportAmount} onInput={event => onReportingFormChange({ reportAmount: event.currentTarget.value })} disabled={reportControlsLocked} />
+							<button
+								className='quiet field-inline-action'
+								type='button'
+								onClick={() => {
+									if (maxContributionAmount.amount === undefined) return
+									onReportingFormChange({ reportAmount: formatCurrencyInputBalance(maxContributionAmount.amount) })
+								}}
+								disabled={reportControlsLocked || maxContributionAmount.amount === undefined}
+								title={reportControlsLocked ? reportControlsLockedReason : maxContributionAmount.reason}
+							>
+								Max
+							</button>
+						</div>
+					</div>
 
 					<div className='actions'>
 						<button
@@ -544,6 +637,7 @@ export function ReportingSection({
 
 			{showWithdrawOnly ? (
 				<SectionBlock title='Withdraw Escalation Deposits'>
+					{reportingStageKey === 'forkTriggered' ? <p className='detail'>{forkAlreadyTriggered ? FORK_ALREADY_TRIGGERED_WITHDRAW_REASON : FORK_TRIGGERED_WITHDRAW_REASON}</p> : undefined}
 					{loadingReportingDetails ? (
 						<p className='detail'>
 							<LoadingText>Loading escalation deposits...</LoadingText>
@@ -629,6 +723,7 @@ export function ReportingSection({
 					})}
 				</SectionBlock>
 			) : undefined}
+			{forkTriggeredActions}
 
 			<ErrorNotice message={reportingError} />
 		</>

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -41,19 +41,40 @@ import {
 	type SelectedPoolView,
 } from '../lib/securityPoolWorkflow.js'
 import { sameCaseInsensitiveText } from '../lib/caseInsensitive.js'
-import { hasForkActivity } from '../lib/forkAuction.js'
 import { getLiquidationNoticeState } from '../lib/liquidationStatus.js'
 import { resolveRequestedLoadableValueState } from '../lib/loadState.js'
 import { isMainnetChain } from '../lib/network.js'
-import { getReportingLockedUntilMessage } from '../lib/reporting.js'
+import { getReportingLockedUntilMessage, getReportingOutcomeLabel } from '../lib/reporting.js'
 import { getSecurityPoolLifecycleLabel } from '../lib/securityPoolLabels.js'
-import { deriveSecurityPoolLifecycleState, evaluateSecurityPoolState, type SecurityPoolLifecycleState } from '../lib/securityPoolState.js'
+import { deriveSecurityPoolLifecycleState, deriveSecurityPoolReportingStage, evaluateSecurityPoolState, type SecurityPoolLifecycleState } from '../lib/securityPoolState.js'
 import { getVaultExecutePendingOperationGuardMessage, getVaultRequestPriceGuardMessage } from '../lib/securityVaultGuards.js'
 import { doesLoadedSecurityVaultMatchSelection, getSelectedVaultAddress, isSelectedVaultOwnedByAccount as isSelectedVaultOwnedByAccountHelper } from '../lib/securityVault.js'
 import { getPoolRegistryPresentation } from '../lib/userCopy.js'
 import { formatUniverseLabel } from '../lib/universe.js'
 import type { SecurityPoolWorkflowRouteContentProps, ViewTabOption } from '../types/components.js'
+import type { ForkAuctionDetails, ListedSecurityPool } from '../types/contracts.js'
 type SelectedVaultView = 'browse-vaults' | 'selected-vault'
+
+function buildSelectedPoolSummaryPool({ forkAuctionDetails, selectedPool }: { forkAuctionDetails: ForkAuctionDetails | undefined; selectedPool: ListedSecurityPool | undefined }) {
+	if (selectedPool === undefined) return undefined
+	if (forkAuctionDetails === undefined) return selectedPool
+	return {
+		...selectedPool,
+		completeSetCollateralAmount: forkAuctionDetails.completeSetCollateralAmount,
+		hasForkActivity: forkAuctionDetails.hasForkActivity,
+		forkOutcome: forkAuctionDetails.forkOutcome,
+		forkOwnSecurityPool: forkAuctionDetails.forkOwnSecurityPool,
+		marketDetails: forkAuctionDetails.marketDetails,
+		migratedRep: forkAuctionDetails.migratedRep,
+		questionOutcome: forkAuctionDetails.questionOutcome,
+		securityPoolAddress: forkAuctionDetails.securityPoolAddress,
+		systemState: forkAuctionDetails.systemState,
+		truthAuctionAddress: forkAuctionDetails.truthAuctionAddress,
+		truthAuctionStartedAt: forkAuctionDetails.truthAuctionStartedAt,
+		universeId: forkAuctionDetails.universeId,
+	}
+}
+
 function getPendingOperationLabel(operation: 'liquidation' | 'setSecurityBondsAllowance' | 'withdrawRep') {
 	switch (operation) {
 		case 'liquidation':
@@ -139,21 +160,43 @@ export function SecurityPoolWorkflowSection({
 		questionOutcome: selectedPoolQuestionOutcome,
 		systemState: selectedPoolState,
 	})
-	const selectedPoolStateModel = evaluateSecurityPoolState({
-		lifecycleState: deriveSecurityPoolLifecycleState({
-			questionOutcome: selectedPoolQuestionOutcome,
-			systemState: selectedPoolState,
-		}),
-		universeHasForked: effectiveSelectedPool?.universeHasForked === true,
-	})
-	const selectedPoolHasForkActivity = (() => {
-		if (selectedPool !== undefined) return hasForkActivity(selectedPool)
-		if (currentForkAuctionDetails !== undefined) return hasForkActivity(currentForkAuctionDetails)
-
-		return false
-	})()
 	const currentTimestamp = chainCurrentTimestamp ?? currentReportingDetails?.currentTime ?? currentForkAuctionDetails?.currentTime
 	const reportingReady = marketDetails !== undefined && currentTimestamp !== undefined && marketDetails.endTime <= currentTimestamp
+	const selectedPoolReportingStage = deriveSecurityPoolReportingStage({
+		reportingDetails: currentReportingDetails,
+		reportingReady,
+	})
+	const selectedPoolHasActualForkActivity = currentForkAuctionDetails?.hasForkActivity ?? selectedPool?.hasForkActivity ?? false
+	const selectedPoolLifecycleState =
+		selectedPoolReportingStage === 'forkTriggered' && selectedPoolState === 'operational' && selectedPoolQuestionOutcome === 'none'
+			? 'poolForked'
+			: deriveSecurityPoolLifecycleState({
+					questionOutcome: selectedPoolQuestionOutcome,
+					systemState: selectedPoolState,
+				})
+	const selectedPoolStateModel = evaluateSecurityPoolState({
+		lifecycleState: selectedPoolLifecycleState,
+		reportingStage: selectedPoolReportingStage,
+		universeHasForked: effectiveSelectedPool?.universeHasForked === true,
+	})
+	const triggerZoltarForkReason = (() => {
+		if (selectedPoolReportingStage === 'forkTriggered' && selectedPoolHasActualForkActivity) {
+			return 'Zoltar fork has already been triggered for this pool. Continue in the Fork workflow.'
+		}
+		if (selectedPoolReportingStage === 'forkTriggered' && selectedPoolState !== 'operational') {
+			return 'This pool has already entered its fork workflow. Continue in the Fork tab.'
+		}
+		return 'Triggering a Zoltar fork is not available in the current pool state.'
+	})()
+	const triggerZoltarForkAvailability = {
+		disabled: !(selectedPoolReportingStage === 'forkTriggered' && !selectedPoolHasActualForkActivity && selectedPoolState === 'operational' && selectedPoolQuestionOutcome === 'none'),
+		reason: triggerZoltarForkReason,
+	}
+	const selectedPoolHasForkActivity = (() => {
+		if (selectedPoolReportingStage === 'forkTriggered') return true
+		return selectedPoolHasActualForkActivity
+	})()
+	const showSelectedPoolForkSummaryMetrics = selectedPoolHasActualForkActivity || (selectedPoolStateModel.lifecycleState !== 'operational' && selectedPoolReportingStage !== 'forkTriggered')
 	const reportingLockedReason = (() => {
 		if (reportingReady) return undefined
 		if (marketDetails === undefined) return 'Reporting opens after market end.'
@@ -168,6 +211,9 @@ export function SecurityPoolWorkflowSection({
 		selectedPoolExists: selectedPool !== undefined,
 		selectedPoolUniverseMismatch,
 	})
+	const shouldRefreshSelectedPoolReporting =
+		showSelectedPoolWorkflowDetails &&
+		(sameAddress(reporting.reportingDetails?.securityPoolAddress, selectedPool?.securityPoolAddress) || ((view === 'reporting' || view === 'withdraw-escalation-deposits') && normalizedSelectedPoolAddress !== undefined && normalizedReportingFormPoolAddress === normalizedSelectedPoolAddress))
 	const selectedPoolWorkflowGuardMessage = getSelectedPoolWorkflowGuardMessage({
 		hasSelectedPoolAddress,
 		selectedPoolLookupState,
@@ -212,10 +258,12 @@ export function SecurityPoolWorkflowSection({
 	const lastSelectedVaultAutoLoadKey = useRef<string | undefined>(undefined)
 	const lastReportingAutoLoadKey = useRef<string | undefined>(undefined)
 	const lastReportingOutcomeRefreshHash = useRef<string | undefined>(undefined)
+	const lastVaultStatusRefreshHash = useRef<string | undefined>(undefined)
 	const lastQueuedOperationRefreshHash = useRef<string | undefined>(undefined)
 	const lastImmediateQueuedOperationRefreshHash = useRef<string | undefined>(undefined)
 	const lastLiquidationOutcomeRefreshKey = useRef<string | undefined>(undefined)
 	const lastExecutedOperationRefreshHash = useRef<string | undefined>(undefined)
+	const lastForkAuctionOutcomeRefreshHash = useRef<string | undefined>(undefined)
 	const queuedVaultOperation = getQueuedVaultOperation({
 		pendingOperation: currentPoolOracleManagerDetails?.pendingOperation,
 		selectedVaultAddress,
@@ -228,6 +276,12 @@ export function SecurityPoolWorkflowSection({
 		securityPoolOverviewResult,
 	})
 	const loadedSelectedPool = effectiveSelectedPool
+	const selectedPoolSummaryPool = buildSelectedPoolSummaryPool({
+		forkAuctionDetails: currentForkAuctionDetails,
+		selectedPool: loadedSelectedPool,
+	})
+	const selectedPoolForkOwnSecurityPool = selectedPoolSummaryPool?.forkOwnSecurityPool
+	const selectedPoolForkOutcome = selectedPoolSummaryPool?.forkOutcome
 	const selectedPoolOracleMetricValues = loadedSelectedPool === undefined ? undefined : getSelectedPoolOracleMetricValues(loadedSelectedPool)
 	const requestPriceGuardMessage = getVaultRequestPriceGuardMessage({
 		accountAddress: accountState.address,
@@ -317,7 +371,9 @@ export function SecurityPoolWorkflowSection({
 		void securityVault.onLoadSecurityVault()
 	}, [accountState.address, hasLoadedCurrentVault, securityVault.loadingSecurityVault, securityVault.onLoadSecurityVault, selectedPool?.securityPoolAddress, selectedVaultAddress, selectedVaultAutoLoadKey, selectedVaultSecurityPoolAddress, showSelectedPoolWorkflowDetails, view])
 	useEffect(() => {
-		if ((view !== 'reporting' && view !== 'withdraw-escalation-deposits') || !reportingReady || !showSelectedPoolWorkflowDetails || normalizedSelectedPoolAddress === undefined) {
+		const shouldAutoloadReportingForFork = view === 'fork' && !selectedPoolHasActualForkActivity && selectedPoolState === 'operational' && selectedPoolQuestionOutcome === 'none'
+		const shouldAutoloadReportingForCurrentView = view === 'reporting' || view === 'withdraw-escalation-deposits' || shouldAutoloadReportingForFork
+		if (!shouldAutoloadReportingForCurrentView || !reportingReady || !showSelectedPoolWorkflowDetails || normalizedSelectedPoolAddress === undefined) {
 			lastReportingAutoLoadKey.current = undefined
 			return
 		}
@@ -328,7 +384,19 @@ export function SecurityPoolWorkflowSection({
 		if (lastReportingAutoLoadKey.current === reportingAutoLoadKey) return
 		lastReportingAutoLoadKey.current = reportingAutoLoadKey
 		void reporting.onLoadReporting()
-	}, [normalizedReportingFormPoolAddress, normalizedSelectedPoolAddress, reporting.loadingReportingDetails, reporting.onLoadReporting, reporting.reportingDetails?.securityPoolAddress, reportingReady, showSelectedPoolWorkflowDetails, view])
+	}, [
+		normalizedReportingFormPoolAddress,
+		normalizedSelectedPoolAddress,
+		reporting.loadingReportingDetails,
+		reporting.onLoadReporting,
+		reporting.reportingDetails?.securityPoolAddress,
+		reportingReady,
+		selectedPoolHasActualForkActivity,
+		selectedPoolQuestionOutcome,
+		selectedPoolState,
+		showSelectedPoolWorkflowDetails,
+		view,
+	])
 	useEffect(() => {
 		const normalizedSelectedPoolAddress = normalizeAddress(selectedPool?.securityPoolAddress)
 		if (view !== 'fork' || !showSelectedPoolWorkflowDetails || normalizedSelectedPoolAddress === undefined) return
@@ -348,6 +416,33 @@ export function SecurityPoolWorkflowSection({
 		if (showSelectedPoolWorkflowDetails && hasLoadedCurrentVault) void securityVault.onLoadSecurityVault()
 	}, [hasLoadedCurrentVault, onRefreshSelectedPoolData, reporting.reportingResult, securityVault.onLoadSecurityVault, showSelectedPoolWorkflowDetails])
 	useEffect(() => {
+		const nextForkAuctionResult = forkAuction.forkAuctionResult
+		const forkAuctionRefreshHash = nextForkAuctionResult?.hash
+		if (forkAuctionRefreshHash === undefined) {
+			lastForkAuctionOutcomeRefreshHash.current = undefined
+			return
+		}
+		if (nextForkAuctionResult === undefined) return
+		if (lastForkAuctionOutcomeRefreshHash.current === forkAuctionRefreshHash) return
+		lastForkAuctionOutcomeRefreshHash.current = forkAuctionRefreshHash
+		void onRefreshSelectedPoolData(nextForkAuctionResult.securityPoolAddress)
+		if (showSelectedPoolWorkflowDetails && hasLoadedCurrentVault && (nextForkAuctionResult.action === 'claimAuctionProceeds' || nextForkAuctionResult.action === 'migrateEscalationDeposits' || nextForkAuctionResult.action === 'migrateVault')) {
+			void securityVault.onLoadSecurityVault()
+		}
+		if (shouldRefreshSelectedPoolReporting && (nextForkAuctionResult.action === 'migrateEscalationDeposits' || nextForkAuctionResult.action === 'forkWithOwnEscalation')) void reporting.onLoadReporting()
+	}, [forkAuction.forkAuctionResult, hasLoadedCurrentVault, onRefreshSelectedPoolData, reporting.onLoadReporting, securityVault.onLoadSecurityVault, shouldRefreshSelectedPoolReporting, showSelectedPoolWorkflowDetails])
+	useEffect(() => {
+		const vaultStatusRefreshHash = securityVault.securityVaultResult?.action === 'depositRep' || securityVault.securityVaultResult?.action === 'redeemRep' ? securityVault.securityVaultResult.hash : undefined
+		if (vaultStatusRefreshHash === undefined) {
+			lastVaultStatusRefreshHash.current = undefined
+			return
+		}
+		if (lastVaultStatusRefreshHash.current === vaultStatusRefreshHash) return
+		lastVaultStatusRefreshHash.current = vaultStatusRefreshHash
+		void onRefreshSelectedPoolData(selectedPool?.securityPoolAddress)
+		if (shouldRefreshSelectedPoolReporting) void reporting.onLoadReporting()
+	}, [onRefreshSelectedPoolData, reporting.onLoadReporting, securityVault.securityVaultResult, selectedPool?.securityPoolAddress, shouldRefreshSelectedPoolReporting])
+	useEffect(() => {
 		const queuedOperationHash = securityVault.securityVaultResult?.action === 'queueSetSecurityBondAllowance' || securityVault.securityVaultResult?.action === 'queueWithdrawRep' ? securityVault.securityVaultResult.hash : undefined
 		if (queuedOperationHash === undefined) {
 			lastImmediateQueuedOperationRefreshHash.current = undefined
@@ -358,8 +453,22 @@ export function SecurityPoolWorkflowSection({
 		if (lastImmediateQueuedOperationRefreshHash.current === queuedOperationHash) return
 		lastImmediateQueuedOperationRefreshHash.current = queuedOperationHash
 		void onRefreshSelectedPoolData(selectedPool?.securityPoolAddress)
+		if (securityVault.securityVaultResult?.action === 'queueWithdrawRep' && shouldRefreshSelectedPoolReporting) void reporting.onLoadReporting()
 		if (showSelectedPoolWorkflowDetails && view === 'vaults' && hasLoadedCurrentVault) void securityVault.onLoadSecurityVault()
-	}, [currentPoolOracleManagerDetails, hasLoadedCurrentVault, loadingPoolOracleManager, onRefreshSelectedPoolData, queuedVaultOperation, securityVault.onLoadSecurityVault, securityVault.securityVaultResult, selectedPool?.securityPoolAddress, showSelectedPoolWorkflowDetails, view])
+	}, [
+		currentPoolOracleManagerDetails,
+		hasLoadedCurrentVault,
+		loadingPoolOracleManager,
+		onRefreshSelectedPoolData,
+		queuedVaultOperation,
+		reporting.onLoadReporting,
+		securityVault.onLoadSecurityVault,
+		securityVault.securityVaultResult,
+		selectedPool?.securityPoolAddress,
+		shouldRefreshSelectedPoolReporting,
+		showSelectedPoolWorkflowDetails,
+		view,
+	])
 	useEffect(() => {
 		const liquidationRefreshKey = securityPoolOverviewResult?.action !== 'queueLiquidation' || liquidationNoticeState === undefined || liquidationNoticeState === 'submitted' ? undefined : `${securityPoolOverviewResult.hash}:${liquidationNoticeState}`
 		if (liquidationRefreshKey === undefined) {
@@ -383,8 +492,9 @@ export function SecurityPoolWorkflowSection({
 		if (lastExecutedOperationRefreshHash.current === poolPriceOracleResult.hash) return
 		lastExecutedOperationRefreshHash.current = poolPriceOracleResult.hash
 		void onRefreshSelectedPoolData(selectedPool?.securityPoolAddress)
+		if (poolPriceOracleResult.stagedExecution?.operation === 'withdrawRep' && shouldRefreshSelectedPoolReporting) void reporting.onLoadReporting()
 		if (showSelectedPoolWorkflowDetails && view === 'vaults' && hasLoadedCurrentVault) void securityVault.onLoadSecurityVault()
-	}, [hasLoadedCurrentVault, onRefreshSelectedPoolData, poolPriceOracleResult, securityVault.onLoadSecurityVault, selectedPool?.securityPoolAddress, showSelectedPoolWorkflowDetails, view])
+	}, [hasLoadedCurrentVault, onRefreshSelectedPoolData, poolPriceOracleResult, reporting.onLoadReporting, securityVault.onLoadSecurityVault, selectedPool?.securityPoolAddress, shouldRefreshSelectedPoolReporting, showSelectedPoolWorkflowDetails, view])
 	return (
 		<RouteWorkflowPanel showHeader={showHeader} title='Selected Pool'>
 			<StickyObjectContext
@@ -412,10 +522,10 @@ export function SecurityPoolWorkflowSection({
 						/>
 					</div>
 				</div>
-				{loadedSelectedPool === undefined ? undefined : (
+				{selectedPoolSummaryPool === undefined ? undefined : (
 					<div className='selected-pool-context-summary'>
 						<div className='selected-pool-context-overview'>
-							<SecurityPoolSummaryMetrics className='selected-pool-context-grid' pool={loadedSelectedPool} repPerEthPrice={repPerEthPrice} repPerEthSource={repPerEthSource} repPerEthSourceUrl={repPerEthSourceUrl} showTotalBacking>
+							<SecurityPoolSummaryMetrics className='selected-pool-context-grid' pool={selectedPoolSummaryPool} repPerEthPrice={repPerEthPrice} repPerEthSource={repPerEthSource} repPerEthSourceUrl={repPerEthSourceUrl} showTotalBacking>
 								<MetricField label='Open Oracle Price' valueTagName='span'>
 									<OpenOraclePriceValue
 										currentTimestamp={currentTimestamp}
@@ -424,10 +534,10 @@ export function SecurityPoolWorkflowSection({
 										priceValidUntilTimestamp={currentPoolOracleManagerDetails?.priceValidUntilTimestamp}
 									/>
 								</MetricField>
-								{loadedSelectedPool.systemState === 'operational' ? undefined : (
+								{!showSelectedPoolForkSummaryMetrics ? undefined : (
 									<>
-										<MetricField label='Fork Mode'>{loadedSelectedPool.forkOwnSecurityPool ? 'Own escalation fork' : 'Parent / Zoltar fork'}</MetricField>
-										<MetricField label='Fork Outcome'>{loadedSelectedPool.forkOutcome}</MetricField>
+										<MetricField label='Fork Mode'>{selectedPoolForkOwnSecurityPool === true ? 'Own escalation fork' : 'Parent / Zoltar fork'}</MetricField>
+										<MetricField label='Fork Outcome'>{selectedPoolForkOutcome === undefined ? '—' : getReportingOutcomeLabel(selectedPoolForkOutcome)}</MetricField>
 									</>
 								)}
 								{currentPoolOracleManagerDetails?.pendingReportId === undefined || currentPoolOracleManagerDetails.pendingReportId === 0n ? undefined : (
@@ -595,12 +705,17 @@ export function SecurityPoolWorkflowSection({
 										{...reporting}
 										currentTimestamp={currentTimestamp}
 										embedInCard
+										forkAlreadyTriggered={selectedPoolHasActualForkActivity}
 										lockedReason={reportingLockedReason}
 										mode='full-reporting'
+										onOpenForkWorkflow={() => onSelectedPoolViewChange('fork')}
+										onTriggerZoltarFork={triggerZoltarForkAvailability.disabled ? undefined : forkAuction.onForkWithOwnEscalation}
 										previewMarketDetails={currentReportingDetails === undefined ? marketDetails : undefined}
 										reportingDetails={currentReportingDetails}
 										showHeader={false}
 										showSecurityPoolAddressInput={false}
+										triggerZoltarForkAvailability={triggerZoltarForkAvailability}
+										triggerZoltarForkPending={forkAuction.forkAuctionActiveAction === 'forkWithOwnEscalation'}
 									/>
 								) : undefined}
 
@@ -609,12 +724,17 @@ export function SecurityPoolWorkflowSection({
 										{...reporting}
 										currentTimestamp={currentTimestamp}
 										embedInCard
+										forkAlreadyTriggered={selectedPoolHasActualForkActivity}
 										lockedReason={reportingLockedReason}
 										mode='withdraw-only'
+										onOpenForkWorkflow={() => onSelectedPoolViewChange('fork')}
+										onTriggerZoltarFork={triggerZoltarForkAvailability.disabled ? undefined : forkAuction.onForkWithOwnEscalation}
 										previewMarketDetails={currentReportingDetails === undefined ? marketDetails : undefined}
 										reportingDetails={currentReportingDetails}
 										showHeader={false}
 										showSecurityPoolAddressInput={false}
+										triggerZoltarForkAvailability={triggerZoltarForkAvailability}
+										triggerZoltarForkPending={forkAuction.forkAuctionActiveAction === 'forkWithOwnEscalation'}
 									/>
 								) : undefined}
 
@@ -626,6 +746,7 @@ export function SecurityPoolWorkflowSection({
 										disabledMessage={forkWorkflowDisabled ? 'This pool is currently operational, so fork and truth auction actions are read only.' : undefined}
 										embedInCard
 										forkAuctionDetails={currentForkAuctionDetails}
+										lifecycleStateOverride={selectedPoolLifecycleState}
 										previewPool={selectedPool}
 										showHeader={false}
 										showSecurityPoolAddressInput={false}

--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -451,7 +451,7 @@ export function SecurityVaultSection({
 				</div>
 			</SectionBlock>
 			<ErrorNotice message={securityVaultError} />
-			<OperationModal isOpen={vaultActionModal === 'deposit-rep'} onClose={() => setVaultActionModal(undefined)} title='Deposit REP' description='Review the selected vault, then deposit REP.'>
+			<OperationModal isOpen={vaultActionModal === 'deposit-rep'} onClose={() => setVaultActionModal(undefined)} title='Deposit REP'>
 				{currentSelectedVaultDetails === undefined ? <p className='detail'>Refresh the selected vault before depositing REP.</p> : null}
 				{currentSelectedVaultDetails === undefined ? null : (
 					<>
@@ -513,13 +513,7 @@ export function SecurityVaultSection({
 							<button className='secondary' type='button' onClick={() => setVaultActionModal(undefined)}>
 								Cancel
 							</button>
-							<TransactionActionButton
-								idleLabel='Create / Deposit REP'
-								pendingLabel='Depositing REP...'
-								onClick={onDepositRep}
-								pending={securityVaultActiveAction === 'depositRep'}
-								availability={{ disabled: !depositRepEnabled || depositGuardMessage !== undefined, reason: depositRepEnabled ? depositGuardMessage : undefined }}
-							/>
+							<TransactionActionButton idleLabel='Deposit REP' pendingLabel='Depositing REP...' onClick={onDepositRep} pending={securityVaultActiveAction === 'depositRep'} availability={{ disabled: !depositRepEnabled || depositGuardMessage !== undefined, reason: depositRepEnabled ? depositGuardMessage : undefined }} />
 						</div>
 					</>
 				)}
@@ -765,13 +759,7 @@ export function SecurityVaultSection({
 					disabled={!approveRepEnabled}
 				/>
 				<div className='actions'>
-					<TransactionActionButton
-						idleLabel='Create / Deposit REP'
-						pendingLabel='Depositing REP...'
-						onClick={onDepositRep}
-						pending={securityVaultActiveAction === 'depositRep'}
-						availability={{ disabled: !depositRepEnabled || depositGuardMessage !== undefined, reason: depositRepEnabled ? depositGuardMessage : undefined }}
-					/>
+					<TransactionActionButton idleLabel='Deposit REP' pendingLabel='Depositing REP...' onClick={onDepositRep} pending={securityVaultActiveAction === 'depositRep'} availability={{ disabled: !depositRepEnabled || depositGuardMessage !== undefined, reason: depositRepEnabled ? depositGuardMessage : undefined }} />
 				</div>
 				{(() => {
 					if (repBalanceGap !== undefined && repBalanceGap > 0n) return <ErrorNotice message={`Insufficient REP balance. Deposit amount exceeds your wallet balance by ${formatCurrencyBalance(repBalanceGap)} REP.`} />

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -2,6 +2,7 @@ import { decodeEventLog, parseAbiItem, zeroAddress, type Address, type ContractF
 import { ABIS } from './abis.js'
 import { sortBigIntsAscending } from './shared/bigInt.js'
 import { assertNever } from './lib/assert.js'
+import { deriveHasForkActivity } from './lib/forkAuction.js'
 import { getOracleManagerPriceValidUntilTimestamp } from './lib/securityVault.js'
 import { addOpenOracleBountyBuffer } from './lib/openOracle.js'
 import { getWethAddress } from './lib/uniswapQuoter.js'
@@ -53,6 +54,7 @@ import type {
 } from './types/contracts.js'
 import {
 	getEscalationSideLabel,
+	getForkOutcomeKey,
 	getMinBigintValue,
 	getQuestionIdHex,
 	getReportingOutcomeKey,
@@ -1077,6 +1079,13 @@ export async function loadForkAuctionDetails(client: ReadClient, securityPoolAdd
 	const forkDataTuple: ForkDataTuple = forkData
 	const [repAtFork, , truthAuctionStartedAt, migratedRep, auctionedSecurityBondAllowance, forkOwnSecurityPool, forkOutcomeIndex] = forkDataTuple
 	const systemState = getSecurityPoolSystemState(systemStateValue)
+	const forkOutcome = getForkOutcomeKey(forkOutcomeIndex, parentSecurityPoolAddress)
+	const hasForkActivity = deriveHasForkActivity({
+		forkOutcome,
+		migratedRep,
+		systemState,
+		truthAuctionStartedAt,
+	})
 	const universeForkTime =
 		truthAuctionStartedAt > 0n
 			? undefined
@@ -1177,8 +1186,9 @@ export async function loadForkAuctionDetails(client: ReadClient, securityPoolAdd
 		claimingAvailable: systemState === 'operational' && truthAuctionAddress !== zeroAddress,
 		completeSetCollateralAmount,
 		currentTime: block.timestamp,
-		forkOutcome: getReportingOutcomeKey(forkOutcomeIndex),
+		forkOutcome,
 		forkOwnSecurityPool,
+		hasForkActivity,
 		marketDetails,
 		migratedRep,
 		migrationEndsAt,
@@ -1611,13 +1621,22 @@ export async function loadAllSecurityPools(client: ReadClient): Promise<ListedSe
 			])
 			const forkDataTuple: ForkDataTuple = forkData
 			const [, , truthAuctionStartedAt, migratedRep, , forkOwnSecurityPool, forkOutcomeIndex] = forkDataTuple
+			const forkOutcome = getForkOutcomeKey(forkOutcomeIndex, parent)
+			const poolSystemState = getSecurityPoolSystemState(systemState)
+			const hasForkActivity = deriveHasForkActivity({
+				forkOutcome,
+				migratedRep,
+				systemState: poolSystemState,
+				truthAuctionStartedAt,
+			})
 			const { vaultCount, vaults } = await loadSecurityPoolVaultSummaries(client, securityPoolAddress)
 			const totalRepDeposit = vaults.reduce((sum, vault) => sum + vault.repDepositShare, 0n)
 			return {
 				completeSetCollateralAmount,
 				currentRetentionRate,
-				forkOutcome: getReportingOutcomeKey(forkOutcomeIndex),
+				forkOutcome,
 				forkOwnSecurityPool,
+				hasForkActivity,
 				lastOraclePrice: lastSettlementTimestamp > 0n ? lastOraclePrice : undefined,
 				lastOracleSettlementTimestamp: lastSettlementTimestamp,
 				managerAddress,
@@ -1628,7 +1647,7 @@ export async function loadAllSecurityPools(client: ReadClient): Promise<ListedSe
 				questionId: getQuestionIdHex(questionId),
 				securityMultiplier,
 				securityPoolAddress,
-				systemState: getSecurityPoolSystemState(systemState),
+				systemState: poolSystemState,
 				totalRepDeposit,
 				totalSecurityBondAllowance,
 				truthAuctionAddress,
@@ -1809,20 +1828,6 @@ export async function forkZoltarUniverse(client: WriteClient, universeId: bigint
 		questionId: getQuestionIdHex(questionId),
 		universeId,
 	} satisfies ZoltarForkActionResult
-}
-export async function withdrawTruthAuctionBids(client: WriteClient, securityPoolAddress: Address, universeId: bigint, truthAuctionAddress: Address, withdrawFor: Address, tick: bigint, bidIndex: bigint) {
-	const hash = await writeContractAndWait(client, () => ({
-		address: truthAuctionAddress,
-		abi: peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.abi,
-		functionName: 'withdrawBids',
-		args: [withdrawFor, [{ tick, bidIndex }]],
-	}))
-	return {
-		action: 'withdrawBids',
-		hash,
-		securityPoolAddress,
-		universeId,
-	} satisfies ForkAuctionActionResult
 }
 export async function createCompleteSetInSecurityPool(client: WriteClient, securityPoolAddress: Address, amount: bigint) {
 	const universeId = await readSecurityPoolUniverseId(client, securityPoolAddress)

--- a/ui/ts/contracts/helpers.ts
+++ b/ui/ts/contracts/helpers.ts
@@ -1,5 +1,5 @@
-import { encodeAbiParameters, getAddress, keccak256, type Address, type Hex } from 'viem'
-import type { MarketType, QuestionData, ReportingOutcomeKey, SecurityPoolSystemState } from '../types/contracts.js'
+import { encodeAbiParameters, getAddress, keccak256, zeroAddress, type Address, type Hex } from 'viem'
+import type { ForkOutcomeKey, MarketType, QuestionData, ReportingOutcomeKey, SecurityPoolSystemState } from '../types/contracts.js'
 
 type IntegerLike = bigint | number
 
@@ -225,6 +225,11 @@ export function getReportingOutcomeKey(outcome: bigint | number): ReportingOutco
 		default:
 			return 'none'
 	}
+}
+
+export function getForkOutcomeKey(outcome: bigint | number, parentSecurityPoolAddress: Address): ForkOutcomeKey {
+	if (parentSecurityPoolAddress === zeroAddress) return 'none'
+	return getReportingOutcomeKey(outcome)
 }
 
 export function getEscalationSideLabel(key: ReportingOutcomeKey) {

--- a/ui/ts/hooks/useForkAuctionOperations.ts
+++ b/ui/ts/hooks/useForkAuctionOperations.ts
@@ -16,7 +16,6 @@ import {
 	refundTruthAuctionBid,
 	startTruthAuctionForSecurityPool,
 	submitTruthAuctionBid,
-	withdrawTruthAuctionBids,
 } from '../contracts.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
 import { getErrorMessage } from '../lib/errors.js'
@@ -40,7 +39,10 @@ export function useForkAuctionOperations({ accountAddress, onTransaction, onTran
 	const { state: forkAuctionForm, setState: setForkAuctionForm } = useFormState<ForkAuctionFormState>(getDefaultForkAuctionFormState())
 	const forkAuctionResult = useSignal<ForkAuctionActionResult | undefined>(undefined)
 	const forkAuctionLoad = useLoadController()
-	const getPendingTitle = (actionName: ForkAuctionActionResult['action']) => actionName.replace(/([A-Z])/g, ' $1').replace(/^./, value => value.toUpperCase())
+	const getPendingTitle = (actionName: ForkAuctionActionResult['action']) => {
+		if (actionName === 'claimAuctionProceeds') return 'Settle Finalized Bid'
+		return actionName.replace(/([A-Z])/g, ' $1').replace(/^./, value => value.toUpperCase())
+	}
 	const getSuccessTitle = (actionName: ForkAuctionActionResult['action']) => `${getPendingTitle(actionName)} submitted`
 	const getFailureTitle = (actionName: ForkAuctionActionResult['action']) => `${getPendingTitle(actionName)} failed`
 
@@ -174,10 +176,17 @@ export function useForkAuctionOperations({ accountAddress, onTransaction, onTran
 		await runForkAuctionAction(
 			'claimAuctionProceeds',
 			async (walletAddress, details) => {
-				const vaultAddress = resolveOptionalAddressInput(forkAuctionForm.value.vaultAddress, walletAddress, 'Vault address')
-				return await claimSecurityPoolAuctionProceeds(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), details.securityPoolAddress, details.universeId, vaultAddress, parseBigIntInput(forkAuctionForm.value.claimBidTick, 'Bid tick'), parseBigIntInput(forkAuctionForm.value.claimBidIndex, 'Bid index'))
+				const bidderAddress = resolveOptionalAddressInput(forkAuctionForm.value.settlementAddress, walletAddress, 'Bidder address')
+				return await claimSecurityPoolAuctionProceeds(
+					createWalletWriteClient(walletAddress, { onTransactionSubmitted }),
+					details.securityPoolAddress,
+					details.universeId,
+					bidderAddress,
+					parseBigIntInput(forkAuctionForm.value.claimBidTick, 'Settlement bid tick'),
+					parseBigIntInput(forkAuctionForm.value.claimBidIndex, 'Settlement bid index'),
+				)
 			},
-			'Failed to claim auction proceeds',
+			'Failed to settle finalized bid',
 		)
 
 	const forkUniverse = async () =>
@@ -186,25 +195,6 @@ export function useForkAuctionOperations({ accountAddress, onTransaction, onTran
 			async (walletAddress, details) =>
 				await forkUniverseDirectly(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), parseBigIntInput(forkAuctionForm.value.directForkUniverseId, 'Fork universe ID'), parseBigIntInput(forkAuctionForm.value.directForkQuestionId, 'Fork question ID'), details.securityPoolAddress),
 			'Failed to fork universe directly',
-		)
-
-	const withdrawBids = async () =>
-		await runForkAuctionAction(
-			'withdrawBids',
-			async (walletAddress, details) => {
-				const truthAuctionAddress = requireDefined(details.truthAuctionAddress, 'Truth auction not available')
-				const withdrawFor = resolveOptionalAddressInput(forkAuctionForm.value.withdrawForAddress, walletAddress, 'Withdraw-for address')
-				return await withdrawTruthAuctionBids(
-					createWalletWriteClient(walletAddress, { onTransactionSubmitted }),
-					details.securityPoolAddress,
-					details.universeId,
-					truthAuctionAddress,
-					withdrawFor,
-					parseBigIntInput(forkAuctionForm.value.withdrawTick, 'Withdraw tick'),
-					parseBigIntInput(forkAuctionForm.value.withdrawBidIndex, 'Withdraw bid index'),
-				)
-			},
-			'Failed to withdraw bids',
 		)
 
 	return {
@@ -228,7 +218,6 @@ export function useForkAuctionOperations({ accountAddress, onTransaction, onTran
 		setForkAuctionForm,
 		startTruthAuction,
 		submitBid,
-		withdrawBids,
 		finalizeTruthAuction,
 	}
 }

--- a/ui/ts/hooks/useOpenOracleOperations.ts
+++ b/ui/ts/hooks/useOpenOracleOperations.ts
@@ -640,7 +640,10 @@ export function useOpenOracleOperations({ accountAddress, enabled, onTransaction
 				return await submitInitialOracleReport(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), getOpenOracleAddress(), reportDetails.reportId, submission.amount1, submission.amount2, parseBytes32Input(openOracleForm.value.stateHash, 'State hash'))
 			},
 			'Failed to submit initial report',
-			{ formatErrorMessage: formatOpenOracleInitialReportWriteErrorMessage },
+			{
+				formatErrorMessage: formatOpenOracleInitialReportWriteErrorMessage,
+				refreshInitialReportTokenAccessOnSuccess: true,
+			},
 		)
 
 	const wrapWethForInitialReport = async () =>
@@ -697,7 +700,10 @@ export function useOpenOracleOperations({ accountAddress, enabled, onTransaction
 				)
 			},
 			'Failed to dispute report',
-			{ formatErrorMessage: formatOpenOracleDisputeWriteErrorMessage },
+			{
+				formatErrorMessage: formatOpenOracleDisputeWriteErrorMessage,
+				refreshInitialReportTokenAccessOnSuccess: true,
+			},
 		)
 
 	useEffect(() => {

--- a/ui/ts/hooks/usePriceOracleManager.ts
+++ b/ui/ts/hooks/usePriceOracleManager.ts
@@ -18,9 +18,10 @@ type UsePriceOracleManagerParameters = {
 	onTransactionFinished: () => void
 	onTransactionRequested: () => void
 	onTransactionSubmitted: (hash: Hash) => void
+	refreshState: () => Promise<void>
 }
 
-export function usePriceOracleManager({ accountAddress, onTransaction, onTransactionFinished, onTransactionRequested, onTransactionSubmitted }: UsePriceOracleManagerParameters) {
+export function usePriceOracleManager({ accountAddress, onTransaction, onTransactionFinished, onTransactionRequested, onTransactionSubmitted, refreshState }: UsePriceOracleManagerParameters) {
 	const poolOracleManagerLoad = useLoadController()
 	const poolOracleActiveAction = useSignal<OpenOracleActionResult['action'] | undefined>(undefined)
 	const poolOracleFeedback = useSignal<ActionFeedback<OpenOracleActionResult['action']> | undefined>(undefined)
@@ -69,6 +70,7 @@ export function usePriceOracleManager({ accountAddress, onTransaction, onTransac
 					},
 					refreshErrorFallback: 'Price request succeeded, but refreshing price oracle details failed',
 					refreshState: async () => {
+						await refreshState()
 						await loadPoolOracleManager(managerAddress)
 					},
 					setErrorMessage: message => {
@@ -119,6 +121,7 @@ export function usePriceOracleManager({ accountAddress, onTransaction, onTransac
 					},
 					refreshErrorFallback: 'Staged operation execution succeeded, but refreshing price oracle details failed',
 					refreshState: async () => {
+						await refreshState()
 						await loadPoolOracleManager(managerAddress)
 					},
 					setErrorMessage: message => {

--- a/ui/ts/hooks/useReportingOperations.ts
+++ b/ui/ts/hooks/useReportingOperations.ts
@@ -8,7 +8,7 @@ import { formatCurrencyBalance } from '../lib/formatters.js'
 import { getErrorMessage } from '../lib/errors.js'
 import { parseAddressInput } from '../lib/inputs.js'
 import { getDefaultReportingFormState, getDefaultReportingWithdrawDepositIndexesByOutcome, parseRepAmountInput } from '../lib/marketForm.js'
-import { previewReportingContribution } from '../lib/reportingDomain.js'
+import { getRemainingSelectedOutcomeContributionCapacity, previewReportingContribution } from '../lib/reportingDomain.js'
 import { useRequestGuard } from '../lib/requestGuard.js'
 import { createErrorActionFeedback, createPendingActionFeedback, createSuccessActionFeedback, createWarningActionFeedback } from '../lib/actionFeedback.js'
 import { buildWriteActionConfig, runWriteAction } from '../lib/writeAction.js'
@@ -139,6 +139,11 @@ export function useReportingOperations({ accountAddress, onTransaction, onTransa
 				const contributionPreview = previewReportingContribution(latestDetails, selectedOutcome, reportAmount)
 				if (contributionPreview.actualDepositAmount === undefined) throw new Error(contributionPreview.reason ?? 'Unable to preview the REP that would be locked for this report.')
 				if (!latestDetails.viewerVaultExists) throw new Error('Reporting locks REP already deposited in your security vault. Deposit REP into your vault before reporting.')
+				const remainingSelectedOutcomeCapacity = getRemainingSelectedOutcomeContributionCapacity(latestDetails, selectedOutcome)
+				if (contributionPreview.actualDepositAmount > remainingSelectedOutcomeCapacity) {
+					if (remainingSelectedOutcomeCapacity === 0n) throw new Error('No remaining contribution capacity is available on the selected side.')
+					throw new Error(`Only ${formatCurrencyBalance(remainingSelectedOutcomeCapacity)} REP remains before the selected side reaches the threshold.`)
+				}
 				const availableVaultRep = latestDetails.viewerVaultAvailableEscalationRep ?? 0n
 				if (contributionPreview.actualDepositAmount > availableVaultRep) throw new Error(`Insufficient unlocked REP in your vault. Need ${formatCurrencyBalance(contributionPreview.actualDepositAmount - availableVaultRep)} more REP deposited and unlocked before reporting.`)
 

--- a/ui/ts/lib/forkAuction.ts
+++ b/ui/ts/lib/forkAuction.ts
@@ -1,5 +1,5 @@
 import type { Address } from 'viem'
-import type { ForkAuctionDetails, ListedSecurityPool, ReportingOutcomeKey, SecurityPoolSystemState, TruthAuctionMetrics } from '../types/contracts.js'
+import type { ForkAuctionDetails, ForkOutcomeKey, ListedSecurityPool, ReportingOutcomeKey, SecurityPoolSystemState, TruthAuctionMetrics } from '../types/contracts.js'
 import { assertNever } from './assert.js'
 import { formatCurrencyBalance } from './formatters.js'
 import { parseBigIntInput } from './marketForm.js'
@@ -16,12 +16,14 @@ export type ForkAuctionStageView = 'initiate' | 'migration' | 'auction' | 'settl
 
 type ForkAuctionStageSource = {
 	claimingAvailable?: boolean
-	forkOutcome: ReportingOutcomeKey | 'none'
+	forkOutcome: ForkOutcomeKey
 	migratedRep: bigint
 	systemState: SecurityPoolSystemState
 	truthAuction?: Pick<TruthAuctionMetrics, 'finalized'> | undefined
 	truthAuctionStartedAt: bigint
 }
+
+type ForkActivitySource = Pick<ListedSecurityPool, 'forkOutcome' | 'migratedRep' | 'systemState' | 'truthAuctionStartedAt'>
 
 export function getOutcomeActionLabel(outcome: ReportingOutcomeKey) {
 	return getReportingOutcomeLabel(outcome)
@@ -46,8 +48,12 @@ export function getForkStageDescription(details: ForkAuctionDetails) {
 	return getForkStageDescriptionForState(details.systemState)
 }
 
-export function hasForkActivity(pool: Pick<ListedSecurityPool, 'forkOutcome' | 'migratedRep' | 'systemState' | 'truthAuctionStartedAt'>) {
-	return pool.systemState !== 'operational' || pool.truthAuctionStartedAt > 0n || pool.migratedRep > 0n || pool.forkOutcome !== 'none'
+export function deriveHasForkActivity(source: ForkActivitySource) {
+	return source.systemState !== 'operational' || source.truthAuctionStartedAt > 0n || source.migratedRep > 0n || source.forkOutcome !== 'none'
+}
+
+export function hasForkActivity(pool: ForkActivitySource) {
+	return deriveHasForkActivity(pool)
 }
 
 export function getForkAuctionStageView(source: ForkAuctionStageSource): ForkAuctionStageView {

--- a/ui/ts/lib/marketForm.ts
+++ b/ui/ts/lib/marketForm.ts
@@ -104,12 +104,10 @@ export function getDefaultForkAuctionFormState(): ForkAuctionFormState {
 		repMigrationOutcomes: 'yes',
 		securityPoolAddress: '',
 		selectedOutcome: 'yes',
+		settlementAddress: '',
 		submitBidAmount: '0',
 		submitBidTick: '0',
 		vaultAddress: '',
-		withdrawBidIndex: '0',
-		withdrawForAddress: '',
-		withdrawTick: '0',
 	}
 }
 

--- a/ui/ts/lib/reportingDomain.ts
+++ b/ui/ts/lib/reportingDomain.ts
@@ -153,6 +153,14 @@ export function getEscalationDepositClaimAmount(details: ReportingDetails | unde
 	if (resolvedOutcome !== outcome) return 0n
 	return getWinningEscalationDepositClaimAmount(details, outcome, deposit)
 }
+
+export function getRemainingSelectedOutcomeContributionCapacity(details: ReportingDetails, outcome: ReportingOutcomeKey) {
+	if (details.status === 'not-started') return details.nonDecisionThreshold
+	const selectedSide = details.sides.find(side => side.key === outcome)
+	if (selectedSide === undefined) return 0n
+	return details.nonDecisionThreshold > selectedSide.balance ? details.nonDecisionThreshold - selectedSide.balance : 0n
+}
+
 export function getReportingTimerPreview(details: ReportingDetails, outcome: ReportingOutcomeKey, amount: bigint): ReportingTimerPreview | undefined {
 	if (amount <= 0n) return undefined
 	const hypotheticalDuration = computeHypotheticalBindingDuration(details.startBond, details.nonDecisionThreshold, amount)
@@ -207,11 +215,18 @@ export function getMinimumOutcomeChangeContribution(details: ActiveReportingDeta
 	const amount = roundUpToRepUnit(enteredAmount)
 	const availableRoom = getAvailableRoom(details, selectedSide.balance)
 	const effectiveAmount = amount > availableRoom ? availableRoom : amount
-	if (availableRoom === 0n || selectedSide.balance + effectiveAmount <= largestOtherBalance)
+	if (availableRoom === 0n)
 		return {
 			amount: undefined,
-			reason: 'Min preset unavailable because the selected side cannot take the lead within the remaining bond capacity.',
+			reason: 'No remaining contribution capacity is available on the selected side.',
 		}
+	if (selectedSide.balance + effectiveAmount <= largestOtherBalance) {
+		const cappedEnteredAmount = details.startBond > availableRoom ? details.startBond : availableRoom
+		return {
+			amount: roundUpToRepUnit(cappedEnteredAmount),
+			reason: undefined,
+		}
+	}
 	return { amount, reason: undefined }
 }
 export function getReportingMinimumOutcomeChangeContribution(details: ReportingDetails | undefined, selectedOutcome: ReportingOutcomeKey): ReportingAmountSuggestion {

--- a/ui/ts/lib/reportingGuards.ts
+++ b/ui/ts/lib/reportingGuards.ts
@@ -9,6 +9,7 @@ export function getReportingReportGuardMessage({
 	accountAddress,
 	contributionPreviewReason,
 	isMainnet,
+	remainingSelectedOutcomeCapacity,
 	reportAmount,
 	reportingStatus,
 	selectedOutcome,
@@ -20,6 +21,7 @@ export function getReportingReportGuardMessage({
 	accountAddress: Address | undefined
 	contributionPreviewReason: string | undefined
 	isMainnet: boolean
+	remainingSelectedOutcomeCapacity: bigint | undefined
 	reportAmount: string
 	reportingStatus: ReportingStatus
 	selectedOutcome: ReportingOutcomeKey | undefined
@@ -37,6 +39,10 @@ export function getReportingReportGuardMessage({
 	if (!viewerVaultExists) return 'Reporting locks REP already deposited in your security vault. Deposit REP into your vault before reporting.'
 	if (actualDepositAmount === undefined) return 'Unable to preview the REP that would be locked for this report.'
 	if (viewerVaultAvailableEscalationRep === undefined) return 'Loading available vault REP.'
+	if (remainingSelectedOutcomeCapacity !== undefined && actualDepositAmount > remainingSelectedOutcomeCapacity) {
+		if (remainingSelectedOutcomeCapacity === 0n) return 'No remaining contribution capacity is available on the selected side.'
+		return `Only ${formatCurrencyBalance(remainingSelectedOutcomeCapacity)} REP remains before the selected side reaches the threshold.`
+	}
 	if (actualDepositAmount > viewerVaultAvailableEscalationRep) return `Need ${formatCurrencyBalance(actualDepositAmount - viewerVaultAvailableEscalationRep)} more unlocked REP in your vault before reporting.`
 	return undefined
 }

--- a/ui/ts/lib/securityPoolState/matrix.ts
+++ b/ui/ts/lib/securityPoolState/matrix.ts
@@ -30,14 +30,13 @@ export const ALL_SECURITY_POOL_ACTIONS: ActionList = [
 	'finalizeTruthAuction',
 	'refundLosingBids',
 	'claimAuctionProceeds',
-	'withdrawBids',
 ]
 
 export const LIFECYCLE_ACTIONS: ActionList = ['approveRep', 'depositRep', 'queueWithdrawRep', 'redeemRep', 'queueSetSecurityBondAllowance', 'redeemFees', 'createCompleteSet', 'redeemCompleteSet', 'migrateShares', 'redeemShares', 'requestPrice', 'executeStagedOperation', 'queueLiquidation']
 
 export const REPORTING_ACTIONS: ActionList = ['reportOutcome', 'withdrawEscalation']
 
-export const FORK_ACTIONS: ActionList = ['forkWithOwnEscalation', 'initiateFork', 'forkUniverse', 'createChildUniverse', 'migrateRepToZoltar', 'migrateVault', 'migrateEscalationDeposits', 'startTruthAuction', 'submitBid', 'finalizeTruthAuction', 'refundLosingBids', 'claimAuctionProceeds', 'withdrawBids']
+export const FORK_ACTIONS: ActionList = ['forkWithOwnEscalation', 'initiateFork', 'forkUniverse', 'createChildUniverse', 'migrateRepToZoltar', 'migrateVault', 'migrateEscalationDeposits', 'startTruthAuction', 'submitBid', 'finalizeTruthAuction', 'refundLosingBids', 'claimAuctionProceeds']
 
 export const ENABLED_ACTIONS_BY_LIFECYCLE: Record<SecurityPoolLifecycleState, ActionList> = {
 	operational: ['approveRep', 'depositRep', 'queueWithdrawRep', 'queueSetSecurityBondAllowance', 'redeemFees', 'createCompleteSet', 'redeemCompleteSet', 'requestPrice', 'executeStagedOperation', 'queueLiquidation'],
@@ -62,7 +61,7 @@ export const ENABLED_ACTIONS_BY_FORK_STAGE: Record<SecurityPoolForkStage, Action
 	initiate: ['forkWithOwnEscalation', 'initiateFork', 'forkUniverse'],
 	migration: ['createChildUniverse', 'migrateRepToZoltar', 'migrateVault', 'migrateEscalationDeposits', 'startTruthAuction'],
 	auction: ['submitBid', 'finalizeTruthAuction', 'refundLosingBids'],
-	settlement: ['claimAuctionProceeds', 'withdrawBids'],
+	settlement: ['claimAuctionProceeds'],
 }
 
 export const UNIVERSE_FORKED_ENABLE: ActionList = ['migrateShares']

--- a/ui/ts/lib/securityPoolState/types.ts
+++ b/ui/ts/lib/securityPoolState/types.ts
@@ -32,7 +32,6 @@ export type SecurityPoolActionId =
 	| 'finalizeTruthAuction'
 	| 'refundLosingBids'
 	| 'claimAuctionProceeds'
-	| 'withdrawBids'
 
 export type SecurityPoolActionState = {
 	enabled: boolean

--- a/ui/ts/tests/contracts.test.ts
+++ b/ui/ts/tests/contracts.test.ts
@@ -1,8 +1,9 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from 'bun:test'
-import { decodeFunctionData, getAddress, type Address, type Hash, type Hex } from 'viem'
-import { getOpenOracleAddress, loadEscalationDeposits, loadTruthAuctionActiveTickPage, loadTruthAuctionBidderBidPage, loadTruthAuctionTickBidPage, loadTruthAuctionTickPage, loadTruthAuctionTickSummary, migrateSharesFromUniverse, settleOracleReport } from '../contracts.js'
+import { decodeFunctionData, getAddress, zeroAddress, type Address, type Hash, type Hex } from 'viem'
+import { getOpenOracleAddress, loadAllSecurityPools, loadEscalationDeposits, loadForkAuctionDetails, loadTruthAuctionActiveTickPage, loadTruthAuctionBidderBidPage, loadTruthAuctionTickBidPage, loadTruthAuctionTickPage, loadTruthAuctionTickSummary, migrateSharesFromUniverse, settleOracleReport } from '../contracts.js'
+import { getForkOutcomeKey } from '../contracts/helpers.js'
 import { peripherals_openOracle_OpenOracle_OpenOracle, peripherals_tokens_ShareToken_ShareToken } from '../contractArtifact.js'
 import type { ReadClient } from '../types/contracts.js'
 
@@ -13,11 +14,29 @@ const transactionHash = '0x00000000000000000000000000000000000000000000000000000
 
 type MockWriteClient = Parameters<typeof migrateSharesFromUniverse>[0]
 type MockReadClient = Parameters<typeof loadEscalationDeposits>[0]
+type MockLoaderClient = Parameters<typeof loadAllSecurityPools>[0]
 type MockReadContractRequest = Parameters<MockReadClient['readContract']>[0]
 type MockReadContractHandler = (request: MockReadContractRequest) => Promise<unknown>
+type MockLoaderMulticallRequest = Parameters<MockLoaderClient['multicall']>[0]
+type MockLoaderMulticallHandler = (request: MockLoaderMulticallRequest) => Promise<unknown>
+
+function getContractFunctionName(contract: unknown) {
+	if (typeof contract !== 'object' || contract === null || !('functionName' in contract)) throw new Error('Unexpected multicall contract')
+	const functionName = contract.functionName
+	if (typeof functionName !== 'string') throw new Error('Unexpected multicall contract')
+	return functionName
+}
+
+function createBlockWithTimestamp(timestamp: bigint) {
+	return { timestamp }
+}
 
 function createReadContractStub(handler: MockReadContractHandler): ReadClient['readContract'] {
 	return async request => (await handler(request as MockReadContractRequest)) as never
+}
+
+function createMulticallStub(handler: MockLoaderMulticallHandler): MockLoaderClient['multicall'] {
+	return async request => (await handler(request as MockLoaderMulticallRequest)) as never
 }
 
 function createMockWriteClient(onSendTransaction: (request: { data?: Hex | undefined; gas?: bigint | undefined; to?: Address | null | undefined }) => void): MockWriteClient {
@@ -43,6 +62,14 @@ function createMockReadClient(readContract: MockReadContractHandler): MockReadCl
 	}
 }
 
+function createMockLoaderClient({ getBlock, multicall, readContract }: { getBlock: () => Promise<{ timestamp: bigint }>; multicall: MockLoaderMulticallHandler; readContract: MockReadContractHandler }): MockLoaderClient {
+	return {
+		getBlock,
+		multicall: createMulticallStub(multicall),
+		readContract: createReadContractStub(readContract),
+	} as unknown as MockLoaderClient
+}
+
 describe('contracts helpers', () => {
 	test('migrateSharesFromUniverse sorts target outcomes before submission without deduplicating', async () => {
 		let capturedData: Hex | undefined
@@ -63,6 +90,87 @@ describe('contracts helpers', () => {
 		expect(decodedCall.functionName).toBe('migrate')
 		expect(decodedCall.args?.[1]).toEqual([3n, 7n, 7n])
 		expect(result.targetOutcomeIndexes).toEqual([3n, 7n, 7n])
+	})
+
+	test('getForkOutcomeKey treats the default root-pool fork outcome as none', () => {
+		expect(getForkOutcomeKey(0n, getAddress('0x0000000000000000000000000000000000000000'))).toBe('none')
+		expect(getForkOutcomeKey(0n, securityPoolAddress)).toBe('invalid')
+		expect(getForkOutcomeKey(1n, securityPoolAddress)).toBe('yes')
+	})
+
+	test('loadForkAuctionDetails keeps the default root-pool fork outcome unset and inactive', async () => {
+		const questionId = 1n
+		const questionTuple = ['Question', 'Description', 1n, 2n, 2n, 0n, 100n, ''] as const
+		const client = createMockLoaderClient({
+			getBlock: async () => createBlockWithTimestamp(5n),
+			multicall: async request => {
+				const contracts = request.contracts
+				const firstContract = contracts[0]
+				if (getContractFunctionName(firstContract) === 'questionId') {
+					return [questionId, zeroAddress, 1n, 0n, zeroAddress, 0n, [0n, zeroAddress, 0n, 0n, 0n, false, 0], 3n]
+				}
+				if (getContractFunctionName(firstContract) === 'getForkTime') return [0n]
+				if (getContractFunctionName(firstContract) === 'questions') return [questionTuple, 1n]
+				throw new Error(`Unexpected multicall contract: ${getContractFunctionName(firstContract)}`)
+			},
+			readContract: async request => {
+				if (request.functionName === 'getOutcomeLabels') return ['Yes', 'No']
+				throw new Error(`Unexpected readContract function: ${request.functionName}`)
+			},
+		})
+
+		const details = await loadForkAuctionDetails(client, securityPoolAddress)
+
+		expect(details.parentSecurityPoolAddress).toBe(zeroAddress)
+		expect(details.forkOutcome).toBe('none')
+		expect(details.hasForkActivity).toBe(false)
+	})
+
+	test('loadAllSecurityPools keeps the default root-pool fork outcome unset and inactive', async () => {
+		const questionId = 1n
+		const questionTuple = ['Question', 'Description', 1n, 2n, 2n, 0n, 100n, ''] as const
+		const client = createMockLoaderClient({
+			getBlock: async () => createBlockWithTimestamp(0n),
+			multicall: async request => {
+				const contracts = request.contracts
+				const firstContract = contracts[0]
+				if (getContractFunctionName(firstContract) === 'completeSetCollateralAmount') {
+					return [0n, 10n, [0n, zeroAddress, 0n, 0n, 0n, false, 0], 0n, 0n, 3n, 0n, 0n, 0n]
+				}
+				if (getContractFunctionName(firstContract) === 'questions') return [questionTuple, 1n]
+				throw new Error(`Unexpected multicall contract: ${getContractFunctionName(firstContract)}`)
+			},
+			readContract: async request => {
+				if (request.functionName === 'securityPoolDeploymentCount') return 1n
+				if (request.functionName === 'securityPoolDeploymentsRange') {
+					return [
+						{
+							completeSetCollateralAmount: 0n,
+							currentRetentionRate: 0n,
+							parent: zeroAddress,
+							priceOracleManagerAndOperatorQueuer: zeroAddress,
+							questionId,
+							securityMultiplier: 2n,
+							securityPool: securityPoolAddress,
+							shareToken: shareTokenAddress,
+							truthAuction: zeroAddress,
+							universeId: 1n,
+						},
+					]
+				}
+				if (request.functionName === 'getVaultCount') return 0n
+				if (request.functionName === 'getOutcomeLabels') return ['Yes', 'No']
+				throw new Error(`Unexpected readContract function: ${request.functionName}`)
+			},
+		})
+
+		const pools = await loadAllSecurityPools(client)
+		const [pool] = pools
+		if (pool === undefined) throw new Error('Expected one security pool')
+
+		expect(pool.parent).toBe(zeroAddress)
+		expect(pool.forkOutcome).toBe('none')
+		expect(pool.hasForkActivity).toBe(false)
 	})
 
 	test('settleOracleReport sends settle with an explicit gas limit', async () => {

--- a/ui/ts/tests/forkAuctionSection.test.tsx
+++ b/ui/ts/tests/forkAuctionSection.test.tsx
@@ -6,10 +6,10 @@ import { h, render } from 'preact'
 import { act } from 'preact/test-utils'
 import { zeroAddress } from 'viem'
 import { ForkAuctionSection } from '../components/ForkAuctionSection.js'
-import { AUCTION_TIME_SECONDS } from '../lib/forkAuction.js'
+import { AUCTION_TIME_SECONDS, deriveHasForkActivity } from '../lib/forkAuction.js'
 import { formatDuration } from '../lib/formatters.js'
 import type { AccountState, ForkAuctionFormState } from '../types/app.js'
-import type { ForkAuctionDetails, MarketDetails, ReadClient, TruthAuctionBidView, TruthAuctionTickSummary } from '../types/contracts.js'
+import type { ForkAuctionDetails, ListedSecurityPool, MarketDetails, ReadClient, TruthAuctionBidView, TruthAuctionTickSummary } from '../types/contracts.js'
 import type { ForkAuctionSectionProps } from '../types/components.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
@@ -73,11 +73,12 @@ function createMarketDetails(): MarketDetails {
 }
 
 function createForkAuctionDetails(): ForkAuctionDetails {
-	return {
+	const forkAuctionDetails: ForkAuctionDetails = {
 		auctionedSecurityBondAllowance: 10n,
 		claimingAvailable: false,
 		completeSetCollateralAmount: 1n,
 		currentTime: 100n,
+		hasForkActivity: false,
 		forkOutcome: 'none',
 		forkOwnSecurityPool: false,
 		marketDetails: createMarketDetails(),
@@ -92,6 +93,44 @@ function createForkAuctionDetails(): ForkAuctionDetails {
 		truthAuctionAddress: zeroAddress,
 		truthAuctionStartedAt: 0n,
 		universeId: 1n,
+	}
+	return {
+		...forkAuctionDetails,
+		hasForkActivity: deriveHasForkActivity(forkAuctionDetails),
+	}
+}
+
+function createPreviewPool(overrides: Partial<ListedSecurityPool> = {}): ListedSecurityPool {
+	const previewPool: ListedSecurityPool = {
+		completeSetCollateralAmount: 1n,
+		currentRetentionRate: 10n,
+		hasForkActivity: false,
+		forkOutcome: 'none',
+		forkOwnSecurityPool: false,
+		lastOraclePrice: undefined,
+		lastOracleSettlementTimestamp: 0n,
+		managerAddress: zeroAddress,
+		marketDetails: createMarketDetails(),
+		migratedRep: 0n,
+		parent: zeroAddress,
+		questionOutcome: 'none',
+		questionId: '0x01',
+		securityMultiplier: 2n,
+		securityPoolAddress: zeroAddress,
+		systemState: 'operational',
+		totalRepDeposit: 0n,
+		totalSecurityBondAllowance: 5n * ETH,
+		truthAuctionAddress: zeroAddress,
+		truthAuctionStartedAt: 0n,
+		universeHasForked: false,
+		universeId: 1n,
+		vaultCount: 0n,
+		vaults: [],
+		...overrides,
+	}
+	return {
+		...previewPool,
+		hasForkActivity: overrides.hasForkActivity ?? deriveHasForkActivity(previewPool),
 	}
 }
 
@@ -127,12 +166,10 @@ function createForkAuctionForm(): ForkAuctionFormState {
 		repMigrationOutcomes: '',
 		securityPoolAddress: zeroAddress,
 		selectedOutcome: 'yes',
+		settlementAddress: '',
 		submitBidAmount: '',
 		submitBidTick: '',
 		vaultAddress: '',
-		withdrawBidIndex: '',
-		withdrawForAddress: '',
-		withdrawTick: '',
 	}
 }
 
@@ -204,7 +241,6 @@ function createProps(overrides: Partial<ForkAuctionSectionProps> = {}): ForkAuct
 		onRefundLosingBids: () => undefined,
 		onStartTruthAuction: () => undefined,
 		onSubmitBid: () => undefined,
-		onWithdrawBids: () => undefined,
 		showHeader: false,
 		showSecurityPoolAddressInput: false,
 		truthAuctionReadClient: createTruthAuctionReadClient(),
@@ -287,7 +323,7 @@ describe('ForkAuctionSection', () => {
 		await act(() => {
 			fireEvent.click(documentQueries.getByRole('tab', { name: 'Initiate' }))
 		})
-		expectTransactionButtonDisabled(document.body, 'Fork With Own Escalation')
+		expect(documentQueries.queryByRole('button', { name: 'Trigger Zoltar Fork' })).toBeNull()
 		expectTransactionButtonDisabled(document.body, 'Initiate Pool Fork')
 		expectTransactionButtonDisabled(document.body, 'Fork Universe Directly')
 
@@ -302,7 +338,7 @@ describe('ForkAuctionSection', () => {
 		})
 		expectTransactionButtonDisabled(document.body, 'Finalize Truth Auction')
 		expectTransactionButtonDisabled(document.body, 'Refund Losing Bid')
-		expectTransactionButtonDisabled(document.body, 'Claim Auction Proceeds')
+		expect(documentQueries.queryByRole('button', { name: 'Settle Finalized Bid' })).toBeNull()
 		expect(documentQueries.queryByRole('button', { name: 'Withdraw Bids' })).toBeNull()
 	})
 
@@ -336,7 +372,7 @@ describe('ForkAuctionSection', () => {
 		})
 		expectTransactionButtonDisabled(document.body, 'Finalize Truth Auction')
 		expectTransactionButtonDisabled(document.body, 'Refund Losing Bid')
-		expectTransactionButtonDisabled(document.body, 'Claim Auction Proceeds')
+		expect(documentQueries.queryByRole('button', { name: 'Settle Finalized Bid' })).toBeNull()
 		expect(documentQueries.queryByRole('button', { name: 'Withdraw Bids' })).toBeNull()
 	})
 
@@ -376,6 +412,33 @@ describe('ForkAuctionSection', () => {
 		expect(document.body.querySelector('.workflow-transaction-status')).not.toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Latest Fork / Auction Action' })).not.toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Latest Fork / Auction Action' }).closest('.actions')).toBeNull()
+	})
+
+	test('does not imply a concrete fork type before a fork path is chosen after non-decision', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					forkAuctionDetails: undefined,
+					lifecycleStateOverride: 'poolForked',
+					previewPool: createPreviewPool({ questionOutcome: 'yes' }),
+					showHeader: true,
+					showSecurityPoolAddressInput: true,
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		const poolContextAccordion = documentQueries.getByText('Pool Context').closest('.read-only-detail-accordion')
+		if (!(poolContextAccordion instanceof HTMLElement)) throw new Error('Expected pool context accordion to render')
+		const poolContextMetrics = poolContextAccordion.querySelector('.fork-summary-grid')
+		if (!(poolContextMetrics instanceof HTMLElement)) throw new Error('Expected pool context metrics to render')
+
+		expect(getMetricValue(poolContextMetrics, 'Fork Type')).toBe('Not chosen yet')
+		expect(getMetricValue(poolContextMetrics, 'Fork Outcome')).toBe('Not chosen yet')
+		expect(document.body.textContent?.includes('If this pool is triggering a Zoltar fork from its own escalation game, use Trigger Zoltar Fork from Reporting first. Otherwise activate fork mode here, then move to Migration and run Migrate Escalation Deposits.')).toBe(true)
+		expect(documentQueries.queryByText('Parent/Zoltar fork')).toBeNull()
 	})
 
 	test('recomputes truth auction time left from the live chain timestamp', async () => {
@@ -570,7 +633,7 @@ describe('ForkAuctionSection', () => {
 
 		expectTransactionButtonDisabled(document.body, 'Finalize Truth Auction', 'Truth auction is still ongoing.')
 		expectTransactionButtonEnabled(document.body, 'Refund Losing Bid')
-		expectTransactionButtonDisabled(document.body, 'Claim Auction Proceeds', 'Claiming becomes available after the truth auction is finalized.')
+		expect(documentQueries.queryByRole('button', { name: 'Settle Finalized Bid' })).toBeNull()
 
 		await act(() => {
 			render(
@@ -608,13 +671,13 @@ describe('ForkAuctionSection', () => {
 		})
 
 		await waitFor(() => {
-			expectTransactionButtonEnabled(document.body, 'Claim Auction Proceeds')
+			expectTransactionButtonEnabled(document.body, 'Settle Finalized Bid')
 		})
 		expect(within(document.body).queryByRole('button', { name: 'Finalize Truth Auction' })).toBeNull()
-		expectTransactionButtonDisabled(document.body, 'Refund Losing Bid', 'Refunds are only available before finalization.')
+		expect(within(document.body).queryByRole('button', { name: 'Refund Losing Bid' })).toBeNull()
 	})
 
-	test('disables claim auction proceeds until the claim inputs are complete', async () => {
+	test('disables finalized settlement until the settlement inputs are complete', async () => {
 		const baseDetails = {
 			...createForkAuctionDetails(),
 			claimingAvailable: true,
@@ -639,7 +702,10 @@ describe('ForkAuctionSection', () => {
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		expectTransactionButtonDisabled(document.body, 'Claim Auction Proceeds', 'Enter a valid claim bid tick.')
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByText('Settlement Available')).not.toBeNull()
+		expect(documentQueries.getAllByText('Bidder Address').length).toBeGreaterThan(0)
+		expectTransactionButtonDisabled(document.body, 'Settle Finalized Bid', 'Enter a valid settlement bid tick.')
 
 		await act(() => {
 			render(
@@ -656,7 +722,7 @@ describe('ForkAuctionSection', () => {
 				renderedComponent.container,
 			)
 		})
-		expectTransactionButtonDisabled(document.body, 'Claim Auction Proceeds', 'Enter a valid claim bid index.')
+		expectTransactionButtonDisabled(document.body, 'Settle Finalized Bid', 'Enter a valid settlement bid index.')
 
 		await act(() => {
 			render(
@@ -668,14 +734,14 @@ describe('ForkAuctionSection', () => {
 							...createForkAuctionForm(),
 							claimBidIndex: '0',
 							claimBidTick: '10',
-							vaultAddress: 'not-an-address',
+							settlementAddress: 'not-an-address',
 						},
 					}),
 				}),
 				renderedComponent.container,
 			)
 		})
-		expectTransactionButtonDisabled(document.body, 'Claim Auction Proceeds', 'Enter a valid vault address.')
+		expectTransactionButtonDisabled(document.body, 'Settle Finalized Bid', 'Enter a valid bidder address.')
 
 		await act(() => {
 			render(
@@ -695,7 +761,7 @@ describe('ForkAuctionSection', () => {
 		})
 
 		await waitFor(() => {
-			expectTransactionButtonEnabled(document.body, 'Claim Auction Proceeds')
+			expectTransactionButtonEnabled(document.body, 'Settle Finalized Bid')
 		})
 	})
 
@@ -762,7 +828,7 @@ describe('ForkAuctionSection', () => {
 		})
 
 		await waitFor(() => {
-			expect(documentQueries.getByRole('heading', { name: 'Settle Selected Bid' })).not.toBeNull()
+			expect(documentQueries.getByRole('heading', { name: 'Settle Finalized Bid' })).not.toBeNull()
 		})
 	})
 
@@ -1023,7 +1089,7 @@ describe('ForkAuctionSection', () => {
 		expect(documentQueries.getAllByText('Winning').length).toBeGreaterThan(0)
 	})
 
-	test('prefills claim inputs from wallet bid shortcuts in settlement mode', async () => {
+	test('prefills finalized settlement inputs from wallet bid shortcuts in settlement mode', async () => {
 		const formUpdates: Partial<ForkAuctionFormState>[] = []
 		const truthAuctionReadClient = createTruthAuctionReadClient(async request => {
 			if (request.functionName === 'activeTickCount') return 1n
@@ -1065,19 +1131,169 @@ describe('ForkAuctionSection', () => {
 
 		const documentQueries = within(document.body)
 		await waitFor(() => {
-			expect(documentQueries.getAllByRole('button', { name: 'Prefill Claim' }).length).toBeGreaterThan(0)
+			expect(documentQueries.getAllByRole('button', { name: 'Prefill Settle' }).length).toBeGreaterThan(0)
 		})
 		fireEvent.click(
-			documentQueries.getAllByRole('button', { name: 'Prefill Claim' })[0] ??
+			documentQueries.getAllByRole('button', { name: 'Prefill Settle' })[0] ??
 				(() => {
-					throw new Error('Expected at least one Prefill Claim button')
+					throw new Error('Expected at least one Prefill Settle button')
 				})(),
 		)
 
 		expect(formUpdates).toContainEqual({
 			claimBidIndex: '0',
 			claimBidTick: '12',
+			settlementAddress: zeroAddress,
 		})
+	})
+
+	test('renders finalized losing bids as refundable settlement rows and settled losing bids as refunded', async () => {
+		const formUpdates: Partial<ForkAuctionFormState>[] = []
+		const truthAuctionReadClient = createTruthAuctionReadClient(async request => {
+			if (request.functionName === 'activeTickCount') return 1n
+			if (request.functionName === 'getActiveTickPage') return [createTruthAuctionTickSummary({ tick: 10n, price: 2n * ETH, currentTotalEth: 5n * ETH, submissionCount: 2n, active: true })]
+			if (request.functionName === 'getTickSummary') {
+				if ((request.args?.[0] ?? 0n) === 9n) return createTruthAuctionTickSummary({ tick: 9n, price: 1n * ETH, currentTotalEth: 0n, submissionCount: 1n, active: false })
+				if ((request.args?.[0] ?? 0n) === 8n) return createTruthAuctionTickSummary({ tick: 8n, price: 1n * ETH, currentTotalEth: 0n, submissionCount: 1n, active: false })
+				return createTruthAuctionTickSummary({ tick: 10n, price: 2n * ETH, currentTotalEth: 5n * ETH, submissionCount: 2n, active: true })
+			}
+			if (request.functionName === 'getBidCountAtTick') {
+				if ((request.args?.[0] ?? 0n) === 9n || (request.args?.[0] ?? 0n) === 8n) return 1n
+				return 2n
+			}
+			if (request.functionName === 'getBidPageAtTick') {
+				if ((request.args?.[0] ?? 0n) === 9n) return [createTruthAuctionBidView({ tick: 9n, bidIndex: 1n, ethAmount: 1n * ETH, cumulativeEth: 1n * ETH })]
+				if ((request.args?.[0] ?? 0n) === 8n) return [createTruthAuctionBidView({ tick: 8n, bidIndex: 2n, ethAmount: 1n * ETH, cumulativeEth: 1n * ETH, claimed: true })]
+				return [createTruthAuctionBidView({ tick: 10n, bidIndex: 0n, ethAmount: 5n * ETH, cumulativeEth: 5n * ETH })]
+			}
+			if (request.functionName === 'getBidderBidCount') return 3n
+			if (request.functionName === 'getBidderBidPage') {
+				return [
+					createTruthAuctionBidView({ tick: 10n, bidIndex: 0n, ethAmount: 5n * ETH, cumulativeEth: 5n * ETH }),
+					createTruthAuctionBidView({ tick: 9n, bidIndex: 1n, ethAmount: 1n * ETH, cumulativeEth: 1n * ETH }),
+					createTruthAuctionBidView({ tick: 8n, bidIndex: 2n, ethAmount: 1n * ETH, cumulativeEth: 1n * ETH, claimed: true }),
+				]
+			}
+			throw new Error(`Unexpected truth auction read: ${String(request.functionName)}`)
+		})
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					accountState: createAccountState({ ethBalance: 10n * ETH }),
+					forkAuctionDetails: {
+						...createForkAuctionDetails(),
+						claimingAvailable: true,
+						systemState: 'operational',
+						truthAuction: {
+							...createTruthAuctionMetrics(),
+							clearingPrice: 2n * ETH,
+							clearingTick: 10n,
+							ethAtClearingTick: 5n * ETH,
+							finalized: true,
+							hitCap: true,
+							timeRemaining: 0n,
+						},
+						truthAuctionAddress: '0x0000000000000000000000000000000000000001',
+						truthAuctionStartedAt: 1n,
+					},
+					onForkAuctionFormChange: update => {
+						formUpdates.push(update)
+					},
+					truthAuctionReadClient,
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		await waitFor(() => {
+			expect(documentQueries.getAllByRole('button', { name: 'Prefill Settle' }).length).toBeGreaterThan(0)
+		})
+
+		expect(document.body.textContent?.includes('Owner Withdrawal')).toBe(false)
+		expect(documentQueries.getAllByText('Refundable').length).toBeGreaterThan(0)
+		expect(documentQueries.getAllByText('Refunded').length).toBeGreaterThan(0)
+
+		const settleButtons = documentQueries.getAllByRole('button', { name: 'Prefill Settle' })
+		const refundableRowButton = settleButtons.find(button => button.closest('.truth-auction-bid-row')?.textContent?.includes('Refundable') === true)
+		if (refundableRowButton === undefined) throw new Error('Expected a refundable Prefill Settle button')
+
+		fireEvent.click(refundableRowButton)
+
+		expect(formUpdates).toContainEqual({
+			claimBidIndex: '1',
+			claimBidTick: '9',
+			settlementAddress: zeroAddress,
+		})
+	})
+
+	test('hides selected price-level settlement shortcuts for bids owned by other wallets', async () => {
+		const truthAuctionReadClient = createTruthAuctionReadClient(async request => {
+			if (request.functionName === 'activeTickCount') return 1n
+			if (request.functionName === 'getActiveTickPage') return [createTruthAuctionTickSummary({ tick: 10n, price: 2n * ETH, currentTotalEth: 5n * ETH, submissionCount: 2n, active: true })]
+			if (request.functionName === 'getTickSummary') return createTruthAuctionTickSummary({ tick: 10n, price: 2n * ETH, currentTotalEth: 5n * ETH, submissionCount: 2n, active: true })
+			if (request.functionName === 'getBidCountAtTick') return 2n
+			if (request.functionName === 'getBidPageAtTick') {
+				return [createTruthAuctionBidView({ tick: 10n, bidIndex: 0n, ethAmount: 2n * ETH, cumulativeEth: 2n * ETH }), createTruthAuctionBidView({ tick: 10n, bidIndex: 1n, bidder: '0x0000000000000000000000000000000000000001', ethAmount: 3n * ETH, cumulativeEth: 5n * ETH, activeCumulativeEthBeforeBid: 2n * ETH })]
+			}
+			if (request.functionName === 'getBidderBidCount') return 1n
+			if (request.functionName === 'getBidderBidPage') return [createTruthAuctionBidView({ tick: 10n, bidIndex: 0n, ethAmount: 2n * ETH, cumulativeEth: 2n * ETH })]
+			throw new Error(`Unexpected truth auction read: ${String(request.functionName)}`)
+		})
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					accountState: createAccountState({ ethBalance: 10n * ETH }),
+					forkAuctionDetails: {
+						...createForkAuctionDetails(),
+						claimingAvailable: true,
+						systemState: 'operational',
+						truthAuction: {
+							...createTruthAuctionMetrics(),
+							clearingPrice: 2n * ETH,
+							clearingTick: 10n,
+							ethAtClearingTick: 5n * ETH,
+							finalized: true,
+							hitCap: true,
+						},
+						truthAuctionAddress: '0x0000000000000000000000000000000000000001',
+						truthAuctionStartedAt: 1n,
+					},
+					truthAuctionReadClient,
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		await waitFor(() => {
+			expect(documentQueries.getByRole('button', { name: 'Select tick 10 from depth chart' })).not.toBeNull()
+		})
+		await act(() => {
+			fireEvent.click(documentQueries.getByRole('button', { name: 'Select tick 10 from depth chart' }))
+		})
+
+		await waitFor(() => {
+			expect(document.body.textContent?.includes('Tick 10 at')).toBe(true)
+		})
+
+		await waitFor(() => {
+			expect(document.body.textContent?.includes('Bid #1')).toBe(true)
+		})
+
+		const selectedLevel = document.body.querySelector('.truth-auction-level-detail')
+		if (!(selectedLevel instanceof HTMLElement)) throw new Error('Expected selected price-level detail to render')
+
+		const bidRows = Array.from(selectedLevel.querySelectorAll('.truth-auction-bid-row')).slice(1)
+		const viewerRow = bidRows.find(row => row.textContent?.includes('Bid #0') === true)
+		const otherWalletRow = bidRows.find(row => row.textContent?.includes('Bid #1') === true)
+		if (!(viewerRow instanceof HTMLElement)) throw new Error('Expected selected price-level viewer row to render')
+		if (!(otherWalletRow instanceof HTMLElement)) throw new Error('Expected selected price-level non-viewer row to render')
+
+		expect(within(viewerRow).getAllByRole('button', { name: 'Prefill Settle' }).length).toBe(1)
+		expect(within(otherWalletRow).queryByRole('button', { name: 'Prefill Settle' })).toBeNull()
 	})
 
 	test('summarizes wallet bids from semantic bid outcomes instead of presentation labels', async () => {
@@ -1134,15 +1350,63 @@ describe('ForkAuctionSection', () => {
 			expect(document.body.querySelector('.truth-auction-wallet-summary')).not.toBeNull()
 		})
 
+		await waitFor(() => {
+			expect(document.body.querySelector('.truth-auction-wallet-summary')).not.toBeNull()
+		})
 		const walletSummary = document.body.querySelector('.truth-auction-wallet-summary')
 		if (!(walletSummary instanceof HTMLElement)) throw new Error('Expected wallet summary to render')
 
 		await waitFor(() => {
 			expect(getMetricValue(walletSummary, 'Winning')).toBe('1')
 			expect(getMetricValue(walletSummary, 'Partial')).toBe('1')
-			expect(getMetricValue(walletSummary, 'Losing')).toBe('1')
-			expect(getMetricValue(walletSummary, 'Claimable')).toBe('2')
+			expect(getMetricValue(walletSummary, 'Refundable')).toBe('1')
+			expect(getMetricValue(walletSummary, 'REP Claimable')).toBe('2')
 			expect(getMetricValue(walletSummary, 'Refunded')).toBe('1')
+		})
+	})
+
+	test('counts live below-clearing bids separately before finalization in the wallet summary', async () => {
+		const truthAuctionReadClient = createTruthAuctionReadClient(async request => {
+			if (request.functionName === 'activeTickCount') return 1n
+			if (request.functionName === 'getActiveTickPage') return [createTruthAuctionTickSummary({ tick: 10n, price: 2n * ETH, currentTotalEth: 5n * ETH, submissionCount: 2n, active: true })]
+			if (request.functionName === 'getTickSummary') return createTruthAuctionTickSummary({ tick: 10n, price: 2n * ETH, currentTotalEth: 5n * ETH, submissionCount: 2n, active: true })
+			if (request.functionName === 'getBidCountAtTick') return 0n
+			if (request.functionName === 'getBidPageAtTick') return []
+			if (request.functionName === 'getBidderBidCount') return 1n
+			if (request.functionName === 'getBidderBidPage') return [createTruthAuctionBidView({ tick: 9n, bidIndex: 0n, ethAmount: 1n * ETH, cumulativeEth: 1n * ETH })]
+			throw new Error(`Unexpected truth auction read: ${String(request.functionName)}`)
+		})
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					accountState: createAccountState({ ethBalance: 10n * ETH }),
+					forkAuctionDetails: {
+						...createForkAuctionDetails(),
+						systemState: 'forkTruthAuction',
+						truthAuction: {
+							...createTruthAuctionMetrics(),
+							clearingPrice: 2n * ETH,
+							clearingTick: 10n,
+							ethAtClearingTick: 5n * ETH,
+							finalized: false,
+							hitCap: true,
+						},
+						truthAuctionAddress: '0x0000000000000000000000000000000000000001',
+						truthAuctionStartedAt: 1n,
+					},
+					truthAuctionReadClient,
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const walletSummary = document.body.querySelector('.truth-auction-wallet-summary')
+		if (!(walletSummary instanceof HTMLElement)) throw new Error('Expected wallet summary to render')
+
+		await waitFor(() => {
+			expect(getMetricValue(walletSummary, 'Below Clearing')).toBe('1')
+			expect(getMetricValue(walletSummary, 'REP Claimable')).toBe('0')
 		})
 	})
 
@@ -1203,7 +1467,7 @@ describe('ForkAuctionSection', () => {
 		expect(document.body.querySelector('.truth-auction-depth-marker.is-preview')).not.toBeNull()
 	})
 
-	test('keeps settlement focused on wallet actions before the market view and leaves operator tools collapsed by default', async () => {
+	test('keeps pre-finalization settlement focused on wallet actions before the market view and leaves operator tools collapsed by default', async () => {
 		const truthAuctionReadClient = createTruthAuctionReadClient(async request => {
 			if (request.functionName === 'activeTickCount') return 1n
 			if (request.functionName === 'getActiveTickPage') return [createTruthAuctionTickSummary({ tick: 12n, price: 3n * ETH, currentTotalEth: 4n * ETH, submissionCount: 1n, active: true })]
@@ -1241,17 +1505,70 @@ describe('ForkAuctionSection', () => {
 
 		const documentQueries = within(document.body)
 		await waitFor(() => {
-			expect(documentQueries.getByRole('heading', { name: 'Settle Selected Bid' })).not.toBeNull()
+			expect(documentQueries.getByRole('heading', { name: 'Refund Losing Bid' })).not.toBeNull()
 		})
 
 		const myBidsHeading = documentQueries.getByRole('heading', { name: 'My Bids' })
-		const settleHeading = documentQueries.getByRole('heading', { name: 'Settle Selected Bid' })
+		const refundHeading = documentQueries.getByRole('heading', { name: 'Refund Losing Bid' })
+		const marketViewHeading = documentQueries.getByRole('heading', { name: 'Market View' })
+
+		expectElementBefore(myBidsHeading, refundHeading)
+		expectElementBefore(refundHeading, marketViewHeading)
+		expect(documentQueries.queryByRole('heading', { name: 'Settle Finalized Bid' })).toBeNull()
+		expect(documentQueries.getByText('Operator Tools')).not.toBeNull()
+		expect(documentQueries.getByText('Operator Tools').closest('details')?.open).toBe(false)
+	})
+
+	test('keeps finalized settlement focused on wallet actions before the market view', async () => {
+		const truthAuctionReadClient = createTruthAuctionReadClient(async request => {
+			if (request.functionName === 'activeTickCount') return 1n
+			if (request.functionName === 'getActiveTickPage') return [createTruthAuctionTickSummary({ tick: 12n, price: 3n * ETH, currentTotalEth: 4n * ETH, submissionCount: 1n, active: true })]
+			if (request.functionName === 'getTickSummary') return createTruthAuctionTickSummary({ tick: 12n, price: 3n * ETH, currentTotalEth: 4n * ETH, submissionCount: 1n, active: true })
+			if (request.functionName === 'getBidCountAtTick') return 1n
+			if (request.functionName === 'getBidPageAtTick') return [createTruthAuctionBidView({ tick: 12n, bidIndex: 0n, ethAmount: 4n * ETH, cumulativeEth: 4n * ETH })]
+			if (request.functionName === 'getBidderBidCount') return 1n
+			if (request.functionName === 'getBidderBidPage') return [createTruthAuctionBidView({ tick: 12n, bidIndex: 0n, ethAmount: 4n * ETH, cumulativeEth: 4n * ETH })]
+			throw new Error(`Unexpected truth auction read: ${String(request.functionName)}`)
+		})
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					accountState: createAccountState({ ethBalance: 10n * ETH }),
+					forkAuctionDetails: {
+						...createForkAuctionDetails(),
+						claimingAvailable: true,
+						systemState: 'operational',
+						truthAuction: {
+							...createTruthAuctionMetrics(),
+							finalized: true,
+							timeRemaining: 0n,
+						},
+						truthAuctionAddress: '0x0000000000000000000000000000000000000001',
+						truthAuctionStartedAt: 1n,
+					},
+					truthAuctionReadClient,
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await act(() => {
+			fireEvent.click(within(document.body).getByRole('tab', { name: 'Settlement' }))
+		})
+
+		const documentQueries = within(document.body)
+		await waitFor(() => {
+			expect(documentQueries.getByRole('heading', { name: 'Settle Finalized Bid' })).not.toBeNull()
+		})
+
+		const myBidsHeading = documentQueries.getByRole('heading', { name: 'My Bids' })
+		const settleHeading = documentQueries.getByRole('heading', { name: 'Settle Finalized Bid' })
 		const marketViewHeading = documentQueries.getByRole('heading', { name: 'Market View' })
 
 		expectElementBefore(myBidsHeading, settleHeading)
 		expectElementBefore(settleHeading, marketViewHeading)
-		expect(documentQueries.getByText('Operator Tools')).not.toBeNull()
-		expect(documentQueries.getByText('Operator Tools').closest('details')?.open).toBe(false)
+		expect(documentQueries.queryByRole('heading', { name: 'Refund Losing Bid' })).toBeNull()
 	})
 
 	test('expands visible depth coverage after loading more price levels', async () => {

--- a/ui/ts/tests/forkAuctionSection.test.tsx
+++ b/ui/ts/tests/forkAuctionSection.test.tsx
@@ -437,7 +437,6 @@ describe('ForkAuctionSection', () => {
 
 		expect(getMetricValue(poolContextMetrics, 'Fork Type')).toBe('Not chosen yet')
 		expect(getMetricValue(poolContextMetrics, 'Fork Outcome')).toBe('Not chosen yet')
-		expect(document.body.textContent?.includes('If this pool is triggering a Zoltar fork from its own escalation game, use Trigger Zoltar Fork from Reporting first. Otherwise activate fork mode here, then move to Migration and run Migrate Escalation Deposits.')).toBe(true)
 		expect(documentQueries.queryByText('Parent/Zoltar fork')).toBeNull()
 	})
 

--- a/ui/ts/tests/liquidationModal.test.tsx
+++ b/ui/ts/tests/liquidationModal.test.tsx
@@ -8,6 +8,7 @@ import { act } from 'preact/test-utils'
 import { getAddress, zeroAddress } from 'viem'
 import { LiquidationModal } from '../components/LiquidationModal.js'
 import { ChainTimestampContext } from '../lib/chainTimestamp.js'
+import { deriveHasForkActivity } from '../lib/forkAuction.js'
 import { evaluateSecurityPoolState } from '../lib/securityPoolState.js'
 import type { ListedSecurityPool, MarketDetails, OracleManagerDetails, SecurityPoolOverviewActionResult, SecurityPoolVaultSummary } from '../types/contracts.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
@@ -67,9 +68,10 @@ function createTargetVaultSummary(overrides: Partial<SecurityPoolVaultSummary> =
 }
 
 function createSelectedPool(overrides: Partial<ListedSecurityPool> = {}): ListedSecurityPool {
-	return {
+	const selectedPool: ListedSecurityPool = {
 		completeSetCollateralAmount: 0n,
 		currentRetentionRate: 10n,
+		hasForkActivity: false,
 		forkOutcome: 'none',
 		forkOwnSecurityPool: false,
 		lastOraclePrice: 3n * 10n ** 18n,
@@ -92,6 +94,10 @@ function createSelectedPool(overrides: Partial<ListedSecurityPool> = {}): Listed
 		vaultCount: 1n,
 		vaults: [createTargetVaultSummary()],
 		...overrides,
+	}
+	return {
+		...selectedPool,
+		hasForkActivity: overrides.hasForkActivity ?? deriveHasForkActivity(selectedPool),
 	}
 }
 

--- a/ui/ts/tests/overviewPanels.test.tsx
+++ b/ui/ts/tests/overviewPanels.test.tsx
@@ -44,6 +44,8 @@ describe('OverviewPanels', () => {
 			repUsdcPrice: undefined,
 			repUsdcSource: undefined,
 			repUsdcSourceUrl: undefined,
+			universeForkTime: undefined,
+			universeHasForked: false,
 			universeLabel: 'Genesis universe',
 			universePresentation: undefined,
 			universeRepBalance: undefined,
@@ -171,6 +173,16 @@ describe('OverviewPanels', () => {
 		fireEvent.click(refreshButton)
 
 		expect(onRefreshRepPrices).toHaveBeenCalledTimes(1)
+	})
+
+	test('surfaces a forked Zoltar status in the operations header', async () => {
+		const documentQueries = await renderOverviewPanels({
+			universeForkTime: 123n,
+			universeHasForked: true,
+		})
+
+		expect(documentQueries.getByText('Forked')).toBeDefined()
+		expect(document.body.textContent?.includes('Zoltar forked on')).toBe(true)
 	})
 
 	test('compacts a large ETH balance without affecting the adjacent WETH metric', async () => {

--- a/ui/ts/tests/reportingDomain.test.ts
+++ b/ui/ts/tests/reportingDomain.test.ts
@@ -272,7 +272,7 @@ describe('reportingDomain', () => {
 		})
 	})
 
-	test('getMinimumOutcomeChangeContribution is unavailable when the selected side cannot lead within remaining room', () => {
+	test('getMinimumOutcomeChangeContribution falls back to the remaining threshold room when the selected side cannot take the lead', () => {
 		const details = createReportingDetails({
 			nonDecisionThreshold: rep(20n),
 			sides: [
@@ -284,8 +284,8 @@ describe('reportingDomain', () => {
 		})
 
 		expect(getMinimumOutcomeChangeContribution(details, 'no')).toEqual({
-			amount: undefined,
-			reason: 'Min preset unavailable because the selected side cannot take the lead within the remaining bond capacity.',
+			amount: rep(1n),
+			reason: undefined,
 		})
 	})
 

--- a/ui/ts/tests/reportingGuards.test.ts
+++ b/ui/ts/tests/reportingGuards.test.ts
@@ -12,12 +12,13 @@ describe('reporting guards', () => {
 				accountAddress: undefined,
 				contributionPreviewReason: undefined,
 				isMainnet: true,
+				remainingSelectedOutcomeCapacity: undefined,
 				reportAmount: '1',
 				reportingStatus: 'active',
 				selectedAmount: 1n,
+				selectedOutcome: 'yes',
 				viewerVaultAvailableEscalationRep: 10n,
 				viewerVaultExists: true,
-				selectedOutcome: 'yes',
 			}),
 		).toBe('Connect a wallet before reporting on a market.')
 
@@ -27,6 +28,7 @@ describe('reporting guards', () => {
 				accountAddress: zeroAddress,
 				contributionPreviewReason: undefined,
 				isMainnet: true,
+				remainingSelectedOutcomeCapacity: undefined,
 				reportAmount: '1',
 				reportingStatus: 'active',
 				selectedAmount: 1n,
@@ -42,12 +44,13 @@ describe('reporting guards', () => {
 				accountAddress: zeroAddress,
 				contributionPreviewReason: undefined,
 				isMainnet: true,
+				remainingSelectedOutcomeCapacity: undefined,
 				reportAmount: '0',
 				reportingStatus: 'active',
 				selectedAmount: 0n,
+				selectedOutcome: 'yes',
 				viewerVaultAvailableEscalationRep: 10n,
 				viewerVaultExists: true,
-				selectedOutcome: 'yes',
 			}),
 		).toBe('Enter a valid report amount greater than zero.')
 	})
@@ -59,6 +62,7 @@ describe('reporting guards', () => {
 				accountAddress: zeroAddress,
 				contributionPreviewReason: undefined,
 				isMainnet: true,
+				remainingSelectedOutcomeCapacity: undefined,
 				reportAmount: '1',
 				reportingStatus: 'missing',
 				selectedAmount: 1n,
@@ -74,6 +78,7 @@ describe('reporting guards', () => {
 				accountAddress: zeroAddress,
 				contributionPreviewReason: undefined,
 				isMainnet: true,
+				remainingSelectedOutcomeCapacity: undefined,
 				reportAmount: '1',
 				reportingStatus: 'not-started',
 				selectedAmount: 1n,
@@ -89,6 +94,7 @@ describe('reporting guards', () => {
 				accountAddress: zeroAddress,
 				contributionPreviewReason: undefined,
 				isMainnet: true,
+				remainingSelectedOutcomeCapacity: undefined,
 				reportAmount: '1',
 				reportingStatus: 'active',
 				selectedAmount: 1n,
@@ -106,6 +112,7 @@ describe('reporting guards', () => {
 				accountAddress: zeroAddress,
 				contributionPreviewReason: undefined,
 				isMainnet: true,
+				remainingSelectedOutcomeCapacity: undefined,
 				reportAmount: '1',
 				reportingStatus: 'active',
 				selectedAmount: 1n,
@@ -123,6 +130,7 @@ describe('reporting guards', () => {
 				accountAddress: zeroAddress,
 				contributionPreviewReason: undefined,
 				isMainnet: true,
+				remainingSelectedOutcomeCapacity: undefined,
 				reportAmount: '1',
 				reportingStatus: 'active',
 				selectedAmount: 1n,
@@ -140,6 +148,7 @@ describe('reporting guards', () => {
 				accountAddress: zeroAddress,
 				contributionPreviewReason: undefined,
 				isMainnet: true,
+				remainingSelectedOutcomeCapacity: undefined,
 				reportAmount: '5',
 				reportingStatus: 'active',
 				selectedAmount: 5n * 10n ** 18n,
@@ -155,6 +164,7 @@ describe('reporting guards', () => {
 				accountAddress: zeroAddress,
 				contributionPreviewReason: 'Increase the report amount slightly to avoid a tie at the minimum bond.',
 				isMainnet: true,
+				remainingSelectedOutcomeCapacity: undefined,
 				reportAmount: '1',
 				reportingStatus: 'active',
 				selectedAmount: 1n * 10n ** 18n,
@@ -170,6 +180,7 @@ describe('reporting guards', () => {
 				accountAddress: zeroAddress,
 				contributionPreviewReason: undefined,
 				isMainnet: true,
+				remainingSelectedOutcomeCapacity: undefined,
 				reportAmount: '1',
 				reportingStatus: 'active',
 				selectedAmount: 1n,
@@ -178,6 +189,40 @@ describe('reporting guards', () => {
 				viewerVaultExists: false,
 			}),
 		).toBe('Reporting locks REP already deposited in your security vault. Deposit REP into your vault before reporting.')
+	})
+
+	test('blocks reporting when the contribution would exceed the remaining selected-side threshold capacity', () => {
+		expect(
+			getReportingReportGuardMessage({
+				actualDepositAmount: 5n * 10n ** 18n,
+				accountAddress: zeroAddress,
+				contributionPreviewReason: undefined,
+				isMainnet: true,
+				remainingSelectedOutcomeCapacity: 2n * 10n ** 18n,
+				reportAmount: '5',
+				reportingStatus: 'active',
+				selectedAmount: 5n * 10n ** 18n,
+				selectedOutcome: 'yes',
+				viewerVaultAvailableEscalationRep: 10n * 10n ** 18n,
+				viewerVaultExists: true,
+			}),
+		).toBe('Only 2 REP remains before the selected side reaches the threshold.')
+
+		expect(
+			getReportingReportGuardMessage({
+				actualDepositAmount: 1n,
+				accountAddress: zeroAddress,
+				contributionPreviewReason: undefined,
+				isMainnet: true,
+				remainingSelectedOutcomeCapacity: 0n,
+				reportAmount: '1',
+				reportingStatus: 'active',
+				selectedAmount: 1n,
+				selectedOutcome: 'yes',
+				viewerVaultAvailableEscalationRep: 10n,
+				viewerVaultExists: true,
+			}),
+		).toBe('No remaining contribution capacity is available on the selected side.')
 	})
 
 	test('blocks withdraw submission when wallet or reporting prerequisites are missing', () => {

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -461,7 +461,7 @@ describe('ReportingSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const reportOutcomeSection = getReportOutcomeSection()
-		const amountInput = within(reportOutcomeSection).getByRole('textbox', { name: 'Report / Contribution Amount (REP)' })
+		const amountInput = within(reportOutcomeSection).getByRole('textbox', { name: /^Contribution Amount \(REP\)/ })
 		const firstSide = reportOutcomeSection.querySelector('.escalation-side')
 		if (!(firstSide instanceof HTMLElement)) throw new Error('Expected escalation side to render')
 		expect(reportOutcomeSection.querySelectorAll('.escalation-side')).toHaveLength(3)
@@ -488,7 +488,7 @@ describe('ReportingSection', () => {
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		expectTransactionButtonDisabled(document.body, 'Report / Contribute No', 'Connect a wallet before reporting on a market.')
+		expectTransactionButtonDisabled(document.body, 'Report No', 'Connect a wallet before reporting on a market.')
 		expect(document.body.querySelector('button[title="Connect a wallet before withdrawing escalation deposits."]')).toBeNull()
 	})
 
@@ -531,7 +531,7 @@ describe('ReportingSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 		expect(document.body.textContent?.includes('It does not spend wallet REP directly or require a wallet approval.')).toBe(false)
 		expect(document.body.textContent?.includes('Available unlocked vault REP for reporting:')).toBe(true)
-		expectTransactionButtonDisabled(document.body, 'Report / Contribute Yes', 'Need 3 more unlocked REP in your vault before reporting.')
+		expectTransactionButtonDisabled(document.body, 'Report Yes', 'Need 3 more unlocked REP in your vault before reporting.')
 	})
 
 	test('renders a compact withdraw-only mode without the reporting banner or report form', async () => {
@@ -722,10 +722,11 @@ describe('ReportingSection', () => {
 
 		const documentQueries = within(document.body)
 		expect((documentQueries.getByRole('button', { name: /^Yes/ }) as HTMLButtonElement).disabled).toBe(true)
-		expect((documentQueries.getByRole('textbox', { name: 'Report / Contribution Amount (REP)' }) as HTMLInputElement).disabled).toBe(true)
+		expect((documentQueries.getByRole('textbox', { name: /^Contribution Amount \(REP\)/ }) as HTMLInputElement).disabled).toBe(true)
+		expect((documentQueries.getByRole('button', { name: 'Max' }) as HTMLButtonElement).disabled).toBe(true)
 		expect((documentQueries.getByRole('button', { name: 'Min to change proposed outcome' }) as HTMLButtonElement).disabled).toBe(true)
 		expect((documentQueries.getByRole('button', { name: 'Max profit' }) as HTMLButtonElement).disabled).toBe(true)
-		expectTransactionButtonDisabled(document.body, 'Report / Contribute Yes')
+		expectTransactionButtonDisabled(document.body, 'Report Yes')
 	})
 
 	test('shows Fork Triggered instead of timeout when non-decision is reached first', async () => {
@@ -739,6 +740,9 @@ describe('ReportingSection', () => {
 						escalationEndTime: 300n,
 						hasReachedNonDecision: true,
 					}),
+					reportingForm: createReportingForm({
+						selectedOutcome: 'yes',
+					}),
 				}),
 			),
 		)
@@ -746,7 +750,8 @@ describe('ReportingSection', () => {
 
 		const documentQueries = within(document.body)
 		expect(documentQueries.getByRole('heading', { name: 'Fork Triggered' })).not.toBeNull()
-		expect(document.body.textContent?.includes('Escalation reached non-decision. Continue in the Fork workflow; this panel does not have a final-resolution action.')).toBe(true)
+		expect(document.body.textContent?.includes('Escalation reached non-decision. Trigger Zoltar Fork here if this pool should fork the universe, or open the Fork workflow if Zoltar is already forked.')).toBe(true)
+		expectTransactionButtonDisabled(document.body, 'Report Yes', 'Escalation reached non-decision. Trigger Zoltar Fork here if this pool should fork the universe, or open the Fork workflow if Zoltar is already forked.')
 	})
 
 	test('auto-refreshes reporting once when the live timestamp reaches an unresolved timeout boundary', async () => {
@@ -846,7 +851,7 @@ describe('ReportingSection', () => {
 		expect(metricsSection.querySelector('[title="3 REP"]')).not.toBeNull()
 		expect(reportOutcomeSection.querySelectorAll('.currency-value.unavailable')).toHaveLength(0)
 		expect(document.body.textContent?.includes('Load reporting details to populate live stakes')).toBe(false)
-		expectTransactionButtonEnabled(document.body, 'Report / Contribute Yes')
+		expectTransactionButtonEnabled(document.body, 'Report Yes')
 		expect(document.body.textContent?.includes('If no one disputes after this report, the market would finalize in 3d 0h 0m.')).toBe(true)
 		expect(document.body.textContent?.includes(`Check back no later than ${formatTimestamp(150n + ESCALATION_GAME_ACTIVATION_DELAY)} (in 3d 0h 0m) to confirm Yes is the leading outcome before finalization.`)).toBe(true)
 	})
@@ -889,7 +894,7 @@ describe('ReportingSection', () => {
 
 		expect(document.body.textContent?.includes('Reporting is open. Select an outcome side below to enable reporting.')).toBe(true)
 		expect(document.body.textContent?.includes('Select an outcome side above to enable reporting.')).toBe(true)
-		expectTransactionButtonDisabled(document.body, 'Report / Contribute On Selected Side', 'Select an outcome side before reporting on a market.')
+		expectTransactionButtonDisabled(document.body, 'Report On Selected Side', 'Select an outcome side before reporting on a market.')
 	})
 
 	test('disables report submission for a pre-start amount below the first-report minimum', async () => {
@@ -907,7 +912,7 @@ describe('ReportingSection', () => {
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		expectTransactionButtonDisabled(document.body, 'Report / Contribute Yes', 'Enter at least 3 REP to start the escalation game.')
+		expectTransactionButtonDisabled(document.body, 'Report Yes', 'Enter at least 3 REP to start the escalation game.')
 	})
 
 	test('accepts decimal report amounts for the profit preview', async () => {
@@ -944,7 +949,7 @@ describe('ReportingSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		const reportButton = documentQueries.getByRole('button', { name: 'Report / Contribute No' })
+		const reportButton = documentQueries.getByRole('button', { name: 'Report No' })
 		const preview = findProjectionPreviewElement()
 		if (preview === undefined) throw new Error('Expected projection preview to render')
 		const expectedCheckBackTimestamp = getSelectedOutcomeRewardWindowFillTimestamp(createDynamicReportingDetails(), 'no', rep(2n))
@@ -1041,7 +1046,7 @@ describe('ReportingSection', () => {
 			fireEvent.click(within(document.body).getByRole('button', { name: 'Min to change proposed outcome' }))
 		})
 
-		const amountInput = within(document.body).getByRole('textbox', { name: 'Report / Contribution Amount (REP)' })
+		const amountInput = within(document.body).getByRole('textbox', { name: /^Contribution Amount \(REP\)/ })
 		expect((amountInput as HTMLInputElement).value).toBe('4')
 	})
 
@@ -1055,10 +1060,95 @@ describe('ReportingSection', () => {
 			fireEvent.click(within(document.body).getByRole('button', { name: 'Max profit' }))
 		})
 
-		const amountInput = within(document.body).getByRole('textbox', { name: 'Report / Contribution Amount (REP)' })
+		const amountInput = within(document.body).getByRole('textbox', { name: /^Contribution Amount \(REP\)/ })
 		const previewAfter = findProjectionPreviewText()
 		expect((amountInput as HTMLInputElement).value).toBe('7')
 		expect(previewBefore).not.toBe(previewAfter)
+	})
+
+	test('autofills the max contribution with the smaller of outcome capacity and available vault REP', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<ReportingSectionHarness
+				initialProps={{
+					reportingDetails: createReportingDetails({
+						nonDecisionThreshold: rep(20n),
+						sides: [
+							{ balance: 0n, deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+							{ balance: rep(19n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+							{ balance: rep(4n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
+						],
+						startBond: rep(1n),
+						viewerVaultAvailableEscalationRep: rep(10n),
+					}),
+					reportingForm: createReportingForm({
+						selectedOutcome: 'yes',
+					}),
+				}}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await act(() => {
+			fireEvent.click(within(document.body).getByRole('button', { name: 'Max' }))
+		})
+
+		const amountInput = within(document.body).getByRole('textbox', { name: /^Contribution Amount \(REP\)/ })
+		expect((amountInput as HTMLInputElement).value).toBe('1')
+	})
+
+	test('autofills the max contribution with the remaining selected-side threshold capacity when that is smaller', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<ReportingSectionHarness
+				initialProps={{
+					reportingDetails: createReportingDetails({
+						sides: [
+							{ balance: 0n, deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+							{ balance: rep(18n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+							{ balance: rep(4n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
+						],
+						nonDecisionThreshold: rep(20n),
+						startBond: rep(1n),
+						viewerVaultAvailableEscalationRep: rep(10n),
+					}),
+					reportingForm: createReportingForm({
+						selectedOutcome: 'yes',
+					}),
+				}}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await act(() => {
+			fireEvent.click(within(document.body).getByRole('button', { name: 'Max' }))
+		})
+
+		const amountInput = within(document.body).getByRole('textbox', { name: /^Contribution Amount \(REP\)/ })
+		expect((amountInput as HTMLInputElement).value).toBe('2')
+	})
+
+	test('autofills the pre-start max contribution with the threshold when it is smaller than available vault REP', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<ReportingSectionHarness
+				initialProps={{
+					reportingDetails: createNotStartedReportingDetails({
+						nonDecisionThreshold: rep(6n),
+						viewerVaultAvailableEscalationRep: rep(10n),
+						viewerVaultRepDepositShare: rep(10n),
+					}),
+					reportingForm: createReportingForm({
+						selectedOutcome: 'yes',
+					}),
+				}}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await act(() => {
+			fireEvent.click(within(document.body).getByRole('button', { name: 'Max' }))
+		})
+
+		const amountInput = within(document.body).getByRole('textbox', { name: /^Contribution Amount \(REP\)/ })
+		expect((amountInput as HTMLInputElement).value).toBe('6')
 	})
 
 	test('autofills the pre-start minimum-outcome-change preset from the pool start bond', async () => {
@@ -1069,7 +1159,7 @@ describe('ReportingSection', () => {
 			fireEvent.click(within(document.body).getByRole('button', { name: 'Min to change proposed outcome' }))
 		})
 
-		const amountInput = within(document.body).getByRole('textbox', { name: 'Report / Contribution Amount (REP)' })
+		const amountInput = within(document.body).getByRole('textbox', { name: /^Contribution Amount \(REP\)/ })
 		expect((amountInput as HTMLInputElement).value).toBe('3')
 	})
 
@@ -1091,6 +1181,158 @@ describe('ReportingSection', () => {
 		expect(maxProfitButton.disabled).toBe(true)
 		expect(maxProfitButton.title).toBe('Max profit becomes available after the escalation game starts.')
 		expect(document.body.textContent?.includes('Max profit becomes available after the escalation game starts.')).toBe(false)
+	})
+
+	test('disables pre-start report submission when the contribution would exceed the remaining selected-side threshold capacity', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					reportingDetails: createNotStartedReportingDetails({
+						nonDecisionThreshold: rep(20n),
+						startBond: rep(1n),
+						viewerVaultAvailableEscalationRep: rep(10n),
+					}),
+					reportingForm: createReportingForm({
+						reportAmount: '25',
+						selectedOutcome: 'yes',
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expectTransactionButtonDisabled(document.body, 'Report Yes', 'Only 20 REP remains before the selected side reaches the threshold.')
+	})
+
+	test('allows active report submission when the entered amount is clamped to the remaining selected-side capacity', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					reportingDetails: createReportingDetails({
+						sides: [
+							{ balance: 0n, deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+							{ balance: rep(18n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+							{ balance: rep(4n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
+						],
+						nonDecisionThreshold: rep(20n),
+						startBond: rep(1n),
+						viewerVaultAvailableEscalationRep: rep(10n),
+					}),
+					reportingForm: createReportingForm({
+						reportAmount: '5',
+						selectedOutcome: 'yes',
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expectTransactionButtonEnabled(document.body, 'Report Yes')
+	})
+
+	test('explains why escalation withdrawals stay disabled after fork is triggered', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					mode: 'withdraw-only',
+					reportingDetails: createReportingDetails({
+						hasReachedNonDecision: true,
+						sides: [
+							{ balance: rep(1n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+							{ balance: rep(5n), deposits: [], key: 'yes', label: 'Yes', userDeposits: [createDeposit()] },
+							{ balance: rep(8n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
+						],
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(document.body.textContent?.includes('Escalation deposits remain locked after non-decision. Trigger Zoltar Fork here if this pool should fork the universe, or continue in the Fork workflow once Zoltar is already forked.')).toBe(true)
+		expectTransactionButtonDisabled(document.body, 'Withdraw All Yes Deposits', 'Escalation deposits remain locked after non-decision. Trigger Zoltar Fork here if this pool should fork the universe, or continue in the Fork workflow once Zoltar is already forked.')
+	})
+
+	test('shows an Open Fork Workflow action when non-decision blocks escalation deposits', async () => {
+		let openedForkWorkflow = 0
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					mode: 'withdraw-only',
+					onOpenForkWorkflow: () => {
+						openedForkWorkflow += 1
+					},
+					reportingDetails: createReportingDetails({
+						hasReachedNonDecision: true,
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		await act(() => {
+			fireEvent.click(documentQueries.getByRole('button', { name: 'Open Fork Workflow' }))
+		})
+
+		expect(openedForkWorkflow).toBe(1)
+	})
+
+	test('keeps only Open Fork Workflow visible after a fork-triggered pool has already entered its fork workflow', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					forkAlreadyTriggered: true,
+					mode: 'withdraw-only',
+					onOpenForkWorkflow: () => undefined,
+					onTriggerZoltarFork: () => undefined,
+					reportingDetails: createReportingDetails({
+						hasReachedNonDecision: true,
+					}),
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.queryByRole('button', { name: 'Trigger Zoltar Fork' })).toBeNull()
+		expect(documentQueries.getByRole('button', { name: 'Open Fork Workflow' })).not.toBeNull()
+		expect(document.body.textContent?.includes('Escalation deposits remain locked after non-decision. Zoltar fork has already been triggered for this pool, so continue in the Fork workflow.')).toBe(true)
+	})
+
+	test('shows a Trigger Zoltar Fork action when non-decision blocks reporting', async () => {
+		let triggerZoltarForkCalls = 0
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ReportingSection,
+				createProps({
+					onTriggerZoltarFork: () => {
+						triggerZoltarForkCalls += 1
+					},
+					reportingDetails: createReportingDetails({
+						hasReachedNonDecision: true,
+					}),
+					triggerZoltarForkAvailability: {
+						disabled: false,
+						reason: undefined,
+					},
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expectTransactionButtonEnabled(document.body, 'Trigger Zoltar Fork')
+
+		await act(() => {
+			fireEvent.click(documentQueries.getByRole('button', { name: 'Trigger Zoltar Fork' }))
+		})
+
+		expect(triggerZoltarForkCalls).toBe(1)
 	})
 
 	test('disables preset buttons when reporting details are missing without showing the load reason inline', async () => {
@@ -1135,7 +1377,12 @@ describe('ReportingSection', () => {
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		expect(document.body.textContent?.includes('Min preset unavailable because the selected side cannot take the lead within the remaining bond capacity.')).toBe(true)
+		const documentQueries = within(document.body)
+		const amountInput = documentQueries.getByLabelText('Contribution Amount (REP)') as HTMLInputElement
+		await act(() => {
+			fireEvent.click(documentQueries.getByRole('button', { name: 'Min to change proposed outcome' }))
+		})
+		expect(amountInput.value).toBe('1')
 	})
 
 	test('removes side-level deposit and projection detail lines from the shared outcome chart', async () => {
@@ -1312,7 +1559,7 @@ describe('ReportingSection', () => {
 			fireEvent.click(within(document.body).getByRole('button', { name: 'Min to change proposed outcome' }))
 		})
 
-		const amountInput = within(document.body).getByRole('textbox', { name: 'Report / Contribution Amount (REP)' })
+		const amountInput = within(document.body).getByRole('textbox', { name: /^Contribution Amount \(REP\)/ })
 		expect((amountInput as HTMLInputElement).value).toBe('1001')
 	})
 
@@ -1342,7 +1589,7 @@ describe('ReportingSection', () => {
 			fireEvent.click(within(document.body).getByRole('button', { name: 'Max profit' }))
 		})
 
-		const amountInput = within(document.body).getByRole('textbox', { name: 'Report / Contribution Amount (REP)' })
+		const amountInput = within(document.body).getByRole('textbox', { name: /^Contribution Amount \(REP\)/ })
 		expect((amountInput as HTMLInputElement).value).toBe('1500')
 		expect(document.body.textContent?.includes('projects roughly')).toBe(true)
 	})
@@ -1418,7 +1665,7 @@ describe('ReportingSection', () => {
 
 		expect(yesButton.getAttribute('aria-pressed')).toBe('false')
 		expect(noButton.getAttribute('aria-pressed')).toBe('false')
-		expect(documentQueries.getByRole('button', { name: 'Report / Contribute On Selected Side' })).not.toBeNull()
+		expect(documentQueries.getByRole('button', { name: 'Report On Selected Side' })).not.toBeNull()
 
 		await act(() => {
 			fireEvent.click(noButton)
@@ -1427,7 +1674,7 @@ describe('ReportingSection', () => {
 		expect(updates).toEqual([{ selectedOutcome: 'no' }])
 		expect((documentQueries.getByRole('button', { name: /^Yes/ }) as HTMLButtonElement).getAttribute('aria-pressed')).toBe('false')
 		expect((documentQueries.getByRole('button', { name: /^No/ }) as HTMLButtonElement).getAttribute('aria-pressed')).toBe('true')
-		expect(documentQueries.getByRole('button', { name: 'Report / Contribute No' })).not.toBeNull()
+		expect(documentQueries.getByRole('button', { name: 'Report No' })).not.toBeNull()
 	})
 
 	test('disables outcome side selection when the reporting workflow is locked', async () => {

--- a/ui/ts/tests/securityPoolState.engine.test.ts
+++ b/ui/ts/tests/securityPoolState.engine.test.ts
@@ -51,7 +51,6 @@ describe('security pool state engine', () => {
 				'finalizeTruthAuction',
 				'refundLosingBids',
 				'claimAuctionProceeds',
-				'withdrawBids',
 			]),
 		)
 		expectActionBlocked(model, 'redeemRep')

--- a/ui/ts/tests/securityPoolState.matrix.test.ts
+++ b/ui/ts/tests/securityPoolState.matrix.test.ts
@@ -21,7 +21,7 @@ describe('security pool action matrix data', () => {
 		expectActionSet(ENABLED_ACTIONS_BY_FORK_STAGE.initiate, ['forkWithOwnEscalation', 'initiateFork', 'forkUniverse'])
 		expectActionSet(ENABLED_ACTIONS_BY_FORK_STAGE.migration, ['createChildUniverse', 'migrateRepToZoltar', 'migrateVault', 'migrateEscalationDeposits', 'startTruthAuction'])
 		expectActionSet(ENABLED_ACTIONS_BY_FORK_STAGE.auction, ['submitBid', 'finalizeTruthAuction', 'refundLosingBids'])
-		expectActionSet(ENABLED_ACTIONS_BY_FORK_STAGE.settlement, ['claimAuctionProceeds', 'withdrawBids'])
+		expectActionSet(ENABLED_ACTIONS_BY_FORK_STAGE.settlement, ['claimAuctionProceeds'])
 		expectActionSet(UNIVERSE_FORKED_ENABLE, ['migrateShares'])
 		expectActionSet(UNIVERSE_FORKED_DISABLE, ['createCompleteSet', 'redeemCompleteSet', 'redeemShares'])
 	})

--- a/ui/ts/tests/securityPoolWorkflowSection.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection.test.tsx
@@ -7,6 +7,7 @@ import { act } from 'preact/test-utils'
 import { getAddress, zeroAddress } from 'viem'
 import { SecurityPoolWorkflowSection } from '../components/SecurityPoolWorkflowSection.js'
 import { ChainTimestampContext } from '../lib/chainTimestamp.js'
+import { deriveHasForkActivity } from '../lib/forkAuction.js'
 import { getReportingLockedUntilMessage } from '../lib/reporting.js'
 import type { AccountState } from '../types/app.js'
 import type { ForkAuctionDetails, ListedSecurityPool, MarketDetails, OracleManagerDetails, SecurityPoolVaultSummary, SecurityVaultDetails } from '../types/contracts.js'
@@ -186,12 +187,10 @@ function createForkAuctionProps(overrides: Partial<ForkAuctionRouteContentProps>
 			repMigrationOutcomes: '',
 			securityPoolAddress: '',
 			selectedOutcome: 'yes',
+			settlementAddress: '',
 			submitBidAmount: '',
 			submitBidTick: '',
 			vaultAddress: '',
-			withdrawBidIndex: '',
-			withdrawForAddress: '',
-			withdrawTick: '',
 		},
 		forkAuctionResult: undefined,
 		loadingForkAuctionDetails: false,
@@ -209,17 +208,17 @@ function createForkAuctionProps(overrides: Partial<ForkAuctionRouteContentProps>
 		onRefundLosingBids: () => undefined,
 		onStartTruthAuction: () => undefined,
 		onSubmitBid: () => undefined,
-		onWithdrawBids: () => undefined,
 		...overrides,
 	}
 }
 
 function createForkAuctionDetails(overrides: Partial<ForkAuctionDetails> = {}): ForkAuctionDetails {
-	return {
+	const forkAuctionDetails: ForkAuctionDetails = {
 		auctionedSecurityBondAllowance: 0n,
 		claimingAvailable: false,
 		completeSetCollateralAmount: 0n,
 		currentTime: 3n,
+		hasForkActivity: false,
 		forkOutcome: 'none',
 		forkOwnSecurityPool: false,
 		marketDetails: createMarketDetails(),
@@ -235,6 +234,10 @@ function createForkAuctionDetails(overrides: Partial<ForkAuctionDetails> = {}): 
 		truthAuctionStartedAt: 0n,
 		universeId: 1n,
 		...overrides,
+	}
+	return {
+		...forkAuctionDetails,
+		hasForkActivity: overrides.hasForkActivity ?? deriveHasForkActivity(forkAuctionDetails),
 	}
 }
 
@@ -258,9 +261,10 @@ function createMarketDetails(overrides: Partial<MarketDetails> = {}): MarketDeta
 }
 
 function createSelectedPool(overrides: Partial<ListedSecurityPool> = {}): ListedSecurityPool {
-	return {
+	const selectedPool: ListedSecurityPool = {
 		completeSetCollateralAmount: 0n,
 		currentRetentionRate: 10n,
+		hasForkActivity: false,
 		forkOutcome: 'none',
 		forkOwnSecurityPool: false,
 		lastOraclePrice: undefined,
@@ -283,6 +287,10 @@ function createSelectedPool(overrides: Partial<ListedSecurityPool> = {}): Listed
 		vaultCount: 0n,
 		vaults: [],
 		...overrides,
+	}
+	return {
+		...selectedPool,
+		hasForkActivity: overrides.hasForkActivity ?? deriveHasForkActivity(selectedPool),
 	}
 }
 
@@ -329,6 +337,13 @@ function createSecurityPoolWorkflowProps(overrides: Partial<SecurityPoolWorkflow
 		trading: createTradingProps(),
 		...overrides,
 	}
+}
+
+function getMetricValue(container: HTMLElement, label: string) {
+	const labelElement = within(container).getByText(label)
+	const metricValue = labelElement.parentElement?.querySelector('.metric-field-value')
+	if (!(metricValue instanceof HTMLElement)) throw new Error(`Missing metric value for ${label}`)
+	return metricValue.textContent
 }
 
 describe('SecurityPoolWorkflowSection', () => {
@@ -1166,6 +1181,61 @@ describe('SecurityPoolWorkflowSection', () => {
 		expect(loadSecurityVaultCalls).toEqual([undefined])
 	})
 
+	test('refreshes loaded reporting after depositing REP into the selected vault', async () => {
+		const refreshSelectedPoolCalls: Array<string | undefined> = []
+		const reportingLoadCalls: string[] = []
+		const selectedPoolAddress = zeroAddress
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					accountState: createAccountState(),
+					onRefreshSelectedPoolData: securityPoolAddressInput => {
+						refreshSelectedPoolCalls.push(securityPoolAddressInput)
+					},
+					reporting: createReportingProps({
+						onLoadReporting: () => {
+							reportingLoadCalls.push('refresh')
+						},
+						reportingDetails: {
+							completeSetCollateralAmount: 1n,
+							currentTime: 3n,
+							forkThreshold: 10n,
+							marketDetails: createMarketDetails({ endTime: 0n }),
+							nonDecisionThreshold: 20n,
+							questionOutcome: 'none',
+							resolution: 'none',
+							securityPoolAddress: selectedPoolAddress,
+							startBond: 1n,
+							status: 'not-started',
+							universeId: 1n,
+							withdrawalEnabled: false,
+							withdrawalState: 'not-finalized',
+							viewerVaultAvailableEscalationRep: 12_000n,
+							viewerVaultExists: true,
+							viewerVaultLockedRepInEscalationGame: 0n,
+							viewerVaultRepDepositShare: 12_000n,
+						},
+					}),
+					securityPoolAddress: selectedPoolAddress,
+					securityPools: [createSelectedPool({ marketDetails: createMarketDetails({ endTime: 0n }), securityPoolAddress: selectedPoolAddress })],
+					securityVault: createSecurityVaultProps({
+						securityVaultDetails: createSecurityVaultDetails({ securityPoolAddress: selectedPoolAddress, vaultAddress: zeroAddress }),
+						securityVaultResult: {
+							action: 'depositRep',
+							hash: '0x00000000000000000000000000000000000000000000000000000000000000df',
+						},
+					}),
+					selectedPoolView: 'vaults',
+				})}
+				showHeader={false}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(refreshSelectedPoolCalls).toEqual([selectedPoolAddress])
+		expect(reportingLoadCalls).toEqual(['refresh'])
+	})
+
 	test('refreshes the selected pool and loaded vault after a liquidation resolves as queued', async () => {
 		const refreshSelectedPoolCalls: Array<string | undefined> = []
 		const loadSecurityVaultCalls: Array<string | undefined> = []
@@ -1368,6 +1438,74 @@ describe('SecurityPoolWorkflowSection', () => {
 
 		expect(refreshSelectedPoolCalls).toEqual([selectedPoolAddress])
 		expect(loadSecurityVaultCalls).toEqual([undefined])
+	})
+
+	test('refreshes loaded reporting after executing a staged REP withdrawal', async () => {
+		const refreshSelectedPoolCalls: Array<string | undefined> = []
+		const reportingLoadCalls: string[] = []
+		const selectedPoolAddress = zeroAddress
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					accountState: createAccountState(),
+					onRefreshSelectedPoolData: securityPoolAddressInput => {
+						refreshSelectedPoolCalls.push(securityPoolAddressInput)
+					},
+					poolPriceOracleResult: {
+						action: 'executeStagedOperation',
+						hash: '0x00000000000000000000000000000000000000000000000000000000000000cf',
+						stagedExecution: {
+							errorMessage: undefined,
+							operation: 'withdrawRep',
+							operationId: 15n,
+							success: true,
+						},
+					},
+					reporting: createReportingProps({
+						onLoadReporting: () => {
+							reportingLoadCalls.push('refresh')
+						},
+						reportingDetails: {
+							completeSetCollateralAmount: 1n,
+							currentTime: 3n,
+							forkThreshold: 10n,
+							marketDetails: createMarketDetails({ endTime: 0n }),
+							nonDecisionThreshold: 20n,
+							questionOutcome: 'none',
+							resolution: 'none',
+							securityPoolAddress: selectedPoolAddress,
+							startBond: 1n,
+							status: 'not-started',
+							universeId: 1n,
+							withdrawalEnabled: false,
+							withdrawalState: 'not-finalized',
+							viewerVaultAvailableEscalationRep: 12_000n,
+							viewerVaultExists: true,
+							viewerVaultLockedRepInEscalationGame: 0n,
+							viewerVaultRepDepositShare: 12_000n,
+						},
+					}),
+					securityPoolAddress: selectedPoolAddress,
+					securityPools: [createSelectedPool({ marketDetails: createMarketDetails({ endTime: 0n }), securityPoolAddress: selectedPoolAddress })],
+					securityVault: createSecurityVaultProps({
+						securityVaultDetails: createSecurityVaultDetails({ securityPoolAddress: selectedPoolAddress, vaultAddress: zeroAddress }),
+						securityVaultForm: {
+							depositAmount: '',
+							repWithdrawAmount: '1',
+							securityBondAllowanceAmount: '',
+							securityPoolAddress: selectedPoolAddress,
+							selectedVaultAddress: zeroAddress,
+						},
+					}),
+					selectedPoolView: 'vaults',
+				})}
+				showHeader={false}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(refreshSelectedPoolCalls).toEqual([selectedPoolAddress])
+		expect(reportingLoadCalls).toEqual(['refresh'])
 	})
 
 	test('does not refresh the selected pool after a failed staged operation execution', async () => {
@@ -1831,7 +1969,7 @@ describe('SecurityPoolWorkflowSection', () => {
 		expect(document.body.textContent?.includes('Projected payout for current amount')).toBe(false)
 		expect(document.body.textContent?.includes('Projected profit if this side wins')).toBe(false)
 
-		const reportButton = documentQueries.getByRole('button', { name: 'Report / Contribute On Selected Side' }) as HTMLButtonElement
+		const reportButton = documentQueries.getByRole('button', { name: 'Report On Selected Side' }) as HTMLButtonElement
 		expect(reportButton.disabled).toBe(true)
 		expect(reportButton.title).toBe(expectedLockedReason)
 	})
@@ -1877,7 +2015,7 @@ describe('SecurityPoolWorkflowSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		const reportButton = documentQueries.getByRole('button', { name: 'Report / Contribute On Selected Side' }) as HTMLButtonElement
+		const reportButton = documentQueries.getByRole('button', { name: 'Report On Selected Side' }) as HTMLButtonElement
 		expect(reportButton.disabled).toBe(true)
 		expect(reportButton.title).toBe('Load reporting details before reporting on an outcome.')
 	})
@@ -2121,6 +2259,79 @@ describe('SecurityPoolWorkflowSection', () => {
 		expect(documentQueries.queryByRole('heading', { name: 'Report Outcome' })).toBeNull()
 	})
 
+	test('opens the fork workflow directly from the non-decision withdraw panel', async () => {
+		const selectedViews: string[] = []
+		const selectedPoolAddress = zeroAddress
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					checkedSecurityPoolAddress: selectedPoolAddress,
+					onSelectedPoolViewChange: view => {
+						selectedViews.push(view ?? '')
+					},
+					reporting: createReportingProps({
+						reportingDetails: {
+							activationTime: 120n,
+							bindingCapital: 10n,
+							completeSetCollateralAmount: 1n,
+							currentRequiredBond: 2n,
+							currentTime: 150n,
+							escalationEndTime: 300n,
+							escalationGameAddress: zeroAddress,
+							forkThreshold: 40n,
+							hasReachedNonDecision: true,
+							marketDetails: createMarketDetails({ endTime: 2n }),
+							nonDecisionThreshold: 20n,
+							questionOutcome: 'none',
+							resolution: 'none',
+							securityPoolAddress: selectedPoolAddress,
+							sides: [
+								{ balance: 7n, deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+								{
+									balance: 20n,
+									deposits: [],
+									key: 'yes',
+									label: 'Yes',
+									userDeposits: [
+										{
+											amount: 1n,
+											cumulativeAmount: 1n,
+											depositIndex: 0n,
+											depositor: zeroAddress,
+										},
+									],
+								},
+								{ balance: 20n, deposits: [], key: 'no', label: 'No', userDeposits: [] },
+							],
+							startBond: 1n,
+							status: 'active',
+							totalCost: 40n,
+							universeId: 1n,
+							viewerVaultAvailableEscalationRep: 12_000n,
+							viewerVaultExists: true,
+							viewerVaultLockedRepInEscalationGame: 2n,
+							viewerVaultRepDepositShare: 12_000n,
+							withdrawalEnabled: false,
+							withdrawalState: 'not-finalized',
+						},
+					}),
+					securityPoolAddress: selectedPoolAddress,
+					securityPools: [createSelectedPool({ marketDetails: createMarketDetails({ endTime: 2n }), securityPoolAddress: selectedPoolAddress, systemState: 'operational' })],
+					selectedPoolView: 'withdraw-escalation-deposits',
+				})}
+				showHeader={false}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		await act(() => {
+			fireEvent.click(documentQueries.getByRole('button', { name: 'Open Fork Workflow' }))
+		})
+
+		expect(selectedViews).toEqual(['fork'])
+	})
+
 	test('shows only the shared question card when the fork tab is active', async () => {
 		const renderedComponent = await renderIntoDocument(
 			<SecurityPoolWorkflowSection
@@ -2138,6 +2349,232 @@ describe('SecurityPoolWorkflowSection', () => {
 		const documentQueries = within(document.body)
 		expect(documentQueries.getAllByRole('heading', { name: 'Question' }).length).toBe(1)
 		expect(documentQueries.getByRole('heading', { name: 'Lifecycle' })).not.toBeNull()
+	})
+
+	test('unlocks the fork workflow and relabels the pool when escalation reaches non-decision', async () => {
+		const selectedPoolAddress = zeroAddress
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					checkedSecurityPoolAddress: selectedPoolAddress,
+					reporting: createReportingProps({
+						reportingDetails: {
+							activationTime: 120n,
+							bindingCapital: 10n,
+							completeSetCollateralAmount: 1n,
+							currentRequiredBond: 2n,
+							currentTime: 150n,
+							escalationEndTime: 300n,
+							escalationGameAddress: zeroAddress,
+							forkThreshold: 40n,
+							hasReachedNonDecision: true,
+							marketDetails: createMarketDetails({ endTime: 2n }),
+							nonDecisionThreshold: 20n,
+							questionOutcome: 'none',
+							resolution: 'none',
+							securityPoolAddress: selectedPoolAddress,
+							sides: [
+								{ balance: 7n, deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+								{ balance: 20n, deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+								{ balance: 20n, deposits: [], key: 'no', label: 'No', userDeposits: [] },
+							],
+							startBond: 1n,
+							status: 'active',
+							totalCost: 40n,
+							universeId: 1n,
+							viewerVaultAvailableEscalationRep: 12_000n,
+							viewerVaultExists: true,
+							viewerVaultLockedRepInEscalationGame: 2n,
+							viewerVaultRepDepositShare: 12_000n,
+							withdrawalEnabled: false,
+							withdrawalState: 'not-finalized',
+						},
+					}),
+					securityPoolAddress: selectedPoolAddress,
+					securityPools: [createSelectedPool({ marketDetails: createMarketDetails({ endTime: 2n }), securityPoolAddress: selectedPoolAddress, systemState: 'operational' })],
+					selectedPoolView: 'fork',
+				})}
+				showHeader={false}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		const selectedPoolSummary = document.body.querySelector('.selected-pool-context-summary')
+		if (!(selectedPoolSummary instanceof HTMLElement)) throw new Error('Expected selected pool summary to render')
+		const selectedPoolSummaryQueries = within(selectedPoolSummary)
+		expect(documentQueries.getByText('Pool Forked')).not.toBeNull()
+		expect(documentQueries.queryByText('This pool is currently operational, so fork and truth auction actions are read only.')).toBeNull()
+		expect(selectedPoolSummaryQueries.queryByText('Fork Mode')).toBeNull()
+		expect(selectedPoolSummaryQueries.queryByText('Fork Outcome')).toBeNull()
+		expect(documentQueries.getByRole('heading', { name: 'Fork Trigger' })).not.toBeNull()
+		expect(documentQueries.queryByRole('button', { name: 'Trigger Zoltar Fork' })).toBeNull()
+	})
+
+	test('shows Trigger Zoltar Fork in the reporting workflow after non-decision', async () => {
+		let triggerZoltarForkCalls = 0
+		const selectedPoolAddress = zeroAddress
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					checkedSecurityPoolAddress: selectedPoolAddress,
+					forkAuction: createForkAuctionProps({
+						onForkWithOwnEscalation: () => {
+							triggerZoltarForkCalls += 1
+						},
+					}),
+					reporting: createReportingProps({
+						reportingDetails: {
+							activationTime: 120n,
+							bindingCapital: 10n,
+							completeSetCollateralAmount: 1n,
+							currentRequiredBond: 2n,
+							currentTime: 150n,
+							escalationEndTime: 300n,
+							escalationGameAddress: zeroAddress,
+							forkThreshold: 40n,
+							hasReachedNonDecision: true,
+							marketDetails: createMarketDetails({ endTime: 2n }),
+							nonDecisionThreshold: 20n,
+							questionOutcome: 'none',
+							resolution: 'none',
+							securityPoolAddress: selectedPoolAddress,
+							sides: [
+								{ balance: 7n, deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+								{ balance: 20n, deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+								{ balance: 20n, deposits: [], key: 'no', label: 'No', userDeposits: [] },
+							],
+							startBond: 1n,
+							status: 'active',
+							totalCost: 40n,
+							universeId: 1n,
+							viewerVaultAvailableEscalationRep: 12_000n,
+							viewerVaultExists: true,
+							viewerVaultLockedRepInEscalationGame: 2n,
+							viewerVaultRepDepositShare: 12_000n,
+							withdrawalEnabled: false,
+							withdrawalState: 'not-finalized',
+						},
+					}),
+					securityPoolAddress: selectedPoolAddress,
+					securityPools: [createSelectedPool({ marketDetails: createMarketDetails({ endTime: 2n }), securityPoolAddress: selectedPoolAddress, systemState: 'operational' })],
+					selectedPoolView: 'reporting',
+				})}
+				showHeader={false}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expectTransactionButtonEnabled(document.body, 'Trigger Zoltar Fork')
+
+		await act(() => {
+			fireEvent.click(documentQueries.getByRole('button', { name: 'Trigger Zoltar Fork' }))
+		})
+
+		expect(triggerZoltarForkCalls).toBe(1)
+	})
+
+	test('hides Trigger Zoltar Fork after the pool has already entered its fork workflow and keeps Open Fork Workflow available', async () => {
+		const selectedPoolAddress = zeroAddress
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					checkedSecurityPoolAddress: selectedPoolAddress,
+					forkAuction: createForkAuctionProps(),
+					reporting: createReportingProps({
+						reportingDetails: {
+							activationTime: 120n,
+							bindingCapital: 10n,
+							completeSetCollateralAmount: 1n,
+							currentRequiredBond: 2n,
+							currentTime: 150n,
+							escalationEndTime: 300n,
+							escalationGameAddress: zeroAddress,
+							forkThreshold: 40n,
+							hasReachedNonDecision: true,
+							marketDetails: createMarketDetails({ endTime: 2n }),
+							nonDecisionThreshold: 20n,
+							questionOutcome: 'none',
+							resolution: 'none',
+							securityPoolAddress: selectedPoolAddress,
+							sides: [
+								{ balance: 7n, deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+								{ balance: 20n, deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+								{ balance: 20n, deposits: [], key: 'no', label: 'No', userDeposits: [] },
+							],
+							startBond: 1n,
+							status: 'active',
+							totalCost: 40n,
+							universeId: 1n,
+							viewerVaultAvailableEscalationRep: 12_000n,
+							viewerVaultExists: true,
+							viewerVaultLockedRepInEscalationGame: 2n,
+							viewerVaultRepDepositShare: 12_000n,
+							withdrawalEnabled: false,
+							withdrawalState: 'not-finalized',
+						},
+					}),
+					securityPoolAddress: selectedPoolAddress,
+					securityPools: [createSelectedPool({ forkOutcome: 'yes', marketDetails: createMarketDetails({ endTime: 2n }), migratedRep: 1n, securityPoolAddress: selectedPoolAddress, systemState: 'poolForked' })],
+					selectedPoolView: 'reporting',
+				})}
+				showHeader={false}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.queryByRole('button', { name: 'Trigger Zoltar Fork' })).toBeNull()
+		expect(documentQueries.getByRole('button', { name: 'Open Fork Workflow' })).not.toBeNull()
+		expect(document.body.textContent?.includes('Escalation reached non-decision and Zoltar fork has already been triggered for this pool. Continue in the Fork workflow.')).toBe(true)
+	})
+
+	test('prefers fresh fork-auction activity over stale pool-list state on the fork tab', async () => {
+		let reportingLoadCalls = 0
+		const selectedPoolAddress = zeroAddress
+		const freshTruthAuctionAddress = getAddress('0x00000000000000000000000000000000000000f1')
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					checkedSecurityPoolAddress: selectedPoolAddress,
+					forkAuction: createForkAuctionProps({
+						forkAuctionDetails: createForkAuctionDetails({
+							completeSetCollateralAmount: 2n,
+							forkOutcome: 'yes',
+							forkOwnSecurityPool: true,
+							marketDetails: createMarketDetails({ endTime: 2n }),
+							migratedRep: 5n,
+							securityPoolAddress: selectedPoolAddress,
+							systemState: 'operational',
+							truthAuctionAddress: freshTruthAuctionAddress,
+						}),
+					}),
+					reporting: createReportingProps({
+						onLoadReporting: () => {
+							reportingLoadCalls += 1
+						},
+					}),
+					securityPoolAddress: selectedPoolAddress,
+					securityPools: [createSelectedPool({ completeSetCollateralAmount: 0n, marketDetails: createMarketDetails({ endTime: 2n }), securityPoolAddress: selectedPoolAddress, systemState: 'operational', truthAuctionAddress: zeroAddress })],
+					selectedPoolView: 'fork',
+				})}
+				showHeader={false}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		const selectedPoolSummary = document.body.querySelector('.selected-pool-context-summary')
+		if (!(selectedPoolSummary instanceof HTMLElement)) throw new Error('Expected selected pool summary to render')
+		const selectedPoolSummaryQueries = within(selectedPoolSummary)
+		expect(reportingLoadCalls).toBe(0)
+		expect(documentQueries.queryByText('This pool is currently operational, so fork and truth auction actions are read only.')).toBeNull()
+		expect(selectedPoolSummaryQueries.getByText('Fork Mode')).not.toBeNull()
+		expect(selectedPoolSummaryQueries.getByText('Fork Outcome')).not.toBeNull()
+		expect(getMetricValue(selectedPoolSummary, 'Fork Mode')).toBe('Own escalation fork')
+		expect(getMetricValue(selectedPoolSummary, 'Fork Outcome')).toBe('Yes')
+		expect(selectedPoolSummaryQueries.getByRole('button', { name: `Copy address ${freshTruthAuctionAddress}` })).not.toBeNull()
 	})
 
 	test('autoloads reporting once after the reporting form pool matches the selected pool', async () => {
@@ -2262,6 +2699,52 @@ describe('SecurityPoolWorkflowSection', () => {
 		expect(reportingLoadCalls).toBe(1)
 	})
 
+	test('autoloads reporting from the fork tab once when it needs non-decision state', async () => {
+		let reportingLoadCalls = 0
+		const selectedPoolAddress = getAddress('0x00000000000000000000000000000000000000c1')
+		const baseProps = createSecurityPoolWorkflowProps({
+			checkedSecurityPoolAddress: selectedPoolAddress,
+			reporting: createReportingProps({
+				onLoadReporting: () => {
+					reportingLoadCalls += 1
+				},
+				reportingForm: {
+					reportAmount: '',
+					securityPoolAddress: selectedPoolAddress,
+					selectedOutcome: 'yes',
+					selectedWithdrawDepositIndexesByOutcome: {
+						invalid: [],
+						yes: [],
+						no: [],
+					},
+				},
+			}),
+			securityPoolAddress: selectedPoolAddress,
+			securityPools: [createSelectedPool({ marketDetails: createMarketDetails({ endTime: 0n }), securityPoolAddress: selectedPoolAddress, systemState: 'operational' })],
+			selectedPoolView: 'fork',
+		})
+
+		const renderedComponent = await renderIntoDocument(
+			<ChainTimestampContext.Provider value={1n}>
+				<SecurityPoolWorkflowSection {...baseProps} showHeader={false} />
+			</ChainTimestampContext.Provider>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(reportingLoadCalls).toBe(1)
+
+		await act(async () => {
+			render(
+				<ChainTimestampContext.Provider value={1n}>
+					<SecurityPoolWorkflowSection {...baseProps} showHeader={false} />
+				</ChainTimestampContext.Provider>,
+				renderedComponent.container,
+			)
+		})
+
+		expect(reportingLoadCalls).toBe(1)
+	})
+
 	test('re-arms reporting autoload after leaving and re-entering the reporting tab', async () => {
 		let reportingLoadCalls = 0
 		const selectedPoolAddress = getAddress('0x00000000000000000000000000000000000000b1')
@@ -2352,5 +2835,134 @@ describe('SecurityPoolWorkflowSection', () => {
 		})
 
 		expect(forkLoadCalls).toBe(2)
+	})
+
+	test('refreshes the selected pool and current vault after finalized auction settlement', async () => {
+		const selectedPoolAddress = zeroAddress
+		let refreshedPoolAddress: string | undefined
+		let vaultLoadCalls = 0
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					accountState: createAccountState(),
+					checkedSecurityPoolAddress: selectedPoolAddress,
+					forkAuction: createForkAuctionProps({
+						forkAuctionResult: {
+							action: 'claimAuctionProceeds',
+							hash: '0x00000000000000000000000000000000000000000000000000000000000000ca',
+							securityPoolAddress: selectedPoolAddress,
+							universeId: 1n,
+						},
+					}),
+					onRefreshSelectedPoolData: securityPoolAddressInput => {
+						refreshedPoolAddress = securityPoolAddressInput
+					},
+					securityPoolAddress: selectedPoolAddress,
+					securityPools: [createSelectedPool({ securityPoolAddress: selectedPoolAddress })],
+					securityVault: createSecurityVaultProps({
+						onLoadSecurityVault: () => {
+							vaultLoadCalls += 1
+						},
+						securityVaultDetails: createSecurityVaultDetails({
+							securityPoolAddress: selectedPoolAddress,
+							vaultAddress: zeroAddress,
+						}),
+						securityVaultForm: {
+							depositAmount: '',
+							repWithdrawAmount: '',
+							securityBondAllowanceAmount: '',
+							securityPoolAddress: selectedPoolAddress,
+							selectedVaultAddress: zeroAddress,
+						},
+					}),
+					selectedPoolView: 'fork',
+				})}
+				showHeader={false}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(refreshedPoolAddress).toBe(selectedPoolAddress)
+		expect(vaultLoadCalls).toBe(1)
+	})
+
+	test('reloads reporting after migrating escalation deposits in the fork workflow', async () => {
+		const selectedPoolAddress = zeroAddress
+		let reportingLoadCalls = 0
+		let refreshedPoolAddress: string | undefined
+		const renderedComponent = await renderIntoDocument(
+			<ChainTimestampContext.Provider value={1n}>
+				<SecurityPoolWorkflowSection
+					{...createSecurityPoolWorkflowProps({
+						checkedSecurityPoolAddress: selectedPoolAddress,
+						forkAuction: createForkAuctionProps({
+							forkAuctionResult: {
+								action: 'migrateEscalationDeposits',
+								hash: '0x00000000000000000000000000000000000000000000000000000000000000cb',
+								securityPoolAddress: selectedPoolAddress,
+								universeId: 1n,
+							},
+						}),
+						onRefreshSelectedPoolData: securityPoolAddressInput => {
+							refreshedPoolAddress = securityPoolAddressInput
+						},
+						reporting: createReportingProps({
+							onLoadReporting: () => {
+								reportingLoadCalls += 1
+							},
+							reportingDetails: {
+								activationTime: 0n,
+								bindingCapital: 0n,
+								completeSetCollateralAmount: 0n,
+								currentRequiredBond: 0n,
+								currentTime: 1n,
+								escalationEndTime: 2n,
+								escalationGameAddress: zeroAddress,
+								forkThreshold: 0n,
+								hasReachedNonDecision: false,
+								marketDetails: createMarketDetails({ endTime: 0n }),
+								nonDecisionThreshold: 0n,
+								questionOutcome: 'none',
+								resolution: 'none',
+								securityPoolAddress: selectedPoolAddress,
+								sides: [
+									{ balance: 0n, deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+									{ balance: 0n, deposits: [], key: 'yes', label: 'Yes', userDeposits: [] },
+									{ balance: 0n, deposits: [], key: 'no', label: 'No', userDeposits: [] },
+								],
+								startBond: 0n,
+								status: 'active',
+								totalCost: 0n,
+								universeId: 1n,
+								viewerVaultAvailableEscalationRep: 0n,
+								viewerVaultExists: true,
+								viewerVaultLockedRepInEscalationGame: 0n,
+								viewerVaultRepDepositShare: 0n,
+								withdrawalEnabled: false,
+								withdrawalState: 'not-finalized',
+							},
+							reportingForm: {
+								reportAmount: '',
+								securityPoolAddress: selectedPoolAddress,
+								selectedOutcome: 'yes',
+								selectedWithdrawDepositIndexesByOutcome: {
+									invalid: [],
+									yes: [],
+									no: [],
+								},
+							},
+						}),
+						securityPoolAddress: selectedPoolAddress,
+						securityPools: [createSelectedPool({ marketDetails: createMarketDetails({ endTime: 0n }), securityPoolAddress: selectedPoolAddress })],
+						selectedPoolView: 'reporting',
+					})}
+					showHeader={false}
+				/>
+			</ChainTimestampContext.Provider>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(refreshedPoolAddress).toBe(selectedPoolAddress)
+		expect(reportingLoadCalls).toBe(1)
 	})
 })

--- a/ui/ts/tests/securityPoolsOverviewSection.test.tsx
+++ b/ui/ts/tests/securityPoolsOverviewSection.test.tsx
@@ -3,6 +3,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { within } from '@testing-library/dom'
 import { SecurityPoolsOverviewSection } from '../components/SecurityPoolsOverviewSection.js'
+import { deriveHasForkActivity } from '../lib/forkAuction.js'
 import type { AccountState } from '../types/app.js'
 import type { ListedSecurityPool, MarketDetails } from '../types/contracts.js'
 import type { SecurityPoolsOverviewSectionProps } from '../types/components.js'
@@ -41,9 +42,10 @@ function createMarketDetails(overrides: Partial<MarketDetails> = {}): MarketDeta
 }
 
 function createSecurityPool(overrides: Partial<ListedSecurityPool> = {}): ListedSecurityPool {
-	return {
+	const securityPool: ListedSecurityPool = {
 		completeSetCollateralAmount: 0n,
 		currentRetentionRate: 10n,
+		hasForkActivity: false,
 		forkOutcome: 'none',
 		forkOwnSecurityPool: false,
 		lastOraclePrice: undefined,
@@ -66,6 +68,10 @@ function createSecurityPool(overrides: Partial<ListedSecurityPool> = {}): Listed
 		vaultCount: 0n,
 		vaults: [],
 		...overrides,
+	}
+	return {
+		...securityPool,
+		hasForkActivity: overrides.hasForkActivity ?? deriveHasForkActivity(securityPool),
 	}
 }
 

--- a/ui/ts/tests/securityPoolsSection.test.ts
+++ b/ui/ts/tests/securityPoolsSection.test.ts
@@ -7,6 +7,7 @@ import { render } from 'preact'
 import { act } from 'preact/test-utils'
 import { zeroAddress } from 'viem'
 import { SecurityPoolsSection, shouldRefreshSelectedPoolDataOnViewOpen } from '../components/SecurityPoolsSection.js'
+import { deriveHasForkActivity } from '../lib/forkAuction.js'
 import type { AccountState } from '../types/app.js'
 import type { ListedSecurityPool, MarketDetails, OracleManagerDetails } from '../types/contracts.js'
 import type { ForkAuctionRouteContentProps, ReportingRouteContentProps, SecurityPoolRouteContentProps, SecurityPoolsOverviewRouteContentProps, SecurityPoolsSectionProps, SecurityPoolWorkflowRouteContentProps, SecurityVaultRouteContentProps, TradingRouteContentProps } from '../types/components.js'
@@ -145,12 +146,10 @@ function createForkAuctionProps(overrides: Partial<ForkAuctionRouteContentProps>
 			repMigrationOutcomes: '',
 			securityPoolAddress: '',
 			selectedOutcome: 'yes',
+			settlementAddress: '',
 			submitBidAmount: '',
 			submitBidTick: '',
 			vaultAddress: '',
-			withdrawBidIndex: '',
-			withdrawForAddress: '',
-			withdrawTick: '',
 		},
 		forkAuctionResult: undefined,
 		loadingForkAuctionDetails: false,
@@ -168,7 +167,6 @@ function createForkAuctionProps(overrides: Partial<ForkAuctionRouteContentProps>
 		onRefundLosingBids: () => undefined,
 		onStartTruthAuction: () => undefined,
 		onSubmitBid: () => undefined,
-		onWithdrawBids: () => undefined,
 		...overrides,
 	}
 }
@@ -193,9 +191,10 @@ function createMarketDetails(overrides: Partial<MarketDetails> = {}): MarketDeta
 }
 
 function createSelectedPool(overrides: Partial<ListedSecurityPool> = {}): ListedSecurityPool {
-	return {
+	const selectedPool: ListedSecurityPool = {
 		completeSetCollateralAmount: 0n,
 		currentRetentionRate: 10n,
+		hasForkActivity: false,
 		forkOutcome: 'none',
 		forkOwnSecurityPool: false,
 		lastOraclePrice: undefined,
@@ -218,6 +217,10 @@ function createSelectedPool(overrides: Partial<ListedSecurityPool> = {}): Listed
 		vaultCount: 3n,
 		vaults: [],
 		...overrides,
+	}
+	return {
+		...selectedPool,
+		hasForkActivity: overrides.hasForkActivity ?? deriveHasForkActivity(selectedPool),
 	}
 }
 

--- a/ui/ts/tests/securityVaultSection.test.tsx
+++ b/ui/ts/tests/securityVaultSection.test.tsx
@@ -268,7 +268,7 @@ describe('SecurityVaultSection', () => {
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		expectTransactionButtonDisabled(document.body, 'Create / Deposit REP')
+		expectTransactionButtonDisabled(document.body, 'Deposit REP')
 		expectTransactionButtonEnabled(document.body, 'Redeem REP')
 		expectTransactionButtonDisabled(document.body, 'Set Security Bond Allowance')
 		expectTransactionButtonEnabled(document.body, 'Claim Fees')

--- a/ui/ts/tests/tradingSection.test.tsx
+++ b/ui/ts/tests/tradingSection.test.tsx
@@ -6,6 +6,7 @@ import { useState } from 'preact/hooks'
 import { act } from 'preact/test-utils'
 import { zeroAddress, zeroHash } from 'viem'
 import { TradingSection } from '../components/TradingSection.js'
+import { deriveHasForkActivity } from '../lib/forkAuction.js'
 import { NEED_MATCHING_COMPLETE_SET_SHARES_MESSAGE, NO_MINT_CAPACITY_NO_ACTIVE_ALLOWANCE_MESSAGE } from '../lib/trading.js'
 import type { AccountState, TradingFormState } from '../types/app.js'
 import type { ListedSecurityPool, MarketDetails, TradingDetails, TradingShareBalances, ZoltarUniverseSummary } from '../types/contracts.js'
@@ -32,9 +33,10 @@ function createMarketDetails(): MarketDetails {
 }
 
 function createSelectedPool(overrides: Partial<ListedSecurityPool> = {}): ListedSecurityPool {
-	return {
+	const selectedPool: ListedSecurityPool = {
 		completeSetCollateralAmount: 0n,
 		currentRetentionRate: 10n,
+		hasForkActivity: false,
 		forkOutcome: 'none',
 		forkOwnSecurityPool: false,
 		lastOraclePrice: undefined,
@@ -57,6 +59,10 @@ function createSelectedPool(overrides: Partial<ListedSecurityPool> = {}): Listed
 		vaultCount: 0n,
 		vaults: [],
 		...overrides,
+	}
+	return {
+		...selectedPool,
+		hasForkActivity: overrides.hasForkActivity ?? deriveHasForkActivity(selectedPool),
 	}
 }
 

--- a/ui/ts/tests/useOpenOracleOperations.test.tsx
+++ b/ui/ts/tests/useOpenOracleOperations.test.tsx
@@ -1,0 +1,350 @@
+/// <reference types="bun-types" />
+
+import { waitFor } from '@testing-library/dom'
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { h } from 'preact'
+import { act } from 'preact/test-utils'
+import { getAddress, zeroAddress } from 'viem'
+import type { OpenOracleReportDetails } from '../types/contracts.js'
+import { installDomEnvironment } from './testUtils/domEnvironment.js'
+import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
+
+type UseOpenOracleOperations = typeof import('../hooks/useOpenOracleOperations.js')['useOpenOracleOperations']
+type UseOpenOracleOperationsState = ReturnType<UseOpenOracleOperations>
+
+const OPEN_ORACLE_ADDRESS = getAddress('0x00000000000000000000000000000000000000aa')
+const REPORT_ID = 1n
+const WALLET_ADDRESS = getAddress('0x00000000000000000000000000000000000000bb')
+const TOKEN1_ADDRESS = getAddress('0x00000000000000000000000000000000000000c1')
+const TOKEN2_ADDRESS = getAddress('0x00000000000000000000000000000000000000c2')
+const STATE_HASH = '0x1111111111111111111111111111111111111111111111111111111111111111'
+
+function createOpenOracleReportDetails(overrides: Partial<OpenOracleReportDetails> = {}): OpenOracleReportDetails {
+	return {
+		callbackContract: zeroAddress,
+		callbackGasLimit: 0,
+		callbackSelector: '0x00000000',
+		currentAmount1: 100n,
+		currentAmount2: 25n,
+		currentBlockNumber: 10n,
+		currentReporter: zeroAddress,
+		currentTime: 10n,
+		disputeDelay: 1n,
+		disputeOccurred: false,
+		escalationHalt: 0n,
+		exactToken1Report: 100n,
+		fee: 0n,
+		feePercentage: 0n,
+		feeToken: false,
+		initialReporter: zeroAddress,
+		isDistributed: false,
+		keepFee: false,
+		lastReportOppoTime: 0n,
+		multiplier: 1n,
+		numReports: 0n,
+		openOracleAddress: OPEN_ORACLE_ADDRESS,
+		price: 4n,
+		protocolFee: 0n,
+		protocolFeeRecipient: zeroAddress,
+		reportId: REPORT_ID,
+		reportTimestamp: 0n,
+		settlementTime: 10n,
+		settlementTimestamp: 0n,
+		settlerReward: 0n,
+		stateHash: STATE_HASH,
+		timeType: true,
+		token1: TOKEN1_ADDRESS,
+		token1Decimals: 18,
+		token1Symbol: 'REP',
+		token2: TOKEN2_ADDRESS,
+		token2Decimals: 18,
+		token2Symbol: 'WETH',
+		trackDisputes: false,
+		...overrides,
+	}
+}
+
+function createHarness(useOpenOracleOperations: UseOpenOracleOperations, onRender: (state: UseOpenOracleOperationsState) => void) {
+	return function OpenOracleOperationsHarness() {
+		const state = useOpenOracleOperations({
+			accountAddress: WALLET_ADDRESS,
+			enabled: true,
+			onTransaction: () => undefined,
+			onTransactionFinished: () => undefined,
+			onTransactionRequested: () => undefined,
+			onTransactionSubmitted: () => undefined,
+			refreshState: async () => undefined,
+		})
+
+		onRender(state)
+
+		return <div />
+	}
+}
+
+function requireHookState(state: UseOpenOracleOperationsState | undefined) {
+	if (state === undefined) throw new Error('Hook state unavailable')
+
+	return state
+}
+
+describe('useOpenOracleOperations', () => {
+	let restoreDomEnvironment: (() => void) | undefined
+	let cleanupRenderedComponent: (() => Promise<void>) | undefined
+
+	beforeEach(() => {
+		const domEnvironment = installDomEnvironment()
+		restoreDomEnvironment = domEnvironment.cleanup
+	})
+
+	afterEach(async () => {
+		await cleanupRenderedComponent?.()
+		cleanupRenderedComponent = undefined
+		restoreDomEnvironment?.()
+		restoreDomEnvironment = undefined
+		mock.restore()
+	})
+
+	test('submitInitialReport reloads token access after a successful write', async () => {
+		const reportDetails = createOpenOracleReportDetails()
+		const readOptionalMulticall = mock(async () => [
+			{ result: 100n, status: 'success' },
+			{ result: 25n, status: 'success' },
+			{ result: 100n, status: 'success' },
+			{ result: 25n, status: 'success' },
+		])
+		const submitInitialOracleReport = mock(async () => ({
+			action: 'submitInitialReport',
+			hash: '0x00000000000000000000000000000000000000000000000000000000000000d1',
+		}))
+
+		mock.module('../contracts.js', () => ({
+			approveErc20: mock(async () => {
+				throw new Error('approveErc20 should not be called in this test')
+			}),
+			createOpenOracleReportInstance: mock(async () => {
+				throw new Error('createOpenOracleReportInstance should not be called in this test')
+			}),
+			disputeOracleReport: mock(async () => {
+				throw new Error('disputeOracleReport should not be called in this test')
+			}),
+			getOpenOracleAddress: () => OPEN_ORACLE_ADDRESS,
+			loadOpenOracleReportDetails: mock(async () => reportDetails),
+			readOptionalMulticall,
+			settleOracleReport: mock(async () => {
+				throw new Error('settleOracleReport should not be called in this test')
+			}),
+			submitInitialOracleReport,
+			wrapWeth: mock(async () => {
+				throw new Error('wrapWeth should not be called in this test')
+			}),
+		}))
+		mock.module('../lib/clients.js', () => ({
+			createConnectedReadClient: mock(() => ({ kind: 'read-client' })),
+			createWalletWriteClient: mock(() => ({ kind: 'write-client' })),
+		}))
+		mock.module('../lib/openOracle.js', () => ({
+			deriveOpenOracleDisputeSubmissionDetails: () => ({
+				blockMessage: undefined,
+				canSubmit: true,
+				expectedNewAmount1: 100n,
+				token1ContributionAmount: 0n,
+				token1Decimals: 18,
+				token1Approval: { hasSufficientApproval: true, requiredAmount: 0n, shortfall: 0n, targetAmount: 0n },
+				token2ContributionAmount: 0n,
+				token2Decimals: 18,
+				token2Approval: { hasSufficientApproval: true, requiredAmount: 0n, shortfall: 0n, targetAmount: 0n },
+			}),
+			deriveOpenOracleInitialReportSubmissionDetails: () => ({
+				amount1: 100n,
+				amount2: 25n,
+				blockMessage: undefined,
+				canSubmit: true,
+				hasWethWrapAction: false,
+				priceSource: 'Manual override',
+				priceSourceUrl: undefined,
+				requiredWethWrapAmount: 0n,
+				token1Approval: { hasSufficientApproval: true, requiredAmount: 100n, shortfall: 0n, targetAmount: 100n },
+				token1Decimals: 18,
+				token2Approval: { hasSufficientApproval: true, requiredAmount: 25n, shortfall: 0n, targetAmount: 25n },
+				token2Decimals: 18,
+				wrapRequiredWethMessage: undefined,
+			}),
+			formatOpenOracleDisputeWriteErrorMessage: (_error: unknown, fallbackMessage: string) => fallbackMessage,
+			formatOpenOracleInitialReportWriteErrorMessage: (_error: unknown, fallbackMessage: string) => fallbackMessage,
+			formatOpenOraclePriceInput: (price: bigint) => price.toString(),
+			formatOpenOracleSettleWriteErrorMessage: (_error: unknown, fallbackMessage: string) => fallbackMessage,
+			getOpenOracleCreateGuardMessage: () => undefined,
+			getOpenOracleDisputeAvailability: () => ({ canAct: true, message: undefined }),
+			getOpenOracleSelectedReportActionMode: (details: OpenOracleReportDetails) => (details.currentReporter === zeroAddress || details.reportTimestamp === 0n ? 'initial-report' : 'dispute'),
+			getOpenOracleSettleAvailability: () => ({ canAct: true, message: undefined }),
+			loadOpenOracleInitialReportPriceResult: mock(async () => ({
+				price: 4n,
+				priceSource: 'MOCK',
+				priceSourceUrl: undefined,
+				status: 'success',
+				token2Amount: 25n,
+			})),
+		}))
+
+		const { useOpenOracleOperations } = await import(`../hooks/useOpenOracleOperations.js?case=${crypto.randomUUID()}`)
+		let hookState: UseOpenOracleOperationsState | undefined
+		const Harness = createHarness(useOpenOracleOperations, state => {
+			hookState = state
+		})
+		const renderedComponent = await renderIntoDocument(h(Harness, {}))
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await act(async () => {
+			await requireHookState(hookState).loadOracleReport(REPORT_ID.toString())
+		})
+		await waitFor(() => {
+			expect(requireHookState(hookState).openOracleReportDetails?.reportId).toBe(REPORT_ID)
+		})
+		await waitFor(() => {
+			expect(readOptionalMulticall).toHaveBeenCalledTimes(1)
+		})
+
+		await act(async () => {
+			requireHookState(hookState).setOpenOracleForm(current => ({
+				...current,
+				price: '4',
+				reportId: REPORT_ID.toString(),
+				stateHash: STATE_HASH,
+			}))
+		})
+
+		const tokenAccessLoadsBeforeSubmit = readOptionalMulticall.mock.calls.length
+
+		await act(async () => {
+			await requireHookState(hookState).submitInitialReport()
+		})
+
+		expect(submitInitialOracleReport).toHaveBeenCalledTimes(1)
+		expect(readOptionalMulticall.mock.calls.length).toBe(tokenAccessLoadsBeforeSubmit + 2)
+	})
+
+	test('disputeReport reloads token access after a successful write', async () => {
+		const reportDetails = createOpenOracleReportDetails({
+			currentReporter: WALLET_ADDRESS,
+			initialReporter: WALLET_ADDRESS,
+			reportTimestamp: 5n,
+		})
+		const readOptionalMulticall = mock(async () => [
+			{ result: 200n, status: 'success' },
+			{ result: 50n, status: 'success' },
+			{ result: 200n, status: 'success' },
+			{ result: 50n, status: 'success' },
+		])
+		const disputeOracleReport = mock(async () => ({
+			action: 'dispute',
+			hash: '0x00000000000000000000000000000000000000000000000000000000000000d2',
+		}))
+
+		mock.module('../contracts.js', () => ({
+			approveErc20: mock(async () => {
+				throw new Error('approveErc20 should not be called in this test')
+			}),
+			createOpenOracleReportInstance: mock(async () => {
+				throw new Error('createOpenOracleReportInstance should not be called in this test')
+			}),
+			disputeOracleReport,
+			getOpenOracleAddress: () => OPEN_ORACLE_ADDRESS,
+			loadOpenOracleReportDetails: mock(async () => reportDetails),
+			readOptionalMulticall,
+			settleOracleReport: mock(async () => {
+				throw new Error('settleOracleReport should not be called in this test')
+			}),
+			submitInitialOracleReport: mock(async () => {
+				throw new Error('submitInitialOracleReport should not be called in this test')
+			}),
+			wrapWeth: mock(async () => {
+				throw new Error('wrapWeth should not be called in this test')
+			}),
+		}))
+		mock.module('../lib/clients.js', () => ({
+			createConnectedReadClient: mock(() => ({ kind: 'read-client' })),
+			createWalletWriteClient: mock(() => ({ kind: 'write-client' })),
+		}))
+		mock.module('../lib/openOracle.js', () => ({
+			deriveOpenOracleDisputeSubmissionDetails: () => ({
+				blockMessage: undefined,
+				canSubmit: true,
+				expectedNewAmount1: 150n,
+				token1ContributionAmount: 50n,
+				token1Decimals: 18,
+				token1Approval: { hasSufficientApproval: true, requiredAmount: 50n, shortfall: 0n, targetAmount: 50n },
+				token2ContributionAmount: 10n,
+				token2Decimals: 18,
+				token2Approval: { hasSufficientApproval: true, requiredAmount: 10n, shortfall: 0n, targetAmount: 10n },
+			}),
+			deriveOpenOracleInitialReportSubmissionDetails: () => ({
+				amount1: 100n,
+				amount2: 25n,
+				blockMessage: undefined,
+				canSubmit: true,
+				hasWethWrapAction: false,
+				priceSource: 'Manual override',
+				priceSourceUrl: undefined,
+				requiredWethWrapAmount: 0n,
+				token1Approval: { hasSufficientApproval: true, requiredAmount: 100n, shortfall: 0n, targetAmount: 100n },
+				token1Decimals: 18,
+				token2Approval: { hasSufficientApproval: true, requiredAmount: 25n, shortfall: 0n, targetAmount: 25n },
+				token2Decimals: 18,
+				wrapRequiredWethMessage: undefined,
+			}),
+			formatOpenOracleDisputeWriteErrorMessage: (_error: unknown, fallbackMessage: string) => fallbackMessage,
+			formatOpenOracleInitialReportWriteErrorMessage: (_error: unknown, fallbackMessage: string) => fallbackMessage,
+			formatOpenOraclePriceInput: (price: bigint) => price.toString(),
+			formatOpenOracleSettleWriteErrorMessage: (_error: unknown, fallbackMessage: string) => fallbackMessage,
+			getOpenOracleCreateGuardMessage: () => undefined,
+			getOpenOracleDisputeAvailability: () => ({ canAct: true, message: undefined }),
+			getOpenOracleSelectedReportActionMode: (details: OpenOracleReportDetails) => (details.currentReporter === zeroAddress || details.reportTimestamp === 0n ? 'initial-report' : 'dispute'),
+			getOpenOracleSettleAvailability: () => ({ canAct: true, message: undefined }),
+			loadOpenOracleInitialReportPriceResult: mock(async () => ({
+				price: 4n,
+				priceSource: 'MOCK',
+				priceSourceUrl: undefined,
+				status: 'success',
+				token2Amount: 25n,
+			})),
+		}))
+
+		const { useOpenOracleOperations } = await import(`../hooks/useOpenOracleOperations.js?case=${crypto.randomUUID()}`)
+		let hookState: UseOpenOracleOperationsState | undefined
+		const Harness = createHarness(useOpenOracleOperations, state => {
+			hookState = state
+		})
+		const renderedComponent = await renderIntoDocument(h(Harness, {}))
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await act(async () => {
+			await requireHookState(hookState).loadOracleReport(REPORT_ID.toString())
+		})
+		await waitFor(() => {
+			expect(requireHookState(hookState).openOracleReportDetails?.reportId).toBe(REPORT_ID)
+		})
+		await waitFor(() => {
+			expect(readOptionalMulticall).toHaveBeenCalledTimes(1)
+		})
+
+		await act(async () => {
+			requireHookState(hookState).setOpenOracleForm(current => ({
+				...current,
+				disputeNewAmount1: '150',
+				disputeNewAmount2: '35',
+				reportId: REPORT_ID.toString(),
+				stateHash: STATE_HASH,
+			}))
+		})
+
+		const tokenAccessLoadsBeforeDispute = readOptionalMulticall.mock.calls.length
+
+		await act(async () => {
+			await requireHookState(hookState).disputeReport()
+		})
+
+		expect(disputeOracleReport).toHaveBeenCalledTimes(1)
+		expect(readOptionalMulticall.mock.calls.length).toBe(tokenAccessLoadsBeforeDispute + 2)
+	})
+})

--- a/ui/ts/tests/useReportingOperations.test.tsx
+++ b/ui/ts/tests/useReportingOperations.test.tsx
@@ -11,6 +11,7 @@ import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
 
 type UseReportingOperations = typeof import('../hooks/useReportingOperations.js')['useReportingOperations']
 type UseReportingOperationsState = ReturnType<UseReportingOperations>
+const REP = 10n ** 18n
 
 function createDeferred<T>() {
 	let resolve: (value: T) => void = () => undefined
@@ -194,6 +195,85 @@ describe('useReportingOperations', () => {
 		expect(requireHookState(hookState).reportingDetails?.securityPoolAddress).toBe(secondPoolAddress)
 		expect(requireHookState(hookState).reportingDetails?.viewerVaultAvailableEscalationRep).toBe(8n)
 		expect(requireHookState(hookState).reportingDetails?.viewerVaultRepDepositShare).toBe(10n)
+	})
+
+	test('reportOutcome blocks pre-start contributions that would exceed the remaining selected-side threshold capacity', async () => {
+		const securityPoolAddress = getAddress('0x00000000000000000000000000000000000000d0')
+		const latestDetails: ReportingDetails = {
+			completeSetCollateralAmount: 1n,
+			currentTime: 150n,
+			forkThreshold: 40n * REP,
+			marketDetails: {
+				answerUnit: '',
+				createdAt: 1n,
+				description: 'Question description',
+				displayValueMax: 100n,
+				displayValueMin: 0n,
+				endTime: 100n,
+				exists: true,
+				marketType: 'binary',
+				numTicks: 2n,
+				outcomeLabels: ['Yes', 'No'],
+				questionId: '0x01',
+				startTime: 1n,
+				title: 'Will this resolve?',
+			},
+			nonDecisionThreshold: 20n * REP,
+			questionOutcome: 'none',
+			resolution: 'none',
+			securityPoolAddress,
+			startBond: 1n * REP,
+			status: 'not-started',
+			universeId: 1n,
+			withdrawalEnabled: false,
+			withdrawalState: 'not-finalized',
+			viewerVaultAvailableEscalationRep: 8n * REP,
+			viewerVaultExists: true,
+			viewerVaultLockedRepInEscalationGame: 0n,
+			viewerVaultRepDepositShare: 8n * REP,
+		}
+		const loadReportingDetails = mock(async () => latestDetails)
+		const reportOutcomeInSecurityPool = mock(async () => {
+			throw new Error('reportOutcomeInSecurityPool should not be called when the remaining selected-side threshold capacity is exhausted')
+		})
+
+		mock.module('../contracts.js', () => ({
+			loadReportingDetails,
+			reportOutcomeInSecurityPool,
+			withdrawEscalationFromSecurityPool: mock(async () => {
+				throw new Error('withdrawEscalationFromSecurityPool should not be called in this test')
+			}),
+		}))
+		mock.module('../lib/clients.js', () => ({
+			createConnectedReadClient: mock(() => ({ kind: 'read-client' })),
+			createWalletWriteClient: mock(() => ({ kind: 'write-client' })),
+		}))
+
+		const { useReportingOperations } = await import(`../hooks/useReportingOperations.js?case=${crypto.randomUUID()}`)
+		let hookState: UseReportingOperationsState | undefined
+		const Harness = createHarness(useReportingOperations, state => {
+			hookState = state
+		})
+		const renderedComponent = await renderIntoDocument(h(Harness, {}))
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await act(async () => {
+			requireHookState(hookState).setReportingForm(current => ({
+				...current,
+				reportAmount: '25',
+				securityPoolAddress,
+				selectedOutcome: 'yes',
+			}))
+		})
+
+		await act(async () => {
+			await requireHookState(hookState).onReportOutcome()
+		})
+
+		expect(loadReportingDetails).toHaveBeenCalledTimes(1)
+		expect(reportOutcomeInSecurityPool).toHaveBeenCalledTimes(0)
+		expect(requireHookState(hookState).reportingResult).toBeUndefined()
+		expect(requireHookState(hookState).reportingFeedback?.status.detail).toBe('Only 20 REP remains before the selected side reaches the threshold')
 	})
 
 	test('withdrawEscalation validates requested deposit indexes against the provided outcome', async () => {

--- a/ui/ts/types/app.ts
+++ b/ui/ts/types/app.ts
@@ -103,12 +103,10 @@ export type ForkAuctionFormState = {
 	repMigrationOutcomes: string
 	securityPoolAddress: string
 	selectedOutcome: ReportingOutcomeKey
+	settlementAddress: string
 	submitBidAmount: string
 	submitBidTick: string
 	vaultAddress: string
-	withdrawBidIndex: string
-	withdrawForAddress: string
-	withdrawTick: string
 }
 
 export type ZoltarMigrationFormState = {

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -28,6 +28,7 @@ import type {
 	ZoltarMigrationActionResult,
 	ZoltarUniverseSummary,
 } from './contracts.js'
+import type { SecurityPoolLifecycleState } from '../lib/securityPoolState.js'
 import type { OpenOracleDisputeSubmissionDetails, OpenOracleInitialReportPriceSource, OpenOracleInitialReportSubmissionDetails } from '../lib/openOracle.js'
 import type { LoadableValueState } from '../lib/loadState.js'
 import type { SecurityPoolStateModel } from '../lib/securityPoolState.js'
@@ -271,6 +272,8 @@ export type OverviewPanelsProps = {
 	walletBootstrapComplete: boolean
 	universeRepBalance: bigint | undefined
 	isLoadingUniverseRepBalance: boolean
+	universeForkTime?: bigint | undefined
+	universeHasForked?: boolean | undefined
 	universePresentation: UserMessagePresentation | undefined
 	universeLabel: string
 	isRefreshing: boolean
@@ -593,11 +596,16 @@ export type ReportingRouteContentProps = {
 export type ReportingSectionProps = ReportingRouteContentProps & {
 	currentTimestamp?: bigint | undefined
 	embedInCard?: boolean
+	forkAlreadyTriggered?: boolean | undefined
 	lockedReason?: string | undefined
 	mode?: 'full-reporting' | 'withdraw-only'
+	onOpenForkWorkflow?: (() => void) | undefined
+	onTriggerZoltarFork?: (() => void) | undefined
 	previewMarketDetails?: MarketDetails | undefined
 	showHeader?: boolean
 	showSecurityPoolAddressInput?: boolean
+	triggerZoltarForkAvailability?: ActionAvailability | undefined
+	triggerZoltarForkPending?: boolean | undefined
 }
 
 export type TradingRouteContentProps = {
@@ -652,7 +660,6 @@ export type ForkAuctionRouteContentProps = {
 	onRefundLosingBids: () => void
 	onStartTruthAuction: () => void
 	onSubmitBid: () => void
-	onWithdrawBids: () => void
 }
 
 export type ForkAuctionSectionProps = ForkAuctionRouteContentProps & {
@@ -660,6 +667,7 @@ export type ForkAuctionSectionProps = ForkAuctionRouteContentProps & {
 	disabled?: boolean
 	disabledMessage?: string | undefined
 	embedInCard?: boolean
+	lifecycleStateOverride?: SecurityPoolLifecycleState | undefined
 	previewPool?: ListedSecurityPool | undefined
 	showSecurityPoolAddressInput?: boolean
 	showHeader?: boolean

--- a/ui/ts/types/contracts.ts
+++ b/ui/ts/types/contracts.ts
@@ -19,8 +19,9 @@ export type DeploymentStepId =
 	| 'securityPoolFactory'
 export type MarketType = 'binary' | 'categorical' | 'scalar'
 export type ReportingOutcomeKey = 'invalid' | 'yes' | 'no'
+export type ForkOutcomeKey = ReportingOutcomeKey | 'none'
 export type SecurityPoolSystemState = 'operational' | 'poolForked' | 'forkMigration' | 'forkTruthAuction'
-export type ForkAuctionAction = 'forkWithOwnEscalation' | 'initiateFork' | 'createChildUniverse' | 'migrateRepToZoltar' | 'migrateVault' | 'migrateEscalationDeposits' | 'startTruthAuction' | 'submitBid' | 'refundLosingBids' | 'finalizeTruthAuction' | 'claimAuctionProceeds' | 'forkUniverse' | 'withdrawBids'
+export type ForkAuctionAction = 'forkWithOwnEscalation' | 'initiateFork' | 'createChildUniverse' | 'migrateRepToZoltar' | 'migrateVault' | 'migrateEscalationDeposits' | 'startTruthAuction' | 'submitBid' | 'refundLosingBids' | 'finalizeTruthAuction' | 'claimAuctionProceeds' | 'forkUniverse'
 export type OracleQueueOperation = 'liquidation' | 'withdrawRep' | 'setSecurityBondsAllowance'
 export type StagedOracleOperation = {
 	amount: bigint
@@ -245,7 +246,8 @@ export type OpenOracleReportDetails = {
 export type ListedSecurityPool = {
 	completeSetCollateralAmount: bigint
 	currentRetentionRate: bigint
-	forkOutcome: ReportingOutcomeKey | 'none'
+	hasForkActivity: boolean
+	forkOutcome: ForkOutcomeKey
 	forkOwnSecurityPool: boolean
 	lastOraclePrice: bigint | undefined
 	lastOracleSettlementTimestamp: bigint
@@ -428,7 +430,8 @@ export type ForkAuctionDetails = {
 	claimingAvailable: boolean
 	completeSetCollateralAmount: bigint
 	currentTime: bigint
-	forkOutcome: ReportingOutcomeKey | 'none'
+	hasForkActivity: boolean
+	forkOutcome: ForkOutcomeKey
 	forkOwnSecurityPool: boolean
 	marketDetails: MarketDetails
 	migratedRep: bigint


### PR DESCRIPTION
## Summary
- Allow finalized losing truth-auction bids to settle through `claimAuctionProceeds` as ETH-only refunds, while keeping REP-crediting winner accounting unchanged.
- Rework the fork and truth-auction UI so finalized settlement is one coherent flow, fork-trigger states load correctly, and users can move from escalation non-decision into the fork workflow without dead-end states.
- Tighten reporting, vault, and fork refresh behavior after writes, fix fork-threshold contribution presets, and harden fork outcome decoding with explicit loader-derived fork activity state.
- Expand Solidity and UI regression coverage across refund-only settlement, own-escalation fork initiation, fork-trigger workflow transitions, reporting presets, refresh behavior, and root-pool fork outcome decoding.

## What Changed
### Contracts
- `SecurityPoolForker.claimAuctionProceeds(...)` now allows finalized refund-only settlement for zero-REP losing bids and returns early without mutating vault accounting.
- `forkZoltarWithOwnEscalationGame(...)` now auto-initiates the pool fork after triggering the Zoltar fork.
- `initiateSecurityPoolFork(...)` now reverts with an explicit message if the pool fork was already initiated.

### Truth Auction UI
- Renamed claim UX to neutral finalized settlement UX and removed the stale direct withdraw path from the UI model.
- Finalized winning, partial, and losing bids now share one settlement path with correct labels, summaries, and prefills.
- Improved the market view, selected-level details, wallet summaries, and action gating around settlement and fork lifecycle transitions.

### Reporting / Fork Workflow UI
- Reporting contribution presets now cap correctly against the fork threshold and selected-side remaining capacity.
- Reporting, vault, and fork screens now refresh the relevant balances and details after REP/ETH-affecting writes.
- The escalation workflow now exposes `Trigger Zoltar Fork` in the right place, guides users into the fork workflow, and no longer hides the trigger early because of root-pool fork-outcome misdecoding.
- Fork workflow summaries now prefer fresher fork-auction details, keep synthetic preview state neutral until a real path is chosen, and use loader-derived `hasForkActivity` instead of ad hoc heuristics.

### Loader / Model Hardening
- Added a distinct `ForkOutcomeKey` domain type and a fork-specific decoder instead of reusing the reporting outcome decoder.
- Added explicit `hasForkActivity` fields to loaded pool and fork-auction data so the UI consumes one authoritative fork-activity signal.
- Added loader-level regressions to lock in the root-pool default fork outcome / inactive-state behavior.

## Testing
- `cd ui && bun x tsc --project tsconfig.json`
- `bun run test` (`863 pass, 1 skip, 0 fail`)
- `bun run format`
- `bun run check`
- `bun run knip`
