### PR TITLE
Bump solc lockfile to 0.8.35

### DIFF
--- a/solidity/bun.lock
+++ b/solidity/bun.lock
@@ -8,7 +8,7 @@
         "esbuild": "0.25.8",
         "funtypes": "5.1.1",
         "knip": "2.4.0",
-        "solc": "0.8.33",
+        "solc": "0.8.35",
         "tsx": "4.19.3",
         "typescript": "5.8.2",
         "viem": "2.38.3",
@@ -294,7 +294,7 @@
 
     "slash": ["slash@4.0.0", "", {}, "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew=="],
 
-    "solc": ["solc@0.8.33", "", { "dependencies": { "command-exists": "^1.2.8", "commander": "^8.1.0", "follow-redirects": "^1.12.1", "js-sha3": "0.8.0", "memorystream": "^0.3.1", "semver": "^5.5.0", "tmp": "0.0.33" }, "bin": { "solcjs": "solc.js" } }, ""],
+    "solc": ["solc@0.8.35", "", { "dependencies": { "command-exists": "^1.2.8", "commander": "^8.1.0", "follow-redirects": "^1.12.1", "js-sha3": "0.8.0", "memorystream": "^0.3.1", "semver": "^5.5.0", "tmp": "0.0.33" }, "bin": { "solcjs": "solc.js" } }, "sha512-OaP/4zyoKRo2CjqZDxbtkeRlEo6MxP4FLCxntw1Agf9OSoecmwYKoFBSB34UcSKBFBucrTh3Mb0nRoJou62ibw=="],
 
     "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 


### PR DESCRIPTION
## Summary
- Updated `solidity/bun.lock` to bump the `solc` dependency from `0.8.33` to `0.8.35`.
- Refreshed the corresponding lockfile integrity metadata entry for the `solc@0.8.35` package.

## Testing
- Not run (dependency lockfile-only change).
- Suggested follow-up checks: `cd /workspace/.t3/worktrees/zoltar/t3code-03bfb1cf && bun run tsc` (if needed by repo policy), then `bun run test`, `bun run check`, `bun run knip`.