### PR TITLE
Add pending truth-auction state and move finalize action in auction flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,38 +57,6 @@ Repeat the cycle iteratively after each fix to ensure clean builds and avoid acc
 
 **Last step**: After the task PR is ready, merge the latest `main` into the branch and resolve any conflicts if they exist.
 
-## Coverage Requirements
-
-After completing each task, agents should also run coverage analysis before finalizing:
-
-1. UI TypeScript coverage:
-   ```bash
-   bun run coverage:ui
-   ```
-
-2. Solidity TypeScript coverage:
-   ```bash
-   bun run coverage:contracts:ts
-   ```
-
-3. Solidity bytecode coverage:
-   ```bash
-   bun run coverage:contracts:bytecode
-   ```
-
-4. Optional unified run (runs all three domains):
-   ```bash
-   bun run coverage
-   ```
-
-Coverage does not need to reach 100%. The requirement is that coverage must not regress relative to the pre-change baseline for the relevant coverage commands.
-
-- If a task only affects UI code, `bun run coverage:ui` must not decrease.
-- If a task affects Solidity code or Solidity-side test/runtime code, `bun run coverage:contracts:ts` and `bun run coverage:contracts:bytecode` must not decrease.
-- If a task affects both areas, all relevant coverage commands must be non-regressing.
-
-Any intentional coverage regression must be explicitly called out in the final response and approved by the user before the task is considered complete.
-
 # Package Guidelines
 
 - **Version pinning**: All dependency versions in `package.json` must be exact (no `^` or `~`). This ensures reproducible builds.

--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -2261,8 +2261,7 @@ strong.metric-value-danger {
 }
 
 .truth-auction-hero-primary,
-.truth-auction-panel,
-.truth-auction-level-detail {
+.truth-auction-panel {
 	padding: 1rem;
 	border: 1px solid var(--border-default);
 	background: linear-gradient(180deg, var(--surface-raised) 0%, var(--surface-card-end) 100%);
@@ -2273,7 +2272,6 @@ strong.metric-value-danger {
 
 .truth-auction-hero-primary,
 .truth-auction-panel,
-.truth-auction-level-detail,
 .truth-auction-progress-group,
 .truth-auction-depth-header,
 .truth-auction-panel-header,
@@ -2284,6 +2282,24 @@ strong.metric-value-danger {
 .truth-auction-bid-row-actions {
 	display: grid;
 	gap: 0.75rem;
+}
+
+.truth-auction-market-section,
+.truth-auction-level-detail {
+	display: grid;
+	gap: 0.75rem;
+	align-content: start;
+}
+
+.truth-auction-market-section {
+	padding-top: 0.85rem;
+	border-top: 1px solid var(--divider-subtle);
+}
+
+.truth-auction-market-stack > .truth-auction-market-section:first-child,
+.truth-auction-market-board > .truth-auction-market-section:first-child {
+	padding-top: 0;
+	border-top: 0;
 }
 
 .truth-auction-hero-grid {
@@ -2350,13 +2366,15 @@ strong.metric-value-danger {
 	grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.truth-auction-wallet-summary {
+.truth-auction-wallet-summary,
+.truth-auction-bid-coverage-summary {
 	display: grid;
 	grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
 	gap: 0.9rem 1rem;
 }
 
-.truth-auction-wallet-summary > div {
+.truth-auction-wallet-summary > div,
+.truth-auction-bid-coverage-summary > div {
 	padding-top: 0.65rem;
 	border-top: 1px solid var(--divider-subtle);
 }
@@ -2649,6 +2667,10 @@ strong.metric-value-danger {
 
 .truth-auction-bid-row.is-wallet {
 	grid-template-columns: minmax(0, 0.85fr) minmax(0, 1fr) minmax(0, 0.85fr) auto minmax(0, 1.4fr);
+}
+
+.truth-auction-bid-row.is-wide {
+	grid-template-columns: minmax(0, 0.72fr) minmax(0, 0.9fr) minmax(0, 0.7fr) minmax(0, 1.2fr) minmax(0, 0.8fr) minmax(0, 0.9fr) auto minmax(0, 1.35fr);
 }
 
 .truth-auction-bid-row.is-header {
@@ -3770,6 +3792,7 @@ button:focus-visible {
 	}
 
 	.truth-auction-bid-row,
+	.truth-auction-bid-row.is-wide,
 	.truth-auction-bid-row.is-wallet {
 		grid-template-columns: 1fr;
 	}

--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -174,7 +174,7 @@ export function App() {
 		setSecurityBondAllowance,
 		setSecurityVaultForm,
 		withdrawRep,
-	} = useSecurityVaultOperations({ ...baseHookConfig, enabled: route === 'security-pools' })
+	} = useSecurityVaultOperations({ ...baseHookConfig, enabled: route === 'security-pools', selectedSecurityPoolAddress: securityPoolAddress })
 	const {
 		approveToken1,
 		approveToken2,
@@ -200,7 +200,7 @@ export function App() {
 		submitInitialReport,
 		wrapWethForInitialReport,
 	} = useOpenOracleOperations({ ...baseHookConfig, enabled: route === 'open-oracle' })
-	const { loadingReportingDetails, loadReporting, onReportOutcome, reportingActiveAction, reportingDetails, reportingError, reportingFeedback, reportingForm, reportingResult, setReportingForm, withdrawEscalation } = useReportingOperations(baseHookConfig)
+	const { loadingReportingDetails, loadReporting, onReportOutcome, reportingActiveAction, reportingDetails, reportingError, reportingFeedback, reportingForm, reportingResult, setReportingForm, withdrawEscalation } = useReportingOperations({ ...baseHookConfig, selectedSecurityPoolAddress: securityPoolAddress })
 	const updateReportingForm = (update: Partial<ReportingFormState>) => {
 		setReportingForm(current => applyReportingFormUpdate(current, update))
 	}
@@ -230,6 +230,7 @@ export function App() {
 		...baseHookConfig,
 		deploymentStatuses,
 		enabled: route === 'security-pools',
+		selectedSecurityPoolAddress: securityPoolAddress,
 	})
 	const {
 		claimAuctionProceeds,
@@ -253,7 +254,7 @@ export function App() {
 		setForkAuctionForm,
 		startTruthAuction,
 		submitBid,
-	} = useForkAuctionOperations(baseHookConfig)
+	} = useForkAuctionOperations({ ...baseHookConfig, selectedSecurityPoolAddress: securityPoolAddress })
 	const { repPerEthPrice, repPerEthSource, repPerEthSourceUrl, repUsdcPrice, repUsdcSource, repUsdcSourceUrl, isLoadingRepPrices, refreshRepPrices } = useRepPrices()
 	const simulationController = getActiveSimulationController()
 	const refreshSimulationView = async () => {
@@ -522,14 +523,14 @@ export function App() {
 				forkAuctionForm,
 				forkAuctionResult,
 				loadingForkAuctionDetails,
-				onClaimAuctionProceeds: () => void claimAuctionProceeds(),
+				onClaimAuctionProceeds: securityPoolAddressOverride => void claimAuctionProceeds(securityPoolAddressOverride),
 				onCreateChildUniverse: () => void createChildUniverse(forkAuctionForm.selectedOutcome),
-				onFinalizeTruthAuction: () => void finalizeTruthAuction(),
+				onFinalizeTruthAuction: securityPoolAddressOverride => void finalizeTruthAuction(securityPoolAddressOverride),
 				onForkAuctionFormChange: update => setForkAuctionForm(current => ({ ...current, ...update })),
 				onForkUniverse: () => void forkUniverse(),
 				onForkWithOwnEscalation: () => void forkWithOwnEscalation(),
 				onInitiateFork: () => void initiateFork(),
-				onLoadForkAuction: () => void loadForkAuction(),
+				onLoadForkAuction: securityPoolAddressOverride => void loadForkAuction(securityPoolAddressOverride),
 				onMigrateEscalationDeposits: (outcome, depositIndexes) =>
 					void migrateEscalation({
 						outcome,
@@ -537,9 +538,9 @@ export function App() {
 					}),
 				onMigrateRepToZoltar: outcomes => void migrateRepToZoltar(outcomes),
 				onMigrateVault: () => void migrateVault(),
-				onRefundLosingBids: () => void refundLosingBids(),
-				onStartTruthAuction: () => void startTruthAuction(),
-				onSubmitBid: () => void submitBid(),
+				onRefundLosingBids: securityPoolAddressOverride => void refundLosingBids(securityPoolAddressOverride),
+				onStartTruthAuction: securityPoolAddressOverride => void startTruthAuction(securityPoolAddressOverride),
+				onSubmitBid: securityPoolAddressOverride => void submitBid(securityPoolAddressOverride),
 			},
 			liquidationAmount,
 			liquidationMaxAmount,

--- a/ui/ts/components/DeploymentSection.tsx
+++ b/ui/ts/components/DeploymentSection.tsx
@@ -53,7 +53,7 @@ function getStepStatus(stepDeployed: boolean, prerequisiteLabel: string | undefi
 	return {
 		badgeClass: 'blocked',
 		detail: `Waiting for ${prerequisiteLabel}.`,
-		label: 'Blocked',
+		label: 'Waiting',
 		buttonLabel: 'Deploy',
 	}
 }

--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -1,5 +1,5 @@
 import { Fragment } from 'preact'
-import { useEffect, useState } from 'preact/hooks'
+import { useEffect, useRef, useState } from 'preact/hooks'
 import type { ComponentChildren } from 'preact'
 import { type Address, isAddress, zeroAddress } from 'viem'
 import { AddressValue } from './AddressValue.js'
@@ -19,14 +19,26 @@ import { TimestampValue } from './TimestampValue.js'
 import { TruthAuctionDepthChart, type TruthAuctionDepthPoint } from './TruthAuctionDepthChart.js'
 import { UniverseLink } from './UniverseLink.js'
 import { WorkflowTransactionStatus } from './WorkflowTransactionStatus.js'
-import { loadForkOutcomeMigrationSeedStatus, loadTruthAuctionActiveTickPage, loadTruthAuctionBidderBidPage, loadTruthAuctionTickBidPage, loadTruthAuctionTickSummary } from '../contracts.js'
+import { loadAllSecurityPools, loadForkAuctionDetails, loadForkOutcomeMigrationSeedStatus, loadTruthAuctionActiveTickPage, loadTruthAuctionBidderBidPage, loadTruthAuctionTickBidPage, loadTruthAuctionTickSummary } from '../contracts.js'
 import { createActionAvailability } from '../lib/actionAvailability.js'
 import { sameAddress } from '../lib/address.js'
 import { createConnectedReadClient } from '../lib/clients.js'
 import { getErrorMessage } from '../lib/errors.js'
-import { AUCTION_TIME_SECONDS, estimateRepPurchased, getForkAuctionStageLabel, getForkAuctionStageOrder, getForkAuctionStageView, getTimeRemaining, getTruthAuctionBidGuardMessage, type ForkAuctionStageView } from '../lib/forkAuction.js'
-import { formatDuration } from '../lib/formatters.js'
-import { tryParseBigIntInput } from '../lib/marketForm.js'
+import {
+	AUCTION_TIME_SECONDS,
+	estimateRepPurchased,
+	getForkAuctionStageLabel,
+	getForkAuctionStageOrder,
+	getForkAuctionStageView,
+	getTimeRemaining,
+	getTruthAuctionBidGuardMessage,
+	getTruthAuctionPriceAtTick,
+	getTruthAuctionTickAtPrice,
+	TRUTH_AUCTION_PRICE_PRECISION,
+	type ForkAuctionStageView,
+} from '../lib/forkAuction.js'
+import { formatCurrencyInputBalance, formatDuration } from '../lib/formatters.js'
+import { tryParseBigIntInput, tryParseTruthAuctionPriceInput } from '../lib/marketForm.js'
 import { isMainnetChain } from '../lib/network.js'
 import { REPORTING_OUTCOME_DROPDOWN_OPTIONS, getReportingOutcomeLabel } from '../lib/reporting.js'
 import { getEscalationDepositClaimAmount } from '../lib/reportingDomain.js'
@@ -34,32 +46,9 @@ import { deriveSecurityPoolForkStage, deriveSecurityPoolLifecycleState, evaluate
 import type { ForkAuctionActionResult, ListedSecurityPool, ReadClient, ReportingOutcomeKey, TruthAuctionBidView, TruthAuctionMetrics, TruthAuctionTickSummary } from '../types/contracts.js'
 import type { ForkAuctionSectionProps } from '../types/components.js'
 const UNKNOWN_VALUE = '—'
-const UNAVAILABLE_UNTIL_FORK = 'Unavailable until fork'
+const UNAVAILABLE_UNTIL_FORK = '-'
 const TRUTH_AUCTION_TICK_PAGE_SIZE = 25
 const TRUTH_AUCTION_BID_PAGE_SIZE = 25
-const PRICE_PRECISION = 10n ** 18n
-const TRUTH_AUCTION_TICK_PRICE_POWERS = [
-	1000100000000000000n,
-	1000200010000000000n,
-	1000400060004000100n,
-	1000800280056007000n,
-	1001601200560182043n,
-	1003204964963598014n,
-	1006420201727613920n,
-	1012881622445451097n,
-	1025929181087729343n,
-	1052530684607338948n,
-	1107820842039993613n,
-	1227267018058200482n,
-	1506184333613467388n,
-	2268591246822644826n,
-	5146506245160322222n,
-	26486526531474198664n,
-	701536087702486644953n,
-	492152882348911033633683n,
-	242214459604341065650571799093n,
-	58667844441422969901301586347865591163491n,
-] as const
 type DisplayMetric = {
 	label: string
 	value: ComponentChildren
@@ -250,11 +239,11 @@ function renderWorkflowMetricGrid(metrics: DisplayMetric[]) {
 		</div>
 	)
 }
-function estimateBidRep(bidAmount: string, selectedAuctionPrice: bigint | undefined) {
-	if (selectedAuctionPrice === undefined) return undefined
+function estimateBidRep(bidAmount: string, bidPrice: bigint | undefined) {
+	if (bidPrice === undefined) return undefined
 	const parsedBidAmount = bidAmount.trim() === '' ? 0n : tryParseBigIntInput(bidAmount)
 	if (parsedBidAmount === undefined) return undefined
-	return estimateRepPurchased(parsedBidAmount, selectedAuctionPrice)
+	return estimateRepPurchased(parsedBidAmount, bidPrice)
 }
 function parseOptionalBigInt(value: string) {
 	const trimmedValue = value.trim()
@@ -266,6 +255,14 @@ function getStartTruthAuctionGuardMessage({ currentTimestamp, migrationEndsAt }:
 	if (migrationEndsAt === undefined) return 'Migration timing is unavailable.'
 	if (currentTimestamp === undefined) return 'Loading current chain time.'
 	if (currentTimestamp <= migrationEndsAt) return 'Migration is still active. Truth auction can start once migration ends.'
+	return undefined
+}
+
+function getTruthAuctionBypassReason({ migratedRep, parentCollateralAmount, repAtFork }: { migratedRep: bigint; parentCollateralAmount: bigint | undefined; repAtFork: bigint | undefined }) {
+	if (parentCollateralAmount === 0n) return 'No parent collateral remains to auction, so this step immediately bypasses bidding and finalizes the child pool.'
+	if (repAtFork === undefined) return undefined
+	if (repAtFork === 0n) return 'No REP was present at fork, so no truth auction is needed for this child universe.'
+	if (migratedRep >= repAtFork) return 'This child universe already has all REP migrated from the parent pool, so no truth auction is needed.'
 	return undefined
 }
 
@@ -318,19 +315,7 @@ function clampPercentage(value: bigint, maxValue: bigint) {
 
 function getTruthAuctionWinningThresholdPrice(truthAuction: TruthAuctionMetrics | undefined) {
 	if (truthAuction === undefined || !truthAuction.finalized || !truthAuction.underfunded || truthAuction.maxRepBeingSold === 0n) return undefined
-	return (truthAuction.ethRaised * PRICE_PRECISION) / truthAuction.maxRepBeingSold
-}
-
-function getTruthAuctionPriceAtTick(tick: bigint) {
-	const absoluteTick = tick < 0n ? -tick : tick
-	let price = PRICE_PRECISION
-	for (let bitIndex = 0; bitIndex < TRUTH_AUCTION_TICK_PRICE_POWERS.length; bitIndex += 1) {
-		const bitMask = 1n << BigInt(bitIndex)
-		const pricePower = TRUTH_AUCTION_TICK_PRICE_POWERS[bitIndex]
-		if (pricePower === undefined) throw new Error(`Missing truth auction tick price power for bit ${bitIndex}`)
-		if ((absoluteTick & bitMask) !== 0n) price = (price * pricePower) / PRICE_PRECISION
-	}
-	return tick < 0n ? (PRICE_PRECISION * PRICE_PRECISION) / price : price
+	return (truthAuction.ethRaised * TRUTH_AUCTION_PRICE_PRECISION) / truthAuction.maxRepBeingSold
 }
 
 function getTickDisposition(tickSummary: TruthAuctionTickSummary, truthAuction: TruthAuctionMetrics | undefined): TruthAuctionDisposition {
@@ -584,8 +569,37 @@ async function loadTruthAuctionBidderBidPages(client: Pick<ReadClient, 'readCont
 		bids,
 	}
 }
+
+function sortTruthAuctionBidsByPriority(bids: TruthAuctionBidView[]) {
+	return [...bids].sort((left, right) => {
+		if (left.tick !== right.tick) return left.tick > right.tick ? -1 : 1
+		if (left.bidIndex !== right.bidIndex) return left.bidIndex < right.bidIndex ? -1 : 1
+		return 0
+	})
+}
+
+async function loadAggregatedTruthAuctionBidPages(client: Pick<ReadClient, 'readContract'>, truthAuctionAddress: Address, tickSummaries: TruthAuctionTickSummary[], pageCount: number) {
+	const uniqueTickSummaries = sortTruthAuctionTickSummariesDescending(Array.from(new Map(tickSummaries.map(tickSummary => [tickSummary.tick.toString(), tickSummary])).values()))
+	const bidPages = await Promise.all(uniqueTickSummaries.map(async tickSummary => ({ bidData: await loadTruthAuctionTickBidPages(client, truthAuctionAddress, tickSummary.tick, pageCount), tickSummary })))
+	const dedupedBids = new Map<string, TruthAuctionBidView>()
+	for (const { bidData } of bidPages) {
+		for (const bid of bidData.bids) {
+			dedupedBids.set(`${bid.tick.toString()}:${bid.bidIndex.toString()}`, bid)
+		}
+	}
+	return {
+		bids: sortTruthAuctionBidsByPriority(Array.from(dedupedBids.values())),
+		bidCountForLoadedTicks: uniqueTickSummaries.reduce((sum, tickSummary) => sum + tickSummary.submissionCount, 0n),
+	}
+}
+
+function isFullReadClient(client: Pick<ReadClient, 'readContract'> | ReadClient | undefined): client is ReadClient {
+	return client !== undefined && 'getBlock' in client && 'multicall' in client
+}
+
 export function ForkAuctionSection({
 	accountState,
+	auctionDetailsOverride,
 	currentTimestamp,
 	disabled = false,
 	embedInCard = false,
@@ -617,22 +631,12 @@ export function ForkAuctionSection({
 	truthAuctionReadClient,
 }: ForkAuctionSectionProps) {
 	const isMainnet = isMainnetChain(accountState.chainId)
-	const selectedAuctionPrice = forkAuctionDetails?.truthAuction?.clearingPrice
-	const estimatedRep = estimateBidRep(forkAuctionForm.submitBidAmount, selectedAuctionPrice)
 	const effectiveCurrentTimestamp = currentTimestamp ?? forkAuctionDetails?.currentTime
 	const securityPoolAddress = forkAuctionDetails?.securityPoolAddress ?? previewPool?.securityPoolAddress
 	const universeId = forkAuctionDetails?.universeId ?? previewPool?.universeId
 	const systemState = forkAuctionDetails?.systemState ?? previewPool?.systemState
 	const forkOutcome = forkAuctionDetails?.forkOutcome ?? previewPool?.forkOutcome
 	const questionOutcome = forkAuctionDetails?.questionOutcome ?? previewPool?.questionOutcome
-	const truthAuctionAddress = forkAuctionDetails?.truthAuctionAddress ?? previewPool?.truthAuctionAddress
-	const optimisticTruthAuctionStartedAt =
-		forkAuctionResult?.action === 'startTruthAuction' && securityPoolAddress !== undefined && sameAddress(forkAuctionResult.securityPoolAddress, securityPoolAddress) ? (effectiveCurrentTimestamp ?? forkAuctionDetails?.migrationEndsAt ?? forkAuctionDetails?.currentTime ?? 1n) : undefined
-	let effectiveTruthAuctionStartedAt = optimisticTruthAuctionStartedAt
-	if (previewPool?.truthAuctionStartedAt !== undefined && previewPool.truthAuctionStartedAt > 0n) effectiveTruthAuctionStartedAt = previewPool.truthAuctionStartedAt
-	if (forkAuctionDetails?.truthAuctionStartedAt !== undefined && forkAuctionDetails.truthAuctionStartedAt > 0n) effectiveTruthAuctionStartedAt = forkAuctionDetails.truthAuctionStartedAt
-	const auctionWindow = getTruthAuctionWindow(effectiveTruthAuctionStartedAt)
-	const truthAuctionEndsAt = forkAuctionDetails?.truthAuction?.auctionEndsAt ?? auctionWindow?.endsAt
 	const previewPoolHasActualForkActivity = previewPool?.hasForkActivity === true
 	const isSyntheticForkTriggerPreview = lifecycleStateOverride === 'poolForked' && !previewPoolHasActualForkActivity
 	const hasPreviewForkActivity = previewPoolHasActualForkActivity || lifecycleStateOverride === 'poolForked'
@@ -649,16 +653,65 @@ export function ForkAuctionSection({
 	const connectedWalletVaultSummary = accountState.address === undefined || previewPool === undefined ? undefined : previewPool.vaults.find(vault => sameAddress(vault.vaultAddress, accountState.address))
 	const selectedOutcomeMigrationChildPool = securityPoolAddress === undefined ? undefined : securityPools.find(pool => sameAddress(pool.parent, securityPoolAddress) && pool.questionOutcome === forkAuctionForm.selectedOutcome)
 	const selectedOutcomeMigrationChildVault = selectedOutcomeMigrationChildPool === undefined || accountState.address === undefined ? undefined : selectedOutcomeMigrationChildPool.vaults.find(vault => sameAddress(vault.vaultAddress, accountState.address))
+	const [selectedAuctionDetails, setSelectedAuctionDetails] = useState<ForkAuctionSectionProps['forkAuctionDetails']>(undefined)
+	const [selectedAuctionError, setSelectedAuctionError] = useState<string | undefined>(undefined)
+	const [loadingSelectedAuctionDetails, setLoadingSelectedAuctionDetails] = useState(false)
+	const [recoveredSelectedAuctionChildPool, setRecoveredSelectedAuctionChildPool] = useState<ListedSecurityPool | undefined>(undefined)
+	const selectedAuctionChildPool = selectedOutcomeMigrationChildPool ?? recoveredSelectedAuctionChildPool
+	const selectedAuctionPoolAddress = selectedAuctionChildPool?.securityPoolAddress
+	const selectedAuctionContext = auctionDetailsOverride ?? (selectedAuctionDetails?.securityPoolAddress !== undefined && selectedAuctionPoolAddress !== undefined && sameAddress(selectedAuctionDetails.securityPoolAddress, selectedAuctionPoolAddress) ? selectedAuctionDetails : undefined)
+	const auctionSecurityPoolAddress = selectedAuctionContext?.securityPoolAddress ?? selectedAuctionChildPool?.securityPoolAddress
+	const auctionTruthAuctionAddress = selectedAuctionContext?.truthAuctionAddress ?? selectedAuctionChildPool?.truthAuctionAddress
+	const auctionTruthAuctionStatus = selectedAuctionContext?.truthAuction
+	const auctionHasStartedAtValue = selectedAuctionContext?.truthAuctionStartedAt ?? selectedAuctionChildPool?.truthAuctionStartedAt ?? 0n
+	const hasSelectedAuctionChildPool = selectedAuctionChildPool !== undefined
+	const selectedAuctionContextError = selectedAuctionError
 	const selectedEscalationMigrationSide = reportingDetails?.status !== 'active' ? undefined : reportingDetails.sides.find(side => side.key === forkAuctionForm.selectedOutcome)
 	const selectedEscalationMigrationDeposits = selectedEscalationMigrationSide?.userDeposits ?? []
 	const selectedEscalationMigrationDepositIndexes = reportingForm?.selectedWithdrawDepositIndexesByOutcome[forkAuctionForm.selectedOutcome] ?? []
 	const showSelectedEscalationMigrationDeposits = !loadingReportingDetails && reportingDetails?.status === 'active'
 	const hasSelectedEscalationMigrationDeposits = selectedEscalationMigrationDeposits.length > 0
+	const [selectedOutcomeMigrationSeedStatus, setSelectedOutcomeMigrationSeedStatus] = useState<ForkOutcomeMigrationSeedStatus | undefined>(undefined)
+	const [selectedOutcomeMigrationSeedStatusError, setSelectedOutcomeMigrationSeedStatusError] = useState<string | undefined>(undefined)
+	const [loadingSelectedOutcomeMigrationSeedStatus, setLoadingSelectedOutcomeMigrationSeedStatus] = useState(false)
+	const [isStartTruthAuctionInProgressState, setIsStartTruthAuctionInProgressState] = useState(false)
+	const [isVaultMigrationPending, setIsVaultMigrationPending] = useState(false)
+	const [hasCompletedVaultMigration, setHasCompletedVaultMigration] = useState(false)
+	const [pendingEscalationMigrationSelection, setPendingEscalationMigrationSelection] = useState<{ depositIndexes: bigint[]; outcome: ReportingOutcomeKey } | undefined>(undefined)
+	const [optimisticMigratedEscalationRep, setOptimisticMigratedEscalationRep] = useState(0n)
+	const previousVaultMigrationContextKeyRef = useRef<string | undefined>(undefined)
+	const [truthAuctionBookData, setTruthAuctionBookData] = useState<TruthAuctionBookData>({
+		tickSummaries: [],
+		tickCount: 0n,
+		viewerBids: [],
+		viewerBidCount: 0n,
+	})
+	const [selectedTickBids, setSelectedTickBids] = useState<TruthAuctionBidView[]>([])
+	const [selectedBookTick, setSelectedBookTick] = useState<bigint | undefined>(undefined)
+	const [selectedTickSummary, setSelectedTickSummary] = useState<TruthAuctionTickSummary | undefined>(undefined)
+	const [selectedTickBidCount, setSelectedTickBidCount] = useState(0n)
+	const [loadedTickPageCount, setLoadedTickPageCount] = useState(1)
+	const [loadedViewerBidPageCount, setLoadedViewerBidPageCount] = useState(1)
+	const [loadedSelectedTickBidPageCount, setLoadedSelectedTickBidPageCount] = useState(1)
+	const [loadedAuctionBidPageCount, setLoadedAuctionBidPageCount] = useState(1)
+	const [aggregatedAuctionBids, setAggregatedAuctionBids] = useState<TruthAuctionBidView[]>([])
+	const [aggregatedAuctionBidCountForLoadedTicks, setAggregatedAuctionBidCountForLoadedTicks] = useState(0n)
+	const [loadingTruthAuctionBook, setLoadingTruthAuctionBook] = useState(false)
+	const [loadingSelectedTickBids, setLoadingSelectedTickBids] = useState(false)
+	const [loadingAggregatedAuctionBids, setLoadingAggregatedAuctionBids] = useState(false)
+	const [truthAuctionBookError, setTruthAuctionBookError] = useState<string | undefined>(undefined)
+	const effectiveLockedRepInEscalationGame = (() => {
+		if (connectedWalletVaultSummary === undefined) return undefined
+		if (connectedWalletVaultSummary.lockedRepInEscalationGame > optimisticMigratedEscalationRep) {
+			return connectedWalletVaultSummary.lockedRepInEscalationGame - optimisticMigratedEscalationRep
+		}
+		return 0n
+	})()
 	const migrationBalancesContent = (() => {
 		if (accountState.address === undefined) return <p className='detail'>Connect wallet to inspect your parent-pool balances.</p>
 		if (connectedWalletVaultSummary === undefined) return <p className='detail'>Parent-pool vault balances are unavailable for the connected wallet. You can still use the migration actions below if this wallet has parent-pool state to move.</p>
 		const selectedOutcomeMigrationVaultBalanceContent = (() => {
-			if (selectedOutcomeMigrationChildPool === undefined) return <p className='detail'>No child pool is currently selected for the selected outcome.</p>
+			if (selectedOutcomeMigrationChildPool === undefined) return undefined
 
 			return (
 				<>
@@ -676,7 +729,7 @@ export function ForkAuctionSection({
 				{renderWorkflowMetricGrid([
 					{ label: 'REP Collateral', value: <CurrencyValue value={connectedWalletVaultSummary.repDepositShare} suffix='REP' /> },
 					{ label: 'Security Bond Allowance', value: <CurrencyValue value={connectedWalletVaultSummary.securityBondAllowance} suffix='ETH' /> },
-					{ label: 'Locked REP', value: <CurrencyValue value={connectedWalletVaultSummary.lockedRepInEscalationGame} suffix='REP' /> },
+					{ label: 'Locked REP', value: <CurrencyValue value={effectiveLockedRepInEscalationGame ?? 0n} suffix='REP' /> },
 				])}
 				<div className='form-grid'>
 					<label className='field'>
@@ -685,12 +738,11 @@ export function ForkAuctionSection({
 					</label>
 				</div>
 				{selectedOutcomeMigrationVaultBalanceContent}
-				<p className='detail'>Migrate Vault moves your REP collateral and security bond allowance for the connected wallet. Locked REP only clears through Migrate Escalation Deposits.</p>
 			</>
 		)
 	})()
 	const hasWalletVaultMigrationBalance = connectedWalletVaultSummary !== undefined && (connectedWalletVaultSummary.repDepositShare > 0n || connectedWalletVaultSummary.securityBondAllowance > 0n)
-	const hasWalletEscalationMigrationBalance = connectedWalletVaultSummary !== undefined && connectedWalletVaultSummary.lockedRepInEscalationGame > 0n
+	const hasWalletEscalationMigrationBalance = effectiveLockedRepInEscalationGame !== undefined && effectiveLockedRepInEscalationGame > 0n
 	const migrateVaultBalanceGuardMessage = connectedWalletVaultSummary !== undefined && !hasWalletVaultMigrationBalance ? 'No REP collateral or security bond allowance remains to migrate for the connected wallet.' : undefined
 	const migrateEscalationBalanceGuardMessage = connectedWalletVaultSummary !== undefined && !hasWalletEscalationMigrationBalance ? 'No locked REP remains to migrate for the connected wallet.' : undefined
 	const currentStage =
@@ -705,48 +757,58 @@ export function ForkAuctionSection({
 					truthAuctionStartedAt: forkAuctionDetails?.truthAuctionStartedAt ?? previewPool?.truthAuctionStartedAt ?? 0n,
 				})
 	const selectedStage = stageView === 'initiate' ? 'migration' : stageView
-	const [selectedOutcomeMigrationSeedStatus, setSelectedOutcomeMigrationSeedStatus] = useState<ForkOutcomeMigrationSeedStatus | undefined>(undefined)
-	const [selectedOutcomeMigrationSeedStatusError, setSelectedOutcomeMigrationSeedStatusError] = useState<string | undefined>(undefined)
-	const [loadingSelectedOutcomeMigrationSeedStatus, setLoadingSelectedOutcomeMigrationSeedStatus] = useState(false)
-	const [isStartTruthAuctionInProgressState, setIsStartTruthAuctionInProgressState] = useState(false)
-	const [pendingVaultMigrationOutcome, setPendingVaultMigrationOutcome] = useState<ReportingOutcomeKey | undefined>(undefined)
-	const [completedVaultMigrationOutcomes, setCompletedVaultMigrationOutcomes] = useState<ReportingOutcomeKey[]>([])
-	const [truthAuctionBookData, setTruthAuctionBookData] = useState<TruthAuctionBookData>({
-		tickSummaries: [],
-		tickCount: 0n,
-		viewerBids: [],
-		viewerBidCount: 0n,
-	})
-	const [selectedTickBids, setSelectedTickBids] = useState<TruthAuctionBidView[]>([])
-	const [selectedBookTick, setSelectedBookTick] = useState<bigint | undefined>(undefined)
-	const [selectedTickSummary, setSelectedTickSummary] = useState<TruthAuctionTickSummary | undefined>(undefined)
-	const [selectedTickBidCount, setSelectedTickBidCount] = useState(0n)
-	const [loadedTickPageCount, setLoadedTickPageCount] = useState(1)
-	const [loadedViewerBidPageCount, setLoadedViewerBidPageCount] = useState(1)
-	const [loadedSelectedTickBidPageCount, setLoadedSelectedTickBidPageCount] = useState(1)
-	const [loadingTruthAuctionBook, setLoadingTruthAuctionBook] = useState(false)
-	const [loadingSelectedTickBids, setLoadingSelectedTickBids] = useState(false)
-	const [truthAuctionBookError, setTruthAuctionBookError] = useState<string | undefined>(undefined)
 	const selectedStageAheadMessage = getStageAheadMessage(selectedStage, currentStage)
-	const truthAuctionFallback = forkAuctionDetails?.truthAuction === undefined ? forkOnlyFallbackText : UNKNOWN_VALUE
-	const truthAuctionStatus = forkAuctionDetails?.truthAuction
-	const shouldShowTruthAuctionVisualization = truthAuctionStatus !== undefined && truthAuctionAddress !== undefined && truthAuctionAddress !== zeroAddress
-	const enteredBidTick = parseOptionalBigInt(forkAuctionForm.submitBidTick)
+	const selectedAuctionLabel = getReportingOutcomeLabel(forkAuctionForm.selectedOutcome)
+	const showAuctionChildPoolMessage = (selectedStage === 'auction' || selectedStage === 'settlement') && !hasSelectedAuctionChildPool
+	const enteredBidPrice = tryParseTruthAuctionPriceInput(forkAuctionForm.submitBidPrice)
+	const enteredBidTick = enteredBidPrice === undefined ? undefined : getTruthAuctionTickAtPrice(enteredBidPrice)
+	const estimatedRep = estimateBidRep(forkAuctionForm.submitBidAmount, enteredBidPrice)
+	const optimisticTruthAuctionStartedAt =
+		forkAuctionResult?.action === 'startTruthAuction' && auctionSecurityPoolAddress !== undefined && sameAddress(forkAuctionResult.securityPoolAddress, auctionSecurityPoolAddress) ? (effectiveCurrentTimestamp ?? forkAuctionDetails?.migrationEndsAt ?? selectedAuctionContext?.currentTime ?? 1n) : undefined
+	let effectiveTruthAuctionStartedAt = optimisticTruthAuctionStartedAt
+	if (auctionHasStartedAtValue > 0n) effectiveTruthAuctionStartedAt = auctionHasStartedAtValue
+	const auctionWindow = getTruthAuctionWindow(effectiveTruthAuctionStartedAt)
+	const truthAuctionEndsAt = auctionTruthAuctionStatus?.auctionEndsAt ?? auctionWindow?.endsAt
+	const hasStartedTruthAuction = effectiveTruthAuctionStartedAt !== undefined && effectiveTruthAuctionStartedAt > 0n
+	const truthAuctionFallback = (() => {
+		if (auctionTruthAuctionStatus !== undefined) return UNKNOWN_VALUE
+		if (hasSelectedAuctionChildPool) return UNKNOWN_VALUE
+		return forkOnlyFallbackText
+	})()
+	const truthAuctionStatus = auctionTruthAuctionStatus
+	const shouldShowTruthAuctionVisualization = truthAuctionStatus !== undefined && auctionTruthAuctionAddress !== undefined && auctionTruthAuctionAddress !== zeroAddress
 	const winningThresholdPrice = getTruthAuctionWinningThresholdPrice(truthAuctionStatus)
 	const startTruthAuctionCountdown = forkAuctionDetails?.migrationEndsAt === undefined || effectiveCurrentTimestamp === undefined ? undefined : getTimeRemaining(forkAuctionDetails.migrationEndsAt, effectiveCurrentTimestamp)
+	const isStartTruthAuctionInProgress = (() => {
+		if (hasStartedTruthAuction) return false
+		if (isStartTruthAuctionInProgressState) return true
+		if (forkAuctionActiveAction === 'startTruthAuction') return true
+
+		return false
+	})()
 	const startedDisplay = (() => {
+		if (hasStartedTruthAuction) {
+			return renderTimestamp({
+				displayTimestamp: effectiveTruthAuctionStartedAt,
+				fallbackText: 'Not started',
+			})
+		}
+		if (isStartTruthAuctionInProgress) return 'Starting...'
 		if (effectiveTruthAuctionStartedAt === undefined || effectiveTruthAuctionStartedAt === 0n) {
 			if (startTruthAuctionCountdown !== undefined && startTruthAuctionCountdown > 0n) return `Starts in ${formatDuration(startTruthAuctionCountdown)}`
 			return 'Not started'
 		}
-
-		return renderTimestamp({
-			displayTimestamp: effectiveTruthAuctionStartedAt,
-			fallbackText: 'Not started',
-		})
+		return 'Not started'
 	})()
-	const endsDisplay = auctionWindow === undefined ? 'Not started' : <TimestampValue {...(effectiveCurrentTimestamp === undefined ? {} : { currentTimestamp: effectiveCurrentTimestamp })} timestamp={auctionWindow.endsAt} />
-	const truthAuctionTimeRemaining = truthAuctionEndsAt === undefined || effectiveCurrentTimestamp === undefined ? forkAuctionDetails?.truthAuction?.timeRemaining : getTimeRemaining(truthAuctionEndsAt, effectiveCurrentTimestamp)
+	const endsDisplay = (() => {
+		if (auctionWindow === undefined) return isStartTruthAuctionInProgress ? 'Pending confirmation' : 'Not started'
+		return <TimestampValue {...(effectiveCurrentTimestamp === undefined ? {} : { currentTimestamp: effectiveCurrentTimestamp })} timestamp={auctionWindow.endsAt} />
+	})()
+	const truthAuctionTimeRemaining = (() => {
+		if (truthAuctionStatus?.finalized === true) return 0n
+		if (truthAuctionEndsAt === undefined || effectiveCurrentTimestamp === undefined) return truthAuctionStatus?.timeRemaining
+		return getTimeRemaining(truthAuctionEndsAt, effectiveCurrentTimestamp)
+	})()
 	const truthAuctionNote = (() => {
 		if (truthAuctionStatus === undefined) return undefined
 		if (!truthAuctionStatus.finalized) return 'The order book below reflects live demand and provisional clearing. Final allocation locks once the auction is finalized.'
@@ -774,6 +836,7 @@ export function ForkAuctionSection({
 	const hasMoreTickSummaries = BigInt(truthAuctionBookData.tickSummaries.length) < truthAuctionBookData.tickCount
 	const hasMoreViewerBids = BigInt(truthAuctionBookData.viewerBids.length) < truthAuctionBookData.viewerBidCount
 	const hasMoreSelectedTickBids = selectedTickSummary?.tick === selectedBookTick && BigInt(resolvedSelectedTickBids.length) < selectedTickBidCount
+	const hasMoreAggregatedAuctionBids = BigInt(aggregatedAuctionBids.length) < aggregatedAuctionBidCountForLoadedTicks
 	const selectTruthAuctionTick = (tick: bigint) => {
 		if (selectedBookTick === tick) return
 		setSelectedBookTick(tick)
@@ -784,39 +847,50 @@ export function ForkAuctionSection({
 		setSelectedTickSummary(matchingSummary)
 	}
 	const timeLeftDisplay = (() => {
-		if (forkAuctionDetails?.truthAuction === undefined) return forkOnlyFallbackText
+		if (truthAuctionStatus === undefined) return truthAuctionFallback
 		if (truthAuctionTimeRemaining === undefined) return formatDuration(AUCTION_TIME_SECONDS)
 
 		return formatDuration(truthAuctionTimeRemaining)
 	})()
+	const truthAuctionEndedNotice = (() => {
+		if (truthAuctionStatus === undefined) return undefined
+		const hasEndedByTime = truthAuctionEndsAt !== undefined && effectiveCurrentTimestamp !== undefined && effectiveCurrentTimestamp >= truthAuctionEndsAt
+		if (!truthAuctionStatus.finalized && !hasEndedByTime) return undefined
+		return (
+			<p className='notice success'>
+				<strong>Truth auction has ended.</strong> {truthAuctionStatus.finalized ? 'Bidding is closed and finalized settlement paths are now in effect.' : 'Bidding is closed. Finalize the truth auction to settle against the final clearing result.'}{' '}
+				{truthAuctionEndsAt === undefined ? undefined : (
+					<Fragment>
+						Ended at: <TimestampValue {...(effectiveCurrentTimestamp === undefined ? {} : { currentTimestamp: effectiveCurrentTimestamp })} timestamp={truthAuctionEndsAt} />
+					</Fragment>
+				)}
+			</p>
+		)
+	})()
 	const ethRaisedCapDisplay =
-		forkAuctionDetails?.truthAuction === undefined ? (
-			forkOnlyFallbackText
+		truthAuctionStatus === undefined ? (
+			truthAuctionFallback
 		) : (
 			<Fragment>
-				<CurrencyValue value={forkAuctionDetails.truthAuction.ethRaised} suffix='ETH' /> / <CurrencyValue value={forkAuctionDetails.truthAuction.ethRaiseCap} suffix='ETH' />
+				<CurrencyValue value={truthAuctionStatus.ethRaised} suffix='ETH' /> / <CurrencyValue value={truthAuctionStatus.ethRaiseCap} suffix='ETH' />
 			</Fragment>
 		)
-	const clearingPriceDisplay = forkAuctionDetails?.truthAuction === undefined ? forkOnlyFallbackText : renderMetricValue(forkAuctionDetails.truthAuction.clearingPrice, 'REP', UNKNOWN_VALUE)
+	const clearingPriceDisplay = truthAuctionStatus === undefined ? truthAuctionFallback : renderMetricValue(truthAuctionStatus.clearingPrice, 'REP', UNKNOWN_VALUE)
 	const finalizedDisplay = (() => {
-		if (forkAuctionDetails?.truthAuction === undefined) return forkOnlyFallbackText
-		if (forkAuctionDetails.truthAuction.finalized) return 'Yes'
+		if (truthAuctionStatus === undefined) return truthAuctionFallback
+		if (truthAuctionStatus.finalized) return 'Yes'
 
 		return 'No'
 	})()
 	const underfundedDisplay = (() => {
-		if (forkAuctionDetails?.truthAuction === undefined) return forkOnlyFallbackText
-		if (forkAuctionDetails.truthAuction.underfunded) return 'Yes'
+		if (truthAuctionStatus === undefined) return truthAuctionFallback
+		if (truthAuctionStatus.underfunded) return 'Yes'
 
 		return 'No'
 	})()
 	const settlementAvailableDisplay = (() => {
-		if (forkAuctionDetails === undefined) {
-			if (hasPreviewForkActivity) return UNKNOWN_VALUE
-
-			return UNAVAILABLE_UNTIL_FORK
-		}
-		if (forkAuctionDetails.claimingAvailable) return 'Yes'
+		if (!hasSelectedAuctionChildPool) return UNAVAILABLE_UNTIL_FORK
+		if (selectedAuctionContext?.claimingAvailable) return 'Yes'
 
 		return 'No'
 	})()
@@ -845,7 +919,7 @@ export function ForkAuctionSection({
 		currentTimestamp: effectiveCurrentTimestamp,
 		isMainnet,
 		submitBidAmountInput: forkAuctionForm.submitBidAmount,
-		truthAuction: forkAuctionDetails?.truthAuction,
+		truthAuction: truthAuctionStatus,
 		walletEthBalance: accountState.ethBalance,
 	})
 	const startTruthAuctionGuardMessage = getStartTruthAuctionGuardMessage({
@@ -857,24 +931,22 @@ export function ForkAuctionSection({
 		truthAuction: truthAuctionStatus,
 		truthAuctionEndsAt,
 	})
-	const hasStartedTruthAuction = effectiveTruthAuctionStartedAt !== undefined && effectiveTruthAuctionStartedAt > 0n
 	const startTruthAuctionReadyInText = (() => {
 		if (startTruthAuctionCountdown === undefined) return undefined
 		if (startTruthAuctionCountdown === 0n) return undefined
 		return `Truth auction can be started in ${formatDuration(startTruthAuctionCountdown)} once migration ends.`
 	})()
-	const isVaultMigrationCompleteForSelectedOutcome = (() => {
-		if (completedVaultMigrationOutcomes.includes(forkAuctionForm.selectedOutcome)) return true
-		if (selectedOutcomeMigrationChildVault === undefined) return false
-		return selectedOutcomeMigrationChildVault.repDepositShare > 0n || selectedOutcomeMigrationChildVault.securityBondAllowance > 0n
-	})()
-	const isVaultMigrationInProgressForSelectedOutcome = pendingVaultMigrationOutcome === forkAuctionForm.selectedOutcome
-	const isStartTruthAuctionInProgress = (() => {
-		if (hasStartedTruthAuction) return false
-		if (isStartTruthAuctionInProgressState) return true
-		if (forkAuctionActiveAction === 'startTruthAuction') return true
-
-		return false
+	const isVaultMigrationComplete = hasCompletedVaultMigration || (connectedWalletVaultSummary !== undefined && !hasWalletVaultMigrationBalance)
+	const truthAuctionBypassReason = getTruthAuctionBypassReason({
+		migratedRep: selectedAuctionContext?.migratedRep ?? selectedAuctionChildPool?.migratedRep ?? 0n,
+		parentCollateralAmount: forkAuctionDetails?.completeSetCollateralAmount ?? previewPool?.completeSetCollateralAmount,
+		repAtFork: forkAuctionDetails?.repAtFork,
+	})
+	const bidPriceValidationMessage = (() => {
+		if (forkAuctionForm.submitBidPrice.trim() === '') return 'Enter a bid price greater than zero.'
+		if (enteredBidPrice === undefined || enteredBidTick === undefined) return 'Enter a valid bid price.'
+		if (enteredBidPrice <= 0n) return 'Enter a bid price greater than zero.'
+		return undefined
 	})()
 	const startTruthAuctionAvailabilityMessage = (() => {
 		if (hasStartedTruthAuction) return 'Truth auction already started.'
@@ -889,7 +961,7 @@ export function ForkAuctionSection({
 	const settleFinalizedTruthAuctionBidGuardMessage = getSettleFinalizedTruthAuctionBidGuardMessage({
 		claimBidIndexInput: forkAuctionForm.claimBidIndex,
 		claimBidTickInput: forkAuctionForm.claimBidTick,
-		claimingAvailable: forkAuctionDetails?.claimingAvailable ?? false,
+		claimingAvailable: selectedAuctionContext?.claimingAvailable ?? false,
 		settlementAddressInput: forkAuctionForm.settlementAddress,
 		truthAuction: truthAuctionStatus,
 	})
@@ -924,39 +996,67 @@ export function ForkAuctionSection({
 		if (selectedEscalationMigrationDeposits.length > 0) return undefined
 		return `No ${selectedOutcomeLabel} escalation deposits are currently available to migrate for this wallet.`
 	})()
+	const migratePoolToUniverseGuardMessage = (() => {
+		if (loadingSelectedOutcomeMigrationSeedStatus) return `Checking whether pool REP has already been migrated for the ${selectedOutcomeLabel} child universe.`
+		if (selectedOutcomeMigrationSeedStatusError !== undefined) return selectedOutcomeMigrationSeedStatusError
+		if (selectedOutcomeMigrationSeedStatus?.seeded) return `Pool REP has already been migrated to the ${selectedOutcomeLabel} universe.`
+		return undefined
+	})()
 	const selectedOutcomeMigrationSeedGuardMessage = (() => {
 		if (migrateVaultBalanceGuardMessage !== undefined) return undefined
-		if (loadingSelectedOutcomeMigrationSeedStatus) return `Checking whether pool REP has already been migrated for the ${selectedOutcomeLabel} child pool.`
+		if (loadingSelectedOutcomeMigrationSeedStatus) return `Checking whether pool REP has already been migrated for the ${selectedOutcomeLabel} child universe.`
 		if (selectedOutcomeMigrationSeedStatusError !== undefined) return selectedOutcomeMigrationSeedStatusError
 		if (selectedOutcomeMigrationSeedStatus === undefined || selectedOutcomeMigrationSeedStatus.seeded) return undefined
-		return `Migrate pool REP to the ${selectedOutcomeLabel} child pool before moving vault balances.`
+		return `Migrate pool to the ${selectedOutcomeLabel} universe before moving vault balances.`
 	})()
-	const migrateVaultCompletedMessage = isVaultMigrationCompleteForSelectedOutcome ? 'Vault migration for this outcome is already complete for this wallet.' : undefined
-	const vaultMigrationInProgressMessage = isVaultMigrationInProgressForSelectedOutcome ? 'Migrating vault...' : undefined
+	const migrateVaultCompletedMessage = isVaultMigrationComplete ? 'Vault migration is already complete for this wallet.' : undefined
+	const vaultMigrationInProgressMessage = isVaultMigrationPending ? 'Migrating vault...' : undefined
 	const migrateVaultGuardMessage = migrateVaultBalanceGuardMessage ?? selectedOutcomeMigrationSeedGuardMessage ?? migrateVaultCompletedMessage ?? vaultMigrationInProgressMessage
+	const submitBidGuardMessage = truthAuctionBidGuardMessage ?? bidPriceValidationMessage
+	const migrationStatusBadge = isVaultMigrationComplete ? <span className='badge ok'>Migrated</span> : undefined
+	const fullTruthAuctionReadClient = isFullReadClient(truthAuctionReadClient) ? truthAuctionReadClient : undefined
 	const onStartTruthAuctionSubmit = () => {
 		setIsStartTruthAuctionInProgressState(true)
-		onStartTruthAuction()
+		onStartTruthAuction(selectedAuctionPoolAddress)
+	}
+	const onSubmitBidForSelectedAuction = () => {
+		onSubmitBid(selectedAuctionPoolAddress)
+	}
+	const onFinalizeTruthAuctionForSelectedAuction = () => {
+		onFinalizeTruthAuction(selectedAuctionPoolAddress)
+	}
+	const onRefundLosingBidsForSelectedAuction = () => {
+		onRefundLosingBids(selectedAuctionPoolAddress)
+	}
+	const onClaimAuctionProceedsForSelectedAuction = () => {
+		onClaimAuctionProceeds(selectedAuctionPoolAddress)
 	}
 	const onMigrateVaultSubmit = () => {
-		setPendingVaultMigrationOutcome(forkAuctionForm.selectedOutcome)
+		setIsVaultMigrationPending(true)
 		onMigrateVault()
 	}
 	const onMigrateSelectedOutcomeRepToZoltar = () => {
 		onMigrateRepToZoltar([forkAuctionForm.selectedOutcome])
 	}
 	const onMigrateSelectedEscalationDeposits = () => {
+		setPendingEscalationMigrationSelection({
+			depositIndexes: selectedEscalationMigrationDepositIndexes,
+			outcome: forkAuctionForm.selectedOutcome,
+		})
 		onMigrateEscalationDeposits(forkAuctionForm.selectedOutcome, selectedEscalationMigrationDepositIndexes)
 	}
 	const onMigrateAllEscalationDeposits = () => {
-		onMigrateEscalationDeposits(
-			forkAuctionForm.selectedOutcome,
-			selectedEscalationMigrationDeposits.map(deposit => deposit.depositIndex),
-		)
+		const depositIndexes = selectedEscalationMigrationDeposits.map(deposit => deposit.depositIndex)
+		setPendingEscalationMigrationSelection({
+			depositIndexes,
+			outcome: forkAuctionForm.selectedOutcome,
+		})
+		onMigrateEscalationDeposits(forkAuctionForm.selectedOutcome, depositIndexes)
 	}
 	const renderStageActionButton = ({
 		action,
 		availability,
+		forceEnabled,
 		idleLabel,
 		onClick,
 		pendingLabel,
@@ -967,13 +1067,14 @@ export function ForkAuctionSection({
 			disabled: boolean
 			reason: string | undefined
 		}
+		forceEnabled?: boolean
 		idleLabel: string
 		onClick: () => void
 		pendingLabel: string
 		tone?: 'primary' | 'secondary'
 	}) => {
 		const resolvedAvailability = availability ?? { disabled: false, reason: undefined }
-		const actionEnabled = forkPoolState.actions[action].enabled
+		const actionEnabled = forceEnabled ?? forkPoolState.actions[action].enabled
 		const disabledReason = interactionDisabledReason ?? resolvedAvailability.reason
 		return (
 			<TransactionActionButton
@@ -989,6 +1090,210 @@ export function ForkAuctionSection({
 			/>
 		)
 	}
+	const renderBidActionButtons = ({ bid, disposition, showEmptyState = false }: { bid: TruthAuctionBidView; disposition: TruthAuctionBidDisposition; showEmptyState?: boolean }) => {
+		const isViewerBid = sameAddress(bid.bidder, accountState.address)
+		const canPrefillRefund = isViewerBid && disposition.canPrefillRefund
+		const canPrefillSettle = isViewerBid && disposition.canPrefillSettle
+		const hasVisibleAction = canPrefillRefund || canPrefillSettle
+		return (
+			<div className='truth-auction-bid-row-actions'>
+				<button className='secondary' onClick={() => selectTruthAuctionTick(bid.tick)} type='button'>
+					Show Price Level
+				</button>
+				{showEmptyState && !hasVisibleAction ? <span className='truth-auction-row-empty'>—</span> : undefined}
+				{canPrefillRefund ? (
+					<button
+						className='secondary'
+						onClick={() =>
+							onForkAuctionFormChange({
+								refundBidIndex: bid.bidIndex.toString(),
+								refundTick: bid.tick.toString(),
+							})
+						}
+						type='button'
+					>
+						Prefill Refund
+					</button>
+				) : undefined}
+				{canPrefillSettle ? (
+					<button className='secondary' onClick={() => prefillSettleBid(bid)} type='button'>
+						Prefill Settle
+					</button>
+				) : undefined}
+			</div>
+		)
+	}
+	const renderSubmitBidSection = ({ description, density = 'balanced', headingLevel = 3, title = 'Submit Bid', variant = 'default' }: { description?: ComponentChildren; density?: 'balanced' | 'compact'; headingLevel?: 3 | 4; title?: ComponentChildren; variant?: 'default' | 'embedded' }) => (
+		<SectionBlock {...(description === undefined ? {} : { description })} density={density} headingLevel={headingLevel} title={title} variant={variant}>
+			<div className='form-grid'>
+				{submitBidPreviewTickSummary === undefined ? undefined : (
+					<p className='detail'>
+						Selected ladder price: <CurrencyValue value={submitBidPreviewTickSummary.price} suffix='ETH / REP' />
+					</p>
+				)}
+				<div className='field-row'>
+					<label className='field'>
+						<span>Bid Price (ETH / REP)</span>
+						<FormInput value={forkAuctionForm.submitBidPrice} onInput={event => onForkAuctionFormChange({ submitBidPrice: event.currentTarget.value })} />
+					</label>
+					<label className='field'>
+						<span>Bid Amount (ETH)</span>
+						<FormInput value={forkAuctionForm.submitBidAmount} onInput={event => onForkAuctionFormChange({ submitBidAmount: event.currentTarget.value })} />
+					</label>
+				</div>
+				{enteredBidPrice === undefined ? undefined : <p className='detail'>At the entered price, this bid would buy roughly {estimatedRep === undefined ? UNKNOWN_VALUE : <CurrencyValue value={estimatedRep} suffix='REP' />} if fully filled.</p>}
+				<div className='actions'>
+					{renderStageActionButton({
+						action: 'submitBid',
+						availability: createActionAvailability(submitBidGuardMessage),
+						forceEnabled: hasSelectedAuctionChildPool,
+						idleLabel: 'Submit Bid',
+						onClick: onSubmitBidForSelectedAuction,
+						pendingLabel: 'Submitting bid...',
+					})}
+				</div>
+			</div>
+		</SectionBlock>
+	)
+	const renderRefundBidSection = ({
+		idleLabel,
+		title,
+		description,
+		density = 'balanced',
+		headingLevel = 3,
+		tone = 'secondary',
+		variant = 'default',
+	}: {
+		description?: ComponentChildren
+		density?: 'balanced' | 'compact'
+		headingLevel?: 3 | 4
+		idleLabel: string
+		title?: ComponentChildren
+		tone?: 'primary' | 'secondary'
+		variant?: 'default' | 'embedded'
+	}) => (
+		<SectionBlock {...(description === undefined ? {} : { description })} density={density} headingLevel={headingLevel} title={title} variant={variant}>
+			<div className='form-grid'>
+				<label className='field'>
+					<span>Refund Tick</span>
+					<FormInput value={forkAuctionForm.refundTick} onInput={event => onForkAuctionFormChange({ refundTick: event.currentTarget.value })} />
+				</label>
+				<label className='field'>
+					<span>Refund Bid Index</span>
+					<FormInput value={forkAuctionForm.refundBidIndex} onInput={event => onForkAuctionFormChange({ refundBidIndex: event.currentTarget.value })} />
+				</label>
+				<div className='actions'>
+					{renderStageActionButton({
+						action: 'refundLosingBids',
+						availability: createActionAvailability(refundTruthAuctionBidGuardMessage),
+						forceEnabled: hasSelectedAuctionChildPool,
+						idleLabel,
+						onClick: onRefundLosingBidsForSelectedAuction,
+						pendingLabel: 'Refunding losing bid...',
+						tone,
+					})}
+				</div>
+			</div>
+		</SectionBlock>
+	)
+	const renderFinalizedSettlementSection = ({
+		density = 'balanced',
+		headingLevel = 3,
+		idleLabel,
+		title,
+		tone = 'secondary',
+		variant = 'default',
+	}: {
+		density?: 'balanced' | 'compact'
+		headingLevel?: 3 | 4
+		idleLabel: string
+		title?: ComponentChildren
+		tone?: 'primary' | 'secondary'
+		variant?: 'default' | 'embedded'
+	}) => (
+		<SectionBlock density={density} headingLevel={headingLevel} title={title} variant={variant}>
+			<div className='form-grid'>
+				<label className='field'>
+					<span>Bidder Address</span>
+					<FormInput value={forkAuctionForm.settlementAddress} onInput={event => onForkAuctionFormChange({ settlementAddress: event.currentTarget.value })} placeholder='Leave empty to use connected wallet' />
+				</label>
+				<div className='field-row'>
+					<label className='field'>
+						<span>Settlement Bid Tick</span>
+						<FormInput value={forkAuctionForm.claimBidTick} onInput={event => onForkAuctionFormChange({ claimBidTick: event.currentTarget.value })} />
+					</label>
+					<label className='field'>
+						<span>Settlement Bid Index</span>
+						<FormInput value={forkAuctionForm.claimBidIndex} onInput={event => onForkAuctionFormChange({ claimBidIndex: event.currentTarget.value })} />
+					</label>
+				</div>
+				<div className='actions'>
+					{renderStageActionButton({
+						action: 'claimAuctionProceeds',
+						availability: createActionAvailability(settleFinalizedTruthAuctionBidGuardMessage),
+						forceEnabled: hasSelectedAuctionChildPool,
+						idleLabel,
+						onClick: onClaimAuctionProceedsForSelectedAuction,
+						pendingLabel: 'Settling finalized bid...',
+						tone,
+					})}
+				</div>
+			</div>
+		</SectionBlock>
+	)
+	useEffect(() => {
+		if (selectedStage === 'migration' || securityPoolAddress === undefined) {
+			setRecoveredSelectedAuctionChildPool(undefined)
+			return
+		}
+		if (selectedOutcomeMigrationChildPool !== undefined) {
+			setRecoveredSelectedAuctionChildPool(currentPool => (currentPool?.securityPoolAddress === selectedOutcomeMigrationChildPool.securityPoolAddress ? currentPool : selectedOutcomeMigrationChildPool))
+			return
+		}
+		let cancelled = false
+		void loadAllSecurityPools(fullTruthAuctionReadClient ?? createConnectedReadClient())
+			.then(allPools => {
+				if (cancelled) return
+				const recoveredPool = allPools.find(pool => sameAddress(pool.parent, securityPoolAddress) && pool.questionOutcome === forkAuctionForm.selectedOutcome)
+				setRecoveredSelectedAuctionChildPool(recoveredPool)
+			})
+			.catch(() => {
+				if (cancelled) return
+				setRecoveredSelectedAuctionChildPool(undefined)
+			})
+		return () => {
+			cancelled = true
+		}
+	}, [forkAuctionForm.selectedOutcome, forkAuctionResult?.hash, fullTruthAuctionReadClient, securityPoolAddress, selectedOutcomeMigrationChildPool, selectedStage])
+	useEffect(() => {
+		if ((selectedStage !== 'auction' && selectedStage !== 'settlement') || selectedAuctionPoolAddress === undefined) {
+			setSelectedAuctionDetails(undefined)
+			setSelectedAuctionError(undefined)
+			setLoadingSelectedAuctionDetails(false)
+			return
+		}
+		const client = fullTruthAuctionReadClient ?? createConnectedReadClient()
+		let cancelled = false
+		setLoadingSelectedAuctionDetails(true)
+		setSelectedAuctionError(undefined)
+		void loadForkAuctionDetails(client, selectedAuctionPoolAddress)
+			.then(details => {
+				if (cancelled) return
+				setSelectedAuctionDetails(details)
+			})
+			.catch(error => {
+				if (cancelled) return
+				setSelectedAuctionDetails(undefined)
+				setSelectedAuctionError(getErrorMessage(error, `Unable to load auction details for the ${selectedAuctionLabel} child universe.`))
+			})
+			.finally(() => {
+				if (cancelled) return
+				setLoadingSelectedAuctionDetails(false)
+			})
+		return () => {
+			cancelled = true
+		}
+	}, [forkAuctionResult?.hash, fullTruthAuctionReadClient, selectedAuctionLabel, selectedAuctionPoolAddress, selectedStage])
 	useEffect(() => {
 		if (selectedStage !== 'migration' || securityPoolAddress === undefined || universeId === undefined) {
 			setSelectedOutcomeMigrationSeedStatus(undefined)
@@ -1024,18 +1329,29 @@ export function ForkAuctionSection({
 		}
 	}, [forkAuctionForm.selectedOutcome, forkAuctionResult?.hash, forkMigrationReadClient, securityPoolAddress, selectedOutcomeLabel, selectedOutcomeMigrationChildPool?.securityPoolAddress, selectedStage, universeId])
 	useEffect(() => {
-		if (securityPoolAddress === undefined || accountState.address === undefined) {
-			setPendingVaultMigrationOutcome(undefined)
-			setCompletedVaultMigrationOutcomes([])
-			return
-		}
+		const nextContextKey = securityPoolAddress === undefined || accountState.address === undefined ? undefined : `${accountState.address.toLowerCase()}:${securityPoolAddress.toLowerCase()}`
+		if (previousVaultMigrationContextKeyRef.current === nextContextKey) return
+		previousVaultMigrationContextKeyRef.current = nextContextKey
+		setIsVaultMigrationPending(false)
+		setHasCompletedVaultMigration(false)
+		setPendingEscalationMigrationSelection(undefined)
+		setOptimisticMigratedEscalationRep(0n)
 	}, [accountState.address, securityPoolAddress])
 	useEffect(() => {
 		if (forkAuctionResult === undefined || forkAuctionResult.action !== 'migrateVault' || forkAuctionResult.securityPoolAddress !== securityPoolAddress) return
-		if (pendingVaultMigrationOutcome === undefined) return
-		setCompletedVaultMigrationOutcomes(currentOutcomes => (currentOutcomes.includes(pendingVaultMigrationOutcome) ? currentOutcomes : [...currentOutcomes, pendingVaultMigrationOutcome]))
-		setPendingVaultMigrationOutcome(undefined)
-	}, [forkAuctionResult?.action, forkAuctionResult?.hash, forkAuctionResult?.securityPoolAddress, pendingVaultMigrationOutcome, securityPoolAddress])
+		setHasCompletedVaultMigration(true)
+		setIsVaultMigrationPending(false)
+	}, [forkAuctionResult?.action, forkAuctionResult?.hash, forkAuctionResult?.securityPoolAddress, securityPoolAddress])
+	useEffect(() => {
+		if (forkAuctionResult === undefined || forkAuctionResult.action !== 'migrateEscalationDeposits' || forkAuctionResult.securityPoolAddress !== securityPoolAddress) return
+		if (pendingEscalationMigrationSelection === undefined) return
+		const migrationSide = reportingDetails?.status !== 'active' ? undefined : reportingDetails.sides.find(side => side.key === pendingEscalationMigrationSelection.outcome)
+		const migratedRep = migrationSide?.userDeposits.filter(deposit => pendingEscalationMigrationSelection.depositIndexes.includes(deposit.depositIndex)).reduce((total, deposit) => total + deposit.amount, 0n)
+		if (migratedRep !== undefined && migratedRep > 0n) {
+			setOptimisticMigratedEscalationRep(currentReduction => currentReduction + migratedRep)
+		}
+		setPendingEscalationMigrationSelection(undefined)
+	}, [forkAuctionResult, pendingEscalationMigrationSelection, reportingDetails, securityPoolAddress])
 	useEffect(() => {
 		if (!isStartTruthAuctionInProgressState) return
 		if (hasStartedTruthAuction) {
@@ -1047,11 +1363,19 @@ export function ForkAuctionSection({
 		}
 	}, [forkAuctionActiveAction, forkAuctionError, hasStartedTruthAuction, isStartTruthAuctionInProgressState, securityPoolAddress])
 	useEffect(() => {
-		if (!isVaultMigrationInProgressForSelectedOutcome) return
+		if (!isVaultMigrationPending) return
 		if (forkAuctionActiveAction === 'migrateVault') return
 		if (forkAuctionError === undefined || securityPoolAddress === undefined) return
-		if (forkAuctionError !== undefined) setPendingVaultMigrationOutcome(undefined)
-	}, [forkAuctionActiveAction, forkAuctionError, isVaultMigrationInProgressForSelectedOutcome, securityPoolAddress])
+		if (forkAuctionError !== undefined) setIsVaultMigrationPending(false)
+	}, [forkAuctionActiveAction, forkAuctionError, isVaultMigrationPending, securityPoolAddress])
+	useEffect(() => {
+		if (forkAuctionActiveAction === 'migrateEscalationDeposits') return
+		if (forkAuctionError === undefined) return
+		setPendingEscalationMigrationSelection(undefined)
+	}, [forkAuctionActiveAction, forkAuctionError])
+	useEffect(() => {
+		setOptimisticMigratedEscalationRep(0n)
+	}, [connectedWalletVaultSummary?.lockedRepInEscalationGame])
 	useEffect(() => {
 		if (!isStartTruthAuctionInProgressState) return
 		if (accountState.address === undefined || securityPoolAddress === undefined) setIsStartTruthAuctionInProgressState(false)
@@ -1060,14 +1384,15 @@ export function ForkAuctionSection({
 		setLoadedTickPageCount(1)
 		setLoadedViewerBidPageCount(1)
 		setLoadedSelectedTickBidPageCount(1)
+		setLoadedAuctionBidPageCount(1)
 		setSelectedBookTick(undefined)
 		setSelectedTickSummary(undefined)
-	}, [accountState.address, truthAuctionAddress])
+	}, [accountState.address, auctionTruthAuctionAddress])
 	useEffect(() => {
 		setLoadedSelectedTickBidPageCount(1)
 	}, [selectedBookTick])
 	useEffect(() => {
-		if (!shouldShowTruthAuctionVisualization || truthAuctionAddress === undefined || truthAuctionAddress === zeroAddress || (selectedStage !== 'auction' && selectedStage !== 'settlement')) {
+		if (!shouldShowTruthAuctionVisualization || auctionTruthAuctionAddress === undefined || auctionTruthAuctionAddress === zeroAddress || (selectedStage !== 'auction' && selectedStage !== 'settlement')) {
 			setTruthAuctionBookData({
 				tickSummaries: [],
 				tickCount: 0n,
@@ -1080,6 +1405,9 @@ export function ForkAuctionSection({
 			setSelectedTickBidCount(0n)
 			setLoadingTruthAuctionBook(false)
 			setLoadingSelectedTickBids(false)
+			setAggregatedAuctionBids([])
+			setAggregatedAuctionBidCountForLoadedTicks(0n)
+			setLoadingAggregatedAuctionBids(false)
 			setTruthAuctionBookError(undefined)
 			return
 		}
@@ -1087,7 +1415,7 @@ export function ForkAuctionSection({
 		let cancelled = false
 		setLoadingTruthAuctionBook(true)
 		setTruthAuctionBookError(undefined)
-		void Promise.all([loadTruthAuctionActiveTickPages(client, truthAuctionAddress, loadedTickPageCount), accountState.address === undefined ? Promise.resolve({ bidCount: 0n, bids: [] }) : loadTruthAuctionBidderBidPages(client, truthAuctionAddress, accountState.address, loadedViewerBidPageCount)])
+		void Promise.all([loadTruthAuctionActiveTickPages(client, auctionTruthAuctionAddress, loadedTickPageCount), accountState.address === undefined ? Promise.resolve({ bidCount: 0n, bids: [] }) : loadTruthAuctionBidderBidPages(client, auctionTruthAuctionAddress, accountState.address, loadedViewerBidPageCount)])
 			.then(([tickPageData, viewerBidData]) => {
 				if (cancelled) return
 				const sortedTickSummaries = sortTruthAuctionTickSummariesDescending(tickPageData.tickSummaries)
@@ -1125,9 +1453,39 @@ export function ForkAuctionSection({
 		return () => {
 			cancelled = true
 		}
-	}, [accountState.address, enteredBidTick, forkAuctionResult?.hash, loadedTickPageCount, loadedViewerBidPageCount, selectedStage, shouldShowTruthAuctionVisualization, truthAuctionAddress, truthAuctionReadClient, truthAuctionStatus?.clearingTick])
+	}, [accountState.address, auctionTruthAuctionAddress, enteredBidTick, forkAuctionResult?.hash, loadedTickPageCount, loadedViewerBidPageCount, selectedStage, shouldShowTruthAuctionVisualization, truthAuctionReadClient, truthAuctionStatus?.clearingTick])
 	useEffect(() => {
-		if (!shouldShowTruthAuctionVisualization || truthAuctionAddress === undefined || truthAuctionAddress === zeroAddress || selectedBookTick === undefined) {
+		if (!shouldShowTruthAuctionVisualization || auctionTruthAuctionAddress === undefined || auctionTruthAuctionAddress === zeroAddress || (selectedStage !== 'auction' && selectedStage !== 'settlement')) {
+			setAggregatedAuctionBids([])
+			setAggregatedAuctionBidCountForLoadedTicks(0n)
+			setLoadingAggregatedAuctionBids(false)
+			return
+		}
+		const client = truthAuctionReadClient ?? createConnectedReadClient()
+		let cancelled = false
+		setLoadingAggregatedAuctionBids(true)
+		void loadAggregatedTruthAuctionBidPages(client, auctionTruthAuctionAddress, truthAuctionBookData.tickSummaries, loadedAuctionBidPageCount)
+			.then(({ bids, bidCountForLoadedTicks }) => {
+				if (cancelled) return
+				setAggregatedAuctionBids(bids)
+				setAggregatedAuctionBidCountForLoadedTicks(bidCountForLoadedTicks)
+			})
+			.catch(error => {
+				if (cancelled) return
+				setAggregatedAuctionBids([])
+				setAggregatedAuctionBidCountForLoadedTicks(0n)
+				setTruthAuctionBookError(currentError => currentError ?? getErrorMessage(error, 'Failed to load truth auction bids across the visible price levels'))
+			})
+			.finally(() => {
+				if (cancelled) return
+				setLoadingAggregatedAuctionBids(false)
+			})
+		return () => {
+			cancelled = true
+		}
+	}, [auctionTruthAuctionAddress, forkAuctionResult?.hash, loadedAuctionBidPageCount, selectedStage, shouldShowTruthAuctionVisualization, truthAuctionBookData.tickSummaries, truthAuctionReadClient])
+	useEffect(() => {
+		if (!shouldShowTruthAuctionVisualization || auctionTruthAuctionAddress === undefined || auctionTruthAuctionAddress === zeroAddress || selectedBookTick === undefined) {
 			setSelectedTickBids([])
 			setSelectedTickSummary(undefined)
 			setSelectedTickBidCount(0n)
@@ -1138,7 +1496,7 @@ export function ForkAuctionSection({
 		let cancelled = false
 		setLoadingSelectedTickBids(true)
 		setTruthAuctionBookError(undefined)
-		void Promise.all([loadTruthAuctionTickSummary(client, truthAuctionAddress, selectedBookTick), loadTruthAuctionTickBidPages(client, truthAuctionAddress, selectedBookTick, loadedSelectedTickBidPageCount)])
+		void Promise.all([loadTruthAuctionTickSummary(client, auctionTruthAuctionAddress, selectedBookTick), loadTruthAuctionTickBidPages(client, auctionTruthAuctionAddress, selectedBookTick, loadedSelectedTickBidPageCount)])
 			.then(([tickSummary, bidData]) => {
 				if (cancelled) return
 				setSelectedTickSummary(tickSummary)
@@ -1159,7 +1517,7 @@ export function ForkAuctionSection({
 		return () => {
 			cancelled = true
 		}
-	}, [forkAuctionResult?.hash, loadedSelectedTickBidPageCount, selectedBookTick, shouldShowTruthAuctionVisualization, truthAuctionAddress, truthAuctionReadClient])
+	}, [auctionTruthAuctionAddress, forkAuctionResult?.hash, loadedSelectedTickBidPageCount, selectedBookTick, shouldShowTruthAuctionVisualization, truthAuctionReadClient])
 	const latestForkAuctionAction =
 		forkAuctionResult === undefined
 			? undefined
@@ -1194,26 +1552,41 @@ export function ForkAuctionSection({
 		},
 	]
 	const auctionStatusMetrics: DisplayMetric[] = [
-		{ label: 'Auction Address', value: renderAddress(truthAuctionAddress) },
+		{ label: 'Auction Address', value: renderAddress(auctionTruthAuctionAddress) },
 		{ label: 'Started', value: startedDisplay },
 		{ label: 'Ends', value: endsDisplay },
 		{ label: 'ETH Raised / Cap', value: ethRaisedCapDisplay },
-		{ label: 'REP Purchased', value: truthAuctionStatus === undefined ? forkOnlyFallbackText : <CurrencyValue value={truthAuctionStatus.totalRepPurchased} suffix='REP' /> },
+		{ label: 'REP Purchased', value: truthAuctionStatus === undefined ? truthAuctionFallback : <CurrencyValue value={truthAuctionStatus.totalRepPurchased} suffix='REP' /> },
 		{ label: 'Clearing Tick', value: truthAuctionStatus?.clearingTick?.toString() ?? truthAuctionFallback },
 		{ label: 'Clearing Price', value: clearingPriceDisplay },
-		{ label: 'Min Bid Size', value: truthAuctionStatus === undefined ? forkOnlyFallbackText : <CurrencyValue value={truthAuctionStatus.minBidSize} suffix='ETH' /> },
-		{ label: 'Max REP Being Sold', value: truthAuctionStatus === undefined ? forkOnlyFallbackText : <CurrencyValue value={truthAuctionStatus.maxRepBeingSold} suffix='REP' /> },
+		{ label: 'Min Bid Size', value: truthAuctionStatus === undefined ? truthAuctionFallback : <CurrencyValue value={truthAuctionStatus.minBidSize} suffix='ETH' /> },
+		{ label: 'Max REP Being Sold', value: truthAuctionStatus === undefined ? truthAuctionFallback : <CurrencyValue value={truthAuctionStatus.maxRepBeingSold} suffix='REP' /> },
 		{ label: 'Finalized', value: finalizedDisplay },
 		{ label: 'Underfunded', value: underfundedDisplay },
 	]
 	const settlementStatusMetrics: DisplayMetric[] = [
 		{ label: 'Finalized', value: finalizedDisplay },
 		{ label: 'Underfunded', value: underfundedDisplay },
-		{ label: 'Auctioned Allowance', value: forkAuctionDetails === undefined ? forkOnlyFallbackText : <CurrencyValue value={forkAuctionDetails.auctionedSecurityBondAllowance} suffix='ETH' /> },
+		{ label: 'Auctioned Allowance', value: selectedAuctionContext === undefined ? truthAuctionFallback : <CurrencyValue value={selectedAuctionContext.auctionedSecurityBondAllowance} suffix='ETH' /> },
 		{ label: 'Settlement Available', value: settlementAvailableDisplay },
 		{ label: 'ETH Raised / Cap', value: ethRaisedCapDisplay },
-		{ label: 'REP Purchased', value: truthAuctionStatus === undefined ? forkOnlyFallbackText : <CurrencyValue value={truthAuctionStatus.totalRepPurchased} suffix='REP' /> },
+		{ label: 'REP Purchased', value: truthAuctionStatus === undefined ? truthAuctionFallback : <CurrencyValue value={truthAuctionStatus.totalRepPurchased} suffix='REP' /> },
 	]
+	const auctionOutcomeSelector = (
+		<div className='form-grid'>
+			<label className='field'>
+				<span>Outcome</span>
+				<EnumDropdown options={REPORTING_OUTCOME_DROPDOWN_OPTIONS} value={forkAuctionForm.selectedOutcome} onChange={selectedOutcome => onForkAuctionFormChange({ selectedOutcome })} />
+			</label>
+		</div>
+	)
+	const selectedAuctionChildPoolNotice = showAuctionChildPoolMessage ? <p className='detail'>Child universe not created for the {selectedAuctionLabel} outcome yet.</p> : undefined
+	const selectedAuctionDetailsNotice = (() => {
+		if (!hasSelectedAuctionChildPool || selectedStage === 'migration') return undefined
+		if (loadingSelectedAuctionDetails) return <p className='detail'>Loading {selectedAuctionLabel} child auction details.</p>
+		if (selectedAuctionContextError === undefined) return undefined
+		return <p className='detail'>{selectedAuctionContextError}</p>
+	})()
 	const truthAuctionHero = (() => {
 		if (!shouldShowTruthAuctionVisualization || truthAuctionStatus === undefined) return undefined
 		return (
@@ -1265,7 +1638,7 @@ export function ForkAuctionSection({
 				{truthAuctionBookError === undefined ? undefined : <p className='detail truth-auction-book-error'>{truthAuctionBookError}</p>}
 				<div className='truth-auction-market-board'>
 					<div className='truth-auction-market-stack'>
-						<div className='truth-auction-panel truth-auction-depth-panel'>
+						<div className='truth-auction-market-section truth-auction-depth-panel'>
 							<div className='truth-auction-depth-header'>
 								<div>
 									<h4>Visible Depth</h4>
@@ -1284,7 +1657,7 @@ export function ForkAuctionSection({
 								/>
 							)}
 						</div>
-						<div className='truth-auction-panel'>
+						<div className='truth-auction-market-section'>
 							<div className='truth-auction-panel-header'>
 								<div>
 									<h4>Price Ladder</h4>
@@ -1337,7 +1710,7 @@ export function ForkAuctionSection({
 							</div>
 						</div>
 					</div>
-					<div className='truth-auction-level-detail'>
+					<div className='truth-auction-market-section truth-auction-level-detail'>
 						{resolvedSelectedTickSummary === undefined ? (
 							<p className='detail'>{loadingSelectedTickBids && selectedBookTick !== undefined ? 'Loading selected price level…' : 'Select a price level to inspect the bids queued there.'}</p>
 						) : (
@@ -1350,8 +1723,8 @@ export function ForkAuctionSection({
 										</p>
 									</div>
 									{selectedStage !== 'settlement' ? (
-										<button className='secondary' onClick={() => onForkAuctionFormChange({ submitBidTick: resolvedSelectedTickSummary.tick.toString() })} type='button'>
-											Use This Tick
+										<button className='secondary' onClick={() => onForkAuctionFormChange({ submitBidPrice: formatCurrencyInputBalance(resolvedSelectedTickSummary.price) })} type='button'>
+											Use This Price
 										</button>
 									) : undefined}
 								</div>
@@ -1375,8 +1748,6 @@ export function ForkAuctionSection({
 										</div>
 										{resolvedSelectedTickBids.map(bid => {
 											const disposition = getBidDisposition(bid, truthAuctionStatus)
-											const isViewerBid = sameAddress(bid.bidder, accountState.address)
-											const hasRowAction = isViewerBid && (disposition.canPrefillRefund || disposition.canPrefillSettle)
 											return (
 												<div className='truth-auction-bid-row' key={`${bid.tick.toString()}:${bid.bidIndex.toString()}`}>
 													<span className='truth-auction-bid-row-label'>Bid #{bid.bidIndex.toString()}</span>
@@ -1392,28 +1763,7 @@ export function ForkAuctionSection({
 													<span className='truth-auction-bid-row-status'>
 														<span className={`truth-auction-status-pill ${getTruthAuctionDispositionClassName(disposition.tone)}`}>{disposition.label}</span>
 													</span>
-													<div className='truth-auction-bid-row-actions'>
-														{!hasRowAction ? <span className='truth-auction-row-empty'>—</span> : undefined}
-														{isViewerBid && disposition.canPrefillRefund ? (
-															<button
-																className='secondary'
-																onClick={() =>
-																	onForkAuctionFormChange({
-																		refundBidIndex: bid.bidIndex.toString(),
-																		refundTick: bid.tick.toString(),
-																	})
-																}
-																type='button'
-															>
-																Prefill Refund
-															</button>
-														) : undefined}
-														{isViewerBid && disposition.canPrefillSettle ? (
-															<button className='secondary' onClick={() => prefillSettleBid(bid)} type='button'>
-																Prefill Settle
-															</button>
-														) : undefined}
-													</div>
+													{renderBidActionButtons({ bid, disposition, showEmptyState: true })}
 												</div>
 											)
 										})}
@@ -1430,6 +1780,68 @@ export function ForkAuctionSection({
 						)}
 					</div>
 				</div>
+			</SectionBlock>
+		)
+	})()
+	const auctionWideBidsSection = (() => {
+		if (!shouldShowTruthAuctionVisualization || truthAuctionStatus === undefined) return undefined
+
+		return (
+			<SectionBlock title='Auction Bids' description='Bids across the currently loaded active price levels. Load more price levels to expand auction coverage.'>
+				<div className='truth-auction-bid-coverage-summary'>
+					<MetricField label='Loaded Levels'>{truthAuctionBookData.tickSummaries.length.toString()}</MetricField>
+					<MetricField label='Loaded Bids'>{aggregatedAuctionBids.length.toString()}</MetricField>
+					<MetricField label='Coverage'>{`Showing ${aggregatedAuctionBids.length.toString()} of ${aggregatedAuctionBidCountForLoadedTicks.toString()} bids across loaded levels`}</MetricField>
+				</div>
+				{loadingAggregatedAuctionBids ? <p className='detail'>Loading auction bids…</p> : undefined}
+				{!loadingAggregatedAuctionBids && truthAuctionBookData.tickSummaries.length === 0 ? <p className='detail'>No active price levels are currently visible for this auction.</p> : undefined}
+				{!loadingAggregatedAuctionBids && truthAuctionBookData.tickSummaries.length > 0 && aggregatedAuctionBids.length === 0 ? <p className='detail'>No bids are currently indexed for the loaded active price levels.</p> : undefined}
+				{aggregatedAuctionBids.length === 0 ? undefined : (
+					<div className='truth-auction-bid-table'>
+						<div className='truth-auction-bid-row is-header is-wide'>
+							<span>Tick</span>
+							<span>Price</span>
+							<span>Bid</span>
+							<span>Bidder</span>
+							<span>Amount</span>
+							<span>Cumulative</span>
+							<span>Status</span>
+							<span>Actions</span>
+						</div>
+						{aggregatedAuctionBids.map(bid => {
+							const disposition = getBidDisposition(bid, truthAuctionStatus)
+							return (
+								<div className='truth-auction-bid-row is-wide' key={`aggregate:${bid.tick.toString()}:${bid.bidIndex.toString()}`}>
+									<span className='truth-auction-bid-row-label'>Tick {bid.tick.toString()}</span>
+									<span>
+										<CurrencyValue value={getTruthAuctionPriceAtTick(bid.tick)} suffix='ETH / REP' />
+									</span>
+									<span>Bid #{bid.bidIndex.toString()}</span>
+									<div className='truth-auction-bid-row-address'>
+										<AddressValue address={bid.bidder} />
+									</div>
+									<span>
+										<CurrencyValue value={bid.ethAmount} suffix='ETH' />
+									</span>
+									<span>
+										<CurrencyValue value={bid.cumulativeEth} suffix='ETH' />
+									</span>
+									<span className='truth-auction-bid-row-status'>
+										<span className={`truth-auction-status-pill ${getTruthAuctionDispositionClassName(disposition.tone)}`}>{disposition.label}</span>
+									</span>
+									{renderBidActionButtons({ bid, disposition })}
+								</div>
+							)
+						})}
+					</div>
+				)}
+				{hasMoreAggregatedAuctionBids ? (
+					<div className='actions'>
+						<button className='secondary' onClick={() => setLoadedAuctionBidPageCount(currentPageCount => currentPageCount + 1)} type='button'>
+							Load More Auction Bids
+						</button>
+					</div>
+				) : undefined}
 			</SectionBlock>
 		)
 	})()
@@ -1476,30 +1888,7 @@ export function ForkAuctionSection({
 									<span className='truth-auction-bid-row-status'>
 										<span className={`truth-auction-status-pill ${getTruthAuctionDispositionClassName(disposition.tone)}`}>{disposition.label}</span>
 									</span>
-									<div className='truth-auction-bid-row-actions'>
-										<button className='secondary' onClick={() => selectTruthAuctionTick(bid.tick)} type='button'>
-											Show Price Level
-										</button>
-										{disposition.canPrefillRefund ? (
-											<button
-												className='secondary'
-												onClick={() =>
-													onForkAuctionFormChange({
-														refundBidIndex: bid.bidIndex.toString(),
-														refundTick: bid.tick.toString(),
-													})
-												}
-												type='button'
-											>
-												Prefill Refund
-											</button>
-										) : undefined}
-										{disposition.canPrefillSettle ? (
-											<button className='secondary' onClick={() => prefillSettleBid(bid)} type='button'>
-												Prefill Settle
-											</button>
-										) : undefined}
-									</div>
+									{renderBidActionButtons({ bid, disposition })}
 								</div>
 							)
 						})}
@@ -1517,95 +1906,41 @@ export function ForkAuctionSection({
 	})()
 	const truthAuctionRefundSection = (() => {
 		if (!shouldShowTruthAuctionVisualization || truthAuctionStatus === undefined || truthAuctionStatus.finalized) return undefined
-		return (
-			<SectionBlock title='Refund Losing Bid' description='Refund a losing bid before finalization when the selected row indicates it is below clearing.'>
-				<div className='truth-auction-panel truth-auction-settlement-panel'>
-					<div className='form-grid'>
-						<div className='field-row'>
-							<label className='field'>
-								<span>Refund Tick</span>
-								<FormInput value={forkAuctionForm.refundTick} onInput={event => onForkAuctionFormChange({ refundTick: event.currentTarget.value })} />
-							</label>
-							<label className='field'>
-								<span>Refund Bid Index</span>
-								<FormInput value={forkAuctionForm.refundBidIndex} onInput={event => onForkAuctionFormChange({ refundBidIndex: event.currentTarget.value })} />
-							</label>
-						</div>
-						<div className='actions'>{renderStageActionButton({ action: 'refundLosingBids', availability: createActionAvailability(refundTruthAuctionBidGuardMessage), idleLabel: 'Refund Losing Bid', onClick: onRefundLosingBids, pendingLabel: 'Refunding losing bid...', tone: 'primary' })}</div>
-					</div>
-				</div>
-			</SectionBlock>
-		)
+		return renderRefundBidSection({
+			description: 'Refund a losing bid before finalization when the selected row indicates it is below clearing.',
+			idleLabel: 'Refund Losing Bid',
+			title: 'Refund Losing Bid',
+			tone: 'primary',
+		})
 	})()
 	const truthAuctionFinalizedSettlementSection = (() => {
 		if (!shouldShowTruthAuctionVisualization || truthAuctionStatus === undefined || !truthAuctionStatus.finalized) return undefined
-		return (
-			<SectionBlock title='Settle Finalized Bid'>
-				<div className='truth-auction-panel truth-auction-settlement-panel'>
-					<div className='form-grid'>
-						<label className='field'>
-							<span>Bidder Address</span>
-							<FormInput value={forkAuctionForm.settlementAddress} onInput={event => onForkAuctionFormChange({ settlementAddress: event.currentTarget.value })} placeholder='Leave empty to use connected wallet' />
-						</label>
-						<div className='field-row'>
-							<label className='field'>
-								<span>Settlement Bid Tick</span>
-								<FormInput value={forkAuctionForm.claimBidTick} onInput={event => onForkAuctionFormChange({ claimBidTick: event.currentTarget.value })} />
-							</label>
-							<label className='field'>
-								<span>Settlement Bid Index</span>
-								<FormInput value={forkAuctionForm.claimBidIndex} onInput={event => onForkAuctionFormChange({ claimBidIndex: event.currentTarget.value })} />
-							</label>
-						</div>
-						<div className='actions'>{renderStageActionButton({ action: 'claimAuctionProceeds', availability: createActionAvailability(settleFinalizedTruthAuctionBidGuardMessage), idleLabel: 'Settle Finalized Bid', onClick: onClaimAuctionProceeds, pendingLabel: 'Settling finalized bid...', tone: 'primary' })}</div>
-					</div>
-				</div>
-			</SectionBlock>
-		)
+		return renderFinalizedSettlementSection({
+			idleLabel: 'Settle Finalized Bid',
+			title: 'Settle Finalized Bid',
+			tone: 'primary',
+		})
 	})()
 	const truthAuctionOperatorToolsSection = (() => {
 		if (!shouldShowTruthAuctionVisualization || truthAuctionStatus === undefined) return undefined
 		return (
 			<ReadOnlyDetailAccordion defaultOpen={false} title='Operator Tools'>
 				<div className='truth-auction-manual-tools'>
-					{truthAuctionStatus.finalized ? undefined : (
-						<SectionBlock density='compact' headingLevel={4} title='Raw Refund Fallback' variant='embedded'>
-							<div className='form-grid'>
-								<div className='field-row'>
-									<label className='field'>
-										<span>Refund Tick</span>
-										<FormInput value={forkAuctionForm.refundTick} onInput={event => onForkAuctionFormChange({ refundTick: event.currentTarget.value })} />
-									</label>
-									<label className='field'>
-										<span>Refund Bid Index</span>
-										<FormInput value={forkAuctionForm.refundBidIndex} onInput={event => onForkAuctionFormChange({ refundBidIndex: event.currentTarget.value })} />
-									</label>
-								</div>
-								<div className='actions'>{renderStageActionButton({ action: 'refundLosingBids', availability: createActionAvailability(refundTruthAuctionBidGuardMessage), idleLabel: 'Run Raw Refund', onClick: onRefundLosingBids, pendingLabel: 'Refunding losing bid...' })}</div>
-							</div>
-						</SectionBlock>
-					)}
-					{!truthAuctionStatus.finalized ? undefined : (
-						<SectionBlock density='compact' headingLevel={4} title='Raw Finalized Settlement' variant='embedded'>
-							<div className='form-grid'>
-								<label className='field'>
-									<span>Bidder Address</span>
-									<FormInput value={forkAuctionForm.settlementAddress} onInput={event => onForkAuctionFormChange({ settlementAddress: event.currentTarget.value })} placeholder='Leave empty to use connected wallet' />
-								</label>
-								<div className='field-row'>
-									<label className='field'>
-										<span>Settlement Bid Tick</span>
-										<FormInput value={forkAuctionForm.claimBidTick} onInput={event => onForkAuctionFormChange({ claimBidTick: event.currentTarget.value })} />
-									</label>
-									<label className='field'>
-										<span>Settlement Bid Index</span>
-										<FormInput value={forkAuctionForm.claimBidIndex} onInput={event => onForkAuctionFormChange({ claimBidIndex: event.currentTarget.value })} />
-									</label>
-								</div>
-								<div className='actions'>{renderStageActionButton({ action: 'claimAuctionProceeds', availability: createActionAvailability(settleFinalizedTruthAuctionBidGuardMessage), idleLabel: 'Run Raw Finalized Settlement', onClick: onClaimAuctionProceeds, pendingLabel: 'Settling finalized bid...' })}</div>
-							</div>
-						</SectionBlock>
-					)}
+					{truthAuctionStatus.finalized
+						? renderFinalizedSettlementSection({
+								density: 'compact',
+								headingLevel: 4,
+								idleLabel: 'Run Raw Finalized Settlement',
+								title: 'Raw Finalized Settlement',
+								variant: 'embedded',
+							})
+						: renderRefundBidSection({
+								density: 'compact',
+								headingLevel: 4,
+								idleLabel: 'Run Raw Refund',
+								title: 'Raw Refund Fallback',
+								variant: 'embedded',
+							})}
 				</div>
 			</ReadOnlyDetailAccordion>
 		)
@@ -1615,7 +1950,9 @@ export function ForkAuctionSection({
 			return (
 				<fieldset className='fork-stage-panel' disabled={disabled}>
 					{selectedStageAheadMessage === undefined ? undefined : <p className='detail'>{selectedStageAheadMessage}</p>}
-					<SectionBlock title='Migration Status'>{renderWorkflowMetricGrid(migrationStatusMetrics)}</SectionBlock>
+					<SectionBlock badge={migrationStatusBadge} title='Migration Status'>
+						{renderWorkflowMetricGrid(migrationStatusMetrics)}
+					</SectionBlock>
 
 					<SectionBlock title='Your Migration Balances' description='Wallet-level balances in the parent pool that may still need migration.'>
 						{migrationBalancesContent}
@@ -1675,37 +2012,37 @@ export function ForkAuctionSection({
 										})}
 									</div>
 								</SectionBlock>
-								<SectionBlock density='compact' headingLevel={4} title='Migrate Vault' description={"Move the connected wallet's REP collateral and security bond allowance into the selected child universe."} variant='embedded'>
-									{connectedWalletVaultSummary !== undefined && !hasWalletVaultMigrationBalance ? <p className='detail'>No REP collateral or security bond allowance remains to migrate for the connected wallet.</p> : undefined}
+								<SectionBlock density='compact' headingLevel={4} title='Migrate Pool To Universe' variant='embedded'>
 									{loadingSelectedOutcomeMigrationSeedStatus ? <p className='detail'>Checking whether pool REP is already ready for the selected child universe.</p> : undefined}
 									{selectedOutcomeMigrationSeedStatusError === undefined || loadingSelectedOutcomeMigrationSeedStatus ? undefined : <p className='detail'>{selectedOutcomeMigrationSeedStatusError}</p>}
 									{loadingSelectedOutcomeMigrationSeedStatus || selectedOutcomeMigrationSeedStatusError !== undefined || selectedOutcomeMigrationSeedStatus === undefined || !selectedOutcomeMigrationSeedStatus.seeded ? undefined : (
-										<p className='detail'>{selectedOutcomeMigrationSeedStatus.childPoolRepBalance > 0n ? 'Pool REP is already available in the selected child universe.' : 'Pool REP for this outcome is already staged and will sweep into the child universe during vault migration.'}</p>
+										<p className='detail'>{selectedOutcomeMigrationSeedStatus.childPoolRepBalance > 0n ? 'Pool REP has already been migrated to the selected child universe.' : 'Pool REP for this outcome is already staged and will sweep into the child universe during vault migration.'}</p>
 									)}
-									{loadingSelectedOutcomeMigrationSeedStatus || selectedOutcomeMigrationSeedStatusError !== undefined || selectedOutcomeMigrationSeedStatus === undefined || selectedOutcomeMigrationSeedStatus.seeded ? undefined : (
-										<>
-											<p className='detail'>This child outcome is not seeded with parent-pool REP yet. Migrate the pool REP first, then move your vault balances.</p>
-											<div className='actions'>
-												{renderStageActionButton({
-													action: 'migrateRepToZoltar',
-													idleLabel: `Migrate Collateral To ${selectedOutcomeLabel} Universe`,
-													onClick: onMigrateSelectedOutcomeRepToZoltar,
-													pendingLabel: 'Migrating pool REP...',
-												})}
-											</div>
-										</>
-									)}
+									<div className='actions'>
+										{renderStageActionButton({
+											action: 'migrateRepToZoltar',
+											availability: createActionAvailability(migratePoolToUniverseGuardMessage),
+											idleLabel: `Migrate Pool To ${selectedOutcomeLabel} Universe`,
+											onClick: onMigrateSelectedOutcomeRepToZoltar,
+											pendingLabel: 'Migrating pool to universe...',
+										})}
+									</div>
+								</SectionBlock>
+								<SectionBlock density='compact' headingLevel={4} title='Migrate Vault' variant='embedded'>
+									{connectedWalletVaultSummary !== undefined && !hasWalletVaultMigrationBalance ? <p className='detail'>No REP collateral or security bond allowance remains to migrate for the connected wallet.</p> : undefined}
+									{loadingSelectedOutcomeMigrationSeedStatus ? <p className='detail'>Checking whether pool REP is already ready for the selected child universe.</p> : undefined}
+									{selectedOutcomeMigrationSeedStatusError === undefined || loadingSelectedOutcomeMigrationSeedStatus ? undefined : <p className='detail'>{selectedOutcomeMigrationSeedStatusError}</p>}
 									<div className='actions'>
 										{renderStageActionButton({
 											action: 'migrateVault',
 											availability: createActionAvailability(migrateVaultGuardMessage),
-											idleLabel: 'Migrate Vault',
+											idleLabel: `Migrate Vault To ${selectedOutcomeLabel}`,
 											onClick: onMigrateVaultSubmit,
 											pendingLabel: 'Migrating vault...',
 											tone: 'primary',
 										})}
 									</div>
-									{isVaultMigrationCompleteForSelectedOutcome ? <p className='detail'>Already migrated</p> : undefined}
+									{isVaultMigrationComplete ? <p className='detail'>Already migrated</p> : undefined}
 								</SectionBlock>
 							</>
 						)}
@@ -1719,38 +2056,30 @@ export function ForkAuctionSection({
 					return (
 						<fieldset className='fork-stage-panel' disabled={disabled}>
 							{selectedStageAheadMessage === undefined ? undefined : <p className='detail'>{selectedStageAheadMessage}</p>}
+							{auctionOutcomeSelector}
+							{selectedAuctionDetailsNotice}
+							{truthAuctionEndedNotice}
 							{truthAuctionHero}
 							{truthAuctionMarketViewSection}
+							{auctionWideBidsSection}
 							<div className='truth-auction-stage-actions'>
-								<SectionBlock title='Submit Bid' description='Enter the tick and ETH amount you want to place into the auction. The ladder above can prefill a tick directly into this form.'>
-									<div className='form-grid'>
-										{submitBidPreviewTickSummary === undefined ? undefined : (
-											<p className='detail'>
-												Selected ladder price: Tick {submitBidPreviewTickSummary.tick.toString()} at <CurrencyValue value={submitBidPreviewTickSummary.price} suffix='ETH / REP' />
-											</p>
-										)}
-										<div className='field-row'>
-											<label className='field'>
-												<span>Bid Tick</span>
-												<FormInput value={forkAuctionForm.submitBidTick} onInput={event => onForkAuctionFormChange({ submitBidTick: event.currentTarget.value })} />
-											</label>
-											<label className='field'>
-												<span>Bid Amount (ETH)</span>
-												<FormInput value={forkAuctionForm.submitBidAmount} onInput={event => onForkAuctionFormChange({ submitBidAmount: event.currentTarget.value })} />
-											</label>
-										</div>
-										{selectedAuctionPrice === undefined ? undefined : <p className='detail'>At the current clearing price, this bid would buy roughly {estimatedRep === undefined ? UNKNOWN_VALUE : <CurrencyValue value={estimatedRep} suffix='REP' />} if it clears.</p>}
+								{renderSubmitBidSection({
+									description: 'Enter the price and ETH amount you want to place into the auction. The ladder above can prefill a price directly into this form.',
+								})}
+								{truthAuctionStatus.finalized ? undefined : (
+									<SectionBlock title='Finalize Truth Auction' description='Finalize the auction once bidding has closed so finalized settlements can settle against the final clearing result.'>
 										<div className='actions'>
 											{renderStageActionButton({
-												action: 'submitBid',
-												availability: createActionAvailability(truthAuctionBidGuardMessage),
-												idleLabel: 'Submit Bid',
-												onClick: onSubmitBid,
-												pendingLabel: 'Submitting bid...',
+												action: 'finalizeTruthAuction',
+												availability: createActionAvailability(finalizeTruthAuctionGuardMessage),
+												forceEnabled: hasSelectedAuctionChildPool,
+												idleLabel: 'Finalize Truth Auction',
+												onClick: onFinalizeTruthAuctionForSelectedAuction,
+												pendingLabel: 'Finalizing truth auction...',
 											})}
 										</div>
-									</div>
-								</SectionBlock>
+									</SectionBlock>
+								)}
 								{viewerTruthAuctionBidsSection}
 							</div>
 						</fieldset>
@@ -1758,44 +2087,44 @@ export function ForkAuctionSection({
 				return (
 					<fieldset className='fork-stage-panel' disabled={disabled}>
 						{selectedStageAheadMessage === undefined ? undefined : <p className='detail'>{selectedStageAheadMessage}</p>}
+						{auctionOutcomeSelector}
+						{selectedAuctionChildPoolNotice}
+						{selectedAuctionDetailsNotice}
+						{truthAuctionEndedNotice}
 						<SectionBlock title='Auction Status'>{renderWorkflowMetricGrid(auctionStatusMetrics)}</SectionBlock>
 
 						<SectionBlock title='Start Truth Auction'>
 							{startTruthAuctionReadyInText === undefined ? undefined : <p className='detail'>{startTruthAuctionReadyInText}</p>}
+							{truthAuctionBypassReason === undefined ? undefined : <p className='detail'>{truthAuctionBypassReason}</p>}
 							<div className='actions'>
 								{renderStageActionButton({
 									action: 'startTruthAuction',
-									availability: createActionAvailability(startTruthAuctionAvailabilityMessage),
-									idleLabel: 'Start Truth Auction',
+									availability: createActionAvailability(!hasSelectedAuctionChildPool ? `Child universe not created for the ${selectedAuctionLabel} outcome yet.` : startTruthAuctionAvailabilityMessage),
+									forceEnabled: hasSelectedAuctionChildPool,
+									idleLabel: truthAuctionBypassReason === undefined ? 'Start Truth Auction' : 'Bypass Auction',
 									onClick: onStartTruthAuctionSubmit,
-									pendingLabel: 'Starting truth auction...',
+									pendingLabel: truthAuctionBypassReason === undefined ? 'Starting truth auction...' : 'Bypassing auction...',
 									tone: 'primary',
 								})}
 							</div>
 						</SectionBlock>
 
-						<SectionBlock title='Submit Bid'>
-							<div className='form-grid'>
-								<label className='field'>
-									<span>Bid Tick</span>
-									<FormInput value={forkAuctionForm.submitBidTick} onInput={event => onForkAuctionFormChange({ submitBidTick: event.currentTarget.value })} />
-								</label>
-								<label className='field'>
-									<span>Bid Amount (ETH)</span>
-									<FormInput value={forkAuctionForm.submitBidAmount} onInput={event => onForkAuctionFormChange({ submitBidAmount: event.currentTarget.value })} />
-								</label>
-								{selectedAuctionPrice === undefined ? undefined : <p className='detail'>At the current clearing price, this bid would buy roughly {estimatedRep === undefined ? UNKNOWN_VALUE : <CurrencyValue value={estimatedRep} suffix='REP' />} if it clears.</p>}
+						{renderSubmitBidSection({})}
+
+						{truthAuctionStatus?.finalized ? undefined : (
+							<SectionBlock title='Finalize Truth Auction'>
 								<div className='actions'>
 									{renderStageActionButton({
-										action: 'submitBid',
-										availability: createActionAvailability(truthAuctionBidGuardMessage),
-										idleLabel: 'Submit Bid',
-										onClick: onSubmitBid,
-										pendingLabel: 'Submitting bid...',
+										action: 'finalizeTruthAuction',
+										availability: createActionAvailability(finalizeTruthAuctionGuardMessage),
+										forceEnabled: hasSelectedAuctionChildPool,
+										idleLabel: 'Finalize Truth Auction',
+										onClick: onFinalizeTruthAuctionForSelectedAuction,
+										pendingLabel: 'Finalizing truth auction...',
 									})}
 								</div>
-							</div>
-						</SectionBlock>
+							</SectionBlock>
+						)}
 					</fieldset>
 				)
 			}
@@ -1804,13 +2133,12 @@ export function ForkAuctionSection({
 					return (
 						<fieldset className='fork-stage-panel' disabled={disabled}>
 							{selectedStageAheadMessage === undefined ? undefined : <p className='detail'>{selectedStageAheadMessage}</p>}
+							{auctionOutcomeSelector}
+							{selectedAuctionDetailsNotice}
+							{truthAuctionEndedNotice}
 							{truthAuctionHero}
+							{auctionWideBidsSection}
 							{viewerTruthAuctionBidsSection}
-							{truthAuctionStatus?.finalized ? undefined : (
-								<SectionBlock title='Finalize Truth Auction' description='Finalize the auction once bidding has closed so finalized settlements can settle against the final clearing result.'>
-									<div className='actions'>{renderStageActionButton({ action: 'finalizeTruthAuction', availability: createActionAvailability(finalizeTruthAuctionGuardMessage), idleLabel: 'Finalize Truth Auction', onClick: onFinalizeTruthAuction, pendingLabel: 'Finalizing truth auction...' })}</div>
-								</SectionBlock>
-							)}
 							{truthAuctionRefundSection}
 							{truthAuctionFinalizedSettlementSection}
 							{truthAuctionMarketViewSection}
@@ -1820,53 +2148,13 @@ export function ForkAuctionSection({
 				return (
 					<fieldset className='fork-stage-panel' disabled={disabled}>
 						{selectedStageAheadMessage === undefined ? undefined : <p className='detail'>{selectedStageAheadMessage}</p>}
+						{auctionOutcomeSelector}
+						{selectedAuctionChildPoolNotice}
+						{selectedAuctionDetailsNotice}
+						{truthAuctionEndedNotice}
 						<SectionBlock title='Settlement Status'>{renderWorkflowMetricGrid(settlementStatusMetrics)}</SectionBlock>
-
-						{truthAuctionStatus?.finalized ? undefined : (
-							<SectionBlock title='Finalize Truth Auction'>
-								<div className='actions'>{renderStageActionButton({ action: 'finalizeTruthAuction', availability: createActionAvailability(finalizeTruthAuctionGuardMessage), idleLabel: 'Finalize Truth Auction', onClick: onFinalizeTruthAuction, pendingLabel: 'Finalizing truth auction...' })}</div>
-							</SectionBlock>
-						)}
-
-						{truthAuctionStatus?.finalized ? undefined : (
-							<SectionBlock title='Refund Losing Bid'>
-								<div className='form-grid'>
-									<label className='field'>
-										<span>Refund Tick</span>
-										<FormInput value={forkAuctionForm.refundTick} onInput={event => onForkAuctionFormChange({ refundTick: event.currentTarget.value })} />
-									</label>
-									<label className='field'>
-										<span>Refund Bid Index</span>
-										<FormInput value={forkAuctionForm.refundBidIndex} onInput={event => onForkAuctionFormChange({ refundBidIndex: event.currentTarget.value })} />
-									</label>
-									<div className='actions'>{renderStageActionButton({ action: 'refundLosingBids', availability: createActionAvailability(refundTruthAuctionBidGuardMessage), idleLabel: 'Refund Losing Bid', onClick: onRefundLosingBids, pendingLabel: 'Refunding losing bid...', tone: 'primary' })}</div>
-								</div>
-							</SectionBlock>
-						)}
-
-						{!truthAuctionStatus?.finalized ? undefined : (
-							<SectionBlock title='Settle Finalized Bid'>
-								<div className='form-grid'>
-									<label className='field'>
-										<span>Bidder Address</span>
-										<FormInput value={forkAuctionForm.settlementAddress} onInput={event => onForkAuctionFormChange({ settlementAddress: event.currentTarget.value })} placeholder='Leave empty to use connected wallet' />
-									</label>
-									<div className='field-row'>
-										<label className='field'>
-											<span>Settlement Bid Tick</span>
-											<FormInput value={forkAuctionForm.claimBidTick} onInput={event => onForkAuctionFormChange({ claimBidTick: event.currentTarget.value })} />
-										</label>
-										<label className='field'>
-											<span>Settlement Bid Index</span>
-											<FormInput value={forkAuctionForm.claimBidIndex} onInput={event => onForkAuctionFormChange({ claimBidIndex: event.currentTarget.value })} />
-										</label>
-									</div>
-									<div className='actions'>
-										{renderStageActionButton({ action: 'claimAuctionProceeds', availability: createActionAvailability(settleFinalizedTruthAuctionBidGuardMessage), idleLabel: 'Settle Finalized Bid', onClick: onClaimAuctionProceeds, pendingLabel: 'Settling finalized bid...', tone: 'primary' })}
-									</div>
-								</div>
-							</SectionBlock>
-						)}
+						{truthAuctionStatus?.finalized ? undefined : renderRefundBidSection({ idleLabel: 'Refund Losing Bid', title: 'Refund Losing Bid', tone: 'primary' })}
+						{!truthAuctionStatus?.finalized ? undefined : renderFinalizedSettlementSection({ idleLabel: 'Settle Finalized Bid', title: 'Settle Finalized Bid', tone: 'primary' })}
 					</fieldset>
 				)
 			}

--- a/ui/ts/components/RequirementsChecklist.tsx
+++ b/ui/ts/components/RequirementsChecklist.tsx
@@ -12,7 +12,7 @@ export function RequirementsChecklist({ items }: RequirementsChecklistProps) {
 		<ul className='requirements-checklist'>
 			{blockedItems.map(item => (
 				<li key={item.key} className='blocked'>
-					<strong>Blocked:</strong> {item.label}
+					{item.label}
 					{item.detail === undefined ? undefined : <span> {item.detail}</span>}
 				</li>
 			))}

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'preact/hooks'
+import { getAddress } from 'viem'
 import { AddressValue } from './AddressValue.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { ErrorNotice } from './ErrorNotice.js'
@@ -52,7 +53,7 @@ import { getLiquidationNoticeState } from '../lib/liquidationStatus.js'
 import { resolveRequestedLoadableValueState } from '../lib/loadState.js'
 import { isMainnetChain } from '../lib/network.js'
 import { getReportingLockedUntilMessage } from '../lib/reporting.js'
-import { getSecurityPoolLifecycleLabel } from '../lib/securityPoolLabels.js'
+import { getSecurityPoolStatusBadgeLabel } from '../lib/securityPoolLabels.js'
 import { deriveSecurityPoolLifecycleState, deriveSecurityPoolReportingStage, evaluateSecurityPoolState, type SecurityPoolLifecycleState } from '../lib/securityPoolState.js'
 import { getVaultExecutePendingOperationGuardMessage, getVaultRequestPriceGuardMessage } from '../lib/securityVaultGuards.js'
 import { doesLoadedSecurityVaultMatchSelection, getSelectedVaultAddress, isSelectedVaultOwnedByAccount as isSelectedVaultOwnedByAccountHelper } from '../lib/securityVault.js'
@@ -399,7 +400,7 @@ export function SecurityPoolWorkflowSection({
 		if (!isSelectedPoolForkStageView(view) || !showSelectedPoolWorkflowDetails || normalizedSelectedPoolAddress === undefined) return
 		if (sameAddress(forkAuction.forkAuctionDetails?.securityPoolAddress, normalizedSelectedPoolAddress)) return
 		if (forkAuction.loadingForkAuctionDetails) return
-		void forkAuction.onLoadForkAuction()
+		void forkAuction.onLoadForkAuction(getAddress(normalizedSelectedPoolAddress))
 	}, [forkAuction.forkAuctionDetails?.securityPoolAddress, forkAuction.loadingForkAuctionDetails, forkAuction.onLoadForkAuction, selectedPool?.securityPoolAddress, showSelectedPoolWorkflowDetails, view])
 	useEffect(() => {
 		const reportingRefreshHash = reporting.reportingResult?.hash
@@ -423,13 +424,16 @@ export function SecurityPoolWorkflowSection({
 		if (lastForkAuctionOutcomeRefreshHash.current === forkAuctionRefreshHash) return
 		lastForkAuctionOutcomeRefreshHash.current = forkAuctionRefreshHash
 		void onRefreshSelectedPoolData(nextForkAuctionResult.securityPoolAddress)
+		if (showSelectedPoolWorkflowDetails && nextForkAuctionResult.action === 'startTruthAuction') {
+			void forkAuction.onLoadForkAuction(nextForkAuctionResult.securityPoolAddress)
+		}
 		if (showSelectedPoolWorkflowDetails && hasLoadedCurrentVault && (nextForkAuctionResult.action === 'claimAuctionProceeds' || nextForkAuctionResult.action === 'migrateEscalationDeposits' || nextForkAuctionResult.action === 'migrateVault' || nextForkAuctionResult.action === 'startTruthAuction')) {
 			void securityVault.onLoadSecurityVault()
 		}
 		if (shouldRefreshSelectedPoolReporting && (nextForkAuctionResult.action === 'migrateEscalationDeposits' || nextForkAuctionResult.action === 'forkWithOwnEscalation' || nextForkAuctionResult.action === 'startTruthAuction')) {
 			void reporting.onLoadReporting()
 		}
-	}, [forkAuction.forkAuctionResult, hasLoadedCurrentVault, onRefreshSelectedPoolData, reporting.onLoadReporting, securityVault.onLoadSecurityVault, shouldRefreshSelectedPoolReporting, showSelectedPoolWorkflowDetails])
+	}, [forkAuction.forkAuctionResult, forkAuction.onLoadForkAuction, hasLoadedCurrentVault, onRefreshSelectedPoolData, reporting.onLoadReporting, securityVault.onLoadSecurityVault, shouldRefreshSelectedPoolReporting, showSelectedPoolWorkflowDetails])
 	useEffect(() => {
 		const vaultStatusRefreshHash = securityVault.securityVaultResult?.action === 'depositRep' || securityVault.securityVaultResult?.action === 'redeemRep' ? securityVault.securityVaultResult.hash : undefined
 		if (vaultStatusRefreshHash === undefined) {
@@ -547,10 +551,10 @@ export function SecurityPoolWorkflowSection({
 	return (
 		<RouteWorkflowPanel showHeader={showHeader} title='Selected Pool'>
 			<StickyObjectContext
-				{...(loadedSelectedPool === undefined
+				{...(loadedSelectedPool === undefined || selectedPoolSummaryPool === undefined
 					? {}
 					: {
-							badge: <span className={`badge ${getSecurityPoolStatusBadgeTone(selectedPoolStateModel.lifecycleState)}`}>{getSecurityPoolLifecycleLabel(selectedPoolStateModel.lifecycleState)}</span>,
+							badge: <span className={`badge ${getSecurityPoolStatusBadgeTone(selectedPoolStateModel.lifecycleState)}`}>{getSecurityPoolStatusBadgeLabel({ hasForkActivity: selectedPoolSummaryPool.hasForkActivity, lifecycleState: selectedPoolStateModel.lifecycleState })}</span>,
 						})}
 				sticky={false}
 				title={getSelectedPoolCardTitle()}

--- a/ui/ts/components/SecurityPoolsOverviewSection.tsx
+++ b/ui/ts/components/SecurityPoolsOverviewSection.tsx
@@ -16,7 +16,7 @@ import { TransactionStatusCard } from './TransactionStatusCard.js'
 import { WorkflowSubsection } from './WorkflowSubsection.js'
 import { sameAddress } from '../lib/address.js'
 import { isMainnetChain } from '../lib/network.js'
-import { getSecurityPoolLifecycleLabel } from '../lib/securityPoolLabels.js'
+import { getSecurityPoolStatusBadgeLabel } from '../lib/securityPoolLabels.js'
 import { deriveSecurityPoolLifecycleState, evaluateSecurityPoolState, type SecurityPoolLifecycleState } from '../lib/securityPoolState.js'
 import { getPoolRegistryPresentation } from '../lib/userCopy.js'
 import type { SecurityPoolsOverviewSectionProps } from '../types/components.js'
@@ -161,7 +161,7 @@ export function SecurityPoolsOverviewSection({
 										key={pool.securityPoolAddress}
 										title={getQuestionTitle(pool.marketDetails)}
 										variant='record'
-										badge={<span className={`badge ${badgeTone}`}>{getSecurityPoolLifecycleLabel(displayState)}</span>}
+										badge={<span className={`badge ${badgeTone}`}>{getSecurityPoolStatusBadgeLabel({ hasForkActivity: pool.hasForkActivity, lifecycleState: displayState })}</span>}
 										actions={
 											onSelectSecurityPool === undefined ? undefined : (
 												<button className='primary' onClick={() => onSelectSecurityPool(pool.securityPoolAddress)}>

--- a/ui/ts/hooks/useForkAuctionOperations.ts
+++ b/ui/ts/hooks/useForkAuctionOperations.ts
@@ -19,19 +19,22 @@ import {
 } from '../contracts.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
 import { getErrorMessage } from '../lib/errors.js'
-import { getTruthAuctionBidGuardMessage } from '../lib/forkAuction.js'
+import { getTruthAuctionBidGuardMessage, getTruthAuctionTickAtPrice } from '../lib/forkAuction.js'
 import { getReportingOutcomeKey, parseAddressInput, parseBigIntListInput, parseReportingOutcomeInput, parseReportingOutcomeListInput, resolveOptionalAddressInput } from '../lib/inputs.js'
+import { sameAddress } from '../lib/address.js'
 import { createErrorActionFeedback, createPendingActionFeedback, createSuccessActionFeedback, createWarningActionFeedback } from '../lib/actionFeedback.js'
 import { requireDefined } from '../lib/required.js'
 import { buildWriteActionConfig, runWriteAction } from '../lib/writeAction.js'
-import { getDefaultForkAuctionFormState, parseBigIntInput } from '../lib/marketForm.js'
+import { getDefaultForkAuctionFormState, parseBigIntInput, parseTruthAuctionPriceInput } from '../lib/marketForm.js'
 import type { ForkAuctionFormState, WriteOperationsParameters } from '../types/app.js'
 import type { ActionFeedback } from '../types/components.js'
 import type { ForkAuctionActionResult, ForkAuctionDetails, ReportingOutcomeKey } from '../types/contracts.js'
 
-type UseForkAuctionOperationsParameters = WriteOperationsParameters
+type UseForkAuctionOperationsParameters = WriteOperationsParameters & {
+	selectedSecurityPoolAddress?: string
+}
 
-export function useForkAuctionOperations({ accountAddress, onTransaction, onTransactionFinished, onTransactionRequested, onTransactionSubmitted, refreshState }: UseForkAuctionOperationsParameters) {
+export function useForkAuctionOperations({ accountAddress, onTransaction, onTransactionFinished, onTransactionRequested, onTransactionSubmitted, refreshState, selectedSecurityPoolAddress }: UseForkAuctionOperationsParameters) {
 	const forkAuctionDetails = useSignal<ForkAuctionDetails | undefined>(undefined)
 	const forkAuctionActiveAction = useSignal<ForkAuctionActionResult['action'] | undefined>(undefined)
 	const forkAuctionFeedback = useSignal<ActionFeedback<ForkAuctionActionResult['action']> | undefined>(undefined)
@@ -45,14 +48,15 @@ export function useForkAuctionOperations({ accountAddress, onTransaction, onTran
 	}
 	const getSuccessTitle = (actionName: ForkAuctionActionResult['action']) => `${getPendingTitle(actionName)} submitted`
 	const getFailureTitle = (actionName: ForkAuctionActionResult['action']) => `${getPendingTitle(actionName)} failed`
+	const resolveForkAuctionSecurityPoolAddress = () => parseAddressInput(selectedSecurityPoolAddress?.trim() === '' || selectedSecurityPoolAddress === undefined ? forkAuctionForm.value.securityPoolAddress : selectedSecurityPoolAddress, 'Security pool address')
 
-	const loadForkAuction = async () => {
+	const loadForkAuction = async (securityPoolAddressOverride?: Address) => {
 		await forkAuctionLoad.run({
 			onStart: () => {
 				forkAuctionError.value = undefined
 			},
 			load: async () => {
-				const securityPoolAddress = parseAddressInput(forkAuctionForm.value.securityPoolAddress, 'Security pool address')
+				const securityPoolAddress = securityPoolAddressOverride ?? resolveForkAuctionSecurityPoolAddress()
 				return await loadForkAuctionDetails(createConnectedReadClient(), securityPoolAddress)
 			},
 			onSuccess: details => {
@@ -65,7 +69,7 @@ export function useForkAuctionOperations({ accountAddress, onTransaction, onTran
 		})
 	}
 
-	const runForkAuctionAction = async (actionName: ForkAuctionActionResult['action'], action: (walletAddress: Address, details: ForkAuctionDetails) => Promise<ForkAuctionActionResult>, errorFallback: string) => {
+	const runForkAuctionAction = async (actionName: ForkAuctionActionResult['action'], action: (walletAddress: Address, details: ForkAuctionDetails) => Promise<ForkAuctionActionResult>, errorFallback: string, securityPoolAddressOverride?: Address) => {
 		try {
 			forkAuctionActiveAction.value = actionName
 			forkAuctionFeedback.value = createPendingActionFeedback(actionName, getPendingTitle(actionName))
@@ -81,14 +85,18 @@ export function useForkAuctionOperations({ accountAddress, onTransaction, onTran
 				},
 				async walletAddress => {
 					forkAuctionResult.value = undefined
-					const details = forkAuctionDetails.value ?? (await loadForkAuctionDetails(createConnectedReadClient(), parseAddressInput(forkAuctionForm.value.securityPoolAddress, 'Security pool address')))
+					const resolvedSecurityPoolAddress = securityPoolAddressOverride ?? resolveForkAuctionSecurityPoolAddress()
+					const canReuseLoadedDetails = securityPoolAddressOverride === undefined && forkAuctionDetails.value !== undefined && sameAddress(forkAuctionDetails.value.securityPoolAddress, resolvedSecurityPoolAddress)
+					const details = canReuseLoadedDetails ? requireDefined(forkAuctionDetails.value, 'Fork auction details unavailable') : await loadForkAuctionDetails(createConnectedReadClient(), resolvedSecurityPoolAddress)
 					return await action(walletAddress, details)
 				},
 				errorFallback,
 				async result => {
 					forkAuctionResult.value = result
 					forkAuctionFeedback.value = createSuccessActionFeedback(actionName, getSuccessTitle(actionName), result.hash)
-					forkAuctionDetails.value = await loadForkAuctionDetails(createConnectedReadClient(), result.securityPoolAddress)
+					if (securityPoolAddressOverride === undefined || sameAddress(result.securityPoolAddress, resolveForkAuctionSecurityPoolAddress())) {
+						forkAuctionDetails.value = await loadForkAuctionDetails(createConnectedReadClient(), result.securityPoolAddress)
+					}
 				},
 			)
 		} finally {
@@ -131,9 +139,10 @@ export function useForkAuctionOperations({ accountAddress, onTransaction, onTran
 			'Failed to migrate escalation deposits',
 		)
 
-	const startTruthAuction = async () => await runForkAuctionAction('startTruthAuction', async (walletAddress, details) => await startTruthAuctionForSecurityPool(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), details.securityPoolAddress, details.universeId), 'Failed to start truth auction')
+	const startTruthAuction = async (securityPoolAddressOverride?: Address) =>
+		await runForkAuctionAction('startTruthAuction', async (walletAddress, details) => await startTruthAuctionForSecurityPool(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), details.securityPoolAddress, details.universeId), 'Failed to start truth auction', securityPoolAddressOverride)
 
-	const submitBid = async () =>
+	const submitBid = async (securityPoolAddressOverride?: Address) =>
 		await runForkAuctionAction(
 			'submitBid',
 			async (walletAddress, details) => {
@@ -148,12 +157,16 @@ export function useForkAuctionOperations({ accountAddress, onTransaction, onTran
 				})
 				if (bidGuardMessage !== undefined) throw new Error(bidGuardMessage)
 				const truthAuctionAddress = requireDefined(details.truthAuctionAddress, 'Truth auction not available')
-				return await submitTruthAuctionBid(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), details.securityPoolAddress, details.universeId, truthAuctionAddress, parseBigIntInput(forkAuctionForm.value.submitBidTick, 'Bid tick'), parseBigIntInput(forkAuctionForm.value.submitBidAmount, 'Bid amount'))
+				const bidPrice = parseTruthAuctionPriceInput(forkAuctionForm.value.submitBidPrice, 'Bid price')
+				const bidTick = getTruthAuctionTickAtPrice(bidPrice)
+				if (bidTick === undefined) throw new Error('Enter a valid bid price.')
+				return await submitTruthAuctionBid(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), details.securityPoolAddress, details.universeId, truthAuctionAddress, bidTick, parseBigIntInput(forkAuctionForm.value.submitBidAmount, 'Bid amount'))
 			},
 			'Failed to submit truth auction bid',
+			securityPoolAddressOverride,
 		)
 
-	const refundLosingBids = async () =>
+	const refundLosingBids = async (securityPoolAddressOverride?: Address) =>
 		await runForkAuctionAction(
 			'refundLosingBids',
 			async (walletAddress, details) => {
@@ -168,11 +181,13 @@ export function useForkAuctionOperations({ accountAddress, onTransaction, onTran
 				)
 			},
 			'Failed to refund losing bids',
+			securityPoolAddressOverride,
 		)
 
-	const finalizeTruthAuction = async () => await runForkAuctionAction('finalizeTruthAuction', async (walletAddress, details) => await finalizeSecurityPoolTruthAuction(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), details.securityPoolAddress, details.universeId), 'Failed to finalize truth auction')
+	const finalizeTruthAuction = async (securityPoolAddressOverride?: Address) =>
+		await runForkAuctionAction('finalizeTruthAuction', async (walletAddress, details) => await finalizeSecurityPoolTruthAuction(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), details.securityPoolAddress, details.universeId), 'Failed to finalize truth auction', securityPoolAddressOverride)
 
-	const claimAuctionProceeds = async () =>
+	const claimAuctionProceeds = async (securityPoolAddressOverride?: Address) =>
 		await runForkAuctionAction(
 			'claimAuctionProceeds',
 			async (walletAddress, details) => {
@@ -187,6 +202,7 @@ export function useForkAuctionOperations({ accountAddress, onTransaction, onTran
 				)
 			},
 			'Failed to settle finalized bid',
+			securityPoolAddressOverride,
 		)
 
 	const forkUniverse = async () =>

--- a/ui/ts/hooks/useReportingOperations.ts
+++ b/ui/ts/hooks/useReportingOperations.ts
@@ -17,6 +17,9 @@ import type { ActionFeedback } from '../types/components.js'
 import type { ReportingActionResult, ReportingDetails, ReportingOutcomeKey } from '../types/contracts.js'
 
 type UseReportingOperationsParameters = WriteOperationsParameters
+type ResolvedReportingOperationsParameters = UseReportingOperationsParameters & {
+	selectedSecurityPoolAddress?: string
+}
 
 function getAvailableWithdrawDepositIndexes(details: ReportingDetails, outcome: ReportingOutcomeKey) {
 	if (details.status !== 'active') return []
@@ -46,7 +49,7 @@ function pruneSelectedWithdrawDepositIndexesByOutcome(currentSelections: Reporti
 	}
 }
 
-export function useReportingOperations({ accountAddress, onTransaction, onTransactionFinished, onTransactionRequested, onTransactionSubmitted, refreshState }: UseReportingOperationsParameters) {
+export function useReportingOperations({ accountAddress, onTransaction, onTransactionFinished, onTransactionRequested, onTransactionSubmitted, refreshState, selectedSecurityPoolAddress }: ResolvedReportingOperationsParameters) {
 	const reportingLoad = useLoadController()
 	const reportingDetails = useSignal<ReportingDetails | undefined>(undefined)
 	const reportingError = useSignal<string | undefined>(undefined)
@@ -65,6 +68,8 @@ export function useReportingOperations({ accountAddress, onTransaction, onTransa
 		throw new Error('Select an outcome side before reporting on a market.')
 	}
 
+	const resolveReportingSecurityPoolAddress = () => parseAddressInput(selectedSecurityPoolAddress?.trim() === '' || selectedSecurityPoolAddress === undefined ? reportingForm.value.securityPoolAddress : selectedSecurityPoolAddress, 'Security pool address')
+
 	const loadReporting = async () => {
 		const isCurrent = nextReportingLoad()
 		await reportingLoad.run({
@@ -73,7 +78,7 @@ export function useReportingOperations({ accountAddress, onTransaction, onTransa
 				reportingError.value = undefined
 			},
 			load: async () => {
-				const securityPoolAddress = parseAddressInput(reportingForm.value.securityPoolAddress, 'Security pool address')
+				const securityPoolAddress = resolveReportingSecurityPoolAddress()
 				return await loadReportingDetails(createConnectedReadClient(), securityPoolAddress, accountAddress)
 			},
 			onSuccess: details => {
@@ -104,15 +109,14 @@ export function useReportingOperations({ accountAddress, onTransaction, onTransa
 				},
 				async walletAddress => {
 					reportingResult.value = undefined
-					const securityPoolAddress = parseAddressInput(currentForm.securityPoolAddress, 'Security pool address')
+					const securityPoolAddress = resolveReportingSecurityPoolAddress()
 					return await action(walletAddress, securityPoolAddress, currentForm)
 				},
 				errorFallback,
 				async result => {
 					reportingResult.value = result
 					reportingFeedback.value = createSuccessActionFeedback(actionName, getSuccessTitle(actionName), result.hash)
-					const securityPoolAddress = parseAddressInput(currentForm.securityPoolAddress, 'Security pool address')
-					const details = await loadReportingDetails(createConnectedReadClient(), securityPoolAddress, accountAddress)
+					const details = await loadReportingDetails(createConnectedReadClient(), result.securityPoolAddress, accountAddress)
 					reportingDetails.value = details
 					setReportingForm(current => {
 						const selectedWithdrawDepositIndexesByOutcome = pruneSelectedWithdrawDepositIndexesByOutcome(current.selectedWithdrawDepositIndexesByOutcome, details)

--- a/ui/ts/hooks/useSecurityVaultOperations.ts
+++ b/ui/ts/hooks/useSecurityVaultOperations.ts
@@ -24,9 +24,10 @@ import type { SecurityVaultActionResult, SecurityVaultDetails } from '../types/c
 
 type UseSecurityVaultOperationsParameters = WriteOperationsParameters & {
 	enabled: boolean
+	selectedSecurityPoolAddress?: string
 }
 
-export function useSecurityVaultOperations({ accountAddress, enabled, onTransaction, onTransactionFinished, onTransactionRequested, onTransactionSubmitted, refreshState }: UseSecurityVaultOperationsParameters) {
+export function useSecurityVaultOperations({ accountAddress, enabled, onTransaction, onTransactionFinished, onTransactionRequested, onTransactionSubmitted, refreshState, selectedSecurityPoolAddress }: UseSecurityVaultOperationsParameters) {
 	const securityVaultLoad = useLoadController()
 	const securityVaultDetails = useSignal<SecurityVaultDetails | undefined>(undefined)
 	const securityVaultMissing = useSignal(false)
@@ -40,7 +41,8 @@ export function useSecurityVaultOperations({ accountAddress, enabled, onTransact
 	const nextSecurityVaultLoad = useRequestGuard()
 	const lastEffectiveVaultSelectionKey = useRef<string | undefined>(undefined)
 	const effectiveSelectedVaultAddress = getSelectedVaultAddress(securityVaultForm.value.selectedVaultAddress, accountAddress)
-	const effectiveVaultSelectionKey = `${normalizeAddress(securityVaultForm.value.securityPoolAddress) ?? ''}:${normalizeAddress(effectiveSelectedVaultAddress) ?? ''}`
+	const effectiveSecurityPoolAddressInput = selectedSecurityPoolAddress?.trim() === '' || selectedSecurityPoolAddress === undefined ? securityVaultForm.value.securityPoolAddress : selectedSecurityPoolAddress
+	const effectiveVaultSelectionKey = `${normalizeAddress(effectiveSecurityPoolAddressInput) ?? ''}:${normalizeAddress(effectiveSelectedVaultAddress) ?? ''}`
 	const getPendingTitle = (actionName: SecurityVaultActionResult['action']) => {
 		switch (actionName) {
 			case 'approveRep':
@@ -123,6 +125,7 @@ export function useSecurityVaultOperations({ accountAddress, enabled, onTransact
 		const selectedVaultAddress = requireDefined(getSelectedVaultAddress(securityVaultForm.value.selectedVaultAddress, accountAddress), 'Enter a vault address or connect a wallet before loading a security vault')
 		return parseAddressInput(selectedVaultAddress, 'Selected vault address')
 	}
+	const resolveSecurityVaultPoolAddress = () => parseAddressInput(effectiveSecurityPoolAddressInput, 'Security pool address')
 
 	useEffect(() => {
 		if (!enabled) {
@@ -180,7 +183,7 @@ export function useSecurityVaultOperations({ accountAddress, enabled, onTransact
 				securityVaultMissing.value = false
 			},
 			load: async () => {
-				const securityPoolAddress = parseAddressInput(securityVaultForm.value.securityPoolAddress, 'Security pool address')
+				const securityPoolAddress = resolveSecurityVaultPoolAddress()
 				const vaultAddress = vaultAddressInput?.trim() === '' || vaultAddressInput === undefined ? resolveSelectedVaultAddress() : parseAddressInput(vaultAddressInput, 'Selected vault address')
 				if (vaultAddressInput !== undefined)
 					securityVaultForm.value = {
@@ -235,8 +238,7 @@ export function useSecurityVaultOperations({ accountAddress, enabled, onTransact
 					},
 				},
 				async walletAddress => {
-					const currentForm = securityVaultForm.value
-					securityPoolAddress = parseAddressInput(currentForm.securityPoolAddress, 'Security pool address')
+					securityPoolAddress = resolveSecurityVaultPoolAddress()
 					if (securityVaultMissing.value) throw new Error('Security pool does not exist')
 					const selectedVaultAddress = resolveSelectedVaultAddress()
 					if (!sameAddress(selectedVaultAddress, walletAddress)) throw new Error('Selected vault is read-only')

--- a/ui/ts/hooks/useTradingOperations.ts
+++ b/ui/ts/hooks/useTradingOperations.ts
@@ -19,9 +19,10 @@ import type { DeploymentStatus, TradingActionResult, TradingDetails, ZoltarUnive
 type UseTradingOperationsParameters = WriteOperationsParameters & {
 	deploymentStatuses: DeploymentStatus[]
 	enabled: boolean
+	selectedSecurityPoolAddress?: string
 }
 
-export function useTradingOperations({ accountAddress, deploymentStatuses, enabled, onTransaction, onTransactionFinished, onTransactionRequested, onTransactionSubmitted, refreshState }: UseTradingOperationsParameters) {
+export function useTradingOperations({ accountAddress, deploymentStatuses, enabled, onTransaction, onTransactionFinished, onTransactionRequested, onTransactionSubmitted, refreshState, selectedSecurityPoolAddress }: UseTradingOperationsParameters) {
 	const tradingDetailsLoad = useLoadController()
 	const nextTradingDetailsLoad = useRequestGuard()
 	const tradingDetails = useSignal<TradingDetails | undefined>(undefined)
@@ -81,6 +82,7 @@ export function useTradingOperations({ accountAddress, deploymentStatuses, enabl
 		if (!trimmed.startsWith('0x') || trimmed.length !== 42) return undefined
 		return tryParseAddressInput(trimmed)
 	}
+	const resolveEffectiveTradingPoolAddressInput = () => (selectedSecurityPoolAddress?.trim() === '' || selectedSecurityPoolAddress === undefined ? tradingForm.value.securityPoolAddress : selectedSecurityPoolAddress)
 
 	const refreshTradingDetails = async (securityPoolAddressInput: string, walletAddress: Address | undefined, isCurrent?: () => boolean) => {
 		if (!tradingSystemDeployed) {
@@ -138,7 +140,7 @@ export function useTradingOperations({ accountAddress, deploymentStatuses, enabl
 					refreshErrorFallback: 'Trading transaction succeeded, but refreshing trading details failed',
 				},
 				async walletAddress => {
-					const securityPoolAddress = parseAddressInput(currentForm.securityPoolAddress, 'Security pool address')
+					const securityPoolAddress = parseAddressInput(resolveEffectiveTradingPoolAddressInput(), 'Security pool address')
 					const result = await action(walletAddress, securityPoolAddress, currentForm)
 					return result
 				},
@@ -147,7 +149,7 @@ export function useTradingOperations({ accountAddress, deploymentStatuses, enabl
 					tradingResult.value = result
 					tradingFeedback.value = createSuccessActionFeedback(actionName, getSuccessTitle(actionName), result.hash)
 					const isCurrent = nextTradingDetailsLoad()
-					await refreshTradingDetails(currentForm.securityPoolAddress, walletAddress, isCurrent)
+					await refreshTradingDetails(result.securityPoolAddress, walletAddress, isCurrent)
 				},
 			)
 		} finally {
@@ -188,7 +190,7 @@ export function useTradingOperations({ accountAddress, deploymentStatuses, enabl
 				...tradingForm.value,
 				targetOutcomeIndexes: '',
 			}
-		if (resolveTradingPoolAddressInput(tradingForm.value.securityPoolAddress) === undefined) {
+		if (resolveTradingPoolAddressInput(resolveEffectiveTradingPoolAddressInput()) === undefined) {
 			tradingDetails.value = undefined
 			tradingForkUniverse.value = undefined
 			tradingError.value = undefined
@@ -199,19 +201,20 @@ export function useTradingOperations({ accountAddress, deploymentStatuses, enabl
 			tradingForkUniverse.value = undefined
 			tradingError.value = undefined
 		}
-	}, [enabled, tradingForm.value.securityPoolAddress, tradingSystemDeployed])
+	}, [enabled, selectedSecurityPoolAddress, tradingForm.value.securityPoolAddress, tradingSystemDeployed])
 
 	useEffect(() => {
 		if (!enabled) return
 		const isCurrent = nextTradingDetailsLoad()
 		if (!tradingSystemDeployed) return
-		if (resolveTradingPoolAddressInput(tradingForm.value.securityPoolAddress) === undefined) return
-		void refreshTradingDetails(tradingForm.value.securityPoolAddress, accountAddress, isCurrent)
-	}, [accountAddress, enabled, tradingForm.value.securityPoolAddress, tradingSystemDeployed])
+		const effectiveSecurityPoolAddressInput = resolveEffectiveTradingPoolAddressInput()
+		if (resolveTradingPoolAddressInput(effectiveSecurityPoolAddressInput) === undefined) return
+		void refreshTradingDetails(effectiveSecurityPoolAddressInput, accountAddress, isCurrent)
+	}, [accountAddress, enabled, selectedSecurityPoolAddress, tradingForm.value.securityPoolAddress, tradingSystemDeployed])
 
 	useEffect(() => {
 		if (!enabled) return
-		const securityPoolAddress = resolveTradingPoolAddressInput(tradingForm.value.securityPoolAddress)
+		const securityPoolAddress = resolveTradingPoolAddressInput(resolveEffectiveTradingPoolAddressInput())
 		if (securityPoolAddress === undefined || tradingForkUniverse.value === undefined) return
 
 		const defaultsKey = `${securityPoolAddress.toLowerCase()}:${tradingForkUniverse.value.universeId.toString()}:${tradingForkUniverse.value.forkTime.toString()}`
@@ -222,7 +225,7 @@ export function useTradingOperations({ accountAddress, deploymentStatuses, enabl
 			targetOutcomeIndexes: getDefaultShareMigrationTargetOutcomeIndexes(tradingForkUniverse.value),
 		}
 		targetOutcomeDefaultsKey.current = defaultsKey
-	}, [enabled, tradingForm.value.securityPoolAddress, tradingForkUniverse.value?.forkTime, tradingForkUniverse.value?.universeId])
+	}, [enabled, selectedSecurityPoolAddress, tradingForm.value.securityPoolAddress, tradingForkUniverse.value?.forkTime, tradingForkUniverse.value?.universeId])
 
 	return {
 		createCompleteSet,

--- a/ui/ts/lib/forkAuction.ts
+++ b/ui/ts/lib/forkAuction.ts
@@ -9,7 +9,29 @@ import { getReportingOutcomeLabel } from './reporting.js'
 const SECONDS_PER_WEEK = 7n * 24n * 60n * 60n
 
 export const AUCTION_TIME_SECONDS = SECONDS_PER_WEEK
-const PRICE_PRECISION = 10n ** 18n
+export const TRUTH_AUCTION_PRICE_PRECISION = 10n ** 18n
+const TRUTH_AUCTION_TICK_PRICE_POWERS = [
+	1000100000000000000n,
+	1000200010000000000n,
+	1000400060004000100n,
+	1000800280056007000n,
+	1001601200560182043n,
+	1003204964963598014n,
+	1006420201727613920n,
+	1012881622445451097n,
+	1025929181087729343n,
+	1052530684607338948n,
+	1107820842039993613n,
+	1227267018058200482n,
+	1506184333613467388n,
+	2268591246822644826n,
+	5146506245160322222n,
+	26486526531474198664n,
+	701536087702486644953n,
+	492152882348911033633683n,
+	242214459604341065650571799093n,
+	58667844441422969901301586347865591163491n,
+] as const
 
 export type ForkAuctionStageView = 'initiate' | 'migration' | 'auction' | 'settlement'
 
@@ -92,7 +114,65 @@ export function getTimeRemaining(targetTime: bigint | undefined, currentTime: bi
 
 export function estimateRepPurchased(ethAmount: bigint, price: bigint) {
 	if (ethAmount <= 0n || price <= 0n) return 0n
-	return (ethAmount * PRICE_PRECISION) / price
+	return (ethAmount * TRUTH_AUCTION_PRICE_PRECISION) / price
+}
+
+export function getTruthAuctionPriceAtTick(tick: bigint) {
+	const absoluteTick = tick < 0n ? -tick : tick
+	let price = TRUTH_AUCTION_PRICE_PRECISION
+	for (let bitIndex = 0; bitIndex < TRUTH_AUCTION_TICK_PRICE_POWERS.length; bitIndex += 1) {
+		const bitMask = 1n << BigInt(bitIndex)
+		const pricePower = TRUTH_AUCTION_TICK_PRICE_POWERS[bitIndex]
+		if (pricePower === undefined) throw new Error(`Missing truth auction tick price power for bit ${bitIndex}`)
+		if ((absoluteTick & bitMask) !== 0n) price = (price * pricePower) / TRUTH_AUCTION_PRICE_PRECISION
+	}
+	return tick < 0n ? (TRUTH_AUCTION_PRICE_PRECISION * TRUTH_AUCTION_PRICE_PRECISION) / price : price
+}
+
+export function getTruthAuctionTickAtPrice(price: bigint): bigint | undefined {
+	if (price <= 0n) return undefined
+	if (price === TRUTH_AUCTION_PRICE_PRECISION) return 0n
+
+	let lowerTick = 0n
+	let upperTick = 1n
+	let upperPrice = getTruthAuctionPriceAtTick(upperTick)
+
+	if (price >= TRUTH_AUCTION_PRICE_PRECISION) {
+		while (upperPrice <= price) {
+			lowerTick = upperTick
+			upperTick *= 2n
+			upperPrice = getTruthAuctionPriceAtTick(upperTick)
+		}
+		while (upperTick - lowerTick > 1n) {
+			const midTick = (lowerTick + upperTick) / 2n
+			const midPrice = getTruthAuctionPriceAtTick(midTick)
+			if (midPrice <= price) {
+				lowerTick = midTick
+				continue
+			}
+			upperTick = midTick
+		}
+		return lowerTick
+	}
+
+	lowerTick = -1n
+	upperTick = 0n
+	let lowerPrice = getTruthAuctionPriceAtTick(lowerTick)
+	while (lowerPrice > price) {
+		upperTick = lowerTick
+		lowerTick *= 2n
+		lowerPrice = getTruthAuctionPriceAtTick(lowerTick)
+	}
+	while (upperTick - lowerTick > 1n) {
+		const midTick = (lowerTick + upperTick) / 2n
+		const midPrice = getTruthAuctionPriceAtTick(midTick)
+		if (midPrice <= price) {
+			lowerTick = midTick
+			continue
+		}
+		upperTick = midTick
+	}
+	return lowerTick
 }
 
 export function getTruthAuctionBidGuardMessage({

--- a/ui/ts/lib/marketForm.ts
+++ b/ui/ts/lib/marketForm.ts
@@ -109,7 +109,7 @@ export function getDefaultForkAuctionFormState(): ForkAuctionFormState {
 		selectedOutcome: 'yes',
 		settlementAddress: '',
 		submitBidAmount: '0',
-		submitBidTick: '0',
+		submitBidPrice: '0',
 		vaultAddress: '',
 	}
 }
@@ -159,6 +159,14 @@ export function parseTradingAmountInput(value: string, label: string) {
 }
 
 export function tryParseTradingAmountInput(value: string) {
+	return tryParseDecimalInput(value, 18)
+}
+
+export function parseTruthAuctionPriceInput(value: string, label: string) {
+	return parseDecimalInput(value, label, 18)
+}
+
+export function tryParseTruthAuctionPriceInput(value: string) {
 	return tryParseDecimalInput(value, 18)
 }
 

--- a/ui/ts/lib/securityPoolLabels.ts
+++ b/ui/ts/lib/securityPoolLabels.ts
@@ -19,3 +19,11 @@ export function getSecurityPoolLifecycleLabel(state: SecurityPoolLifecycleState 
 			return assertNever(state)
 	}
 }
+
+export function getSecurityPoolStatusBadgeLabel({ hasForkActivity, lifecycleState }: { hasForkActivity: boolean; lifecycleState: SecurityPoolLifecycleState | undefined }) {
+	if (lifecycleState === undefined) return 'Unknown'
+	if (lifecycleState === 'poolForked' || lifecycleState === 'forkMigration') return 'Fork Migration'
+	if (lifecycleState === 'forkTruthAuction') return 'Truth Auction'
+	if (lifecycleState === 'operational' && hasForkActivity) return 'Fork Finalized'
+	return getSecurityPoolLifecycleLabel(lifecycleState)
+}

--- a/ui/ts/simulation/bootstrap.ts
+++ b/ui/ts/simulation/bootstrap.ts
@@ -3,23 +3,34 @@ import { encodeAbiParameters, encodeDeployData, getCreateAddress, keccak256, toH
 import {
 	approveErc20,
 	createMarket,
+	createChildUniverseFromSecurityPool,
+	createCompleteSetInSecurityPool,
 	createSecurityPool,
 	depositRepToSecurityPool,
+	forkZoltarWithOwnEscalation,
 	getDeploymentSteps,
 	loadAllSecurityPools,
 	loadErc20Balance,
+	loadForkAuctionDetails,
 	loadOracleManagerDetails,
 	loadOpenOracleReportDetails,
+	loadReportingDetails,
 	loadSecurityVaultDetails,
+	loadZoltarUniverseSummary,
+	migrateRepToZoltarFromSecurityPool,
 	queueOracleManagerOperation,
+	reportOutcomeInSecurityPool,
 	settleOracleReport,
+	startTruthAuctionForSecurityPool,
 	submitInitialOracleReport,
+	submitTruthAuctionBid,
 } from '../contracts.js'
 import { ReputationToken_ReputationToken, peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator, peripherals_WETH9_WETH9 } from '../contractArtifact.js'
 import { assertNever } from '../lib/assert.js'
+import { getTruthAuctionPriceAtTick, getTruthAuctionTickAtPrice } from '../lib/forkAuction.js'
 import type { ReadClient, WriteClient } from '../lib/chainBackend.js'
 import { MAINNET_WETH_ADDRESS, type NetworkProfile } from '../lib/networkProfile.js'
-import type { QuestionData } from '../types/contracts.js'
+import type { ListedSecurityPool, QuestionData } from '../types/contracts.js'
 import { advanceSimulationTime, getSimulationChainTimestamp, initializeSimulationClock } from './clock.js'
 import type { SimulationScenario } from './scenarios.js'
 
@@ -41,6 +52,9 @@ const SECURITY_POOL_X2_PRIMARY_REP_DEPOSIT = 12_000n * 10n ** 18n
 const SECURITY_POOL_X2_PRIMARY_SECURITY_BOND_ALLOWANCE = 1_000n * 10n ** 18n
 const SECURITY_POOL_X2_SECONDARY_REP_DEPOSIT = SECURITY_POOL_REP_DEPOSIT
 const SECURITY_POOL_X2_SECONDARY_SECURITY_BOND_ALLOWANCE = SECURITY_BOND_ALLOWANCE
+const SECURITY_POOL_X2_AUCTION_EXTRA_REP_DEPOSIT = 20_000_000n * 10n ** 18n
+const SECURITY_POOL_X2_AUCTION_BID_PRICES = [getTruthAuctionPriceAtTick(12n), getTruthAuctionPriceAtTick(10n), getTruthAuctionPriceAtTick(8n)] as const
+const SECURITY_POOL_X2_AUCTION_BID_AMOUNTS = [3n * 10n ** 18n, 4n * 10n ** 18n, 5n * 10n ** 18n, 6n * 10n ** 18n, 3n * 10n ** 18n, 4n * 10n ** 18n, 5n * 10n ** 18n, 3n * 10n ** 18n, 4n * 10n ** 18n, 5n * 10n ** 18n] as const
 const WETH_TOKEN_MINT_AMOUNT = 10_000n * 10n ** 18n
 const ZOLTAR_GENESIS_REPUTATION_TOKEN_OFFSET = 3n
 const ZOLTAR_UNIVERSE_THEORETICAL_SUPPLIES_SLOT = 2n
@@ -760,6 +774,107 @@ async function seedSecurityPoolX2Scenario({
 	await reportStep('Seeded securitypoolx2 scenario is ready')
 }
 
+async function loadRequiredChildSecurityPool(readClient: ReadClient, parentSecurityPoolAddress: Address, questionOutcome: ListedSecurityPool['questionOutcome']) {
+	const childPool = (await loadAllSecurityPools(readClient)).find(pool => pool.parent === parentSecurityPoolAddress && pool.questionOutcome === questionOutcome)
+	if (childPool === undefined) throw new Error(`Expected a ${questionOutcome} child pool for ${parentSecurityPoolAddress}`)
+	return childPool
+}
+
+async function seedSecurityPoolX2AuctionScenario({
+	accounts,
+	createReadClient,
+	createWriteClient,
+	memoryClient,
+	onProgress,
+	profile,
+}: {
+	accounts: readonly Address[]
+	createReadClient: () => ReadClient
+	createWriteClient: (accountAddress: Address) => WriteClient
+	memoryClient: TevmLikeClient
+	onProgress: BootstrapProgressHandler | undefined
+	profile: NetworkProfile
+}) {
+	await seedSecurityPoolX2Scenario({
+		accounts,
+		createReadClient,
+		createWriteClient,
+		memoryClient,
+		onProgress,
+		profile,
+	})
+
+	const primaryAccount = requireQaAccount(accounts[0], 'Expected simulation QA account A1 for securitypoolx2-auction')
+	const secondaryAccount = requireQaAccount(accounts[1], 'Expected simulation QA account B2 for securitypoolx2-auction')
+	const readClient = createReadClient()
+	const writeClient = createWriteClient(primaryAccount)
+	const x2Pools = await loadAllSecurityPools(readClient)
+	const parentPool = x2Pools.find(pool => pool.marketDetails.title === 'Will this resolve? (securitypoolx2 #1)')
+	if (parentPool === undefined) throw new Error('Expected the first securitypoolx2 parent pool for auction scenario seeding')
+
+	await reportBootstrapProgress(onProgress, 'Preparing fork-auction seed pool', 0.985)
+	await approveErc20(writeClient, profile.genesisRepTokenAddress, parentPool.securityPoolAddress, SECURITY_POOL_X2_AUCTION_EXTRA_REP_DEPOSIT, 'approveRep')
+	await depositRepToSecurityPool(writeClient, parentPool.securityPoolAddress, SECURITY_POOL_X2_AUCTION_EXTRA_REP_DEPOSIT)
+	await createCompleteSetInSecurityPool(createWriteClient(secondaryAccount), parentPool.securityPoolAddress, 20n * 10n ** 18n)
+
+	const universeSummary = await loadZoltarUniverseSummary(readClient, parentPool.universeId)
+	if (universeSummary === undefined) throw new Error(`Expected a Zoltar universe summary for parent pool ${parentPool.securityPoolAddress}`)
+	const reportingDetailsBeforeFork = await loadReportingDetails(readClient, parentPool.securityPoolAddress, primaryAccount)
+	if (reportingDetailsBeforeFork.marketDetails.endTime >= reportingDetailsBeforeFork.currentTime) {
+		await advanceSimulationTime(memoryClient, reportingDetailsBeforeFork.marketDetails.endTime - reportingDetailsBeforeFork.currentTime + DAY_IN_SECONDS)
+	}
+
+	const ownForkDepositAmount = universeSummary.forkThreshold / SECURITY_MULTIPLIER
+	await reportBootstrapProgress(onProgress, 'Triggering own-escalation fork', 0.988)
+	await reportOutcomeInSecurityPool(writeClient, parentPool.securityPoolAddress, 'yes', ownForkDepositAmount)
+	await reportOutcomeInSecurityPool(writeClient, parentPool.securityPoolAddress, 'no', ownForkDepositAmount)
+	await forkZoltarWithOwnEscalation(writeClient, parentPool.securityPoolAddress, parentPool.universeId)
+
+	await reportBootstrapProgress(onProgress, 'Creating and funding Yes child universe', 0.99)
+	await createChildUniverseFromSecurityPool(writeClient, parentPool.securityPoolAddress, parentPool.universeId, 'yes')
+	await migrateRepToZoltarFromSecurityPool(writeClient, parentPool.securityPoolAddress, parentPool.universeId, ['yes'])
+	await advanceSimulationTime(memoryClient, 8n * DAY_IN_SECONDS + DAY_IN_SECONDS)
+
+	const yesChildPool = await loadRequiredChildSecurityPool(readClient, parentPool.securityPoolAddress, 'yes')
+	const yesForkDetailsBeforeAuction = await loadForkAuctionDetails(readClient, yesChildPool.securityPoolAddress)
+	await reportBootstrapProgress(onProgress, 'Starting seeded truth auction', 0.992)
+	await startTruthAuctionForSecurityPool(writeClient, yesChildPool.securityPoolAddress, yesForkDetailsBeforeAuction.universeId)
+
+	const yesForkDetails = await loadForkAuctionDetails(readClient, yesChildPool.securityPoolAddress)
+	if (yesForkDetails.truthAuctionAddress === undefined || yesForkDetails.truthAuctionAddress === '0x0000000000000000000000000000000000000000') {
+		throw new Error('Expected a seeded truth auction address for the Yes child pool')
+	}
+	if (yesForkDetails.truthAuction?.finalized) {
+		throw new Error('Expected the seeded truth auction to remain active after startTruthAuction')
+	}
+
+	const biddingAccounts = [primaryAccount, secondaryAccount, ...accounts.slice(2)]
+	const bidPriceByIndex = [
+		SECURITY_POOL_X2_AUCTION_BID_PRICES[0],
+		SECURITY_POOL_X2_AUCTION_BID_PRICES[0],
+		SECURITY_POOL_X2_AUCTION_BID_PRICES[0],
+		SECURITY_POOL_X2_AUCTION_BID_PRICES[0],
+		SECURITY_POOL_X2_AUCTION_BID_PRICES[1],
+		SECURITY_POOL_X2_AUCTION_BID_PRICES[1],
+		SECURITY_POOL_X2_AUCTION_BID_PRICES[1],
+		SECURITY_POOL_X2_AUCTION_BID_PRICES[2],
+		SECURITY_POOL_X2_AUCTION_BID_PRICES[2],
+		SECURITY_POOL_X2_AUCTION_BID_PRICES[2],
+	] as const
+
+	for (const [index, bidAmount] of SECURITY_POOL_X2_AUCTION_BID_AMOUNTS.entries()) {
+		const bidderAccount = biddingAccounts[index % biddingAccounts.length]
+		if (bidderAccount === undefined) throw new Error('Expected at least one QA account for seeded truth auction bids')
+		const bidPrice = bidPriceByIndex[index]
+		if (bidPrice === undefined) throw new Error(`Missing seeded truth auction bid price for bid ${index + 1}`)
+		const bidTick = getTruthAuctionTickAtPrice(bidPrice)
+		if (bidTick === undefined) throw new Error(`Unable to map seeded truth auction bid price to a tick for bid ${index + 1}`)
+		await submitTruthAuctionBid(createWriteClient(bidderAccount), yesChildPool.securityPoolAddress, yesForkDetails.universeId, yesForkDetails.truthAuctionAddress, bidTick, bidAmount)
+	}
+
+	await reportBootstrapProgress(onProgress, 'Seeded securitypoolx2-auction scenario is ready', 0.995)
+}
+
 async function applyScenario({
 	accounts,
 	createReadClient,
@@ -800,6 +915,17 @@ async function applyScenario({
 		case 'securitypoolx2':
 			await deploySimulationAppContracts(createWriteClient(primaryAccount), memoryClient, onProgress, { start: 0.32, end: 0.7 })
 			await seedSecurityPoolX2Scenario({
+				accounts,
+				createReadClient,
+				createWriteClient,
+				memoryClient,
+				onProgress,
+				profile,
+			})
+			return
+		case 'securitypoolx2-auction':
+			await deploySimulationAppContracts(createWriteClient(primaryAccount), memoryClient, onProgress, { start: 0.32, end: 0.7 })
+			await seedSecurityPoolX2AuctionScenario({
 				accounts,
 				createReadClient,
 				createWriteClient,

--- a/ui/ts/simulation/scenarios.ts
+++ b/ui/ts/simulation/scenarios.ts
@@ -1,6 +1,6 @@
 import { assertNever } from '../lib/assert.js'
 
-export const SIMULATION_SCENARIOS = ['baseline', 'deployed', 'security-pool', 'securitypoolx2'] as const
+export const SIMULATION_SCENARIOS = ['baseline', 'deployed', 'security-pool', 'securitypoolx2', 'securitypoolx2-auction'] as const
 
 export type SimulationScenario = (typeof SIMULATION_SCENARIOS)[number]
 
@@ -22,6 +22,8 @@ export function getSimulationScenarioLabel(scenario: SimulationScenario) {
 			return 'Security pool'
 		case 'securitypoolx2':
 			return 'Security pool x2'
+		case 'securitypoolx2-auction':
+			return 'Security pool x2 auction'
 		default:
 			return assertNever(scenario)
 	}
@@ -37,6 +39,8 @@ export function getSimulationScenarioDescription(scenario: SimulationScenario) {
 			return 'One seeded market, one security pool, and one funded vault with an active security bond allowance. Use it to test pool workflows and liquidation paths.'
 		case 'securitypoolx2':
 			return 'Two seeded markets with two security pools and two funded vaults in each pool. Use it to test multi-pool selection and repeated pool workflows.'
+		case 'securitypoolx2-auction':
+			return 'Two seeded markets with one own-escalation fork already triggered and one child truth auction seeded with ten bids. Use it to test fork-auction bidbook and settlement workflows.'
 		default:
 			return assertNever(scenario)
 	}

--- a/ui/ts/tests/activeEnvironment.test.ts
+++ b/ui/ts/tests/activeEnvironment.test.ts
@@ -2,7 +2,7 @@
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
 import { getAddress } from 'viem'
-import { loadAllSecurityPools, loadDeploymentStatusOracleSnapshot, loadErc20Balance, loadOracleManagerDetails, loadReportingDetails, loadSecurityVaultDetails, loadZoltarUniverseSummary, queueOracleManagerOperation } from '../contracts.js'
+import { loadAllSecurityPools, loadDeploymentStatusOracleSnapshot, loadErc20Balance, loadForkAuctionDetails, loadOracleManagerDetails, loadReportingDetails, loadSecurityVaultDetails, loadTruthAuctionActiveTickPage, loadZoltarUniverseSummary, queueOracleManagerOperation } from '../contracts.js'
 import { getWrongNetworkMessage, isSupportedAppChain } from '../lib/network.js'
 import { getSecurityVaultWithdrawableRepAmount } from '../lib/securityVault.js'
 import { getActiveBackend, getActiveSimulationController, initializeActiveEnvironment, installActiveEnvironmentForTesting, resetActiveEnvironmentForTesting, shouldUseSimulationLocation } from '../lib/activeEnvironment.js'
@@ -519,6 +519,34 @@ void describe('simulation backend', () => {
 			await backend.dispose()
 		}
 	}, 90_000)
+
+	void test('bootstraps the securitypoolx2-auction scenario with an active child truth auction and ten bids', async () => {
+		const backend = await createBootstrappedSimulationBackendWithRetry('securitypoolx2-auction')
+		backend.setTransactionDelayMilliseconds(0)
+
+		try {
+			const readClient = backend.createReadClient()
+			const pools = await loadAllSecurityPools(readClient)
+			const parentPools = pools.filter(pool => pool.parent === getAddress('0x0000000000000000000000000000000000000000'))
+			const childPools = pools.filter(pool => pool.parent !== getAddress('0x0000000000000000000000000000000000000000'))
+			const yesAuctionChildPool = childPools.find(pool => pool.questionOutcome === 'yes' && pool.systemState === 'forkTruthAuction')
+			if (yesAuctionChildPool === undefined) throw new Error('Expected a seeded Yes child pool with an active truth auction')
+
+			const forkAuctionDetails = await loadForkAuctionDetails(readClient, yesAuctionChildPool.securityPoolAddress)
+			const activeTickPage = await loadTruthAuctionActiveTickPage(readClient, forkAuctionDetails.truthAuctionAddress, 0, 25)
+			const totalSeededBidCount = activeTickPage.ticks.reduce((sum, tickSummary) => sum + tickSummary.submissionCount, 0n)
+
+			expect(backend.currentScenario).toBe('securitypoolx2-auction')
+			expect(parentPools.length).toBeGreaterThanOrEqual(2)
+			expect(childPools.length).toBeGreaterThanOrEqual(1)
+			expect(forkAuctionDetails.truthAuctionAddress === getAddress('0x0000000000000000000000000000000000000000')).toBe(false)
+			expect(forkAuctionDetails.truthAuction?.finalized).toBe(false)
+			expect(activeTickPage.ticks.length).toBeGreaterThanOrEqual(3)
+			expect(totalSeededBidCount).toBe(10n)
+		} finally {
+			await backend.dispose()
+		}
+	}, 120_000)
 
 	void test('loads reporting without errors before the first escalation report in securitypoolx2', async () => {
 		const backend = await createBootstrappedSimulationBackendWithRetry('securitypoolx2')

--- a/ui/ts/tests/deploymentSection.test.tsx
+++ b/ui/ts/tests/deploymentSection.test.tsx
@@ -89,7 +89,7 @@ describe('DeploymentSection', () => {
 		expectTransactionButtonDisabled(document.body, 'Deploy', 'Switch to Ethereum mainnet to deploy this contract.')
 	})
 
-	test('shows blocked state while prerequisite step is missing', async () => {
+	test('shows waiting state while prerequisite step is missing', async () => {
 		const prerequisite = createDeploymentStep({ id: 'proxyDeployer', deployed: false, label: 'Proxy Deployer' })
 		const dependent = createDeploymentStep({ id: 'deploymentStatusOracle', deployed: false, dependencies: ['proxyDeployer'], label: 'Deployment Status Oracle' })
 		const rendered = await renderIntoDocument(<DeploymentSection title='Deployment' steps={[dependent]} allSteps={[prerequisite, dependent]} accountAddress={zeroAddress} busyStepId={undefined} isMainnet={true} onDeploy={async () => undefined} />)
@@ -97,7 +97,8 @@ describe('DeploymentSection', () => {
 
 		expect(rendered.container.textContent).toContain('Waiting for Proxy Deployer.')
 		expectTransactionButtonDisabled(document.body, 'Deploy', 'Waiting for Proxy Deployer.')
-		expect(rendered.container.textContent).toContain('Blocked')
+		expect(rendered.container.textContent).toContain('Waiting')
+		expect(rendered.container.textContent).not.toContain('Blocked')
 		expect(rendered.container.textContent).toContain('Deployment Status Oracle')
 	})
 

--- a/ui/ts/tests/forkAuction.test.ts
+++ b/ui/ts/tests/forkAuction.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, test } from 'bun:test'
 import { zeroAddress } from 'viem'
-import { getForkAuctionStageLabel, getForkAuctionStageOrder, getForkAuctionStageView, getForkStageDescriptionForState, getOutcomeActionLabel, getTruthAuctionBidGuardMessage, hasForkActivity } from '../lib/forkAuction.js'
+import { getForkAuctionStageLabel, getForkAuctionStageOrder, getForkAuctionStageView, getForkStageDescriptionForState, getOutcomeActionLabel, getTruthAuctionBidGuardMessage, getTruthAuctionPriceAtTick, getTruthAuctionTickAtPrice, hasForkActivity, TRUTH_AUCTION_PRICE_PRECISION } from '../lib/forkAuction.js'
 import type { TruthAuctionMetrics } from '../types/contracts.js'
 
 function createTruthAuction(overrides: Partial<TruthAuctionMetrics> = {}): TruthAuctionMetrics {
@@ -125,6 +125,21 @@ void describe('fork auction helpers', () => {
 		expect(getForkAuctionStageOrder('migration')).toBe(1)
 		expect(getForkAuctionStageOrder('auction')).toBe(2)
 		expect(getForkAuctionStageOrder('settlement')).toBe(3)
+	})
+
+	void test('maps exact truth auction prices back to their ticks', () => {
+		expect(getTruthAuctionTickAtPrice(TRUTH_AUCTION_PRICE_PRECISION)).toBe(0n)
+		expect(getTruthAuctionTickAtPrice(getTruthAuctionPriceAtTick(12n))).toBe(12n)
+		expect(getTruthAuctionTickAtPrice(getTruthAuctionPriceAtTick(-3n))).toBe(-3n)
+	})
+
+	void test('rounds entered truth auction prices down to the nearest valid tick', () => {
+		const tick12Price = getTruthAuctionPriceAtTick(12n)
+		const tick13Price = getTruthAuctionPriceAtTick(13n)
+		const betweenPositiveTicksPrice = (tick12Price + tick13Price) / 2n
+
+		expect(getTruthAuctionTickAtPrice(betweenPositiveTicksPrice)).toBe(12n)
+		expect(getTruthAuctionTickAtPrice(0n)).toBeUndefined()
 	})
 
 	void test('uses settlement after finalized auction and after active fork flags in settled-like states', () => {

--- a/ui/ts/tests/forkAuctionChildPoolRecovery.test.tsx
+++ b/ui/ts/tests/forkAuctionChildPoolRecovery.test.tsx
@@ -1,0 +1,237 @@
+/// <reference types='bun-types' />
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { waitFor, within } from '@testing-library/dom'
+import { h } from 'preact'
+import { zeroAddress, type Address } from 'viem'
+import type { ForkAuctionSectionProps } from '../types/components.js'
+import type { AccountState, ForkAuctionFormState } from '../types/app.js'
+import type { ForkAuctionDetails, ListedSecurityPool, MarketDetails } from '../types/contracts.js'
+import { installDomEnvironment } from './testUtils/domEnvironment.js'
+import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
+import { expectTransactionButtonEnabled } from './testUtils/transactionActionButton.js'
+
+const actualContracts = await import('../contracts.js')
+const actualClients = await import('../lib/clients.js')
+
+const PARENT_POOL_ADDRESS: Address = '0x00000000000000000000000000000000000000f0'
+const YES_CHILD_POOL_ADDRESS: Address = '0x00000000000000000000000000000000000000f1'
+const YES_TRUTH_AUCTION_ADDRESS: Address = '0x0000000000000000000000000000000000000aa1'
+
+let recoveredPools: ListedSecurityPool[] = []
+
+mock.module('../contracts.js', () => ({
+	...actualContracts,
+	loadAllSecurityPools: mock(async () => recoveredPools),
+	loadForkAuctionDetails: mock(async (_client: unknown, securityPoolAddress: Address) => createChildAuctionDetails(securityPoolAddress)),
+}))
+
+mock.module('../lib/clients.js', () => ({
+	...actualClients,
+	createConnectedReadClient: mock(() => ({
+		readContract: mock(async () => {
+			throw new Error('Unexpected readContract call in child-pool recovery test')
+		}),
+	})),
+}))
+
+const { ForkAuctionSection } = await import('../components/ForkAuctionSection.js')
+
+function createAccountState(overrides: Partial<AccountState> = {}): AccountState {
+	return {
+		address: zeroAddress,
+		chainId: '0x1',
+		ethBalance: 0n,
+		wethBalance: 0n,
+		...overrides,
+	}
+}
+
+function createMarketDetails(): MarketDetails {
+	return {
+		answerUnit: '',
+		createdAt: 1n,
+		description: 'Question description',
+		displayValueMax: 100n,
+		displayValueMin: 0n,
+		endTime: 2n,
+		exists: true,
+		marketType: 'binary',
+		numTicks: 2n,
+		outcomeLabels: ['Yes', 'No'],
+		questionId: '0x01',
+		startTime: 1n,
+		title: 'Will this resolve?',
+	}
+}
+
+function createForkAuctionForm(overrides: Partial<ForkAuctionFormState> = {}): ForkAuctionFormState {
+	return {
+		claimBidIndex: '',
+		claimBidTick: '',
+		depositIndexes: '',
+		directForkQuestionId: '',
+		directForkUniverseId: '',
+		refundBidIndex: '',
+		refundTick: '',
+		repMigrationOutcomes: '',
+		securityPoolAddress: PARENT_POOL_ADDRESS,
+		selectedOutcome: 'yes',
+		settlementAddress: '',
+		submitBidAmount: '',
+		submitBidPrice: '',
+		vaultAddress: '',
+		...overrides,
+	}
+}
+
+function createParentDetails(): ForkAuctionDetails {
+	return {
+		auctionedSecurityBondAllowance: 0n,
+		claimingAvailable: false,
+		completeSetCollateralAmount: 1n,
+		currentTime: 250n,
+		forkOutcome: 'none',
+		forkOwnSecurityPool: false,
+		hasForkActivity: true,
+		marketDetails: createMarketDetails(),
+		migratedRep: 1n,
+		migrationEndsAt: 200n,
+		parentSecurityPoolAddress: zeroAddress,
+		questionOutcome: 'yes',
+		repAtFork: 20n,
+		securityPoolAddress: PARENT_POOL_ADDRESS,
+		systemState: 'forkMigration',
+		truthAuction: undefined,
+		truthAuctionAddress: zeroAddress,
+		truthAuctionStartedAt: 0n,
+		universeId: 1n,
+	}
+}
+
+function createChildPool(): ListedSecurityPool {
+	return {
+		completeSetCollateralAmount: 1n,
+		currentRetentionRate: 10n,
+		forkOutcome: 'none',
+		forkOwnSecurityPool: false,
+		hasForkActivity: false,
+		lastOraclePrice: undefined,
+		lastOracleSettlementTimestamp: 0n,
+		managerAddress: zeroAddress,
+		marketDetails: createMarketDetails(),
+		migratedRep: 0n,
+		parent: PARENT_POOL_ADDRESS,
+		questionOutcome: 'yes',
+		questionId: '0x01',
+		securityMultiplier: 2n,
+		securityPoolAddress: YES_CHILD_POOL_ADDRESS,
+		systemState: 'forkMigration',
+		totalRepDeposit: 0n,
+		totalSecurityBondAllowance: 0n,
+		truthAuctionAddress: YES_TRUTH_AUCTION_ADDRESS,
+		truthAuctionStartedAt: 0n,
+		universeHasForked: true,
+		universeId: 11n,
+		vaultCount: 0n,
+		vaults: [],
+	}
+}
+
+function createChildAuctionDetails(securityPoolAddress: Address): ForkAuctionDetails {
+	return {
+		auctionedSecurityBondAllowance: 0n,
+		claimingAvailable: false,
+		completeSetCollateralAmount: 1n,
+		currentTime: 250n,
+		forkOutcome: 'none',
+		forkOwnSecurityPool: false,
+		hasForkActivity: true,
+		marketDetails: createMarketDetails(),
+		migratedRep: 1n,
+		migrationEndsAt: 200n,
+		parentSecurityPoolAddress: PARENT_POOL_ADDRESS,
+		questionOutcome: 'yes',
+		repAtFork: 20n,
+		securityPoolAddress,
+		systemState: 'forkMigration',
+		truthAuction: undefined,
+		truthAuctionAddress: YES_TRUTH_AUCTION_ADDRESS,
+		truthAuctionStartedAt: 0n,
+		universeId: 11n,
+	}
+}
+
+function createProps(overrides: Partial<ForkAuctionSectionProps> = {}): ForkAuctionSectionProps {
+	return {
+		accountState: createAccountState(),
+		auctionDetailsOverride: undefined,
+		forkAuctionActiveAction: undefined,
+		forkAuctionDetails: createParentDetails(),
+		forkAuctionError: undefined,
+		forkAuctionForm: createForkAuctionForm(),
+		forkAuctionResult: {
+			action: 'migrateRepToZoltar',
+			hash: '0x00000000000000000000000000000000000000000000000000000000000000f1',
+			securityPoolAddress: PARENT_POOL_ADDRESS,
+			universeId: 1n,
+		},
+		loadingForkAuctionDetails: false,
+		onClaimAuctionProceeds: () => undefined,
+		onCreateChildUniverse: () => undefined,
+		onFinalizeTruthAuction: () => undefined,
+		onForkAuctionFormChange: () => undefined,
+		onForkUniverse: () => undefined,
+		onForkWithOwnEscalation: () => undefined,
+		onInitiateFork: () => undefined,
+		onLoadForkAuction: () => undefined,
+		onMigrateEscalationDeposits: () => undefined,
+		onMigrateRepToZoltar: () => undefined,
+		onMigrateVault: () => undefined,
+		onRefundLosingBids: () => undefined,
+		onStartTruthAuction: () => undefined,
+		onSubmitBid: () => undefined,
+		previewPool: {
+			...createChildPool(),
+			parent: zeroAddress,
+			questionOutcome: 'none',
+			securityPoolAddress: PARENT_POOL_ADDRESS,
+			truthAuctionAddress: zeroAddress,
+			universeId: 1n,
+			universeHasForked: false,
+		},
+		securityPools: [],
+		showHeader: true,
+		showSecurityPoolAddressInput: true,
+		stageView: 'auction',
+		...overrides,
+	}
+}
+
+describe('ForkAuctionSection child pool recovery', () => {
+	let cleanupDom: (() => void) | undefined
+	let cleanupRenderedComponent: (() => Promise<void>) | undefined
+
+	beforeEach(() => {
+		recoveredPools = []
+		cleanupDom = installDomEnvironment().cleanup
+	})
+
+	afterEach(async () => {
+		await cleanupRenderedComponent?.()
+		cleanupRenderedComponent = undefined
+		cleanupDom?.()
+		cleanupDom = undefined
+	})
+
+	test('recovers a migrated child pool from the registry when the local security-pools list is stale', async () => {
+		recoveredPools = [createChildPool()]
+		const renderedComponent = await renderIntoDocument(h(ForkAuctionSection, createProps()))
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await waitFor(() => {
+			expect(within(document.body).queryByText('Child universe not created for the Yes outcome yet.')).toBeNull()
+			expectTransactionButtonEnabled(document.body, 'Start Truth Auction')
+		})
+	})
+})

--- a/ui/ts/tests/forkAuctionSection.test.tsx
+++ b/ui/ts/tests/forkAuctionSection.test.tsx
@@ -4,10 +4,10 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { fireEvent, waitFor, within } from '@testing-library/dom'
 import { h, render } from 'preact'
 import { act } from 'preact/test-utils'
-import { zeroAddress } from 'viem'
+import { type Address, zeroAddress } from 'viem'
 import { ForkAuctionSection } from '../components/ForkAuctionSection.js'
-import { AUCTION_TIME_SECONDS, deriveHasForkActivity, getForkAuctionStageView } from '../lib/forkAuction.js'
-import { formatDuration } from '../lib/formatters.js'
+import { AUCTION_TIME_SECONDS, deriveHasForkActivity, getForkAuctionStageView, getTruthAuctionPriceAtTick } from '../lib/forkAuction.js'
+import { formatCurrencyInputBalance, formatDuration } from '../lib/formatters.js'
 import type { AccountState, ForkAuctionFormState, ReportingFormState } from '../types/app.js'
 import type { ActiveReportingDetails, EscalationDeposit, ForkAuctionDetails, ListedSecurityPool, MarketDetails, ReadClient, TruthAuctionBidView, TruthAuctionTickSummary } from '../types/contracts.js'
 import type { ForkAuctionSectionProps } from '../types/components.js'
@@ -17,6 +17,11 @@ import { expectTransactionButtonDisabled, expectTransactionButtonEnabled } from 
 
 const ETH = 10n ** 18n
 const REP = 10n ** 18n
+const PARENT_POOL_ADDRESS: Address = '0x00000000000000000000000000000000000000f0'
+const YES_CHILD_POOL_ADDRESS: Address = '0x00000000000000000000000000000000000000f1'
+const NO_CHILD_POOL_ADDRESS: Address = '0x00000000000000000000000000000000000000f2'
+const YES_TRUTH_AUCTION_ADDRESS: Address = '0x0000000000000000000000000000000000000aa1'
+const NO_TRUTH_AUCTION_ADDRESS: Address = '0x0000000000000000000000000000000000000aa2'
 type TruthAuctionReadContractRequest = Parameters<ReadClient['readContract']>[0]
 type TruthAuctionReadContractHandler = (request: TruthAuctionReadContractRequest) => Promise<unknown>
 
@@ -218,7 +223,7 @@ function createTruthAuctionMetrics() {
 	}
 }
 
-function createForkAuctionForm(): ForkAuctionFormState {
+function createForkAuctionForm(overrides: Partial<ForkAuctionFormState> = {}): ForkAuctionFormState {
 	return {
 		claimBidIndex: '',
 		claimBidTick: '',
@@ -232,8 +237,9 @@ function createForkAuctionForm(): ForkAuctionFormState {
 		selectedOutcome: 'yes',
 		settlementAddress: '',
 		submitBidAmount: '',
-		submitBidTick: '',
+		submitBidPrice: '',
 		vaultAddress: '',
+		...overrides,
 	}
 }
 
@@ -301,8 +307,19 @@ function createForkMigrationReadClient(
 function createProps(overrides: Partial<ForkAuctionSectionProps> = {}): ForkAuctionSectionProps {
 	const forkAuctionDetails = overrides.forkAuctionDetails ?? createForkAuctionDetails()
 	const previewPool = overrides.previewPool
+	const stageView =
+		overrides.stageView ??
+		getForkAuctionStageView({
+			claimingAvailable: forkAuctionDetails?.claimingAvailable ?? false,
+			forkOutcome: forkAuctionDetails?.forkOutcome ?? previewPool?.forkOutcome ?? 'none',
+			migratedRep: forkAuctionDetails?.migratedRep ?? previewPool?.migratedRep ?? 0n,
+			systemState: forkAuctionDetails?.systemState ?? previewPool?.systemState ?? 'operational',
+			truthAuction: forkAuctionDetails?.truthAuction,
+			truthAuctionStartedAt: forkAuctionDetails?.truthAuctionStartedAt ?? previewPool?.truthAuctionStartedAt ?? 0n,
+		})
 	return {
 		accountState: createAccountState(),
+		auctionDetailsOverride: overrides.auctionDetailsOverride ?? (stageView === 'auction' || stageView === 'settlement' ? forkAuctionDetails : undefined),
 		embedInCard: false,
 		forkAuctionActiveAction: undefined,
 		forkAuctionDetails,
@@ -331,16 +348,7 @@ function createProps(overrides: Partial<ForkAuctionSectionProps> = {}): ForkAuct
 		reportingDetails: undefined,
 		reportingForm: createReportingForm(),
 		securityPools: [],
-		stageView:
-			overrides.stageView ??
-			getForkAuctionStageView({
-				claimingAvailable: forkAuctionDetails?.claimingAvailable ?? false,
-				forkOutcome: forkAuctionDetails?.forkOutcome ?? previewPool?.forkOutcome ?? 'none',
-				migratedRep: forkAuctionDetails?.migratedRep ?? previewPool?.migratedRep ?? 0n,
-				systemState: forkAuctionDetails?.systemState ?? previewPool?.systemState ?? 'operational',
-				truthAuction: forkAuctionDetails?.truthAuction,
-				truthAuctionStartedAt: forkAuctionDetails?.truthAuctionStartedAt ?? previewPool?.truthAuctionStartedAt ?? 0n,
-			}),
+		stageView,
 		showHeader: false,
 		showSecurityPoolAddressInput: false,
 		truthAuctionReadClient: createTruthAuctionReadClient(),
@@ -408,7 +416,7 @@ describe('ForkAuctionSection', () => {
 		expect(documentQueries.queryByRole('heading', { name: 'Fork Trigger' })).toBeNull()
 		expect(documentQueries.queryByRole('button', { name: 'Refresh fork' })).toBeNull()
 		expect(document.body.textContent?.includes('This pool is currently operational. Migration controls become meaningful once the pool has forked.')).toBe(false)
-		expect(getMetricValue(migrationSection, 'Fork Type')).toBe('Unavailable until fork')
+		expect(getMetricValue(migrationSection, 'Fork Type')).toBe('-')
 	})
 
 	test('keeps migration actions available while gating later-stage writes through the shared action matrix', async () => {
@@ -439,7 +447,7 @@ describe('ForkAuctionSection', () => {
 
 		expect(documentQueries.queryByRole('button', { name: 'Trigger Zoltar Fork' })).toBeNull()
 		await waitFor(() => {
-			expectTransactionButtonEnabled(document.body, 'Migrate Vault')
+			expectTransactionButtonEnabled(document.body, 'Migrate Vault To Yes')
 			expectTransactionButtonDisabled(document.body, 'Migrate Selected Yes Deposits', 'Select at least one deposit to migrate or use the all-deposits action below.')
 			expectTransactionButtonEnabled(document.body, 'Migrate All Yes Deposits')
 		})
@@ -453,7 +461,7 @@ describe('ForkAuctionSection', () => {
 		await act(() => {
 			render(h(ForkAuctionSection, createProps({ stageView: 'settlement' })), renderedComponent.container)
 		})
-		expectTransactionButtonDisabled(document.body, 'Finalize Truth Auction')
+		expect(documentQueries.queryByRole('button', { name: 'Finalize Truth Auction' })).toBeNull()
 		expectTransactionButtonDisabled(document.body, 'Refund Losing Bid')
 		expect(documentQueries.queryByRole('button', { name: 'Settle Finalized Bid' })).toBeNull()
 		expect(documentQueries.queryByRole('button', { name: 'Withdraw Bids' })).toBeNull()
@@ -474,7 +482,7 @@ describe('ForkAuctionSection', () => {
 
 		const documentQueries = within(document.body)
 
-		expectTransactionButtonDisabled(document.body, 'Migrate Vault')
+		expectTransactionButtonDisabled(document.body, 'Migrate Vault To Yes')
 		expectTransactionButtonDisabled(document.body, 'Migrate Selected Yes Deposits')
 		expectTransactionButtonDisabled(document.body, 'Migrate All Yes Deposits')
 
@@ -507,7 +515,7 @@ describe('ForkAuctionSection', () => {
 				renderedComponent.container,
 			)
 		})
-		expectTransactionButtonDisabled(document.body, 'Finalize Truth Auction')
+		expect(documentQueries.queryByRole('button', { name: 'Finalize Truth Auction' })).toBeNull()
 		expectTransactionButtonDisabled(document.body, 'Refund Losing Bid')
 		expect(documentQueries.queryByRole('button', { name: 'Settle Finalized Bid' })).toBeNull()
 		expect(documentQueries.queryByRole('button', { name: 'Withdraw Bids' })).toBeNull()
@@ -570,7 +578,7 @@ describe('ForkAuctionSection', () => {
 		expect(within(migrationBalancesSection).getByText('Locked REP')).not.toBeNull()
 		expect(within(migrationBalancesSection).getByRole('heading', { name: 'Migrate Vault' })).not.toBeNull()
 		expect(within(migrationBalancesSection).getByRole('heading', { name: 'Migrate Escalation Deposits' })).not.toBeNull()
-		expect(within(migrationBalancesSection).getByRole('button', { name: 'Migrate Vault' })).not.toBeNull()
+		expect(within(migrationBalancesSection).getByRole('button', { name: 'Migrate Vault To Yes' })).not.toBeNull()
 		expect(within(migrationBalancesSection).getByRole('button', { name: 'Migrate Selected Yes Deposits' })).not.toBeNull()
 		expect(within(migrationBalancesSection).getByRole('button', { name: 'Migrate All Yes Deposits' })).not.toBeNull()
 		expect(within(migrationBalancesSection).getByRole('checkbox', { name: /Deposit #1/i })).not.toBeNull()
@@ -686,7 +694,129 @@ describe('ForkAuctionSection', () => {
 		])
 	})
 
-	test('requires pool REP migration before vault migration when the selected child has not been seeded', async () => {
+	test('updates locked rep in the parent migration balances after escalation migration succeeds', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					previewPool: createPreviewPool({
+						systemState: 'forkMigration',
+						vaultCount: 1n,
+						vaults: [
+							{
+								lockedRepInEscalationGame: rep(3n),
+								repDepositShare: 0n,
+								securityBondAllowance: 0n,
+								unpaidEthFees: 0n,
+								vaultAddress: zeroAddress,
+							},
+						],
+					}),
+					reportingDetails: createReportingDetails({
+						sides: [
+							{ balance: rep(1n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+							{
+								balance: rep(5n),
+								deposits: [],
+								key: 'yes',
+								label: 'Yes',
+								userDeposits: [
+									createDeposit({
+										amount: rep(2n),
+										cumulativeAmount: rep(3n),
+										depositIndex: 1n,
+									}),
+								],
+							},
+							{ balance: rep(5n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
+						],
+					}),
+					reportingForm: createReportingForm({
+						selectedWithdrawDepositIndexesByOutcome: {
+							invalid: [],
+							yes: [1n],
+							no: [],
+						},
+					}),
+					stageView: 'migration',
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const migrationBalancesSection = within(document.body).getByRole('heading', { name: 'Your Migration Balances' }).closest('section')
+		if (!(migrationBalancesSection instanceof HTMLElement)) throw new Error('Expected migration balances section to render')
+		const lockedRepMetric = within(migrationBalancesSection).getByText('Locked REP').closest('div')
+		if (!(lockedRepMetric instanceof HTMLElement)) throw new Error('Expected locked REP metric to render')
+		expect(within(lockedRepMetric).getByRole('button', { name: 'Copy exact value 3' })).not.toBeNull()
+
+		await act(() => {
+			fireEvent.click(within(document.body).getByRole('button', { name: 'Migrate Selected Yes Deposits' }))
+		})
+
+		await act(() => {
+			render(
+				h(
+					ForkAuctionSection,
+					createProps({
+						forkAuctionResult: {
+							action: 'migrateEscalationDeposits',
+							hash: '0x00000000000000000000000000000000000000000000000000000000000000e1',
+							securityPoolAddress: zeroAddress,
+							universeId: 1n,
+						},
+						previewPool: createPreviewPool({
+							systemState: 'forkMigration',
+							vaultCount: 1n,
+							vaults: [
+								{
+									lockedRepInEscalationGame: rep(3n),
+									repDepositShare: 0n,
+									securityBondAllowance: 0n,
+									unpaidEthFees: 0n,
+									vaultAddress: zeroAddress,
+								},
+							],
+						}),
+						reportingDetails: createReportingDetails({
+							sides: [
+								{ balance: rep(1n), deposits: [], key: 'invalid', label: 'Invalid', userDeposits: [] },
+								{
+									balance: rep(5n),
+									deposits: [],
+									key: 'yes',
+									label: 'Yes',
+									userDeposits: [
+										createDeposit({
+											amount: rep(2n),
+											cumulativeAmount: rep(3n),
+											depositIndex: 1n,
+										}),
+									],
+								},
+								{ balance: rep(5n), deposits: [], key: 'no', label: 'No', userDeposits: [] },
+							],
+						}),
+						reportingForm: createReportingForm({
+							selectedWithdrawDepositIndexesByOutcome: {
+								invalid: [],
+								yes: [1n],
+								no: [],
+							},
+						}),
+						stageView: 'migration',
+					}),
+				),
+				renderedComponent.container,
+			)
+		})
+
+		await waitFor(() => {
+			expect(within(lockedRepMetric).getByRole('button', { name: 'Copy exact value 1' })).not.toBeNull()
+		})
+	})
+
+	test('requires pool migration before vault migration when the selected child pool has not been funded yet', async () => {
 		const migrateRepCalls: Array<string[] | undefined> = []
 		const renderedComponent = await renderIntoDocument(
 			h(
@@ -709,10 +839,549 @@ describe('ForkAuctionSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		await waitFor(() => {
-			expectTransactionButtonDisabled(document.body, 'Migrate Vault', 'Migrate pool REP to the Yes child pool before moving vault balances.')
+			expectTransactionButtonDisabled(document.body, 'Migrate Vault To Yes', 'Migrate pool to the Yes universe before moving vault balances.')
 		})
-		fireEvent.click(within(document.body).getByRole('button', { name: 'Migrate Collateral To Yes Universe' }))
+		fireEvent.click(within(document.body).getByRole('button', { name: 'Migrate Pool To Yes Universe' }))
 		expect(migrateRepCalls).toEqual([['yes']])
+	})
+
+	test('shows pool migration as already complete and disables the pool migration button once funded', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					forkMigrationReadClient: createForkMigrationReadClient(async request => {
+						if (request.functionName === 'getChildUniverseId') return 11n
+						if (request.functionName === 'getMigrationProxyAddress') return '0x00000000000000000000000000000000000000aa'
+						if (request.functionName === 'getRepToken') return '0x00000000000000000000000000000000000000bb'
+						if (request.functionName === 'balanceOf') return request.address === '0x00000000000000000000000000000000000000aa' ? 0n : 1n
+						throw new Error(`Unexpected fork migration read: ${String(request.functionName)}`)
+					}),
+					stageView: 'migration',
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await waitFor(() => {
+			expect(within(document.body).getByText('Pool REP for this outcome is already staged and will sweep into the child universe during vault migration.')).not.toBeNull()
+			expectTransactionButtonDisabled(document.body, 'Migrate Pool To Yes Universe', 'Pool REP has already been migrated to the Yes universe.')
+		})
+	})
+
+	test('shows the selected child pool auction status and switches with the selected outcome', async () => {
+		const parentDetails = {
+			...createForkAuctionDetails(),
+			currentTime: 300n,
+			migrationEndsAt: 200n,
+			securityPoolAddress: PARENT_POOL_ADDRESS,
+			systemState: 'forkMigration' as const,
+		}
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					auctionDetailsOverride: undefined,
+					forkAuctionDetails: parentDetails,
+					forkAuctionForm: createForkAuctionForm({
+						selectedOutcome: 'yes',
+					}),
+					securityPools: [
+						createPreviewPool({
+							parent: PARENT_POOL_ADDRESS,
+							questionOutcome: 'yes',
+							securityPoolAddress: YES_CHILD_POOL_ADDRESS,
+							truthAuctionAddress: YES_TRUTH_AUCTION_ADDRESS,
+							truthAuctionStartedAt: 310n,
+						}),
+						createPreviewPool({
+							parent: PARENT_POOL_ADDRESS,
+							questionOutcome: 'no',
+							securityPoolAddress: NO_CHILD_POOL_ADDRESS,
+							truthAuctionAddress: NO_TRUTH_AUCTION_ADDRESS,
+							truthAuctionStartedAt: 410n,
+						}),
+					],
+					stageView: 'auction',
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const auctionStatusSection = within(document.body).getByRole('heading', { name: 'Auction Status' }).closest('section')
+		if (!(auctionStatusSection instanceof HTMLElement)) throw new Error('Expected auction status section to render')
+		expect(getMetricValue(auctionStatusSection, 'Auction Address')).toContain('0x0000')
+		expect(getMetricValue(auctionStatusSection, 'Auction Address')).toContain('0aa1')
+
+		await act(() => {
+			render(
+				h(
+					ForkAuctionSection,
+					createProps({
+						auctionDetailsOverride: undefined,
+						forkAuctionDetails: parentDetails,
+						forkAuctionForm: createForkAuctionForm({
+							selectedOutcome: 'no',
+						}),
+						securityPools: [
+							createPreviewPool({
+								parent: PARENT_POOL_ADDRESS,
+								questionOutcome: 'yes',
+								securityPoolAddress: YES_CHILD_POOL_ADDRESS,
+								truthAuctionAddress: YES_TRUTH_AUCTION_ADDRESS,
+								truthAuctionStartedAt: 310n,
+							}),
+							createPreviewPool({
+								parent: PARENT_POOL_ADDRESS,
+								questionOutcome: 'no',
+								securityPoolAddress: NO_CHILD_POOL_ADDRESS,
+								truthAuctionAddress: NO_TRUTH_AUCTION_ADDRESS,
+								truthAuctionStartedAt: 410n,
+							}),
+						],
+						stageView: 'auction',
+					}),
+				),
+				renderedComponent.container,
+			)
+		})
+
+		expect(getMetricValue(auctionStatusSection, 'Auction Address')).toContain('0aa2')
+	})
+
+	test('shows a passive missing-child message on the auction tab without child-creation actions', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					auctionDetailsOverride: undefined,
+					forkAuctionDetails: {
+						...createForkAuctionDetails(),
+						currentTime: 300n,
+						migrationEndsAt: 200n,
+						securityPoolAddress: PARENT_POOL_ADDRESS,
+						systemState: 'forkMigration',
+					},
+					stageView: 'auction',
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(within(document.body).getByText('Child universe not created for the Yes outcome yet.')).not.toBeNull()
+		expect(within(document.body).queryByRole('button', { name: 'Create Child Universe' })).toBeNull()
+		expectTransactionButtonDisabled(document.body, 'Start Truth Auction', 'Child universe not created for the Yes outcome yet.')
+	})
+
+	test('starts the truth auction for the selected child pool instead of the parent pool', async () => {
+		const startTruthAuctionCalls: Array<string | undefined> = []
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					auctionDetailsOverride: undefined,
+					forkAuctionDetails: {
+						...createForkAuctionDetails(),
+						currentTime: 300n,
+						migrationEndsAt: 200n,
+						securityPoolAddress: PARENT_POOL_ADDRESS,
+						systemState: 'forkMigration',
+					},
+					onStartTruthAuction: securityPoolAddressOverride => {
+						startTruthAuctionCalls.push(securityPoolAddressOverride)
+					},
+					securityPools: [
+						createPreviewPool({
+							parent: PARENT_POOL_ADDRESS,
+							questionOutcome: 'yes',
+							securityPoolAddress: YES_CHILD_POOL_ADDRESS,
+						}),
+					],
+					stageView: 'auction',
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await act(() => {
+			fireEvent.click(within(document.body).getByRole('button', { name: 'Start Truth Auction' }))
+		})
+
+		expect(startTruthAuctionCalls).toEqual([YES_CHILD_POOL_ADDRESS])
+	})
+
+	test('does not mark vault migration complete just because the selected child vault already has balances', async () => {
+		const selectedOutcomeChildPool = createPreviewPool({
+			parent: zeroAddress,
+			questionOutcome: 'yes',
+			securityPoolAddress: '0x0000000000000000000000000000000000000100',
+			systemState: 'forkMigration',
+			vaults: [
+				{
+					lockedRepInEscalationGame: 0n,
+					repDepositShare: rep(1n),
+					securityBondAllowance: 0n,
+					unpaidEthFees: 0n,
+					vaultAddress: zeroAddress,
+				},
+			],
+		})
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					forkAuctionDetails: {
+						...createForkAuctionDetails(),
+						systemState: 'forkMigration',
+					},
+					previewPool: createPreviewPool({
+						systemState: 'forkMigration',
+						vaults: [
+							{
+								lockedRepInEscalationGame: 0n,
+								repDepositShare: rep(2n),
+								securityBondAllowance: 1n,
+								unpaidEthFees: 0n,
+								vaultAddress: zeroAddress,
+							},
+						],
+					}),
+					securityPools: [selectedOutcomeChildPool],
+					stageView: 'migration',
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await waitFor(() => {
+			expectTransactionButtonEnabled(document.body, 'Migrate Vault To Yes')
+		})
+		expect(document.body.textContent?.includes('Already migrated')).toBe(false)
+	})
+
+	test('marks vault migration complete globally after a successful migration result', async () => {
+		let migrateVaultCalls = 0
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					forkAuctionDetails: {
+						...createForkAuctionDetails(),
+						systemState: 'forkMigration',
+					},
+					forkAuctionForm: {
+						...createForkAuctionForm(),
+						selectedOutcome: 'yes',
+					},
+					forkAuctionResult: undefined,
+					onMigrateVault: () => {
+						migrateVaultCalls += 1
+					},
+					previewPool: createPreviewPool({
+						systemState: 'forkMigration',
+						vaults: [
+							{
+								lockedRepInEscalationGame: 0n,
+								repDepositShare: rep(2n),
+								securityBondAllowance: 1n,
+								unpaidEthFees: 0n,
+								vaultAddress: zeroAddress,
+							},
+						],
+					}),
+					securityPools: [
+						createPreviewPool({
+							parent: zeroAddress,
+							questionOutcome: 'yes',
+							securityPoolAddress: '0x0000000000000000000000000000000000000101',
+							systemState: 'forkMigration',
+							vaults: [
+								{
+									lockedRepInEscalationGame: 0n,
+									repDepositShare: rep(2n),
+									securityBondAllowance: 1n,
+									unpaidEthFees: 0n,
+									vaultAddress: zeroAddress,
+								},
+							],
+						}),
+						createPreviewPool({
+							parent: zeroAddress,
+							questionOutcome: 'invalid',
+							securityPoolAddress: '0x0000000000000000000000000000000000000102',
+							systemState: 'forkMigration',
+							vaults: [],
+						}),
+					],
+					stageView: 'migration',
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await waitFor(() => {
+			expectTransactionButtonEnabled(document.body, 'Migrate Vault To Yes')
+		})
+		await act(() => {
+			fireEvent.click(within(document.body).getByRole('button', { name: 'Migrate Vault To Yes' }))
+		})
+		expect(migrateVaultCalls).toBe(1)
+
+		await act(() => {
+			render(
+				h(
+					ForkAuctionSection,
+					createProps({
+						forkAuctionDetails: {
+							...createForkAuctionDetails(),
+							systemState: 'forkMigration',
+						},
+						forkAuctionForm: {
+							...createForkAuctionForm(),
+							selectedOutcome: 'yes',
+						},
+						onMigrateVault: () => {
+							migrateVaultCalls += 1
+						},
+						forkAuctionResult: {
+							action: 'migrateVault',
+							hash: '0x00000000000000000000000000000000000000000000000000000000000000f3',
+							securityPoolAddress: zeroAddress,
+							universeId: 1n,
+						},
+						previewPool: createPreviewPool({
+							systemState: 'forkMigration',
+							vaults: [
+								{
+									lockedRepInEscalationGame: 0n,
+									repDepositShare: rep(2n),
+									securityBondAllowance: 1n,
+									unpaidEthFees: 0n,
+									vaultAddress: zeroAddress,
+								},
+							],
+						}),
+						securityPools: [
+							createPreviewPool({
+								parent: zeroAddress,
+								questionOutcome: 'yes',
+								securityPoolAddress: '0x0000000000000000000000000000000000000101',
+								systemState: 'forkMigration',
+								vaults: [
+									{
+										lockedRepInEscalationGame: 0n,
+										repDepositShare: rep(2n),
+										securityBondAllowance: 1n,
+										unpaidEthFees: 0n,
+										vaultAddress: zeroAddress,
+									},
+								],
+							}),
+							createPreviewPool({
+								parent: zeroAddress,
+								questionOutcome: 'invalid',
+								securityPoolAddress: '0x0000000000000000000000000000000000000102',
+								systemState: 'forkMigration',
+								vaults: [],
+							}),
+						],
+						stageView: 'migration',
+					}),
+				),
+				renderedComponent.container,
+			)
+		})
+
+		await act(() => {
+			render(
+				h(
+					ForkAuctionSection,
+					createProps({
+						forkAuctionDetails: {
+							...createForkAuctionDetails(),
+							systemState: 'forkMigration',
+						},
+						forkAuctionForm: {
+							...createForkAuctionForm(),
+							selectedOutcome: 'invalid',
+						},
+						onMigrateVault: () => {
+							migrateVaultCalls += 1
+						},
+						forkAuctionResult: {
+							action: 'migrateVault',
+							hash: '0x00000000000000000000000000000000000000000000000000000000000000f3',
+							securityPoolAddress: zeroAddress,
+							universeId: 1n,
+						},
+						previewPool: createPreviewPool({
+							systemState: 'forkMigration',
+							vaults: [
+								{
+									lockedRepInEscalationGame: 0n,
+									repDepositShare: rep(2n),
+									securityBondAllowance: 1n,
+									unpaidEthFees: 0n,
+									vaultAddress: zeroAddress,
+								},
+							],
+						}),
+						securityPools: [
+							createPreviewPool({
+								parent: zeroAddress,
+								questionOutcome: 'yes',
+								securityPoolAddress: '0x0000000000000000000000000000000000000101',
+								systemState: 'forkMigration',
+								vaults: [
+									{
+										lockedRepInEscalationGame: 0n,
+										repDepositShare: rep(2n),
+										securityBondAllowance: 1n,
+										unpaidEthFees: 0n,
+										vaultAddress: zeroAddress,
+									},
+								],
+							}),
+							createPreviewPool({
+								parent: zeroAddress,
+								questionOutcome: 'invalid',
+								securityPoolAddress: '0x0000000000000000000000000000000000000102',
+								systemState: 'forkMigration',
+								vaults: [],
+							}),
+						],
+						stageView: 'migration',
+					}),
+				),
+				renderedComponent.container,
+			)
+		})
+
+		await waitFor(() => {
+			expectTransactionButtonDisabled(document.body, 'Migrate Vault To Invalid', 'Vault migration is already complete for this wallet.')
+		})
+		expect(document.body.textContent?.includes('Already migrated')).toBe(true)
+	})
+
+	test('keeps vault migration available while no successful migration result or refreshed empty balances exist', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					forkAuctionDetails: {
+						...createForkAuctionDetails(),
+						systemState: 'forkMigration',
+					},
+					forkAuctionForm: {
+						...createForkAuctionForm(),
+						selectedOutcome: 'no',
+					},
+					previewPool: createPreviewPool({
+						systemState: 'forkMigration',
+						vaults: [
+							{
+								lockedRepInEscalationGame: 0n,
+								repDepositShare: rep(2n),
+								securityBondAllowance: 1n,
+								unpaidEthFees: 0n,
+								vaultAddress: zeroAddress,
+							},
+						],
+					}),
+					securityPools: [
+						createPreviewPool({
+							parent: zeroAddress,
+							questionOutcome: 'no',
+							securityPoolAddress: '0x0000000000000000000000000000000000000201',
+							systemState: 'forkMigration',
+							vaults: [
+								{
+									lockedRepInEscalationGame: 0n,
+									repDepositShare: rep(2n),
+									securityBondAllowance: 1n,
+									unpaidEthFees: 0n,
+									vaultAddress: zeroAddress,
+								},
+							],
+						}),
+						createPreviewPool({
+							parent: zeroAddress,
+							questionOutcome: 'yes',
+							securityPoolAddress: '0x0000000000000000000000000000000000000202',
+							systemState: 'forkMigration',
+							vaults: [],
+						}),
+					],
+					stageView: 'migration',
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await waitFor(() => {
+			expectTransactionButtonEnabled(document.body, 'Migrate Vault To No')
+		})
+
+		await act(() => {
+			render(
+				h(
+					ForkAuctionSection,
+					createProps({
+						forkAuctionDetails: {
+							...createForkAuctionDetails(),
+							systemState: 'forkMigration',
+						},
+						forkAuctionForm: {
+							...createForkAuctionForm(),
+							selectedOutcome: 'yes',
+						},
+						previewPool: createPreviewPool({
+							systemState: 'forkMigration',
+							vaults: [
+								{
+									lockedRepInEscalationGame: 0n,
+									repDepositShare: rep(2n),
+									securityBondAllowance: 1n,
+									unpaidEthFees: 0n,
+									vaultAddress: zeroAddress,
+								},
+							],
+						}),
+						securityPools: [
+							createPreviewPool({
+								parent: zeroAddress,
+								questionOutcome: 'no',
+								securityPoolAddress: '0x0000000000000000000000000000000000000201',
+								systemState: 'forkMigration',
+								vaults: [
+									{
+										lockedRepInEscalationGame: 0n,
+										repDepositShare: rep(2n),
+										securityBondAllowance: 1n,
+										unpaidEthFees: 0n,
+										vaultAddress: zeroAddress,
+									},
+								],
+							}),
+							createPreviewPool({
+								parent: zeroAddress,
+								questionOutcome: 'yes',
+								securityPoolAddress: '0x0000000000000000000000000000000000000202',
+								systemState: 'forkMigration',
+								vaults: [],
+							}),
+						],
+						stageView: 'migration',
+					}),
+				),
+				renderedComponent.container,
+			)
+		})
+
+		await waitFor(() => {
+			expectTransactionButtonEnabled(document.body, 'Migrate Vault To Yes')
+		})
+		expect(document.body.textContent?.includes('Already migrated')).toBe(false)
 	})
 
 	test('renders latest fork action status outside action rows', async () => {
@@ -762,7 +1431,7 @@ describe('ForkAuctionSection', () => {
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		expectTransactionButtonDisabled(document.body, 'Migrate Vault', 'No REP collateral or security bond allowance remains to migrate for the connected wallet.')
+		expectTransactionButtonDisabled(document.body, 'Migrate Vault To Yes', 'No REP collateral or security bond allowance remains to migrate for the connected wallet.')
 		expectTransactionButtonDisabled(document.body, 'Migrate Selected Yes Deposits', 'No locked REP remains to migrate for the connected wallet.')
 		expectTransactionButtonDisabled(document.body, 'Migrate All Yes Deposits', 'No locked REP remains to migrate for the connected wallet.')
 	})
@@ -848,7 +1517,7 @@ describe('ForkAuctionSection', () => {
 					forkAuctionForm: {
 						...createForkAuctionForm(),
 						submitBidAmount: (1n * ETH).toString(),
-						submitBidTick: '1',
+						submitBidPrice: '1',
 					},
 				}),
 			),
@@ -873,7 +1542,7 @@ describe('ForkAuctionSection', () => {
 					forkAuctionForm: {
 						...createForkAuctionForm(),
 						submitBidAmount: (3n * ETH).toString(),
-						submitBidTick: '1',
+						submitBidPrice: '1',
 					},
 				}),
 			),
@@ -883,14 +1552,89 @@ describe('ForkAuctionSection', () => {
 		expectTransactionButtonDisabled(document.body, 'Submit Bid', 'Need 1 more ETH in this wallet to bid the selected amount.')
 	})
 
+	test('uses finalized-aware time left and finalized bid guard on the auction tab', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					accountState: createAccountState({ ethBalance: 10n * ETH }),
+					currentTimestamp: 150n,
+					forkAuctionDetails: {
+						...createForkAuctionDetails(),
+						currentTime: 150n,
+						systemState: 'forkTruthAuction',
+						truthAuction: {
+							...createTruthAuctionMetrics(),
+							auctionEndsAt: 1_000n,
+							finalized: true,
+							timeRemaining: 500n,
+						},
+						truthAuctionAddress: '0x0000000000000000000000000000000000000001',
+						truthAuctionStartedAt: 1n,
+					},
+					forkAuctionForm: {
+						...createForkAuctionForm(),
+						submitBidAmount: (3n * ETH).toString(),
+						submitBidPrice: 'abc',
+					},
+					stageView: 'auction',
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(within(document.body).getByText('Bid Price (ETH / REP)')).not.toBeNull()
+		expect(within(document.body).queryByText('Bid Tick')).toBeNull()
+
+		const auctionOverviewSection = within(document.body).getByRole('heading', { name: 'Auction Overview' }).closest('section')
+		if (!(auctionOverviewSection instanceof HTMLElement)) throw new Error('Expected auction overview section to render')
+		expect(getMetricValue(auctionOverviewSection, 'Time Left')).toBe('0m')
+		expectTransactionButtonDisabled(document.body, 'Submit Bid', 'Truth auction is already finalized.')
+	})
+
+	test('shows a price-specific bid validation error for malformed live-auction prices', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					accountState: createAccountState({ ethBalance: 10n * ETH }),
+					forkAuctionDetails: {
+						...createForkAuctionDetails(),
+						systemState: 'forkTruthAuction',
+						truthAuction: createTruthAuctionMetrics(),
+						truthAuctionAddress: '0x0000000000000000000000000000000000000001',
+						truthAuctionStartedAt: 1n,
+					},
+					forkAuctionForm: {
+						...createForkAuctionForm(),
+						submitBidAmount: (3n * ETH).toString(),
+						submitBidPrice: 'abc',
+					},
+					stageView: 'auction',
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expectTransactionButtonDisabled(document.body, 'Submit Bid', 'Enter a valid bid price.')
+	})
+
 	test('disables start truth auction until migration ends and enables it afterwards', async () => {
 		const baseProps = createProps({
 			currentTimestamp: 150n,
+			auctionDetailsOverride: undefined,
 			forkAuctionDetails: {
 				...createForkAuctionDetails(),
 				migrationEndsAt: 200n,
 				systemState: 'forkMigration',
 			},
+			securityPools: [
+				createPreviewPool({
+					parent: zeroAddress,
+					questionOutcome: 'yes',
+					securityPoolAddress: YES_CHILD_POOL_ADDRESS,
+				}),
+			],
 			stageView: 'auction',
 		})
 		const renderedComponent = await renderIntoDocument(h(ForkAuctionSection, baseProps))
@@ -938,10 +1682,41 @@ describe('ForkAuctionSection', () => {
 		expect(document.body.textContent?.includes('This pool is currently in Migration. Auction controls become meaningful after migration completes and the truth auction starts.')).toBe(false)
 	})
 
+	test('shows bypass auction copy when no parent collateral remains to auction', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					currentTimestamp: 201n,
+					forkAuctionDetails: {
+						...createForkAuctionDetails(),
+						completeSetCollateralAmount: 0n,
+						migrationEndsAt: 200n,
+						systemState: 'forkMigration',
+					},
+					securityPools: [
+						createPreviewPool({
+							parent: zeroAddress,
+							questionOutcome: 'yes',
+							securityPoolAddress: YES_CHILD_POOL_ADDRESS,
+						}),
+					],
+					stageView: 'auction',
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expectTransactionButtonEnabled(document.body, 'Bypass Auction')
+		expect(document.body.textContent?.includes('No parent collateral remains to auction, so this step immediately bypasses bidding and finalizes the child pool.')).toBe(true)
+		expect(within(document.body).queryByRole('button', { name: 'Start Truth Auction' })).toBeNull()
+	})
+
 	test('refreshes auction status immediately after truth auction start succeeds', async () => {
 		let startTruthAuctionCalls = 0
 		const baseProps = createProps({
 			currentTimestamp: 201n,
+			auctionDetailsOverride: undefined,
 			forkAuctionDetails: {
 				...createForkAuctionDetails(),
 				migrationEndsAt: 200n,
@@ -950,6 +1725,13 @@ describe('ForkAuctionSection', () => {
 			onStartTruthAuction: () => {
 				startTruthAuctionCalls += 1
 			},
+			securityPools: [
+				createPreviewPool({
+					parent: zeroAddress,
+					questionOutcome: 'yes',
+					securityPoolAddress: YES_CHILD_POOL_ADDRESS,
+				}),
+			],
 			stageView: 'auction',
 		})
 		const renderedComponent = await renderIntoDocument(h(ForkAuctionSection, baseProps))
@@ -962,6 +1744,10 @@ describe('ForkAuctionSection', () => {
 		})
 		expect(startTruthAuctionCalls).toBe(1)
 		expectTransactionButtonDisabled(document.body, 'Start Truth Auction', 'Starting truth auction...')
+		const pendingAuctionStatusSection = documentQueries.getByRole('heading', { name: 'Auction Status' }).closest('section')
+		if (!(pendingAuctionStatusSection instanceof HTMLElement)) throw new Error('Expected auction status section to render')
+		expect(getMetricValue(pendingAuctionStatusSection, 'Started')).toBe('Starting...')
+		expect(getMetricValue(pendingAuctionStatusSection, 'Ends')).toBe('Pending confirmation')
 		await act(() => {
 			fireEvent.click(documentQueries.getByRole('button', { name: 'Start Truth Auction' }))
 		})
@@ -976,7 +1762,7 @@ describe('ForkAuctionSection', () => {
 						forkAuctionResult: {
 							action: 'startTruthAuction',
 							hash: '0x00000000000000000000000000000000000000000000000000000000000000f0',
-							securityPoolAddress: zeroAddress,
+							securityPoolAddress: YES_CHILD_POOL_ADDRESS,
 							universeId: 1n,
 						},
 					}),
@@ -992,7 +1778,7 @@ describe('ForkAuctionSection', () => {
 		expect(getMetricValue(auctionStatusSection, 'Ends')).not.toBe('Not started')
 	})
 
-	test('locks the vault migration button after submit until the wallet is marked migrated for that outcome', async () => {
+	test('locks the vault migration button after submit until the wallet is marked fully migrated', async () => {
 		let migrateVaultCalls = 0
 		const selectedOutcomeVaults = [
 			{
@@ -1041,16 +1827,16 @@ describe('ForkAuctionSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		await waitFor(() => {
-			expectTransactionButtonEnabled(document.body, 'Migrate Vault')
+			expectTransactionButtonEnabled(document.body, 'Migrate Vault To Yes')
 		})
 
 		await act(() => {
-			fireEvent.click(within(document.body).getByRole('button', { name: 'Migrate Vault' }))
+			fireEvent.click(within(document.body).getByRole('button', { name: 'Migrate Vault To Yes' }))
 		})
 		expect(migrateVaultCalls).toBe(1)
-		expectTransactionButtonDisabled(document.body, 'Migrate Vault', 'Migrating vault...')
+		expectTransactionButtonDisabled(document.body, 'Migrate Vault To Yes', 'Migrating vault...')
 		await act(() => {
-			fireEvent.click(within(document.body).getByRole('button', { name: 'Migrate Vault' }))
+			fireEvent.click(within(document.body).getByRole('button', { name: 'Migrate Vault To Yes' }))
 		})
 		expect(migrateVaultCalls).toBe(1)
 
@@ -1084,9 +1870,94 @@ describe('ForkAuctionSection', () => {
 			)
 		})
 		await waitFor(() => {
-			expectTransactionButtonDisabled(document.body, 'Migrate Vault', 'Vault migration for this outcome is already complete for this wallet.')
+			expectTransactionButtonDisabled(document.body, 'Migrate Vault To Yes', 'Vault migration is already complete for this wallet.')
 		})
 		expect(document.body.textContent?.includes('Already migrated')).toBe(true)
+		const migrationStatusSection = within(document.body).getByRole('heading', { name: 'Migration Status' }).closest('section')
+		if (!(migrationStatusSection instanceof HTMLElement)) throw new Error('Expected migration status section to render')
+		expect(within(migrationStatusSection).getByText('Migrated')).not.toBeNull()
+	})
+
+	test('clears vault migration completion when the connected wallet or parent pool changes', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					accountState: createAccountState({ address: zeroAddress }),
+					forkAuctionDetails: {
+						...createForkAuctionDetails(),
+						securityPoolAddress: zeroAddress,
+						systemState: 'forkMigration',
+					},
+					forkAuctionResult: {
+						action: 'migrateVault',
+						hash: '0x00000000000000000000000000000000000000000000000000000000000000f2',
+						securityPoolAddress: zeroAddress,
+						universeId: 1n,
+					},
+					previewPool: createPreviewPool({
+						securityPoolAddress: zeroAddress,
+						systemState: 'forkMigration',
+						vaults: [
+							{
+								lockedRepInEscalationGame: 0n,
+								repDepositShare: rep(2n),
+								securityBondAllowance: 1n,
+								unpaidEthFees: 0n,
+								vaultAddress: zeroAddress,
+							},
+						],
+					}),
+					securityPools: [createPreviewPool({ parent: zeroAddress, questionOutcome: 'yes', securityPoolAddress: YES_CHILD_POOL_ADDRESS })],
+					stageView: 'migration',
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await waitFor(() => {
+			expectTransactionButtonDisabled(document.body, 'Migrate Vault To Yes', 'Vault migration is already complete for this wallet.')
+		})
+
+		const otherAccount = '0x0000000000000000000000000000000000000001'
+		const otherPool = '0x00000000000000000000000000000000000000aa'
+		await act(() => {
+			render(
+				h(
+					ForkAuctionSection,
+					createProps({
+						accountState: createAccountState({ address: otherAccount }),
+						forkAuctionDetails: {
+							...createForkAuctionDetails(),
+							securityPoolAddress: otherPool,
+							systemState: 'forkMigration',
+						},
+						forkAuctionResult: undefined,
+						previewPool: createPreviewPool({
+							securityPoolAddress: otherPool,
+							systemState: 'forkMigration',
+							vaults: [
+								{
+									lockedRepInEscalationGame: 0n,
+									repDepositShare: rep(2n),
+									securityBondAllowance: 1n,
+									unpaidEthFees: 0n,
+									vaultAddress: otherAccount,
+								},
+							],
+						}),
+						securityPools: [createPreviewPool({ parent: otherPool, questionOutcome: 'yes', securityPoolAddress: '0x00000000000000000000000000000000000000ab' })],
+						stageView: 'migration',
+					}),
+				),
+				renderedComponent.container,
+			)
+		})
+
+		await waitFor(() => {
+			expectTransactionButtonEnabled(document.body, 'Migrate Vault To Yes')
+		})
+		expect(document.body.textContent?.includes('Already migrated')).toBe(false)
 	})
 
 	test('disables submit bid after auction end to prevent reverted bids', async () => {
@@ -1111,7 +1982,7 @@ describe('ForkAuctionSection', () => {
 					forkAuctionForm: {
 						...createForkAuctionForm(),
 						submitBidAmount: (3n * ETH).toString(),
-						submitBidTick: '10',
+						submitBidPrice: '1',
 					},
 				}),
 			),
@@ -1119,6 +1990,67 @@ describe('ForkAuctionSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		expectTransactionButtonDisabled(document.body, 'Submit Bid', 'Truth auction has ended.')
+	})
+
+	test('shows an auction-ended notice with the end timestamp once bidding has closed', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					currentTimestamp: 201n,
+					forkAuctionDetails: {
+						...createForkAuctionDetails(),
+						systemState: 'forkTruthAuction',
+						truthAuction: {
+							...createTruthAuctionMetrics(),
+							auctionEndsAt: 200n,
+							finalized: false,
+							timeRemaining: 0n,
+						},
+						truthAuctionAddress: '0x0000000000000000000000000000000000000001',
+						truthAuctionStartedAt: 200n - AUCTION_TIME_SECONDS,
+					},
+					stageView: 'auction',
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const endedNotice = document.body.querySelector('.notice.success')
+		expect(endedNotice?.textContent).toContain('Truth auction has ended.')
+		expect(endedNotice?.textContent).toContain('Ended at:')
+		expect(endedNotice?.textContent).toContain('Finalize the truth auction')
+	})
+
+	test('shows the ended notice for finalized auctions too', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					currentTimestamp: 201n,
+					forkAuctionDetails: {
+						...createForkAuctionDetails(),
+						claimingAvailable: true,
+						systemState: 'operational',
+						truthAuction: {
+							...createTruthAuctionMetrics(),
+							auctionEndsAt: 200n,
+							finalized: true,
+							timeRemaining: 0n,
+						},
+						truthAuctionAddress: '0x0000000000000000000000000000000000000001',
+						truthAuctionStartedAt: 200n - AUCTION_TIME_SECONDS,
+					},
+					stageView: 'settlement',
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const endedNotice = document.body.querySelector('.notice.success')
+		expect(endedNotice?.textContent).toContain('Truth auction has ended.')
+		expect(endedNotice?.textContent).toContain('finalized settlement paths are now in effect')
+		expect(endedNotice?.textContent).toContain('Ended at:')
 	})
 
 	test('gates settlement actions against lifecycle conditions that would otherwise revert onchain', async () => {
@@ -1147,13 +2079,20 @@ describe('ForkAuctionSection', () => {
 				refundBidIndex: '1',
 				refundTick: '9',
 			},
+			securityPools: [
+				createPreviewPool({
+					parent: zeroAddress,
+					questionOutcome: 'yes',
+					securityPoolAddress: YES_CHILD_POOL_ADDRESS,
+				}),
+			],
 			stageView: 'settlement',
 		})
 		const renderedComponent = await renderIntoDocument(h(ForkAuctionSection, baseProps))
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		expectTransactionButtonDisabled(document.body, 'Finalize Truth Auction', 'Truth auction is still ongoing.')
+		expect(documentQueries.queryByRole('button', { name: 'Finalize Truth Auction' })).toBeNull()
 		expectTransactionButtonEnabled(document.body, 'Refund Losing Bid')
 		expect(documentQueries.queryByRole('button', { name: 'Settle Finalized Bid' })).toBeNull()
 
@@ -1168,25 +2107,27 @@ describe('ForkAuctionSection', () => {
 		})
 
 		await waitFor(() => {
-			expectTransactionButtonEnabled(document.body, 'Finalize Truth Auction')
+			expect(documentQueries.queryByRole('button', { name: 'Finalize Truth Auction' })).toBeNull()
 		})
 		expectTransactionButtonEnabled(document.body, 'Refund Losing Bid')
 
 		await act(() => {
+			const finalizedDetails = {
+				...baseDetails,
+				claimingAvailable: true,
+				systemState: 'operational',
+				truthAuction: {
+					...baseDetails.truthAuction,
+					finalized: true,
+					timeRemaining: 0n,
+				},
+			} satisfies ForkAuctionDetails
 			render(
 				h(ForkAuctionSection, {
 					...baseProps,
+					auctionDetailsOverride: finalizedDetails,
 					currentTimestamp: 201n,
-					forkAuctionDetails: {
-						...baseDetails,
-						claimingAvailable: true,
-						systemState: 'operational',
-						truthAuction: {
-							...baseDetails.truthAuction,
-							finalized: true,
-							timeRemaining: 0n,
-						},
-					},
+					forkAuctionDetails: finalizedDetails,
 				}),
 				renderedComponent.container,
 			)
@@ -1219,6 +2160,13 @@ describe('ForkAuctionSection', () => {
 					accountState: createAccountState({ ethBalance: 10n * ETH }),
 					forkAuctionDetails: baseDetails,
 					forkAuctionForm: createForkAuctionForm(),
+					securityPools: [
+						createPreviewPool({
+							parent: zeroAddress,
+							questionOutcome: 'yes',
+							securityPoolAddress: YES_CHILD_POOL_ADDRESS,
+						}),
+					],
 				}),
 			),
 		)
@@ -1239,6 +2187,13 @@ describe('ForkAuctionSection', () => {
 							...createForkAuctionForm(),
 							claimBidTick: '10',
 						},
+						securityPools: [
+							createPreviewPool({
+								parent: zeroAddress,
+								questionOutcome: 'yes',
+								securityPoolAddress: YES_CHILD_POOL_ADDRESS,
+							}),
+						],
 					}),
 				}),
 				renderedComponent.container,
@@ -1258,6 +2213,13 @@ describe('ForkAuctionSection', () => {
 							claimBidTick: '10',
 							settlementAddress: 'not-an-address',
 						},
+						securityPools: [
+							createPreviewPool({
+								parent: zeroAddress,
+								questionOutcome: 'yes',
+								securityPoolAddress: YES_CHILD_POOL_ADDRESS,
+							}),
+						],
 					}),
 				}),
 				renderedComponent.container,
@@ -1276,6 +2238,13 @@ describe('ForkAuctionSection', () => {
 							claimBidIndex: '0',
 							claimBidTick: '10',
 						},
+						securityPools: [
+							createPreviewPool({
+								parent: zeroAddress,
+								questionOutcome: 'yes',
+								securityPoolAddress: YES_CHILD_POOL_ADDRESS,
+							}),
+						],
 					}),
 				}),
 				renderedComponent.container,
@@ -1932,7 +2901,7 @@ describe('ForkAuctionSection', () => {
 		})
 	})
 
-	test('keeps the auction stage ordered as market view, submit bid, then my bids and shows the form-linked preview state', async () => {
+	test('keeps the auction stage ordered as market view, submit bid, finalize, then my bids and shows the form-linked preview state', async () => {
 		const truthAuctionReadClient = createTruthAuctionReadClient(async request => {
 			if (request.functionName === 'activeTickCount') return 1n
 			if (request.functionName === 'getActiveTickPage') return [createTruthAuctionTickSummary({ tick: 12n, price: 3n * ETH, currentTotalEth: 4n * ETH, submissionCount: 1n, active: true })]
@@ -1961,7 +2930,7 @@ describe('ForkAuctionSection', () => {
 					forkAuctionForm: {
 						...createForkAuctionForm(),
 						submitBidAmount: (4n * ETH).toString(),
-						submitBidTick: '12',
+						submitBidPrice: formatCurrencyInputBalance(getTruthAuctionPriceAtTick(12n)),
 					},
 					truthAuctionReadClient,
 				}),
@@ -1980,13 +2949,20 @@ describe('ForkAuctionSection', () => {
 
 		const marketViewHeading = documentQueries.getByRole('heading', { name: 'Market View' })
 		const submitBidHeading = documentQueries.getByRole('heading', { name: 'Submit Bid' })
+		const finalizeHeading = documentQueries.getByRole('heading', { name: 'Finalize Truth Auction' })
 		const myBidsHeading = documentQueries.getByRole('heading', { name: 'My Bids' })
 
 		expectElementBefore(marketViewHeading, submitBidHeading)
-		expectElementBefore(submitBidHeading, myBidsHeading)
+		expectElementBefore(submitBidHeading, finalizeHeading)
+		expectElementBefore(finalizeHeading, myBidsHeading)
 		expect(documentQueries.getByText(/Selected ladder price:/)).not.toBeNull()
 		expect(document.body.textContent?.includes('Current form tick')).toBe(true)
+		expect(documentQueries.getByRole('button', { name: 'Use This Price' })).not.toBeNull()
+		expect(documentQueries.getByText('Bid Price (ETH / REP)')).not.toBeNull()
+		expect(documentQueries.queryByText('Bid Tick')).toBeNull()
 		expect(document.body.querySelector('.truth-auction-depth-marker.is-preview')).not.toBeNull()
+		expect(document.body.querySelector('.truth-auction-market-section')).not.toBeNull()
+		expect(document.body.querySelector('.truth-auction-market-board .truth-auction-panel')).toBeNull()
 	})
 
 	test('keeps pre-finalization settlement focused on wallet actions before the market view and leaves operator tools collapsed by default', async () => {
@@ -2135,6 +3111,250 @@ describe('ForkAuctionSection', () => {
 		fireEvent.click(documentQueries.getByRole('button', { name: 'Load More Price Levels' }))
 		await waitFor(() => {
 			expect(document.body.textContent?.includes('Showing 26 of 26 active price levels')).toBe(true)
+		})
+	})
+
+	test('shows aggregated auction bids without requiring a selected tick and keeps the section ordered after market view', async () => {
+		const truthAuctionReadClient = createTruthAuctionReadClient(async request => {
+			if (request.functionName === 'activeTickCount') return 2n
+			if (request.functionName === 'getActiveTickPage') {
+				return [createTruthAuctionTickSummary({ tick: 12n, price: getTruthAuctionPriceAtTick(12n), currentTotalEth: 5n * ETH, submissionCount: 2n, active: true }), createTruthAuctionTickSummary({ tick: 10n, price: getTruthAuctionPriceAtTick(10n), currentTotalEth: 4n * ETH, submissionCount: 1n, active: true })]
+			}
+			if (request.functionName === 'getTickSummary') return createTruthAuctionTickSummary({ tick: 12n, price: getTruthAuctionPriceAtTick(12n), currentTotalEth: 5n * ETH, submissionCount: 2n, active: true })
+			if (request.functionName === 'getBidCountAtTick') return (request.args?.[0] ?? 0n) === 12n ? 2n : 1n
+			if (request.functionName === 'getBidPageAtTick') {
+				if ((request.args?.[0] ?? 0n) === 12n) {
+					return [createTruthAuctionBidView({ tick: 12n, bidIndex: 0n, ethAmount: 2n * ETH, cumulativeEth: 2n * ETH }), createTruthAuctionBidView({ tick: 12n, bidIndex: 1n, bidder: '0x0000000000000000000000000000000000000001', ethAmount: 3n * ETH, cumulativeEth: 5n * ETH, activeCumulativeEthBeforeBid: 2n * ETH })]
+				}
+				return [createTruthAuctionBidView({ tick: 10n, bidIndex: 0n, ethAmount: 4n * ETH, cumulativeEth: 4n * ETH })]
+			}
+			if (request.functionName === 'getBidderBidCount') return 1n
+			if (request.functionName === 'getBidderBidPage') return [createTruthAuctionBidView({ tick: 12n, bidIndex: 0n, ethAmount: 2n * ETH, cumulativeEth: 2n * ETH })]
+			throw new Error(`Unexpected truth auction read: ${String(request.functionName)}`)
+		})
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					accountState: createAccountState({ ethBalance: 10n * ETH }),
+					forkAuctionDetails: {
+						...createForkAuctionDetails(),
+						systemState: 'forkTruthAuction',
+						truthAuction: createTruthAuctionMetrics(),
+						truthAuctionAddress: '0x0000000000000000000000000000000000000001',
+						truthAuctionStartedAt: 1n,
+					},
+					truthAuctionReadClient,
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		await waitFor(() => {
+			expect(documentQueries.getByRole('heading', { name: 'Auction Bids' })).not.toBeNull()
+			expect(document.body.textContent?.includes('Showing 3 of 3 bids across loaded levels')).toBe(true)
+		})
+
+		const marketViewHeading = documentQueries.getByRole('heading', { name: 'Market View' })
+		const auctionBidsHeading = documentQueries.getByRole('heading', { name: 'Auction Bids' })
+		const submitBidHeading = documentQueries.getByRole('heading', { name: 'Submit Bid' })
+
+		expectElementBefore(marketViewHeading, auctionBidsHeading)
+		expectElementBefore(auctionBidsHeading, submitBidHeading)
+		expect(document.body.textContent?.includes('Bid #1')).toBe(true)
+		expect(document.body.textContent?.includes('Tick 10')).toBe(true)
+	})
+
+	test('sorts aggregated auction bids by tick descending then bid index ascending and can prefill actions from that table', async () => {
+		const formUpdates: Partial<ForkAuctionFormState>[] = []
+		const truthAuctionReadClient = createTruthAuctionReadClient(async request => {
+			if (request.functionName === 'activeTickCount') return 2n
+			if (request.functionName === 'getActiveTickPage') {
+				return [createTruthAuctionTickSummary({ tick: 12n, price: getTruthAuctionPriceAtTick(12n), currentTotalEth: 5n * ETH, submissionCount: 2n, active: true }), createTruthAuctionTickSummary({ tick: 10n, price: getTruthAuctionPriceAtTick(10n), currentTotalEth: 4n * ETH, submissionCount: 1n, active: true })]
+			}
+			if (request.functionName === 'getTickSummary') return createTruthAuctionTickSummary({ tick: 12n, price: getTruthAuctionPriceAtTick(12n), currentTotalEth: 5n * ETH, submissionCount: 2n, active: true })
+			if (request.functionName === 'getBidCountAtTick') return (request.args?.[0] ?? 0n) === 12n ? 2n : 1n
+			if (request.functionName === 'getBidPageAtTick') {
+				if ((request.args?.[0] ?? 0n) === 12n) {
+					return [createTruthAuctionBidView({ tick: 12n, bidIndex: 1n, bidder: '0x0000000000000000000000000000000000000001', ethAmount: 3n * ETH, cumulativeEth: 5n * ETH, activeCumulativeEthBeforeBid: 2n * ETH }), createTruthAuctionBidView({ tick: 12n, bidIndex: 0n, ethAmount: 2n * ETH, cumulativeEth: 2n * ETH })]
+				}
+				return [createTruthAuctionBidView({ tick: 10n, bidIndex: 0n, ethAmount: 4n * ETH, cumulativeEth: 4n * ETH, claimed: true })]
+			}
+			if (request.functionName === 'getBidderBidCount') return 2n
+			if (request.functionName === 'getBidderBidPage') {
+				return [createTruthAuctionBidView({ tick: 12n, bidIndex: 0n, ethAmount: 2n * ETH, cumulativeEth: 2n * ETH }), createTruthAuctionBidView({ tick: 10n, bidIndex: 0n, ethAmount: 4n * ETH, cumulativeEth: 4n * ETH, claimed: true })]
+			}
+			throw new Error(`Unexpected truth auction read: ${String(request.functionName)}`)
+		})
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					accountState: createAccountState({ ethBalance: 10n * ETH }),
+					forkAuctionDetails: {
+						...createForkAuctionDetails(),
+						claimingAvailable: true,
+						systemState: 'operational',
+						truthAuction: {
+							...createTruthAuctionMetrics(),
+							clearingPrice: getTruthAuctionPriceAtTick(10n),
+							clearingTick: 10n,
+							ethAtClearingTick: 4n * ETH,
+							finalized: true,
+							hitCap: true,
+							timeRemaining: 0n,
+						},
+						truthAuctionAddress: '0x0000000000000000000000000000000000000001',
+						truthAuctionStartedAt: 1n,
+					},
+					onForkAuctionFormChange: update => {
+						formUpdates.push(update)
+					},
+					stageView: 'settlement',
+					truthAuctionReadClient,
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		await waitFor(() => {
+			expect(documentQueries.getByRole('heading', { name: 'Auction Bids' })).not.toBeNull()
+			expect(documentQueries.getAllByRole('button', { name: 'Prefill Settle' }).length).toBeGreaterThan(0)
+		})
+
+		const aggregateTable = documentQueries.getByRole('heading', { name: 'Auction Bids' }).closest('.section-block')
+		if (!(aggregateTable instanceof HTMLElement)) throw new Error('Expected aggregated auction bids section to render')
+		await waitFor(() => {
+			expect(aggregateTable.textContent?.includes('Bid #0')).toBe(true)
+		})
+		const aggregateRows = Array.from(aggregateTable.querySelectorAll('.truth-auction-bid-row.is-wide')).filter(row => !row.classList.contains('is-header'))
+		expect(aggregateRows.length).toBeGreaterThanOrEqual(3)
+		expect(aggregateRows[0]?.textContent).toContain('Tick 12')
+		expect(aggregateRows[0]?.textContent).toContain('Bid #0')
+		expect(aggregateRows[1]?.textContent).toContain('Tick 12')
+		expect(aggregateRows[1]?.textContent).toContain('Bid #1')
+		expect(aggregateRows[2]?.textContent).toContain('Tick 10')
+
+		fireEvent.click(within(aggregateTable).getAllByRole('button', { name: 'Prefill Settle' })[0] as HTMLElement)
+		expect(formUpdates).toContainEqual({
+			claimBidIndex: '0',
+			claimBidTick: '12',
+			settlementAddress: zeroAddress,
+		})
+		expect(aggregateRows[1]?.textContent?.includes('Prefill Settle')).toBe(false)
+	})
+
+	test('expands aggregated auction bid coverage after loading more price levels and more bid pages', async () => {
+		const truthAuctionReadClient = createTruthAuctionReadClient(async request => {
+			if (request.functionName === 'activeTickCount') return 2n
+			if (request.functionName === 'getActiveTickPage') {
+				const offset = request.args?.[0] ?? 0n
+				if (offset === 25n) {
+					return [createTruthAuctionTickSummary({ tick: 9n, price: getTruthAuctionPriceAtTick(9n), currentTotalEth: 5n * ETH, submissionCount: 1n, active: true })]
+				}
+				return [createTruthAuctionTickSummary({ tick: 12n, price: getTruthAuctionPriceAtTick(12n), currentTotalEth: 5n * ETH, submissionCount: 2n, active: true })]
+			}
+			if (request.functionName === 'getTickSummary') return createTruthAuctionTickSummary({ tick: 12n, price: getTruthAuctionPriceAtTick(12n), currentTotalEth: 5n * ETH, submissionCount: 2n, active: true })
+			if (request.functionName === 'getBidCountAtTick') return (request.args?.[0] ?? 0n) === 12n ? 2n : 1n
+			if (request.functionName === 'getBidPageAtTick') {
+				const tick = request.args?.[0] ?? 0n
+				const offset = request.args?.[1] ?? 0n
+				if (tick === 12n && offset === 0n) return [createTruthAuctionBidView({ tick: 12n, bidIndex: 0n, ethAmount: 2n * ETH, cumulativeEth: 2n * ETH })]
+				if (tick === 12n && offset === 25n) return [createTruthAuctionBidView({ tick: 12n, bidIndex: 1n, ethAmount: 3n * ETH, cumulativeEth: 5n * ETH, activeCumulativeEthBeforeBid: 2n * ETH })]
+				return [createTruthAuctionBidView({ tick: 9n, bidIndex: 0n, ethAmount: 5n * ETH, cumulativeEth: 5n * ETH })]
+			}
+			if (request.functionName === 'getBidderBidCount') return 0n
+			if (request.functionName === 'getBidderBidPage') return []
+			throw new Error(`Unexpected truth auction read: ${String(request.functionName)}`)
+		})
+		const firstPageTicks = Array.from({ length: 25 }, (_, index) =>
+			createTruthAuctionTickSummary({
+				tick: BigInt(100 - index),
+				price: getTruthAuctionPriceAtTick(BigInt(100 - index)),
+				currentTotalEth: 1n * ETH,
+				submissionCount: index === 0 ? 2n : 0n,
+				active: true,
+			}),
+		)
+		const expandedTruthAuctionReadClient = createTruthAuctionReadClient(async request => {
+			if (request.functionName === 'activeTickCount') return 26n
+			if (request.functionName === 'getActiveTickPage') {
+				const offset = request.args?.[0] ?? 0n
+				if (offset === 25n) return [createTruthAuctionTickSummary({ tick: 75n, price: getTruthAuctionPriceAtTick(75n), currentTotalEth: 1n * ETH, submissionCount: 1n, active: true })]
+				return firstPageTicks
+			}
+			if (request.functionName === 'getTickSummary') return firstPageTicks[0] ?? createTruthAuctionTickSummary()
+			if (request.functionName === 'getBidCountAtTick') {
+				const tick = request.args?.[0] ?? 0n
+				if (tick === 100n) return 2n
+				if (tick === 75n) return 1n
+				return 0n
+			}
+			if (request.functionName === 'getBidPageAtTick') {
+				const tick = request.args?.[0] ?? 0n
+				const offset = request.args?.[1] ?? 0n
+				if (tick === 100n && offset === 0n) return [createTruthAuctionBidView({ tick: 100n, bidIndex: 0n, ethAmount: 2n * ETH, cumulativeEth: 2n * ETH })]
+				if (tick === 100n && offset === 25n) return [createTruthAuctionBidView({ tick: 100n, bidIndex: 1n, ethAmount: 3n * ETH, cumulativeEth: 5n * ETH, activeCumulativeEthBeforeBid: 2n * ETH })]
+				if (tick === 75n) return [createTruthAuctionBidView({ tick: 75n, bidIndex: 0n, ethAmount: 4n * ETH, cumulativeEth: 4n * ETH })]
+				return []
+			}
+			if (request.functionName === 'getBidderBidCount') return 0n
+			if (request.functionName === 'getBidderBidPage') return []
+			throw new Error(`Unexpected truth auction read: ${String(request.functionName)}`)
+		})
+
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					accountState: createAccountState({ ethBalance: 10n * ETH }),
+					forkAuctionDetails: {
+						...createForkAuctionDetails(),
+						systemState: 'forkTruthAuction',
+						truthAuction: createTruthAuctionMetrics(),
+						truthAuctionAddress: '0x0000000000000000000000000000000000000001',
+						truthAuctionStartedAt: 1n,
+					},
+					truthAuctionReadClient,
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		await waitFor(() => {
+			expect(document.body.textContent?.includes('Showing 1 of 2 bids across loaded levels')).toBe(true)
+		})
+		fireEvent.click(documentQueries.getByRole('button', { name: 'Load More Auction Bids' }))
+		await waitFor(() => {
+			expect(document.body.textContent?.includes('Showing 2 of 2 bids across loaded levels')).toBe(true)
+		})
+
+		await act(() => {
+			render(
+				h(
+					ForkAuctionSection,
+					createProps({
+						accountState: createAccountState({ ethBalance: 10n * ETH }),
+						forkAuctionDetails: {
+							...createForkAuctionDetails(),
+							systemState: 'forkTruthAuction',
+							truthAuction: createTruthAuctionMetrics(),
+							truthAuctionAddress: '0x0000000000000000000000000000000000000001',
+							truthAuctionStartedAt: 1n,
+						},
+						truthAuctionReadClient: expandedTruthAuctionReadClient,
+					}),
+				),
+				renderedComponent.container,
+			)
+		})
+
+		fireEvent.click(documentQueries.getByRole('button', { name: 'Load More Price Levels' }))
+		await waitFor(() => {
+			expect(document.body.textContent?.includes('Showing 3 of 3 bids across loaded levels')).toBe(true)
 		})
 	})
 })

--- a/ui/ts/tests/securityPoolLabels.test.ts
+++ b/ui/ts/tests/securityPoolLabels.test.ts
@@ -1,7 +1,7 @@
 /// <reference types='bun-types' />
 
 import { describe, expect, test } from 'bun:test'
-import { getSecurityPoolLifecycleLabel } from '../lib/securityPoolLabels.js'
+import { getSecurityPoolLifecycleLabel, getSecurityPoolStatusBadgeLabel } from '../lib/securityPoolLabels.js'
 
 void describe('security pool lifecycle label', () => {
 	void test('maps each known lifecycle state and undefined', () => {
@@ -11,5 +11,15 @@ void describe('security pool lifecycle label', () => {
 		expect(getSecurityPoolLifecycleLabel('poolForked')).toBe('Pool Forked')
 		expect(getSecurityPoolLifecycleLabel('forkMigration')).toBe('Fork Migration')
 		expect(getSecurityPoolLifecycleLabel('forkTruthAuction')).toBe('Truth Auction')
+	})
+
+	void test('derives fork-aware status badge labels', () => {
+		expect(getSecurityPoolStatusBadgeLabel({ hasForkActivity: false, lifecycleState: undefined })).toBe('Unknown')
+		expect(getSecurityPoolStatusBadgeLabel({ hasForkActivity: false, lifecycleState: 'operational' })).toBe('Operational')
+		expect(getSecurityPoolStatusBadgeLabel({ hasForkActivity: true, lifecycleState: 'operational' })).toBe('Fork Finalized')
+		expect(getSecurityPoolStatusBadgeLabel({ hasForkActivity: true, lifecycleState: 'poolForked' })).toBe('Fork Migration')
+		expect(getSecurityPoolStatusBadgeLabel({ hasForkActivity: true, lifecycleState: 'forkMigration' })).toBe('Fork Migration')
+		expect(getSecurityPoolStatusBadgeLabel({ hasForkActivity: true, lifecycleState: 'forkTruthAuction' })).toBe('Truth Auction')
+		expect(getSecurityPoolStatusBadgeLabel({ hasForkActivity: false, lifecycleState: 'ended' })).toBe('Ended')
 	})
 })

--- a/ui/ts/tests/securityPoolWorkflowSection.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection.test.tsx
@@ -189,7 +189,7 @@ function createForkAuctionProps(overrides: Partial<ForkAuctionRouteContentProps>
 			selectedOutcome: 'yes',
 			settlementAddress: '',
 			submitBidAmount: '',
-			submitBidTick: '',
+			submitBidPrice: '',
 			vaultAddress: '',
 		},
 		forkAuctionResult: undefined,
@@ -775,6 +775,56 @@ describe('SecurityPoolWorkflowSection', () => {
 		expectTransactionButtonDisabled(document.body, 'Set Bond Allowance')
 		expectTransactionButtonEnabled(document.body, 'Claim Fees')
 		expectTransactionButtonDisabled(document.body, 'Liquidate Vault')
+	})
+
+	test('shows Fork Migration in the selected-pool badge once fork migration has started', async () => {
+		const selectedPoolAddress = zeroAddress
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					checkedSecurityPoolAddress: selectedPoolAddress,
+					securityPoolAddress: selectedPoolAddress,
+					securityPools: [createSelectedPool({ forkOutcome: 'yes', migratedRep: 1n, securityPoolAddress: selectedPoolAddress, systemState: 'poolForked' })],
+					selectedPoolView: 'reporting',
+				})}
+				showHeader={false}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(within(document.body).getByText('Fork Migration')).not.toBeNull()
+	})
+
+	test('shows Fork Finalized in the selected-pool badge after child-pool fork flow completes', async () => {
+		const selectedPoolAddress = zeroAddress
+		const freshTruthAuctionAddress = getAddress('0x00000000000000000000000000000000000000f1')
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					checkedSecurityPoolAddress: selectedPoolAddress,
+					forkAuction: createForkAuctionProps({
+						forkAuctionDetails: createForkAuctionDetails({
+							completeSetCollateralAmount: 2n,
+							forkOutcome: 'yes',
+							forkOwnSecurityPool: true,
+							marketDetails: createMarketDetails({ endTime: 2n }),
+							migratedRep: 5n,
+							securityPoolAddress: selectedPoolAddress,
+							systemState: 'operational',
+							truthAuctionAddress: freshTruthAuctionAddress,
+							truthAuctionStartedAt: 10n,
+						}),
+					}),
+					securityPoolAddress: selectedPoolAddress,
+					securityPools: [createSelectedPool({ completeSetCollateralAmount: 0n, marketDetails: createMarketDetails({ endTime: 2n }), securityPoolAddress: selectedPoolAddress, systemState: 'operational', truthAuctionAddress: zeroAddress })],
+					selectedPoolView: 'fork-migration',
+				})}
+				showHeader={false}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(within(document.body).getByText('Fork Finalized')).not.toBeNull()
 	})
 
 	test('disables minting in trading when the workflow state shows the selected pool has ended', async () => {
@@ -2515,7 +2565,7 @@ describe('SecurityPoolWorkflowSection', () => {
 		const selectedPoolSummary = document.body.querySelector('.selected-pool-context-summary')
 		if (!(selectedPoolSummary instanceof HTMLElement)) throw new Error('Expected selected pool summary to render')
 		const selectedPoolSummaryQueries = within(selectedPoolSummary)
-		expect(documentQueries.getAllByText('Pool Forked').length).toBeGreaterThan(0)
+		expect(documentQueries.getAllByText('Fork Migration').length).toBeGreaterThan(0)
 		expect(documentQueries.queryByText('This pool is currently operational, so fork and truth auction actions are read only.')).toBeNull()
 		expect(selectedPoolSummaryQueries.queryByText('Fork Mode')).toBeNull()
 		expect(selectedPoolSummaryQueries.queryByText('Fork Outcome')).toBeNull()
@@ -3000,11 +3050,15 @@ describe('SecurityPoolWorkflowSection', () => {
 	test('refreshes the selected pool after starting truth auction', async () => {
 		const selectedPoolAddress = zeroAddress
 		let refreshedPoolAddress: string | undefined
+		const loadedForkAuctionAddresses: string[] = []
 		const renderedComponent = await renderIntoDocument(
 			<SecurityPoolWorkflowSection
 				{...createSecurityPoolWorkflowProps({
 					checkedSecurityPoolAddress: selectedPoolAddress,
 					forkAuction: createForkAuctionProps({
+						onLoadForkAuction: securityPoolAddressOverride => {
+							if (securityPoolAddressOverride !== undefined) loadedForkAuctionAddresses.push(securityPoolAddressOverride)
+						},
 						forkAuctionResult: {
 							action: 'startTruthAuction',
 							hash: '0x00000000000000000000000000000000000000000000000000000000000000cc',
@@ -3025,6 +3079,7 @@ describe('SecurityPoolWorkflowSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		expect(refreshedPoolAddress).toBe(selectedPoolAddress)
+		expect(loadedForkAuctionAddresses).toContain(selectedPoolAddress)
 	})
 
 	test('reloads reporting after migrating escalation deposits in the fork workflow', async () => {

--- a/ui/ts/tests/securityPoolsOverviewSection.test.tsx
+++ b/ui/ts/tests/securityPoolsOverviewSection.test.tsx
@@ -162,6 +162,49 @@ describe('SecurityPoolsOverviewSection', () => {
 		expect(badgeTexts).toContain('Ended')
 	})
 
+	test('shows Fork Migration for pools already in fork migration flow', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolsOverviewSection
+				{...createProps({
+					securityPools: [
+						createSecurityPool({
+							forkOutcome: 'yes',
+							migratedRep: 1n,
+							systemState: 'poolForked',
+						}),
+					],
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const badgeTexts = Array.from(document.body.querySelectorAll('.entity-card .badge')).map(element => element.textContent?.trim() ?? '')
+		expect(badgeTexts).toContain('Fork Migration')
+	})
+
+	test('shows Fork Finalized for operational pools with completed fork history', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolsOverviewSection
+				{...createProps({
+					securityPools: [
+						createSecurityPool({
+							forkOutcome: 'yes',
+							hasForkActivity: true,
+							migratedRep: 1n,
+							systemState: 'operational',
+							truthAuctionAddress: '0x0000000000000000000000000000000000000001',
+							truthAuctionStartedAt: 10n,
+						}),
+					],
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const badgeTexts = Array.from(document.body.querySelectorAll('.entity-card .badge')).map(element => element.textContent?.trim() ?? '')
+		expect(badgeTexts).toContain('Fork Finalized')
+	})
+
 	test('filters the registry by the derived Ended state', async () => {
 		const renderedComponent = await renderIntoDocument(
 			<SecurityPoolsOverviewSection

--- a/ui/ts/tests/securityPoolsSection.test.ts
+++ b/ui/ts/tests/securityPoolsSection.test.ts
@@ -148,7 +148,7 @@ function createForkAuctionProps(overrides: Partial<ForkAuctionRouteContentProps>
 			selectedOutcome: 'yes',
 			settlementAddress: '',
 			submitBidAmount: '',
-			submitBidTick: '',
+			submitBidPrice: '',
 			vaultAddress: '',
 		},
 		forkAuctionResult: undefined,

--- a/ui/ts/tests/simulationBootstrap.test.ts
+++ b/ui/ts/tests/simulationBootstrap.test.ts
@@ -22,7 +22,7 @@ function createBaselineProfile(overrides: Partial<NetworkProfile> = {}): Network
 	}
 }
 
-function createMockedBootstrapDependencies({ accounts, scenario, profile }: { accounts: readonly string[]; scenario: 'security-pool' | 'securitypoolx2'; profile: NetworkProfile }) {
+function createMockedBootstrapDependencies({ accounts, scenario, profile }: { accounts: readonly string[]; scenario: 'security-pool' | 'securitypoolx2' | 'securitypoolx2-auction'; profile: NetworkProfile }) {
 	const eth = 10n ** 18n
 	const primaryVaultRepDeposit = 10_000n * eth
 	const primaryVaultSecurityBondAllowance = 2_500n * eth
@@ -50,6 +50,7 @@ function createMockedBootstrapDependencies({ accounts, scenario, profile }: { ac
 	const firstDeploymentAddress = deployments[0]?.address ?? getAddress('0x00000000000000000000000000000000000000a1')
 	const primaryPoolAddress = poolAddresses[0] ?? getAddress('0x00000000000000000000000000000000000000b1')
 	const secondaryPoolAddress = poolAddresses[1] ?? getAddress('0x00000000000000000000000000000000000000b2')
+	const yesChildPoolAddress = getAddress('0x00000000000000000000000000000000000000c1')
 	const deployedCodes = new Map<string, string>([[firstDeploymentAddress, '0x01']])
 	const managerByPool = new Map<Address, Address>()
 	const openOracleByManager = new Map<Address, Address>()
@@ -88,15 +89,23 @@ function createMockedBootstrapDependencies({ accounts, scenario, profile }: { ac
 			approveErc20: 0,
 			createMarket: 0,
 			createSecurityPool: 0,
+			createCompleteSetInSecurityPool: 0,
 			depositRepToSecurityPool: 0,
 			loadAllSecurityPools: 0,
 			loadErc20Balance: 0,
+			loadForkAuctionDetails: 0,
 			loadOracleManagerDetails: 0,
 			loadOpenOracleReportDetails: 0,
+			loadReportingDetails: 0,
 			loadSecurityVaultDetails: 0,
+			loadZoltarUniverseSummary: 0,
+			migrateRepToZoltarFromSecurityPool: 0,
 			queueOracleManagerOperation: 0,
+			reportOutcomeInSecurityPool: 0,
 			settleOracleReport: 0,
+			startTruthAuctionForSecurityPool: 0,
 			submitInitialOracleReport: 0,
+			submitTruthAuctionBid: 0,
 			writeContract: 0,
 			setSecurityPoolDeployCalls: 0,
 			setSimulationCodeCalls: 0,
@@ -157,6 +166,24 @@ function createMockedBootstrapDependencies({ accounts, scenario, profile }: { ac
 				managerAddress,
 			} as never
 		}),
+		createCompleteSetInSecurityPool: mock(async () => {
+			state.callLog.createCompleteSetInSecurityPool += 1
+			return {
+				action: 'createCompleteSet',
+				hash: '0x01',
+				securityPoolAddress: primaryPoolAddress,
+				universeId: 0n,
+			} as never
+		}),
+		createChildUniverseFromSecurityPool: mock(
+			async () =>
+				({
+					action: 'createChildUniverse',
+					hash: '0x01',
+					securityPoolAddress: primaryPoolAddress,
+					universeId: 1n,
+				}) as never,
+		),
 		depositRepToSecurityPool: mock(async (client: { account?: Address }, poolAddress: Address, amount: bigint) => {
 			state.callLog.depositRepToSecurityPool += 1
 			const vaultAddress = vaultAddressByPool[poolAddress]?.find((vaultAddressCandidate: Address) => vaultAddressCandidate === client.account) ?? vaultAddressByPool[poolAddress]?.[0]
@@ -169,6 +196,15 @@ function createMockedBootstrapDependencies({ accounts, scenario, profile }: { ac
 				hash: '0x01',
 			} as never
 		}),
+		forkZoltarWithOwnEscalation: mock(
+			async () =>
+				({
+					action: 'forkWithOwnEscalation',
+					hash: '0x01',
+					securityPoolAddress: primaryPoolAddress,
+					universeId: 0n,
+				}) as never,
+		),
 		getDeploymentSteps: mock(() =>
 			deployments.map(step => ({
 				id: step.id,
@@ -187,7 +223,7 @@ function createMockedBootstrapDependencies({ accounts, scenario, profile }: { ac
 		),
 		loadAllSecurityPools: mock(async () => {
 			state.callLog.loadAllSecurityPools += 1
-			return poolPlan.map((_pool, index) => {
+			const parentPools = poolPlan.map((_pool, index) => {
 				const securityPoolAddress = getPoolAddressForMarket(index)
 				const vaultAddresses = vaultAddressByPool[securityPoolAddress] ?? []
 				const vaultRows: Array<{ vaultAddress: Address; repDepositShare: bigint; securityBondAllowance: bigint }> = vaultAddresses.map(vaultAddress => ({
@@ -196,6 +232,11 @@ function createMockedBootstrapDependencies({ accounts, scenario, profile }: { ac
 					securityBondAllowance: securityBondAllowances[securityPoolAddress]?.[vaultAddress] ?? 0n,
 				}))
 				return {
+					marketDetails: {
+						title: poolPlan[index]?.question ?? `Pool ${index + 1}`,
+					},
+					parent: getAddress('0x0000000000000000000000000000000000000000'),
+					questionOutcome: 'none',
 					securityPoolAddress,
 					vaultCount: BigInt(vaultRows.length),
 					totalRepDeposit: vaultRows.reduce<bigint>((sum, row) => sum + row.repDepositShare, 0n),
@@ -203,10 +244,39 @@ function createMockedBootstrapDependencies({ accounts, scenario, profile }: { ac
 					vaults: vaultRows,
 				} as never
 			})
+			if (scenario !== 'securitypoolx2-auction') return parentPools
+			return [
+				...parentPools,
+				{
+					parent: primaryPoolAddress,
+					questionOutcome: 'yes',
+					securityPoolAddress: yesChildPoolAddress,
+					systemState: 'forkTruthAuction',
+					totalRepDeposit: 0n,
+					totalSecurityBondAllowance: 0n,
+					vaultCount: 0n,
+					vaults: [],
+				} as never,
+			]
 		}),
 		loadErc20Balance: mock(async () => {
 			state.callLog.loadErc20Balance += 1
 			return 0n
+		}),
+		loadForkAuctionDetails: mock(async () => {
+			state.callLog.loadForkAuctionDetails += 1
+			return {
+				currentTime: SIMULATION_INITIAL_TIMESTAMP,
+				migratedRep: 1n,
+				securityPoolAddress: primaryPoolAddress,
+				systemState: 'forkTruthAuction',
+				truthAuction: {
+					finalized: false,
+				},
+				truthAuctionAddress: getAddress('0x0000000000000000000000000000000000000aa1'),
+				truthAuctionStartedAt: 1n,
+				universeId: 1n,
+			} as never
 		}),
 		loadOracleManagerDetails: mock(async (_client: never, managerAddress: Address) => {
 			state.callLog.loadOracleManagerDetails += 1
@@ -242,6 +312,15 @@ function createMockedBootstrapDependencies({ accounts, scenario, profile }: { ac
 				isDistributed: true,
 			} as never
 		}),
+		loadReportingDetails: mock(async () => {
+			state.callLog.loadReportingDetails += 1
+			return {
+				currentTime: SIMULATION_INITIAL_TIMESTAMP,
+				marketDetails: {
+					endTime: SIMULATION_INITIAL_TIMESTAMP - 1n,
+				},
+			} as never
+		}),
 		loadSecurityVaultDetails: mock(async (_client: never, securityPoolAddress: Address, vaultAddress: Address) => {
 			state.callLog.loadSecurityVaultDetails += 1
 			return {
@@ -257,6 +336,21 @@ function createMockedBootstrapDependencies({ accounts, scenario, profile }: { ac
 				unpaidEthFees: 0n,
 				universeId: 0n,
 				vaultAddress,
+			} as never
+		}),
+		loadZoltarUniverseSummary: mock(async () => {
+			state.callLog.loadZoltarUniverseSummary += 1
+			return {
+				forkThreshold: 100n,
+			} as never
+		}),
+		migrateRepToZoltarFromSecurityPool: mock(async () => {
+			state.callLog.migrateRepToZoltarFromSecurityPool += 1
+			return {
+				action: 'migrateRepToZoltar',
+				hash: '0x01',
+				securityPoolAddress: primaryPoolAddress,
+				universeId: 0n,
 			} as never
 		}),
 		queueOracleManagerOperation: mock(async (_client: never, managerAddress: Address, operation: string, targetVault: Address, amount: bigint) => {
@@ -277,13 +371,39 @@ function createMockedBootstrapDependencies({ accounts, scenario, profile }: { ac
 				hash: '0x01',
 			} as never
 		}),
+		reportOutcomeInSecurityPool: mock(async () => {
+			state.callLog.reportOutcomeInSecurityPool += 1
+			return {
+				action: 'reportOutcome',
+				hash: '0x01',
+				securityPoolAddress: primaryPoolAddress,
+			} as never
+		}),
 		settleOracleReport: mock(async () => {
 			state.callLog.settleOracleReport += 1
 			return { hash: '0x01' } as never
 		}),
+		startTruthAuctionForSecurityPool: mock(async () => {
+			state.callLog.startTruthAuctionForSecurityPool += 1
+			return {
+				action: 'startTruthAuction',
+				hash: '0x01',
+				securityPoolAddress: primaryPoolAddress,
+				universeId: 1n,
+			} as never
+		}),
 		submitInitialOracleReport: mock(async () => {
 			state.callLog.submitInitialOracleReport += 1
 			return { action: 'submitInitialReport', hash: '0x01' } as never
+		}),
+		submitTruthAuctionBid: mock(async () => {
+			state.callLog.submitTruthAuctionBid += 1
+			return {
+				action: 'submitBid',
+				hash: '0x01',
+				securityPoolAddress: primaryPoolAddress,
+				universeId: 1n,
+			} as never
 		}),
 	}))
 
@@ -709,6 +829,36 @@ describe('simulation bootstrap', () => {
 		expect(state.callLog.writeContract).toBe(2)
 		expect(state.callLog.queueOracleManagerOperation).toBe(4)
 		expect(state.callLog.setSecurityPoolDeployCalls).toBe(1)
+		expect(writeCalls.length).toBeGreaterThan(0)
+	})
+
+	test('boots the securitypoolx2-auction simulation path with forked child-auction seeding and ten bids', async () => {
+		const profile = createBaselineProfile()
+		const { createWriteClient, memoryClient, state, writeCalls } = createMockedBootstrapDependencies({
+			accounts: [MOCK_PRIMARY_ACCOUNT, MOCK_SECONDARY_ACCOUNT],
+			scenario: 'securitypoolx2-auction',
+			profile,
+		})
+		const { bootstrapSimulationChain } = await import(`../simulation/bootstrap.js?case=${crypto.randomUUID()}`)
+
+		await bootstrapSimulationChain({
+			accounts: [MOCK_PRIMARY_ACCOUNT, MOCK_SECONDARY_ACCOUNT],
+			createReadClient: () => ({}) as never,
+			createWriteClient,
+			memoryClient,
+			onProgress: async () => undefined,
+			primaryAccount: MOCK_PRIMARY_ACCOUNT,
+			profile,
+			scenario: 'securitypoolx2-auction',
+		})
+
+		expect(state.callLog.createMarket).toBe(2)
+		expect(state.callLog.createSecurityPool).toBe(2)
+		expect(state.callLog.reportOutcomeInSecurityPool).toBe(2)
+		expect(state.callLog.migrateRepToZoltarFromSecurityPool).toBe(1)
+		expect(state.callLog.startTruthAuctionForSecurityPool).toBe(1)
+		expect(state.callLog.submitTruthAuctionBid).toBe(10)
+		expect(state.callLog.loadForkAuctionDetails).toBeGreaterThanOrEqual(2)
 		expect(writeCalls.length).toBeGreaterThan(0)
 	})
 })

--- a/ui/ts/tests/simulationScenarios.test.ts
+++ b/ui/ts/tests/simulationScenarios.test.ts
@@ -6,10 +6,12 @@ import { getSimulationScenarioDescription, getSimulationScenarioLabel, normalize
 void describe('simulation scenarios', () => {
 	void test('normalizes the securitypoolx2 scenario', () => {
 		expect(normalizeSimulationScenario('securitypoolx2')).toBe('securitypoolx2')
+		expect(normalizeSimulationScenario('securitypoolx2-auction')).toBe('securitypoolx2-auction')
 	})
 
 	void test('returns the securitypoolx2 scenario label', () => {
 		expect(getSimulationScenarioLabel('securitypoolx2')).toBe('Security pool x2')
+		expect(getSimulationScenarioLabel('securitypoolx2-auction')).toBe('Security pool x2 auction')
 	})
 
 	void test('returns descriptions for each scenario', () => {
@@ -17,5 +19,6 @@ void describe('simulation scenarios', () => {
 		expect(getSimulationScenarioDescription('deployed')).toBe('App contracts are deployed, but no security pools or seeded markets are created. Use it to test setup flows from an empty deployment.')
 		expect(getSimulationScenarioDescription('security-pool')).toBe('One seeded market, one security pool, and one funded vault with an active security bond allowance. Use it to test pool workflows and liquidation paths.')
 		expect(getSimulationScenarioDescription('securitypoolx2')).toBe('Two seeded markets with two security pools and two funded vaults in each pool. Use it to test multi-pool selection and repeated pool workflows.')
+		expect(getSimulationScenarioDescription('securitypoolx2-auction')).toBe('Two seeded markets with one own-escalation fork already triggered and one child truth auction seeded with ten bids. Use it to test fork-auction bidbook and settlement workflows.')
 	})
 })

--- a/ui/ts/types/app.ts
+++ b/ui/ts/types/app.ts
@@ -105,7 +105,7 @@ export type ForkAuctionFormState = {
 	selectedOutcome: ReportingOutcomeKey
 	settlementAddress: string
 	submitBidAmount: string
-	submitBidTick: string
+	submitBidPrice: string
 	vaultAddress: string
 }
 

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -647,28 +647,29 @@ export type ForkAuctionRouteContentProps = {
 	forkAuctionForm: ForkAuctionFormState
 	forkAuctionResult: ForkAuctionActionResult | undefined
 	loadingForkAuctionDetails: boolean
-	onClaimAuctionProceeds: () => void
+	onClaimAuctionProceeds: (securityPoolAddressOverride?: Address) => void
 	onCreateChildUniverse: () => void
-	onFinalizeTruthAuction: () => void
+	onFinalizeTruthAuction: (securityPoolAddressOverride?: Address) => void
 	onForkAuctionFormChange: (update: Partial<ForkAuctionFormState>) => void
 	onForkUniverse: () => void
 	onForkWithOwnEscalation: () => void
 	onInitiateFork: () => void
-	onLoadForkAuction: () => void
+	onLoadForkAuction: (securityPoolAddressOverride?: Address) => void
 	onMigrateEscalationDeposits: (outcome: ReportingOutcomeKey, depositIndexes?: bigint[]) => void
 	onMigrateRepToZoltar: (outcomes?: ReportingOutcomeKey[]) => void
 	onMigrateVault: () => void
-	onRefundLosingBids: () => void
-	onStartTruthAuction: () => void
-	onSubmitBid: () => void
+	onRefundLosingBids: (securityPoolAddressOverride?: Address) => void
+	onStartTruthAuction: (securityPoolAddressOverride?: Address) => void
+	onSubmitBid: (securityPoolAddressOverride?: Address) => void
 }
 
 export type ForkAuctionSectionProps = ForkAuctionRouteContentProps & {
+	auctionDetailsOverride?: ForkAuctionDetails | undefined
 	currentTimestamp?: bigint | undefined
 	disabled?: boolean
 	disabledMessage?: string | undefined
 	embedInCard?: boolean
-	forkMigrationReadClient?: Pick<ReadClient, 'readContract'> | undefined
+	forkMigrationReadClient?: Pick<ReadClient, 'readContract'> | ReadClient | undefined
 	lifecycleStateOverride?: SecurityPoolLifecycleState | undefined
 	loadingReportingDetails?: boolean
 	onReportingFormChange?: ((update: Partial<ReportingFormState>) => void) | undefined
@@ -679,5 +680,5 @@ export type ForkAuctionSectionProps = ForkAuctionRouteContentProps & {
 	stageView: ForkAuctionStageView
 	showSecurityPoolAddressInput?: boolean
 	showHeader?: boolean
-	truthAuctionReadClient?: Pick<ReadClient, 'readContract'> | undefined
+	truthAuctionReadClient?: Pick<ReadClient, 'readContract'> | ReadClient | undefined
 }


### PR DESCRIPTION
## Summary
- Updated `ForkAuctionSection` to handle a pending `Start Truth Auction` state by showing `Starting...` for start time and `Pending confirmation` for end time before on-chain confirmation.
- Added `hasStartedTruthAuction` handling to keep started/end metrics stable and avoid premature timestamp rendering.
- Reordered auction stage layout so Finalize action appears between `Submit Bid` and `My Bids`, and removed duplicate finalize sections in other lifecycle views.
- Adjusted copy for unseeded-child flow: wording now says `Seed <Outcome> Pool REP` and clarifies seed requirement text.
- Updated unit tests to reflect the new stage ordering, new button label, and updated visibility/disablement behavior of finalize controls.

## Testing
- Updated assertions in `ui/ts/tests/forkAuctionSection.test.tsx` for: 
  - metric display during pending start (`Started`, `Ends`),
  - new finalize stage ordering (`Market View` -> `Submit Bid` -> `Finalize Truth Auction` -> `My Bids`),
  - visibility/absence changes for finalize button in finalized/active states.
- Not run: `bun run tsc`
- Not run: `bun run test`
- Not run: `bun run format`
- Not run: `bun run check`
- Not run: `bun run knip`
- Not run: `bun run coverage:ui`