### PR TITLE
Add simulation state save/load/import/export workflows in simulation mode

### DIFF
--- a/ui/ts/components/SimulationBanner.tsx
+++ b/ui/ts/components/SimulationBanner.tsx
@@ -7,7 +7,7 @@ import { tryParseDecimalInput } from '../lib/decimal.js'
 import { formatCurrencyInputBalance } from '../lib/formatters.js'
 import { useCopyToClipboard } from '../hooks/useCopyToClipboard.js'
 import { getSimulationScenarioDescription, getSimulationScenarioLabel, SIMULATION_SCENARIOS } from '../simulation/scenarios.js'
-import { deleteSavedSimulationState, getSavedSimulationStateStorageWarning, listSavedSimulationStateRecords, persistSavedSimulationState, type SavedSimulationStateRecord } from '../simulation/savedStates.js'
+import { deleteSavedSimulationState, getSavedSimulationStateStorageWarning, listSavedSimulationStateRecords, persistSavedSimulationState, removeCorruptedSavedSimulationStates, type SavedSimulationStateRecord } from '../simulation/savedStates.js'
 import { OperationModal } from './OperationModal.js'
 import { TimestampValue } from './TimestampValue.js'
 
@@ -24,7 +24,7 @@ type SimulationBannerProps = {
 	onRefresh: () => Promise<void>
 }
 
-type SimulationModal = 'delete' | 'export' | 'import' | 'save' | undefined
+type SimulationModal = 'cleanup' | 'delete' | 'export' | 'import' | 'save' | undefined
 
 function buildSimulationSearch(update: (params: URLSearchParams) => void) {
 	const params = new URLSearchParams(getRouteHashSearch())
@@ -421,6 +421,18 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 								>
 									Import state
 								</button>
+								{savedStateStorageWarning.value === undefined ? undefined : (
+									<button
+										className='destructive'
+										onClick={() => {
+											savedStateError.value = undefined
+											modal.value = 'cleanup'
+										}}
+										disabled={busy.value}
+									>
+										Remove corrupted saves
+									</button>
+								)}
 								{currentSource.value.kind !== 'saved-state' ? undefined : (
 									<button
 										className='destructive'
@@ -531,6 +543,27 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 						}
 					>
 						Delete save
+					</button>
+				</div>
+			</OperationModal>
+			<OperationModal isOpen={modal.value === 'cleanup'} onClose={closeModal} title='Remove Corrupted Saved States'>
+				<p className='detail'>Remove saved simulation state entries that are no longer readable from browser storage. Valid saved states will be kept.</p>
+				{savedStateStorageWarning.value === undefined ? undefined : <p className='detail'>{savedStateStorageWarning.value}</p>}
+				{savedStateError.value === undefined ? undefined : <p className='detail'>{savedStateError.value}</p>}
+				<div className='actions'>
+					<button
+						type='button'
+						className='destructive'
+						onClick={() =>
+							void runNavigationControl(async () => {
+								const removedCount = removeCorruptedSavedSimulationStates()
+								if (removedCount === 0) throw new Error('No corrupted saved simulation states were found')
+								reloadSavedStateRecords()
+								closeModal()
+							})
+						}
+					>
+						Remove corrupted saves
 					</button>
 				</div>
 			</OperationModal>

--- a/ui/ts/components/SimulationBanner.tsx
+++ b/ui/ts/components/SimulationBanner.tsx
@@ -7,7 +7,7 @@ import { tryParseDecimalInput } from '../lib/decimal.js'
 import { formatCurrencyInputBalance } from '../lib/formatters.js'
 import { useCopyToClipboard } from '../hooks/useCopyToClipboard.js'
 import { getSimulationScenarioDescription, getSimulationScenarioLabel, SIMULATION_SCENARIOS } from '../simulation/scenarios.js'
-import { deleteSavedSimulationState, getSavedSimulationStateStorageWarning, listSavedSimulationStateRecords, persistSavedSimulationState, removeCorruptedSavedSimulationStates, type SavedSimulationStateRecord } from '../simulation/savedStates.js'
+import { deleteSavedSimulationState, getSavedSimulationStateStorageSummary, persistSavedSimulationState, removeCorruptedSavedSimulationStates, type SavedSimulationStateRecord, type SavedSimulationStateStorageSummary } from '../simulation/savedStates.js'
 import { OperationModal } from './OperationModal.js'
 import { TimestampValue } from './TimestampValue.js'
 
@@ -55,6 +55,12 @@ function navigateToSavedSimulationState(stateId: string) {
 	navigateToSimulationSearch(nextSearch)
 }
 
+function hasSavedSimulationStateRoute() {
+	const params = new URLSearchParams(getRouteHashSearch())
+	const stateId = params.get('simState')
+	return stateId !== null && stateId.trim() !== ''
+}
+
 function getScenarioStatus(parameters: { bootstrapError: string | undefined; isBootstrapped: boolean }) {
 	if (parameters.bootstrapError !== undefined) {
 		return {
@@ -88,8 +94,9 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 	const repPerEthPrice = useSignal(formatCurrencyInputBalance(controller.repPerEthPrice))
 	const repPerUsdcPrice = useSignal(formatCurrencyInputBalance(controller.repPerUsdcPrice, 6))
 	const savedStateError = useSignal<string | undefined>(undefined)
-	const savedStateRecords = useSignal<SavedSimulationStateRecord[]>(listSavedSimulationStateRecords())
-	const savedStateStorageWarning = useSignal<string | undefined>(getSavedSimulationStateStorageWarning())
+	const initialSavedStateSummary: SavedSimulationStateStorageSummary = getSavedSimulationStateStorageSummary()
+	const savedStateRecords = useSignal<SavedSimulationStateRecord[]>(initialSavedStateSummary.records)
+	const savedStateStorageWarning = useSignal<string | undefined>(initialSavedStateSummary.warning)
 	const saveName = useSignal('')
 	const exportName = useSignal('')
 	const exportStateText = useSignal('')
@@ -102,8 +109,9 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 	const transactionDelayMilliseconds = useSignal(controller.transactionDelayMilliseconds.toString())
 
 	const reloadSavedStateRecords = () => {
-		savedStateRecords.value = listSavedSimulationStateRecords()
-		savedStateStorageWarning.value = getSavedSimulationStateStorageWarning()
+		const summary = getSavedSimulationStateStorageSummary()
+		savedStateRecords.value = summary.records
+		savedStateStorageWarning.value = summary.warning
 	}
 
 	const getDefaultSavedStateName = () => (currentSource.value.kind === 'saved-state' ? currentSource.value.name : `${getSimulationScenarioLabel(currentScenario.value)} ${new Date().toISOString().slice(0, 16)}`)
@@ -559,6 +567,10 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 								const removedCount = removeCorruptedSavedSimulationStates()
 								if (removedCount === 0) throw new Error('No corrupted saved simulation states were found')
 								reloadSavedStateRecords()
+								if (hasSavedSimulationStateRoute()) {
+									navigateToBuiltInScenario(currentScenario.value)
+									return
+								}
 								closeModal()
 							})
 						}

--- a/ui/ts/components/SimulationBanner.tsx
+++ b/ui/ts/components/SimulationBanner.tsx
@@ -1,10 +1,15 @@
 import { useSignal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
+import { getErrorMessage } from '../lib/errors.js'
 import type { SimulationController } from '../simulation/controller.js'
 import { tryParseDecimalInput } from '../lib/decimal.js'
 import { formatCurrencyInputBalance } from '../lib/formatters.js'
+import { useCopyToClipboard } from '../hooks/useCopyToClipboard.js'
 import { getSimulationScenarioDescription, getSimulationScenarioLabel, SIMULATION_SCENARIOS } from '../simulation/scenarios.js'
+import { deleteSavedSimulationState, listSavedSimulationStateRecords, persistSavedSimulationState, type SavedSimulationStateRecord } from '../simulation/savedStates.js'
+import { OperationModal } from './OperationModal.js'
 import { TimestampValue } from './TimestampValue.js'
+
 const SIMULATION_TIME_PRESETS = [
 	{ label: '+1 hour', seconds: 60n * 60n },
 	{ label: '+1 day', seconds: 24n * 60n * 60n },
@@ -17,22 +22,69 @@ type SimulationBannerProps = {
 	controller: SimulationController
 	onRefresh: () => Promise<void>
 }
+
+type SimulationModal = 'delete' | 'export' | 'import' | 'save' | undefined
+
+function buildSimulationUrl(update: (nextUrl: URL) => void) {
+	const nextUrl = new URL(window.location.href)
+	nextUrl.searchParams.set('simulate', '1')
+	update(nextUrl)
+	return nextUrl
+}
+
+function navigateToBuiltInScenario(scenario: string) {
+	const nextUrl = buildSimulationUrl(url => {
+		url.searchParams.set('simScenario', scenario)
+		url.searchParams.delete('simState')
+	})
+	window.location.assign(nextUrl.toString())
+}
+
+function navigateToSavedSimulationState(stateId: string) {
+	const nextUrl = buildSimulationUrl(url => {
+		url.searchParams.delete('simScenario')
+		url.searchParams.set('simState', stateId)
+	})
+	window.location.assign(nextUrl.toString())
+}
+
 export function SimulationBanner({ controller, onRefresh }: SimulationBannerProps) {
+	const { copied, copyText } = useCopyToClipboard()
 	const busy = useSignal(false)
 	const blockCountSinceReset = useSignal(controller.blockCountSinceReset)
 	const currentTimestamp = useSignal(controller.currentTimestamp)
 	const currentScenario = useSignal(controller.currentScenario)
+	const currentSource = useSignal(controller.simulationSource)
 	const isBootstrapped = useSignal(controller.isBootstrapped)
 	const isBootstrapping = useSignal(controller.isBootstrapping)
+	const modal = useSignal<SimulationModal>(undefined)
 	const queryDelayMilliseconds = useSignal(controller.queryDelayMilliseconds.toString())
 	const repPerEthPrice = useSignal(formatCurrencyInputBalance(controller.repPerEthPrice))
 	const repPerUsdcPrice = useSignal(formatCurrencyInputBalance(controller.repPerUsdcPrice, 6))
+	const savedStateError = useSignal<string | undefined>(undefined)
+	const savedStateRecords = useSignal<SavedSimulationStateRecord[]>(listSavedSimulationStateRecords())
+	const saveName = useSignal('')
+	const exportName = useSignal('')
+	const exportStateText = useSignal('')
+	const importStateText = useSignal('')
 	const selectedAccount = useSignal(controller.selectedAccount)
 	const bootstrapError = useSignal(controller.bootstrapError)
 	const bootstrapLabel = useSignal(controller.bootstrapLabel)
 	const bootstrapProgress = useSignal(controller.bootstrapProgress)
 	const transactionCountSinceReset = useSignal(controller.transactionCountSinceReset)
 	const transactionDelayMilliseconds = useSignal(controller.transactionDelayMilliseconds.toString())
+
+	const reloadSavedStateRecords = () => {
+		savedStateRecords.value = listSavedSimulationStateRecords()
+	}
+
+	const getDefaultSavedStateName = () => (currentSource.value.kind === 'saved-state' ? currentSource.value.name : `${getSimulationScenarioLabel(currentScenario.value)} ${new Date().toISOString().slice(0, 16)}`)
+
+	const closeModal = () => {
+		modal.value = undefined
+		savedStateError.value = undefined
+	}
+
 	const resetRepPerEthPriceInput = () => {
 		repPerEthPrice.value = formatCurrencyInputBalance(controller.repPerEthPrice)
 	}
@@ -48,6 +100,7 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 				bootstrapProgress.value = controller.bootstrapProgress
 				currentTimestamp.value = controller.currentTimestamp
 				currentScenario.value = controller.currentScenario
+				currentSource.value = controller.simulationSource
 				isBootstrapped.value = controller.isBootstrapped
 				isBootstrapping.value = controller.isBootstrapping
 				queryDelayMilliseconds.value = controller.queryDelayMilliseconds.toString()
@@ -69,6 +122,37 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 			busy.value = false
 		}
 	}
+	const runNavigationControl = async (work: () => Promise<void>) => {
+		if (busy.value) return
+		busy.value = true
+		savedStateError.value = undefined
+		try {
+			await work()
+		} catch (error) {
+			savedStateError.value = getErrorMessage(error, 'Failed to update the saved simulation state')
+		} finally {
+			busy.value = false
+		}
+	}
+
+	const showExportModal = async () => {
+		const nextName = getDefaultSavedStateName()
+		exportName.value = nextName
+		exportStateText.value = ''
+		savedStateError.value = undefined
+		modal.value = 'export'
+		try {
+			exportStateText.value = await controller.exportState(nextName)
+		} catch (error) {
+			savedStateError.value = getErrorMessage(error, 'Failed to export the current simulation state')
+		}
+	}
+
+	let scenarioDetail = bootstrapError.value
+	if (scenarioDetail === undefined) {
+		scenarioDetail = currentSource.value.kind === 'saved-state' ? `Custom state "${currentSource.value.name}" based on ${getSimulationScenarioLabel(currentSource.value.baseScenario)}. Saved ${new Date(currentSource.value.savedAt).toLocaleString()}.` : getSimulationScenarioDescription(currentScenario.value)
+	}
+
 	return (
 		<section className='panel contract-panel simulation-banner'>
 			<div className='contract-panel-header simulation-banner-header'>
@@ -104,7 +188,7 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 							</span>
 							<h3>Scenario</h3>
 						</div>
-						<p className='detail'>{bootstrapError.value ?? getSimulationScenarioDescription(currentScenario.value)}</p>
+						<p className='detail'>{scenarioDetail}</p>
 						{bootstrapError.value === undefined && isBootstrapping.value ? (
 							<p className='detail'>
 								<span className='spinner' aria-hidden='true' />
@@ -119,21 +203,33 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 					</div>
 					<select
 						className='simulation-control-select'
-						value={currentScenario.value}
+						value={currentSource.value.kind === 'saved-state' ? `saved:${currentSource.value.stateId}` : `scenario:${currentScenario.value}`}
 						disabled={busy.value || isBootstrapping.value}
 						onChange={event => {
-							const nextScenario = event.currentTarget.value
-							const nextUrl = new URL(window.location.href)
-							nextUrl.searchParams.set('simulate', '1')
-							nextUrl.searchParams.set('simScenario', nextScenario)
-							window.location.assign(nextUrl.toString())
+							const nextSelection = event.currentTarget.value
+							if (nextSelection.startsWith('saved:')) {
+								navigateToSavedSimulationState(nextSelection.slice('saved:'.length))
+								return
+							}
+							navigateToBuiltInScenario(nextSelection.slice('scenario:'.length))
 						}}
 					>
-						{SIMULATION_SCENARIOS.map(scenario => (
-							<option key={scenario} value={scenario}>
-								{getSimulationScenarioLabel(scenario)}
-							</option>
-						))}
+						<optgroup label='Built-in scenarios'>
+							{SIMULATION_SCENARIOS.map(scenario => (
+								<option key={scenario} value={`scenario:${scenario}`}>
+									{getSimulationScenarioLabel(scenario)}
+								</option>
+							))}
+						</optgroup>
+						{savedStateRecords.value.length === 0 ? undefined : (
+							<optgroup label='Saved states'>
+								{savedStateRecords.value.map(record => (
+									<option key={record.id} value={`saved:${record.id}`}>
+										{record.name}
+									</option>
+								))}
+							</optgroup>
+						)}
 					</select>
 				</div>
 				<div className='contract-row simulation-banner-row'>
@@ -281,6 +377,43 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 								<button className='secondary' onClick={() => void runControl(async () => await controller.mintRep(SIMULATION_REP_MINT_AMOUNT))} disabled={busy.value || !isBootstrapped.value}>
 									Mint 1 million REP
 								</button>
+								<button
+									className='secondary'
+									onClick={() => {
+										saveName.value = getDefaultSavedStateName()
+										savedStateError.value = undefined
+										modal.value = 'save'
+									}}
+									disabled={busy.value || !isBootstrapped.value}
+								>
+									Save state
+								</button>
+								<button className='secondary' onClick={() => void showExportModal()} disabled={busy.value || !isBootstrapped.value}>
+									Export state
+								</button>
+								<button
+									className='secondary'
+									onClick={() => {
+										importStateText.value = ''
+										savedStateError.value = undefined
+										modal.value = 'import'
+									}}
+									disabled={busy.value}
+								>
+									Import state
+								</button>
+								{currentSource.value.kind !== 'saved-state' ? undefined : (
+									<button
+										className='destructive'
+										onClick={() => {
+											savedStateError.value = undefined
+											modal.value = 'delete'
+										}}
+										disabled={busy.value}
+									>
+										Delete save
+									</button>
+								)}
 							</div>
 						</div>
 						<div className='simulation-control-group'>
@@ -296,6 +429,96 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 					</div>
 				</div>
 			</div>
+			<OperationModal isOpen={modal.value === 'save'} onClose={closeModal} title='Save Simulation State'>
+				<div className='field'>
+					<label htmlFor='simulation-save-name'>State name</label>
+					<input id='simulation-save-name' className='simulation-control-input' type='text' value={saveName.value} onInput={event => (saveName.value = event.currentTarget.value)} />
+				</div>
+				{savedStateError.value === undefined ? undefined : <p className='detail'>{savedStateError.value}</p>}
+				<div className='actions'>
+					<button
+						type='button'
+						onClick={() =>
+							void runNavigationControl(async () => {
+								const record = persistSavedSimulationState(await controller.exportState(saveName.value))
+								reloadSavedStateRecords()
+								navigateToSavedSimulationState(record.id)
+							})
+						}
+					>
+						Save
+					</button>
+				</div>
+			</OperationModal>
+			<OperationModal isOpen={modal.value === 'export'} onClose={closeModal} title='Export Simulation State'>
+				<div className='field'>
+					<label htmlFor='simulation-export-name'>Export name</label>
+					<input id='simulation-export-name' className='simulation-control-input' type='text' value={exportName.value} onInput={event => (exportName.value = event.currentTarget.value)} />
+				</div>
+				<div className='field'>
+					<label htmlFor='simulation-export-json'>JSON state</label>
+					<textarea id='simulation-export-json' rows={14} value={exportStateText.value} readOnly />
+				</div>
+				{savedStateError.value === undefined ? undefined : <p className='detail'>{savedStateError.value}</p>}
+				<div className='actions'>
+					<button
+						type='button'
+						className='secondary'
+						onClick={() =>
+							void runNavigationControl(async () => {
+								exportStateText.value = await controller.exportState(exportName.value)
+							})
+						}
+					>
+						Refresh export
+					</button>
+					<button type='button' className='secondary' disabled={exportStateText.value.trim() === ''} onClick={() => void copyText(exportStateText.value)}>
+						{copied.value ? 'Copied' : 'Copy JSON'}
+					</button>
+				</div>
+			</OperationModal>
+			<OperationModal isOpen={modal.value === 'import'} onClose={closeModal} title='Import Simulation State'>
+				<div className='field'>
+					<label htmlFor='simulation-import-json'>JSON state</label>
+					<textarea id='simulation-import-json' rows={14} value={importStateText.value} onInput={event => (importStateText.value = event.currentTarget.value)} />
+				</div>
+				{savedStateError.value === undefined ? undefined : <p className='detail'>{savedStateError.value}</p>}
+				<div className='actions'>
+					<button
+						type='button'
+						onClick={() =>
+							void runNavigationControl(async () => {
+								const record = persistSavedSimulationState(importStateText.value)
+								reloadSavedStateRecords()
+								navigateToSavedSimulationState(record.id)
+							})
+						}
+					>
+						Import and load
+					</button>
+				</div>
+			</OperationModal>
+			<OperationModal isOpen={modal.value === 'delete'} onClose={closeModal} title='Delete Saved Simulation State'>
+				<p className='detail'>{currentSource.value.kind === 'saved-state' ? `Delete the saved state "${currentSource.value.name}" from browser storage. Built-in scenarios are not affected.` : 'Built-in scenarios cannot be deleted.'}</p>
+				{savedStateError.value === undefined ? undefined : <p className='detail'>{savedStateError.value}</p>}
+				<div className='actions'>
+					<button
+						type='button'
+						className='destructive'
+						disabled={currentSource.value.kind !== 'saved-state'}
+						onClick={() =>
+							void runNavigationControl(async () => {
+								if (currentSource.value.kind !== 'saved-state') return
+								if (!deleteSavedSimulationState(currentSource.value.stateId)) throw new Error(`Saved simulation state "${currentSource.value.name}" no longer exists`)
+								reloadSavedStateRecords()
+								navigateToBuiltInScenario(currentSource.value.baseScenario)
+							})
+						}
+					>
+						Delete save
+					</button>
+				</div>
+			</OperationModal>
 		</section>
 	)
 }

--- a/ui/ts/components/SimulationBanner.tsx
+++ b/ui/ts/components/SimulationBanner.tsx
@@ -1,12 +1,13 @@
 import { useSignal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { getErrorMessage } from '../lib/errors.js'
+import { buildRouteHref, getCurrentRouteHash, getRouteHashSearch } from '../lib/routing.js'
 import type { SimulationController } from '../simulation/controller.js'
 import { tryParseDecimalInput } from '../lib/decimal.js'
 import { formatCurrencyInputBalance } from '../lib/formatters.js'
 import { useCopyToClipboard } from '../hooks/useCopyToClipboard.js'
 import { getSimulationScenarioDescription, getSimulationScenarioLabel, SIMULATION_SCENARIOS } from '../simulation/scenarios.js'
-import { deleteSavedSimulationState, listSavedSimulationStateRecords, persistSavedSimulationState, type SavedSimulationStateRecord } from '../simulation/savedStates.js'
+import { deleteSavedSimulationState, getSavedSimulationStateStorageWarning, listSavedSimulationStateRecords, persistSavedSimulationState, type SavedSimulationStateRecord } from '../simulation/savedStates.js'
 import { OperationModal } from './OperationModal.js'
 import { TimestampValue } from './TimestampValue.js'
 
@@ -25,27 +26,52 @@ type SimulationBannerProps = {
 
 type SimulationModal = 'delete' | 'export' | 'import' | 'save' | undefined
 
-function buildSimulationUrl(update: (nextUrl: URL) => void) {
-	const nextUrl = new URL(window.location.href)
-	nextUrl.searchParams.set('simulate', '1')
-	update(nextUrl)
-	return nextUrl
+function buildSimulationSearch(update: (params: URLSearchParams) => void) {
+	const params = new URLSearchParams(getRouteHashSearch())
+	params.set('simulate', '1')
+	update(params)
+	const nextSearch = params.toString()
+	return nextSearch === '' ? '' : `?${nextSearch}`
+}
+
+function navigateToSimulationSearch(nextSearch: string) {
+	window.history.pushState({}, '', buildRouteHref(getCurrentRouteHash(), nextSearch))
+	window.dispatchEvent(new PopStateEvent('popstate'))
 }
 
 function navigateToBuiltInScenario(scenario: string) {
-	const nextUrl = buildSimulationUrl(url => {
-		url.searchParams.set('simScenario', scenario)
-		url.searchParams.delete('simState')
+	const nextSearch = buildSimulationSearch(params => {
+		params.set('simScenario', scenario)
+		params.delete('simState')
 	})
-	window.location.assign(nextUrl.toString())
+	navigateToSimulationSearch(nextSearch)
 }
 
 function navigateToSavedSimulationState(stateId: string) {
-	const nextUrl = buildSimulationUrl(url => {
-		url.searchParams.delete('simScenario')
-		url.searchParams.set('simState', stateId)
+	const nextSearch = buildSimulationSearch(params => {
+		params.delete('simScenario')
+		params.set('simState', stateId)
 	})
-	window.location.assign(nextUrl.toString())
+	navigateToSimulationSearch(nextSearch)
+}
+
+function getScenarioStatus(parameters: { bootstrapError: string | undefined; isBootstrapped: boolean }) {
+	if (parameters.bootstrapError !== undefined) {
+		return {
+			badgeClassName: 'error',
+			label: 'Error',
+		}
+	}
+	if (parameters.isBootstrapped) {
+		return {
+			badgeClassName: 'ok',
+			label: 'Ready',
+		}
+	}
+	return {
+		badgeClassName: 'pending',
+		label: 'Bootstrapping',
+	}
 }
 
 export function SimulationBanner({ controller, onRefresh }: SimulationBannerProps) {
@@ -63,6 +89,7 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 	const repPerUsdcPrice = useSignal(formatCurrencyInputBalance(controller.repPerUsdcPrice, 6))
 	const savedStateError = useSignal<string | undefined>(undefined)
 	const savedStateRecords = useSignal<SavedSimulationStateRecord[]>(listSavedSimulationStateRecords())
+	const savedStateStorageWarning = useSignal<string | undefined>(getSavedSimulationStateStorageWarning())
 	const saveName = useSignal('')
 	const exportName = useSignal('')
 	const exportStateText = useSignal('')
@@ -76,6 +103,7 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 
 	const reloadSavedStateRecords = () => {
 		savedStateRecords.value = listSavedSimulationStateRecords()
+		savedStateStorageWarning.value = getSavedSimulationStateStorageWarning()
 	}
 
 	const getDefaultSavedStateName = () => (currentSource.value.kind === 'saved-state' ? currentSource.value.name : `${getSimulationScenarioLabel(currentScenario.value)} ${new Date().toISOString().slice(0, 16)}`)
@@ -135,6 +163,12 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 		}
 	}
 
+	const persistAndNavigateToSavedState = async (serialized: string) => {
+		const record = persistSavedSimulationState(serialized)
+		reloadSavedStateRecords()
+		navigateToSavedSimulationState(record.id)
+	}
+
 	const showExportModal = async () => {
 		const nextName = getDefaultSavedStateName()
 		exportName.value = nextName
@@ -152,6 +186,10 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 	if (scenarioDetail === undefined) {
 		scenarioDetail = currentSource.value.kind === 'saved-state' ? `Custom state "${currentSource.value.name}" based on ${getSimulationScenarioLabel(currentSource.value.baseScenario)}. Saved ${new Date(currentSource.value.savedAt).toLocaleString()}.` : getSimulationScenarioDescription(currentScenario.value)
 	}
+	const scenarioStatus = getScenarioStatus({
+		bootstrapError: bootstrapError.value,
+		isBootstrapped: isBootstrapped.value,
+	})
 
 	return (
 		<section className='panel contract-panel simulation-banner'>
@@ -165,30 +203,11 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 				<div className='contract-row simulation-banner-row'>
 					<div className='contract-copy'>
 						<div className='contract-topline'>
-							<span
-								className={`badge ${(() => {
-									if (bootstrapError.value === undefined) {
-										if (isBootstrapped.value) return 'ok'
-
-										return 'pending'
-									}
-
-									return 'error'
-								})()}`}
-							>
-								{(() => {
-									if (bootstrapError.value === undefined) {
-										if (isBootstrapped.value) return 'Ready'
-
-										return 'Bootstrapping'
-									}
-
-									return 'Error'
-								})()}
-							</span>
+							<span className={`badge ${scenarioStatus.badgeClassName}`}>{scenarioStatus.label}</span>
 							<h3>Scenario</h3>
 						</div>
 						<p className='detail'>{scenarioDetail}</p>
+						{savedStateStorageWarning.value === undefined ? undefined : <p className='detail'>{savedStateStorageWarning.value}</p>}
 						{bootstrapError.value === undefined && isBootstrapping.value ? (
 							<p className='detail'>
 								<span className='spinner' aria-hidden='true' />
@@ -440,9 +459,7 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 						type='button'
 						onClick={() =>
 							void runNavigationControl(async () => {
-								const record = persistSavedSimulationState(await controller.exportState(saveName.value))
-								reloadSavedStateRecords()
-								navigateToSavedSimulationState(record.id)
+								await persistAndNavigateToSavedState(await controller.exportState(saveName.value))
 							})
 						}
 					>
@@ -488,9 +505,7 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 						type='button'
 						onClick={() =>
 							void runNavigationControl(async () => {
-								const record = persistSavedSimulationState(importStateText.value)
-								reloadSavedStateRecords()
-								navigateToSavedSimulationState(record.id)
+								await persistAndNavigateToSavedState(importStateText.value)
 							})
 						}
 					>

--- a/ui/ts/lib/activeEnvironment.ts
+++ b/ui/ts/lib/activeEnvironment.ts
@@ -1,7 +1,9 @@
 import type { ChainBackend } from './chainBackend.js'
 import { createInjectedBackend } from './chainBackend.js'
+import { getErrorMessage } from '../lib/errors.js'
 import type { NetworkProfile } from './networkProfile.js'
 import type { SimulationController } from '../simulation/controller.js'
+import { getSavedSimulationStateEnvelope } from '../simulation/savedStates.js'
 import { createSimulationBackend } from '../simulation/tevmBackend.js'
 import { normalizeSimulationScenario, type SimulationScenario } from '../simulation/scenarios.js'
 
@@ -39,6 +41,12 @@ function getSimulationScenario(location: LocationLike): SimulationScenario {
 	return normalizeSimulationScenario(params.get('simScenario') ?? undefined)
 }
 
+function getSimulationStateId(location: LocationLike) {
+	const params = readLocationParams(location)
+	const stateId = params.get('simState')
+	return stateId === null || stateId.trim() === '' ? undefined : stateId
+}
+
 export async function initializeActiveEnvironment(location: LocationLike = window.location) {
 	if (activeSimulationController !== undefined) {
 		await activeSimulationController.dispose()
@@ -50,9 +58,29 @@ export async function initializeActiveEnvironment(location: LocationLike = windo
 		return injectedBackend
 	}
 
-	const simulationBackend = await createSimulationBackend({
-		scenario: getSimulationScenario(location),
-	})
+	const savedStateId = getSimulationStateId(location)
+	let initialBootstrapError: string | undefined = undefined
+	let savedState = undefined
+	if (savedStateId !== undefined) {
+		try {
+			savedState = getSavedSimulationStateEnvelope(savedStateId)
+		} catch (error) {
+			initialBootstrapError = `Saved simulation state "${savedStateId}" could not be loaded. ${getErrorMessage(error, 'The saved state is invalid')}. Falling back to the baseline scenario.`
+		}
+		if (savedState === undefined && initialBootstrapError === undefined) {
+			initialBootstrapError = `Saved simulation state "${savedStateId}" could not be loaded. Falling back to the baseline scenario.`
+		}
+	}
+	const simulationBackend =
+		savedStateId !== undefined && savedState !== undefined
+			? await createSimulationBackend({
+					savedState,
+					savedStateId,
+				})
+			: await createSimulationBackend({
+					...(initialBootstrapError === undefined ? {} : { initialBootstrapError }),
+					scenario: savedStateId === undefined ? getSimulationScenario(location) : 'baseline',
+				})
 	activeBackend = simulationBackend
 	activeSimulationController = simulationBackend
 	void simulationBackend.bootstrap().catch(error => {

--- a/ui/ts/simulation/controller.ts
+++ b/ui/ts/simulation/controller.ts
@@ -1,5 +1,6 @@
 import type { Address } from 'viem'
 import type { SimulationScenario } from './scenarios.js'
+import type { SimulationSource } from './savedStates.js'
 
 export type SimulationController = {
 	accounts: readonly Address[]
@@ -11,6 +12,7 @@ export type SimulationController = {
 	currentTimestamp: bigint
 	currentScenario: SimulationScenario
 	dispose(): Promise<void>
+	exportState(name: string): Promise<string>
 	isActive: true
 	isBootstrapped: boolean
 	isBootstrapping: boolean
@@ -22,6 +24,7 @@ export type SimulationController = {
 	reset(): Promise<void>
 	selectAccount(address: Address): Promise<void>
 	selectedAccount: Address
+	simulationSource: SimulationSource
 	setRepPerEthPrice(value: bigint): void
 	setRepPerUsdcPrice(value: bigint): void
 	setQueryDelayMilliseconds(value: number): void

--- a/ui/ts/simulation/savedStates.ts
+++ b/ui/ts/simulation/savedStates.ts
@@ -253,6 +253,14 @@ export function getSavedSimulationStateStorageWarning(storage?: Storage) {
 	return droppedRecordCount === 1 ? 'Ignored 1 corrupted saved simulation state in browser storage.' : `Ignored ${droppedRecordCount} corrupted saved simulation states in browser storage.`
 }
 
+export function removeCorruptedSavedSimulationStates(storage?: Storage) {
+	const storageReference = getStorage(storage)
+	const snapshot = parseSavedStateStorageRecords(storageReference.getItem(SAVED_SIMULATION_STATES_STORAGE_KEY))
+	if (snapshot.droppedRecordCount === 0) return 0
+	writeSavedStateStorageRecords(snapshot.records, storageReference)
+	return snapshot.droppedRecordCount
+}
+
 function getSavedSimulationStateRecord(stateId: string, storage?: Storage) {
 	return listSavedSimulationStateRecords(storage).find(record => record.id === stateId)
 }

--- a/ui/ts/simulation/savedStates.ts
+++ b/ui/ts/simulation/savedStates.ts
@@ -2,6 +2,8 @@ import { getErrorMessage } from '../lib/errors.js'
 import { isSimulationScenario, type SimulationScenario } from './scenarios.js'
 
 const SAVED_SIMULATION_STATES_STORAGE_KEY = 'zoltar.simulation.savedStates'
+const SAVED_SIMULATION_STATES_CORRUPTED_BACKUP_STORAGE_KEY = 'zoltar.simulation.savedStates.corruptedBackup'
+const MAX_CORRUPTED_SAVED_STATE_BACKUPS = 5
 
 export const SAVED_SIMULATION_STATE_VERSION = 1 as const
 
@@ -32,6 +34,16 @@ export type SavedSimulationStateRecord = {
 	persistedAt: string
 	savedAt: string
 	serialized: string
+}
+
+export type SavedSimulationStateStorageSummary = {
+	records: SavedSimulationStateRecord[]
+	warning: string | undefined
+}
+
+type SavedSimulationStateCorruptedBackup = {
+	backedUpAt: string
+	rawValue: string
 }
 
 export type SimulationSource =
@@ -68,7 +80,9 @@ type SavedSimulationStateStorageRecord = {
 }
 
 type SavedSimulationStateStorageSnapshot = {
+	hasMalformedStorageValue: boolean
 	droppedRecordCount: number
+	rawValue: string | null
 	records: SavedSimulationStateStorageRecord[]
 }
 
@@ -172,15 +186,15 @@ function normalizeSavedStateStorageRecord(record: SavedSimulationStateStorageRec
 }
 
 function parseSavedStateStorageRecords(serialized: string | null): SavedSimulationStateStorageSnapshot {
-	if (serialized === null || serialized.trim() === '') return { droppedRecordCount: 0, records: [] }
+	if (serialized === null || serialized.trim() === '') return { droppedRecordCount: 0, hasMalformedStorageValue: false, rawValue: serialized, records: [] }
 	let parsed: unknown
 	try {
 		parsed = JSON.parse(serialized)
 	} catch (error) {
 		if (!(error instanceof SyntaxError)) throw error
-		return { droppedRecordCount: 1, records: [] }
+		return { droppedRecordCount: 0, hasMalformedStorageValue: true, rawValue: serialized, records: [] }
 	}
-	if (!Array.isArray(parsed)) return { droppedRecordCount: 1, records: [] }
+	if (!Array.isArray(parsed)) return { droppedRecordCount: 0, hasMalformedStorageValue: true, rawValue: serialized, records: [] }
 	const validRecords: SavedSimulationStateStorageRecord[] = []
 	let droppedRecordCount = 0
 	for (const item of parsed) {
@@ -196,6 +210,8 @@ function parseSavedStateStorageRecords(serialized: string | null): SavedSimulati
 	}
 	return {
 		droppedRecordCount,
+		hasMalformedStorageValue: false,
+		rawValue: serialized,
 		records: validRecords,
 	}
 }
@@ -225,6 +241,49 @@ function toSavedSimulationStateRecord(storageRecord: SavedSimulationStateStorage
 	}
 }
 
+function getSavedSimulationStateStorageSnapshot(storage?: Storage) {
+	return parseSavedStateStorageRecords(getStorage(storage).getItem(SAVED_SIMULATION_STATES_STORAGE_KEY))
+}
+
+function getSavedSimulationStateStorageWarningFromSnapshot(snapshot: SavedSimulationStateStorageSnapshot) {
+	if (snapshot.hasMalformedStorageValue) return 'Saved simulation state storage is corrupted in browser storage.'
+	const droppedRecordCount = snapshot.droppedRecordCount
+	if (droppedRecordCount === 0) return undefined
+	return droppedRecordCount === 1 ? 'Ignored 1 corrupted saved simulation state in browser storage.' : `Ignored ${droppedRecordCount} corrupted saved simulation states in browser storage.`
+}
+
+function toSavedSimulationStateStorageSummary(snapshot: SavedSimulationStateStorageSnapshot): SavedSimulationStateStorageSummary {
+	return {
+		records: snapshot.records.map(toSavedSimulationStateRecord).sort((left, right) => right.persistedAt.localeCompare(left.persistedAt)),
+		warning: getSavedSimulationStateStorageWarningFromSnapshot(snapshot),
+	}
+}
+
+function writeCorruptedSavedStateStorageBackup(rawValue: string, storage?: Storage) {
+	const storageReference = getStorage(storage)
+	const serializedExistingBackups = storageReference.getItem(SAVED_SIMULATION_STATES_CORRUPTED_BACKUP_STORAGE_KEY)
+	let existingBackups: SavedSimulationStateCorruptedBackup[] = []
+	if (serializedExistingBackups !== null && serializedExistingBackups.trim() !== '') {
+		try {
+			const parsed = JSON.parse(serializedExistingBackups)
+			if (Array.isArray(parsed)) {
+				existingBackups = parsed.filter((item): item is SavedSimulationStateCorruptedBackup => isObjectRecord(item) && typeof item['backedUpAt'] === 'string' && typeof item['rawValue'] === 'string')
+			}
+		} catch (error) {
+			if (!(error instanceof SyntaxError)) throw error
+			existingBackups = []
+		}
+	}
+	const nextBackups = [
+		{
+			backedUpAt: new Date().toISOString(),
+			rawValue,
+		},
+		...existingBackups,
+	].slice(0, MAX_CORRUPTED_SAVED_STATE_BACKUPS)
+	storageReference.setItem(SAVED_SIMULATION_STATES_CORRUPTED_BACKUP_STORAGE_KEY, JSON.stringify(nextBackups))
+}
+
 export function serializeSavedSimulationStateEnvelope(envelope: SavedSimulationStateEnvelopeV1) {
 	assertSavedStateEnvelope(envelope)
 	return stringifySimulationValue(envelope)
@@ -241,28 +300,27 @@ export function parseSavedSimulationStateEnvelope(serialized: string) {
 	return parsed
 }
 
-export function listSavedSimulationStateRecords(storage?: Storage) {
-	return parseSavedStateStorageRecords(getStorage(storage).getItem(SAVED_SIMULATION_STATES_STORAGE_KEY))
-		.records.map(toSavedSimulationStateRecord)
-		.sort((left, right) => right.persistedAt.localeCompare(left.persistedAt))
-}
-
-export function getSavedSimulationStateStorageWarning(storage?: Storage) {
-	const droppedRecordCount = parseSavedStateStorageRecords(getStorage(storage).getItem(SAVED_SIMULATION_STATES_STORAGE_KEY)).droppedRecordCount
-	if (droppedRecordCount === 0) return undefined
-	return droppedRecordCount === 1 ? 'Ignored 1 corrupted saved simulation state in browser storage.' : `Ignored ${droppedRecordCount} corrupted saved simulation states in browser storage.`
+export function getSavedSimulationStateStorageSummary(storage?: Storage) {
+	return toSavedSimulationStateStorageSummary(getSavedSimulationStateStorageSnapshot(storage))
 }
 
 export function removeCorruptedSavedSimulationStates(storage?: Storage) {
 	const storageReference = getStorage(storage)
-	const snapshot = parseSavedStateStorageRecords(storageReference.getItem(SAVED_SIMULATION_STATES_STORAGE_KEY))
+	const snapshot = getSavedSimulationStateStorageSnapshot(storageReference)
+	if (snapshot.hasMalformedStorageValue) {
+		if (snapshot.rawValue !== null && snapshot.rawValue.trim() !== '') {
+			writeCorruptedSavedStateStorageBackup(snapshot.rawValue, storageReference)
+		}
+		writeSavedStateStorageRecords([], storageReference)
+		return 1
+	}
 	if (snapshot.droppedRecordCount === 0) return 0
 	writeSavedStateStorageRecords(snapshot.records, storageReference)
 	return snapshot.droppedRecordCount
 }
 
 function getSavedSimulationStateRecord(stateId: string, storage?: Storage) {
-	return listSavedSimulationStateRecords(storage).find(record => record.id === stateId)
+	return getSavedSimulationStateStorageSummary(storage).records.find(record => record.id === stateId)
 }
 
 export function getSavedSimulationStateEnvelope(stateId: string, storage?: Storage) {
@@ -278,7 +336,7 @@ export function persistSavedSimulationState(serialized: string, storage?: Storag
 		name: normalizeSavedStateName(parsedEnvelope.name),
 	}
 	const normalizedSerialized = serializeSavedSimulationStateEnvelope(envelope)
-	const currentRecords = parseSavedStateStorageRecords(getStorage(storage).getItem(SAVED_SIMULATION_STATES_STORAGE_KEY)).records
+	const currentRecords = getSavedSimulationStateStorageSnapshot(storage).records
 	const persistedAt = new Date().toISOString()
 	const id = createSavedStateRecordId({
 		existingIds: new Set(currentRecords.map(record => record.id)),
@@ -298,7 +356,7 @@ export function persistSavedSimulationState(serialized: string, storage?: Storag
 }
 
 export function deleteSavedSimulationState(stateId: string, storage?: Storage) {
-	const currentRecords = parseSavedStateStorageRecords(getStorage(storage).getItem(SAVED_SIMULATION_STATES_STORAGE_KEY)).records
+	const currentRecords = getSavedSimulationStateStorageSnapshot(storage).records
 	const nextRecords = currentRecords.filter(record => record.id !== stateId)
 	if (nextRecords.length === currentRecords.length) return false
 	writeSavedStateStorageRecords(nextRecords, storage)

--- a/ui/ts/simulation/savedStates.ts
+++ b/ui/ts/simulation/savedStates.ts
@@ -1,0 +1,261 @@
+import { getErrorMessage } from '../lib/errors.js'
+import { isSimulationScenario, type SimulationScenario } from './scenarios.js'
+
+const SAVED_SIMULATION_STATES_STORAGE_KEY = 'zoltar.simulation.savedStates'
+
+export const SAVED_SIMULATION_STATE_VERSION = 1 as const
+
+export type SimulationSnapshotV1 = {
+	blockCountSinceReset: bigint
+	currentTimestamp: bigint
+	queryDelayMilliseconds: number
+	repPerEthPrice: bigint
+	repPerUsdcPrice: bigint
+	selectedAccount: string
+	snapshot: Record<string, unknown>
+	transactionCountSinceReset: bigint
+	transactionDelayMilliseconds: number
+}
+
+export type SavedSimulationStateEnvelopeV1 = {
+	baseScenario: SimulationScenario
+	name: string
+	savedAt: string
+	state: SimulationSnapshotV1
+	version: typeof SAVED_SIMULATION_STATE_VERSION
+}
+
+export type SavedSimulationStateRecord = {
+	baseScenario: SimulationScenario
+	id: string
+	name: string
+	savedAt: string
+	serialized: string
+}
+
+export type SimulationSource =
+	| {
+			kind: 'scenario'
+			scenario: SimulationScenario
+	  }
+	| {
+			baseScenario: SimulationScenario
+			kind: 'saved-state'
+			name: string
+			savedAt: string
+			stateId: string
+	  }
+
+export type SimulationInitialization =
+	| {
+			kind: 'scenario'
+			scenario: SimulationScenario
+	  }
+	| {
+			envelope: SavedSimulationStateEnvelopeV1
+			kind: 'saved-state'
+			stateId: string
+	  }
+
+type SavedSimulationStateStorageRecord = {
+	baseScenario: SimulationScenario
+	id: string
+	name: string
+	savedAt: string
+	serialized: string
+}
+
+class SavedSimulationStateError extends Error {
+	constructor(message: string) {
+		super(message)
+		this.name = 'SavedSimulationStateError'
+	}
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null
+}
+
+function getStorage(storage?: Storage) {
+	if (storage !== undefined) return storage
+	if (typeof window === 'undefined' || window.localStorage === undefined) throw new Error('Local storage is unavailable')
+	return window.localStorage
+}
+
+function stringifySimulationValue(value: unknown) {
+	const serialized = JSON.stringify(value, (_key, item) => (typeof item === 'bigint' ? `${item.toString()}n` : (item as never)), 2)
+	if (serialized === undefined) throw new Error('Saved simulation state could not be serialized')
+	return serialized
+}
+
+function parseSimulationValue(serialized: string) {
+	return JSON.parse(serialized, (_key, value) => {
+		if (typeof value === 'string' && /^-?\d+n$/.test(value)) return BigInt(value.slice(0, -1))
+		return value
+	})
+}
+
+function normalizeSavedStateName(name: string) {
+	return name.trim().replace(/\s+/g, ' ')
+}
+
+function slugifySavedStateName(name: string) {
+	const normalized = normalizeSavedStateName(name)
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '')
+	return normalized === '' ? 'saved-state' : normalized
+}
+
+function createSavedStateTimestamp(savedAt: string) {
+	return savedAt.replace(/[^0-9]/g, '').slice(0, 14)
+}
+
+function isFiniteNonNegativeNumber(value: unknown) {
+	return typeof value === 'number' && Number.isFinite(value) && value >= 0
+}
+
+function isNonNegativeBigInt(value: unknown) {
+	return typeof value === 'bigint' && value >= 0n
+}
+
+function assertSavedStateEnvelope(value: unknown): asserts value is SavedSimulationStateEnvelopeV1 {
+	if (!isObjectRecord(value)) throw new SavedSimulationStateError('Saved simulation state must be a JSON object')
+	if (value['version'] !== SAVED_SIMULATION_STATE_VERSION) throw new SavedSimulationStateError(`Unsupported saved simulation state version: ${String(value['version'])}`)
+	if (typeof value['name'] !== 'string' || normalizeSavedStateName(value['name']) === '') throw new SavedSimulationStateError('Saved simulation state is missing a name')
+	if (typeof value['savedAt'] !== 'string' || value['savedAt'].trim() === '') throw new SavedSimulationStateError('Saved simulation state is missing a savedAt timestamp')
+	if (Number.isNaN(Date.parse(value['savedAt']))) throw new SavedSimulationStateError('Saved simulation state is missing a valid savedAt timestamp')
+	if (typeof value['baseScenario'] !== 'string' || !isSimulationScenario(value['baseScenario'])) throw new SavedSimulationStateError('Saved simulation state is missing a valid baseScenario')
+	if (!isObjectRecord(value['state'])) throw new SavedSimulationStateError('Saved simulation state is missing its state payload')
+	const state = value['state']
+	if (typeof state['selectedAccount'] !== 'string' || state['selectedAccount'].trim() === '') throw new SavedSimulationStateError('Saved simulation state is missing a selectedAccount')
+	if (!isFiniteNonNegativeNumber(state['queryDelayMilliseconds'])) throw new SavedSimulationStateError('Saved simulation state is missing a valid query delay')
+	if (!isFiniteNonNegativeNumber(state['transactionDelayMilliseconds'])) throw new SavedSimulationStateError('Saved simulation state is missing a valid transaction delay')
+	if (!isNonNegativeBigInt(state['blockCountSinceReset'])) throw new SavedSimulationStateError('Saved simulation state is missing a valid block count')
+	if (!isNonNegativeBigInt(state['currentTimestamp'])) throw new SavedSimulationStateError('Saved simulation state is missing a valid timestamp')
+	if (!isNonNegativeBigInt(state['transactionCountSinceReset'])) throw new SavedSimulationStateError('Saved simulation state is missing a valid transaction count')
+	if (!isNonNegativeBigInt(state['repPerEthPrice']) || state['repPerEthPrice'] === 0n) throw new SavedSimulationStateError('Saved simulation state is missing a valid REP/ETH price')
+	if (!isNonNegativeBigInt(state['repPerUsdcPrice']) || state['repPerUsdcPrice'] === 0n) throw new SavedSimulationStateError('Saved simulation state is missing a valid REP/USDC price')
+	if (!isObjectRecord(state['snapshot'])) throw new SavedSimulationStateError('Saved simulation state is missing a valid TEVM snapshot')
+}
+
+function assertSavedStateRecord(value: unknown): asserts value is SavedSimulationStateStorageRecord {
+	if (!isObjectRecord(value)) throw new SavedSimulationStateError('Saved simulation state record must be an object')
+	if (typeof value['id'] !== 'string' || value['id'].trim() === '') throw new SavedSimulationStateError('Saved simulation state record is missing an id')
+	if (typeof value['serialized'] !== 'string' || value['serialized'].trim() === '') throw new SavedSimulationStateError('Saved simulation state record is missing its serialized payload')
+	if (typeof value['name'] !== 'string' || normalizeSavedStateName(value['name']) === '') throw new SavedSimulationStateError('Saved simulation state record is missing a name')
+	if (typeof value['savedAt'] !== 'string' || value['savedAt'].trim() === '') throw new SavedSimulationStateError('Saved simulation state record is missing its savedAt timestamp')
+	if (typeof value['baseScenario'] !== 'string' || !isSimulationScenario(value['baseScenario'])) throw new SavedSimulationStateError('Saved simulation state record is missing a valid baseScenario')
+}
+
+function parseSavedStateStorageRecords(serialized: string | null) {
+	if (serialized === null || serialized.trim() === '') return []
+	let parsed: unknown
+	try {
+		parsed = JSON.parse(serialized)
+	} catch (error) {
+		if (!(error instanceof SyntaxError)) throw error
+		return []
+	}
+	if (!Array.isArray(parsed)) return []
+	const validRecords: SavedSimulationStateStorageRecord[] = []
+	for (const item of parsed) {
+		try {
+			assertSavedStateRecord(item)
+			parseSavedSimulationStateEnvelope(item.serialized)
+			validRecords.push(item)
+		} catch (error) {
+			if (!(error instanceof SavedSimulationStateError)) throw error
+			continue
+		}
+	}
+	return validRecords
+}
+
+function writeSavedStateStorageRecords(records: readonly SavedSimulationStateStorageRecord[], storage?: Storage) {
+	getStorage(storage).setItem(SAVED_SIMULATION_STATES_STORAGE_KEY, JSON.stringify(records))
+}
+
+function createSavedStateRecordId({ existingIds, name, savedAt }: { existingIds: ReadonlySet<string>; name: string; savedAt: string }) {
+	const baseId = `${slugifySavedStateName(name)}-${createSavedStateTimestamp(savedAt)}`
+	if (!existingIds.has(baseId)) return baseId
+	let suffix = 2
+	while (existingIds.has(`${baseId}-${suffix}`)) {
+		suffix += 1
+	}
+	return `${baseId}-${suffix}`
+}
+
+function toSavedSimulationStateRecord(storageRecord: SavedSimulationStateStorageRecord): SavedSimulationStateRecord {
+	return {
+		baseScenario: storageRecord.baseScenario,
+		id: storageRecord.id,
+		name: storageRecord.name,
+		savedAt: storageRecord.savedAt,
+		serialized: storageRecord.serialized,
+	}
+}
+
+export function serializeSavedSimulationStateEnvelope(envelope: SavedSimulationStateEnvelopeV1) {
+	assertSavedStateEnvelope(envelope)
+	return stringifySimulationValue(envelope)
+}
+
+export function parseSavedSimulationStateEnvelope(serialized: string) {
+	let parsed: unknown
+	try {
+		parsed = parseSimulationValue(serialized)
+	} catch (error) {
+		throw new SavedSimulationStateError(getErrorMessage(error, 'Failed to parse the saved simulation state JSON'))
+	}
+	assertSavedStateEnvelope(parsed)
+	return parsed
+}
+
+export function listSavedSimulationStateRecords(storage?: Storage) {
+	return parseSavedStateStorageRecords(getStorage(storage).getItem(SAVED_SIMULATION_STATES_STORAGE_KEY))
+		.map(toSavedSimulationStateRecord)
+		.sort((left, right) => right.savedAt.localeCompare(left.savedAt))
+}
+
+function getSavedSimulationStateRecord(stateId: string, storage?: Storage) {
+	return listSavedSimulationStateRecords(storage).find(record => record.id === stateId)
+}
+
+export function getSavedSimulationStateEnvelope(stateId: string, storage?: Storage) {
+	const record = getSavedSimulationStateRecord(stateId, storage)
+	if (record === undefined) return undefined
+	return parseSavedSimulationStateEnvelope(record.serialized)
+}
+
+export function persistSavedSimulationState(serialized: string, storage?: Storage) {
+	const parsedEnvelope = parseSavedSimulationStateEnvelope(serialized)
+	const envelope = {
+		...parsedEnvelope,
+		name: normalizeSavedStateName(parsedEnvelope.name),
+	}
+	const normalizedSerialized = serializeSavedSimulationStateEnvelope(envelope)
+	const currentRecords = parseSavedStateStorageRecords(getStorage(storage).getItem(SAVED_SIMULATION_STATES_STORAGE_KEY))
+	const id = createSavedStateRecordId({
+		existingIds: new Set(currentRecords.map(record => record.id)),
+		name: envelope.name,
+		savedAt: envelope.savedAt,
+	})
+	const nextRecord = {
+		baseScenario: envelope.baseScenario,
+		id,
+		name: envelope.name,
+		savedAt: envelope.savedAt,
+		serialized: normalizedSerialized,
+	} satisfies SavedSimulationStateStorageRecord
+	writeSavedStateStorageRecords([...currentRecords, nextRecord], storage)
+	return toSavedSimulationStateRecord(nextRecord)
+}
+
+export function deleteSavedSimulationState(stateId: string, storage?: Storage) {
+	const currentRecords = parseSavedStateStorageRecords(getStorage(storage).getItem(SAVED_SIMULATION_STATES_STORAGE_KEY))
+	const nextRecords = currentRecords.filter(record => record.id !== stateId)
+	if (nextRecords.length === currentRecords.length) return false
+	writeSavedStateStorageRecords(nextRecords, storage)
+	return true
+}

--- a/ui/ts/simulation/savedStates.ts
+++ b/ui/ts/simulation/savedStates.ts
@@ -29,6 +29,7 @@ export type SavedSimulationStateRecord = {
 	baseScenario: SimulationScenario
 	id: string
 	name: string
+	persistedAt: string
 	savedAt: string
 	serialized: string
 }
@@ -61,9 +62,17 @@ type SavedSimulationStateStorageRecord = {
 	baseScenario: SimulationScenario
 	id: string
 	name: string
+	persistedAt?: string | undefined
 	savedAt: string
 	serialized: string
 }
+
+type SavedSimulationStateStorageSnapshot = {
+	droppedRecordCount: number
+	records: SavedSimulationStateStorageRecord[]
+}
+
+const BIGINT_VALUE_TAG = '$zoltarBigInt'
 
 class SavedSimulationStateError extends Error {
 	constructor(message: string) {
@@ -76,6 +85,10 @@ function isObjectRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null
 }
 
+function isTaggedBigIntValue(value: unknown): value is Record<typeof BIGINT_VALUE_TAG, string> {
+	return isObjectRecord(value) && Object.keys(value).length === 1 && typeof value[BIGINT_VALUE_TAG] === 'string'
+}
+
 function getStorage(storage?: Storage) {
 	if (storage !== undefined) return storage
 	if (typeof window === 'undefined' || window.localStorage === undefined) throw new Error('Local storage is unavailable')
@@ -83,14 +96,14 @@ function getStorage(storage?: Storage) {
 }
 
 function stringifySimulationValue(value: unknown) {
-	const serialized = JSON.stringify(value, (_key, item) => (typeof item === 'bigint' ? `${item.toString()}n` : (item as never)), 2)
+	const serialized = JSON.stringify(value, (_key, item) => (typeof item === 'bigint' ? { [BIGINT_VALUE_TAG]: item.toString() } : (item as never)), 2)
 	if (serialized === undefined) throw new Error('Saved simulation state could not be serialized')
 	return serialized
 }
 
 function parseSimulationValue(serialized: string) {
 	return JSON.parse(serialized, (_key, value) => {
-		if (typeof value === 'string' && /^-?\d+n$/.test(value)) return BigInt(value.slice(0, -1))
+		if (isTaggedBigIntValue(value)) return BigInt(value[BIGINT_VALUE_TAG])
 		return value
 	})
 }
@@ -146,30 +159,45 @@ function assertSavedStateRecord(value: unknown): asserts value is SavedSimulatio
 	if (typeof value['name'] !== 'string' || normalizeSavedStateName(value['name']) === '') throw new SavedSimulationStateError('Saved simulation state record is missing a name')
 	if (typeof value['savedAt'] !== 'string' || value['savedAt'].trim() === '') throw new SavedSimulationStateError('Saved simulation state record is missing its savedAt timestamp')
 	if (typeof value['baseScenario'] !== 'string' || !isSimulationScenario(value['baseScenario'])) throw new SavedSimulationStateError('Saved simulation state record is missing a valid baseScenario')
+	if (value['persistedAt'] !== undefined && (typeof value['persistedAt'] !== 'string' || value['persistedAt'].trim() === '' || Number.isNaN(Date.parse(value['persistedAt'])))) {
+		throw new SavedSimulationStateError('Saved simulation state record is missing a valid persistedAt timestamp')
+	}
 }
 
-function parseSavedStateStorageRecords(serialized: string | null) {
-	if (serialized === null || serialized.trim() === '') return []
+function normalizeSavedStateStorageRecord(record: SavedSimulationStateStorageRecord): SavedSimulationStateStorageRecord {
+	return {
+		...record,
+		persistedAt: record.persistedAt ?? record.savedAt,
+	}
+}
+
+function parseSavedStateStorageRecords(serialized: string | null): SavedSimulationStateStorageSnapshot {
+	if (serialized === null || serialized.trim() === '') return { droppedRecordCount: 0, records: [] }
 	let parsed: unknown
 	try {
 		parsed = JSON.parse(serialized)
 	} catch (error) {
 		if (!(error instanceof SyntaxError)) throw error
-		return []
+		return { droppedRecordCount: 1, records: [] }
 	}
-	if (!Array.isArray(parsed)) return []
+	if (!Array.isArray(parsed)) return { droppedRecordCount: 1, records: [] }
 	const validRecords: SavedSimulationStateStorageRecord[] = []
+	let droppedRecordCount = 0
 	for (const item of parsed) {
 		try {
 			assertSavedStateRecord(item)
 			parseSavedSimulationStateEnvelope(item.serialized)
-			validRecords.push(item)
+			validRecords.push(normalizeSavedStateStorageRecord(item))
 		} catch (error) {
 			if (!(error instanceof SavedSimulationStateError)) throw error
+			droppedRecordCount += 1
 			continue
 		}
 	}
-	return validRecords
+	return {
+		droppedRecordCount,
+		records: validRecords,
+	}
 }
 
 function writeSavedStateStorageRecords(records: readonly SavedSimulationStateStorageRecord[], storage?: Storage) {
@@ -191,6 +219,7 @@ function toSavedSimulationStateRecord(storageRecord: SavedSimulationStateStorage
 		baseScenario: storageRecord.baseScenario,
 		id: storageRecord.id,
 		name: storageRecord.name,
+		persistedAt: storageRecord.persistedAt ?? storageRecord.savedAt,
 		savedAt: storageRecord.savedAt,
 		serialized: storageRecord.serialized,
 	}
@@ -214,8 +243,14 @@ export function parseSavedSimulationStateEnvelope(serialized: string) {
 
 export function listSavedSimulationStateRecords(storage?: Storage) {
 	return parseSavedStateStorageRecords(getStorage(storage).getItem(SAVED_SIMULATION_STATES_STORAGE_KEY))
-		.map(toSavedSimulationStateRecord)
-		.sort((left, right) => right.savedAt.localeCompare(left.savedAt))
+		.records.map(toSavedSimulationStateRecord)
+		.sort((left, right) => right.persistedAt.localeCompare(left.persistedAt))
+}
+
+export function getSavedSimulationStateStorageWarning(storage?: Storage) {
+	const droppedRecordCount = parseSavedStateStorageRecords(getStorage(storage).getItem(SAVED_SIMULATION_STATES_STORAGE_KEY)).droppedRecordCount
+	if (droppedRecordCount === 0) return undefined
+	return droppedRecordCount === 1 ? 'Ignored 1 corrupted saved simulation state in browser storage.' : `Ignored ${droppedRecordCount} corrupted saved simulation states in browser storage.`
 }
 
 function getSavedSimulationStateRecord(stateId: string, storage?: Storage) {
@@ -235,7 +270,8 @@ export function persistSavedSimulationState(serialized: string, storage?: Storag
 		name: normalizeSavedStateName(parsedEnvelope.name),
 	}
 	const normalizedSerialized = serializeSavedSimulationStateEnvelope(envelope)
-	const currentRecords = parseSavedStateStorageRecords(getStorage(storage).getItem(SAVED_SIMULATION_STATES_STORAGE_KEY))
+	const currentRecords = parseSavedStateStorageRecords(getStorage(storage).getItem(SAVED_SIMULATION_STATES_STORAGE_KEY)).records
+	const persistedAt = new Date().toISOString()
 	const id = createSavedStateRecordId({
 		existingIds: new Set(currentRecords.map(record => record.id)),
 		name: envelope.name,
@@ -245,6 +281,7 @@ export function persistSavedSimulationState(serialized: string, storage?: Storag
 		baseScenario: envelope.baseScenario,
 		id,
 		name: envelope.name,
+		persistedAt,
 		savedAt: envelope.savedAt,
 		serialized: normalizedSerialized,
 	} satisfies SavedSimulationStateStorageRecord
@@ -253,7 +290,7 @@ export function persistSavedSimulationState(serialized: string, storage?: Storag
 }
 
 export function deleteSavedSimulationState(stateId: string, storage?: Storage) {
-	const currentRecords = parseSavedStateStorageRecords(getStorage(storage).getItem(SAVED_SIMULATION_STATES_STORAGE_KEY))
+	const currentRecords = parseSavedStateStorageRecords(getStorage(storage).getItem(SAVED_SIMULATION_STATES_STORAGE_KEY)).records
 	const nextRecords = currentRecords.filter(record => record.id !== stateId)
 	if (nextRecords.length === currentRecords.length) return false
 	writeSavedStateStorageRecords(nextRecords, storage)

--- a/ui/ts/simulation/scenarios.ts
+++ b/ui/ts/simulation/scenarios.ts
@@ -4,7 +4,7 @@ export const SIMULATION_SCENARIOS = ['baseline', 'deployed', 'security-pool', 's
 
 export type SimulationScenario = (typeof SIMULATION_SCENARIOS)[number]
 
-function isSimulationScenario(value: string): value is SimulationScenario {
+export function isSimulationScenario(value: string): value is SimulationScenario {
 	return SIMULATION_SCENARIOS.includes(value as SimulationScenario)
 }
 

--- a/ui/ts/simulation/tevmBackend.ts
+++ b/ui/ts/simulation/tevmBackend.ts
@@ -6,6 +6,7 @@ import { createSimulationProfile } from '../lib/networkProfile.js'
 import type { SimulationController } from './controller.js'
 import { predictSimulationTokenAddresses } from './bootstrap.js'
 import type { SimulationScenario } from './scenarios.js'
+import type { SavedSimulationStateEnvelopeV1, SimulationInitialization } from './savedStates.js'
 import type { SimulationWorkerCallMap, SimulationWorkerCallMessage, SimulationWorkerCallMethod, SimulationWorkerEvent, SimulationWorkerMessage, SimulationWorkerRpcMessage, SimulationWorkerState } from './tevmWorkerProtocol.js'
 
 const QA_ACCOUNTS = [normalizeAccount('0x00000000000000000000000000000000000000a1'), normalizeAccount('0x00000000000000000000000000000000000000b2'), normalizeAccount('0x00000000000000000000000000000000000000c3')].filter((account): account is Address => account !== undefined)
@@ -56,10 +57,21 @@ function createSimulationProvider(requestRpc: (parameters: RequestArguments) => 
 	}
 }
 
-export async function createSimulationBackend({ scenario }: { scenario: SimulationScenario }): Promise<SimulationBackend> {
+export async function createSimulationBackend({ initialBootstrapError, savedState, savedStateId, scenario }: { initialBootstrapError?: string; savedState?: SavedSimulationStateEnvelopeV1; savedStateId?: string; scenario?: SimulationScenario }): Promise<SimulationBackend> {
 	const primaryAccount = QA_ACCOUNTS[0]
 	if (primaryAccount === undefined) throw new Error('No simulation QA accounts configured')
 	const profile = createSimulationProfile(predictSimulationTokenAddresses(primaryAccount))
+	const initialization: SimulationInitialization =
+		savedState !== undefined && savedStateId !== undefined
+			? {
+					envelope: savedState,
+					kind: 'saved-state',
+					stateId: savedStateId,
+				}
+			: {
+					kind: 'scenario',
+					scenario: scenario ?? 'baseline',
+				}
 	const listeners = createListenerMap()
 	const workerPath = resolveWorkerPath()
 	const worker = new Worker(workerPath, { type: 'module' })
@@ -166,12 +178,18 @@ export async function createSimulationBackend({ scenario }: { scenario: Simulati
 			reject(new Error(`Simulation worker message deserialization failed (worker: ${workerPath.toString()})`))
 		}
 		worker.postMessage({
-			scenario,
+			initialization,
 			type: 'init',
 		} satisfies SimulationWorkerMessage)
 	})
 
 	await waitForReady
+
+	if (initialBootstrapError !== undefined) {
+		const state = currentState
+		if (state === undefined) throw new Error('Simulation worker state is unavailable')
+		applyState(Object.assign({}, state, { bootstrapError: initialBootstrapError }))
+	}
 
 	const requireState = () => {
 		if (currentState === undefined) throw new Error('Simulation worker state is unavailable')
@@ -194,7 +212,7 @@ export async function createSimulationBackend({ scenario }: { scenario: Simulati
 		bootstrap: async () => {
 			if (bootstrapPromise === undefined) {
 				patchState({
-					bootstrapError: undefined,
+					bootstrapError: currentState?.bootstrapError,
 					bootstrapLabel: 'Starting simulation bootstrap',
 					bootstrapProgress: 0,
 					isBootstrapping: true,
@@ -271,6 +289,7 @@ export async function createSimulationBackend({ scenario }: { scenario: Simulati
 			rejectPendingRequests(new Error('Simulation backend has been disposed'))
 			worker.terminate()
 		},
+		exportState: async name => await callWorker('exportState', { name }),
 		get isBootstrapped() {
 			return requireState().isBootstrapped
 		},
@@ -308,6 +327,9 @@ export async function createSimulationBackend({ scenario }: { scenario: Simulati
 		},
 		get selectedAccount() {
 			return requireState().selectedAccount
+		},
+		get simulationSource() {
+			return requireState().currentSource
 		},
 		setRepPerEthPrice: value => {
 			patchState({

--- a/ui/ts/simulation/tevmEngine.ts
+++ b/ui/ts/simulation/tevmEngine.ts
@@ -494,6 +494,27 @@ export async function createSimulationEngine({ initialization }: { initializatio
 			getTransactionDelay: () => 0,
 			onReceiptResolved: async () => undefined,
 		})
+	const bootstrapBuiltInScenario = async (scenario: SimulationScenario) => {
+		await bootstrapSimulationChain({
+			accounts: QA_ACCOUNTS,
+			createReadClient: createBootstrapReadClient,
+			createWriteClient: createBootstrapWriteClient,
+			memoryClient,
+			onProgress: progress => {
+				bootstrapLabel = progress.label
+				bootstrapProgress = progress.value
+				emitState()
+			},
+			primaryAccount,
+			profile,
+			scenario,
+		})
+		await refreshSimulationState()
+		baselineTransactionCount = transactionCountSinceReset
+		bootstrapLabel = 'Simulation scenario ready'
+		bootstrapProgress = 1
+		bootstrapped = true
+	}
 	const bootstrap = async () => {
 		if (bootstrapPromise !== undefined) return await bootstrapPromise
 		bootstrapping = true
@@ -504,25 +525,7 @@ export async function createSimulationEngine({ initialization }: { initializatio
 		bootstrapPromise = (async () => {
 			try {
 				if (initialization.kind === 'scenario') {
-					await bootstrapSimulationChain({
-						accounts: QA_ACCOUNTS,
-						createReadClient: createBootstrapReadClient,
-						createWriteClient: createBootstrapWriteClient,
-						memoryClient,
-						onProgress: progress => {
-							bootstrapLabel = progress.label
-							bootstrapProgress = progress.value
-							emitState()
-						},
-						primaryAccount,
-						profile,
-						scenario: initialization.scenario,
-					})
-					await refreshSimulationState()
-					baselineTransactionCount = transactionCountSinceReset
-					bootstrapLabel = 'Simulation scenario ready'
-					bootstrapProgress = 1
-					bootstrapped = true
+					await bootstrapBuiltInScenario(initialization.scenario)
 				} else {
 					await restoreSavedStateEnvelope(initialization.envelope, 'Loading saved simulation state')
 				}
@@ -643,20 +646,7 @@ export async function createSimulationEngine({ initialization }: { initializatio
 					memoryClient = createSimulationMemoryClient(profile)
 					impersonatedAccounts.clear()
 					await initializeSimulationAccounts()
-					await bootstrapSimulationChain({
-						accounts: QA_ACCOUNTS,
-						createReadClient: createBootstrapReadClient,
-						createWriteClient: createBootstrapWriteClient,
-						memoryClient,
-						onProgress: progress => {
-							bootstrapLabel = progress.label
-							bootstrapProgress = progress.value
-							emitState()
-						},
-						primaryAccount,
-						profile,
-						scenario: initialization.scenario,
-					})
+					await bootstrapBuiltInScenario(initialization.scenario)
 					selectedAccount = primaryAccount
 					transactionCountSinceReset = baselineTransactionCount
 					repPerEthPrice = DEFAULT_SIMULATION_REP_PER_ETH_PRICE

--- a/ui/ts/simulation/tevmEngine.ts
+++ b/ui/ts/simulation/tevmEngine.ts
@@ -9,9 +9,11 @@ import { createSimulationProfile } from '../lib/networkProfile.js'
 import { bootstrapSimulationChain, mintSimulationGenesisRep, predictSimulationTokenAddresses, updateZoltarGenesisRepToken } from './bootstrap.js'
 import { advanceSimulationTime, getNextSimulationTimestamp, getSimulationChainTimestamp, mineNextSimulationBlock, minePendingSimulationTransactionAtTimestamp } from './clock.js'
 import type { SimulationScenario } from './scenarios.js'
+import { serializeSavedSimulationStateEnvelope, type SavedSimulationStateEnvelopeV1, type SimulationInitialization, type SimulationSource } from './savedStates.js'
 import type { SimulationWorkerState } from './tevmWorkerProtocol.js'
 const QA_ACCOUNTS = [getAddress('0x00000000000000000000000000000000000000a1'), getAddress('0x00000000000000000000000000000000000000b2'), getAddress('0x00000000000000000000000000000000000000c3')] as const satisfies readonly Address[]
 type MemoryClientLike = ReturnType<typeof createMemoryClient>
+type DumpedTevmState = Awaited<ReturnType<MemoryClientLike['tevmDumpState']>>['state']
 type RequestArguments = {
 	method: string
 	params?: unknown
@@ -185,6 +187,7 @@ type SimulationEngine = {
 	accounts: readonly Address[]
 	advanceTime(seconds: bigint): Promise<void>
 	bootstrap(): Promise<void>
+	exportState(name: string): Promise<string>
 	getAccounts(): Promise<readonly Address[]>
 	getChainId(): Promise<string>
 	getProfile(): ChainBackend['profile']
@@ -204,11 +207,38 @@ type SimulationEngine = {
 	waitForTransactionReceipt(hash: Hash): Promise<Awaited<ReturnType<ReadClient['getTransactionReceipt']>>>
 	waitUntilReady(): Promise<void>
 }
-export async function createSimulationEngine({ scenario }: { scenario: SimulationScenario }): Promise<SimulationEngine> {
+
+function getInitializationScenario(initialization: SimulationInitialization): SimulationScenario {
+	return initialization.kind === 'scenario' ? initialization.scenario : initialization.envelope.baseScenario
+}
+
+function getSimulationSource(initialization: SimulationInitialization): SimulationSource {
+	return initialization.kind === 'scenario'
+		? {
+				kind: 'scenario',
+				scenario: initialization.scenario,
+			}
+		: {
+				baseScenario: initialization.envelope.baseScenario,
+				kind: 'saved-state',
+				name: initialization.envelope.name,
+				savedAt: initialization.envelope.savedAt,
+				stateId: initialization.stateId,
+			}
+}
+
+async function requireSuccessfulLoadState(memoryClient: MemoryClientLike, state: DumpedTevmState) {
+	const result = await memoryClient.tevmLoadState({ state })
+	if (result.errors === undefined || result.errors.length === 0) return
+	throw new Error(result.errors.map(error => error.message).join(', '))
+}
+
+export async function createSimulationEngine({ initialization }: { initialization: SimulationInitialization }): Promise<SimulationEngine> {
 	const primaryAccount = QA_ACCOUNTS[0]
 	if (primaryAccount === undefined) throw new Error('No simulation QA accounts configured')
 	const predictedTokenAddresses = predictSimulationTokenAddresses(primaryAccount)
 	const profile = createSimulationProfile(predictedTokenAddresses)
+	const baseScenario = getInitializationScenario(initialization)
 	let memoryClient = createSimulationMemoryClient(profile)
 	const stateListeners = new Set<() => void>()
 	const impersonatedAccounts = new Set<string>()
@@ -225,6 +255,7 @@ export async function createSimulationEngine({ scenario }: { scenario: Simulatio
 	let repPerEthPrice = DEFAULT_SIMULATION_REP_PER_ETH_PRICE
 	let repPerUsdcPrice = DEFAULT_SIMULATION_REP_PER_USDC_PRICE
 	let selectedAccount = primaryAccount
+	const simulationSource = getSimulationSource(initialization)
 	let transactionCountSinceReset = 0n
 	let transactionDelayMilliseconds = 1000
 	const emitState = () => {
@@ -251,6 +282,30 @@ export async function createSimulationEngine({ scenario }: { scenario: Simulatio
 		const chainState = await getSimulationChainState(memoryClient)
 		currentTimestamp = chainState.currentTimestamp
 		blockCountSinceReset = chainState.blockNumber
+	}
+	const restoreSavedStateEnvelope = async (envelope: SavedSimulationStateEnvelopeV1, progressLabel: string) => {
+		bootstrapError = undefined
+		bootstrapLabel = progressLabel
+		bootstrapProgress = 0
+		memoryClient = createSimulationMemoryClient(profile)
+		impersonatedAccounts.clear()
+		await initializeSimulationAccounts()
+		await requireSuccessfulLoadState(memoryClient, envelope.state.snapshot as DumpedTevmState)
+		await initializeSimulationAccounts()
+		queryDelayMilliseconds = clampDelayMilliseconds(envelope.state.queryDelayMilliseconds)
+		repPerEthPrice = envelope.state.repPerEthPrice
+		repPerUsdcPrice = envelope.state.repPerUsdcPrice
+		transactionDelayMilliseconds = clampDelayMilliseconds(envelope.state.transactionDelayMilliseconds)
+		transactionCountSinceReset = envelope.state.transactionCountSinceReset
+		const nextSelectedAccount = QA_ACCOUNTS.find(account => account.toLowerCase() === envelope.state.selectedAccount.toLowerCase())
+		if (nextSelectedAccount === undefined) throw new Error(`Unknown saved simulation account: ${envelope.state.selectedAccount}`)
+		selectedAccount = nextSelectedAccount
+		await ensureImpersonated(selectedAccount)
+		await refreshSimulationState()
+		baselineTransactionCount = envelope.state.transactionCountSinceReset
+		bootstrapLabel = 'Simulation scenario ready'
+		bootstrapProgress = 1
+		bootstrapped = true
 	}
 	const sendRawTransactionInternal = async (serializedTransaction: SerializedTransaction) => {
 		const parsedTransaction = parseTransaction(serializedTransaction)
@@ -443,30 +498,34 @@ export async function createSimulationEngine({ scenario }: { scenario: Simulatio
 		if (bootstrapPromise !== undefined) return await bootstrapPromise
 		bootstrapping = true
 		bootstrapError = undefined
-		bootstrapLabel = 'Starting simulation bootstrap'
+		bootstrapLabel = initialization.kind === 'scenario' ? 'Starting simulation bootstrap' : 'Loading saved simulation state'
 		bootstrapProgress = 0
 		emitState()
 		bootstrapPromise = (async () => {
 			try {
-				await bootstrapSimulationChain({
-					accounts: QA_ACCOUNTS,
-					createReadClient: createBootstrapReadClient,
-					createWriteClient: createBootstrapWriteClient,
-					memoryClient,
-					onProgress: progress => {
-						bootstrapLabel = progress.label
-						bootstrapProgress = progress.value
-						emitState()
-					},
-					primaryAccount,
-					profile,
-					scenario,
-				})
-				await refreshSimulationState()
-				baselineTransactionCount = transactionCountSinceReset
-				bootstrapLabel = 'Simulation scenario ready'
-				bootstrapProgress = 1
-				bootstrapped = true
+				if (initialization.kind === 'scenario') {
+					await bootstrapSimulationChain({
+						accounts: QA_ACCOUNTS,
+						createReadClient: createBootstrapReadClient,
+						createWriteClient: createBootstrapWriteClient,
+						memoryClient,
+						onProgress: progress => {
+							bootstrapLabel = progress.label
+							bootstrapProgress = progress.value
+							emitState()
+						},
+						primaryAccount,
+						profile,
+						scenario: initialization.scenario,
+					})
+					await refreshSimulationState()
+					baselineTransactionCount = transactionCountSinceReset
+					bootstrapLabel = 'Simulation scenario ready'
+					bootstrapProgress = 1
+					bootstrapped = true
+				} else {
+					await restoreSavedStateEnvelope(initialization.envelope, 'Loading saved simulation state')
+				}
 			} catch (error) {
 				bootstrapError = error instanceof Error ? error.message : 'Failed to bootstrap simulation scenario'
 				throw error
@@ -486,8 +545,9 @@ export async function createSimulationEngine({ scenario }: { scenario: Simulatio
 		bootstrapLabel,
 		bootstrapProgress,
 		blockCountSinceReset,
-		currentScenario: scenario,
+		currentScenario: baseScenario,
 		currentTimestamp,
+		currentSource: simulationSource,
 		isBootstrapped: bootstrapped,
 		isBootstrapping: bootstrapping,
 		queryDelayMilliseconds,
@@ -505,6 +565,32 @@ export async function createSimulationEngine({ scenario }: { scenario: Simulatio
 			emitState()
 		},
 		bootstrap,
+		exportState: async name => {
+			if (!bootstrapped) throw new Error('Simulation scenario must be bootstrapped before exporting state')
+			const snapshot = await memoryClient.tevmDumpState()
+			if (snapshot.errors !== undefined && snapshot.errors.length > 0) {
+				throw new Error(snapshot.errors.map(error => error.message).join(', '))
+			}
+			const normalizedName = name.trim()
+			if (normalizedName === '') throw new Error('Saved simulation state name is required')
+			return serializeSavedSimulationStateEnvelope({
+				baseScenario,
+				name: normalizedName,
+				savedAt: new Date().toISOString(),
+				state: {
+					blockCountSinceReset,
+					currentTimestamp,
+					queryDelayMilliseconds,
+					repPerEthPrice,
+					repPerUsdcPrice,
+					selectedAccount,
+					snapshot: snapshot.state,
+					transactionCountSinceReset,
+					transactionDelayMilliseconds,
+				},
+				version: 1,
+			})
+		},
 		getAccounts: async () => [selectedAccount],
 		getChainId: async () => profile.chainIdHex,
 		getProfile: () => profile,
@@ -550,31 +636,43 @@ export async function createSimulationEngine({ scenario }: { scenario: Simulatio
 			bootstrapError = undefined
 			bootstrapLabel = 'Resetting simulation scenario'
 			bootstrapProgress = 0
-			memoryClient = createSimulationMemoryClient(profile)
-			impersonatedAccounts.clear()
-			await initializeSimulationAccounts()
-			await bootstrapSimulationChain({
-				accounts: QA_ACCOUNTS,
-				createReadClient: createBootstrapReadClient,
-				createWriteClient: createBootstrapWriteClient,
-				memoryClient,
-				onProgress: progress => {
-					bootstrapLabel = progress.label
-					bootstrapProgress = progress.value
-					emitState()
-				},
-				primaryAccount,
-				profile,
-				scenario,
-			})
-			selectedAccount = primaryAccount
-			transactionCountSinceReset = baselineTransactionCount
-			repPerEthPrice = DEFAULT_SIMULATION_REP_PER_ETH_PRICE
-			repPerUsdcPrice = DEFAULT_SIMULATION_REP_PER_USDC_PRICE
-			await refreshSimulationState()
-			bootstrapLabel = undefined
-			bootstrapProgress = undefined
+			bootstrapping = true
 			emitState()
+			try {
+				if (initialization.kind === 'scenario') {
+					memoryClient = createSimulationMemoryClient(profile)
+					impersonatedAccounts.clear()
+					await initializeSimulationAccounts()
+					await bootstrapSimulationChain({
+						accounts: QA_ACCOUNTS,
+						createReadClient: createBootstrapReadClient,
+						createWriteClient: createBootstrapWriteClient,
+						memoryClient,
+						onProgress: progress => {
+							bootstrapLabel = progress.label
+							bootstrapProgress = progress.value
+							emitState()
+						},
+						primaryAccount,
+						profile,
+						scenario: initialization.scenario,
+					})
+					selectedAccount = primaryAccount
+					transactionCountSinceReset = baselineTransactionCount
+					repPerEthPrice = DEFAULT_SIMULATION_REP_PER_ETH_PRICE
+					repPerUsdcPrice = DEFAULT_SIMULATION_REP_PER_USDC_PRICE
+					queryDelayMilliseconds = 0
+					transactionDelayMilliseconds = 1000
+					await refreshSimulationState()
+				} else {
+					await restoreSavedStateEnvelope(initialization.envelope, 'Resetting saved simulation state')
+				}
+				bootstrapLabel = undefined
+				bootstrapProgress = undefined
+			} finally {
+				bootstrapping = false
+				emitState()
+			}
 		},
 		selectAccount: async address => {
 			if (!QA_ACCOUNTS.includes(address)) throw new Error(`Unknown simulation account: ${address}`)

--- a/ui/ts/simulation/tevmWorker.ts
+++ b/ui/ts/simulation/tevmWorker.ts
@@ -37,6 +37,8 @@ async function handleCall(message: SimulationWorkerCallMessage) {
 		case 'bootstrap':
 			await engine.bootstrap()
 			return undefined
+		case 'exportState':
+			return await engine.exportState(message.params.name)
 		case 'getAccounts':
 			return await engine.getAccounts()
 		case 'getState':
@@ -96,7 +98,7 @@ scope.onmessage = event => {
 			if (message.type === 'init') {
 				if (enginePromise !== undefined) throw new Error('Simulation worker was already initialized')
 				enginePromise = createSimulationEngine({
-					scenario: message.scenario,
+					initialization: message.initialization,
 				})
 				const engine = await enginePromise
 				engine.subscribe(() => {

--- a/ui/ts/simulation/tevmWorkerProtocol.ts
+++ b/ui/ts/simulation/tevmWorkerProtocol.ts
@@ -1,5 +1,6 @@
 import type { Address, Hash, Hex, TransactionReceipt } from 'viem'
 import type { SimulationScenario } from './scenarios.js'
+import type { SimulationInitialization, SimulationSource } from './savedStates.js'
 
 export type SimulationWorkerState = {
 	bootstrapError: string | undefined
@@ -8,6 +9,7 @@ export type SimulationWorkerState = {
 	blockCountSinceReset: bigint
 	currentScenario: SimulationScenario
 	currentTimestamp: bigint
+	currentSource: SimulationSource
 	isBootstrapped: boolean
 	isBootstrapping: boolean
 	queryDelayMilliseconds: number
@@ -21,6 +23,7 @@ export type SimulationWorkerState = {
 export type SimulationWorkerCallMap = {
 	advanceTime: { params: { seconds: bigint }; result: undefined }
 	bootstrap: { params: undefined; result: undefined }
+	exportState: { params: { name: string }; result: string }
 	getAccounts: { params: undefined; result: readonly Address[] }
 	getState: { params: undefined; result: SimulationWorkerState }
 	installSimulationProxyDeployer: { params: { address: Address; runtimeCode: Hex }; result: undefined }
@@ -40,7 +43,7 @@ export type SimulationWorkerCallMap = {
 export type SimulationWorkerCallMethod = keyof SimulationWorkerCallMap
 
 export type SimulationWorkerInitMessage = {
-	scenario: SimulationScenario
+	initialization: SimulationInitialization
 	type: 'init'
 }
 

--- a/ui/ts/tests/activeEnvironment.test.ts
+++ b/ui/ts/tests/activeEnvironment.test.ts
@@ -7,9 +7,11 @@ import { getWrongNetworkMessage, isSupportedAppChain } from '../lib/network.js'
 import { getSecurityVaultWithdrawableRepAmount } from '../lib/securityVault.js'
 import { getActiveBackend, getActiveSimulationController, initializeActiveEnvironment, installActiveEnvironmentForTesting, resetActiveEnvironmentForTesting, shouldUseSimulationLocation } from '../lib/activeEnvironment.js'
 import { SIMULATION_BLOCK_INTERVAL_SECONDS, SIMULATION_INITIAL_TIMESTAMP } from '../simulation/clock.js'
+import { parseSavedSimulationStateEnvelope, persistSavedSimulationState, serializeSavedSimulationStateEnvelope } from '../simulation/savedStates.js'
 import { createSimulationBackend } from '../simulation/tevmBackend.js'
 import type { SimulationScenario } from '../simulation/scenarios.js'
 import { createFakeBackend, createFakeSimulationProfile } from './testUtils/fakeBackend.js'
+import { installDomEnvironment } from './testUtils/domEnvironment.js'
 
 const DEFAULT_SIMULATION_REP_PER_ETH_PRICE = 3n * 10n ** 18n
 const SIMULATION_REP_MINT_AMOUNT = 1_000_000n * 10n ** 18n
@@ -109,6 +111,91 @@ void describe('active environment', () => {
 			resetActiveEnvironmentForTesting()
 		}
 	}, 30_000)
+
+	void test('initializes a saved simulation state from simState query params', async () => {
+		const domEnvironment = installDomEnvironment()
+		const record = persistSavedSimulationState(
+			serializeSavedSimulationStateEnvelope({
+				baseScenario: 'baseline',
+				name: 'Saved baseline',
+				savedAt: '2026-06-02T12:34:56.000Z',
+				state: {
+					blockCountSinceReset: 1n,
+					currentTimestamp: 2n,
+					queryDelayMilliseconds: 0,
+					repPerEthPrice: DEFAULT_SIMULATION_REP_PER_ETH_PRICE,
+					repPerUsdcPrice: 10n ** 6n,
+					selectedAccount: '0x00000000000000000000000000000000000000a1',
+					snapshot: {},
+					transactionCountSinceReset: 3n,
+					transactionDelayMilliseconds: 0,
+				},
+				version: 1,
+			}),
+		)
+
+		try {
+			const backend = await initializeActiveEnvironment({
+				hash: `#/zoltar?simulate=1&simState=${record.id}&simScenario=securitypoolx2`,
+				hostname: 'localhost',
+				search: '',
+			})
+			if (backend.id !== 'simulation') throw new Error('Expected the simulation backend')
+			const simulationBackend = backend as Awaited<ReturnType<typeof createSimulationBackend>>
+			expect(simulationBackend.simulationSource.kind).toBe('saved-state')
+			expect(simulationBackend.currentScenario).toBe('baseline')
+		} finally {
+			domEnvironment.cleanup()
+		}
+	})
+
+	void test('falls back to baseline when a saved state is missing', async () => {
+		const domEnvironment = installDomEnvironment()
+
+		try {
+			const backend = await initializeActiveEnvironment({
+				hash: '#/zoltar?simulate=1&simState=missing-state',
+				hostname: 'localhost',
+				search: '',
+			})
+			if (backend.id !== 'simulation') throw new Error('Expected the simulation backend')
+			const simulationBackend = backend as Awaited<ReturnType<typeof createSimulationBackend>>
+			expect(simulationBackend.currentScenario).toBe('baseline')
+			expect(simulationBackend.bootstrapError).toContain('could not be loaded')
+		} finally {
+			domEnvironment.cleanup()
+		}
+	})
+
+	void test('falls back to baseline when a saved state record is invalid', async () => {
+		const domEnvironment = installDomEnvironment()
+		window.localStorage.setItem(
+			'zoltar.simulation.savedStates',
+			JSON.stringify([
+				{
+					baseScenario: 'baseline',
+					id: 'broken-state',
+					name: 'Broken state',
+					savedAt: '2026-06-02T12:34:56.000Z',
+					serialized: '{bad json',
+				},
+			]),
+		)
+
+		try {
+			const backend = await initializeActiveEnvironment({
+				hash: '#/zoltar?simulate=1&simState=broken-state',
+				hostname: 'localhost',
+				search: '',
+			})
+			if (backend.id !== 'simulation') throw new Error('Expected the simulation backend')
+			const simulationBackend = backend as Awaited<ReturnType<typeof createSimulationBackend>>
+			expect(simulationBackend.currentScenario).toBe('baseline')
+			expect(simulationBackend.bootstrapError).toContain('could not be loaded')
+		} finally {
+			domEnvironment.cleanup()
+		}
+	})
 })
 
 void describe('simulation backend', () => {
@@ -410,6 +497,47 @@ void describe('simulation backend', () => {
 			await backend.dispose()
 		}
 	}, 90_000)
+
+	void test('exports and restores a custom saved simulation state', async () => {
+		const sourceBackend = await createSimulationBackend({ scenario: 'baseline' })
+		await sourceBackend.bootstrap()
+
+		try {
+			const secondaryAccount = sourceBackend.accounts[1]
+			if (secondaryAccount === undefined) throw new Error('Expected a secondary simulation QA account')
+
+			sourceBackend.setQueryDelayMilliseconds(250)
+			sourceBackend.setTransactionDelayMilliseconds(0)
+			sourceBackend.setRepPerEthPrice(2n * 10n ** 18n)
+			await sourceBackend.selectAccount(secondaryAccount)
+			await sourceBackend.mintRep(SIMULATION_REP_MINT_AMOUNT)
+
+			const restoredBackend = await createSimulationBackend({
+				savedState: parseSavedSimulationStateEnvelope(await sourceBackend.exportState('Saved baseline')),
+				savedStateId: 'saved-baseline-20260602123456',
+			})
+			await restoredBackend.bootstrap()
+
+			try {
+				expect(restoredBackend.simulationSource.kind).toBe('saved-state')
+				expect(restoredBackend.selectedAccount).toBe(secondaryAccount)
+				expect(restoredBackend.queryDelayMilliseconds).toBe(250)
+				expect(restoredBackend.transactionDelayMilliseconds).toBe(0)
+				expect(restoredBackend.repPerEthPrice).toBe(2n * 10n ** 18n)
+				const repBalance = await loadErc20Balance(restoredBackend.createReadClient(), restoredBackend.profile.genesisRepTokenAddress, secondaryAccount)
+				expect(repBalance >= SIMULATION_REP_MINT_AMOUNT).toBe(true)
+
+				await restoredBackend.reset()
+				expect(restoredBackend.selectedAccount).toBe(secondaryAccount)
+				expect(restoredBackend.queryDelayMilliseconds).toBe(250)
+				expect(restoredBackend.repPerEthPrice).toBe(2n * 10n ** 18n)
+			} finally {
+				await restoredBackend.dispose()
+			}
+		} finally {
+			await sourceBackend.dispose()
+		}
+	}, 60_000)
 
 	void test('bootstraps the deployed scenario with app contracts already deployed', async () => {
 		const backend = deployedBackend

--- a/ui/ts/tests/savedSimulationStates.test.ts
+++ b/ui/ts/tests/savedSimulationStates.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from 'bun:test'
-import { deleteSavedSimulationState, getSavedSimulationStateEnvelope, getSavedSimulationStateStorageWarning, listSavedSimulationStateRecords, parseSavedSimulationStateEnvelope, persistSavedSimulationState, serializeSavedSimulationStateEnvelope } from '../simulation/savedStates.js'
+import { deleteSavedSimulationState, getSavedSimulationStateEnvelope, getSavedSimulationStateStorageWarning, listSavedSimulationStateRecords, parseSavedSimulationStateEnvelope, persistSavedSimulationState, removeCorruptedSavedSimulationStates, serializeSavedSimulationStateEnvelope } from '../simulation/savedStates.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 
 function createSerializedSavedState({ name, savedAt }: { name: string; savedAt: string }) {
@@ -191,6 +191,42 @@ describe('saved simulation states', () => {
 
 			expect(listSavedSimulationStateRecords().map(record => record.id)).toEqual(['saved-baseline-20260602123456'])
 			expect(getSavedSimulationStateStorageWarning()).toBe('Ignored 1 corrupted saved simulation state in browser storage.')
+		} finally {
+			domEnvironment.cleanup()
+		}
+	})
+
+	test('removes corrupted saved-state storage records while preserving valid saves', () => {
+		const domEnvironment = installDomEnvironment()
+
+		try {
+			window.localStorage.setItem(
+				'zoltar.simulation.savedStates',
+				JSON.stringify([
+					{
+						baseScenario: 'baseline',
+						id: 'saved-baseline-20260602123456',
+						name: 'Saved baseline',
+						savedAt: '2026-06-02T12:34:56.000Z',
+						serialized: createSerializedSavedState({
+							name: 'Saved baseline',
+							savedAt: '2026-06-02T12:34:56.000Z',
+						}),
+					},
+					{
+						baseScenario: 'baseline',
+						id: 'broken-state',
+						name: 'Broken state',
+						savedAt: '2026-06-02T12:35:56.000Z',
+						serialized: '{bad json',
+					},
+				]),
+			)
+
+			expect(removeCorruptedSavedSimulationStates()).toBe(1)
+			expect(getSavedSimulationStateStorageWarning()).toBeUndefined()
+			expect(listSavedSimulationStateRecords().map(record => record.id)).toEqual(['saved-baseline-20260602123456'])
+			expect(removeCorruptedSavedSimulationStates()).toBe(0)
 		} finally {
 			domEnvironment.cleanup()
 		}

--- a/ui/ts/tests/savedSimulationStates.test.ts
+++ b/ui/ts/tests/savedSimulationStates.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from 'bun:test'
-import { deleteSavedSimulationState, getSavedSimulationStateEnvelope, getSavedSimulationStateStorageWarning, listSavedSimulationStateRecords, parseSavedSimulationStateEnvelope, persistSavedSimulationState, removeCorruptedSavedSimulationStates, serializeSavedSimulationStateEnvelope } from '../simulation/savedStates.js'
+import { deleteSavedSimulationState, getSavedSimulationStateEnvelope, getSavedSimulationStateStorageSummary, parseSavedSimulationStateEnvelope, persistSavedSimulationState, removeCorruptedSavedSimulationStates, serializeSavedSimulationStateEnvelope } from '../simulation/savedStates.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 
 function createSerializedSavedState({ name, savedAt }: { name: string; savedAt: string }) {
@@ -27,6 +27,8 @@ function createSerializedSavedState({ name, savedAt }: { name: string; savedAt: 
 }
 
 describe('saved simulation states', () => {
+	const listSavedSimulationStateRecordIds = () => getSavedSimulationStateStorageSummary().records.map(record => record.id)
+
 	test('serializes and parses a versioned simulation state envelope', () => {
 		const serialized = createSerializedSavedState({
 			name: 'Saved baseline',
@@ -110,7 +112,7 @@ describe('saved simulation states', () => {
 				}),
 			)
 
-			const records = listSavedSimulationStateRecords()
+			const records = getSavedSimulationStateStorageSummary().records
 			expect(records).toHaveLength(2)
 			expect(first.id).toBe('saved-baseline-20260602123456')
 			expect(second.id).toBe('saved-baseline-20260602123556')
@@ -118,7 +120,7 @@ describe('saved simulation states', () => {
 
 			expect(deleteSavedSimulationState(first.id)).toBe(true)
 			expect(deleteSavedSimulationState('missing-state')).toBe(false)
-			expect(listSavedSimulationStateRecords().map(record => record.id)).toEqual([second.id])
+			expect(listSavedSimulationStateRecordIds()).toEqual([second.id])
 		} finally {
 			domEnvironment.cleanup()
 		}
@@ -156,7 +158,7 @@ describe('saved simulation states', () => {
 				]),
 			)
 
-			expect(listSavedSimulationStateRecords().map(record => record.id)).toEqual(['older-export-20260601123456', 'newer-export-20260602123456'])
+			expect(listSavedSimulationStateRecordIds()).toEqual(['older-export-20260601123456', 'newer-export-20260602123456'])
 		} finally {
 			domEnvironment.cleanup()
 		}
@@ -189,8 +191,8 @@ describe('saved simulation states', () => {
 				]),
 			)
 
-			expect(listSavedSimulationStateRecords().map(record => record.id)).toEqual(['saved-baseline-20260602123456'])
-			expect(getSavedSimulationStateStorageWarning()).toBe('Ignored 1 corrupted saved simulation state in browser storage.')
+			expect(listSavedSimulationStateRecordIds()).toEqual(['saved-baseline-20260602123456'])
+			expect(getSavedSimulationStateStorageSummary().warning).toBe('Ignored 1 corrupted saved simulation state in browser storage.')
 		} finally {
 			domEnvironment.cleanup()
 		}
@@ -224,9 +226,59 @@ describe('saved simulation states', () => {
 			)
 
 			expect(removeCorruptedSavedSimulationStates()).toBe(1)
-			expect(getSavedSimulationStateStorageWarning()).toBeUndefined()
-			expect(listSavedSimulationStateRecords().map(record => record.id)).toEqual(['saved-baseline-20260602123456'])
+			expect(getSavedSimulationStateStorageSummary().warning).toBeUndefined()
+			expect(listSavedSimulationStateRecordIds()).toEqual(['saved-baseline-20260602123456'])
 			expect(removeCorruptedSavedSimulationStates()).toBe(0)
+		} finally {
+			domEnvironment.cleanup()
+		}
+	})
+
+	test('reports malformed saved-state storage with a generic warning', () => {
+		const domEnvironment = installDomEnvironment()
+
+		try {
+			window.localStorage.setItem('zoltar.simulation.savedStates', '{bad json')
+
+			expect(getSavedSimulationStateStorageSummary().warning).toBe('Saved simulation state storage is corrupted in browser storage.')
+			expect(removeCorruptedSavedSimulationStates()).toBe(1)
+			expect(getSavedSimulationStateStorageSummary().warning).toBeUndefined()
+			expect(getSavedSimulationStateStorageSummary().records).toEqual([])
+			const backupValue = window.localStorage.getItem('zoltar.simulation.savedStates.corruptedBackup')
+			expect(backupValue).not.toBeNull()
+			if (backupValue === null) throw new Error('Expected corrupted saved-state backup to be written')
+			expect(JSON.parse(backupValue)).toEqual([
+				expect.objectContaining({
+					rawValue: '{bad json',
+				}),
+			])
+		} finally {
+			domEnvironment.cleanup()
+		}
+	})
+
+	test('keeps a bounded history of malformed saved-state storage backups', () => {
+		const domEnvironment = installDomEnvironment()
+
+		try {
+			window.localStorage.setItem(
+				'zoltar.simulation.savedStates.corruptedBackup',
+				JSON.stringify([
+					{ backedUpAt: '2026-06-03T00:00:05.000Z', rawValue: 'older-1' },
+					{ backedUpAt: '2026-06-03T00:00:04.000Z', rawValue: 'older-2' },
+					{ backedUpAt: '2026-06-03T00:00:03.000Z', rawValue: 'older-3' },
+					{ backedUpAt: '2026-06-03T00:00:02.000Z', rawValue: 'older-4' },
+					{ backedUpAt: '2026-06-03T00:00:01.000Z', rawValue: 'older-5' },
+				]),
+			)
+			window.localStorage.setItem('zoltar.simulation.savedStates', '{new-bad-json')
+
+			expect(removeCorruptedSavedSimulationStates()).toBe(1)
+
+			const backupValue = window.localStorage.getItem('zoltar.simulation.savedStates.corruptedBackup')
+			expect(backupValue).not.toBeNull()
+			if (backupValue === null) throw new Error('Expected corrupted saved-state backup history to be written')
+			expect(JSON.parse(backupValue)).toEqual([expect.objectContaining({ rawValue: '{new-bad-json' }), expect.objectContaining({ rawValue: 'older-1' }), expect.objectContaining({ rawValue: 'older-2' }), expect.objectContaining({ rawValue: 'older-3' }), expect.objectContaining({ rawValue: 'older-4' })])
 		} finally {
 			domEnvironment.cleanup()
 		}

--- a/ui/ts/tests/savedSimulationStates.test.ts
+++ b/ui/ts/tests/savedSimulationStates.test.ts
@@ -1,0 +1,148 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { deleteSavedSimulationState, getSavedSimulationStateEnvelope, listSavedSimulationStateRecords, parseSavedSimulationStateEnvelope, persistSavedSimulationState, serializeSavedSimulationStateEnvelope } from '../simulation/savedStates.js'
+import { installDomEnvironment } from './testUtils/domEnvironment.js'
+
+function createSerializedSavedState({ name, savedAt }: { name: string; savedAt: string }) {
+	return serializeSavedSimulationStateEnvelope({
+		baseScenario: 'baseline',
+		name,
+		savedAt,
+		state: {
+			blockCountSinceReset: 1n,
+			currentTimestamp: 2n,
+			queryDelayMilliseconds: 0,
+			repPerEthPrice: 3n * 10n ** 18n,
+			repPerUsdcPrice: 10n ** 6n,
+			selectedAccount: '0x00000000000000000000000000000000000000a1',
+			snapshot: {
+				accounts: [],
+			},
+			transactionCountSinceReset: 4n,
+			transactionDelayMilliseconds: 1000,
+		},
+		version: 1,
+	})
+}
+
+describe('saved simulation states', () => {
+	test('serializes and parses a versioned simulation state envelope', () => {
+		const serialized = createSerializedSavedState({
+			name: 'Saved baseline',
+			savedAt: '2026-06-02T12:34:56.000Z',
+		})
+
+		const parsed = parseSavedSimulationStateEnvelope(serialized)
+
+		expect(parsed.version).toBe(1)
+		expect(parsed.name).toBe('Saved baseline')
+		expect(parsed.state.blockCountSinceReset).toBe(1n)
+	})
+
+	test('rejects malformed saved state json', () => {
+		expect(() => parseSavedSimulationStateEnvelope('{bad json')).toThrow('Failed to parse the saved simulation state JSON')
+	})
+
+	test('rejects unsupported saved state versions', () => {
+		expect(() =>
+			parseSavedSimulationStateEnvelope(
+				JSON.stringify({
+					baseScenario: 'baseline',
+					name: 'Bad state',
+					savedAt: '2026-06-02T12:34:56.000Z',
+					state: {},
+					version: 99,
+				}),
+			),
+		).toThrow('Unsupported saved simulation state version: 99')
+	})
+
+	test('rejects invalid savedAt timestamps', () => {
+		expect(() =>
+			parseSavedSimulationStateEnvelope(
+				JSON.stringify({
+					baseScenario: 'baseline',
+					name: 'Bad state',
+					savedAt: 'not-a-date',
+					state: {
+						blockCountSinceReset: '1n',
+						currentTimestamp: '2n',
+						queryDelayMilliseconds: 0,
+						repPerEthPrice: '3000000000000000000n',
+						repPerUsdcPrice: '1000000n',
+						selectedAccount: '0x00000000000000000000000000000000000000a1',
+						snapshot: {},
+						transactionCountSinceReset: '4n',
+						transactionDelayMilliseconds: 1000,
+					},
+					version: 1,
+				}),
+			),
+		).toThrow('Saved simulation state is missing a valid savedAt timestamp')
+	})
+
+	test('persists, lists, and deletes saved states from local storage', () => {
+		const domEnvironment = installDomEnvironment()
+
+		try {
+			const first = persistSavedSimulationState(
+				createSerializedSavedState({
+					name: 'Saved baseline',
+					savedAt: '2026-06-02T12:34:56.000Z',
+				}),
+			)
+			const second = persistSavedSimulationState(
+				createSerializedSavedState({
+					name: 'Saved baseline',
+					savedAt: '2026-06-02T12:35:56.000Z',
+				}),
+			)
+
+			const records = listSavedSimulationStateRecords()
+			expect(records).toHaveLength(2)
+			expect(first.id).toBe('saved-baseline-20260602123456')
+			expect(second.id).toBe('saved-baseline-20260602123556')
+			expect(getSavedSimulationStateEnvelope(first.id)?.name).toBe('Saved baseline')
+
+			expect(deleteSavedSimulationState(first.id)).toBe(true)
+			expect(deleteSavedSimulationState('missing-state')).toBe(false)
+			expect(listSavedSimulationStateRecords().map(record => record.id)).toEqual([second.id])
+		} finally {
+			domEnvironment.cleanup()
+		}
+	})
+
+	test('ignores corrupted or invalid saved-state storage records', () => {
+		const domEnvironment = installDomEnvironment()
+
+		try {
+			window.localStorage.setItem(
+				'zoltar.simulation.savedStates',
+				JSON.stringify([
+					{
+						baseScenario: 'baseline',
+						id: 'saved-baseline-20260602123456',
+						name: 'Saved baseline',
+						savedAt: '2026-06-02T12:34:56.000Z',
+						serialized: createSerializedSavedState({
+							name: 'Saved baseline',
+							savedAt: '2026-06-02T12:34:56.000Z',
+						}),
+					},
+					{
+						baseScenario: 'baseline',
+						id: 'broken-state',
+						name: 'Broken state',
+						savedAt: '2026-06-02T12:35:56.000Z',
+						serialized: '{bad json',
+					},
+				]),
+			)
+
+			expect(listSavedSimulationStateRecords().map(record => record.id)).toEqual(['saved-baseline-20260602123456'])
+		} finally {
+			domEnvironment.cleanup()
+		}
+	})
+})

--- a/ui/ts/tests/savedSimulationStates.test.ts
+++ b/ui/ts/tests/savedSimulationStates.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from 'bun:test'
-import { deleteSavedSimulationState, getSavedSimulationStateEnvelope, listSavedSimulationStateRecords, parseSavedSimulationStateEnvelope, persistSavedSimulationState, serializeSavedSimulationStateEnvelope } from '../simulation/savedStates.js'
+import { deleteSavedSimulationState, getSavedSimulationStateEnvelope, getSavedSimulationStateStorageWarning, listSavedSimulationStateRecords, parseSavedSimulationStateEnvelope, persistSavedSimulationState, serializeSavedSimulationStateEnvelope } from '../simulation/savedStates.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 
 function createSerializedSavedState({ name, savedAt }: { name: string; savedAt: string }) {
@@ -38,6 +38,17 @@ describe('saved simulation states', () => {
 		expect(parsed.version).toBe(1)
 		expect(parsed.name).toBe('Saved baseline')
 		expect(parsed.state.blockCountSinceReset).toBe(1n)
+	})
+
+	test('round-trips names that look like bigint strings', () => {
+		const serialized = createSerializedSavedState({
+			name: '123n',
+			savedAt: '2026-06-02T12:34:56.000Z',
+		})
+
+		const parsed = parseSavedSimulationStateEnvelope(serialized)
+
+		expect(parsed.name).toBe('123n')
 	})
 
 	test('rejects malformed saved state json', () => {
@@ -113,6 +124,44 @@ describe('saved simulation states', () => {
 		}
 	})
 
+	test('sorts imported saves by local persistence time instead of export time', () => {
+		const domEnvironment = installDomEnvironment()
+
+		try {
+			window.localStorage.setItem(
+				'zoltar.simulation.savedStates',
+				JSON.stringify([
+					{
+						baseScenario: 'baseline',
+						id: 'older-export-20260601123456',
+						name: 'Older export',
+						persistedAt: '2026-06-03T00:10:00.000Z',
+						savedAt: '2026-06-01T12:34:56.000Z',
+						serialized: createSerializedSavedState({
+							name: 'Older export',
+							savedAt: '2026-06-01T12:34:56.000Z',
+						}),
+					},
+					{
+						baseScenario: 'baseline',
+						id: 'newer-export-20260602123456',
+						name: 'Newer export',
+						persistedAt: '2026-06-03T00:00:00.000Z',
+						savedAt: '2026-06-02T12:34:56.000Z',
+						serialized: createSerializedSavedState({
+							name: 'Newer export',
+							savedAt: '2026-06-02T12:34:56.000Z',
+						}),
+					},
+				]),
+			)
+
+			expect(listSavedSimulationStateRecords().map(record => record.id)).toEqual(['older-export-20260601123456', 'newer-export-20260602123456'])
+		} finally {
+			domEnvironment.cleanup()
+		}
+	})
+
 	test('ignores corrupted or invalid saved-state storage records', () => {
 		const domEnvironment = installDomEnvironment()
 
@@ -141,6 +190,7 @@ describe('saved simulation states', () => {
 			)
 
 			expect(listSavedSimulationStateRecords().map(record => record.id)).toEqual(['saved-baseline-20260602123456'])
+			expect(getSavedSimulationStateStorageWarning()).toBe('Ignored 1 corrupted saved simulation state in browser storage.')
 		} finally {
 			domEnvironment.cleanup()
 		}

--- a/ui/ts/tests/simulationBanner.test.tsx
+++ b/ui/ts/tests/simulationBanner.test.tsx
@@ -297,7 +297,7 @@ describe('SimulationBanner', () => {
 	})
 
 	test('lets the user remove corrupted saved states from browser storage', async () => {
-		const domEnvironment = installDomEnvironment()
+		const domEnvironment = installDomEnvironment('http://localhost/#/zoltar?simulate=1&simState=broken-state')
 		window.localStorage.setItem(
 			'zoltar.simulation.savedStates',
 			JSON.stringify([
@@ -346,6 +346,8 @@ describe('SimulationBanner', () => {
 			await waitFor(() => {
 				expect(documentQueries.queryByText('Ignored 1 corrupted saved simulation state in browser storage.')).toBeNull()
 				expect(window.localStorage.getItem('zoltar.simulation.savedStates')).not.toContain('{bad json')
+				expect(window.location.hash).toContain('simScenario=baseline')
+				expect(window.location.hash).not.toContain('simState=')
 			})
 		} finally {
 			await renderedComponent.cleanup()

--- a/ui/ts/tests/simulationBanner.test.tsx
+++ b/ui/ts/tests/simulationBanner.test.tsx
@@ -246,12 +246,60 @@ describe('SimulationBanner', () => {
 		}
 	})
 
+	test('shows a warning when corrupted saved states are ignored', async () => {
+		const domEnvironment = installDomEnvironment()
+		window.localStorage.setItem(
+			'zoltar.simulation.savedStates',
+			JSON.stringify([
+				{
+					baseScenario: 'baseline',
+					id: 'saved-baseline-20260602123456',
+					name: 'Saved baseline',
+					savedAt: '2026-06-02T12:34:56.000Z',
+					serialized: serializeSavedSimulationStateEnvelope({
+						baseScenario: 'baseline',
+						name: 'Saved baseline',
+						savedAt: '2026-06-02T12:34:56.000Z',
+						state: {
+							blockCountSinceReset: 0n,
+							currentTimestamp: 1n,
+							queryDelayMilliseconds: 0,
+							repPerEthPrice: 10n ** 18n,
+							repPerUsdcPrice: 10n ** 6n,
+							selectedAccount: '0x00000000000000000000000000000000000000a1',
+							snapshot: {},
+							transactionCountSinceReset: 0n,
+							transactionDelayMilliseconds: 0,
+						},
+						version: 1,
+					}),
+				},
+				{
+					baseScenario: 'baseline',
+					id: 'broken-state',
+					name: 'Broken state',
+					savedAt: '2026-06-02T12:35:56.000Z',
+					serialized: '{bad json',
+				},
+			]),
+		)
+		const onRefresh = mock(async () => undefined)
+		const controller = createSimulationController()
+		const renderedComponent = await renderIntoDocument(<SimulationBanner controller={controller} onRefresh={onRefresh} />)
+
+		try {
+			const documentQueries = within(renderedComponent.container)
+			expect(documentQueries.getByText('Ignored 1 corrupted saved simulation state in browser storage.')).toBeTruthy()
+		} finally {
+			await renderedComponent.cleanup()
+			domEnvironment.cleanup()
+		}
+	})
+
 	test('imports a saved state and navigates to its saved-state URL', async () => {
 		const domEnvironment = installDomEnvironment()
 		const onRefresh = mock(async () => undefined)
 		const controller = createSimulationController()
-		const locationAssign = mock(() => undefined)
-		window.location.assign = locationAssign as typeof window.location.assign
 		const renderedComponent = await renderIntoDocument(<SimulationBanner controller={controller} onRefresh={onRefresh} />)
 		const importedState = serializeSavedSimulationStateEnvelope({
 			baseScenario: 'baseline',
@@ -284,8 +332,34 @@ describe('SimulationBanner', () => {
 			fireEvent.click(dialogQueries.getByRole('button', { name: 'Import and load' }))
 
 			await waitFor(() => {
-				expect(locationAssign).toHaveBeenCalledTimes(1)
-				expect(locationAssign).toHaveBeenCalledWith(expect.stringContaining('simState=imported-state-20260602123456'))
+				expect(window.location.hash).toContain('simState=imported-state-20260602123456')
+			})
+		} finally {
+			await renderedComponent.cleanup()
+			domEnvironment.cleanup()
+		}
+	})
+
+	test('switches scenarios through route-state navigation without a full-page reload', async () => {
+		const domEnvironment = installDomEnvironment('http://localhost/#/zoltar?simulate=1&simScenario=baseline')
+		const onRefresh = mock(async () => undefined)
+		const controller = createSimulationController()
+		const pushState = mock(window.history.pushState.bind(window.history))
+		window.history.pushState = pushState as typeof window.history.pushState
+		const renderedComponent = await renderIntoDocument(<SimulationBanner controller={controller} onRefresh={onRefresh} />)
+
+		try {
+			const documentQueries = within(renderedComponent.container)
+			const picker = documentQueries.getAllByRole('combobox')[0]
+			if (picker === undefined || picker.tagName !== 'SELECT') throw new Error('Expected the scenario picker')
+			fireEvent.change(picker, {
+				currentTarget: { value: 'scenario:deployed' },
+				target: { value: 'scenario:deployed' },
+			})
+
+			await waitFor(() => {
+				expect(pushState).toHaveBeenCalledTimes(1)
+				expect(window.location.hash).toContain('simScenario=deployed')
 			})
 		} finally {
 			await renderedComponent.cleanup()

--- a/ui/ts/tests/simulationBanner.test.tsx
+++ b/ui/ts/tests/simulationBanner.test.tsx
@@ -296,6 +296,63 @@ describe('SimulationBanner', () => {
 		}
 	})
 
+	test('lets the user remove corrupted saved states from browser storage', async () => {
+		const domEnvironment = installDomEnvironment()
+		window.localStorage.setItem(
+			'zoltar.simulation.savedStates',
+			JSON.stringify([
+				{
+					baseScenario: 'baseline',
+					id: 'saved-baseline-20260602123456',
+					name: 'Saved baseline',
+					savedAt: '2026-06-02T12:34:56.000Z',
+					serialized: serializeSavedSimulationStateEnvelope({
+						baseScenario: 'baseline',
+						name: 'Saved baseline',
+						savedAt: '2026-06-02T12:34:56.000Z',
+						state: {
+							blockCountSinceReset: 0n,
+							currentTimestamp: 1n,
+							queryDelayMilliseconds: 0,
+							repPerEthPrice: 10n ** 18n,
+							repPerUsdcPrice: 10n ** 6n,
+							selectedAccount: '0x00000000000000000000000000000000000000a1',
+							snapshot: {},
+							transactionCountSinceReset: 0n,
+							transactionDelayMilliseconds: 0,
+						},
+						version: 1,
+					}),
+				},
+				{
+					baseScenario: 'baseline',
+					id: 'broken-state',
+					name: 'Broken state',
+					savedAt: '2026-06-02T12:35:56.000Z',
+					serialized: '{bad json',
+				},
+			]),
+		)
+		const onRefresh = mock(async () => undefined)
+		const controller = createSimulationController()
+		const renderedComponent = await renderIntoDocument(<SimulationBanner controller={controller} onRefresh={onRefresh} />)
+
+		try {
+			const documentQueries = within(renderedComponent.container)
+			fireEvent.click(documentQueries.getByRole('button', { name: 'Remove corrupted saves' }))
+			const cleanupDialog = await waitFor(() => documentQueries.getByRole('dialog'))
+			fireEvent.click(within(cleanupDialog).getByRole('button', { name: 'Remove corrupted saves' }))
+
+			await waitFor(() => {
+				expect(documentQueries.queryByText('Ignored 1 corrupted saved simulation state in browser storage.')).toBeNull()
+				expect(window.localStorage.getItem('zoltar.simulation.savedStates')).not.toContain('{bad json')
+			})
+		} finally {
+			await renderedComponent.cleanup()
+			domEnvironment.cleanup()
+		}
+	})
+
 	test('imports a saved state and navigates to its saved-state URL', async () => {
 		const domEnvironment = installDomEnvironment()
 		const onRefresh = mock(async () => undefined)

--- a/ui/ts/tests/simulationBanner.test.tsx
+++ b/ui/ts/tests/simulationBanner.test.tsx
@@ -5,6 +5,7 @@ import { describe, expect, mock, test } from 'bun:test'
 import type { Address } from 'viem'
 import { SimulationBanner } from '../components/SimulationBanner.js'
 import type { SimulationController } from '../simulation/controller.js'
+import { serializeSavedSimulationStateEnvelope } from '../simulation/savedStates.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
 
@@ -23,6 +24,24 @@ function createSimulationController(overrides: Partial<SimulationController> = {
 		currentTimestamp: 1n,
 		currentScenario: 'baseline',
 		dispose: async () => undefined,
+		exportState: async name =>
+			serializeSavedSimulationStateEnvelope({
+				baseScenario: 'baseline',
+				name,
+				savedAt: '2026-06-02T12:34:56.000Z',
+				state: {
+					blockCountSinceReset: 0n,
+					currentTimestamp: 1n,
+					queryDelayMilliseconds: 0,
+					repPerEthPrice: 10n ** 18n,
+					repPerUsdcPrice: 10n ** 6n,
+					selectedAccount,
+					snapshot: {},
+					transactionCountSinceReset: 0n,
+					transactionDelayMilliseconds: 0,
+				},
+				version: 1,
+			}),
 		isActive: true,
 		isBootstrapped: true,
 		isBootstrapping: false,
@@ -34,6 +53,10 @@ function createSimulationController(overrides: Partial<SimulationController> = {
 		reset: async () => undefined,
 		selectAccount: async () => undefined,
 		selectedAccount,
+		simulationSource: {
+			kind: 'scenario',
+			scenario: 'baseline',
+		},
 		setQueryDelayMilliseconds: () => undefined,
 		setRepPerEthPrice: () => undefined,
 		setRepPerUsdcPrice: () => undefined,
@@ -169,6 +192,156 @@ describe('SimulationBanner', () => {
 			}
 		} finally {
 			await renderedComponent.cleanup()
+			domEnvironment.cleanup()
+		}
+	})
+
+	test('renders saved states in the scenario picker and opens the export modal', async () => {
+		const domEnvironment = installDomEnvironment()
+		window.localStorage.setItem(
+			'zoltar.simulation.savedStates',
+			JSON.stringify([
+				{
+					baseScenario: 'baseline',
+					id: 'saved-baseline-20260602123456',
+					name: 'Saved baseline',
+					savedAt: '2026-06-02T12:34:56.000Z',
+					serialized: serializeSavedSimulationStateEnvelope({
+						baseScenario: 'baseline',
+						name: 'Saved baseline',
+						savedAt: '2026-06-02T12:34:56.000Z',
+						state: {
+							blockCountSinceReset: 0n,
+							currentTimestamp: 1n,
+							queryDelayMilliseconds: 0,
+							repPerEthPrice: 10n ** 18n,
+							repPerUsdcPrice: 10n ** 6n,
+							selectedAccount: '0x00000000000000000000000000000000000000a1',
+							snapshot: {},
+							transactionCountSinceReset: 0n,
+							transactionDelayMilliseconds: 0,
+						},
+						version: 1,
+					}),
+				},
+			]),
+		)
+		const onRefresh = mock(async () => undefined)
+		const controller = createSimulationController()
+		const renderedComponent = await renderIntoDocument(<SimulationBanner controller={controller} onRefresh={onRefresh} />)
+
+		try {
+			const documentQueries = within(renderedComponent.container)
+			expect(documentQueries.getByRole('option', { name: 'Saved baseline' })).toBeTruthy()
+
+			fireEvent.click(documentQueries.getByRole('button', { name: 'Export state' }))
+
+			await waitFor(() => {
+				const exportDialog = documentQueries.getByRole('dialog')
+				expect(within(exportDialog).getByLabelText('JSON state')).toBeTruthy()
+			})
+		} finally {
+			await renderedComponent.cleanup()
+			domEnvironment.cleanup()
+		}
+	})
+
+	test('imports a saved state and navigates to its saved-state URL', async () => {
+		const domEnvironment = installDomEnvironment()
+		const onRefresh = mock(async () => undefined)
+		const controller = createSimulationController()
+		const locationAssign = mock(() => undefined)
+		window.location.assign = locationAssign as typeof window.location.assign
+		const renderedComponent = await renderIntoDocument(<SimulationBanner controller={controller} onRefresh={onRefresh} />)
+		const importedState = serializeSavedSimulationStateEnvelope({
+			baseScenario: 'baseline',
+			name: 'Imported state',
+			savedAt: '2026-06-02T12:34:56.000Z',
+			state: {
+				blockCountSinceReset: 0n,
+				currentTimestamp: 1n,
+				queryDelayMilliseconds: 0,
+				repPerEthPrice: 10n ** 18n,
+				repPerUsdcPrice: 10n ** 6n,
+				selectedAccount: '0x00000000000000000000000000000000000000a1',
+				snapshot: {},
+				transactionCountSinceReset: 0n,
+				transactionDelayMilliseconds: 0,
+			},
+			version: 1,
+		})
+
+		try {
+			const documentQueries = within(renderedComponent.container)
+			fireEvent.click(documentQueries.getByRole('button', { name: 'Import state' }))
+			const importDialog = await waitFor(() => documentQueries.getByRole('dialog'))
+			const dialogQueries = within(importDialog)
+			const textArea = dialogQueries.getByLabelText('JSON state') as HTMLTextAreaElement
+			fireEvent.input(textArea, {
+				currentTarget: { value: importedState },
+				target: { value: importedState },
+			})
+			fireEvent.click(dialogQueries.getByRole('button', { name: 'Import and load' }))
+
+			await waitFor(() => {
+				expect(locationAssign).toHaveBeenCalledTimes(1)
+				expect(locationAssign).toHaveBeenCalledWith(expect.stringContaining('simState=imported-state-20260602123456'))
+			})
+		} finally {
+			await renderedComponent.cleanup()
+			domEnvironment.cleanup()
+		}
+	})
+
+	test('shows inline import errors for malformed JSON', async () => {
+		const domEnvironment = installDomEnvironment()
+		const onRefresh = mock(async () => undefined)
+		const controller = createSimulationController()
+		const renderedComponent = await renderIntoDocument(<SimulationBanner controller={controller} onRefresh={onRefresh} />)
+
+		try {
+			const documentQueries = within(renderedComponent.container)
+			fireEvent.click(documentQueries.getByRole('button', { name: 'Import state' }))
+			const importDialog = await waitFor(() => documentQueries.getByRole('dialog'))
+			const dialogQueries = within(importDialog)
+			const textArea = dialogQueries.getByLabelText('JSON state') as HTMLTextAreaElement
+			fireEvent.input(textArea, {
+				currentTarget: { value: '{bad json' },
+				target: { value: '{bad json' },
+			})
+			fireEvent.click(dialogQueries.getByRole('button', { name: 'Import and load' }))
+
+			await waitFor(() => {
+				expect(dialogQueries.getByText(/Failed to update the saved simulation state/i)).toBeTruthy()
+			})
+		} finally {
+			await renderedComponent.cleanup()
+			domEnvironment.cleanup()
+		}
+	})
+
+	test('shows the delete control only for custom saved states', async () => {
+		const domEnvironment = installDomEnvironment()
+		const onRefresh = mock(async () => undefined)
+		const builtInController = createSimulationController()
+		const customController = createSimulationController({
+			simulationSource: {
+				baseScenario: 'baseline',
+				kind: 'saved-state',
+				name: 'Saved baseline',
+				savedAt: '2026-06-02T12:34:56.000Z',
+				stateId: 'saved-baseline-20260602123456',
+			},
+		})
+		const builtInRendered = await renderIntoDocument(<SimulationBanner controller={builtInController} onRefresh={onRefresh} />)
+		const customRendered = await renderIntoDocument(<SimulationBanner controller={customController} onRefresh={onRefresh} />)
+
+		try {
+			expect(within(builtInRendered.container).queryByRole('button', { name: 'Delete save' })).toBeNull()
+			expect(within(customRendered.container).getByRole('button', { name: 'Delete save' })).toBeTruthy()
+		} finally {
+			await builtInRendered.cleanup()
+			await customRendered.cleanup()
 			domEnvironment.cleanup()
 		}
 	})

--- a/ui/ts/tests/uniswapQuoter.test.ts
+++ b/ui/ts/tests/uniswapQuoter.test.ts
@@ -22,6 +22,7 @@ import {
 	quoteTokenForEth,
 } from '../lib/uniswapQuoter.js'
 import { installActiveEnvironmentForTesting, resetActiveEnvironmentForTesting } from '../lib/activeEnvironment.js'
+import { serializeSavedSimulationStateEnvelope } from '../simulation/savedStates.js'
 import { createConnectedReadClient, type ReadClient } from '../lib/clients.js'
 import { MAINNET_NETWORK_PROFILE } from '../lib/networkProfile.js'
 import { createFakeBackend, createFakeSimulationProfile } from './testUtils/fakeBackend.js'
@@ -151,6 +152,24 @@ void describe('quoteExactInput', () => {
 				currentTimestamp: 0n,
 				currentScenario: 'baseline',
 				dispose: async () => undefined,
+				exportState: async name =>
+					serializeSavedSimulationStateEnvelope({
+						baseScenario: 'baseline',
+						name,
+						savedAt: '2026-06-02T12:34:56.000Z',
+						state: {
+							blockCountSinceReset: 0n,
+							currentTimestamp: 0n,
+							queryDelayMilliseconds: 0,
+							repPerEthPrice: 2n * 10n ** 18n,
+							repPerUsdcPrice: 5n * 10n ** 6n,
+							selectedAccount: '0x00000000000000000000000000000000000000a1',
+							snapshot: {},
+							transactionCountSinceReset: 0n,
+							transactionDelayMilliseconds: 0,
+						},
+						version: 1,
+					}),
 				isActive: true,
 				isBootstrapped: true,
 				isBootstrapping: false,
@@ -162,6 +181,10 @@ void describe('quoteExactInput', () => {
 				reset: async () => undefined,
 				selectAccount: async () => undefined,
 				selectedAccount: getAddress('0x00000000000000000000000000000000000000a1'),
+				simulationSource: {
+					kind: 'scenario',
+					scenario: 'baseline',
+				},
 				setRepPerEthPrice: () => undefined,
 				setRepPerUsdcPrice: () => undefined,
 				setQueryDelayMilliseconds: () => undefined,

--- a/ui/ts/tests/useRepPrices.test.tsx
+++ b/ui/ts/tests/useRepPrices.test.tsx
@@ -9,6 +9,7 @@ import { useRepPrices } from '../hooks/useRepPrices.js'
 import { installActiveEnvironmentForTesting, resetActiveEnvironmentForTesting } from '../lib/activeEnvironment.js'
 import type { ChainBackend, ReadClient } from '../lib/chainBackend.js'
 import { createFakeBackend, createFakeSimulationProfile } from './testUtils/fakeBackend.js'
+import { serializeSavedSimulationStateEnvelope } from '../simulation/savedStates.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
 
@@ -25,6 +26,24 @@ function createSimulationController(): SimulationController {
 		currentTimestamp: 0n,
 		currentScenario: 'baseline',
 		dispose: async () => undefined,
+		exportState: async name =>
+			serializeSavedSimulationStateEnvelope({
+				baseScenario: 'baseline',
+				name,
+				savedAt: '2026-06-02T12:34:56.000Z',
+				state: {
+					blockCountSinceReset: 0n,
+					currentTimestamp: 0n,
+					queryDelayMilliseconds: 0,
+					repPerEthPrice: 10n ** 18n,
+					repPerUsdcPrice: 10n ** 6n,
+					selectedAccount,
+					snapshot: {},
+					transactionCountSinceReset: 0n,
+					transactionDelayMilliseconds: 0,
+				},
+				version: 1,
+			}),
 		isActive: true,
 		isBootstrapped: true,
 		isBootstrapping: false,
@@ -36,6 +55,10 @@ function createSimulationController(): SimulationController {
 		reset: async () => undefined,
 		selectAccount: async () => undefined,
 		selectedAccount,
+		simulationSource: {
+			kind: 'scenario',
+			scenario: 'baseline',
+		},
 		setRepPerEthPrice: () => undefined,
 		setRepPerUsdcPrice: () => undefined,
 		setQueryDelayMilliseconds: () => undefined,


### PR DESCRIPTION
## Summary
- Added saved-simulation-state persistence in `ui/ts/simulation/savedStates.ts`, including schema validation, localStorage indexing, serialization/parsing with bigint support, and list/get/delete helpers.
- Extended initialization flow to support loading by `?simState=<id>` via `activeEnvironment` and simulation backend plumbing, including fallback behavior for missing/invalid saved states.
- Added simulation source tracking (`scenario` vs `saved-state`) through `SimulationController` and wired banner state display/details to reflect loaded state provenance.
- Implemented save, export, import, and delete flows in `SimulationBanner`, including modals and URL-based navigation to restore selected saved states.
- Updated TEVM backend/engine protocol to initialize from saved snapshots and expose `exportState` so users can generate portable JSON state.
- Added/expanded tests for saved state parsing/validation and environment/controller integration: `ui/ts/tests/savedSimulationStates.test.ts`, `activeEnvironment.test.ts`, `simulationBanner.test.tsx`, plus related updates to existing simulation/unit tests.

## Testing
- Not run: `bun run tsc`
- Not run: `bun run test`
- Not run: `bun run format`
- Not run: `bun run check`
- Not run: `bun run knip`
- Not run: `bun run coverage:ui`
- Not run: `bun run coverage:contracts:ts`
- Not run: `bun run coverage:contracts:bytecode`