### PR TITLE
Improve truth auction price selection and settlement flow

### DIFF
--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -4052,6 +4052,8 @@ button:focus-visible {
 	gap: var(--space-3);
 	align-items: center;
 	flex-wrap: wrap;
+	justify-content: space-between;
+	width: 100%;
 }
 
 .route-header-actions,

--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -2289,6 +2289,7 @@ strong.metric-value-danger {
 	display: grid;
 	gap: 0.75rem;
 	align-content: start;
+	min-width: 0;
 }
 
 .truth-auction-market-section {
@@ -2297,6 +2298,7 @@ strong.metric-value-danger {
 }
 
 .truth-auction-market-stack > .truth-auction-market-section:first-child,
+.truth-auction-market-detail-grid > .truth-auction-market-section:first-child,
 .truth-auction-market-board > .truth-auction-market-section:first-child {
 	padding-top: 0;
 	border-top: 0;
@@ -2349,16 +2351,23 @@ strong.metric-value-danger {
 }
 
 .truth-auction-market-board {
-	grid-template-columns: minmax(0, 1fr) minmax(18rem, 0.9fr);
+	grid-template-columns: minmax(0, 1fr);
 	gap: 1rem 1.25rem;
 }
 
+.truth-auction-market-detail-grid,
 .truth-auction-market-stack,
 .truth-auction-ladder,
 .truth-auction-manual-tools,
 .truth-auction-stage-actions,
 .truth-auction-settlement-grid {
 	gap: 0.75rem;
+}
+
+.truth-auction-market-detail-grid {
+	display: grid;
+	grid-template-columns: minmax(0, 1.45fr) minmax(20rem, 0.85fr);
+	align-items: start;
 }
 
 .truth-auction-stage-actions,
@@ -2385,7 +2394,6 @@ strong.metric-value-danger {
 .truth-auction-level-header,
 .truth-auction-depth-legend-range,
 .truth-auction-price-row-main,
-.truth-auction-price-row-meta,
 .truth-auction-bid-row,
 .truth-auction-depth-header {
 	display: flex;
@@ -2548,6 +2556,13 @@ strong.metric-value-danger {
 	padding: 0.95rem 1rem;
 }
 
+.truth-auction-price-value {
+	display: inline-block;
+	max-width: 100%;
+	overflow-wrap: anywhere;
+	font-variant-numeric: tabular-nums;
+}
+
 .truth-auction-price-row-main strong {
 	font-size: var(--font-base);
 }
@@ -2563,6 +2578,17 @@ strong.metric-value-danger {
 .truth-auction-bid-row {
 	color: var(--muted);
 	font-size: var(--font-small);
+}
+
+.truth-auction-price-row-meta {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 0.45rem 0.75rem;
+}
+
+.truth-auction-level-detail {
+	position: sticky;
+	top: 1rem;
 }
 
 .truth-auction-status-pill {
@@ -3782,9 +3808,15 @@ button:focus-visible {
 
 	.truth-auction-hero,
 	.truth-auction-market-board,
+	.truth-auction-market-detail-grid,
 	.truth-auction-stage-actions,
 	.truth-auction-settlement-grid {
 		grid-template-columns: 1fr;
+	}
+
+	.truth-auction-level-detail {
+		position: static;
+		top: auto;
 	}
 
 	.truth-auction-depth-chart {

--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -1535,11 +1535,17 @@ button.currency-value.copyable:hover:not(:disabled) {
 	border-top: 1px solid var(--divider-subtle);
 }
 
+.workflow-metric-grid .metric-label,
+.workflow-question-grid .metric-label,
+.workflow-vault-grid .metric-label {
+	display: block;
+	margin-bottom: 0.2rem;
+}
+
 .workflow-metric-grid .metric-field-value,
 .workflow-question-grid .metric-field-value,
 .workflow-vault-grid .metric-field-value {
 	display: block;
-	margin-top: 0.15rem;
 	overflow-wrap: anywhere;
 }
 
@@ -1547,7 +1553,6 @@ button.currency-value.copyable:hover:not(:disabled) {
 .workflow-question-grid strong.metric-field-value,
 .workflow-vault-grid strong.metric-field-value {
 	display: block;
-	margin-top: 0.15rem;
 	font-family: "IBM Plex Mono", "Courier New", monospace;
 	font-size: var(--font-value);
 	font-weight: 600;
@@ -2364,7 +2369,7 @@ strong.metric-value-danger {
 
 .truth-auction-market-detail-grid {
 	display: grid;
-	grid-template-columns: minmax(0, 1.45fr) minmax(20rem, 0.85fr);
+	grid-template-columns: minmax(0, 1fr);
 	align-items: start;
 }
 
@@ -2386,6 +2391,13 @@ strong.metric-value-danger {
 .truth-auction-selected-bid-summary > div {
 	padding-top: 0.65rem;
 	border-top: 1px solid var(--divider-subtle);
+}
+
+.truth-auction-wallet-summary .metric-label,
+.truth-auction-bid-coverage-summary .metric-label,
+.truth-auction-selected-bid-summary .metric-label {
+	display: block;
+	margin-bottom: 0.2rem;
 }
 
 .truth-auction-panel-header,
@@ -2510,12 +2522,12 @@ strong.metric-value-danger {
 }
 
 .truth-auction-depth-y-axis {
-	display: grid;
-	grid-template-rows: auto 1fr auto 1fr auto;
-	align-items: center;
-	justify-items: end;
+	position: relative;
+	display: flex;
+	align-items: stretch;
 	gap: 0.3rem;
 	min-width: 0;
+	min-height: 13rem;
 }
 
 .truth-auction-depth-x-axis {
@@ -2560,15 +2572,25 @@ strong.metric-value-danger {
 	overflow-wrap: anywhere;
 }
 
-.truth-auction-depth-y-axis .truth-auction-depth-axis-tick {
-	text-align: right;
+.truth-auction-depth-y-ticks {
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
 }
 
-.truth-auction-depth-x-axis .truth-auction-depth-axis-tick.is-mid {
+.truth-auction-depth-y-tick {
+	position: absolute;
+	right: 0;
+	left: 0;
+	text-align: right;
+	transform: translateY(-50%);
+}
+
+.truth-auction-depth-x-tick.is-mid {
 	text-align: center;
 }
 
-.truth-auction-depth-x-axis .truth-auction-depth-axis-tick.is-min {
+.truth-auction-depth-x-tick.is-min {
 	text-align: right;
 }
 
@@ -4022,13 +4044,19 @@ button:focus-visible {
 	box-shadow: 0 14px 28px rgba(0, 0, 0, 0.08);
 }
 
-.route-header-main,
-.section-block-header {
+.route-header-main {
 	display: flex;
 	gap: var(--space-4);
 	align-items: flex-start;
 	justify-content: space-between;
 	flex-wrap: wrap;
+}
+
+.section-block-header {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto auto;
+	gap: var(--space-4);
+	align-items: start;
 }
 
 .route-header-copy,
@@ -4057,10 +4085,17 @@ button:focus-visible {
 }
 
 .route-header-actions,
+.section-block-badge,
 .section-block-actions {
 	display: flex;
 	gap: var(--space-3);
 	align-items: flex-start;
+}
+
+.section-block-badge {
+	margin-left: auto;
+	justify-self: end;
+	align-self: start;
 }
 
 .compact-actions {
@@ -4721,6 +4756,7 @@ button:focus-visible {
 
 	.route-header-main,
 	.section-block-header {
+		display: flex;
 		flex-direction: column;
 	}
 

--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -2277,8 +2277,6 @@ strong.metric-value-danger {
 .truth-auction-panel-header,
 .truth-auction-level-header,
 .truth-auction-price-row-copy,
-.truth-auction-depth-legend,
-.truth-auction-depth-legend-copy,
 .truth-auction-bid-row-actions {
 	display: grid;
 	gap: 0.75rem;
@@ -2392,7 +2390,6 @@ strong.metric-value-danger {
 
 .truth-auction-panel-header,
 .truth-auction-level-header,
-.truth-auction-depth-legend-range,
 .truth-auction-price-row-main,
 .truth-auction-bid-row,
 .truth-auction-depth-header {
@@ -2505,19 +2502,74 @@ strong.metric-value-danger {
 	box-shadow: 0 0 0 2px rgba(232, 166, 68, 0.16);
 }
 
-.truth-auction-depth-legend {
-	grid-template-columns: minmax(0, 1fr);
+.truth-auction-depth-frame {
+	display: grid;
+	grid-template-columns: minmax(4.4rem, auto) minmax(0, 1fr);
+	gap: 0.65rem;
+	align-items: stretch;
 }
 
-.truth-auction-depth-legend-copy strong {
-	font-size: var(--font-small);
+.truth-auction-depth-y-axis {
+	display: grid;
+	grid-template-rows: auto 1fr auto 1fr auto;
+	align-items: center;
+	justify-items: end;
+	gap: 0.3rem;
+	min-width: 0;
+}
+
+.truth-auction-depth-x-axis {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 0.75rem;
+	margin-top: 0.6rem;
+}
+
+.truth-auction-depth-x-axis.no-midpoint {
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.truth-auction-depth-axis-title {
+	font-size: 0.72rem;
 	font-weight: 600;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
 }
 
-.truth-auction-depth-legend-copy span,
-.truth-auction-depth-legend-range {
+.truth-auction-depth-axis-title-y {
+	color: var(--muted);
+	writing-mode: vertical-rl;
+	transform: rotate(180deg);
+	justify-self: center;
+	align-self: stretch;
+	text-align: center;
+}
+
+.truth-auction-depth-axis-title-x {
+	margin-top: 0.3rem;
+	color: var(--muted);
+	text-align: center;
+}
+
+.truth-auction-depth-axis-tick {
+	min-width: 0;
 	color: var(--muted);
 	font-size: var(--font-small);
+	line-height: 1.35;
+	font-variant-numeric: tabular-nums;
+	overflow-wrap: anywhere;
+}
+
+.truth-auction-depth-y-axis .truth-auction-depth-axis-tick {
+	text-align: right;
+}
+
+.truth-auction-depth-x-axis .truth-auction-depth-axis-tick.is-mid {
+	text-align: center;
+}
+
+.truth-auction-depth-x-axis .truth-auction-depth-axis-tick.is-min {
+	text-align: right;
 }
 
 .truth-auction-price-row {
@@ -2680,7 +2732,7 @@ strong.metric-value-danger {
 
 .truth-auction-bid-table {
 	display: grid;
-	gap: 0.45rem;
+	gap: 0.6rem;
 }
 
 .truth-auction-bid-row {
@@ -2699,23 +2751,6 @@ strong.metric-value-danger {
 
 .truth-auction-bid-row.is-wide {
 	grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.2fr) minmax(0, 0.8fr) minmax(0, 0.9fr) auto minmax(0, 1.35fr);
-}
-
-.truth-auction-bid-row.is-header {
-	padding-top: 0;
-	padding-bottom: 0.35rem;
-	border: 0;
-	border-radius: 0;
-	background: transparent;
-	color: var(--muted);
-	font-size: 0.72rem;
-	font-weight: 600;
-	letter-spacing: 0.04em;
-	text-transform: uppercase;
-}
-
-.truth-auction-bid-row.is-header span {
-	overflow-wrap: anywhere;
 }
 
 .truth-auction-bid-row-label {
@@ -3830,9 +3865,46 @@ button:focus-visible {
 	.truth-auction-level-header,
 	.truth-auction-price-row-main,
 	.truth-auction-price-row-meta,
-	.truth-auction-depth-header,
-	.truth-auction-depth-legend-range {
+	.truth-auction-depth-header {
 		align-items: flex-start;
+	}
+
+	.truth-auction-depth-frame {
+		grid-template-columns: 1fr;
+	}
+
+	.truth-auction-depth-y-axis {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		grid-template-rows: auto auto;
+		justify-items: stretch;
+	}
+
+	.truth-auction-depth-axis-title-y {
+		grid-column: 1 / -1;
+		writing-mode: initial;
+		transform: none;
+		justify-self: start;
+		text-align: left;
+	}
+
+	.truth-auction-depth-y-axis .truth-auction-depth-axis-tick {
+		text-align: left;
+	}
+
+	.truth-auction-depth-x-axis {
+		gap: 0.45rem;
+	}
+
+	.truth-auction-depth-x-axis .truth-auction-depth-axis-tick.is-mid {
+		display: none;
+	}
+
+	.truth-auction-depth-x-axis.no-midpoint {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.truth-auction-depth-x-axis:not(.no-midpoint) {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
 	}
 
 	.truth-auction-price-row-badges {

--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -2367,14 +2367,16 @@ strong.metric-value-danger {
 }
 
 .truth-auction-wallet-summary,
-.truth-auction-bid-coverage-summary {
+.truth-auction-bid-coverage-summary,
+.truth-auction-selected-bid-summary {
 	display: grid;
 	grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
 	gap: 0.9rem 1rem;
 }
 
 .truth-auction-wallet-summary > div,
-.truth-auction-bid-coverage-summary > div {
+.truth-auction-bid-coverage-summary > div,
+.truth-auction-selected-bid-summary > div {
 	padding-top: 0.65rem;
 	border-top: 1px solid var(--divider-subtle);
 }
@@ -2670,7 +2672,7 @@ strong.metric-value-danger {
 }
 
 .truth-auction-bid-row.is-wide {
-	grid-template-columns: minmax(0, 0.72fr) minmax(0, 0.9fr) minmax(0, 0.7fr) minmax(0, 1.2fr) minmax(0, 0.8fr) minmax(0, 0.9fr) auto minmax(0, 1.35fr);
+	grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.2fr) minmax(0, 0.8fr) minmax(0, 0.9fr) auto minmax(0, 1.35fr);
 }
 
 .truth-auction-bid-row.is-header {
@@ -2693,8 +2695,15 @@ strong.metric-value-danger {
 .truth-auction-bid-row-label {
 	display: grid;
 	gap: 0.15rem;
+	min-width: 0;
 	color: var(--text);
 	font-weight: 600;
+}
+
+.truth-auction-bid-row > *,
+.truth-auction-bid-row.is-wallet > *,
+.truth-auction-bid-row.is-wide > * {
+	min-width: 0;
 }
 
 .truth-auction-bid-row-address {
@@ -2707,11 +2716,18 @@ strong.metric-value-danger {
 }
 
 .truth-auction-bid-row-actions {
-	grid-auto-flow: column;
-	grid-auto-columns: max-content;
+	display: flex;
+	flex-wrap: wrap;
 	align-items: center;
 	justify-content: flex-start;
 	gap: 0.45rem;
+	min-width: 0;
+}
+
+.truth-auction-bid-row-actions > button {
+	flex: 0 1 auto;
+	max-width: 100%;
+	min-width: 0;
 }
 
 .truth-auction-row-empty {
@@ -3802,8 +3818,11 @@ button:focus-visible {
 	}
 
 	.truth-auction-bid-row-actions {
-		grid-auto-flow: row;
-		grid-auto-columns: unset;
+		align-items: stretch;
+	}
+
+	.truth-auction-bid-row-actions > button {
+		width: 100%;
 	}
 
 	.lookup-field-controls.has-action {

--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -84,6 +84,12 @@ type TruthAuctionViewerBidSummary = {
 	winningCount: number
 }
 
+type TruthAuctionSelectedBidSummary = {
+	bid: TruthAuctionBidView
+	disposition: TruthAuctionBidDisposition
+	price: bigint
+}
+
 type ForkOutcomeMigrationSeedStatus = Awaited<ReturnType<typeof loadForkOutcomeMigrationSeedStatus>>
 
 function getTruthAuctionWindow(startedAt: bigint | undefined) {
@@ -578,6 +584,10 @@ function sortTruthAuctionBidsByPriority(bids: TruthAuctionBidView[]) {
 	})
 }
 
+function dedupeTruthAuctionBids(bids: TruthAuctionBidView[]) {
+	return sortTruthAuctionBidsByPriority(Array.from(new Map(bids.map(bid => [`${bid.tick.toString()}:${bid.bidIndex.toString()}`, bid])).values()))
+}
+
 async function loadAggregatedTruthAuctionBidPages(client: Pick<ReadClient, 'readContract'>, truthAuctionAddress: Address, tickSummaries: TruthAuctionTickSummary[], pageCount: number) {
 	const uniqueTickSummaries = sortTruthAuctionTickSummariesDescending(Array.from(new Map(tickSummaries.map(tickSummary => [tickSummary.tick.toString(), tickSummary])).values()))
 	const bidPages = await Promise.all(uniqueTickSummaries.map(async tickSummary => ({ bidData: await loadTruthAuctionTickBidPages(client, truthAuctionAddress, tickSummary.tick, pageCount), tickSummary })))
@@ -833,6 +843,7 @@ export function ForkAuctionSection({
 	const previewTickSummary = enteredBidTick === undefined ? undefined : activeTickSummaries.find(tickSummary => tickSummary.tick === enteredBidTick)
 	const submitBidPreviewTickSummary = previewTickSummary ?? (enteredBidTick !== undefined && selectedLoadedTickSummary?.tick === enteredBidTick ? selectedLoadedTickSummary : undefined) ?? (enteredBidTick !== undefined && resolvedSelectedTickSummary?.tick === enteredBidTick ? resolvedSelectedTickSummary : undefined)
 	const maxTickEth = truthAuctionDepthPoints.reduce((maximumEth, point) => (point.currentTotalEth > maximumEth ? point.currentTotalEth : maximumEth), 0n)
+	const knownTruthAuctionBids = dedupeTruthAuctionBids([...truthAuctionBookData.viewerBids, ...selectedTickBids, ...aggregatedAuctionBids])
 	const hasMoreTickSummaries = BigInt(truthAuctionBookData.tickSummaries.length) < truthAuctionBookData.tickCount
 	const hasMoreViewerBids = BigInt(truthAuctionBookData.viewerBids.length) < truthAuctionBookData.viewerBidCount
 	const hasMoreSelectedTickBids = selectedTickSummary?.tick === selectedBookTick && BigInt(resolvedSelectedTickBids.length) < selectedTickBidCount
@@ -895,6 +906,30 @@ export function ForkAuctionSection({
 		return 'No'
 	})()
 	const viewerRefundMetricLabel = truthAuctionStatus?.finalized ? 'Refundable' : 'Below Clearing'
+	const selectedRefundBidSummary = (() => {
+		const refundTick = parseOptionalBigInt(forkAuctionForm.refundTick)
+		const refundBidIndex = parseOptionalBigInt(forkAuctionForm.refundBidIndex)
+		if (refundTick === undefined || refundBidIndex === undefined || truthAuctionStatus === undefined) return undefined
+		const bid = knownTruthAuctionBids.find(candidate => candidate.tick === refundTick && candidate.bidIndex === refundBidIndex)
+		if (bid === undefined) return undefined
+		return {
+			bid,
+			disposition: getBidDisposition(bid, truthAuctionStatus),
+			price: getTruthAuctionPriceAtTick(bid.tick),
+		} satisfies TruthAuctionSelectedBidSummary
+	})()
+	const selectedSettlementBidSummary = (() => {
+		const claimBidTick = parseOptionalBigInt(forkAuctionForm.claimBidTick)
+		const claimBidIndex = parseOptionalBigInt(forkAuctionForm.claimBidIndex)
+		if (claimBidTick === undefined || claimBidIndex === undefined || truthAuctionStatus === undefined) return undefined
+		const bid = knownTruthAuctionBids.find(candidate => candidate.tick === claimBidTick && candidate.bidIndex === claimBidIndex)
+		if (bid === undefined) return undefined
+		return {
+			bid,
+			disposition: getBidDisposition(bid, truthAuctionStatus),
+			price: getTruthAuctionPriceAtTick(bid.tick),
+		} satisfies TruthAuctionSelectedBidSummary
+	})()
 	const interactionDisabledReason = (() => {
 		if (accountState.address === undefined) return 'Connect a wallet before using fork and auction actions.'
 		if (!isMainnet) return 'Switch to Ethereum mainnet before using fork and auction actions.'
@@ -958,6 +993,7 @@ export function ForkAuctionSection({
 		refundTickInput: forkAuctionForm.refundTick,
 		truthAuction: truthAuctionStatus,
 	})
+	const primaryRefundTruthAuctionBidGuardMessage = selectedRefundBidSummary === undefined ? 'Pick one of your bids to load a refund target.' : refundTruthAuctionBidGuardMessage
 	const settleFinalizedTruthAuctionBidGuardMessage = getSettleFinalizedTruthAuctionBidGuardMessage({
 		claimBidIndexInput: forkAuctionForm.claimBidIndex,
 		claimBidTickInput: forkAuctionForm.claimBidTick,
@@ -965,6 +1001,7 @@ export function ForkAuctionSection({
 		settlementAddressInput: forkAuctionForm.settlementAddress,
 		truthAuction: truthAuctionStatus,
 	})
+	const primarySettleFinalizedTruthAuctionBidGuardMessage = selectedSettlementBidSummary === undefined ? 'Pick one of your bids to load a settlement target.' : settleFinalizedTruthAuctionBidGuardMessage
 	const prefillSettleBid = (bid: TruthAuctionBidView) => {
 		onForkAuctionFormChange({
 			claimBidIndex: bid.bidIndex.toString(),
@@ -1090,6 +1127,19 @@ export function ForkAuctionSection({
 			/>
 		)
 	}
+	const renderSelectedBidSummary = ({ emptyCopy, selectedBidSummary }: { emptyCopy: string; selectedBidSummary: TruthAuctionSelectedBidSummary | undefined }) => {
+		if (selectedBidSummary === undefined) return <p className='detail'>{emptyCopy}</p>
+		return (
+			<div className='truth-auction-selected-bid-summary'>
+				<MetricField label='Price'>{<CurrencyValue value={selectedBidSummary.price} suffix='ETH / REP' />}</MetricField>
+				<MetricField label='Bidder'>{<AddressValue address={selectedBidSummary.bid.bidder} />}</MetricField>
+				<MetricField label='Amount'>{<CurrencyValue value={selectedBidSummary.bid.ethAmount} suffix='ETH' />}</MetricField>
+				<MetricField label='Status'>
+					<span className={`truth-auction-status-pill ${getTruthAuctionDispositionClassName(selectedBidSummary.disposition.tone)}`}>{selectedBidSummary.disposition.label}</span>
+				</MetricField>
+			</div>
+		)
+	}
 	const renderBidActionButtons = ({ bid, disposition, showEmptyState = false }: { bid: TruthAuctionBidView; disposition: TruthAuctionBidDisposition; showEmptyState?: boolean }) => {
 		const isViewerBid = sameAddress(bid.bidder, accountState.address)
 		const canPrefillRefund = isViewerBid && disposition.canPrefillRefund
@@ -1098,7 +1148,7 @@ export function ForkAuctionSection({
 		return (
 			<div className='truth-auction-bid-row-actions'>
 				<button className='secondary' onClick={() => selectTruthAuctionTick(bid.tick)} type='button'>
-					Show Price Level
+					View Price
 				</button>
 				{showEmptyState && !hasVisibleAction ? <span className='truth-auction-row-empty'>—</span> : undefined}
 				{canPrefillRefund ? (
@@ -1112,12 +1162,12 @@ export function ForkAuctionSection({
 						}
 						type='button'
 					>
-						Prefill Refund
+						Refund
 					</button>
 				) : undefined}
 				{canPrefillSettle ? (
 					<button className='secondary' onClick={() => prefillSettleBid(bid)} type='button'>
-						Prefill Settle
+						Settle
 					</button>
 				) : undefined}
 			</div>
@@ -1174,18 +1224,27 @@ export function ForkAuctionSection({
 	}) => (
 		<SectionBlock {...(description === undefined ? {} : { description })} density={density} headingLevel={headingLevel} title={title} variant={variant}>
 			<div className='form-grid'>
-				<label className='field'>
-					<span>Refund Tick</span>
-					<FormInput value={forkAuctionForm.refundTick} onInput={event => onForkAuctionFormChange({ refundTick: event.currentTarget.value })} />
-				</label>
-				<label className='field'>
-					<span>Refund Bid Index</span>
-					<FormInput value={forkAuctionForm.refundBidIndex} onInput={event => onForkAuctionFormChange({ refundBidIndex: event.currentTarget.value })} />
-				</label>
+				{variant === 'embedded' ? (
+					<>
+						<label className='field'>
+							<span>Refund Tick</span>
+							<FormInput value={forkAuctionForm.refundTick} onInput={event => onForkAuctionFormChange({ refundTick: event.currentTarget.value })} />
+						</label>
+						<label className='field'>
+							<span>Refund Bid Index</span>
+							<FormInput value={forkAuctionForm.refundBidIndex} onInput={event => onForkAuctionFormChange({ refundBidIndex: event.currentTarget.value })} />
+						</label>
+					</>
+				) : (
+					renderSelectedBidSummary({
+						emptyCopy: 'Pick one of your bids to load a refund target.',
+						selectedBidSummary: selectedRefundBidSummary,
+					})
+				)}
 				<div className='actions'>
 					{renderStageActionButton({
 						action: 'refundLosingBids',
-						availability: createActionAvailability(refundTruthAuctionBidGuardMessage),
+						availability: createActionAvailability(variant === 'embedded' ? refundTruthAuctionBidGuardMessage : primaryRefundTruthAuctionBidGuardMessage),
 						forceEnabled: hasSelectedAuctionChildPool,
 						idleLabel,
 						onClick: onRefundLosingBidsForSelectedAuction,
@@ -1213,24 +1272,33 @@ export function ForkAuctionSection({
 	}) => (
 		<SectionBlock density={density} headingLevel={headingLevel} title={title} variant={variant}>
 			<div className='form-grid'>
-				<label className='field'>
-					<span>Bidder Address</span>
-					<FormInput value={forkAuctionForm.settlementAddress} onInput={event => onForkAuctionFormChange({ settlementAddress: event.currentTarget.value })} placeholder='Leave empty to use connected wallet' />
-				</label>
-				<div className='field-row'>
-					<label className='field'>
-						<span>Settlement Bid Tick</span>
-						<FormInput value={forkAuctionForm.claimBidTick} onInput={event => onForkAuctionFormChange({ claimBidTick: event.currentTarget.value })} />
-					</label>
-					<label className='field'>
-						<span>Settlement Bid Index</span>
-						<FormInput value={forkAuctionForm.claimBidIndex} onInput={event => onForkAuctionFormChange({ claimBidIndex: event.currentTarget.value })} />
-					</label>
-				</div>
+				{variant === 'embedded' ? (
+					<>
+						<label className='field'>
+							<span>Bidder Address</span>
+							<FormInput value={forkAuctionForm.settlementAddress} onInput={event => onForkAuctionFormChange({ settlementAddress: event.currentTarget.value })} placeholder='Leave empty to use connected wallet' />
+						</label>
+						<div className='field-row'>
+							<label className='field'>
+								<span>Settlement Bid Tick</span>
+								<FormInput value={forkAuctionForm.claimBidTick} onInput={event => onForkAuctionFormChange({ claimBidTick: event.currentTarget.value })} />
+							</label>
+							<label className='field'>
+								<span>Settlement Bid Index</span>
+								<FormInput value={forkAuctionForm.claimBidIndex} onInput={event => onForkAuctionFormChange({ claimBidIndex: event.currentTarget.value })} />
+							</label>
+						</div>
+					</>
+				) : (
+					renderSelectedBidSummary({
+						emptyCopy: 'Pick one of your bids to load a settlement target.',
+						selectedBidSummary: selectedSettlementBidSummary,
+					})
+				)}
 				<div className='actions'>
 					{renderStageActionButton({
 						action: 'claimAuctionProceeds',
-						availability: createActionAvailability(settleFinalizedTruthAuctionBidGuardMessage),
+						availability: createActionAvailability(variant === 'embedded' ? settleFinalizedTruthAuctionBidGuardMessage : primarySettleFinalizedTruthAuctionBidGuardMessage),
 						forceEnabled: hasSelectedAuctionChildPool,
 						idleLabel,
 						onClick: onClaimAuctionProceedsForSelectedAuction,
@@ -1557,7 +1625,6 @@ export function ForkAuctionSection({
 		{ label: 'Ends', value: endsDisplay },
 		{ label: 'ETH Raised / Cap', value: ethRaisedCapDisplay },
 		{ label: 'REP Purchased', value: truthAuctionStatus === undefined ? truthAuctionFallback : <CurrencyValue value={truthAuctionStatus.totalRepPurchased} suffix='REP' /> },
-		{ label: 'Clearing Tick', value: truthAuctionStatus?.clearingTick?.toString() ?? truthAuctionFallback },
 		{ label: 'Clearing Price', value: clearingPriceDisplay },
 		{ label: 'Min Bid Size', value: truthAuctionStatus === undefined ? truthAuctionFallback : <CurrencyValue value={truthAuctionStatus.minBidSize} suffix='ETH' /> },
 		{ label: 'Max REP Being Sold', value: truthAuctionStatus === undefined ? truthAuctionFallback : <CurrencyValue value={truthAuctionStatus.maxRepBeingSold} suffix='REP' /> },
@@ -1617,7 +1684,6 @@ export function ForkAuctionSection({
 						</div>
 					</div>
 					<div className='truth-auction-hero-grid'>
-						<MetricField label='Clearing Tick'>{truthAuctionStatus.clearingTick?.toString() ?? UNKNOWN_VALUE}</MetricField>
 						<MetricField label='Clearing Price'>{truthAuctionStatus.clearingPrice === undefined ? UNKNOWN_VALUE : <CurrencyValue value={truthAuctionStatus.clearingPrice} suffix='ETH / REP' />}</MetricField>
 						<MetricField label='Min Bid'>{<CurrencyValue value={truthAuctionStatus.minBidSize} suffix='ETH' />}</MetricField>
 						<MetricField label='Time Left'>{timeLeftDisplay}</MetricField>
@@ -1634,7 +1700,7 @@ export function ForkAuctionSection({
 		const selectedTickDisposition = resolvedSelectedTickSummary === undefined ? undefined : getTickDisposition(resolvedSelectedTickSummary, truthAuctionStatus)
 
 		return (
-			<SectionBlock title='Market View' description={selectedStage === 'settlement' ? 'Review loaded visible depth, inspect the active ladder, and open an individual price level before settling bids.' : 'Review visible depth, inspect the active ladder, and choose a price level before placing a bid.'}>
+			<SectionBlock title='Market View' description={selectedStage === 'settlement' ? 'Review prices and open one before settling.' : 'Review prices and choose one before bidding.'}>
 				{truthAuctionBookError === undefined ? undefined : <p className='detail truth-auction-book-error'>{truthAuctionBookError}</p>}
 				<div className='truth-auction-market-board'>
 					<div className='truth-auction-market-stack'>
@@ -1642,7 +1708,7 @@ export function ForkAuctionSection({
 							<div className='truth-auction-depth-header'>
 								<div>
 									<h4>Visible Depth</h4>
-									<p className='detail'>Loaded price levels only. Use Load More to extend the visible portion of the book.</p>
+									<p className='detail'>Loaded prices only. Load more to extend the view.</p>
 								</div>
 							</div>
 							{loadingTruthAuctionBook ? <p className='detail'>Loading order book…</p> : undefined}
@@ -1661,7 +1727,7 @@ export function ForkAuctionSection({
 							<div className='truth-auction-panel-header'>
 								<div>
 									<h4>Price Ladder</h4>
-									<p className='detail'>Highest tick first. Each row shows the live size at that level and the loaded depth above it.</p>
+									<p className='detail'>Highest price first. Each row shows size and loaded depth.</p>
 								</div>
 							</div>
 							<div className='truth-auction-ladder'>
@@ -1679,12 +1745,12 @@ export function ForkAuctionSection({
 										<div className='truth-auction-price-row-copy'>
 											<div className='truth-auction-price-row-main'>
 												<div>
-													<strong>Tick {point.tick.toString()}</strong>
-													<span className='truth-auction-price-row-price'>{<CurrencyValue value={point.price} suffix='ETH / REP' />}</span>
+													<strong>{<CurrencyValue value={point.price} suffix='ETH / REP' />}</strong>
+													<span className='truth-auction-price-row-price'>Price level</span>
 												</div>
 												<div className='truth-auction-price-row-badges'>
 													{truthAuctionStatus.clearingTick === point.tick ? <span className='truth-auction-ladder-helper'>Clearing level</span> : undefined}
-													{point.isPreviewTick ? <span className='truth-auction-ladder-helper'>Current form tick</span> : undefined}
+													{point.isPreviewTick ? <span className='truth-auction-ladder-helper'>Current form price</span> : undefined}
 													<span className={`truth-auction-status-pill ${getTruthAuctionDispositionClassName(point.disposition.tone)}`}>{point.disposition.label}</span>
 												</div>
 											</div>
@@ -1712,14 +1778,14 @@ export function ForkAuctionSection({
 					</div>
 					<div className='truth-auction-market-section truth-auction-level-detail'>
 						{resolvedSelectedTickSummary === undefined ? (
-							<p className='detail'>{loadingSelectedTickBids && selectedBookTick !== undefined ? 'Loading selected price level…' : 'Select a price level to inspect the bids queued there.'}</p>
+							<p className='detail'>{loadingSelectedTickBids && selectedBookTick !== undefined ? 'Loading selected price…' : 'Select a price to inspect its bids.'}</p>
 						) : (
 							<>
 								<div className='truth-auction-level-header'>
 									<div>
-										<h4>Selected Price Level</h4>
+										<h4>Selected Price</h4>
 										<p className='detail'>
-											Tick {resolvedSelectedTickSummary.tick.toString()} at <CurrencyValue value={resolvedSelectedTickSummary.price} suffix='ETH / REP' />
+											<CurrencyValue value={resolvedSelectedTickSummary.price} suffix='ETH / REP' />
 										</p>
 									</div>
 									{selectedStage !== 'settlement' ? (
@@ -1734,12 +1800,12 @@ export function ForkAuctionSection({
 									<MetricField label='Historical Bids'>{resolvedSelectedTickSummary.submissionCount.toString()}</MetricField>
 									<MetricField label='Status'>{selectedTickDisposition?.label ?? UNKNOWN_VALUE}</MetricField>
 								</div>
-								{loadingSelectedTickBids ? <p className='detail'>Loading bids at this price level…</p> : undefined}
-								{!loadingSelectedTickBids && resolvedSelectedTickBids.length === 0 ? <p className='detail'>No bids are currently indexed for this price level.</p> : undefined}
+								{loadingSelectedTickBids ? <p className='detail'>Loading bids at this price…</p> : undefined}
+								{!loadingSelectedTickBids && resolvedSelectedTickBids.length === 0 ? <p className='detail'>No bids are currently indexed for this price.</p> : undefined}
 								{resolvedSelectedTickBids.length === 0 ? undefined : (
 									<div className='truth-auction-bid-table'>
 										<div className='truth-auction-bid-row is-header'>
-											<span>Bid</span>
+											<span>Price</span>
 											<span>Bidder</span>
 											<span>Amount</span>
 											<span>Cumulative</span>
@@ -1750,7 +1816,9 @@ export function ForkAuctionSection({
 											const disposition = getBidDisposition(bid, truthAuctionStatus)
 											return (
 												<div className='truth-auction-bid-row' key={`${bid.tick.toString()}:${bid.bidIndex.toString()}`}>
-													<span className='truth-auction-bid-row-label'>Bid #{bid.bidIndex.toString()}</span>
+													<span className='truth-auction-bid-row-label'>
+														<CurrencyValue value={getTruthAuctionPriceAtTick(bid.tick)} suffix='ETH / REP' />
+													</span>
 													<div className='truth-auction-bid-row-address'>
 														<AddressValue address={bid.bidder} />
 													</div>
@@ -1787,21 +1855,19 @@ export function ForkAuctionSection({
 		if (!shouldShowTruthAuctionVisualization || truthAuctionStatus === undefined) return undefined
 
 		return (
-			<SectionBlock title='Auction Bids' description='Bids across the currently loaded active price levels. Load more price levels to expand auction coverage.'>
+			<SectionBlock title='Auction Bids' description='Bids across the loaded prices.'>
 				<div className='truth-auction-bid-coverage-summary'>
 					<MetricField label='Loaded Levels'>{truthAuctionBookData.tickSummaries.length.toString()}</MetricField>
 					<MetricField label='Loaded Bids'>{aggregatedAuctionBids.length.toString()}</MetricField>
 					<MetricField label='Coverage'>{`Showing ${aggregatedAuctionBids.length.toString()} of ${aggregatedAuctionBidCountForLoadedTicks.toString()} bids across loaded levels`}</MetricField>
 				</div>
 				{loadingAggregatedAuctionBids ? <p className='detail'>Loading auction bids…</p> : undefined}
-				{!loadingAggregatedAuctionBids && truthAuctionBookData.tickSummaries.length === 0 ? <p className='detail'>No active price levels are currently visible for this auction.</p> : undefined}
-				{!loadingAggregatedAuctionBids && truthAuctionBookData.tickSummaries.length > 0 && aggregatedAuctionBids.length === 0 ? <p className='detail'>No bids are currently indexed for the loaded active price levels.</p> : undefined}
+				{!loadingAggregatedAuctionBids && truthAuctionBookData.tickSummaries.length === 0 ? <p className='detail'>No active prices are currently visible for this auction.</p> : undefined}
+				{!loadingAggregatedAuctionBids && truthAuctionBookData.tickSummaries.length > 0 && aggregatedAuctionBids.length === 0 ? <p className='detail'>No bids are currently indexed for the loaded prices.</p> : undefined}
 				{aggregatedAuctionBids.length === 0 ? undefined : (
 					<div className='truth-auction-bid-table'>
 						<div className='truth-auction-bid-row is-header is-wide'>
-							<span>Tick</span>
 							<span>Price</span>
-							<span>Bid</span>
 							<span>Bidder</span>
 							<span>Amount</span>
 							<span>Cumulative</span>
@@ -1812,11 +1878,9 @@ export function ForkAuctionSection({
 							const disposition = getBidDisposition(bid, truthAuctionStatus)
 							return (
 								<div className='truth-auction-bid-row is-wide' key={`aggregate:${bid.tick.toString()}:${bid.bidIndex.toString()}`}>
-									<span className='truth-auction-bid-row-label'>Tick {bid.tick.toString()}</span>
-									<span>
+									<span className='truth-auction-bid-row-label'>
 										<CurrencyValue value={getTruthAuctionPriceAtTick(bid.tick)} suffix='ETH / REP' />
 									</span>
-									<span>Bid #{bid.bidIndex.toString()}</span>
 									<div className='truth-auction-bid-row-address'>
 										<AddressValue address={bid.bidder} />
 									</div>
@@ -1849,7 +1913,7 @@ export function ForkAuctionSection({
 		if (!shouldShowTruthAuctionVisualization || truthAuctionStatus === undefined) return undefined
 
 		return (
-			<SectionBlock title='My Bids' description='Your submitted bids and their current status. Use the row shortcuts to jump to the price level or prefill settlement actions.'>
+			<SectionBlock title='My Bids' description='Your bids and their current status.'>
 				{accountState.address === undefined ? <p className='detail'>Connect a wallet to inspect your submitted truth auction bids.</p> : undefined}
 				{accountState.address !== undefined ? (
 					<div className='truth-auction-wallet-summary'>
@@ -1865,7 +1929,6 @@ export function ForkAuctionSection({
 				{truthAuctionBookData.viewerBids.length === 0 ? undefined : (
 					<div className='truth-auction-bid-table'>
 						<div className='truth-auction-bid-row is-header is-wallet'>
-							<span>Tick</span>
 							<span>Price</span>
 							<span>Amount</span>
 							<span>Status</span>
@@ -1876,10 +1939,6 @@ export function ForkAuctionSection({
 							return (
 								<div className='truth-auction-bid-row is-wallet' key={`viewer:${bid.tick.toString()}:${bid.bidIndex.toString()}`}>
 									<span className='truth-auction-bid-row-label'>
-										Tick {bid.tick.toString()}
-										<small>Bid #{bid.bidIndex.toString()}</small>
-									</span>
-									<span>
 										<CurrencyValue value={getTruthAuctionPriceAtTick(bid.tick)} suffix='ETH / REP' />
 									</span>
 									<span>
@@ -1907,7 +1966,7 @@ export function ForkAuctionSection({
 	const truthAuctionRefundSection = (() => {
 		if (!shouldShowTruthAuctionVisualization || truthAuctionStatus === undefined || truthAuctionStatus.finalized) return undefined
 		return renderRefundBidSection({
-			description: 'Refund a losing bid before finalization when the selected row indicates it is below clearing.',
+			description: 'Use a bid row to load a refund target.',
 			idleLabel: 'Refund Losing Bid',
 			title: 'Refund Losing Bid',
 			tone: 'primary',
@@ -2064,24 +2123,24 @@ export function ForkAuctionSection({
 							{auctionWideBidsSection}
 							<div className='truth-auction-stage-actions'>
 								{renderSubmitBidSection({
-									description: 'Enter the price and ETH amount you want to place into the auction. The ladder above can prefill a price directly into this form.',
+									description: 'Enter a price and ETH amount.',
 								})}
-								{truthAuctionStatus.finalized ? undefined : (
-									<SectionBlock title='Finalize Truth Auction' description='Finalize the auction once bidding has closed so finalized settlements can settle against the final clearing result.'>
-										<div className='actions'>
-											{renderStageActionButton({
-												action: 'finalizeTruthAuction',
-												availability: createActionAvailability(finalizeTruthAuctionGuardMessage),
-												forceEnabled: hasSelectedAuctionChildPool,
-												idleLabel: 'Finalize Truth Auction',
-												onClick: onFinalizeTruthAuctionForSelectedAuction,
-												pendingLabel: 'Finalizing truth auction...',
-											})}
-										</div>
-									</SectionBlock>
-								)}
 								{viewerTruthAuctionBidsSection}
 							</div>
+							{truthAuctionStatus.finalized ? undefined : (
+								<SectionBlock title='Finalize Truth Auction' description='Finalize once bidding has closed.'>
+									<div className='actions'>
+										{renderStageActionButton({
+											action: 'finalizeTruthAuction',
+											availability: createActionAvailability(finalizeTruthAuctionGuardMessage),
+											forceEnabled: hasSelectedAuctionChildPool,
+											idleLabel: 'Finalize Truth Auction',
+											onClick: onFinalizeTruthAuctionForSelectedAuction,
+											pendingLabel: 'Finalizing truth auction...',
+										})}
+									</div>
+								</SectionBlock>
+							)}
 						</fieldset>
 					)
 				return (
@@ -2109,10 +2168,10 @@ export function ForkAuctionSection({
 							</div>
 						</SectionBlock>
 
-						{renderSubmitBidSection({})}
+						{renderSubmitBidSection({ description: 'Enter a price and ETH amount.' })}
 
 						{truthAuctionStatus?.finalized ? undefined : (
-							<SectionBlock title='Finalize Truth Auction'>
+							<SectionBlock title='Finalize Truth Auction' description='Finalize once bidding has closed.'>
 								<div className='actions'>
 									{renderStageActionButton({
 										action: 'finalizeTruthAuction',

--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -90,6 +90,11 @@ type TruthAuctionSelectedBidSummary = {
 	price: bigint
 }
 
+type TruthAuctionStateBadge = {
+	label: string
+	tone: 'blocked' | 'muted' | 'ok' | 'pending'
+}
+
 type ForkOutcomeMigrationSeedStatus = Awaited<ReturnType<typeof loadForkOutcomeMigrationSeedStatus>>
 
 function getTruthAuctionWindow(startedAt: bigint | undefined) {
@@ -102,6 +107,16 @@ function getTruthAuctionWindow(startedAt: bigint | undefined) {
 function renderMetricValue(value: bigint | undefined, suffix: string, fallbackText: string) {
 	if (value === undefined) return fallbackText
 	return <CurrencyValue value={value} suffix={suffix} />
+}
+
+function renderTruthAuctionPriceValue(value: bigint | undefined, fallbackText: string = UNKNOWN_VALUE) {
+	if (value === undefined) return fallbackText
+	const formattedPrice = formatCurrencyInputBalance(value)
+	return (
+		<span className='truth-auction-price-value' title={`${formattedPrice} ETH / REP`}>
+			{formattedPrice} ETH / REP
+		</span>
+	)
 }
 function renderAddress(address: string | undefined) {
 	if (address === undefined) return UNKNOWN_VALUE
@@ -588,6 +603,36 @@ function dedupeTruthAuctionBids(bids: TruthAuctionBidView[]) {
 	return sortTruthAuctionBidsByPriority(Array.from(new Map(bids.map(bid => [`${bid.tick.toString()}:${bid.bidIndex.toString()}`, bid])).values()))
 }
 
+function getTruthAuctionStateBadge({
+	hasSelectedAuctionChildPool,
+	isStartTruthAuctionInProgress,
+	startTruthAuctionCountdown,
+	truthAuction,
+	truthAuctionStartedAt,
+}: {
+	hasSelectedAuctionChildPool: boolean
+	isStartTruthAuctionInProgress: boolean
+	startTruthAuctionCountdown: bigint | undefined
+	truthAuction: TruthAuctionMetrics | undefined
+	truthAuctionStartedAt: bigint
+}): TruthAuctionStateBadge {
+	if (truthAuction === undefined) {
+		if (isStartTruthAuctionInProgress || (hasSelectedAuctionChildPool && truthAuctionStartedAt === 0n && startTruthAuctionCountdown !== undefined && startTruthAuctionCountdown > 0n)) {
+			return { label: 'Pending', tone: 'pending' }
+		}
+		return { label: 'Inactive', tone: 'muted' }
+	}
+	if (!truthAuction.finalized) {
+		if (truthAuction.hitCap && truthAuction.clearingTick !== undefined && truthAuction.clearingPrice !== undefined) {
+			return { label: 'Clearing', tone: 'pending' }
+		}
+		return { label: 'Open', tone: 'pending' }
+	}
+	if (truthAuction.underfunded) return { label: 'Shortfall', tone: 'blocked' }
+	if (truthAuction.hitCap) return { label: 'Settled', tone: 'ok' }
+	return { label: 'Unfilled', tone: 'muted' }
+}
+
 async function loadAggregatedTruthAuctionBidPages(client: Pick<ReadClient, 'readContract'>, truthAuctionAddress: Address, tickSummaries: TruthAuctionTickSummary[], pageCount: number) {
 	const uniqueTickSummaries = sortTruthAuctionTickSummariesDescending(Array.from(new Map(tickSummaries.map(tickSummary => [tickSummary.tick.toString(), tickSummary])).values()))
 	const bidPages = await Promise.all(uniqueTickSummaries.map(async tickSummary => ({ bidData: await loadTruthAuctionTickBidPages(client, truthAuctionAddress, tickSummary.tick, pageCount), tickSummary })))
@@ -796,6 +841,13 @@ export function ForkAuctionSection({
 
 		return false
 	})()
+	const truthAuctionStateBadge = getTruthAuctionStateBadge({
+		hasSelectedAuctionChildPool,
+		isStartTruthAuctionInProgress,
+		startTruthAuctionCountdown,
+		truthAuction: truthAuctionStatus,
+		truthAuctionStartedAt: auctionHasStartedAtValue,
+	})
 	const startedDisplay = (() => {
 		if (hasStartedTruthAuction) {
 			return renderTimestamp({
@@ -886,19 +938,7 @@ export function ForkAuctionSection({
 				<CurrencyValue value={truthAuctionStatus.ethRaised} suffix='ETH' /> / <CurrencyValue value={truthAuctionStatus.ethRaiseCap} suffix='ETH' />
 			</Fragment>
 		)
-	const clearingPriceDisplay = truthAuctionStatus === undefined ? truthAuctionFallback : renderMetricValue(truthAuctionStatus.clearingPrice, 'REP', UNKNOWN_VALUE)
-	const finalizedDisplay = (() => {
-		if (truthAuctionStatus === undefined) return truthAuctionFallback
-		if (truthAuctionStatus.finalized) return 'Yes'
-
-		return 'No'
-	})()
-	const underfundedDisplay = (() => {
-		if (truthAuctionStatus === undefined) return truthAuctionFallback
-		if (truthAuctionStatus.underfunded) return 'Yes'
-
-		return 'No'
-	})()
+	const clearingPriceDisplay = truthAuctionStatus === undefined ? truthAuctionFallback : renderTruthAuctionPriceValue(truthAuctionStatus.clearingPrice)
 	const settlementAvailableDisplay = (() => {
 		if (!hasSelectedAuctionChildPool) return UNAVAILABLE_UNTIL_FORK
 		if (selectedAuctionContext?.claimingAvailable) return 'Yes'
@@ -1131,7 +1171,7 @@ export function ForkAuctionSection({
 		if (selectedBidSummary === undefined) return <p className='detail'>{emptyCopy}</p>
 		return (
 			<div className='truth-auction-selected-bid-summary'>
-				<MetricField label='Price'>{<CurrencyValue value={selectedBidSummary.price} suffix='ETH / REP' />}</MetricField>
+				<MetricField label='Price'>{renderTruthAuctionPriceValue(selectedBidSummary.price)}</MetricField>
 				<MetricField label='Bidder'>{<AddressValue address={selectedBidSummary.bid.bidder} />}</MetricField>
 				<MetricField label='Amount'>{<CurrencyValue value={selectedBidSummary.bid.ethAmount} suffix='ETH' />}</MetricField>
 				<MetricField label='Status'>
@@ -1176,11 +1216,7 @@ export function ForkAuctionSection({
 	const renderSubmitBidSection = ({ description, density = 'balanced', headingLevel = 3, title = 'Submit Bid', variant = 'default' }: { description?: ComponentChildren; density?: 'balanced' | 'compact'; headingLevel?: 3 | 4; title?: ComponentChildren; variant?: 'default' | 'embedded' }) => (
 		<SectionBlock {...(description === undefined ? {} : { description })} density={density} headingLevel={headingLevel} title={title} variant={variant}>
 			<div className='form-grid'>
-				{submitBidPreviewTickSummary === undefined ? undefined : (
-					<p className='detail'>
-						Selected ladder price: <CurrencyValue value={submitBidPreviewTickSummary.price} suffix='ETH / REP' />
-					</p>
-				)}
+				{submitBidPreviewTickSummary === undefined ? undefined : <p className='detail'>Selected ladder price: {renderTruthAuctionPriceValue(submitBidPreviewTickSummary.price)}</p>}
 				<div className='field-row'>
 					<label className='field'>
 						<span>Bid Price (ETH / REP)</span>
@@ -1619,6 +1655,7 @@ export function ForkAuctionSection({
 			value: resolvedForkTypeLabel,
 		},
 	]
+	const truthAuctionStateBadgeElement = <span className={`badge ${truthAuctionStateBadge.tone}`}>{truthAuctionStateBadge.label}</span>
 	const auctionStatusMetrics: DisplayMetric[] = [
 		{ label: 'Auction Address', value: renderAddress(auctionTruthAuctionAddress) },
 		{ label: 'Started', value: startedDisplay },
@@ -1628,12 +1665,8 @@ export function ForkAuctionSection({
 		{ label: 'Clearing Price', value: clearingPriceDisplay },
 		{ label: 'Min Bid Size', value: truthAuctionStatus === undefined ? truthAuctionFallback : <CurrencyValue value={truthAuctionStatus.minBidSize} suffix='ETH' /> },
 		{ label: 'Max REP Being Sold', value: truthAuctionStatus === undefined ? truthAuctionFallback : <CurrencyValue value={truthAuctionStatus.maxRepBeingSold} suffix='REP' /> },
-		{ label: 'Finalized', value: finalizedDisplay },
-		{ label: 'Underfunded', value: underfundedDisplay },
 	]
 	const settlementStatusMetrics: DisplayMetric[] = [
-		{ label: 'Finalized', value: finalizedDisplay },
-		{ label: 'Underfunded', value: underfundedDisplay },
 		{ label: 'Auctioned Allowance', value: selectedAuctionContext === undefined ? truthAuctionFallback : <CurrencyValue value={selectedAuctionContext.auctionedSecurityBondAllowance} suffix='ETH' /> },
 		{ label: 'Settlement Available', value: settlementAvailableDisplay },
 		{ label: 'ETH Raised / Cap', value: ethRaisedCapDisplay },
@@ -1657,7 +1690,7 @@ export function ForkAuctionSection({
 	const truthAuctionHero = (() => {
 		if (!shouldShowTruthAuctionVisualization || truthAuctionStatus === undefined) return undefined
 		return (
-			<SectionBlock title={selectedStage === 'settlement' ? 'Settlement Overview' : 'Auction Overview'} description={truthAuctionNote}>
+			<SectionBlock badge={truthAuctionStateBadgeElement} title={selectedStage === 'settlement' ? 'Settlement Overview' : 'Auction Overview'} description={truthAuctionNote}>
 				<div className='truth-auction-hero'>
 					<div className='truth-auction-hero-primary'>
 						<div className='truth-auction-progress-group'>
@@ -1684,12 +1717,10 @@ export function ForkAuctionSection({
 						</div>
 					</div>
 					<div className='truth-auction-hero-grid'>
-						<MetricField label='Clearing Price'>{truthAuctionStatus.clearingPrice === undefined ? UNKNOWN_VALUE : <CurrencyValue value={truthAuctionStatus.clearingPrice} suffix='ETH / REP' />}</MetricField>
+						<MetricField label='Clearing Price'>{renderTruthAuctionPriceValue(truthAuctionStatus.clearingPrice)}</MetricField>
 						<MetricField label='Min Bid'>{<CurrencyValue value={truthAuctionStatus.minBidSize} suffix='ETH' />}</MetricField>
 						<MetricField label='Time Left'>{timeLeftDisplay}</MetricField>
-						<MetricField label='Finalized'>{truthAuctionStatus.finalized ? 'Yes' : 'No'}</MetricField>
-						<MetricField label='Underfunded'>{truthAuctionStatus.underfunded ? 'Yes' : 'No'}</MetricField>
-						{winningThresholdPrice === undefined ? undefined : <MetricField label='Winning Threshold'>{<CurrencyValue value={winningThresholdPrice} suffix='ETH / REP' />}</MetricField>}
+						{winningThresholdPrice === undefined ? undefined : <MetricField label='Winning Threshold'>{renderTruthAuctionPriceValue(winningThresholdPrice)}</MetricField>}
 					</div>
 				</div>
 			</SectionBlock>
@@ -1703,26 +1734,26 @@ export function ForkAuctionSection({
 			<SectionBlock title='Market View' description={selectedStage === 'settlement' ? 'Review prices and open one before settling.' : 'Review prices and choose one before bidding.'}>
 				{truthAuctionBookError === undefined ? undefined : <p className='detail truth-auction-book-error'>{truthAuctionBookError}</p>}
 				<div className='truth-auction-market-board'>
-					<div className='truth-auction-market-stack'>
-						<div className='truth-auction-market-section truth-auction-depth-panel'>
-							<div className='truth-auction-depth-header'>
-								<div>
-									<h4>Visible Depth</h4>
-									<p className='detail'>Loaded prices only. Load more to extend the view.</p>
-								</div>
+					<div className='truth-auction-market-section truth-auction-depth-panel'>
+						<div className='truth-auction-depth-header'>
+							<div>
+								<h4>Visible Depth</h4>
+								<p className='detail'>Loaded prices only. Load more to extend the view.</p>
 							</div>
-							{loadingTruthAuctionBook ? <p className='detail'>Loading order book…</p> : undefined}
-							{!loadingTruthAuctionBook && truthAuctionDepthPoints.length === 0 ? <p className='detail'>No live price levels are currently active for this auction.</p> : undefined}
-							{truthAuctionDepthPoints.length === 0 ? undefined : (
-								<TruthAuctionDepthChart
-									loadedTickCount={truthAuctionDepthPoints.length}
-									onSelectTick={selectTruthAuctionTick}
-									points={truthAuctionDepthPoints}
-									totalActiveTickCount={truthAuctionBookData.tickCount}
-									{...(truthAuctionStatus.hitCap && truthAuctionStatus.clearingTick !== undefined ? { clearingTick: truthAuctionStatus.clearingTick } : {})}
-								/>
-							)}
 						</div>
+						{loadingTruthAuctionBook ? <p className='detail'>Loading order book…</p> : undefined}
+						{!loadingTruthAuctionBook && truthAuctionDepthPoints.length === 0 ? <p className='detail'>No live price levels are currently active for this auction.</p> : undefined}
+						{truthAuctionDepthPoints.length === 0 ? undefined : (
+							<TruthAuctionDepthChart
+								loadedTickCount={truthAuctionDepthPoints.length}
+								onSelectTick={selectTruthAuctionTick}
+								points={truthAuctionDepthPoints}
+								totalActiveTickCount={truthAuctionBookData.tickCount}
+								{...(truthAuctionStatus.hitCap && truthAuctionStatus.clearingTick !== undefined ? { clearingTick: truthAuctionStatus.clearingTick } : {})}
+							/>
+						)}
+					</div>
+					<div className='truth-auction-market-detail-grid'>
 						<div className='truth-auction-market-section'>
 							<div className='truth-auction-panel-header'>
 								<div>
@@ -1745,7 +1776,7 @@ export function ForkAuctionSection({
 										<div className='truth-auction-price-row-copy'>
 											<div className='truth-auction-price-row-main'>
 												<div>
-													<strong>{<CurrencyValue value={point.price} suffix='ETH / REP' />}</strong>
+													<strong>{renderTruthAuctionPriceValue(point.price)}</strong>
 													<span className='truth-auction-price-row-price'>Price level</span>
 												</div>
 												<div className='truth-auction-price-row-badges'>
@@ -1775,77 +1806,73 @@ export function ForkAuctionSection({
 								) : undefined}
 							</div>
 						</div>
-					</div>
-					<div className='truth-auction-market-section truth-auction-level-detail'>
-						{resolvedSelectedTickSummary === undefined ? (
-							<p className='detail'>{loadingSelectedTickBids && selectedBookTick !== undefined ? 'Loading selected price…' : 'Select a price to inspect its bids.'}</p>
-						) : (
-							<>
-								<div className='truth-auction-level-header'>
-									<div>
-										<h4>Selected Price</h4>
-										<p className='detail'>
-											<CurrencyValue value={resolvedSelectedTickSummary.price} suffix='ETH / REP' />
-										</p>
-									</div>
-									{selectedStage !== 'settlement' ? (
-										<button className='secondary' onClick={() => onForkAuctionFormChange({ submitBidPrice: formatCurrencyInputBalance(resolvedSelectedTickSummary.price) })} type='button'>
-											Use This Price
-										</button>
-									) : undefined}
-								</div>
-								<div className='workflow-metric-grid'>
-									<MetricField label='Live ETH'>{<CurrencyValue value={resolvedSelectedTickSummary.currentTotalEth} suffix='ETH' />}</MetricField>
-									<MetricField label='Loaded Depth'>{selectedLoadedDepthPoint === undefined ? 'Not in loaded ladder' : <CurrencyValue value={selectedLoadedDepthPoint.cumulativeEth} suffix='ETH' />}</MetricField>
-									<MetricField label='Historical Bids'>{resolvedSelectedTickSummary.submissionCount.toString()}</MetricField>
-									<MetricField label='Status'>{selectedTickDisposition?.label ?? UNKNOWN_VALUE}</MetricField>
-								</div>
-								{loadingSelectedTickBids ? <p className='detail'>Loading bids at this price…</p> : undefined}
-								{!loadingSelectedTickBids && resolvedSelectedTickBids.length === 0 ? <p className='detail'>No bids are currently indexed for this price.</p> : undefined}
-								{resolvedSelectedTickBids.length === 0 ? undefined : (
-									<div className='truth-auction-bid-table'>
-										<div className='truth-auction-bid-row is-header'>
-											<span>Price</span>
-											<span>Bidder</span>
-											<span>Amount</span>
-											<span>Cumulative</span>
-											<span>Status</span>
-											<span>Actions</span>
+						<div className='truth-auction-market-section truth-auction-level-detail'>
+							{resolvedSelectedTickSummary === undefined ? (
+								<p className='detail'>{loadingSelectedTickBids && selectedBookTick !== undefined ? 'Loading selected price…' : 'Select a price to inspect its bids.'}</p>
+							) : (
+								<>
+									<div className='truth-auction-level-header'>
+										<div>
+											<h4>Selected Price</h4>
+											<p className='detail'>{renderTruthAuctionPriceValue(resolvedSelectedTickSummary.price)}</p>
 										</div>
-										{resolvedSelectedTickBids.map(bid => {
-											const disposition = getBidDisposition(bid, truthAuctionStatus)
-											return (
-												<div className='truth-auction-bid-row' key={`${bid.tick.toString()}:${bid.bidIndex.toString()}`}>
-													<span className='truth-auction-bid-row-label'>
-														<CurrencyValue value={getTruthAuctionPriceAtTick(bid.tick)} suffix='ETH / REP' />
-													</span>
-													<div className='truth-auction-bid-row-address'>
-														<AddressValue address={bid.bidder} />
+										{selectedStage !== 'settlement' ? (
+											<button className='secondary' onClick={() => onForkAuctionFormChange({ submitBidPrice: formatCurrencyInputBalance(resolvedSelectedTickSummary.price) })} type='button'>
+												Use This Price
+											</button>
+										) : undefined}
+									</div>
+									<div className='workflow-metric-grid'>
+										<MetricField label='Live ETH'>{<CurrencyValue value={resolvedSelectedTickSummary.currentTotalEth} suffix='ETH' />}</MetricField>
+										<MetricField label='Loaded Depth'>{selectedLoadedDepthPoint === undefined ? 'Not in loaded ladder' : <CurrencyValue value={selectedLoadedDepthPoint.cumulativeEth} suffix='ETH' />}</MetricField>
+										<MetricField label='Historical Bids'>{resolvedSelectedTickSummary.submissionCount.toString()}</MetricField>
+										<MetricField label='Status'>{selectedTickDisposition?.label ?? UNKNOWN_VALUE}</MetricField>
+									</div>
+									{loadingSelectedTickBids ? <p className='detail'>Loading bids at this price…</p> : undefined}
+									{!loadingSelectedTickBids && resolvedSelectedTickBids.length === 0 ? <p className='detail'>No bids are currently indexed for this price.</p> : undefined}
+									{resolvedSelectedTickBids.length === 0 ? undefined : (
+										<div className='truth-auction-bid-table'>
+											<div className='truth-auction-bid-row is-header'>
+												<span>Price</span>
+												<span>Bidder</span>
+												<span>Amount</span>
+												<span>Cumulative</span>
+												<span>Status</span>
+												<span>Actions</span>
+											</div>
+											{resolvedSelectedTickBids.map(bid => {
+												const disposition = getBidDisposition(bid, truthAuctionStatus)
+												return (
+													<div className='truth-auction-bid-row' key={`${bid.tick.toString()}:${bid.bidIndex.toString()}`}>
+														<span className='truth-auction-bid-row-label'>{renderTruthAuctionPriceValue(getTruthAuctionPriceAtTick(bid.tick))}</span>
+														<div className='truth-auction-bid-row-address'>
+															<AddressValue address={bid.bidder} />
+														</div>
+														<span>
+															<CurrencyValue value={bid.ethAmount} suffix='ETH' />
+														</span>
+														<span>
+															<CurrencyValue value={bid.cumulativeEth} suffix='ETH' />
+														</span>
+														<span className='truth-auction-bid-row-status'>
+															<span className={`truth-auction-status-pill ${getTruthAuctionDispositionClassName(disposition.tone)}`}>{disposition.label}</span>
+														</span>
+														{renderBidActionButtons({ bid, disposition, showEmptyState: true })}
 													</div>
-													<span>
-														<CurrencyValue value={bid.ethAmount} suffix='ETH' />
-													</span>
-													<span>
-														<CurrencyValue value={bid.cumulativeEth} suffix='ETH' />
-													</span>
-													<span className='truth-auction-bid-row-status'>
-														<span className={`truth-auction-status-pill ${getTruthAuctionDispositionClassName(disposition.tone)}`}>{disposition.label}</span>
-													</span>
-													{renderBidActionButtons({ bid, disposition, showEmptyState: true })}
-												</div>
-											)
-										})}
-									</div>
-								)}
-								{hasMoreSelectedTickBids ? (
-									<div className='actions'>
-										<button className='secondary' onClick={() => setLoadedSelectedTickBidPageCount(currentPageCount => currentPageCount + 1)} type='button'>
-											Load More Bids At This Level
-										</button>
-									</div>
-								) : undefined}
-							</>
-						)}
+												)
+											})}
+										</div>
+									)}
+									{hasMoreSelectedTickBids ? (
+										<div className='actions'>
+											<button className='secondary' onClick={() => setLoadedSelectedTickBidPageCount(currentPageCount => currentPageCount + 1)} type='button'>
+												Load More Bids At This Level
+											</button>
+										</div>
+									) : undefined}
+								</>
+							)}
+						</div>
 					</div>
 				</div>
 			</SectionBlock>
@@ -1878,9 +1905,7 @@ export function ForkAuctionSection({
 							const disposition = getBidDisposition(bid, truthAuctionStatus)
 							return (
 								<div className='truth-auction-bid-row is-wide' key={`aggregate:${bid.tick.toString()}:${bid.bidIndex.toString()}`}>
-									<span className='truth-auction-bid-row-label'>
-										<CurrencyValue value={getTruthAuctionPriceAtTick(bid.tick)} suffix='ETH / REP' />
-									</span>
+									<span className='truth-auction-bid-row-label'>{renderTruthAuctionPriceValue(getTruthAuctionPriceAtTick(bid.tick))}</span>
 									<div className='truth-auction-bid-row-address'>
 										<AddressValue address={bid.bidder} />
 									</div>
@@ -1938,9 +1963,7 @@ export function ForkAuctionSection({
 							const disposition = getBidDisposition(bid, truthAuctionStatus)
 							return (
 								<div className='truth-auction-bid-row is-wallet' key={`viewer:${bid.tick.toString()}:${bid.bidIndex.toString()}`}>
-									<span className='truth-auction-bid-row-label'>
-										<CurrencyValue value={getTruthAuctionPriceAtTick(bid.tick)} suffix='ETH / REP' />
-									</span>
+									<span className='truth-auction-bid-row-label'>{renderTruthAuctionPriceValue(getTruthAuctionPriceAtTick(bid.tick))}</span>
 									<span>
 										<CurrencyValue value={bid.ethAmount} suffix='ETH' />
 									</span>
@@ -2150,7 +2173,9 @@ export function ForkAuctionSection({
 						{selectedAuctionChildPoolNotice}
 						{selectedAuctionDetailsNotice}
 						{truthAuctionEndedNotice}
-						<SectionBlock title='Auction Status'>{renderWorkflowMetricGrid(auctionStatusMetrics)}</SectionBlock>
+						<SectionBlock badge={truthAuctionStateBadgeElement} title='Auction Status'>
+							{renderWorkflowMetricGrid(auctionStatusMetrics)}
+						</SectionBlock>
 
 						<SectionBlock title='Start Truth Auction'>
 							{startTruthAuctionReadyInText === undefined ? undefined : <p className='detail'>{startTruthAuctionReadyInText}</p>}
@@ -2211,7 +2236,9 @@ export function ForkAuctionSection({
 						{selectedAuctionChildPoolNotice}
 						{selectedAuctionDetailsNotice}
 						{truthAuctionEndedNotice}
-						<SectionBlock title='Settlement Status'>{renderWorkflowMetricGrid(settlementStatusMetrics)}</SectionBlock>
+						<SectionBlock badge={truthAuctionStateBadgeElement} title='Settlement Status'>
+							{renderWorkflowMetricGrid(settlementStatusMetrics)}
+						</SectionBlock>
 						{truthAuctionStatus?.finalized ? undefined : renderRefundBidSection({ idleLabel: 'Refund Losing Bid', title: 'Refund Losing Bid', tone: 'primary' })}
 						{!truthAuctionStatus?.finalized ? undefined : renderFinalizedSettlementSection({ idleLabel: 'Settle Finalized Bid', title: 'Settle Finalized Bid', tone: 'primary' })}
 					</fieldset>

--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -19,7 +19,7 @@ import { TimestampValue } from './TimestampValue.js'
 import { TruthAuctionDepthChart, type TruthAuctionDepthPoint } from './TruthAuctionDepthChart.js'
 import { UniverseLink } from './UniverseLink.js'
 import { WorkflowTransactionStatus } from './WorkflowTransactionStatus.js'
-import { loadAllSecurityPools, loadForkAuctionDetails, loadForkOutcomeMigrationSeedStatus, loadTruthAuctionActiveTickPage, loadTruthAuctionBidderBidPage, loadTruthAuctionTickBidPage, loadTruthAuctionTickSummary } from '../contracts.js'
+import { loadAllSecurityPools, loadForkAuctionDetails, loadForkOutcomeMigrationSeedStatus, loadTruthAuctionActiveTickPage, loadTruthAuctionBidderBidPage, loadTruthAuctionTickBidPage } from '../contracts.js'
 import { createActionAvailability } from '../lib/actionAvailability.js'
 import { sameAddress } from '../lib/address.js'
 import { createConnectedReadClient } from '../lib/clients.js'
@@ -37,7 +37,7 @@ import {
 	TRUTH_AUCTION_PRICE_PRECISION,
 	type ForkAuctionStageView,
 } from '../lib/forkAuction.js'
-import { formatCurrencyInputBalance, formatDuration } from '../lib/formatters.js'
+import { formatCurrencyInputBalance, formatDuration, formatRoundedCurrencyBalance } from '../lib/formatters.js'
 import { tryParseBigIntInput, tryParseTruthAuctionPriceInput } from '../lib/marketForm.js'
 import { isMainnetChain } from '../lib/network.js'
 import { REPORTING_OUTCOME_DROPDOWN_OPTIONS, getReportingOutcomeLabel } from '../lib/reporting.js'
@@ -111,9 +111,10 @@ function renderMetricValue(value: bigint | undefined, suffix: string, fallbackTe
 
 function renderTruthAuctionPriceValue(value: bigint | undefined, fallbackText: string = UNKNOWN_VALUE) {
 	if (value === undefined) return fallbackText
-	const formattedPrice = formatCurrencyInputBalance(value)
+	const formattedPrice = formatRoundedCurrencyBalance(value, 18, 4)
+	const exactPrice = formatCurrencyInputBalance(value)
 	return (
-		<span className='truth-auction-price-value' title={`${formattedPrice} ETH / REP`}>
+		<span className='truth-auction-price-value' title={`${exactPrice} ETH / REP`}>
 			{formattedPrice} ETH / REP
 		</span>
 	)
@@ -793,17 +794,13 @@ export function ForkAuctionSection({
 		viewerBids: [],
 		viewerBidCount: 0n,
 	})
-	const [selectedTickBids, setSelectedTickBids] = useState<TruthAuctionBidView[]>([])
 	const [selectedBookTick, setSelectedBookTick] = useState<bigint | undefined>(undefined)
-	const [selectedTickSummary, setSelectedTickSummary] = useState<TruthAuctionTickSummary | undefined>(undefined)
 	const [loadedTickPageCount, setLoadedTickPageCount] = useState(1)
 	const [loadedViewerBidPageCount, setLoadedViewerBidPageCount] = useState(1)
-	const [loadedSelectedTickBidPageCount, setLoadedSelectedTickBidPageCount] = useState(1)
 	const [loadedAuctionBidPageCount, setLoadedAuctionBidPageCount] = useState(1)
 	const [aggregatedAuctionBids, setAggregatedAuctionBids] = useState<TruthAuctionBidView[]>([])
 	const [aggregatedAuctionBidCountForLoadedTicks, setAggregatedAuctionBidCountForLoadedTicks] = useState(0n)
 	const [loadingTruthAuctionBook, setLoadingTruthAuctionBook] = useState(false)
-	const [loadingSelectedTickBids, setLoadingSelectedTickBids] = useState(false)
 	const [loadingAggregatedAuctionBids, setLoadingAggregatedAuctionBids] = useState(false)
 	const [truthAuctionBookError, setTruthAuctionBookError] = useState<string | undefined>(undefined)
 	const effectiveLockedRepInEscalationGame = (() => {
@@ -935,23 +932,17 @@ export function ForkAuctionSection({
 		truthAuction: truthAuctionStatus,
 	})
 	const viewerBidSummary = summarizeViewerTruthAuctionBids(truthAuctionBookData.viewerBids, truthAuctionStatus)
-	const selectedLoadedDepthPoint = selectedBookTick === undefined ? undefined : truthAuctionDepthPoints.find(point => point.tick === selectedBookTick)
 	const selectedLoadedTickSummary = selectedBookTick === undefined ? undefined : activeTickSummaries.find(tickSummary => tickSummary.tick === selectedBookTick)
-	const resolvedSelectedTickSummary = selectedBookTick === undefined ? undefined : (selectedLoadedTickSummary ?? (selectedTickSummary?.tick === selectedBookTick ? selectedTickSummary : undefined))
 	const previewTickSummary = enteredBidTick === undefined ? undefined : activeTickSummaries.find(tickSummary => tickSummary.tick === enteredBidTick)
-	const submitBidPreviewTickSummary = previewTickSummary ?? (enteredBidTick !== undefined && selectedLoadedTickSummary?.tick === enteredBidTick ? selectedLoadedTickSummary : undefined) ?? (enteredBidTick !== undefined && resolvedSelectedTickSummary?.tick === enteredBidTick ? resolvedSelectedTickSummary : undefined)
+	const submitBidPreviewTickSummary = previewTickSummary ?? (enteredBidTick !== undefined && selectedLoadedTickSummary?.tick === enteredBidTick ? selectedLoadedTickSummary : undefined)
 	const maxTickEth = truthAuctionDepthPoints.reduce((maximumEth, point) => (point.currentTotalEth > maximumEth ? point.currentTotalEth : maximumEth), 0n)
-	const knownTruthAuctionBids = dedupeTruthAuctionBids([...truthAuctionBookData.viewerBids, ...selectedTickBids, ...aggregatedAuctionBids])
+	const knownTruthAuctionBids = dedupeTruthAuctionBids([...truthAuctionBookData.viewerBids, ...aggregatedAuctionBids])
 	const hasMoreTickSummaries = BigInt(truthAuctionBookData.tickSummaries.length) < truthAuctionBookData.tickCount
 	const hasMoreViewerBids = BigInt(truthAuctionBookData.viewerBids.length) < truthAuctionBookData.viewerBidCount
 	const hasMoreAggregatedAuctionBids = BigInt(aggregatedAuctionBids.length) < aggregatedAuctionBidCountForLoadedTicks
 	const selectTruthAuctionTick = (tick: bigint) => {
 		if (selectedBookTick === tick) return
 		setSelectedBookTick(tick)
-		setSelectedTickBids([])
-		setLoadingSelectedTickBids(true)
-		const matchingSummary = activeTickSummaries.find(tickSummary => tickSummary.tick === tick)
-		setSelectedTickSummary(matchingSummary)
 	}
 	const timeLeftDisplay = (() => {
 		if (truthAuctionStatus === undefined) return truthAuctionFallback
@@ -1531,14 +1522,9 @@ export function ForkAuctionSection({
 	useEffect(() => {
 		setLoadedTickPageCount(1)
 		setLoadedViewerBidPageCount(1)
-		setLoadedSelectedTickBidPageCount(1)
 		setLoadedAuctionBidPageCount(1)
 		setSelectedBookTick(undefined)
-		setSelectedTickSummary(undefined)
 	}, [accountState.address, auctionTruthAuctionAddress])
-	useEffect(() => {
-		setLoadedSelectedTickBidPageCount(1)
-	}, [selectedBookTick])
 	useEffect(() => {
 		if (!shouldShowTruthAuctionVisualization || auctionTruthAuctionAddress === undefined || auctionTruthAuctionAddress === zeroAddress || (selectedStage !== 'auction' && selectedStage !== 'settlement')) {
 			setTruthAuctionBookData({
@@ -1547,11 +1533,8 @@ export function ForkAuctionSection({
 				viewerBids: [],
 				viewerBidCount: 0n,
 			})
-			setSelectedTickBids([])
 			setSelectedBookTick(undefined)
-			setSelectedTickSummary(undefined)
 			setLoadingTruthAuctionBook(false)
-			setLoadingSelectedTickBids(false)
 			setAggregatedAuctionBids([])
 			setAggregatedAuctionBidCountForLoadedTicks(0n)
 			setLoadingAggregatedAuctionBids(false)
@@ -1573,7 +1556,7 @@ export function ForkAuctionSection({
 					viewerBidCount: viewerBidData.bidCount,
 				})
 				setSelectedBookTick(currentSelection => {
-					if (currentSelection !== undefined && (sortedTickSummaries.some(tickSummary => tickSummary.tick === currentSelection) || (selectedTickSummary?.tick === currentSelection && selectedTickSummary.submissionCount > 0n))) return currentSelection
+					if (currentSelection !== undefined && sortedTickSummaries.some(tickSummary => tickSummary.tick === currentSelection)) return currentSelection
 					if (enteredBidTick !== undefined && sortedTickSummaries.some(tickSummary => tickSummary.tick === enteredBidTick)) return enteredBidTick
 					if (truthAuctionStatus?.clearingTick !== undefined && sortedTickSummaries.some(tickSummary => tickSummary.tick === truthAuctionStatus.clearingTick)) return truthAuctionStatus.clearingTick
 					return sortedTickSummaries[0]?.tick
@@ -1587,9 +1570,7 @@ export function ForkAuctionSection({
 					viewerBids: [],
 					viewerBidCount: 0n,
 				})
-				setSelectedTickBids([])
 				setSelectedBookTick(undefined)
-				setSelectedTickSummary(undefined)
 				setTruthAuctionBookError(getErrorMessage(error, 'Failed to load truth auction bidbook'))
 			})
 			.finally(() => {
@@ -1630,37 +1611,6 @@ export function ForkAuctionSection({
 			cancelled = true
 		}
 	}, [auctionTruthAuctionAddress, forkAuctionResult?.hash, loadedAuctionBidPageCount, selectedStage, shouldShowTruthAuctionVisualization, truthAuctionBookData.tickSummaries, truthAuctionReadClient])
-	useEffect(() => {
-		if (!shouldShowTruthAuctionVisualization || auctionTruthAuctionAddress === undefined || auctionTruthAuctionAddress === zeroAddress || selectedBookTick === undefined) {
-			setSelectedTickBids([])
-			setSelectedTickSummary(undefined)
-			setLoadingSelectedTickBids(false)
-			return
-		}
-		const client = truthAuctionReadClient ?? createConnectedReadClient()
-		let cancelled = false
-		setLoadingSelectedTickBids(true)
-		setTruthAuctionBookError(undefined)
-		void Promise.all([loadTruthAuctionTickSummary(client, auctionTruthAuctionAddress, selectedBookTick), loadTruthAuctionTickBidPages(client, auctionTruthAuctionAddress, selectedBookTick, loadedSelectedTickBidPageCount)])
-			.then(([tickSummary, bidData]) => {
-				if (cancelled) return
-				setSelectedTickSummary(tickSummary)
-				setSelectedTickBids(bidData.bids)
-			})
-			.catch(error => {
-				if (cancelled) return
-				setSelectedTickBids([])
-				setSelectedTickSummary(undefined)
-				setTruthAuctionBookError(getErrorMessage(error, 'Failed to load truth auction bids at the selected price level'))
-			})
-			.finally(() => {
-				if (cancelled) return
-				setLoadingSelectedTickBids(false)
-			})
-		return () => {
-			cancelled = true
-		}
-	}, [auctionTruthAuctionAddress, forkAuctionResult?.hash, loadedSelectedTickBidPageCount, selectedBookTick, shouldShowTruthAuctionVisualization, truthAuctionReadClient])
 	const latestForkAuctionAction =
 		forkAuctionResult === undefined
 			? undefined
@@ -1767,8 +1717,6 @@ export function ForkAuctionSection({
 	})()
 	const truthAuctionMarketViewSection = (() => {
 		if (!shouldShowTruthAuctionVisualization || truthAuctionStatus === undefined) return undefined
-		const selectedTickDisposition = resolvedSelectedTickSummary === undefined ? undefined : getTickDisposition(resolvedSelectedTickSummary, truthAuctionStatus)
-
 		return (
 			<SectionBlock title='Market View' description={selectedStage === 'settlement' ? 'Review prices and open one before settling.' : 'Review prices and choose one before bidding.'}>
 				{truthAuctionBookError === undefined ? undefined : <p className='detail truth-auction-book-error'>{truthAuctionBookError}</p>}
@@ -1777,7 +1725,6 @@ export function ForkAuctionSection({
 						<div className='truth-auction-depth-header'>
 							<div>
 								<h4>Visible Depth</h4>
-								<p className='detail'>Loaded prices only. Load more to extend the view.</p>
 							</div>
 						</div>
 						{loadingTruthAuctionBook ? <p className='detail'>Loading order book…</p> : undefined}
@@ -1836,31 +1783,6 @@ export function ForkAuctionSection({
 									</div>
 								) : undefined}
 							</div>
-						</div>
-						<div className='truth-auction-market-section truth-auction-level-detail'>
-							{resolvedSelectedTickSummary === undefined ? (
-								<p className='detail'>{loadingSelectedTickBids && selectedBookTick !== undefined ? 'Loading selected price…' : 'Select a price to inspect its bids.'}</p>
-							) : (
-								<>
-									<div className='truth-auction-level-header'>
-										<div>
-											<h4>Selected Price</h4>
-											<p className='detail'>{renderTruthAuctionPriceValue(resolvedSelectedTickSummary.price)}</p>
-										</div>
-										{selectedStage !== 'settlement' ? (
-											<button className='secondary' onClick={() => onForkAuctionFormChange({ submitBidPrice: formatCurrencyInputBalance(resolvedSelectedTickSummary.price) })} type='button'>
-												Use This Price
-											</button>
-										) : undefined}
-									</div>
-									<div className='workflow-metric-grid'>
-										<MetricField label='Live ETH'>{<CurrencyValue value={resolvedSelectedTickSummary.currentTotalEth} suffix='ETH' />}</MetricField>
-										<MetricField label='Loaded Depth'>{selectedLoadedDepthPoint === undefined ? 'Not in loaded ladder' : <CurrencyValue value={selectedLoadedDepthPoint.cumulativeEth} suffix='ETH' />}</MetricField>
-										<MetricField label='Historical Bids'>{resolvedSelectedTickSummary.submissionCount.toString()}</MetricField>
-										<MetricField label='Status'>{selectedTickDisposition?.label ?? UNKNOWN_VALUE}</MetricField>
-									</div>
-								</>
-							)}
 						</div>
 					</div>
 				</div>

--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -516,6 +516,58 @@ function buildTruthAuctionDepthPoints({ enteredBidTick, selectedBookTick, tickSu
 		})
 }
 
+function getTruthAuctionOverviewProgress(truthAuction: TruthAuctionMetrics | undefined, tickSummaries: TruthAuctionTickSummary[]) {
+	if (truthAuction === undefined) return undefined
+	if (truthAuction.finalized) {
+		return {
+			ethRaised: truthAuction.ethRaised,
+			repSold: truthAuction.totalRepPurchased,
+		}
+	}
+
+	const activeTickSummaries = sortTruthAuctionTickSummariesDescending(tickSummaries).filter(tickSummary => tickSummary.currentTotalEth > 0n)
+	if (activeTickSummaries.length === 0) {
+		return {
+			ethRaised: truthAuction.ethRaised,
+			repSold: truthAuction.totalRepPurchased,
+		}
+	}
+
+	let provisionalEthRaised = 0n
+	let provisionalRepSold = 0n
+
+	if (!truthAuction.hitCap || truthAuction.clearingTick === undefined || truthAuction.clearingPrice === undefined) {
+		for (const tickSummary of activeTickSummaries) {
+			provisionalEthRaised += tickSummary.currentTotalEth
+			provisionalRepSold += estimateRepPurchased(tickSummary.currentTotalEth, tickSummary.price)
+		}
+	} else {
+		let remainingCap = truthAuction.ethRaiseCap
+		for (const tickSummary of activeTickSummaries) {
+			if (remainingCap <= 0n) break
+
+			let acceptedEth = 0n
+			if (tickSummary.tick > truthAuction.clearingTick) acceptedEth = tickSummary.currentTotalEth
+			else if (tickSummary.tick === truthAuction.clearingTick) acceptedEth = truthAuction.ethAtClearingTick < tickSummary.currentTotalEth ? truthAuction.ethAtClearingTick : tickSummary.currentTotalEth
+
+			if (acceptedEth <= 0n) continue
+			if (acceptedEth > remainingCap) acceptedEth = remainingCap
+
+			provisionalEthRaised += acceptedEth
+			provisionalRepSold += estimateRepPurchased(acceptedEth, tickSummary.price)
+			remainingCap -= acceptedEth
+		}
+	}
+
+	const ethRaised = provisionalEthRaised > truthAuction.ethRaiseCap ? truthAuction.ethRaiseCap : provisionalEthRaised
+	const repSold = provisionalRepSold > truthAuction.maxRepBeingSold ? truthAuction.maxRepBeingSold : provisionalRepSold
+
+	return {
+		ethRaised,
+		repSold,
+	}
+}
+
 function summarizeViewerTruthAuctionBids(viewerBids: TruthAuctionBidView[], truthAuction: TruthAuctionMetrics | undefined): TruthAuctionViewerBidSummary {
 	return viewerBids.reduce<TruthAuctionViewerBidSummary>(
 		(summary, bid) => {
@@ -744,7 +796,6 @@ export function ForkAuctionSection({
 	const [selectedTickBids, setSelectedTickBids] = useState<TruthAuctionBidView[]>([])
 	const [selectedBookTick, setSelectedBookTick] = useState<bigint | undefined>(undefined)
 	const [selectedTickSummary, setSelectedTickSummary] = useState<TruthAuctionTickSummary | undefined>(undefined)
-	const [selectedTickBidCount, setSelectedTickBidCount] = useState(0n)
 	const [loadedTickPageCount, setLoadedTickPageCount] = useState(1)
 	const [loadedViewerBidPageCount, setLoadedViewerBidPageCount] = useState(1)
 	const [loadedSelectedTickBidPageCount, setLoadedSelectedTickBidPageCount] = useState(1)
@@ -871,16 +922,12 @@ export function ForkAuctionSection({
 		if (truthAuctionEndsAt === undefined || effectiveCurrentTimestamp === undefined) return truthAuctionStatus?.timeRemaining
 		return getTimeRemaining(truthAuctionEndsAt, effectiveCurrentTimestamp)
 	})()
-	const truthAuctionNote = (() => {
-		if (truthAuctionStatus === undefined) return undefined
-		if (!truthAuctionStatus.finalized) return 'The order book below reflects live demand and provisional clearing. Final allocation locks once the auction is finalized.'
-		if (winningThresholdPrice !== undefined) return 'This auction finalized underfunded. Bids at or above the winning threshold share REP pro rata.'
-		if (truthAuctionStatus.hitCap) return 'This auction finalized at a clearing tick. Bids above the clearing tick fill first and the clearing tick fills FIFO.'
-		return 'This auction finalized without exhausting the configured cap.'
-	})()
-	const ethRaisedProgress = truthAuctionStatus === undefined ? 0 : clampPercentage(truthAuctionStatus.ethRaised, truthAuctionStatus.ethRaiseCap)
-	const repSoldProgress = truthAuctionStatus === undefined ? 0 : clampPercentage(truthAuctionStatus.totalRepPurchased, truthAuctionStatus.maxRepBeingSold)
 	const activeTickSummaries = sortTruthAuctionTickSummariesDescending(truthAuctionBookData.tickSummaries)
+	const truthAuctionOverviewProgress = getTruthAuctionOverviewProgress(truthAuctionStatus, activeTickSummaries)
+	const displayedEthRaised = truthAuctionOverviewProgress?.ethRaised ?? truthAuctionStatus?.ethRaised ?? 0n
+	const displayedRepSold = truthAuctionOverviewProgress?.repSold ?? truthAuctionStatus?.totalRepPurchased ?? 0n
+	const ethRaisedProgress = truthAuctionStatus === undefined ? 0 : clampPercentage(displayedEthRaised, truthAuctionStatus.ethRaiseCap)
+	const repSoldProgress = truthAuctionStatus === undefined ? 0 : clampPercentage(displayedRepSold, truthAuctionStatus.maxRepBeingSold)
 	const truthAuctionDepthPoints = buildTruthAuctionDepthPoints({
 		enteredBidTick,
 		selectedBookTick,
@@ -891,20 +938,17 @@ export function ForkAuctionSection({
 	const selectedLoadedDepthPoint = selectedBookTick === undefined ? undefined : truthAuctionDepthPoints.find(point => point.tick === selectedBookTick)
 	const selectedLoadedTickSummary = selectedBookTick === undefined ? undefined : activeTickSummaries.find(tickSummary => tickSummary.tick === selectedBookTick)
 	const resolvedSelectedTickSummary = selectedBookTick === undefined ? undefined : (selectedLoadedTickSummary ?? (selectedTickSummary?.tick === selectedBookTick ? selectedTickSummary : undefined))
-	const resolvedSelectedTickBids = selectedBookTick === undefined ? [] : selectedTickBids.filter(bid => bid.tick === selectedBookTick)
 	const previewTickSummary = enteredBidTick === undefined ? undefined : activeTickSummaries.find(tickSummary => tickSummary.tick === enteredBidTick)
 	const submitBidPreviewTickSummary = previewTickSummary ?? (enteredBidTick !== undefined && selectedLoadedTickSummary?.tick === enteredBidTick ? selectedLoadedTickSummary : undefined) ?? (enteredBidTick !== undefined && resolvedSelectedTickSummary?.tick === enteredBidTick ? resolvedSelectedTickSummary : undefined)
 	const maxTickEth = truthAuctionDepthPoints.reduce((maximumEth, point) => (point.currentTotalEth > maximumEth ? point.currentTotalEth : maximumEth), 0n)
 	const knownTruthAuctionBids = dedupeTruthAuctionBids([...truthAuctionBookData.viewerBids, ...selectedTickBids, ...aggregatedAuctionBids])
 	const hasMoreTickSummaries = BigInt(truthAuctionBookData.tickSummaries.length) < truthAuctionBookData.tickCount
 	const hasMoreViewerBids = BigInt(truthAuctionBookData.viewerBids.length) < truthAuctionBookData.viewerBidCount
-	const hasMoreSelectedTickBids = selectedTickSummary?.tick === selectedBookTick && BigInt(resolvedSelectedTickBids.length) < selectedTickBidCount
 	const hasMoreAggregatedAuctionBids = BigInt(aggregatedAuctionBids.length) < aggregatedAuctionBidCountForLoadedTicks
 	const selectTruthAuctionTick = (tick: bigint) => {
 		if (selectedBookTick === tick) return
 		setSelectedBookTick(tick)
 		setSelectedTickBids([])
-		setSelectedTickBidCount(0n)
 		setLoadingSelectedTickBids(true)
 		const matchingSummary = activeTickSummaries.find(tickSummary => tickSummary.tick === tick)
 		setSelectedTickSummary(matchingSummary)
@@ -935,7 +979,7 @@ export function ForkAuctionSection({
 			truthAuctionFallback
 		) : (
 			<Fragment>
-				<CurrencyValue value={truthAuctionStatus.ethRaised} suffix='ETH' /> / <CurrencyValue value={truthAuctionStatus.ethRaiseCap} suffix='ETH' />
+				<CurrencyValue value={displayedEthRaised} suffix='ETH' /> / <CurrencyValue value={truthAuctionStatus.ethRaiseCap} suffix='ETH' />
 			</Fragment>
 		)
 	const clearingPriceDisplay = truthAuctionStatus === undefined ? truthAuctionFallback : renderTruthAuctionPriceValue(truthAuctionStatus.clearingPrice)
@@ -1506,7 +1550,6 @@ export function ForkAuctionSection({
 			setSelectedTickBids([])
 			setSelectedBookTick(undefined)
 			setSelectedTickSummary(undefined)
-			setSelectedTickBidCount(0n)
 			setLoadingTruthAuctionBook(false)
 			setLoadingSelectedTickBids(false)
 			setAggregatedAuctionBids([])
@@ -1547,7 +1590,6 @@ export function ForkAuctionSection({
 				setSelectedTickBids([])
 				setSelectedBookTick(undefined)
 				setSelectedTickSummary(undefined)
-				setSelectedTickBidCount(0n)
 				setTruthAuctionBookError(getErrorMessage(error, 'Failed to load truth auction bidbook'))
 			})
 			.finally(() => {
@@ -1592,7 +1634,6 @@ export function ForkAuctionSection({
 		if (!shouldShowTruthAuctionVisualization || auctionTruthAuctionAddress === undefined || auctionTruthAuctionAddress === zeroAddress || selectedBookTick === undefined) {
 			setSelectedTickBids([])
 			setSelectedTickSummary(undefined)
-			setSelectedTickBidCount(0n)
 			setLoadingSelectedTickBids(false)
 			return
 		}
@@ -1605,13 +1646,11 @@ export function ForkAuctionSection({
 				if (cancelled) return
 				setSelectedTickSummary(tickSummary)
 				setSelectedTickBids(bidData.bids)
-				setSelectedTickBidCount(bidData.bidCount)
 			})
 			.catch(error => {
 				if (cancelled) return
 				setSelectedTickBids([])
 				setSelectedTickSummary(undefined)
-				setSelectedTickBidCount(0n)
 				setTruthAuctionBookError(getErrorMessage(error, 'Failed to load truth auction bids at the selected price level'))
 			})
 			.finally(() => {
@@ -1661,7 +1700,7 @@ export function ForkAuctionSection({
 		{ label: 'Started', value: startedDisplay },
 		{ label: 'Ends', value: endsDisplay },
 		{ label: 'ETH Raised / Cap', value: ethRaisedCapDisplay },
-		{ label: 'REP Purchased', value: truthAuctionStatus === undefined ? truthAuctionFallback : <CurrencyValue value={truthAuctionStatus.totalRepPurchased} suffix='REP' /> },
+		{ label: 'REP Purchased', value: truthAuctionStatus === undefined ? truthAuctionFallback : <CurrencyValue value={displayedRepSold} suffix='REP' /> },
 		{ label: 'Clearing Price', value: clearingPriceDisplay },
 		{ label: 'Min Bid Size', value: truthAuctionStatus === undefined ? truthAuctionFallback : <CurrencyValue value={truthAuctionStatus.minBidSize} suffix='ETH' /> },
 		{ label: 'Max REP Being Sold', value: truthAuctionStatus === undefined ? truthAuctionFallback : <CurrencyValue value={truthAuctionStatus.maxRepBeingSold} suffix='REP' /> },
@@ -1670,7 +1709,7 @@ export function ForkAuctionSection({
 		{ label: 'Auctioned Allowance', value: selectedAuctionContext === undefined ? truthAuctionFallback : <CurrencyValue value={selectedAuctionContext.auctionedSecurityBondAllowance} suffix='ETH' /> },
 		{ label: 'Settlement Available', value: settlementAvailableDisplay },
 		{ label: 'ETH Raised / Cap', value: ethRaisedCapDisplay },
-		{ label: 'REP Purchased', value: truthAuctionStatus === undefined ? truthAuctionFallback : <CurrencyValue value={truthAuctionStatus.totalRepPurchased} suffix='REP' /> },
+		{ label: 'REP Purchased', value: truthAuctionStatus === undefined ? truthAuctionFallback : <CurrencyValue value={displayedRepSold} suffix='REP' /> },
 	]
 	const auctionOutcomeSelector = (
 		<div className='form-grid'>
@@ -1690,14 +1729,14 @@ export function ForkAuctionSection({
 	const truthAuctionHero = (() => {
 		if (!shouldShowTruthAuctionVisualization || truthAuctionStatus === undefined) return undefined
 		return (
-			<SectionBlock badge={truthAuctionStateBadgeElement} title={selectedStage === 'settlement' ? 'Settlement Overview' : 'Auction Overview'} description={truthAuctionNote}>
+			<SectionBlock badge={truthAuctionStateBadgeElement} title={selectedStage === 'settlement' ? 'Settlement Overview' : 'Auction Overview'}>
 				<div className='truth-auction-hero'>
 					<div className='truth-auction-hero-primary'>
 						<div className='truth-auction-progress-group'>
 							<div className='truth-auction-progress-copy'>
 								<span>ETH Raised</span>
 								<strong>
-									<CurrencyValue value={truthAuctionStatus.ethRaised} suffix='ETH' /> / <CurrencyValue value={truthAuctionStatus.ethRaiseCap} suffix='ETH' />
+									<CurrencyValue value={displayedEthRaised} suffix='ETH' /> / <CurrencyValue value={truthAuctionStatus.ethRaiseCap} suffix='ETH' />
 								</strong>
 							</div>
 							<div className='truth-auction-progress-track'>
@@ -1708,7 +1747,7 @@ export function ForkAuctionSection({
 							<div className='truth-auction-progress-copy'>
 								<span>REP Sold</span>
 								<strong>
-									<CurrencyValue value={truthAuctionStatus.totalRepPurchased} suffix='REP' /> / <CurrencyValue value={truthAuctionStatus.maxRepBeingSold} suffix='REP' />
+									<CurrencyValue value={displayedRepSold} suffix='REP' /> / <CurrencyValue value={truthAuctionStatus.maxRepBeingSold} suffix='REP' />
 								</strong>
 							</div>
 							<div className='truth-auction-progress-track'>
@@ -1820,40 +1859,6 @@ export function ForkAuctionSection({
 										<MetricField label='Historical Bids'>{resolvedSelectedTickSummary.submissionCount.toString()}</MetricField>
 										<MetricField label='Status'>{selectedTickDisposition?.label ?? UNKNOWN_VALUE}</MetricField>
 									</div>
-									{loadingSelectedTickBids ? <p className='detail'>Loading bids at this price…</p> : undefined}
-									{!loadingSelectedTickBids && resolvedSelectedTickBids.length === 0 ? <p className='detail'>No bids are currently indexed for this price.</p> : undefined}
-									{resolvedSelectedTickBids.length === 0 ? undefined : (
-										<div className='truth-auction-bid-table'>
-											{resolvedSelectedTickBids.map(bid => {
-												const disposition = getBidDisposition(bid, truthAuctionStatus)
-												return (
-													<div className='truth-auction-bid-row' key={`${bid.tick.toString()}:${bid.bidIndex.toString()}`}>
-														<span className='truth-auction-bid-row-label'>{renderTruthAuctionPriceValue(getTruthAuctionPriceAtTick(bid.tick))}</span>
-														<div className='truth-auction-bid-row-address'>
-															<AddressValue address={bid.bidder} />
-														</div>
-														<span>
-															<CurrencyValue value={bid.ethAmount} suffix='ETH' />
-														</span>
-														<span>
-															<CurrencyValue value={bid.cumulativeEth} suffix='ETH' />
-														</span>
-														<span className='truth-auction-bid-row-status'>
-															<span className={`truth-auction-status-pill ${getTruthAuctionDispositionClassName(disposition.tone)}`}>{disposition.label}</span>
-														</span>
-														{renderBidActionButtons({ bid, disposition, showEmptyState: true })}
-													</div>
-												)
-											})}
-										</div>
-									)}
-									{hasMoreSelectedTickBids ? (
-										<div className='actions'>
-											<button className='secondary' onClick={() => setLoadedSelectedTickBidPageCount(currentPageCount => currentPageCount + 1)} type='button'>
-												Load More Bids At This Level
-											</button>
-										</div>
-									) : undefined}
 								</>
 							)}
 						</div>

--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -1743,15 +1743,7 @@ export function ForkAuctionSection({
 						</div>
 						{loadingTruthAuctionBook ? <p className='detail'>Loading order book…</p> : undefined}
 						{!loadingTruthAuctionBook && truthAuctionDepthPoints.length === 0 ? <p className='detail'>No live price levels are currently active for this auction.</p> : undefined}
-						{truthAuctionDepthPoints.length === 0 ? undefined : (
-							<TruthAuctionDepthChart
-								loadedTickCount={truthAuctionDepthPoints.length}
-								onSelectTick={selectTruthAuctionTick}
-								points={truthAuctionDepthPoints}
-								totalActiveTickCount={truthAuctionBookData.tickCount}
-								{...(truthAuctionStatus.hitCap && truthAuctionStatus.clearingTick !== undefined ? { clearingTick: truthAuctionStatus.clearingTick } : {})}
-							/>
-						)}
+						{truthAuctionDepthPoints.length === 0 ? undefined : <TruthAuctionDepthChart onSelectTick={selectTruthAuctionTick} points={truthAuctionDepthPoints} {...(truthAuctionStatus.hitCap && truthAuctionStatus.clearingTick !== undefined ? { clearingTick: truthAuctionStatus.clearingTick } : {})} />}
 					</div>
 					<div className='truth-auction-market-detail-grid'>
 						<div className='truth-auction-market-section'>
@@ -1832,14 +1824,6 @@ export function ForkAuctionSection({
 									{!loadingSelectedTickBids && resolvedSelectedTickBids.length === 0 ? <p className='detail'>No bids are currently indexed for this price.</p> : undefined}
 									{resolvedSelectedTickBids.length === 0 ? undefined : (
 										<div className='truth-auction-bid-table'>
-											<div className='truth-auction-bid-row is-header'>
-												<span>Price</span>
-												<span>Bidder</span>
-												<span>Amount</span>
-												<span>Cumulative</span>
-												<span>Status</span>
-												<span>Actions</span>
-											</div>
 											{resolvedSelectedTickBids.map(bid => {
 												const disposition = getBidDisposition(bid, truthAuctionStatus)
 												return (
@@ -1893,14 +1877,6 @@ export function ForkAuctionSection({
 				{!loadingAggregatedAuctionBids && truthAuctionBookData.tickSummaries.length > 0 && aggregatedAuctionBids.length === 0 ? <p className='detail'>No bids are currently indexed for the loaded prices.</p> : undefined}
 				{aggregatedAuctionBids.length === 0 ? undefined : (
 					<div className='truth-auction-bid-table'>
-						<div className='truth-auction-bid-row is-header is-wide'>
-							<span>Price</span>
-							<span>Bidder</span>
-							<span>Amount</span>
-							<span>Cumulative</span>
-							<span>Status</span>
-							<span>Actions</span>
-						</div>
 						{aggregatedAuctionBids.map(bid => {
 							const disposition = getBidDisposition(bid, truthAuctionStatus)
 							return (
@@ -1953,12 +1929,6 @@ export function ForkAuctionSection({
 				{accountState.address !== undefined && !loadingTruthAuctionBook && truthAuctionBookData.viewerBids.length === 0 ? <p className='detail'>No bids from this wallet are indexed for the current auction.</p> : undefined}
 				{truthAuctionBookData.viewerBids.length === 0 ? undefined : (
 					<div className='truth-auction-bid-table'>
-						<div className='truth-auction-bid-row is-header is-wallet'>
-							<span>Price</span>
-							<span>Amount</span>
-							<span>Status</span>
-							<span>Actions</span>
-						</div>
 						{truthAuctionBookData.viewerBids.map(bid => {
 							const disposition = getBidDisposition(bid, truthAuctionStatus)
 							return (
@@ -2144,12 +2114,10 @@ export function ForkAuctionSection({
 							{truthAuctionHero}
 							{truthAuctionMarketViewSection}
 							{auctionWideBidsSection}
-							<div className='truth-auction-stage-actions'>
-								{renderSubmitBidSection({
-									description: 'Enter a price and ETH amount.',
-								})}
-								{viewerTruthAuctionBidsSection}
-							</div>
+							{renderSubmitBidSection({
+								description: 'Enter a price and ETH amount.',
+							})}
+							{viewerTruthAuctionBidsSection}
 							{truthAuctionStatus.finalized ? undefined : (
 								<SectionBlock title='Finalize Truth Auction' description='Finalize once bidding has closed.'>
 									<div className='actions'>

--- a/ui/ts/components/SectionBlock.tsx
+++ b/ui/ts/components/SectionBlock.tsx
@@ -9,12 +9,10 @@ export function SectionBlock({ actions, badge, children, className = '', descrip
 			{title === undefined && badge === undefined && actions === undefined && description === undefined ? undefined : (
 				<div className='section-block-header'>
 					<div className='section-block-copy'>
-						<div className='section-block-title-row'>
-							{title === undefined ? undefined : <HeadingTag>{title}</HeadingTag>}
-							{badge === undefined ? undefined : <div className='section-block-badge'>{badge}</div>}
-						</div>
+						<div className='section-block-title-row'>{title === undefined ? undefined : <HeadingTag>{title}</HeadingTag>}</div>
 						{description === undefined ? undefined : <p className='detail'>{description}</p>}
 					</div>
+					{badge === undefined ? undefined : <div className='section-block-badge'>{badge}</div>}
 					{actions === undefined ? undefined : <div className='section-block-actions'>{actions}</div>}
 				</div>
 			)}

--- a/ui/ts/components/TruthAuctionDepthChart.tsx
+++ b/ui/ts/components/TruthAuctionDepthChart.tsx
@@ -1,5 +1,6 @@
 import { useRef } from 'preact/hooks'
 import { CurrencyValue } from './CurrencyValue.js'
+import { formatCurrencyInputBalance } from '../lib/formatters.js'
 
 type TruthAuctionDisposition = {
 	label: string
@@ -133,7 +134,7 @@ export function TruthAuctionDepthChart({ clearingTick, loadedTickCount, onSelect
 				<div className='truth-auction-depth-hit-targets'>
 					{points.map((point, index) => (
 						<button
-							aria-label={`Select tick ${point.tick.toString()} from depth chart`}
+							aria-label={`Select price ${formatCurrencyInputBalance(point.price)} ETH / REP from depth chart`}
 							aria-pressed={point.isSelected}
 							className='truth-auction-depth-hit-target'
 							key={point.tick.toString()}

--- a/ui/ts/components/TruthAuctionDepthChart.tsx
+++ b/ui/ts/components/TruthAuctionDepthChart.tsx
@@ -1,6 +1,6 @@
 import { useRef } from 'preact/hooks'
 import { CurrencyValue } from './CurrencyValue.js'
-import { formatCurrencyInputBalance } from '../lib/formatters.js'
+import { formatCurrencyInputBalance, formatRoundedCurrencyBalance } from '../lib/formatters.js'
 
 type TruthAuctionDisposition = {
 	label: string
@@ -35,7 +35,7 @@ const CHART_PADDING = {
 let nextDepthGradientId = 0
 
 function formatTruthAuctionPriceLabel(price: bigint) {
-	return `${formatCurrencyInputBalance(price)} ETH / REP`
+	return `${formatRoundedCurrencyBalance(price, 18, 4)} ETH / REP`
 }
 
 function getDepthRatio(value: bigint, maxDepth: bigint) {
@@ -111,6 +111,8 @@ export function TruthAuctionDepthChart({ clearingTick, onSelectTick, points }: T
 	if (points.length === 0) return null
 
 	const plotWidth = CHART_WIDTH - CHART_PADDING.left - CHART_PADDING.right
+	const plotHeight = CHART_HEIGHT - CHART_PADDING.top - CHART_PADDING.bottom
+	const baselineY = CHART_HEIGHT - CHART_PADDING.bottom
 	const gradientIdRef = useRef<string | undefined>(undefined)
 	if (gradientIdRef.current === undefined) {
 		gradientIdRef.current = `truth-auction-depth-fill-${nextDepthGradientId.toString()}`
@@ -123,21 +125,29 @@ export function TruthAuctionDepthChart({ clearingTick, onSelectTick, points }: T
 	const midpointPrice = midpointIndex === undefined ? undefined : points[midpointIndex]?.price
 	const maxLoadedDepth = points.reduce((currentMax, point) => (point.cumulativeEth > currentMax ? point.cumulativeEth : currentMax), 0n)
 	const midpointDepth = maxLoadedDepth >= 2n ? maxLoadedDepth / 2n : undefined
+	const getDepthYPosition = (value: bigint) => {
+		if (value <= 0n || maxLoadedDepth <= 0n) return baselineY
+		return baselineY - getDepthRatio(value, maxLoadedDepth) * plotHeight
+	}
 
 	return (
 		<>
 			<div className='truth-auction-depth-frame'>
 				<div className='truth-auction-depth-y-axis'>
 					<span className='truth-auction-depth-axis-title truth-auction-depth-axis-title-y'>Loaded Depth (ETH)</span>
-					<span className='truth-auction-depth-axis-tick is-max'>
-						<CurrencyValue copyable={false} value={maxLoadedDepth} suffix='ETH' />
-					</span>
-					{midpointDepth === undefined ? undefined : (
-						<span className='truth-auction-depth-axis-tick is-mid'>
-							<CurrencyValue copyable={false} value={midpointDepth} suffix='ETH' />
+					<div className='truth-auction-depth-y-ticks' aria-hidden='true'>
+						<span className='truth-auction-depth-axis-tick truth-auction-depth-y-tick is-max' style={{ top: `${(getDepthYPosition(maxLoadedDepth) / CHART_HEIGHT) * 100}%` }}>
+							<CurrencyValue copyable={false} value={maxLoadedDepth} suffix='ETH' />
 						</span>
-					)}
-					<span className='truth-auction-depth-axis-tick is-min'>0 ETH</span>
+						{midpointDepth === undefined ? undefined : (
+							<span className='truth-auction-depth-axis-tick truth-auction-depth-y-tick is-mid' style={{ top: `${(getDepthYPosition(midpointDepth) / CHART_HEIGHT) * 100}%` }}>
+								<CurrencyValue copyable={false} value={midpointDepth} suffix='ETH' />
+							</span>
+						)}
+						<span className='truth-auction-depth-axis-tick truth-auction-depth-y-tick is-min' style={{ top: `${(getDepthYPosition(0n) / CHART_HEIGHT) * 100}%` }}>
+							0 ETH
+						</span>
+					</div>
 				</div>
 				<div className='truth-auction-depth-chart' role='group' aria-label='Truth auction visible depth chart'>
 					<svg aria-hidden='true' viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`} preserveAspectRatio='none'>
@@ -174,9 +184,9 @@ export function TruthAuctionDepthChart({ clearingTick, onSelectTick, points }: T
 				</div>
 			</div>
 			<div className={`truth-auction-depth-x-axis${midpointPrice === undefined ? ' no-midpoint' : ''}`}>
-				{highestLoadedPrice === undefined ? undefined : <span className='truth-auction-depth-axis-tick is-max'>{formatTruthAuctionPriceLabel(highestLoadedPrice)}</span>}
-				{midpointPrice === undefined ? undefined : <span className='truth-auction-depth-axis-tick is-mid'>{formatTruthAuctionPriceLabel(midpointPrice)}</span>}
-				{lowestLoadedPrice === undefined ? undefined : <span className='truth-auction-depth-axis-tick is-min'>{formatTruthAuctionPriceLabel(lowestLoadedPrice)}</span>}
+				{highestLoadedPrice === undefined ? undefined : <span className='truth-auction-depth-axis-tick truth-auction-depth-x-tick is-max'>{formatTruthAuctionPriceLabel(highestLoadedPrice)}</span>}
+				{midpointPrice === undefined ? undefined : <span className='truth-auction-depth-axis-tick truth-auction-depth-x-tick is-mid'>{formatTruthAuctionPriceLabel(midpointPrice)}</span>}
+				{lowestLoadedPrice === undefined ? undefined : <span className='truth-auction-depth-axis-tick truth-auction-depth-x-tick is-min'>{formatTruthAuctionPriceLabel(lowestLoadedPrice)}</span>}
 			</div>
 			<div className='truth-auction-depth-axis-title truth-auction-depth-axis-title-x'>Price (ETH / REP)</div>
 		</>

--- a/ui/ts/components/TruthAuctionDepthChart.tsx
+++ b/ui/ts/components/TruthAuctionDepthChart.tsx
@@ -19,10 +19,8 @@ export type TruthAuctionDepthPoint = {
 
 type TruthAuctionDepthChartProps = {
 	clearingTick?: bigint
-	loadedTickCount: number
 	onSelectTick: (tick: bigint) => void
 	points: TruthAuctionDepthPoint[]
-	totalActiveTickCount: bigint
 }
 
 const CHART_WIDTH = 560
@@ -35,6 +33,10 @@ const CHART_PADDING = {
 	top: 10,
 }
 let nextDepthGradientId = 0
+
+function formatTruthAuctionPriceLabel(price: bigint) {
+	return `${formatCurrencyInputBalance(price)} ETH / REP`
+}
 
 function getDepthRatio(value: bigint, maxDepth: bigint) {
 	if (value <= 0n || maxDepth <= 0n) return 0
@@ -105,69 +107,78 @@ function buildDepthLinePath(points: TruthAuctionDepthPoint[]) {
 	return path
 }
 
-export function TruthAuctionDepthChart({ clearingTick, loadedTickCount, onSelectTick, points, totalActiveTickCount }: TruthAuctionDepthChartProps) {
+export function TruthAuctionDepthChart({ clearingTick, onSelectTick, points }: TruthAuctionDepthChartProps) {
 	if (points.length === 0) return null
 
 	const plotWidth = CHART_WIDTH - CHART_PADDING.left - CHART_PADDING.right
-	const visibleCoverageText = `Showing ${loadedTickCount.toString()} of ${totalActiveTickCount.toString()} active price levels`
 	const gradientIdRef = useRef<string | undefined>(undefined)
 	if (gradientIdRef.current === undefined) {
 		gradientIdRef.current = `truth-auction-depth-fill-${nextDepthGradientId.toString()}`
 		nextDepthGradientId += 1
 	}
 	const gradientId = gradientIdRef.current
+	const highestLoadedPrice = points[0]?.price
+	const lowestLoadedPrice = points[points.length - 1]?.price
+	const midpointIndex = points.length >= 3 ? Math.floor(points.length / 2) : undefined
+	const midpointPrice = midpointIndex === undefined ? undefined : points[midpointIndex]?.price
+	const maxLoadedDepth = points.reduce((currentMax, point) => (point.cumulativeEth > currentMax ? point.cumulativeEth : currentMax), 0n)
+	const midpointDepth = maxLoadedDepth >= 2n ? maxLoadedDepth / 2n : undefined
 
 	return (
 		<>
-			<div className='truth-auction-depth-chart' role='group' aria-label='Truth auction visible depth chart'>
-				<svg aria-hidden='true' viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`} preserveAspectRatio='none'>
-					<defs>
-						<linearGradient id={gradientId} x1='0%' x2='100%' y1='0%' y2='0%'>
-							<stop offset='0%' stop-color='#e8a644' stop-opacity='0.28' />
-							<stop offset='100%' stop-color='#3e9f78' stop-opacity='0.28' />
-						</linearGradient>
-					</defs>
-					<rect className='truth-auction-depth-base' height={CHART_HEIGHT - CHART_PADDING.top - CHART_PADDING.bottom} rx='14' ry='14' width={plotWidth} x={CHART_PADDING.left} y={CHART_PADDING.top} />
-					<path className='truth-auction-depth-area' d={buildDepthAreaPath(points)} fill={`url(#${gradientId})`} />
-					<path className='truth-auction-depth-line' d={buildDepthLinePath(points)} />
-				</svg>
-				<div className='truth-auction-depth-hit-targets'>
-					{points.map((point, index) => (
-						<button
-							aria-label={`Select price ${formatCurrencyInputBalance(point.price)} ETH / REP from depth chart`}
-							aria-pressed={point.isSelected}
-							className='truth-auction-depth-hit-target'
-							key={point.tick.toString()}
-							onClick={() => onSelectTick(point.tick)}
-							style={{
-								left: `${(index / points.length) * 100}%`,
-								width: `${100 / points.length}%`,
-							}}
-							type='button'
-						>
-							<span className={getMarkerClassName(point, clearingTick)}>
-								<span className='truth-auction-depth-marker-dot' />
-							</span>
-						</button>
-					))}
-				</div>
-			</div>
-			<div className='truth-auction-depth-legend'>
-				<div className='truth-auction-depth-legend-copy'>
-					<strong>Visible depth from loaded price levels</strong>
-					<span>{visibleCoverageText}</span>
-				</div>
-				{points[0] === undefined ? undefined : (
-					<div className='truth-auction-depth-legend-range'>
-						<span>
-							Highest loaded price <CurrencyValue value={points[0].price} suffix='ETH / REP' />
+			<div className='truth-auction-depth-frame'>
+				<div className='truth-auction-depth-y-axis'>
+					<span className='truth-auction-depth-axis-title truth-auction-depth-axis-title-y'>Loaded Depth (ETH)</span>
+					<span className='truth-auction-depth-axis-tick is-max'>
+						<CurrencyValue copyable={false} value={maxLoadedDepth} suffix='ETH' />
+					</span>
+					{midpointDepth === undefined ? undefined : (
+						<span className='truth-auction-depth-axis-tick is-mid'>
+							<CurrencyValue copyable={false} value={midpointDepth} suffix='ETH' />
 						</span>
-						<span>
-							Loaded depth <CurrencyValue value={points[points.length - 1]?.cumulativeEth} suffix='ETH' />
-						</span>
+					)}
+					<span className='truth-auction-depth-axis-tick is-min'>0 ETH</span>
+				</div>
+				<div className='truth-auction-depth-chart' role='group' aria-label='Truth auction visible depth chart'>
+					<svg aria-hidden='true' viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`} preserveAspectRatio='none'>
+						<defs>
+							<linearGradient id={gradientId} x1='0%' x2='100%' y1='0%' y2='0%'>
+								<stop offset='0%' stop-color='#e8a644' stop-opacity='0.28' />
+								<stop offset='100%' stop-color='#3e9f78' stop-opacity='0.28' />
+							</linearGradient>
+						</defs>
+						<rect className='truth-auction-depth-base' height={CHART_HEIGHT - CHART_PADDING.top - CHART_PADDING.bottom} rx='14' ry='14' width={plotWidth} x={CHART_PADDING.left} y={CHART_PADDING.top} />
+						<path className='truth-auction-depth-area' d={buildDepthAreaPath(points)} fill={`url(#${gradientId})`} />
+						<path className='truth-auction-depth-line' d={buildDepthLinePath(points)} />
+					</svg>
+					<div className='truth-auction-depth-hit-targets'>
+						{points.map((point, index) => (
+							<button
+								aria-label={`Select price ${formatCurrencyInputBalance(point.price)} ETH / REP from depth chart`}
+								aria-pressed={point.isSelected}
+								className='truth-auction-depth-hit-target'
+								key={point.tick.toString()}
+								onClick={() => onSelectTick(point.tick)}
+								style={{
+									left: `${(index / points.length) * 100}%`,
+									width: `${100 / points.length}%`,
+								}}
+								type='button'
+							>
+								<span className={getMarkerClassName(point, clearingTick)}>
+									<span className='truth-auction-depth-marker-dot' />
+								</span>
+							</button>
+						))}
 					</div>
-				)}
+				</div>
 			</div>
+			<div className={`truth-auction-depth-x-axis${midpointPrice === undefined ? ' no-midpoint' : ''}`}>
+				{highestLoadedPrice === undefined ? undefined : <span className='truth-auction-depth-axis-tick is-max'>{formatTruthAuctionPriceLabel(highestLoadedPrice)}</span>}
+				{midpointPrice === undefined ? undefined : <span className='truth-auction-depth-axis-tick is-mid'>{formatTruthAuctionPriceLabel(midpointPrice)}</span>}
+				{lowestLoadedPrice === undefined ? undefined : <span className='truth-auction-depth-axis-tick is-min'>{formatTruthAuctionPriceLabel(lowestLoadedPrice)}</span>}
+			</div>
+			<div className='truth-auction-depth-axis-title truth-auction-depth-axis-title-x'>Price (ETH / REP)</div>
 		</>
 	)
 }

--- a/ui/ts/tests/forkAuctionSection.test.tsx
+++ b/ui/ts/tests/forkAuctionSection.test.tsx
@@ -2519,14 +2519,18 @@ describe('ForkAuctionSection', () => {
 			expect(documentQueries.getByRole('heading', { name: 'My Bids' })).not.toBeNull()
 		})
 		expect(documentQueries.getByRole('heading', { name: 'Market View' })).not.toBeNull()
-		expect(document.body.textContent?.includes('Showing 2 of 2 active price levels')).toBe(true)
-		expect(document.body.textContent?.includes('Loaded depth')).toBe(true)
+		expect(document.body.textContent?.includes('Visible depth from loaded price levels')).toBe(false)
+		expect(document.body.textContent?.includes('Showing 2 of 2 active price levels')).toBe(false)
+		expect(document.body.textContent?.includes('Highest loaded price')).toBe(false)
+		expect(documentQueries.getByText('Loaded Depth (ETH)')).not.toBeNull()
+		expect(documentQueries.getByText('Price (ETH / REP)')).not.toBeNull()
 		expect(document.body.textContent?.includes('Winning')).toBe(true)
 		fireEvent.click(documentQueries.getByRole('button', { name: 'Select price 3 ETH / REP from depth chart' }))
 		await waitFor(() => {
 			expect(document.body.textContent?.includes('Selected Price')).toBe(true)
 		})
 		expect(documentQueries.getByText('Selected Price')).not.toBeNull()
+		expect(document.body.querySelector('.truth-auction-bid-row.is-header')).toBeNull()
 		expect(document.body.textContent?.includes('2 submissions')).toBe(true)
 	})
 
@@ -2922,7 +2926,7 @@ describe('ForkAuctionSection', () => {
 		const selectedLevel = document.body.querySelector('.truth-auction-level-detail')
 		if (!(selectedLevel instanceof HTMLElement)) throw new Error('Expected selected price-level detail to render')
 
-		const bidRows = Array.from(selectedLevel.querySelectorAll('.truth-auction-bid-row')).slice(1)
+		const bidRows = Array.from(selectedLevel.querySelectorAll('.truth-auction-bid-row'))
 		const viewerRow = bidRows.find(row => row.textContent?.includes(zeroAddress) === true)
 		const otherWalletRow = bidRows.find(row => row.textContent?.includes('0x0000000000000000000000000000000000000001') === true)
 		if (!(viewerRow instanceof HTMLElement)) throw new Error('Expected selected price-level viewer row to render')
@@ -3110,12 +3114,13 @@ describe('ForkAuctionSection', () => {
 		expect(document.body.textContent?.includes('Current form price')).toBe(true)
 		expect(documentQueries.getByRole('button', { name: 'Use This Price' })).not.toBeNull()
 		expect(documentQueries.getByText('Bid Price (ETH / REP)')).not.toBeNull()
-		expect(documentQueries.getByText(`${formatCurrencyInputBalance(getTruthAuctionPriceAtTick(1n))} ETH / REP`)).not.toBeNull()
-		expect(documentQueries.getByText(`${formatCurrencyInputBalance(getTruthAuctionPriceAtTick(2n))} ETH / REP`)).not.toBeNull()
+		expect(documentQueries.getAllByText(`${formatCurrencyInputBalance(getTruthAuctionPriceAtTick(1n))} ETH / REP`).length).toBeGreaterThan(0)
+		expect(documentQueries.getAllByText(`${formatCurrencyInputBalance(getTruthAuctionPriceAtTick(2n))} ETH / REP`).length).toBeGreaterThan(0)
 		expect(documentQueries.queryByText('Bid Tick')).toBeNull()
 		expect(document.body.querySelector('.truth-auction-depth-marker.is-preview')).not.toBeNull()
 		expect(document.body.querySelector('.truth-auction-market-section')).not.toBeNull()
 		expect(document.body.querySelector('.truth-auction-market-detail-grid')).not.toBeNull()
+		expect(document.body.querySelector('.truth-auction-stage-actions')).toBeNull()
 		expect(document.body.querySelector('.truth-auction-market-board .truth-auction-panel')).toBeNull()
 	})
 
@@ -3260,11 +3265,11 @@ describe('ForkAuctionSection', () => {
 
 		const documentQueries = within(document.body)
 		await waitFor(() => {
-			expect(document.body.textContent?.includes('Showing 25 of 26 active price levels')).toBe(true)
+			expect(document.body.querySelectorAll('.truth-auction-ladder-row').length).toBe(25)
 		})
 		fireEvent.click(documentQueries.getByRole('button', { name: 'Load More Price Levels' }))
 		await waitFor(() => {
-			expect(document.body.textContent?.includes('Showing 26 of 26 active price levels')).toBe(true)
+			expect(document.body.querySelectorAll('.truth-auction-ladder-row').length).toBe(26)
 		})
 	})
 

--- a/ui/ts/tests/forkAuctionSection.test.tsx
+++ b/ui/ts/tests/forkAuctionSection.test.tsx
@@ -29,27 +29,6 @@ function createReadContractStub(handler: TruthAuctionReadContractHandler): ReadC
 	return async request => (await handler(request as TruthAuctionReadContractRequest)) as never
 }
 
-function createDeferred<T>() {
-	let resolve: ((value: T | PromiseLike<T>) => void) | undefined
-	let reject: ((reason?: unknown) => void) | undefined
-	const promise = new Promise<T>((innerResolve, innerReject) => {
-		resolve = innerResolve
-		reject = innerReject
-	})
-
-	return {
-		promise,
-		reject: (reason?: unknown) => {
-			if (reject === undefined) throw new Error('Deferred promise reject handler was not initialized')
-			reject(reason)
-		},
-		resolve: (value: T | PromiseLike<T>) => {
-			if (resolve === undefined) throw new Error('Deferred promise resolve handler was not initialized')
-			resolve(value)
-		},
-	}
-}
-
 function createAccountState(overrides: Partial<AccountState> = {}): AccountState {
 	return {
 		address: zeroAddress,
@@ -2528,24 +2507,25 @@ describe('ForkAuctionSection', () => {
 		const auctionOverviewSection = documentQueries.getByRole('heading', { name: 'Auction Overview' }).closest('section')
 		if (!(auctionOverviewSection instanceof HTMLElement)) throw new Error('Expected auction overview section to render')
 		expect(within(auctionOverviewSection).queryByText('The order book below reflects live demand and provisional clearing. Final allocation locks once the auction is finalized.')).toBeNull()
+		const overviewHeader = auctionOverviewSection.querySelector('.section-block-header')
+		const overviewBadge = auctionOverviewSection.querySelector('.section-block-badge .badge')
+		if (!(overviewHeader instanceof HTMLElement) || !(overviewBadge instanceof HTMLElement)) throw new Error('Expected auction overview header and badge to render')
+		expect(overviewHeader.lastElementChild === overviewBadge.parentElement).toBe(true)
 		expect(auctionOverviewSection.textContent?.includes('ETH Raised')).toBe(true)
 		expect(auctionOverviewSection.textContent?.includes('≈ 9.00 ETH / ≈ 100.00 ETH')).toBe(true)
 		expect(auctionOverviewSection.textContent?.includes('REP Sold')).toBe(true)
 		expect(auctionOverviewSection.textContent?.includes('≈ 0.00 REP / ≈ 100.00 REP')).toBe(false)
 		expect(document.body.textContent?.includes('Winning')).toBe(true)
 		fireEvent.click(documentQueries.getByRole('button', { name: 'Select price 3 ETH / REP from depth chart' }))
-		await waitFor(() => {
-			expect(document.body.textContent?.includes('Selected Price')).toBe(true)
-		})
-		expect(documentQueries.getByText('Selected Price')).not.toBeNull()
+		expect(documentQueries.queryByText('Selected Price')).toBeNull()
 		expect(document.body.querySelector('.truth-auction-bid-row.is-header')).toBeNull()
 		expect(document.body.querySelector('.truth-auction-level-detail .truth-auction-bid-row')).toBeNull()
 		expect(document.body.textContent?.includes('2 submissions')).toBe(true)
+		expect(document.body.textContent?.includes('3.0000 ETH / REP')).toBe(true)
+		expect(document.body.textContent?.includes('2.0000 ETH / REP')).toBe(true)
 	})
 
-	test('clears stale selected price-level details while a historical wallet tick is loading', async () => {
-		const historicalTickSummaryLoad = createDeferred<TruthAuctionTickSummary>()
-		const historicalTickBidLoad = createDeferred<TruthAuctionBidView[]>()
+	test('keeps the market view on the ladder and chart without rendering a selected price panel', async () => {
 		const activeTickSummary = createTruthAuctionTickSummary({
 			tick: 12n,
 			price: 3n * ETH,
@@ -2556,15 +2536,6 @@ describe('ForkAuctionSection', () => {
 		const truthAuctionReadClient = createTruthAuctionReadClient(async request => {
 			if (request.functionName === 'activeTickCount') return 1n
 			if (request.functionName === 'getActiveTickPage') return [activeTickSummary]
-			if (request.functionName === 'getTickSummary') {
-				if ((request.args?.[0] ?? 0n) === 9n) return await historicalTickSummaryLoad.promise
-				return activeTickSummary
-			}
-			if (request.functionName === 'getBidCountAtTick') return 1n
-			if (request.functionName === 'getBidPageAtTick') {
-				if ((request.args?.[0] ?? 0n) === 9n) return await historicalTickBidLoad.promise
-				return [createTruthAuctionBidView({ tick: 12n, bidIndex: 0n, ethAmount: 4n * ETH, cumulativeEth: 4n * ETH })]
-			}
 			if (request.functionName === 'getBidderBidCount') return 2n
 			if (request.functionName === 'getBidderBidPage') {
 				return [createTruthAuctionBidView({ tick: 12n, bidIndex: 0n, ethAmount: 4n * ETH, cumulativeEth: 4n * ETH }), createTruthAuctionBidView({ tick: 9n, bidIndex: 1n, ethAmount: 2n * ETH, cumulativeEth: 2n * ETH })]
@@ -2594,7 +2565,7 @@ describe('ForkAuctionSection', () => {
 
 		const documentQueries = within(document.body)
 		await waitFor(() => {
-			expect(document.body.textContent?.includes('Selected Price')).toBe(true)
+			expect(documentQueries.getByRole('button', { name: 'Select price 3 ETH / REP from depth chart' })).not.toBeNull()
 		})
 
 		fireEvent.click(
@@ -2604,24 +2575,8 @@ describe('ForkAuctionSection', () => {
 				})(),
 		)
 
-		await waitFor(() => {
-			expect(document.body.textContent?.includes('Loading selected price…')).toBe(true)
-		})
-
-		historicalTickSummaryLoad.resolve(
-			createTruthAuctionTickSummary({
-				tick: 9n,
-				price: 2n * ETH,
-				currentTotalEth: 0n,
-				submissionCount: 1n,
-				active: false,
-			}),
-		)
-		historicalTickBidLoad.resolve([createTruthAuctionBidView({ tick: 9n, bidIndex: 1n, ethAmount: 2n * ETH, cumulativeEth: 2n * ETH })])
-
-		await waitFor(() => {
-			expect(document.body.textContent?.includes('Loading selected price…')).toBe(false)
-		})
+		expect(documentQueries.queryByText('Selected Price')).toBeNull()
+		expect(document.body.textContent?.includes('Loading selected price…')).toBe(false)
 	})
 
 	test('reloads the paged bidbook after a successful fork-auction action result changes', async () => {
@@ -2877,15 +2832,10 @@ describe('ForkAuctionSection', () => {
 		})
 	})
 
-	test('keeps selected price-level detail summary-only without settlement shortcut rows', async () => {
+	test('does not render a selected price detail panel after choosing a ladder price', async () => {
 		const truthAuctionReadClient = createTruthAuctionReadClient(async request => {
 			if (request.functionName === 'activeTickCount') return 1n
 			if (request.functionName === 'getActiveTickPage') return [createTruthAuctionTickSummary({ tick: 10n, price: 2n * ETH, currentTotalEth: 5n * ETH, submissionCount: 2n, active: true })]
-			if (request.functionName === 'getTickSummary') return createTruthAuctionTickSummary({ tick: 10n, price: 2n * ETH, currentTotalEth: 5n * ETH, submissionCount: 2n, active: true })
-			if (request.functionName === 'getBidCountAtTick') return 2n
-			if (request.functionName === 'getBidPageAtTick') {
-				return [createTruthAuctionBidView({ tick: 10n, bidIndex: 0n, ethAmount: 2n * ETH, cumulativeEth: 2n * ETH }), createTruthAuctionBidView({ tick: 10n, bidIndex: 1n, bidder: '0x0000000000000000000000000000000000000001', ethAmount: 3n * ETH, cumulativeEth: 5n * ETH, activeCumulativeEthBeforeBid: 2n * ETH })]
-			}
 			if (request.functionName === 'getBidderBidCount') return 1n
 			if (request.functionName === 'getBidderBidPage') return [createTruthAuctionBidView({ tick: 10n, bidIndex: 0n, ethAmount: 2n * ETH, cumulativeEth: 2n * ETH })]
 			throw new Error(`Unexpected truth auction read: ${String(request.functionName)}`)
@@ -2924,14 +2874,8 @@ describe('ForkAuctionSection', () => {
 			fireEvent.click(documentQueries.getByRole('button', { name: 'Select price 2 ETH / REP from depth chart' }))
 		})
 
-		await waitFor(() => {
-			expect(document.body.textContent?.includes('Selected Price')).toBe(true)
-		})
-
-		const selectedLevel = document.body.querySelector('.truth-auction-level-detail')
-		if (!(selectedLevel instanceof HTMLElement)) throw new Error('Expected selected price-level detail to render')
-		expect(selectedLevel.querySelector('.truth-auction-bid-row')).toBeNull()
-		expect(within(selectedLevel).queryByRole('button', { name: 'Settle' })).toBeNull()
+		expect(documentQueries.queryByText('Selected Price')).toBeNull()
+		expect(document.body.querySelector('.truth-auction-level-detail')).toBeNull()
 	})
 
 	test('summarizes wallet bids from semantic bid outcomes instead of presentation labels', async () => {
@@ -3110,10 +3054,9 @@ describe('ForkAuctionSection', () => {
 		expectElementBefore(myBidsHeading, finalizeHeading)
 		expect(documentQueries.getByText(/Selected ladder price:/)).not.toBeNull()
 		expect(document.body.textContent?.includes('Current form price')).toBe(true)
-		expect(documentQueries.getByRole('button', { name: 'Use This Price' })).not.toBeNull()
 		expect(documentQueries.getByText('Bid Price (ETH / REP)')).not.toBeNull()
-		expect(documentQueries.getAllByText(`${formatCurrencyInputBalance(getTruthAuctionPriceAtTick(1n))} ETH / REP`).length).toBeGreaterThan(0)
-		expect(documentQueries.getAllByText(`${formatCurrencyInputBalance(getTruthAuctionPriceAtTick(2n))} ETH / REP`).length).toBeGreaterThan(0)
+		expect(documentQueries.getAllByText('1.0001 ETH / REP').length).toBeGreaterThan(0)
+		expect(documentQueries.getAllByText('1.0002 ETH / REP').length).toBeGreaterThan(0)
 		expect(documentQueries.queryByText('Bid Tick')).toBeNull()
 		expect(document.body.querySelector('.truth-auction-depth-marker.is-preview')).not.toBeNull()
 		expect(document.body.querySelector('.truth-auction-market-section')).not.toBeNull()

--- a/ui/ts/tests/forkAuctionSection.test.tsx
+++ b/ui/ts/tests/forkAuctionSection.test.tsx
@@ -1590,6 +1590,7 @@ describe('ForkAuctionSection', () => {
 		if (!(auctionOverviewSection instanceof HTMLElement)) throw new Error('Expected auction overview section to render')
 		expect(getMetricValue(auctionOverviewSection, 'Time Left')).toBe('0m')
 		expect(within(auctionOverviewSection).getByText('Unfilled')).not.toBeNull()
+		expect(within(auctionOverviewSection).queryByText('The order book below reflects live demand and provisional clearing. Final allocation locks once the auction is finalized.')).toBeNull()
 		expect(within(auctionOverviewSection).queryByText('Finalized')).toBeNull()
 		expect(within(auctionOverviewSection).queryByText('Underfunded')).toBeNull()
 		expectTransactionButtonDisabled(document.body, 'Submit Bid', 'Truth auction is already finalized.')
@@ -2524,6 +2525,13 @@ describe('ForkAuctionSection', () => {
 		expect(document.body.textContent?.includes('Highest loaded price')).toBe(false)
 		expect(documentQueries.getByText('Loaded Depth (ETH)')).not.toBeNull()
 		expect(documentQueries.getByText('Price (ETH / REP)')).not.toBeNull()
+		const auctionOverviewSection = documentQueries.getByRole('heading', { name: 'Auction Overview' }).closest('section')
+		if (!(auctionOverviewSection instanceof HTMLElement)) throw new Error('Expected auction overview section to render')
+		expect(within(auctionOverviewSection).queryByText('The order book below reflects live demand and provisional clearing. Final allocation locks once the auction is finalized.')).toBeNull()
+		expect(auctionOverviewSection.textContent?.includes('ETH Raised')).toBe(true)
+		expect(auctionOverviewSection.textContent?.includes('≈ 9.00 ETH / ≈ 100.00 ETH')).toBe(true)
+		expect(auctionOverviewSection.textContent?.includes('REP Sold')).toBe(true)
+		expect(auctionOverviewSection.textContent?.includes('≈ 0.00 REP / ≈ 100.00 REP')).toBe(false)
 		expect(document.body.textContent?.includes('Winning')).toBe(true)
 		fireEvent.click(documentQueries.getByRole('button', { name: 'Select price 3 ETH / REP from depth chart' }))
 		await waitFor(() => {
@@ -2531,6 +2539,7 @@ describe('ForkAuctionSection', () => {
 		})
 		expect(documentQueries.getByText('Selected Price')).not.toBeNull()
 		expect(document.body.querySelector('.truth-auction-bid-row.is-header')).toBeNull()
+		expect(document.body.querySelector('.truth-auction-level-detail .truth-auction-bid-row')).toBeNull()
 		expect(document.body.textContent?.includes('2 submissions')).toBe(true)
 	})
 
@@ -2868,7 +2877,7 @@ describe('ForkAuctionSection', () => {
 		})
 	})
 
-	test('hides selected price-level settlement shortcuts for bids owned by other wallets', async () => {
+	test('keeps selected price-level detail summary-only without settlement shortcut rows', async () => {
 		const truthAuctionReadClient = createTruthAuctionReadClient(async request => {
 			if (request.functionName === 'activeTickCount') return 1n
 			if (request.functionName === 'getActiveTickPage') return [createTruthAuctionTickSummary({ tick: 10n, price: 2n * ETH, currentTotalEth: 5n * ETH, submissionCount: 2n, active: true })]
@@ -2919,21 +2928,10 @@ describe('ForkAuctionSection', () => {
 			expect(document.body.textContent?.includes('Selected Price')).toBe(true)
 		})
 
-		await waitFor(() => {
-			expect(document.body.textContent?.includes('0x0000000000000000000000000000000000000001')).toBe(true)
-		})
-
 		const selectedLevel = document.body.querySelector('.truth-auction-level-detail')
 		if (!(selectedLevel instanceof HTMLElement)) throw new Error('Expected selected price-level detail to render')
-
-		const bidRows = Array.from(selectedLevel.querySelectorAll('.truth-auction-bid-row'))
-		const viewerRow = bidRows.find(row => row.textContent?.includes(zeroAddress) === true)
-		const otherWalletRow = bidRows.find(row => row.textContent?.includes('0x0000000000000000000000000000000000000001') === true)
-		if (!(viewerRow instanceof HTMLElement)) throw new Error('Expected selected price-level viewer row to render')
-		if (!(otherWalletRow instanceof HTMLElement)) throw new Error('Expected selected price-level non-viewer row to render')
-
-		expect(within(viewerRow).getAllByRole('button', { name: 'Settle' }).length).toBe(1)
-		expect(within(otherWalletRow).queryByRole('button', { name: 'Settle' })).toBeNull()
+		expect(selectedLevel.querySelector('.truth-auction-bid-row')).toBeNull()
+		expect(within(selectedLevel).queryByRole('button', { name: 'Settle' })).toBeNull()
 	})
 
 	test('summarizes wallet bids from semantic bid outcomes instead of presentation labels', async () => {

--- a/ui/ts/tests/forkAuctionSection.test.tsx
+++ b/ui/ts/tests/forkAuctionSection.test.tsx
@@ -2054,6 +2054,16 @@ describe('ForkAuctionSection', () => {
 	})
 
 	test('gates settlement actions against lifecycle conditions that would otherwise revert onchain', async () => {
+		const truthAuctionReadClient = createTruthAuctionReadClient(async request => {
+			if (request.functionName === 'activeTickCount') return 1n
+			if (request.functionName === 'getActiveTickPage') return [createTruthAuctionTickSummary({ tick: 10n, price: 2n * ETH, currentTotalEth: 5n * ETH, submissionCount: 2n, active: true })]
+			if (request.functionName === 'getTickSummary') return createTruthAuctionTickSummary({ tick: 10n, price: 2n * ETH, currentTotalEth: 5n * ETH, submissionCount: 2n, active: true })
+			if (request.functionName === 'getBidCountAtTick') return 2n
+			if (request.functionName === 'getBidPageAtTick') return [createTruthAuctionBidView({ tick: 10n, bidIndex: 0n, ethAmount: 2n * ETH, cumulativeEth: 2n * ETH }), createTruthAuctionBidView({ tick: 9n, bidIndex: 1n, ethAmount: 1n * ETH, cumulativeEth: 1n * ETH })]
+			if (request.functionName === 'getBidderBidCount') return 2n
+			if (request.functionName === 'getBidderBidPage') return [createTruthAuctionBidView({ tick: 10n, bidIndex: 0n, ethAmount: 2n * ETH, cumulativeEth: 2n * ETH }), createTruthAuctionBidView({ tick: 9n, bidIndex: 1n, ethAmount: 1n * ETH, cumulativeEth: 1n * ETH })]
+			throw new Error(`Unexpected truth auction read: ${String(request.functionName)}`)
+		})
 		const baseDetails = {
 			...createForkAuctionDetails(),
 			systemState: 'forkTruthAuction',
@@ -2087,13 +2097,16 @@ describe('ForkAuctionSection', () => {
 				}),
 			],
 			stageView: 'settlement',
+			truthAuctionReadClient,
 		})
 		const renderedComponent = await renderIntoDocument(h(ForkAuctionSection, baseProps))
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
 		expect(documentQueries.queryByRole('button', { name: 'Finalize Truth Auction' })).toBeNull()
-		expectTransactionButtonEnabled(document.body, 'Refund Losing Bid')
+		await waitFor(() => {
+			expectTransactionButtonEnabled(document.body, 'Refund Losing Bid')
+		})
 		expect(documentQueries.queryByRole('button', { name: 'Settle Finalized Bid' })).toBeNull()
 
 		await act(() => {
@@ -2141,6 +2154,16 @@ describe('ForkAuctionSection', () => {
 	})
 
 	test('disables finalized settlement until the settlement inputs are complete', async () => {
+		const truthAuctionReadClient = createTruthAuctionReadClient(async request => {
+			if (request.functionName === 'activeTickCount') return 1n
+			if (request.functionName === 'getActiveTickPage') return [createTruthAuctionTickSummary({ tick: 10n, price: 2n * ETH, currentTotalEth: 5n * ETH, submissionCount: 1n, active: true })]
+			if (request.functionName === 'getTickSummary') return createTruthAuctionTickSummary({ tick: 10n, price: 2n * ETH, currentTotalEth: 5n * ETH, submissionCount: 1n, active: true })
+			if (request.functionName === 'getBidCountAtTick') return 1n
+			if (request.functionName === 'getBidPageAtTick') return [createTruthAuctionBidView({ tick: 10n, bidIndex: 0n, ethAmount: 2n * ETH, cumulativeEth: 2n * ETH })]
+			if (request.functionName === 'getBidderBidCount') return 1n
+			if (request.functionName === 'getBidderBidPage') return [createTruthAuctionBidView({ tick: 10n, bidIndex: 0n, ethAmount: 2n * ETH, cumulativeEth: 2n * ETH })]
+			throw new Error(`Unexpected truth auction read: ${String(request.functionName)}`)
+		})
 		const baseDetails = {
 			...createForkAuctionDetails(),
 			claimingAvailable: true,
@@ -2167,65 +2190,19 @@ describe('ForkAuctionSection', () => {
 							securityPoolAddress: YES_CHILD_POOL_ADDRESS,
 						}),
 					],
+					truthAuctionReadClient,
 				}),
 			),
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
+		const settlementSection = documentQueries.getByRole('heading', { name: 'Settle Finalized Bid' }).closest('.section-block')
+		if (!(settlementSection instanceof HTMLElement)) throw new Error('Expected finalized settlement section to render')
 		expect(documentQueries.getByRole('heading', { name: 'Settlement Overview' })).not.toBeNull()
-		expect(documentQueries.getAllByText('Bidder Address').length).toBeGreaterThan(0)
-		expectTransactionButtonDisabled(document.body, 'Settle Finalized Bid', 'Enter a valid settlement bid tick.')
-
-		await act(() => {
-			render(
-				h(ForkAuctionSection, {
-					...createProps({
-						accountState: createAccountState({ ethBalance: 10n * ETH }),
-						forkAuctionDetails: baseDetails,
-						forkAuctionForm: {
-							...createForkAuctionForm(),
-							claimBidTick: '10',
-						},
-						securityPools: [
-							createPreviewPool({
-								parent: zeroAddress,
-								questionOutcome: 'yes',
-								securityPoolAddress: YES_CHILD_POOL_ADDRESS,
-							}),
-						],
-					}),
-				}),
-				renderedComponent.container,
-			)
-		})
-		expectTransactionButtonDisabled(document.body, 'Settle Finalized Bid', 'Enter a valid settlement bid index.')
-
-		await act(() => {
-			render(
-				h(ForkAuctionSection, {
-					...createProps({
-						accountState: createAccountState({ ethBalance: 10n * ETH }),
-						forkAuctionDetails: baseDetails,
-						forkAuctionForm: {
-							...createForkAuctionForm(),
-							claimBidIndex: '0',
-							claimBidTick: '10',
-							settlementAddress: 'not-an-address',
-						},
-						securityPools: [
-							createPreviewPool({
-								parent: zeroAddress,
-								questionOutcome: 'yes',
-								securityPoolAddress: YES_CHILD_POOL_ADDRESS,
-							}),
-						],
-					}),
-				}),
-				renderedComponent.container,
-			)
-		})
-		expectTransactionButtonDisabled(document.body, 'Settle Finalized Bid', 'Enter a valid bidder address.')
+		expect(within(settlementSection).queryByText('Bidder Address')).toBeNull()
+		expect(within(settlementSection).queryByText('Settlement Bid Tick')).toBeNull()
+		expectTransactionButtonDisabled(document.body, 'Settle Finalized Bid', 'Pick one of your bids to load a settlement target.')
 
 		await act(() => {
 			render(
@@ -2245,6 +2222,7 @@ describe('ForkAuctionSection', () => {
 								securityPoolAddress: YES_CHILD_POOL_ADDRESS,
 							}),
 						],
+						truthAuctionReadClient,
 					}),
 				}),
 				renderedComponent.container,
@@ -2376,11 +2354,11 @@ describe('ForkAuctionSection', () => {
 		expect(document.body.textContent?.includes('Showing 2 of 2 active price levels')).toBe(true)
 		expect(document.body.textContent?.includes('Loaded depth')).toBe(true)
 		expect(document.body.textContent?.includes('Winning')).toBe(true)
-		fireEvent.click(documentQueries.getByRole('button', { name: 'Select tick 12 from depth chart' }))
+		fireEvent.click(documentQueries.getByRole('button', { name: 'Select price 3 ETH / REP from depth chart' }))
 		await waitFor(() => {
-			expect(document.body.textContent?.includes('Tick 12 at')).toBe(true)
+			expect(document.body.textContent?.includes('Selected Price')).toBe(true)
 		})
-		expect(documentQueries.getByText('Selected Price Level')).not.toBeNull()
+		expect(documentQueries.getByText('Selected Price')).not.toBeNull()
 		expect(document.body.textContent?.includes('2 submissions')).toBe(true)
 	})
 
@@ -2435,19 +2413,18 @@ describe('ForkAuctionSection', () => {
 
 		const documentQueries = within(document.body)
 		await waitFor(() => {
-			expect(document.body.textContent?.includes('Tick 12 at')).toBe(true)
+			expect(document.body.textContent?.includes('Selected Price')).toBe(true)
 		})
 
 		fireEvent.click(
-			documentQueries.getAllByRole('button', { name: 'Show Price Level' })[1] ??
+			documentQueries.getAllByRole('button', { name: 'View Price' })[1] ??
 				(() => {
-					throw new Error('Expected a historical Show Price Level button')
+					throw new Error('Expected a historical View Price button')
 				})(),
 		)
 
 		await waitFor(() => {
-			expect(document.body.textContent?.includes('Tick 12 at')).toBe(false)
-			expect(document.body.textContent?.includes('Loading selected price level…')).toBe(true)
+			expect(document.body.textContent?.includes('Loading selected price…')).toBe(true)
 		})
 
 		historicalTickSummaryLoad.resolve(
@@ -2462,7 +2439,7 @@ describe('ForkAuctionSection', () => {
 		historicalTickBidLoad.resolve([createTruthAuctionBidView({ tick: 9n, bidIndex: 1n, ethAmount: 2n * ETH, cumulativeEth: 2n * ETH })])
 
 		await waitFor(() => {
-			expect(document.body.textContent?.includes('Tick 9 at')).toBe(true)
+			expect(document.body.textContent?.includes('Loading selected price…')).toBe(false)
 		})
 	})
 
@@ -2622,12 +2599,12 @@ describe('ForkAuctionSection', () => {
 
 		const documentQueries = within(document.body)
 		await waitFor(() => {
-			expect(documentQueries.getAllByRole('button', { name: 'Prefill Settle' }).length).toBeGreaterThan(0)
+			expect(documentQueries.getAllByRole('button', { name: 'Settle' }).length).toBeGreaterThan(0)
 		})
 		fireEvent.click(
-			documentQueries.getAllByRole('button', { name: 'Prefill Settle' })[0] ??
+			documentQueries.getAllByRole('button', { name: 'Settle' })[0] ??
 				(() => {
-					throw new Error('Expected at least one Prefill Settle button')
+					throw new Error('Expected at least one Settle button')
 				})(),
 		)
 
@@ -2699,16 +2676,16 @@ describe('ForkAuctionSection', () => {
 
 		const documentQueries = within(document.body)
 		await waitFor(() => {
-			expect(documentQueries.getAllByRole('button', { name: 'Prefill Settle' }).length).toBeGreaterThan(0)
+			expect(documentQueries.getAllByRole('button', { name: 'Settle' }).length).toBeGreaterThan(0)
 		})
 
 		expect(document.body.textContent?.includes('Owner Withdrawal')).toBe(false)
 		expect(documentQueries.getAllByText('Refundable').length).toBeGreaterThan(0)
 		expect(documentQueries.getAllByText('Refunded').length).toBeGreaterThan(0)
 
-		const settleButtons = documentQueries.getAllByRole('button', { name: 'Prefill Settle' })
+		const settleButtons = documentQueries.getAllByRole('button', { name: 'Settle' })
 		const refundableRowButton = settleButtons.find(button => button.closest('.truth-auction-bid-row')?.textContent?.includes('Refundable') === true)
-		if (refundableRowButton === undefined) throw new Error('Expected a refundable Prefill Settle button')
+		if (refundableRowButton === undefined) throw new Error('Expected a refundable Settle button')
 
 		fireEvent.click(refundableRowButton)
 
@@ -2760,31 +2737,31 @@ describe('ForkAuctionSection', () => {
 
 		const documentQueries = within(document.body)
 		await waitFor(() => {
-			expect(documentQueries.getByRole('button', { name: 'Select tick 10 from depth chart' })).not.toBeNull()
+			expect(documentQueries.getByRole('button', { name: 'Select price 2 ETH / REP from depth chart' })).not.toBeNull()
 		})
 		await act(() => {
-			fireEvent.click(documentQueries.getByRole('button', { name: 'Select tick 10 from depth chart' }))
+			fireEvent.click(documentQueries.getByRole('button', { name: 'Select price 2 ETH / REP from depth chart' }))
 		})
 
 		await waitFor(() => {
-			expect(document.body.textContent?.includes('Tick 10 at')).toBe(true)
+			expect(document.body.textContent?.includes('Selected Price')).toBe(true)
 		})
 
 		await waitFor(() => {
-			expect(document.body.textContent?.includes('Bid #1')).toBe(true)
+			expect(document.body.textContent?.includes('0x0000000000000000000000000000000000000001')).toBe(true)
 		})
 
 		const selectedLevel = document.body.querySelector('.truth-auction-level-detail')
 		if (!(selectedLevel instanceof HTMLElement)) throw new Error('Expected selected price-level detail to render')
 
 		const bidRows = Array.from(selectedLevel.querySelectorAll('.truth-auction-bid-row')).slice(1)
-		const viewerRow = bidRows.find(row => row.textContent?.includes('Bid #0') === true)
-		const otherWalletRow = bidRows.find(row => row.textContent?.includes('Bid #1') === true)
+		const viewerRow = bidRows.find(row => row.textContent?.includes(zeroAddress) === true)
+		const otherWalletRow = bidRows.find(row => row.textContent?.includes('0x0000000000000000000000000000000000000001') === true)
 		if (!(viewerRow instanceof HTMLElement)) throw new Error('Expected selected price-level viewer row to render')
 		if (!(otherWalletRow instanceof HTMLElement)) throw new Error('Expected selected price-level non-viewer row to render')
 
-		expect(within(viewerRow).getAllByRole('button', { name: 'Prefill Settle' }).length).toBe(1)
-		expect(within(otherWalletRow).queryByRole('button', { name: 'Prefill Settle' })).toBeNull()
+		expect(within(viewerRow).getAllByRole('button', { name: 'Settle' }).length).toBe(1)
+		expect(within(otherWalletRow).queryByRole('button', { name: 'Settle' })).toBeNull()
 	})
 
 	test('summarizes wallet bids from semantic bid outcomes instead of presentation labels', async () => {
@@ -2901,7 +2878,7 @@ describe('ForkAuctionSection', () => {
 		})
 	})
 
-	test('keeps the auction stage ordered as market view, submit bid, finalize, then my bids and shows the form-linked preview state', async () => {
+	test('keeps the auction stage ordered as market view, submit bid, my bids, then finalize and shows the form-linked preview state', async () => {
 		const truthAuctionReadClient = createTruthAuctionReadClient(async request => {
 			if (request.functionName === 'activeTickCount') return 1n
 			if (request.functionName === 'getActiveTickPage') return [createTruthAuctionTickSummary({ tick: 12n, price: 3n * ETH, currentTotalEth: 4n * ETH, submissionCount: 1n, active: true })]
@@ -2953,10 +2930,10 @@ describe('ForkAuctionSection', () => {
 		const myBidsHeading = documentQueries.getByRole('heading', { name: 'My Bids' })
 
 		expectElementBefore(marketViewHeading, submitBidHeading)
-		expectElementBefore(submitBidHeading, finalizeHeading)
-		expectElementBefore(finalizeHeading, myBidsHeading)
+		expectElementBefore(submitBidHeading, myBidsHeading)
+		expectElementBefore(myBidsHeading, finalizeHeading)
 		expect(documentQueries.getByText(/Selected ladder price:/)).not.toBeNull()
-		expect(document.body.textContent?.includes('Current form tick')).toBe(true)
+		expect(document.body.textContent?.includes('Current form price')).toBe(true)
 		expect(documentQueries.getByRole('button', { name: 'Use This Price' })).not.toBeNull()
 		expect(documentQueries.getByText('Bid Price (ETH / REP)')).not.toBeNull()
 		expect(documentQueries.queryByText('Bid Tick')).toBeNull()
@@ -3162,8 +3139,8 @@ describe('ForkAuctionSection', () => {
 
 		expectElementBefore(marketViewHeading, auctionBidsHeading)
 		expectElementBefore(auctionBidsHeading, submitBidHeading)
-		expect(document.body.textContent?.includes('Bid #1')).toBe(true)
-		expect(document.body.textContent?.includes('Tick 10')).toBe(true)
+		expect(document.body.textContent?.includes('Bid #1')).toBe(false)
+		expect(document.body.textContent?.includes('Tick 10')).toBe(false)
 	})
 
 	test('sorts aggregated auction bids by tick descending then bid index ascending and can prefill actions from that table', async () => {
@@ -3221,29 +3198,26 @@ describe('ForkAuctionSection', () => {
 		const documentQueries = within(document.body)
 		await waitFor(() => {
 			expect(documentQueries.getByRole('heading', { name: 'Auction Bids' })).not.toBeNull()
-			expect(documentQueries.getAllByRole('button', { name: 'Prefill Settle' }).length).toBeGreaterThan(0)
+			expect(documentQueries.getAllByRole('button', { name: 'Settle' }).length).toBeGreaterThan(0)
 		})
 
 		const aggregateTable = documentQueries.getByRole('heading', { name: 'Auction Bids' }).closest('.section-block')
 		if (!(aggregateTable instanceof HTMLElement)) throw new Error('Expected aggregated auction bids section to render')
 		await waitFor(() => {
-			expect(aggregateTable.textContent?.includes('Bid #0')).toBe(true)
+			expect(aggregateTable.querySelectorAll('.truth-auction-bid-row.is-wide').length).toBeGreaterThanOrEqual(3)
 		})
 		const aggregateRows = Array.from(aggregateTable.querySelectorAll('.truth-auction-bid-row.is-wide')).filter(row => !row.classList.contains('is-header'))
-		expect(aggregateRows.length).toBeGreaterThanOrEqual(3)
-		expect(aggregateRows[0]?.textContent).toContain('Tick 12')
-		expect(aggregateRows[0]?.textContent).toContain('Bid #0')
-		expect(aggregateRows[1]?.textContent).toContain('Tick 12')
-		expect(aggregateRows[1]?.textContent).toContain('Bid #1')
-		expect(aggregateRows[2]?.textContent).toContain('Tick 10')
+		expect(aggregateRows[0]?.textContent).toContain('≈ 2.00 ETH')
+		expect(aggregateRows[1]?.textContent).toContain('≈ 3.00 ETH')
+		expect(aggregateRows[2]?.textContent).toContain('≈ 4.00 ETH')
 
-		fireEvent.click(within(aggregateTable).getAllByRole('button', { name: 'Prefill Settle' })[0] as HTMLElement)
+		fireEvent.click(within(aggregateTable).getAllByRole('button', { name: 'Settle' })[0] as HTMLElement)
 		expect(formUpdates).toContainEqual({
 			claimBidIndex: '0',
 			claimBidTick: '12',
 			settlementAddress: zeroAddress,
 		})
-		expect(aggregateRows[1]?.textContent?.includes('Prefill Settle')).toBe(false)
+		expect(aggregateRows[1]?.textContent?.includes('Settle')).toBe(false)
 	})
 
 	test('expands aggregated auction bid coverage after loading more price levels and more bid pages', async () => {

--- a/ui/ts/tests/forkAuctionSection.test.tsx
+++ b/ui/ts/tests/forkAuctionSection.test.tsx
@@ -1589,7 +1589,175 @@ describe('ForkAuctionSection', () => {
 		const auctionOverviewSection = within(document.body).getByRole('heading', { name: 'Auction Overview' }).closest('section')
 		if (!(auctionOverviewSection instanceof HTMLElement)) throw new Error('Expected auction overview section to render')
 		expect(getMetricValue(auctionOverviewSection, 'Time Left')).toBe('0m')
+		expect(within(auctionOverviewSection).getByText('Unfilled')).not.toBeNull()
+		expect(within(auctionOverviewSection).queryByText('Finalized')).toBeNull()
+		expect(within(auctionOverviewSection).queryByText('Underfunded')).toBeNull()
 		expectTransactionButtonDisabled(document.body, 'Submit Bid', 'Truth auction is already finalized.')
+	})
+
+	test('shows auction overview badge states instead of finalized and underfunded metrics', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					accountState: createAccountState({ ethBalance: 10n * ETH }),
+					forkAuctionDetails: {
+						...createForkAuctionDetails(),
+						systemState: 'forkTruthAuction',
+						truthAuction: createTruthAuctionMetrics(),
+						truthAuctionAddress: '0x0000000000000000000000000000000000000001',
+						truthAuctionStartedAt: 1n,
+					},
+					stageView: 'auction',
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const getAuctionOverviewSection = () => {
+			const section = within(document.body).getByRole('heading', { name: 'Auction Overview' }).closest('section')
+			if (!(section instanceof HTMLElement)) throw new Error('Expected auction overview section to render')
+			return section
+		}
+
+		await waitFor(() => {
+			expect(within(getAuctionOverviewSection()).getByText('Open')).not.toBeNull()
+		})
+		expect(within(getAuctionOverviewSection()).queryByText('Finalized')).toBeNull()
+		expect(within(getAuctionOverviewSection()).queryByText('Underfunded')).toBeNull()
+
+		await act(() => {
+			render(
+				h(
+					ForkAuctionSection,
+					createProps({
+						accountState: createAccountState({ ethBalance: 10n * ETH }),
+						forkAuctionDetails: {
+							...createForkAuctionDetails(),
+							systemState: 'forkTruthAuction',
+							truthAuction: {
+								...createTruthAuctionMetrics(),
+								clearingPrice: 2n * ETH,
+								clearingTick: 10n,
+								ethAtClearingTick: 5n * ETH,
+								hitCap: true,
+							},
+							truthAuctionAddress: '0x0000000000000000000000000000000000000001',
+							truthAuctionStartedAt: 1n,
+						},
+						stageView: 'auction',
+					}),
+				),
+				renderedComponent.container,
+			)
+		})
+		expect(within(getAuctionOverviewSection()).getByText('Clearing')).not.toBeNull()
+
+		await act(() => {
+			render(
+				h(
+					ForkAuctionSection,
+					createProps({
+						accountState: createAccountState({ ethBalance: 10n * ETH }),
+						forkAuctionDetails: {
+							...createForkAuctionDetails(),
+							systemState: 'operational',
+							truthAuction: {
+								...createTruthAuctionMetrics(),
+								clearingPrice: 2n * ETH,
+								clearingTick: 10n,
+								ethAtClearingTick: 5n * ETH,
+								finalized: true,
+								hitCap: true,
+								timeRemaining: 0n,
+							},
+							truthAuctionAddress: '0x0000000000000000000000000000000000000001',
+							truthAuctionStartedAt: 1n,
+						},
+						stageView: 'auction',
+					}),
+				),
+				renderedComponent.container,
+			)
+		})
+		expect(within(getAuctionOverviewSection()).getByText('Settled')).not.toBeNull()
+
+		await act(() => {
+			render(
+				h(
+					ForkAuctionSection,
+					createProps({
+						accountState: createAccountState({ ethBalance: 10n * ETH }),
+						forkAuctionDetails: {
+							...createForkAuctionDetails(),
+							systemState: 'operational',
+							truthAuction: {
+								...createTruthAuctionMetrics(),
+								finalized: true,
+								underfunded: true,
+								timeRemaining: 0n,
+							},
+							truthAuctionAddress: '0x0000000000000000000000000000000000000001',
+							truthAuctionStartedAt: 1n,
+						},
+						stageView: 'auction',
+					}),
+				),
+				renderedComponent.container,
+			)
+		})
+		expect(within(getAuctionOverviewSection()).getByText('Shortfall')).not.toBeNull()
+	})
+
+	test('shows inactive and pending auction status badges before the truth auction is live', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					forkAuctionDetails: {
+						...createForkAuctionDetails(),
+						systemState: 'forkMigration',
+					},
+					securityPools: [],
+					stageView: 'auction',
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const getAuctionStatusSection = () => {
+			const section = within(document.body).getByRole('heading', { name: 'Auction Status' }).closest('section')
+			if (!(section instanceof HTMLElement)) throw new Error('Expected auction status section to render')
+			return section
+		}
+
+		expect(within(getAuctionStatusSection()).getByText('Inactive')).not.toBeNull()
+
+		await act(() => {
+			render(
+				h(
+					ForkAuctionSection,
+					createProps({
+						forkAuctionDetails: {
+							...createForkAuctionDetails(),
+							systemState: 'forkMigration',
+						},
+						securityPools: [
+							createPreviewPool({
+								parent: zeroAddress,
+								questionOutcome: 'yes',
+								securityPoolAddress: YES_CHILD_POOL_ADDRESS,
+								truthAuctionAddress: YES_TRUTH_AUCTION_ADDRESS,
+							}),
+						],
+						stageView: 'auction',
+					}),
+				),
+				renderedComponent.container,
+			)
+		})
+
+		expect(within(getAuctionStatusSection()).getByText('Pending')).not.toBeNull()
 	})
 
 	test('shows a price-specific bid validation error for malformed live-auction prices', async () => {
@@ -2880,9 +3048,15 @@ describe('ForkAuctionSection', () => {
 
 	test('keeps the auction stage ordered as market view, submit bid, my bids, then finalize and shows the form-linked preview state', async () => {
 		const truthAuctionReadClient = createTruthAuctionReadClient(async request => {
-			if (request.functionName === 'activeTickCount') return 1n
-			if (request.functionName === 'getActiveTickPage') return [createTruthAuctionTickSummary({ tick: 12n, price: 3n * ETH, currentTotalEth: 4n * ETH, submissionCount: 1n, active: true })]
-			if (request.functionName === 'getTickSummary') return createTruthAuctionTickSummary({ tick: 12n, price: 3n * ETH, currentTotalEth: 4n * ETH, submissionCount: 1n, active: true })
+			if (request.functionName === 'activeTickCount') return 3n
+			if (request.functionName === 'getActiveTickPage') {
+				return [
+					createTruthAuctionTickSummary({ tick: 12n, price: getTruthAuctionPriceAtTick(12n), currentTotalEth: 4n * ETH, submissionCount: 1n, active: true }),
+					createTruthAuctionTickSummary({ tick: 2n, price: getTruthAuctionPriceAtTick(2n), currentTotalEth: 4n * ETH, submissionCount: 1n, active: true }),
+					createTruthAuctionTickSummary({ tick: 1n, price: getTruthAuctionPriceAtTick(1n), currentTotalEth: 3n * ETH, submissionCount: 1n, active: true }),
+				]
+			}
+			if (request.functionName === 'getTickSummary') return createTruthAuctionTickSummary({ tick: 12n, price: getTruthAuctionPriceAtTick(12n), currentTotalEth: 4n * ETH, submissionCount: 1n, active: true })
 			if (request.functionName === 'getBidCountAtTick') return 1n
 			if (request.functionName === 'getBidPageAtTick') return [createTruthAuctionBidView({ tick: 12n, bidIndex: 0n, ethAmount: 4n * ETH, cumulativeEth: 4n * ETH })]
 			if (request.functionName === 'getBidderBidCount') return 1n
@@ -2936,9 +3110,12 @@ describe('ForkAuctionSection', () => {
 		expect(document.body.textContent?.includes('Current form price')).toBe(true)
 		expect(documentQueries.getByRole('button', { name: 'Use This Price' })).not.toBeNull()
 		expect(documentQueries.getByText('Bid Price (ETH / REP)')).not.toBeNull()
+		expect(documentQueries.getByText(`${formatCurrencyInputBalance(getTruthAuctionPriceAtTick(1n))} ETH / REP`)).not.toBeNull()
+		expect(documentQueries.getByText(`${formatCurrencyInputBalance(getTruthAuctionPriceAtTick(2n))} ETH / REP`)).not.toBeNull()
 		expect(documentQueries.queryByText('Bid Tick')).toBeNull()
 		expect(document.body.querySelector('.truth-auction-depth-marker.is-preview')).not.toBeNull()
 		expect(document.body.querySelector('.truth-auction-market-section')).not.toBeNull()
+		expect(document.body.querySelector('.truth-auction-market-detail-grid')).not.toBeNull()
 		expect(document.body.querySelector('.truth-auction-market-board .truth-auction-panel')).toBeNull()
 	})
 


### PR DESCRIPTION
## Summary
- Updated the fork auction UI to use **price-centric** terminology and layout in market/bid views (price labels, copy, loading states, and bid table headers) while preserving underlying tick logic.
- Added selected bid summary panels for refund/settlement in non-embedded mode, showing price, bidder, amount, and status, and wired these into action-guard messaging.
- Introduced bid deduplication via `dedupeTruthAuctionBids(...)` across viewer bids, selected-tick bids, and aggregated bids to keep selected bid lookups deterministic.
- Adjusted action behavior to avoid manual tick/index entry in non-embedded mode by using the currently picked bid context, with clearer disabled-state messaging when a bid target is not selected.
- Refined bid row and auction action layouts in CSS for better wrapping/truncation and mobile button behavior; renamed “Show Price Level” and related button labels/copy for consistency.
- Updated depth chart accessibility label to reference price directly (`Select price ... ETH / REP`) and removed explicit clearing tick exposure in several summaries to match revised layout.
- Updated and expanded `ForkAuctionSection` tests to match the new UX/labels and settlement gating flow (including new mocked truth-auction reads for settlement/settlement gating cases).

## Testing
- Not run: `bun run tsc`
- Not run: `bun run test`
- Not run: `bun run format`
- Not run: `bun run check`
- Not run: `bun run knip`
- Not run: `bun run knip:fix`