### PR TITLE
Move Child Security Pools into Settlement Fork Stage

### DIFF
--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -4531,7 +4531,23 @@ button:focus-visible {
 
 .fork-workflow-stage-copy {
 	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 0.25rem;
+}
+
+.fork-workflow-stage-indicator {
+	display: inline-flex;
 	align-items: center;
+	padding: 0.12rem 0.45rem;
+	border: 1px solid rgba(56, 213, 255, 0.28);
+	border-radius: 999px;
+	background: rgba(56, 213, 255, 0.12);
+	color: rgba(181, 243, 255, 0.96);
+	font-size: 0.68rem;
+	font-weight: 600;
+	letter-spacing: 0.03em;
+	text-transform: uppercase;
 }
 
 .fork-workflow-stage-icon-triggered::before {
@@ -4610,12 +4626,23 @@ button:focus-visible {
 }
 
 .fork-workflow-stage.is-selected {
-	background: rgba(56, 213, 255, 0.1);
+	border-color: rgba(56, 213, 255, 0.34);
+	background: linear-gradient(135deg, rgba(56, 213, 255, 0.16), rgba(56, 213, 255, 0.06)), rgba(10, 20, 36, 0.34);
+	box-shadow: 0 0 0 1px rgba(56, 213, 255, 0.12);
+	color: rgb(233, 251, 255);
 }
 
 .fork-workflow-stage.is-current .fork-workflow-stage-icon,
 .fork-workflow-stage.is-selected .fork-workflow-stage-icon {
 	background: rgba(56, 213, 255, 0.18);
+}
+
+.fork-workflow-stage.is-selected .fork-workflow-stage-icon {
+	box-shadow: inset 0 0 0 1px rgba(56, 213, 255, 0.18);
+}
+
+.fork-workflow-stage.is-selected .fork-workflow-stage-copy strong {
+	color: rgb(243, 253, 255);
 }
 
 .fork-workflow-stage.is-complete:not(.is-current) {

--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -75,13 +75,12 @@ type TruthAuctionStateBadge = {
 }
 
 type ForkOutcomeMigrationSeedStatus = Awaited<ReturnType<typeof loadForkOutcomeMigrationSeedStatus>>
-const FORK_WORKFLOW_NAV_STAGES: readonly ForkWorkflowSelectionStage[] = ['fork-triggered', 'migration', 'auction', 'settlement', 'new-security-pools']
+const FORK_WORKFLOW_NAV_STAGES: readonly ForkWorkflowSelectionStage[] = ['fork-triggered', 'migration', 'auction', 'settlement']
 const FORK_WORKFLOW_STAGE_LABELS: Record<ForkWorkflowSelectionStage, string> = {
 	'fork-triggered': 'Fork Triggered',
 	migration: 'Migration',
 	auction: 'Truth Auction',
 	settlement: 'Settlement',
-	'new-security-pools': 'New Security Pools',
 }
 
 function getForkWorkflowStageLabel(stage: ForkWorkflowSelectionStage) {
@@ -102,8 +101,6 @@ function getForkWorkflowStageIcon(stage: ForkWorkflowSelectionStage) {
 			return <span aria-hidden='true' className='fork-workflow-stage-icon fork-workflow-stage-icon-auction' />
 		case 'settlement':
 			return <span aria-hidden='true' className='fork-workflow-stage-icon fork-workflow-stage-icon-settlement' />
-		case 'new-security-pools':
-			return <span aria-hidden='true' className='fork-workflow-stage-icon fork-workflow-stage-icon-pools' />
 		default:
 			return undefined
 	}
@@ -256,8 +253,6 @@ function getForkWorkflowStageAheadMessage(stage: ForkWorkflowSelectionStage, cur
 			return 'This step becomes active once migration is underway.'
 		case 'settlement':
 			return 'This step becomes active once the truth auction has started.'
-		case 'new-security-pools':
-			return 'This step becomes active once settlement completes and the new security pools are ready to inspect.'
 		default:
 			return undefined
 	}
@@ -289,6 +284,38 @@ function renderWorkflowMetricGrid(metrics: DisplayMetric[]) {
 		</div>
 	)
 }
+
+function renderChildSecurityPoolsSection({ childSecurityPools, renderSelectedOutcomeChildPoolNotice, auctionOutcomeSelector }: { childSecurityPools: ListedSecurityPool[]; renderSelectedOutcomeChildPoolNotice: () => ComponentChildren; auctionOutcomeSelector: ComponentChildren }) {
+	return (
+		<SectionBlock density='compact' headingLevel={4} title='Child Security Pools' variant='embedded'>
+			{auctionOutcomeSelector}
+			{renderSelectedOutcomeChildPoolNotice()}
+			{childSecurityPools.length === 0 ? <p className='detail'>No child security pools are available yet.</p> : null}
+			{childSecurityPools.length === 0 ? null : (
+				<div className='fork-workflow-child-pool-list'>
+					{childSecurityPools.map(pool => {
+						const childPoolHref = buildRouteHref(SECURITY_POOLS_ROUTE, writeUniverseQueryParam(writeSecurityPoolQueryParam('', pool.securityPoolAddress), pool.universeId))
+						return (
+							<article className='fork-workflow-child-pool-card' key={pool.securityPoolAddress}>
+								<div className='fork-workflow-child-pool-card-copy'>
+									<strong>{pool.questionOutcome === 'none' ? 'Pending outcome' : getReportingOutcomeLabel(pool.questionOutcome)}</strong>
+									<span>{pool.systemState === 'operational' ? 'Operational' : getForkAuctionStageLabel(getForkAuctionStageView({ forkOutcome: pool.forkOutcome, migratedRep: pool.migratedRep, systemState: pool.systemState, truthAuctionStartedAt: pool.truthAuctionStartedAt }))}</span>
+								</div>
+								<div className='fork-workflow-child-pool-card-meta'>
+									<span>
+										<AddressValue address={pool.securityPoolAddress} />
+									</span>
+									<a href={childPoolHref}>Open security pool</a>
+								</div>
+							</article>
+						)
+					})}
+				</div>
+			)}
+		</SectionBlock>
+	)
+}
+
 function estimateBidRep(bidAmount: string, bidPrice: bigint | undefined) {
 	if (bidPrice === undefined) return undefined
 	const parsedBidAmount = bidAmount.trim() === '' ? 0n : tryParseTruthAuctionAmountInput(bidAmount)
@@ -2021,37 +2048,6 @@ export function ForkAuctionSection({
 		const nextTab = document.getElementById(`fork-workflow-stage-${nextStage}`)
 		if (nextTab instanceof HTMLElement) nextTab.focus()
 	}
-	const childSecurityPoolsPanel = (
-		<fieldset aria-labelledby='fork-workflow-stage-new-security-pools' className='fork-stage-panel' disabled={disabled} id='fork-workflow-stage-panel-new-security-pools' role='tabpanel'>
-			{selectedStageAheadMessage === undefined ? undefined : <p className='detail'>{selectedStageAheadMessage}</p>}
-			<SectionBlock title='New Security Pools' description='Child pools created during the fork workflow appear here once they exist.'>
-				{auctionOutcomeSelector}
-				{renderSelectedOutcomeChildPoolNotice()}
-				{childSecurityPools.length === 0 ? <p className='detail'>No new security pools are available yet.</p> : null}
-				{childSecurityPools.length === 0 ? null : (
-					<div className='fork-workflow-child-pool-list'>
-						{childSecurityPools.map(pool => {
-							const childPoolHref = buildRouteHref(SECURITY_POOLS_ROUTE, writeUniverseQueryParam(writeSecurityPoolQueryParam('', pool.securityPoolAddress), pool.universeId))
-							return (
-								<article className='fork-workflow-child-pool-card' key={pool.securityPoolAddress}>
-									<div className='fork-workflow-child-pool-card-copy'>
-										<strong>{pool.questionOutcome === 'none' ? 'Pending outcome' : getReportingOutcomeLabel(pool.questionOutcome)}</strong>
-										<span>{pool.systemState === 'operational' ? 'Operational' : getForkAuctionStageLabel(getForkAuctionStageView({ forkOutcome: pool.forkOutcome, migratedRep: pool.migratedRep, systemState: pool.systemState, truthAuctionStartedAt: pool.truthAuctionStartedAt }))}</span>
-									</div>
-									<div className='fork-workflow-child-pool-card-meta'>
-										<span>
-											<AddressValue address={pool.securityPoolAddress} />
-										</span>
-										<a href={childPoolHref}>Open security pool</a>
-									</div>
-								</article>
-							)
-						})}
-					</div>
-				)}
-			</SectionBlock>
-		</fieldset>
-	)
 	const forkWorkflowStageNavigator = !hasLoadedPoolContext ? undefined : (
 		<div className='fork-workflow-stage-nav-shell'>
 			<div aria-label='Fork lifecycle stages' className='fork-workflow-stage-nav' role='tablist'>
@@ -2079,6 +2075,7 @@ export function ForkAuctionSection({
 								{getForkWorkflowStageIcon(stage)}
 								<span className='fork-workflow-stage-copy'>
 									<strong>{stageLabel}</strong>
+									{selectedStage === stage && currentWorkflowStage !== stage ? <span className='fork-workflow-stage-indicator'>Viewing</span> : undefined}
 								</span>
 							</button>
 							{stage === FORK_WORKFLOW_NAV_STAGES[FORK_WORKFLOW_NAV_STAGES.length - 1] ? undefined : (
@@ -2276,30 +2273,35 @@ export function ForkAuctionSection({
 					return (
 						<fieldset aria-labelledby='fork-workflow-stage-settlement' className='fork-stage-panel' disabled={disabled} id='fork-workflow-stage-panel-settlement' role='tabpanel'>
 							{selectedStageAheadMessage === undefined ? undefined : <p className='detail'>{selectedStageAheadMessage}</p>}
-							{auctionOutcomeSelector}
-							{renderSelectedOutcomeChildPoolNotice()}
 							{selectedAuctionDetailsNotice}
 							{truthAuctionEndedNotice}
 							{truthAuctionHero}
 							{viewerTruthAuctionBidsSection}
 							{truthAuctionSettlementSection}
+							{renderChildSecurityPoolsSection({
+								auctionOutcomeSelector,
+								childSecurityPools,
+								renderSelectedOutcomeChildPoolNotice,
+							})}
 						</fieldset>
 					)
 				return (
 					<fieldset aria-labelledby='fork-workflow-stage-settlement' className='fork-stage-panel' disabled={disabled} id='fork-workflow-stage-panel-settlement' role='tabpanel'>
 						{selectedStageAheadMessage === undefined ? undefined : <p className='detail'>{selectedStageAheadMessage}</p>}
-						{auctionOutcomeSelector}
-						{renderSelectedOutcomeChildPoolNotice()}
 						{selectedAuctionDetailsNotice}
 						{truthAuctionEndedNotice}
 						<SectionBlock badge={truthAuctionStateBadgeElement} title='Settlement Status'>
 							{renderWorkflowMetricGrid(settlementStatusMetrics)}
 						</SectionBlock>
 						{truthAuctionSettlementSection}
+						{renderChildSecurityPoolsSection({
+							auctionOutcomeSelector,
+							childSecurityPools,
+							renderSelectedOutcomeChildPoolNotice,
+						})}
 					</fieldset>
 				)
 			}
-			if (selectedStage === 'new-security-pools') return childSecurityPoolsPanel
 
 			return undefined
 		})()

--- a/ui/ts/lib/securityPoolWorkflow.ts
+++ b/ui/ts/lib/securityPoolWorkflow.ts
@@ -9,7 +9,7 @@ import type { UserMessagePresentation } from './userCopy.js'
 import { resolveEnumValue } from './viewState.js'
 import type { ListedSecurityPool, OracleManagerDetails, ReportingOutcomeKey, SecurityPoolSystemState, TruthAuctionMetrics } from '../types/contracts.js'
 
-export const FORK_WORKFLOW_SELECTION_STAGES = ['fork-triggered', 'migration', 'auction', 'settlement', 'new-security-pools'] as const
+export const FORK_WORKFLOW_SELECTION_STAGES = ['fork-triggered', 'migration', 'auction', 'settlement'] as const
 export type ForkWorkflowSelectionStage = (typeof FORK_WORKFLOW_SELECTION_STAGES)[number]
 export type SelectedPoolView = 'vaults' | 'trading' | 'reporting' | 'withdraw-escalation-deposits' | 'fork-workflow' | 'staged-operations' | 'price-oracle'
 
@@ -97,7 +97,7 @@ export function getCurrentForkWorkflowSelectionStage({
 	truthAuctionFinalized?: boolean
 }): ForkWorkflowSelectionStage {
 	if (systemState === 'poolForked') return 'fork-triggered'
-	if (systemState === 'operational' && hasForkActivity && truthAuctionFinalized && !claimingAvailable) return 'new-security-pools'
+	if (systemState === 'operational' && hasForkActivity && truthAuctionFinalized && !claimingAvailable) return 'settlement'
 	return normalizeForkWorkflowSelectionStage(currentForkStage)
 }
 

--- a/ui/ts/tests/forkAuctionSection.test.tsx
+++ b/ui/ts/tests/forkAuctionSection.test.tsx
@@ -201,33 +201,28 @@ describe('ForkAuctionSection', () => {
 		const migrationTab = documentQueries.getByRole('tab', { name: 'Migration' })
 		const auctionTab = documentQueries.getByRole('tab', { name: 'Truth Auction' })
 		const settlementTab = documentQueries.getByRole('tab', { name: 'Settlement' })
-		const newSecurityPoolsTab = documentQueries.getByRole('tab', { name: 'New Security Pools' })
 
 		expect(documentQueries.queryByText('View stage')).toBeNull()
-		expect(documentQueries.queryByText('Viewing stage')).toBeNull()
 		expect(documentQueries.queryByText('Current stage')).toBeNull()
 		expect(forkTriggeredTab.querySelector('.fork-workflow-stage-icon')).not.toBeNull()
 		expect(migrationTab.className.includes('is-selected')).toBe(true)
 		expect(migrationTab.className.includes('is-complete')).toBe(true)
+		expect(within(migrationTab).getByText('Viewing')).not.toBeNull()
 		expect(auctionTab.getAttribute('aria-current')).toBe('step')
 		expect(auctionTab.className.includes('is-current')).toBe(true)
 		expect(settlementTab.className.includes('is-upcoming')).toBe(true)
-		expect(newSecurityPoolsTab.className.includes('is-upcoming')).toBe(true)
+		expect(documentQueries.queryByRole('tab', { name: 'New Security Pools' })).toBeNull()
 		const separators = Array.from(document.body.querySelectorAll('.fork-workflow-stage-separator'))
-		expect(separators).toHaveLength(4)
+		expect(separators).toHaveLength(3)
 		expect(separators[0]?.className.includes('is-complete')).toBe(true)
 		expect(separators[1]?.className.includes('is-complete')).toBe(true)
 		expect(separators[2]?.className.includes('is-upcoming')).toBe(true)
-		expect(separators[3]?.className.includes('is-upcoming')).toBe(true)
 
 		fireEvent.click(settlementTab)
 		expect(onSelectedStageViewChange).toHaveBeenLastCalledWith('settlement')
 
 		fireEvent.keyDown(forkTriggeredTab, { key: 'ArrowRight' })
 		expect(onSelectedStageViewChange).toHaveBeenLastCalledWith('migration')
-
-		fireEvent.click(newSecurityPoolsTab)
-		expect(onSelectedStageViewChange).toHaveBeenLastCalledWith('new-security-pools')
 
 		fireEvent.keyDown(migrationTab, { key: 'ArrowRight' })
 		expect(onSelectedStageViewChange).toHaveBeenLastCalledWith('auction')
@@ -305,18 +300,18 @@ describe('ForkAuctionSection', () => {
 
 		const documentQueries = within(document.body)
 		expect(documentQueries.getByRole('tab', { name: 'Settlement' }).className.includes('is-current')).toBe(true)
-		expect(documentQueries.getByRole('tab', { name: 'New Security Pools' }).className.includes('is-current')).toBe(false)
+		expect(documentQueries.queryByRole('tab', { name: 'New Security Pools' })).toBeNull()
 		expect(documentQueries.getByRole('tabpanel', { name: 'Settlement' })).not.toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Settlement Status' })).not.toBeNull()
 	})
 
-	test('shows the selected outcome field and child-pool link in the new security pools panel', async () => {
+	test('shows the selected outcome field and child-pool link in the settlement child pools section', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(
 				ForkAuctionSection,
 				createProps({
 					currentStageView: 'settlement',
-					selectedStageView: 'new-security-pools',
+					selectedStageView: 'settlement',
 				}),
 			),
 		)
@@ -325,7 +320,7 @@ describe('ForkAuctionSection', () => {
 		const documentQueries = within(document.body)
 		expect(documentQueries.getByRole('button', { name: 'Outcome' })).not.toBeNull()
 		expect(documentQueries.getByRole('link', { name: 'Selected Yes Child pool' })).not.toBeNull()
-		expect(documentQueries.getByRole('heading', { name: 'New Security Pools' })).not.toBeNull()
+		expect(documentQueries.getByRole('heading', { name: 'Child Security Pools' })).not.toBeNull()
 	})
 
 	test('uses the current child pool as the selected outcome pool during truth auction', async () => {
@@ -373,7 +368,7 @@ describe('ForkAuctionSection', () => {
 					}),
 					onCreateChildUniverse,
 					securityPools: [],
-					selectedStageView: 'new-security-pools',
+					selectedStageView: 'settlement',
 				}),
 			),
 		)

--- a/ui/ts/tests/securityPoolWorkflow.test.ts
+++ b/ui/ts/tests/securityPoolWorkflow.test.ts
@@ -132,7 +132,7 @@ void describe('selected pool workflow lookup state', () => {
 				systemState: 'operational',
 				truthAuctionFinalized: true,
 			}),
-		).toBe('new-security-pools')
+		).toBe('settlement')
 		expect(
 			getCurrentForkWorkflowSelectionStage({
 				claimingAvailable: true,

--- a/ui/ts/tests/securityPoolWorkflowSection.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection.test.tsx
@@ -2501,8 +2501,10 @@ describe('SecurityPoolWorkflowSection', () => {
 		})
 
 		documentQueries = within(document.body)
-		expect(documentQueries.getByRole('heading', { name: 'New Security Pools' })).not.toBeNull()
-		expect(documentQueries.getByRole('tab', { name: 'New Security Pools' }).className.includes('is-selected')).toBe(true)
+		expect(documentQueries.getByRole('heading', { name: 'Settlement Status' })).not.toBeNull()
+		expect(documentQueries.getByRole('heading', { name: 'Child Security Pools' })).not.toBeNull()
+		expect(documentQueries.getByRole('tab', { name: 'Settlement' }).className.includes('is-selected')).toBe(true)
+		expect(documentQueries.queryByRole('tab', { name: 'New Security Pools' })).toBeNull()
 	})
 
 	test('shows Trigger Zoltar Fork in the reporting workflow after non-decision', async () => {


### PR DESCRIPTION
## Summary
- Removes the separate `New Security Pools` fork workflow tab/stage and reclassifies that terminal state as part of `Settlement`.
- Updates fork workflow stage definitions and current-stage resolution so completed settlement/auction flows now map to `settlement` instead of the removed `new-security-pools` stage.
- Relocates child security pool UI into Settlement via a dedicated embedded `Child Security Pools` section.
- Updates stage navigation visuals and behavior: selected non-current stage shows a `Viewing` badge, selected stage icon/text styling was tightened, and separator count is reduced with the new 4-stage flow.
- Removes now-obsolete `new-security-pools` tab expectations in related tests and migrates assertions to settlement-based child-pool presentation.

## Testing
- `ui/ts/tests/forkAuctionSection.test.tsx`: updated tab count/navigation assertions and moved child-pool panel checks from `New Security Pools` to `Child Security Pools` under settlement.
- `ui/ts/tests/securityPoolWorkflow.test.ts`: updated expected stage transition from `new-security-pools` to `settlement` when truth auction is finalized and claims are not yet available.
- `ui/ts/tests/securityPoolWorkflowSection.test.tsx`: updated workflow assertions to verify settlement status + child pools are present and no `New Security Pools` tab exists.
- AGENTS.md-required checks: **Not run** (typecheck/tests/format/check/knip not executed here).