### PR TITLE
Remove child-universe creation CTA from missing-universe notice

### DIFF
--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -677,7 +677,6 @@ export function ForkAuctionSection({
 	lifecycleStateOverride,
 	loadingReportingDetails = false,
 	onClaimAuctionProceeds,
-	onCreateChildUniverse,
 	onFinalizeTruthAuction,
 	onForkAuctionFormChange,
 	onMigrateRepToZoltar,
@@ -1295,15 +1294,7 @@ export function ForkAuctionSection({
 		if (selectedAuctionChildPool === undefined)
 			return (
 				<div className='fork-workflow-outcome-notice'>
-					<p className='detail'>Child universe not created for the {selectedOutcomeLabel} outcome yet.</p>
-					<div className='actions'>
-						{renderStageActionButton({
-							action: 'createChildUniverse',
-							idleLabel: `Create ${selectedOutcomeLabel} Child Universe`,
-							onClick: onCreateChildUniverse,
-							pendingLabel: 'Creating child universe...',
-						})}
-					</div>
+					<p className='detail'>{selectedOutcomeLabel} universe does not exist.</p>
 				</div>
 			)
 

--- a/ui/ts/tests/forkAuctionChildPoolRecovery.test.tsx
+++ b/ui/ts/tests/forkAuctionChildPoolRecovery.test.tsx
@@ -230,7 +230,7 @@ describe('ForkAuctionSection child pool recovery', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		await waitFor(() => {
-			expect(within(document.body).queryByText('Child universe not created for the Yes outcome yet.')).toBeNull()
+			expect(within(document.body).queryByText('Yes universe does not exist.')).toBeNull()
 			expectTransactionButtonEnabled(document.body, 'Start Truth Auction')
 		})
 	})

--- a/ui/ts/tests/forkAuctionSection.test.tsx
+++ b/ui/ts/tests/forkAuctionSection.test.tsx
@@ -354,10 +354,10 @@ describe('ForkAuctionSection', () => {
 
 		const documentQueries = within(document.body)
 		expect(documentQueries.getByRole('link', { name: 'Selected Yes Child pool' })).not.toBeNull()
-		expect(documentQueries.queryByText('Child universe not created for the Yes outcome yet.')).toBeNull()
+		expect(documentQueries.queryByText('Yes universe does not exist.')).toBeNull()
 	})
 
-	test('offers child-universe creation from the missing child-pool notice', async () => {
+	test('shows a missing-universe notice without a creation button', async () => {
 		const onCreateChildUniverse = mock(() => undefined)
 		const renderedComponent = await renderIntoDocument(
 			h(
@@ -380,10 +380,8 @@ describe('ForkAuctionSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		expect(documentQueries.getByText('Child universe not created for the Yes outcome yet.')).not.toBeNull()
-
-		const createChildUniverseButton = documentQueries.getByRole('button', { name: 'Create Yes Child Universe' })
-		fireEvent.click(createChildUniverseButton)
-		expect(onCreateChildUniverse).toHaveBeenCalledTimes(1)
+		expect(documentQueries.getByText('Yes universe does not exist.')).not.toBeNull()
+		expect(documentQueries.queryByRole('button', { name: 'Create Yes Child Universe' })).toBeNull()
+		expect(onCreateChildUniverse).not.toHaveBeenCalled()
 	})
 })


### PR DESCRIPTION
## Summary
- Removed the child-universe creation action button from `ForkAuctionSection` when no child pool is selected.
- Updated the missing-universe notice text from "Child universe not created for the {outcome} outcome yet." to "{Outcome} universe does not exist.".
- Adjusted unit tests in `forkAuctionSection.test.tsx` and `forkAuctionChildPoolRecovery.test.tsx` to reflect the new notice behavior and absence of the create button.

## Testing
- Not run (no test command execution was provided in this request).
- Verified diff-level expectations by updating assertions for the new copy and removed button interaction path in affected tests.