### PR TITLE
Add configurable RPC endpoint and deferred vault loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ If you are iterating on the app and want rebuilds, use:
 bun run app:watch
 ```
 
+## RPC Configuration
+
+The UI read backend defaults to `https://ethereum.dark.florist`, but you can override it without changing code:
+
+- Add `?rpcUrl=https://your-rpc.example` to the app URL
+- Set `localStorage['zoltar.rpcUrl']`
+- Set `globalThis.__ZOLTAR_RPC_URL__` before bootstrapping the app
+- Set the `ZOLTAR_RPC_URL` environment variable for environments that inject `process.env`
+
 ## Browser Simulation
 
 The UI also supports a walletless browser-local simulation mode for manual QA.

--- a/solidity/contracts/peripherals/SecurityPoolOracleCoordinator.sol
+++ b/solidity/contracts/peripherals/SecurityPoolOracleCoordinator.sol
@@ -162,7 +162,9 @@ contract SecurityPoolOracleCoordinator {
 	}
 
 	function requestPriceIfNeededAndStageOperation(OperationType operation, address targetVault, uint256 amount) public payable {
-		require(amount > 0, 'need to do non zero operation');
+		if (operation != OperationType.SetSecurityBondsAllowance) {
+			require(amount > 0, 'need to do non zero operation');
+		}
 		require(!securityPool.isEscalationResolved(), 'question already resolved');
 		stagedOperationCounter++;
 		// Capture snapshot of the target vault state at queue time to prevent manipulation.
@@ -210,7 +212,7 @@ contract SecurityPoolOracleCoordinator {
 	}
 
 	function executeStagedOperation(uint256 operationId) public {
-		require(stagedOperations[operationId].amount > 0, 'no such operation or already executed');
+		require(stagedOperations[operationId].initiatorVault != address(0), 'no such operation or already executed');
 		require(isPriceValid(), 'price is not valid to execute');
 		StagedOperation memory stagedOperation = stagedOperations[operationId];
 		bool success;
@@ -263,7 +265,7 @@ contract SecurityPoolOracleCoordinator {
 			}
 		}
 		if (success) {
-			stagedOperations[operationId].amount = 0;
+			stagedOperations[operationId].initiatorVault = address(0);
 		}
 	}
 

--- a/solidity/ts/tests/peripherals.test.ts
+++ b/solidity/ts/tests/peripherals.test.ts
@@ -535,6 +535,17 @@ describe('Peripherals Contract Test Suite', () => {
 		await assert.rejects(requestPriceIfNeededAndStageOperation(client, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.WithdrawRep, client.account.address, 1n), /question already resolved/)
 	})
 
+	test('oracle-staged security bond allowance updates can clear the allowance to zero', async () => {
+		const securityPoolAllowance = repDeposit / 4n
+		await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, securityPoolAllowance)
+		await manipulatePriceOracle(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer)
+
+		await requestPriceIfNeededAndStageOperation(client, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, 0n)
+
+		const vaultAfterClearingAllowance = await getSecurityVault(client, securityPoolAddresses.securityPool, client.account.address)
+		strictEqualTypeSafe(vaultAfterClearingAllowance.securityBondAllowance, 0n, 'setting the security bond allowance to zero should succeed')
+	})
+
 	test('withdrawFromEscalationGame gives safety-boundary deposits a pro-rata share of the binding-capital reward pool', async () => {
 		const endTime = await getQuestionEndDate(client, questionId)
 		await mockWindow.setTime(endTime + 10000n)

--- a/ui/ts/components/SecurityPoolsOverviewSection.tsx
+++ b/ui/ts/components/SecurityPoolsOverviewSection.tsx
@@ -79,8 +79,8 @@ export function SecurityPoolsOverviewSection({
 	const filteredSecurityPools = securityPoolsWithState.filter(({ pool, poolState }) => {
 		const displayState = poolState.lifecycleState
 		if (systemStateFilter !== 'all' && displayState !== systemStateFilter) return false
-		if (vaultFilter === 'has-vaults' && pool.vaults.length === 0) return false
-		if (vaultFilter === 'empty' && pool.vaults.length > 0) return false
+		if (vaultFilter === 'has-vaults' && pool.vaultCount === 0n) return false
+		if (vaultFilter === 'empty' && pool.vaultCount > 0n) return false
 		if (normalizedSearchText === '') return true
 		return pool.securityPoolAddress.toLowerCase().includes(normalizedSearchText) || pool.questionId.toLowerCase().includes(normalizedSearchText) || pool.marketDetails.title.toLowerCase().includes(normalizedSearchText) || pool.marketDetails.description.toLowerCase().includes(normalizedSearchText)
 	})
@@ -178,18 +178,29 @@ export function SecurityPoolsOverviewSection({
 										</WorkflowSubsection>
 
 										<WorkflowSubsection title='Vaults'>
-											<SecurityPoolVaultDirectory
-												emptyState={<StateHint presentation={{ key: 'empty', badgeLabel: 'None yet', badgeTone: 'muted', detail: 'No vaults in this pool yet.' }} />}
-												pool={pool}
-												renderActions={vault => (
-													<button className='destructive' onClick={() => onOpenLiquidationModal(pool.managerAddress, pool.securityPoolAddress, vault.vaultAddress, vault.securityBondAllowance)} disabled={accountState.address === undefined || !isMainnet || !liquidationEnabled}>
-														Liquidate Vault
-													</button>
-												)}
-												repPerEthPrice={repPerEthPrice}
-												repPerEthSource={repPerEthSource}
-												repPerEthSourceUrl={repPerEthSourceUrl}
-											/>
+											{pool.hasLoadedVaults === false ? (
+												<StateHint
+													presentation={{
+														key: 'action_needed',
+														badgeLabel: 'Deferred',
+														badgeTone: 'muted',
+														detail: `Open this pool to load ${pool.vaultCount.toString()} vault${pool.vaultCount === 1n ? '' : 's'}.`,
+													}}
+												/>
+											) : (
+												<SecurityPoolVaultDirectory
+													emptyState={<StateHint presentation={{ key: 'empty', badgeLabel: 'None yet', badgeTone: 'muted', detail: 'No vaults in this pool yet.' }} />}
+													pool={pool}
+													renderActions={vault => (
+														<button className='destructive' onClick={() => onOpenLiquidationModal(pool.managerAddress, pool.securityPoolAddress, vault.vaultAddress, vault.securityBondAllowance)} disabled={accountState.address === undefined || !isMainnet || !liquidationEnabled}>
+															Liquidate Vault
+														</button>
+													)}
+													repPerEthPrice={repPerEthPrice}
+													repPerEthSource={repPerEthSource}
+													repPerEthSourceUrl={repPerEthSourceUrl}
+												/>
+											)}
 										</WorkflowSubsection>
 									</EntityCard>
 								)

--- a/ui/ts/components/SecurityPoolsSection.tsx
+++ b/ui/ts/components/SecurityPoolsSection.tsx
@@ -5,10 +5,10 @@ import { SecurityPoolsOverviewSection } from './SecurityPoolsOverviewSection.js'
 import { sameCaseInsensitiveText } from '../lib/caseInsensitive.js'
 import type { SecurityPoolsSectionProps, SecurityPoolsView } from '../types/components.js'
 
-export function shouldRefreshSelectedPoolDataOnViewOpen({ currentSecurityPoolAddress, nextSecurityPoolAddress, nextView, selectedPoolExists }: { currentSecurityPoolAddress: string; nextSecurityPoolAddress?: string | undefined; nextView: SecurityPoolsView; selectedPoolExists: boolean }) {
+export function shouldRefreshSelectedPoolDataOnViewOpen({ currentSecurityPoolAddress, nextSecurityPoolAddress, nextView, selectedPoolHasLoadedDetails }: { currentSecurityPoolAddress: string; nextSecurityPoolAddress?: string | undefined; nextView: SecurityPoolsView; selectedPoolHasLoadedDetails: boolean }) {
 	if (nextView !== 'operate') return false
 	const resolvedSecurityPoolAddress = nextSecurityPoolAddress ?? currentSecurityPoolAddress
-	return resolvedSecurityPoolAddress.trim() !== '' && !selectedPoolExists
+	return resolvedSecurityPoolAddress.trim() !== '' && !selectedPoolHasLoadedDetails
 }
 
 export function SecurityPoolsSection({ activeView, createPool, onActiveViewChange, overview, workflow }: SecurityPoolsSectionProps) {
@@ -30,8 +30,9 @@ export function SecurityPoolsSection({ activeView, createPool, onActiveViewChang
 	const openView = (nextView: SecurityPoolsView, nextSecurityPoolAddress?: string) => {
 		onActiveViewChange(nextView)
 		const resolvedSecurityPoolAddress = nextSecurityPoolAddress ?? workflow.securityPoolAddress
-		const selectedPoolExists = overview.securityPools.some(pool => sameCaseInsensitiveText(pool.securityPoolAddress, resolvedSecurityPoolAddress))
-		if (!shouldRefreshSelectedPoolDataOnViewOpen({ currentSecurityPoolAddress: workflow.securityPoolAddress, nextSecurityPoolAddress, nextView, selectedPoolExists })) return
+		const selectedPool = overview.securityPools.find(pool => sameCaseInsensitiveText(pool.securityPoolAddress, resolvedSecurityPoolAddress))
+		const selectedPoolHasLoadedDetails = selectedPool !== undefined && selectedPool.hasLoadedVaults !== false
+		if (!shouldRefreshSelectedPoolDataOnViewOpen({ currentSecurityPoolAddress: workflow.securityPoolAddress, nextSecurityPoolAddress, nextView, selectedPoolHasLoadedDetails })) return
 		workflow.onRefreshSelectedPoolData(resolvedSecurityPoolAddress)
 	}
 

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -109,6 +109,10 @@ type TruthAuctionBidViewStruct = {
 	refunded: boolean
 }
 type ReportingBootstrapReadResult = readonly [bigint, Address, bigint, bigint, Address, bigint]
+type LoadAllSecurityPoolsOptions = {
+	selectedSecurityPoolAddress?: Address | string
+	vaultDetailMode?: 'all' | 'selected'
+}
 type SecurityPoolDeploymentQueryResult = {
 	completeSetCollateralAmount: bigint
 	currentRetentionRate: bigint
@@ -436,12 +440,13 @@ async function loadSecurityPoolVaultSummaries(
 	client: ReadClient,
 	securityPoolAddress: Address,
 ): Promise<{
+	hasLoadedVaults: boolean
 	vaultCount: bigint
 	vaults: SecurityPoolVaultSummary[]
 }> {
 	const vaultCount = await getSecurityPoolVaultCount(client, securityPoolAddress)
 	const vaultAddresses = vaultCount === 0n ? [] : await getSecurityPoolVaults(client, securityPoolAddress, 0n, vaultCount)
-	if (vaultAddresses.length === 0) return { vaultCount, vaults: [] }
+	if (vaultAddresses.length === 0) return { hasLoadedVaults: true, vaultCount, vaults: [] }
 	const vaultDataContracts: ContractFunctionParameters[] = vaultAddresses.map(vaultAddress => ({
 		abi: peripherals_SecurityPool_SecurityPool.abi,
 		functionName: 'securityVaults',
@@ -492,7 +497,7 @@ async function loadSecurityPoolVaultSummaries(
 			vaultAddress,
 		} satisfies SecurityPoolVaultSummary
 	})
-	return { vaultCount, vaults }
+	return { hasLoadedVaults: true, vaultCount, vaults }
 }
 export async function approveErc20<Action extends SecurityVaultActionResult['action'] | OpenOracleActionResult['action'] | ZoltarForkActionResult['action']>(client: WriteClient, tokenAddress: Address, spenderAddress: Address, amount: bigint, action: Action) {
 	const hash = await writeContractAndWait(client, () => ({
@@ -603,7 +608,7 @@ export async function loadOracleManagerDetails(client: ReadClient, managerAddres
 			address: managerAddress,
 			args: [],
 		})
-		if (stagedOperation.amount > 0n)
+		if (stagedOperation.initiatorVault !== zeroAddress)
 			pendingOperation = {
 				amount: stagedOperation.amount,
 				initiatorVault: stagedOperation.initiatorVault,
@@ -1617,7 +1622,9 @@ export async function finalizeSecurityPoolTruthAuction(client: WriteClient, secu
 			})),
 	)
 }
-export async function loadAllSecurityPools(client: ReadClient): Promise<ListedSecurityPool[]> {
+export async function loadAllSecurityPools(client: ReadClient, options: LoadAllSecurityPoolsOptions = {}): Promise<ListedSecurityPool[]> {
+	const vaultDetailMode = options.vaultDetailMode ?? 'all'
+	const selectedSecurityPoolAddress = options.selectedSecurityPoolAddress
 	const deploymentCount = await client.readContract({
 		address: getInfraContractAddresses().securityPoolFactory,
 		abi: peripherals_factories_SecurityPoolFactory_SecurityPoolFactory.abi,
@@ -1636,7 +1643,8 @@ export async function loadAllSecurityPools(client: ReadClient): Promise<ListedSe
 	const loadedPools = await Promise.all(
 		deployments.map(async deployment => {
 			const { parent, priceOracleManagerAndOperatorQueuer: managerAddress, questionId, securityMultiplier, securityPool: securityPoolAddress, truthAuction: truthAuctionAddress, universeId } = deployment
-			const [[completeSetCollateralAmount, currentRetentionRate, forkData, lastOraclePrice, lastSettlementTimestamp, questionOutcome, systemState, totalSecurityBondAllowance, universeForkTime], marketDetails] = await Promise.all([
+			const shouldLoadVaults = vaultDetailMode === 'all' || (selectedSecurityPoolAddress !== undefined && (sameAddress(securityPoolAddress, selectedSecurityPoolAddress) || sameAddress(parent, selectedSecurityPoolAddress)))
+			const [[completeSetCollateralAmount, currentRetentionRate, forkData, lastOraclePrice, lastSettlementTimestamp, questionOutcome, systemState, totalRepDeposit, totalSecurityBondAllowance, universeForkTime], marketDetails, vaultSummary] = await Promise.all([
 				readRequiredMulticall(client, [
 					{
 						abi: peripherals_SecurityPool_SecurityPool.abi,
@@ -1682,6 +1690,12 @@ export async function loadAllSecurityPools(client: ReadClient): Promise<ListedSe
 					},
 					{
 						abi: peripherals_SecurityPool_SecurityPool.abi,
+						functionName: 'getTotalRepBalance',
+						address: securityPoolAddress,
+						args: [],
+					},
+					{
+						abi: peripherals_SecurityPool_SecurityPool.abi,
 						functionName: 'totalSecurityBondAllowance',
 						address: securityPoolAddress,
 						args: [],
@@ -1694,6 +1708,7 @@ export async function loadAllSecurityPools(client: ReadClient): Promise<ListedSe
 					},
 				]),
 				loadMarketDetails(client, questionId),
+				shouldLoadVaults ? loadSecurityPoolVaultSummaries(client, securityPoolAddress) : Promise.all([getSecurityPoolVaultCount(client, securityPoolAddress)]).then(([vaultCount]) => ({ hasLoadedVaults: vaultCount === 0n, vaultCount, vaults: [] })),
 			])
 			const forkDataTuple: ForkDataTuple = forkData
 			const [, , truthAuctionStartedAt, migratedRep, , forkOwnSecurityPool, forkOutcomeIndex] = forkDataTuple
@@ -1705,8 +1720,7 @@ export async function loadAllSecurityPools(client: ReadClient): Promise<ListedSe
 				systemState: poolSystemState,
 				truthAuctionStartedAt,
 			})
-			const { vaultCount, vaults } = await loadSecurityPoolVaultSummaries(client, securityPoolAddress)
-			const totalRepDeposit = vaults.reduce((sum, vault) => sum + vault.repDepositShare, 0n)
+			const { hasLoadedVaults, vaultCount, vaults } = vaultSummary
 			return {
 				completeSetCollateralAmount,
 				currentRetentionRate,
@@ -1730,6 +1744,7 @@ export async function loadAllSecurityPools(client: ReadClient): Promise<ListedSe
 				truthAuctionStartedAt,
 				universeHasForked: universeForkTime > 0n,
 				universeId,
+				hasLoadedVaults,
 				vaultCount,
 				vaults,
 			}

--- a/ui/ts/hooks/useSecurityPoolsOverview.ts
+++ b/ui/ts/hooks/useSecurityPoolsOverview.ts
@@ -53,7 +53,10 @@ export function useSecurityPoolsOverview({ accountAddress, onTransactionFailed, 
 				if (!isCurrent()) return
 				securityPoolOverviewError.value = undefined
 			},
-			load: async () => await loadAllSecurityPools(createConnectedReadClient()),
+			load: async () => {
+				const loadOptions = nextCheckedAddress === undefined ? { vaultDetailMode: 'selected' as const } : { selectedSecurityPoolAddress: nextCheckedAddress, vaultDetailMode: 'selected' as const }
+				return await loadAllSecurityPools(createConnectedReadClient(), loadOptions)
+			},
 			onSuccess: pools => {
 				hasLoadedSecurityPools.value = true
 				checkedSecurityPoolAddress.value = nextCheckedAddress

--- a/ui/ts/lib/chainBackend.ts
+++ b/ui/ts/lib/chainBackend.ts
@@ -3,8 +3,7 @@ import { getInjectedEthereum, type InjectedEthereum } from '../injectedEthereum.
 import { hasErrorCode, hasErrorMessage } from './errors.js'
 import { tryParseAddressInput } from './inputs.js'
 import { MAINNET_NETWORK_PROFILE, type NetworkProfile } from './networkProfile.js'
-
-const DEFAULT_RPC_URL = 'https://ethereum.dark.florist'
+import { resolveConfiguredRpcUrl } from './rpcConfig.js'
 
 export type ReadClient = ReturnType<typeof createPublicClient>
 export type WriteClient = WalletClient<Transport, NetworkProfile['chain'], Account> &
@@ -42,10 +41,10 @@ export type ChainBackend = {
 	waitUntilReady?(): Promise<void>
 }
 
-function createReadClientForProfile(profile: NetworkProfile, transportMode: ReadTransportMode, ethereum?: InjectedEthereum): ReadClient {
+function createReadClientForProfile(profile: NetworkProfile, transportMode: ReadTransportMode, rpcUrl: string, ethereum?: InjectedEthereum): ReadClient {
 	return createPublicClient({
 		chain: profile.chain,
-		transport: transportMode === 'provider' && ethereum !== undefined ? custom(ethereum) : http(DEFAULT_RPC_URL, { batch: { wait: 100 } }),
+		transport: transportMode === 'provider' && ethereum !== undefined ? custom(ethereum) : http(rpcUrl, { batch: { wait: 100 } }),
 	})
 }
 
@@ -84,15 +83,16 @@ function isProviderRequestError(error: unknown) {
 	return hasErrorCode(error) || hasErrorMessage(error)
 }
 
-export function createInjectedBackend(): ChainBackend {
+export function createInjectedBackend({ rpcUrl }: { rpcUrl?: string } = {}): ChainBackend {
 	const getProvider = () => getInjectedEthereum()
 	let readTransportMode: ReadTransportMode = 'provider'
+	const configuredRpcUrl = resolveConfiguredRpcUrl(rpcUrl === undefined ? {} : { overrideRpcUrl: rpcUrl })
 
 	return {
 		bootstrapError: undefined,
 		bootstrapLabel: undefined,
 		bootstrapProgress: undefined,
-		createReadClient: () => createReadClientForProfile(MAINNET_NETWORK_PROFILE, readTransportMode, getProvider()),
+		createReadClient: () => createReadClientForProfile(MAINNET_NETWORK_PROFILE, readTransportMode, configuredRpcUrl, getProvider()),
 		createWriteClient: (accountAddress, callbacks = {}) => {
 			const ethereum = getProvider()
 			if (ethereum === undefined) throw new Error('No injected wallet found')

--- a/ui/ts/lib/rpcConfig.ts
+++ b/ui/ts/lib/rpcConfig.ts
@@ -1,0 +1,68 @@
+export const DEFAULT_RPC_URL = 'https://ethereum.dark.florist'
+const RPC_URL_SEARCH_PARAM = 'rpcUrl'
+const RPC_URL_STORAGE_KEY = 'zoltar.rpcUrl'
+
+type LocationLike = {
+	hash?: string
+	search?: string
+}
+
+type StorageLike = {
+	getItem(key: string): string | null
+}
+
+type GlobalWithRpcConfig = typeof globalThis & {
+	__ZOLTAR_RPC_URL__?: unknown
+	location?: LocationLike
+	localStorage?: StorageLike
+	process?: {
+		env?: Record<string, string | undefined>
+	}
+}
+
+function resolveNonEmptyString(value: unknown) {
+	if (typeof value !== 'string') return undefined
+	const normalizedValue = value.trim()
+	return normalizedValue === '' ? undefined : normalizedValue
+}
+
+function readLocationParams(location: LocationLike | undefined) {
+	const params = new URLSearchParams(location?.search ?? '')
+	const hash = location?.hash ?? ''
+	const hashQueryIndex = hash.indexOf('?')
+	if (hashQueryIndex === -1) return params
+	for (const [key, value] of new URLSearchParams(hash.slice(hashQueryIndex))) {
+		params.set(key, value)
+	}
+	return params
+}
+
+function readStoredRpcUrl(storage: StorageLike | undefined) {
+	if (storage === undefined) return undefined
+	try {
+		return storage.getItem(RPC_URL_STORAGE_KEY)
+	} catch (error) {
+		if (error instanceof Error) return undefined
+		return undefined
+	}
+}
+
+export function resolveConfiguredRpcUrl({ fallbackRpcUrl = DEFAULT_RPC_URL, location, overrideRpcUrl, storage }: { fallbackRpcUrl?: string; location?: LocationLike; overrideRpcUrl?: string; storage?: StorageLike } = {}) {
+	const normalizedOverrideRpcUrl = resolveNonEmptyString(overrideRpcUrl)
+	if (normalizedOverrideRpcUrl !== undefined) return normalizedOverrideRpcUrl
+
+	const globalWithRpcConfig = globalThis as GlobalWithRpcConfig
+	const rpcUrlSearchParam = resolveNonEmptyString(readLocationParams(location ?? globalWithRpcConfig.location).get(RPC_URL_SEARCH_PARAM))
+	if (rpcUrlSearchParam !== undefined) return rpcUrlSearchParam
+
+	const storedRpcUrl = resolveNonEmptyString(readStoredRpcUrl(storage ?? globalWithRpcConfig.localStorage))
+	if (storedRpcUrl !== undefined) return storedRpcUrl
+
+	const globalRpcUrl = resolveNonEmptyString(globalWithRpcConfig.__ZOLTAR_RPC_URL__)
+	if (globalRpcUrl !== undefined) return globalRpcUrl
+
+	const environmentRpcUrl = resolveNonEmptyString(globalWithRpcConfig.process?.env?.['ZOLTAR_RPC_URL'])
+	if (environmentRpcUrl !== undefined) return environmentRpcUrl
+
+	return fallbackRpcUrl
+}

--- a/ui/ts/lib/securityPoolState/matrix.ts
+++ b/ui/ts/lib/securityPoolState/matrix.ts
@@ -41,9 +41,9 @@ export const FORK_ACTIONS: ActionList = ['forkWithOwnEscalation', 'initiateFork'
 export const ENABLED_ACTIONS_BY_LIFECYCLE: Record<SecurityPoolLifecycleState, ActionList> = {
 	operational: ['approveRep', 'depositRep', 'queueWithdrawRep', 'queueSetSecurityBondAllowance', 'redeemFees', 'createCompleteSet', 'redeemCompleteSet', 'requestPrice', 'executeStagedOperation', 'queueLiquidation'],
 	ended: ['redeemRep', 'redeemFees', 'redeemCompleteSet', 'redeemShares', 'requestPrice'],
-	poolForked: ['approveRep', 'depositRep', 'queueWithdrawRep', 'queueSetSecurityBondAllowance', 'redeemFees', 'requestPrice', 'executeStagedOperation', 'queueLiquidation'],
-	forkMigration: ['approveRep', 'depositRep', 'queueWithdrawRep', 'queueSetSecurityBondAllowance', 'redeemFees', 'requestPrice', 'executeStagedOperation', 'queueLiquidation'],
-	forkTruthAuction: ['approveRep', 'depositRep', 'queueWithdrawRep', 'queueSetSecurityBondAllowance', 'redeemFees', 'requestPrice', 'executeStagedOperation', 'queueLiquidation'],
+	poolForked: ['redeemFees'],
+	forkMigration: ['redeemFees'],
+	forkTruthAuction: ['redeemFees'],
 }
 
 export const ENABLED_ACTIONS_BY_REPORTING_STAGE: Record<SecurityPoolReportingStage, ActionList> = {

--- a/ui/ts/tests/chainBackend.test.ts
+++ b/ui/ts/tests/chainBackend.test.ts
@@ -103,7 +103,7 @@ describe('injected backend read transport', () => {
 		expect(fetchCalled).toBe(false)
 	})
 
-	test('switches injected reads to the shared RPC backend when requested', async () => {
+	test('switches injected reads to the configured RPC backend when requested', async () => {
 		const requestCalls: string[] = []
 		ensureWindowObject().ethereum = createMockInjectedEthereum(async parameters => {
 			requestCalls.push(parameters.method)
@@ -129,11 +129,11 @@ describe('injected backend read transport', () => {
 				},
 			})
 		})
-		const backend = createInjectedBackend()
+		const backend = createInjectedBackend({ rpcUrl: 'https://rpc.example' })
 		backend.setReadTransportMode?.('rpc')
 		const code = await backend.createReadClient().getCode({ address: zeroAddress })
 		expect(code).toBeUndefined()
-		expect(fetchCalls).toEqual(['https://ethereum.dark.florist'])
+		expect(fetchCalls).toEqual(['https://rpc.example'])
 		expect(requestCalls).toEqual([])
 	})
 

--- a/ui/ts/tests/contracts.test.ts
+++ b/ui/ts/tests/contracts.test.ts
@@ -8,7 +8,9 @@ import { peripherals_openOracle_OpenOracle_OpenOracle, peripherals_tokens_ShareT
 import type { ReadClient } from '../types/contracts.js'
 
 const securityPoolAddress = getAddress('0x00000000000000000000000000000000000000a1')
+const alternateSecurityPoolAddress = getAddress('0x00000000000000000000000000000000000000a2')
 const shareTokenAddress = getAddress('0x00000000000000000000000000000000000000b2')
+const vaultAddress = getAddress('0x00000000000000000000000000000000000000c1')
 const truthAuctionAddress = getAddress('0x00000000000000000000000000000000000000f6')
 const transactionHash = '0x00000000000000000000000000000000000000000000000000000000000000c3' satisfies Hash
 
@@ -166,7 +168,7 @@ describe('contracts helpers', () => {
 				const contracts = request.contracts
 				const firstContract = contracts[0]
 				if (getContractFunctionName(firstContract) === 'completeSetCollateralAmount') {
-					return [0n, 10n, [0n, zeroAddress, 0n, 0n, 0n, false, 0], 0n, 0n, 3n, 0n, 0n, 0n]
+					return [0n, 10n, [0n, zeroAddress, 0n, 0n, 0n, false, 0], 0n, 0n, 3n, 0n, 0n, 0n, 0n]
 				}
 				if (getContractFunctionName(firstContract) === 'questions') return [questionTuple, 1n]
 				throw new Error(`Unexpected multicall contract: ${getContractFunctionName(firstContract)}`)
@@ -202,6 +204,96 @@ describe('contracts helpers', () => {
 		expect(pool.parent).toBe(zeroAddress)
 		expect(pool.forkOutcome).toBe('none')
 		expect(pool.hasForkActivity).toBe(false)
+	})
+
+	test('loadAllSecurityPools defers vault detail loading for unselected pools in selected mode', async () => {
+		const questionId = 1n
+		const questionTuple = ['Question', 'Description', 1n, 2n, 2n, 0n, 100n, ''] as const
+		const getVaultCalls: Address[] = []
+		const securityVaultCalls: Address[] = []
+		const client = createMockLoaderClient({
+			getBlock: async () => createBlockWithTimestamp(0n),
+			multicall: async request => {
+				const contracts = request.contracts
+				const firstContract = contracts[0]
+				if (getContractFunctionName(firstContract) === 'completeSetCollateralAmount') {
+					return [0n, 10n, [0n, zeroAddress, 0n, 0n, 0n, false, 0], 0n, 0n, 3n, 0n, 5n, 0n, 0n]
+				}
+				if (getContractFunctionName(firstContract) === 'questions') return [questionTuple, 1n]
+				if (getContractFunctionName(firstContract) === 'securityVaults') {
+					const address = Reflect.get(firstContract, 'address')
+					if (typeof address !== 'string') throw new Error('Expected vault security pool address')
+					securityVaultCalls.push(getAddress(address))
+					return [[1n, 3n, 0n, 0n, 0n]]
+				}
+				if (getContractFunctionName(firstContract) === 'poolOwnershipToRep') return [5n]
+				throw new Error(`Unexpected multicall contract: ${getContractFunctionName(firstContract)}`)
+			},
+			readContract: async request => {
+				if (request.functionName === 'securityPoolDeploymentCount') return 2n
+				if (request.functionName === 'securityPoolDeploymentsRange') {
+					return [
+						{
+							completeSetCollateralAmount: 0n,
+							currentRetentionRate: 0n,
+							parent: zeroAddress,
+							priceOracleManagerAndOperatorQueuer: zeroAddress,
+							questionId,
+							securityMultiplier: 2n,
+							securityPool: securityPoolAddress,
+							shareToken: shareTokenAddress,
+							truthAuction: zeroAddress,
+							universeId: 1n,
+						},
+						{
+							completeSetCollateralAmount: 0n,
+							currentRetentionRate: 0n,
+							parent: zeroAddress,
+							priceOracleManagerAndOperatorQueuer: zeroAddress,
+							questionId,
+							securityMultiplier: 2n,
+							securityPool: alternateSecurityPoolAddress,
+							shareToken: shareTokenAddress,
+							truthAuction: zeroAddress,
+							universeId: 2n,
+						},
+					]
+				}
+				if (request.functionName === 'getVaultCount') {
+					const address = Reflect.get(request, 'address')
+					if (typeof address !== 'string') throw new Error('Expected security pool address')
+					return getAddress(address) === securityPoolAddress ? 1n : 2n
+				}
+				if (request.functionName === 'getVaults') {
+					const address = Reflect.get(request, 'address')
+					if (typeof address !== 'string') throw new Error('Expected security pool address')
+					const normalizedAddress = getAddress(address)
+					getVaultCalls.push(normalizedAddress)
+					if (normalizedAddress === alternateSecurityPoolAddress) throw new Error('Unexpected vault load for unselected pool')
+					return [vaultAddress]
+				}
+				if (request.functionName === 'getOutcomeLabels') return ['Yes', 'No']
+				throw new Error(`Unexpected readContract function: ${request.functionName}`)
+			},
+		})
+
+		const pools = await loadAllSecurityPools(client, {
+			selectedSecurityPoolAddress: securityPoolAddress,
+			vaultDetailMode: 'selected',
+		})
+
+		const selectedPool = pools.find(pool => pool.securityPoolAddress === securityPoolAddress)
+		const deferredPool = pools.find(pool => pool.securityPoolAddress === alternateSecurityPoolAddress)
+		if (selectedPool === undefined || deferredPool === undefined) throw new Error('Expected both security pools')
+
+		expect(getVaultCalls).toEqual([securityPoolAddress])
+		expect(securityVaultCalls).toEqual([securityPoolAddress])
+		expect(selectedPool.hasLoadedVaults).toBe(true)
+		expect(selectedPool.vaults).toHaveLength(1)
+		expect(selectedPool.totalRepDeposit).toBe(5n)
+		expect(deferredPool.hasLoadedVaults).toBe(false)
+		expect(deferredPool.vaults).toEqual([])
+		expect(deferredPool.vaultCount).toBe(2n)
 	})
 
 	test('settleOracleReport sends settle with an explicit gas limit', async () => {

--- a/ui/ts/tests/openOracle.test.ts
+++ b/ui/ts/tests/openOracle.test.ts
@@ -35,7 +35,7 @@ import { createWriteClient, type WriteClient } from '../../../solidity/ts/testsu
 import { deployOriginSecurityPool, ensureInfraDeployed, getSecurityPoolAddresses } from '../../../solidity/ts/testsuite/simulator/utils/contracts/deployPeripherals'
 import { ensureZoltarDeployed } from '../../../solidity/ts/testsuite/simulator/utils/contracts/zoltar'
 import { createQuestion, getQuestionId } from '../../../solidity/ts/testsuite/simulator/utils/contracts/zoltarQuestionData'
-import { getOpenOracleExtraData, wrapWeth as wrapWethTestHelper } from '../../../solidity/ts/testsuite/simulator/utils/contracts/peripherals'
+import { getOpenOracleExtraData, OperationType, requestPriceIfNeededAndStageOperation, wrapWeth as wrapWethTestHelper } from '../../../solidity/ts/testsuite/simulator/utils/contracts/peripherals'
 
 setDefaultTimeout(TEST_TIMEOUT_MS)
 
@@ -971,6 +971,18 @@ describe('Open Oracle helpers', () => {
 		expect(reportDetails.token1Decimals).toBe(18)
 		expect(reportDetails.token2Decimals).toBe(0)
 		expect(reportDetails.stateHash).toBe((await getOpenOracleExtraData(client, reportId)).stateHash)
+	})
+
+	test('loadOracleManagerDetails preserves queued zero-amount security bond allowance operations', async () => {
+		await requestPriceIfNeededAndStageOperation(client, managerAddress, OperationType.SetSecurityBondsAllowance, client.account.address, 0n)
+
+		const details = await loadOracleManagerDetails(uiReadClient, managerAddress)
+
+		expect(details.pendingOperationSlotId).toBeGreaterThan(0n)
+		expect(details.pendingOperation).toBeDefined()
+		expect(details.pendingOperation?.operation).toBe('setSecurityBondsAllowance')
+		expect(details.pendingOperation?.amount).toBe(0n)
+		expect(details.pendingOperation?.targetVault).toBe(client.account.address)
 	})
 
 	test('submitted and settled reports are tracked in loadOpenOracleReportDetails', async () => {

--- a/ui/ts/tests/rpcConfig.test.ts
+++ b/ui/ts/tests/rpcConfig.test.ts
@@ -1,0 +1,82 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { DEFAULT_RPC_URL, resolveConfiguredRpcUrl } from '../lib/rpcConfig.js'
+
+describe('rpc config', () => {
+	test('prefers explicit overrides over every other source', () => {
+		expect(
+			resolveConfiguredRpcUrl({
+				fallbackRpcUrl: 'https://fallback.example',
+				location: {
+					search: '?rpcUrl=https://query.example',
+				},
+				overrideRpcUrl: 'https://override.example',
+				storage: {
+					getItem: () => 'https://storage.example',
+				},
+			}),
+		).toBe('https://override.example')
+	})
+
+	test('reads rpcUrl from the location search params and hash query', () => {
+		expect(
+			resolveConfiguredRpcUrl({
+				location: {
+					search: '?rpcUrl=https://query.example',
+				},
+			}),
+		).toBe('https://query.example')
+
+		expect(
+			resolveConfiguredRpcUrl({
+				location: {
+					hash: '#/browse?rpcUrl=https://hash.example',
+				},
+			}),
+		).toBe('https://hash.example')
+	})
+
+	test('uses storage when no override or query parameter is present', () => {
+		expect(
+			resolveConfiguredRpcUrl({
+				location: {
+					search: '',
+				},
+				storage: {
+					getItem: () => 'https://storage.example',
+				},
+			}),
+		).toBe('https://storage.example')
+	})
+
+	test('ignores storage access failures and falls back to the next source', () => {
+		expect(
+			resolveConfiguredRpcUrl({
+				fallbackRpcUrl: 'https://fallback.example',
+				location: {
+					search: '',
+				},
+				storage: {
+					getItem: () => {
+						throw new Error('SecurityError')
+					},
+				},
+			}),
+		).toBe('https://fallback.example')
+	})
+
+	test('falls back to the default shared RPC when no config source is set', () => {
+		expect(
+			resolveConfiguredRpcUrl({
+				fallbackRpcUrl: DEFAULT_RPC_URL,
+				location: {
+					search: '',
+				},
+				storage: {
+					getItem: () => null,
+				},
+			}),
+		).toBe(DEFAULT_RPC_URL)
+	})
+})

--- a/ui/ts/tests/securityPoolState.engine.test.ts
+++ b/ui/ts/tests/securityPoolState.engine.test.ts
@@ -123,6 +123,9 @@ describe('security pool state engine', () => {
 		expect(migration.forkStage).toBe('migration')
 		expectActionEnabled(migration, 'createChildUniverse')
 		expectActionBlocked(migration, 'initiateFork')
+		expectActionBlocked(migration, 'depositRep')
+		expectActionBlocked(migration, 'requestPrice')
+		expectActionBlocked(migration, 'executeStagedOperation')
 
 		const disabled = evaluateSecurityPoolState({
 			forkStage: 'disabled',

--- a/ui/ts/tests/securityPoolState.matrix.test.ts
+++ b/ui/ts/tests/securityPoolState.matrix.test.ts
@@ -12,7 +12,9 @@ describe('security pool action matrix data', () => {
 	test('lists the exact lifecycle allowlists', () => {
 		expectActionSet(ENABLED_ACTIONS_BY_LIFECYCLE.operational, ['approveRep', 'depositRep', 'queueWithdrawRep', 'queueSetSecurityBondAllowance', 'redeemFees', 'createCompleteSet', 'redeemCompleteSet', 'requestPrice', 'executeStagedOperation', 'queueLiquidation'])
 		expectActionSet(ENABLED_ACTIONS_BY_LIFECYCLE.ended, ['redeemRep', 'redeemFees', 'redeemCompleteSet', 'redeemShares', 'requestPrice'])
-		expectActionSet(ENABLED_ACTIONS_BY_LIFECYCLE.forkMigration, ['approveRep', 'depositRep', 'queueWithdrawRep', 'queueSetSecurityBondAllowance', 'redeemFees', 'requestPrice', 'executeStagedOperation', 'queueLiquidation'])
+		expectActionSet(ENABLED_ACTIONS_BY_LIFECYCLE.poolForked, ['redeemFees'])
+		expectActionSet(ENABLED_ACTIONS_BY_LIFECYCLE.forkMigration, ['redeemFees'])
+		expectActionSet(ENABLED_ACTIONS_BY_LIFECYCLE.forkTruthAuction, ['redeemFees'])
 	})
 
 	test('lists the exact reporting, fork, and overlay allowlists', () => {

--- a/ui/ts/tests/securityPoolsOverviewSection.test.tsx
+++ b/ui/ts/tests/securityPoolsOverviewSection.test.tsx
@@ -65,6 +65,7 @@ function createSecurityPool(overrides: Partial<ListedSecurityPool> = {}): Listed
 		truthAuctionStartedAt: 0n,
 		universeHasForked: false,
 		universeId: 1n,
+		hasLoadedVaults: true,
 		vaultCount: 0n,
 		vaults: [],
 		...overrides,
@@ -310,5 +311,31 @@ describe('SecurityPoolsOverviewSection', () => {
 
 		expect(documentQueries.queryByText('Operational pool')).toBeNull()
 		expect(documentQueries.getAllByText('Ended pool').length).toBeGreaterThan(0)
+	})
+
+	test('shows a deferred vault placeholder when browse mode has not loaded vault details yet', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolsOverviewSection
+				{...createProps({
+					securityPools: [
+						createSecurityPool({
+							hasLoadedVaults: false,
+							marketDetails: createMarketDetails({ title: 'Deferred vault pool' }),
+							securityPoolAddress: '0x0000000000000000000000000000000000000200',
+							vaultCount: 2n,
+							vaults: [],
+						}),
+					],
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		const poolCard = documentQueries.getByRole('heading', { name: 'Deferred vault pool' }).closest('.entity-card')
+		if (!(poolCard instanceof HTMLElement)) throw new Error('Expected deferred vault pool card')
+		const poolCardQueries = within(poolCard)
+		expect(poolCardQueries.getByText('Open this pool to load 2 vaults.')).not.toBeNull()
+		expect(poolCardQueries.queryByText('No vaults in this pool yet.')).toBeNull()
 	})
 })

--- a/ui/ts/tests/securityPoolsSection.test.ts
+++ b/ui/ts/tests/securityPoolsSection.test.ts
@@ -361,7 +361,7 @@ void describe('security pools selected tab refresh', () => {
 				currentSecurityPoolAddress,
 				nextView: 'browse',
 				nextSecurityPoolAddress: currentSecurityPoolAddress,
-				selectedPoolExists: false,
+				selectedPoolHasLoadedDetails: false,
 			}),
 		).toBe(false)
 
@@ -370,7 +370,7 @@ void describe('security pools selected tab refresh', () => {
 				currentSecurityPoolAddress,
 				nextView: 'create',
 				nextSecurityPoolAddress: currentSecurityPoolAddress,
-				selectedPoolExists: false,
+				selectedPoolHasLoadedDetails: false,
 			}),
 		).toBe(false)
 
@@ -379,7 +379,7 @@ void describe('security pools selected tab refresh', () => {
 				currentSecurityPoolAddress,
 				nextView: 'operate',
 				nextSecurityPoolAddress: '',
-				selectedPoolExists: false,
+				selectedPoolHasLoadedDetails: false,
 			}),
 		).toBe(false)
 
@@ -388,7 +388,7 @@ void describe('security pools selected tab refresh', () => {
 				currentSecurityPoolAddress,
 				nextView: 'operate',
 				nextSecurityPoolAddress: currentSecurityPoolAddress,
-				selectedPoolExists: true,
+				selectedPoolHasLoadedDetails: true,
 			}),
 		).toBe(false)
 
@@ -397,7 +397,7 @@ void describe('security pools selected tab refresh', () => {
 				currentSecurityPoolAddress,
 				nextView: 'operate',
 				nextSecurityPoolAddress: currentSecurityPoolAddress,
-				selectedPoolExists: false,
+				selectedPoolHasLoadedDetails: false,
 			}),
 		).toBe(true)
 
@@ -406,7 +406,7 @@ void describe('security pools selected tab refresh', () => {
 				currentSecurityPoolAddress,
 				nextView: 'operate',
 				nextSecurityPoolAddress,
-				selectedPoolExists: true,
+				selectedPoolHasLoadedDetails: true,
 			}),
 		).toBe(false)
 
@@ -415,7 +415,7 @@ void describe('security pools selected tab refresh', () => {
 				currentSecurityPoolAddress,
 				nextView: 'operate',
 				nextSecurityPoolAddress,
-				selectedPoolExists: false,
+				selectedPoolHasLoadedDetails: false,
 			}),
 		).toBe(true)
 
@@ -424,7 +424,7 @@ void describe('security pools selected tab refresh', () => {
 				currentSecurityPoolAddress: '   ',
 				nextView: 'operate',
 				nextSecurityPoolAddress: currentSecurityPoolAddress,
-				selectedPoolExists: true,
+				selectedPoolHasLoadedDetails: true,
 			}),
 		).toBe(false)
 
@@ -432,7 +432,7 @@ void describe('security pools selected tab refresh', () => {
 			shouldRefreshSelectedPoolDataOnViewOpen({
 				currentSecurityPoolAddress: '   ',
 				nextView: 'operate',
-				selectedPoolExists: false,
+				selectedPoolHasLoadedDetails: false,
 			}),
 		).toBe(false)
 
@@ -441,9 +441,20 @@ void describe('security pools selected tab refresh', () => {
 				currentSecurityPoolAddress,
 				nextView: 'operate',
 				nextSecurityPoolAddress: '   ',
-				selectedPoolExists: false,
+				selectedPoolHasLoadedDetails: false,
 			}),
 		).toBe(false)
+	})
+
+	void test('refreshes selected pool data when the summary exists but vault details were deferred', () => {
+		expect(
+			shouldRefreshSelectedPoolDataOnViewOpen({
+				currentSecurityPoolAddress,
+				nextView: 'operate',
+				nextSecurityPoolAddress: currentSecurityPoolAddress,
+				selectedPoolHasLoadedDetails: false,
+			}),
+		).toBe(true)
 	})
 })
 

--- a/ui/ts/types/contracts.ts
+++ b/ui/ts/types/contracts.ts
@@ -267,6 +267,7 @@ export type ListedSecurityPool = {
 	universeHasForked: boolean
 	universeId: bigint
 	vaultCount: bigint
+	hasLoadedVaults?: boolean
 	vaults: SecurityPoolVaultSummary[]
 }
 


### PR DESCRIPTION
## Summary

- Added configurable RPC resolution in `ui/ts/lib/rpcConfig.ts` with deterministic precedence:
  - explicit `overrideRpcUrl`
  - URL query `?rpcUrl=`
  - `location.hash` query
  - `localStorage['zoltar.rpcUrl']`
  - `globalThis.__ZOLTAR_RPC_URL__`
  - `process.env.ZOLTAR_RPC_URL`
  - fallback default `https://ethereum.dark.florist`
- Wired configured RPC into backend creation via `createInjectedBackend({ rpcUrl? })` and updated injected-read transport test coverage.
- Introduced lazy/deferred vault loading for security pools:
  - `loadAllSecurityPools` now supports `vaultDetailMode` and optional `selectedSecurityPoolAddress`.
  - Unselected pools in `selected` mode only fetch vault count and surface `hasLoadedVaults`/`vaultCount`.
  - `SecurityPoolsSection` and `SecurityPoolsOverviewSection` now refresh/open behavior based on `hasLoadedVaults` and show a deferred vault placeholder in Browse cards.
- Updated pool filtering to use `vaultCount` instead of `vaults.length`, which now reflects unloaded cases correctly.
- Contract-level fix for staged security bond allowance operations:
  - `requestPriceIfNeededAndStageOperation` now allows zero-amount for `SetSecurityBondsAllowance`.
  - Staged operation execution now uses `initiatorVault` presence as execution marker, preserving zero-amount allowanced operations.
  - `loadOracleManagerDetails` and pending operation parsing aligned to this marker.
- Updated lifecycle matrix and engine tests to block request/execute/deposit actions in forked states.
- Expanded test coverage in:
  - `ui/ts/tests/rpcConfig.test.ts` (new)
  - security pool loading/overview/section tests
  - contract staging behavior tests
  - OpenOracle and contracts tests

## Testing

- Not run: `bun run tsc`
- Not run: `bun run test`
- Not run: `bun run format`
- Not run: `bun run check`
- Not run: `bun run knip`
- New/updated tests added in codebase for covered paths (as per diff), including:
  - `ui/ts/tests/rpcConfig.test.ts`
  - `ui/ts/tests/chainBackend.test.ts`
  - `ui/ts/tests/contracts.test.ts`
  - `ui/ts/tests/openOracle.test.ts`
  - `ui/ts/tests/securityPoolsOverviewSection.test.tsx`
  - `ui/ts/tests/securityPoolsSection.test.ts`
  - `ui/ts/tests/securityPoolState.matrix.test.ts`
  - `ui/ts/tests/securityPoolState.engine.test.ts`
  - `solidity/ts/tests/peripherals.test.ts`