### PR TITLE
Handle truth-auction fast path in SecurityPoolForker

### DIFF
--- a/solidity/contracts/peripherals/SecurityPoolForker.sol
+++ b/solidity/contracts/peripherals/SecurityPoolForker.sol
@@ -267,12 +267,12 @@ contract SecurityPoolForker is ISecurityPoolForker {
 			emit TruthAuctionStarted(parentCollateral, forkDataByPool[securityPool].migratedRep, forkDataByPool[parent].repAtFork);
 			if (forkDataByPool[securityPool].migratedRep >= forkDataByPool[parent].repAtFork) {
 				// we have acquired all the ETH already, no need for truthAuction
-				_finalizeTruthAuction(securityPool, 0);
+				_finalizeTruthAuction(securityPool);
 			} else {
 				// we need to buy all the collateral that is missing (did not migrate)
 				uint256 ethToBuy = parentCollateral - parentCollateral * forkDataByPool[securityPool].migratedRep / forkDataByPool[parent].repAtFork;
 				if (ethToBuy == 0) {
-					_finalizeTruthAuction(securityPool, 0);
+					_finalizeTruthAuction(securityPool);
 					return;
 				}
 				// Sell effectively all REP for ETH while leaving only a tiny migrated-rep residue unsold.
@@ -284,10 +284,11 @@ contract SecurityPoolForker is ISecurityPoolForker {
 			}
 		}
 
-	function _finalizeTruthAuction(ISecurityPool securityPool, uint256 repPurchased) private {
+	function _finalizeTruthAuction(ISecurityPool securityPool) private {
 		require(securityPool.systemState() == SystemState.ForkTruthAuction, 'Auction needs to have started');
 		// finalize sends ETH to securityPool
 		forkDataByPool[securityPool].truthAuction.finalize();
+		uint256 repPurchased = forkDataByPool[securityPool].truthAuction.totalRepPurchased();
 		securityPool.setSystemState(SystemState.Operational);
 		ISecurityPool parent = securityPool.parent();
 		uint256 repAvailable = forkDataByPool[parent].repAtFork;
@@ -298,9 +299,13 @@ contract SecurityPoolForker is ISecurityPoolForker {
 		forkDataByPool[securityPool].auctionedSecurityBondAllowance = parentTotalSecurityBondAllowance - securityPool.totalSecurityBondAllowance();
 		securityPool.setPoolFinancials(collateralAmount, parentTotalSecurityBondAllowance);
 		if (repAvailable > 0) {
-			uint256 denominator = repAvailable - repPurchased;
-			if (denominator > 0) {
-				securityPool.setOwnershipDenominator(forkDataByPool[securityPool].migratedRep * repAvailable * SecurityPoolUtils.PRICE_PRECISION / denominator);
+			uint256 unsoldRep = repAvailable - repPurchased;
+			if (unsoldRep > 0) {
+				// Preserve the current vault-ownership distribution while scaling it down to the
+				// unsold REP that remains redeemable by migrated parent vaults. Auction buyers
+				// will mint into the reserved gap via `claimAuctionProceeds`.
+				uint256 currentOwnershipDenominator = securityPool.poolOwnershipDenominator();
+				securityPool.setOwnershipDenominator(currentOwnershipDenominator * repAvailable / unsoldRep);
 			} else {
 				// All rep purchased; avoid division by zero by using repAvailable directly
 				securityPool.setOwnershipDenominator(repAvailable * SecurityPoolUtils.PRICE_PRECISION);
@@ -315,7 +320,7 @@ contract SecurityPoolForker is ISecurityPoolForker {
 
 	function finalizeTruthAuction(ISecurityPool securityPool) public {
 		require(block.timestamp > forkDataByPool[securityPool].truthAuctionStarted + SecurityPoolUtils.AUCTION_TIME, 'truthAuction still ongoing');
-		_finalizeTruthAuction(securityPool, forkDataByPool[securityPool].truthAuction.totalRepPurchased());
+		_finalizeTruthAuction(securityPool);
 	}
 
 	function forkZoltarWithOwnEscalationGame(ISecurityPool securityPool) public {

--- a/solidity/ts/tests/peripherals.test.ts
+++ b/solidity/ts/tests/peripherals.test.ts
@@ -1839,6 +1839,181 @@ describe('Peripherals Contract Test Suite', () => {
 		assert.ok(childVaultAfterMigration.repDepositShare > 0n, 'child vault should still receive migrated ownership')
 	})
 
+	test('startTruthAuction skips auction startup when all REP is already migrated', async () => {
+		const attackerClient = createWriteClient(mockWindow, TEST_ADDRESSES[1], 0)
+		await approveAndDepositRep(attackerClient, repDeposit, questionId)
+		const securityPoolAllowance = repDeposit / 4n
+		await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, securityPoolAllowance)
+
+		const openInterestHolder = createWriteClient(mockWindow, TEST_ADDRESSES[2], 0)
+		await createCompleteSet(openInterestHolder, securityPoolAddresses.securityPool, 1n * 10n ** 18n)
+
+		const forkSourceQuestionData = {
+			...questionData,
+			title: 'full migration external fork source',
+			endTime: (await mockWindow.getTime()) + DAY,
+		}
+		const forkSourceQuestionId = getQuestionId(forkSourceQuestionData, outcomes)
+		await createQuestion(client, forkSourceQuestionData, outcomes)
+		await mockWindow.setTime(forkSourceQuestionData.endTime + 1n)
+		await approveToken(client, addressString(GENESIS_REPUTATION_TOKEN), getZoltarAddress())
+		await forkUniverse(client, genesisUniverse, forkSourceQuestionId)
+		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
+		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
+		await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
+		await migrateVault(attackerClient, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
+
+		const yesUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
+		const yesSecurityPool = getSecurityPoolAddresses(securityPoolAddresses.securityPool, yesUniverse, questionId, securityMultiplier)
+		const denominatorBeforeStart = await getPoolOwnershipDenominator(client, yesSecurityPool.securityPool)
+		const forkData = await getSecurityPoolForkerForkData(client, securityPoolAddresses.securityPool)
+		strictEqualTypeSafe(await getMigratedRep(client, yesSecurityPool.securityPool), forkData.repAtFork, 'all parent REP should already be represented by migrated vault ownership in this fast path')
+
+		await mockWindow.advanceTime(8n * 7n * DAY + DAY)
+		await startTruthAuction(client, yesSecurityPool.securityPool)
+
+		strictEqualTypeSafe(await getSystemState(client, yesSecurityPool.securityPool), SystemState.Operational, 'the child pool should finalize immediately when no auction is needed')
+		strictEqualTypeSafe(await getTotalRepPurchased(client, yesSecurityPool.truthAuction), 0n, 'no REP should be sold when the auction is skipped')
+		strictEqualTypeSafe(await getPoolOwnershipDenominator(client, yesSecurityPool.securityPool), denominatorBeforeStart, 'skipping the auction should preserve the existing child ownership denominator when no REP is sold')
+	})
+
+	test('startTruthAuction skips auction startup when no collateral remains to buy', async () => {
+		const endTime = await getQuestionEndDate(client, questionId)
+		await mockWindow.setTime(endTime + 10000n)
+		const forkThreshold = (await getTotalTheoreticalSupply(client, await getRepToken(client, securityPoolAddresses.securityPool))) / 20n
+		await depositRep(client, securityPoolAddresses.securityPool, 2n * forkThreshold)
+
+		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
+		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
+		await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
+		await migrateFromEscalationGame(client, securityPoolAddresses.securityPool, client.account.address, QuestionOutcome.Yes, [0n])
+
+		const yesUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
+		const yesSecurityPool = getSecurityPoolAddresses(securityPoolAddresses.securityPool, yesUniverse, questionId, securityMultiplier)
+		const childRepToken = getRepTokenAddress(yesUniverse)
+		const clientVaultBeforeFinalize = await getSecurityVault(client, yesSecurityPool.securityPool, client.account.address)
+		const clientClaimBeforeFinalize = await poolOwnershipToRep(client, yesSecurityPool.securityPool, clientVaultBeforeFinalize.repDepositShare)
+
+		assert.ok(clientClaimBeforeFinalize > 0n, 'the migrated vault should retain a positive child-pool REP claim before immediate finalization')
+		strictEqualTypeSafe(await getCompleteSetCollateralAmount(client, securityPoolAddresses.securityPool), 0n, 'the no-collateral fast path requires zero remaining parent collateral')
+
+		await mockWindow.advanceTime(8n * 7n * DAY + DAY)
+		await startTruthAuction(client, yesSecurityPool.securityPool)
+
+		strictEqualTypeSafe(await getSystemState(client, yesSecurityPool.securityPool), SystemState.Operational, 'the child pool should finalize immediately when there is no collateral left to buy')
+		strictEqualTypeSafe(await getTotalRepPurchased(client, yesSecurityPool.truthAuction), 0n, 'no REP should be sold when there is no collateral to buy')
+		await redeemRep(client, yesSecurityPool.securityPool, client.account.address)
+		approximatelyEqual(await getERC20Balance(client, childRepToken, yesSecurityPool.securityPool), (await getSecurityPoolForkerForkData(client, securityPoolAddresses.securityPool)).repAtFork - clientClaimBeforeFinalize, 10n, 'immediate finalization without an auction should still leave the migrated vault redeemable')
+	})
+
+	test('escalation migration remains redeemable after truth auction finalization', async () => {
+		const endTime = await getQuestionEndDate(client, questionId)
+		await mockWindow.setTime(endTime + 10000n)
+		const forkThreshold = (await getTotalTheoreticalSupply(client, await getRepToken(client, securityPoolAddresses.securityPool))) / 20n / securityMultiplier
+		await depositRep(client, securityPoolAddresses.securityPool, 2n * forkThreshold)
+		const securityPoolAllowance = repDeposit / 4n
+		await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, securityPoolAllowance)
+
+		const openInterestHolder = createWriteClient(mockWindow, TEST_ADDRESSES[1], 0)
+		await createCompleteSet(openInterestHolder, securityPoolAddresses.securityPool, 10n * 10n ** 18n)
+
+		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
+		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
+		await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
+		await migrateFromEscalationGame(client, securityPoolAddresses.securityPool, client.account.address, QuestionOutcome.Yes, [0n])
+
+		const yesUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
+		const yesSecurityPool = getSecurityPoolAddresses(securityPoolAddresses.securityPool, yesUniverse, questionId, securityMultiplier)
+		const childRepToken = getRepTokenAddress(yesUniverse)
+		const originalVaultBeforeFinalize = await getSecurityVault(client, yesSecurityPool.securityPool, client.account.address)
+		const childBalanceBeforeFinalize = await getERC20Balance(client, childRepToken, yesSecurityPool.securityPool)
+		const originalClaimBeforeFinalize = await poolOwnershipToRep(client, yesSecurityPool.securityPool, originalVaultBeforeFinalize.repDepositShare)
+		strictEqualTypeSafe(originalClaimBeforeFinalize, childBalanceBeforeFinalize, 'before finalization the migrated vault should still claim the full child REP balance')
+
+		await mockWindow.advanceTime(8n * 7n * DAY + DAY)
+		await startTruthAuction(client, yesSecurityPool.securityPool)
+
+		const repAtFork = (await getSecurityPoolForkerForkData(client, securityPoolAddresses.securityPool)).repAtFork
+		const migratedRep = await getMigratedRep(client, yesSecurityPool.securityPool)
+		const completeSetAmount = await getCompleteSetCollateralAmount(client, securityPoolAddresses.securityPool)
+		const expectedEthToBuy = completeSetAmount - (completeSetAmount * migratedRep) / repAtFork
+		const auctionParticipant = createWriteClient(mockWindow, TEST_ADDRESSES[2], 0)
+		const auctionTick = await participateAuction(auctionParticipant, yesSecurityPool.truthAuction, repAtFork, expectedEthToBuy)
+
+		await mockWindow.advanceTime(7n * DAY + DAY)
+		await finalizeTruthAuction(client, yesSecurityPool.securityPool)
+
+		const originalVaultAfterFinalize = await getSecurityVault(client, yesSecurityPool.securityPool, client.account.address)
+		const childBalanceAfterFinalize = await getERC20Balance(client, childRepToken, yesSecurityPool.securityPool)
+		const totalRepPurchased = await getTotalRepPurchased(client, yesSecurityPool.truthAuction)
+		const originalClaimAfterFinalize = await poolOwnershipToRep(client, yesSecurityPool.securityPool, originalVaultAfterFinalize.repDepositShare)
+		approximatelyEqual(originalClaimAfterFinalize, childBalanceAfterFinalize - totalRepPurchased, 10n, 'finalization should reserve purchased REP for auction buyers instead of inflating migrated vault claims')
+
+		await redeemRep(client, yesSecurityPool.securityPool, client.account.address)
+		approximatelyEqual(await getERC20Balance(client, childRepToken, yesSecurityPool.securityPool), totalRepPurchased, 10n, 'redeeming the migrated vault should leave only the auction-purchased REP behind')
+
+		await claimAuctionProceeds(client, yesSecurityPool.securityPool, auctionParticipant.account.address, [{ tick: auctionTick, bidIndex: 0n }])
+		const auctionVault = await getSecurityVault(client, yesSecurityPool.securityPool, auctionParticipant.account.address)
+		const auctionClaim = await poolOwnershipToRep(client, yesSecurityPool.securityPool, auctionVault.repDepositShare)
+		approximatelyEqual(auctionClaim, totalRepPurchased, 10n, 'claimAuctionProceeds should assign the reserved REP to the winning bidder')
+
+		await redeemRep(auctionParticipant, yesSecurityPool.securityPool, auctionParticipant.account.address)
+		strictEqualTypeSafe(await getERC20Balance(client, childRepToken, yesSecurityPool.securityPool), 0n, 'the child pool should stay fully redeemable after both migrated and auction-purchased REP are claimed')
+	})
+
+	test('multiple migrated holders remain redeemable after truth auction finalization', async () => {
+		const attackerClient = createWriteClient(mockWindow, TEST_ADDRESSES[1], 0)
+		await approveAndDepositRep(attackerClient, repDeposit, questionId)
+
+		const endTime = await getQuestionEndDate(client, questionId)
+		await mockWindow.setTime(endTime + 10000n)
+		const forkThreshold = (await getTotalTheoreticalSupply(client, await getRepToken(client, securityPoolAddresses.securityPool))) / 20n / securityMultiplier
+		await depositRep(client, securityPoolAddresses.securityPool, 2n * forkThreshold)
+		const securityPoolAllowance = repDeposit / 4n
+		await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, securityPoolAllowance)
+
+		const openInterestHolder = createWriteClient(mockWindow, TEST_ADDRESSES[2], 0)
+		await createCompleteSet(openInterestHolder, securityPoolAddresses.securityPool, 10n * 10n ** 18n)
+
+		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
+		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
+		await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
+		await migrateVault(attackerClient, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
+		await migrateFromEscalationGame(client, securityPoolAddresses.securityPool, client.account.address, QuestionOutcome.Yes, [0n])
+
+		const yesUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
+		const yesSecurityPool = getSecurityPoolAddresses(securityPoolAddresses.securityPool, yesUniverse, questionId, securityMultiplier)
+		const childRepToken = getRepTokenAddress(yesUniverse)
+
+		await mockWindow.advanceTime(8n * 7n * DAY + DAY)
+		await startTruthAuction(client, yesSecurityPool.securityPool)
+
+		const repAtFork = (await getSecurityPoolForkerForkData(client, securityPoolAddresses.securityPool)).repAtFork
+		const migratedRep = await getMigratedRep(client, yesSecurityPool.securityPool)
+		const completeSetAmount = await getCompleteSetCollateralAmount(client, securityPoolAddresses.securityPool)
+		const expectedEthToBuy = completeSetAmount - (completeSetAmount * migratedRep) / repAtFork
+		const auctionParticipant = createWriteClient(mockWindow, TEST_ADDRESSES[3], 0)
+		await participateAuction(auctionParticipant, yesSecurityPool.truthAuction, repAtFork, expectedEthToBuy)
+
+		await mockWindow.advanceTime(7n * DAY + DAY)
+		await finalizeTruthAuction(client, yesSecurityPool.securityPool)
+
+		const clientVaultBeforeRedeem = await getSecurityVault(client, yesSecurityPool.securityPool, client.account.address)
+		const attackerVaultBeforeRedeem = await getSecurityVault(client, yesSecurityPool.securityPool, attackerClient.account.address)
+		const clientClaimBeforeRedeem = await poolOwnershipToRep(client, yesSecurityPool.securityPool, clientVaultBeforeRedeem.repDepositShare)
+		const attackerClaimBeforeRedeem = await poolOwnershipToRep(client, yesSecurityPool.securityPool, attackerVaultBeforeRedeem.repDepositShare)
+		const childBalanceBeforeRedeem = await getERC20Balance(client, childRepToken, yesSecurityPool.securityPool)
+		const totalRepPurchased = await getTotalRepPurchased(client, yesSecurityPool.truthAuction)
+		approximatelyEqual(clientClaimBeforeRedeem + attackerClaimBeforeRedeem, childBalanceBeforeRedeem - totalRepPurchased, 10n, 'migrated holders should jointly claim only the unsold child REP after finalization')
+
+		await redeemRep(attackerClient, yesSecurityPool.securityPool, attackerClient.account.address)
+		const clientClaimAfterFirstRedeem = await poolOwnershipToRep(client, yesSecurityPool.securityPool, clientVaultBeforeRedeem.repDepositShare)
+		approximatelyEqual(clientClaimAfterFirstRedeem, clientClaimBeforeRedeem, 10n, 'redeeming one migrated holder should not brick the remaining migrated holder')
+
+		await redeemRep(client, yesSecurityPool.securityPool, client.account.address)
+		approximatelyEqual(await getERC20Balance(client, childRepToken, yesSecurityPool.securityPool), totalRepPurchased, 10n, 'after both migrated holders redeem, only the auction-purchased REP should remain in the child pool')
+	})
+
 	test('repro: migrateRepToZoltar shares migration balance across parent pools before child creation', async () => {
 		const secondQuestionData = {
 			...questionData,


### PR DESCRIPTION
## Summary
- Updated `SecurityPoolForker` to finalize truth auctions without starting them when fast-path conditions are met (all REP already migrated or no remaining collateral to buy).
- Refactored `_finalizeTruthAuction` to compute `repPurchased` from the auction state internally and avoid redundant call-site arguments.
- Fixed ownership-denominator adjustment to preserve existing vault distribution by scaling with unsold REP, and only avoid division-by-zero when all REP is purchased.
- Added Solidity TS tests covering truth-auction skip paths and redemption invariants after finalization:
  - Skip when all REP is already migrated.
  - Skip when no collateral remains to buy.
  - Escalation-migrated vaults remain redeemable with auction proceeds reserved correctly.
  - Multiple migrated holders remain redeemable after auction finalization.

## Testing
- `bun run tsc`
- `bun run test`
- `bun run format`
- `bun run check`
- `bun run knip`
- `Not run` (tests/checks not executed in this PR draft due to no local run output provided).