### PR TITLE
Add oracle self-operation anti-stale safeguards and paginated browsing UI

### DIFF
--- a/solidity/contracts/peripherals/SecurityPoolOracleCoordinator.sol
+++ b/solidity/contracts/peripherals/SecurityPoolOracleCoordinator.sol
@@ -15,16 +15,18 @@ enum OperationType {
 	SetSecurityBondsAllowance
 }
 
-struct StagedOperation {
-	OperationType operation;
-	address initiatorVault;
-	address targetVault;
-	uint256 amount;
-	uint256 snapshotTargetOwnership;
-	uint256 snapshotTargetAllowance;
-	uint256 snapshotTotalRep;
-	uint256 snapshotDenominator;
-}
+	struct StagedOperation {
+		OperationType operation;
+		address initiatorVault;
+		address targetVault;
+		uint256 amount;
+		uint256 queuedAt;
+		uint256 validForSeconds;
+		uint256 snapshotTargetOwnership;
+		uint256 snapshotTargetAllowance;
+		uint256 snapshotTotalRep;
+		uint256 snapshotDenominator;
+	}
 
 contract SecurityPoolOracleCoordinator {
 	uint256 public pendingReportId;
@@ -163,9 +165,13 @@ contract SecurityPoolOracleCoordinator {
 		return lastSettlementTimestamp != 0 && lastSettlementTimestamp + PRICE_VALID_FOR_SECONDS > block.timestamp;
 	}
 
-	function requestPriceIfNeededAndStageOperation(OperationType operation, address targetVault, uint256 amount) public payable {
+	function requestPriceIfNeededAndStageOperation(OperationType operation, address targetVault, uint256 amount, uint256 validForSeconds) public payable {
 		if (operation != OperationType.SetSecurityBondsAllowance) {
 			require(amount > 0, 'need to do non zero operation');
+		}
+		require(validForSeconds > 0, 'operation timeout must be positive');
+		if (operation != OperationType.Liquidation) {
+			require(targetVault == msg.sender, 'self operation target must match initiator');
 		}
 		require(!securityPool.isEscalationResolved(), 'question already resolved');
 		stagedOperationCounter++;
@@ -181,6 +187,8 @@ contract SecurityPoolOracleCoordinator {
 			initiatorVault: msg.sender,
 			targetVault: targetVault,
 			amount: amount,
+			queuedAt: block.timestamp,
+			validForSeconds: validForSeconds,
 			snapshotTargetOwnership: snapshotTargetOwnership,
 			snapshotTargetAllowance: snapshotTargetAllowance,
 			snapshotTotalRep: snapshotTotalRep,
@@ -218,10 +226,10 @@ contract SecurityPoolOracleCoordinator {
 	}
 
 	function executeStagedOperation(uint256 operationId) public {
-		require(stagedOperations[operationId].initiatorVault != address(0), 'no such operation or already executed');
+		StagedOperation storage stagedOperation = stagedOperations[operationId];
+		require(stagedOperation.initiatorVault != address(0), 'no such operation or already executed');
 		require(isPriceValid(), 'price is not valid to execute');
-		StagedOperation memory stagedOperation = stagedOperations[operationId];
-		bool success;
+		require(block.timestamp <= stagedOperation.queuedAt + settlementTime + stagedOperation.validForSeconds, 'staged operation expired');
 		if (stagedOperation.operation == OperationType.Liquidation) {
 			try
 					securityPool.performLiquidation(
@@ -234,7 +242,6 @@ contract SecurityPoolOracleCoordinator {
 						stagedOperation.snapshotDenominator
 					)
 			{
-				success = true;
 				emit ExecutedStagedOperation(operationId, stagedOperation.operation, true, '');
 			} catch Error(string memory reason) {
 				emit ExecutedStagedOperation(operationId, stagedOperation.operation, false, reason);
@@ -247,7 +254,6 @@ contract SecurityPoolOracleCoordinator {
 			try
 				securityPool.performWithdrawRep(stagedOperation.initiatorVault, stagedOperation.amount)
 			{
-				success = true;
 				emit ExecutedStagedOperation(operationId, stagedOperation.operation, true, '');
 			} catch Error(string memory reason) {
 				emit ExecutedStagedOperation(operationId, stagedOperation.operation, false, reason);
@@ -260,7 +266,6 @@ contract SecurityPoolOracleCoordinator {
 			try
 				securityPool.performSetSecurityBondsAllowance(stagedOperation.initiatorVault, stagedOperation.amount)
 			{
-				success = true;
 				emit ExecutedStagedOperation(operationId, stagedOperation.operation, true, '');
 			} catch Error(string memory reason) {
 				emit ExecutedStagedOperation(operationId, stagedOperation.operation, false, reason);
@@ -270,7 +275,7 @@ contract SecurityPoolOracleCoordinator {
 				emit ExecutedStagedOperation(operationId, stagedOperation.operation, false, 'Unknown error');
 			}
 		}
-		stagedOperations[operationId].initiatorVault = address(0);
+		stagedOperation.initiatorVault = address(0);
 	}
 
 	function getPendingOperationSlot() public view returns (StagedOperation memory) {

--- a/solidity/ts/tests/peripherals.test.ts
+++ b/solidity/ts/tests/peripherals.test.ts
@@ -864,7 +864,7 @@ describe('Peripherals Contract Test Suite', () => {
 		await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, securityPoolAllowance)
 		const attackerClient = createWriteClient(mockWindow, TEST_ADDRESSES[1], 0)
 		await approveAndDepositRep(attackerClient, repDeposit, questionId)
-		await manipulatePriceOracleAndPerformOperation(attackerClient, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, securityPoolAllowance)
+		await manipulatePriceOracleAndPerformOperation(attackerClient, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, attackerClient.account.address, securityPoolAllowance)
 		const forkThreshold = (await getTotalTheoreticalSupply(client, await getRepToken(client, securityPoolAddresses.securityPool))) / 20n
 		await depositRep(client, securityPoolAddresses.securityPool, 2n * forkThreshold)
 		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
@@ -1333,7 +1333,7 @@ describe('Peripherals Contract Test Suite', () => {
 		await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, securityPoolAllowance)
 		const attackerClient = createWriteClient(mockWindow, TEST_ADDRESSES[1], 0)
 		await approveAndDepositRep(attackerClient, repDeposit, questionId)
-		await manipulatePriceOracleAndPerformOperation(attackerClient, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, securityPoolAllowance)
+		await manipulatePriceOracleAndPerformOperation(attackerClient, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, attackerClient.account.address, securityPoolAllowance)
 		const forkThreshold = (await getTotalTheoreticalSupply(client, await getRepToken(client, securityPoolAddresses.securityPool))) / 20n
 
 		const zoltarForkThreshold = await getZoltarForkThreshold(client, genesisUniverse)
@@ -2778,7 +2778,7 @@ describe('Peripherals Contract Test Suite', () => {
 		await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, securityPoolAllowance)
 		const attackerClient = createWriteClient(mockWindow, TEST_ADDRESSES[1], 0)
 		await approveAndDepositRep(attackerClient, repDeposit, questionId)
-		await manipulatePriceOracleAndPerformOperation(attackerClient, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, securityPoolAllowance)
+		await manipulatePriceOracleAndPerformOperation(attackerClient, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, attackerClient.account.address, securityPoolAllowance)
 		const forkThreshold = (await getTotalTheoreticalSupply(client, await getRepToken(client, securityPoolAddresses.securityPool))) / 20n
 		const zoltarForkThreshold = await getZoltarForkThreshold(client, genesisUniverse)
 		const burnAmount = zoltarForkThreshold / 5n

--- a/solidity/ts/tests/priceOracleSecurity.test.ts
+++ b/solidity/ts/tests/priceOracleSecurity.test.ts
@@ -18,6 +18,7 @@ import { peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator
 setDefaultTimeout(TEST_TIMEOUT_MS)
 
 describe('Price Oracle Refund Security Tests', () => {
+	const DEFAULT_SELF_OPERATION_TIMEOUT_SECONDS = 30n * 60n
 	const { getAnvilWindowEthereum } = useIsolatedAnvilNode()
 	let mockWindow: AnvilWindowEthereum
 	let client: WriteClient
@@ -106,7 +107,7 @@ describe('Price Oracle Refund Security Tests', () => {
 					abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
 					address: priceOracle,
 					functionName: 'requestPriceIfNeededAndStageOperation',
-					args: [OperationType.WithdrawRep, caller, 100n],
+					args: [OperationType.WithdrawRep, caller, 100n, DEFAULT_SELF_OPERATION_TIMEOUT_SECONDS],
 					value: sendValue,
 				}),
 		)
@@ -129,7 +130,7 @@ describe('Price Oracle Refund Security Tests', () => {
 					abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
 					address: priceOracle,
 					functionName: 'requestPriceIfNeededAndStageOperation',
-					args: [OperationType.SetSecurityBondsAllowance, client.account.address, impossibleAllowance],
+					args: [OperationType.SetSecurityBondsAllowance, client.account.address, impossibleAllowance, DEFAULT_SELF_OPERATION_TIMEOUT_SECONDS],
 					value: ethCost,
 				}),
 		)
@@ -166,6 +167,256 @@ describe('Price Oracle Refund Security Tests', () => {
 						}),
 				),
 			/no such operation or already executed/i,
+		)
+	})
+
+	test('newer self operations do not replace an existing pending slot and stay manually executable', async () => {
+		const ethCost = await getRequestPriceEthCost(client, priceOracle)
+
+		await writeContractAndWait(
+			client,
+			async () =>
+				await client.writeContract({
+					abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+					address: priceOracle,
+					functionName: 'requestPriceIfNeededAndStageOperation',
+					args: [OperationType.SetSecurityBondsAllowance, client.account.address, 1n, DEFAULT_SELF_OPERATION_TIMEOUT_SECONDS],
+					value: ethCost,
+				}),
+		)
+		await writeContractAndWait(
+			client,
+			async () =>
+				await client.writeContract({
+					abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+					address: priceOracle,
+					functionName: 'requestPriceIfNeededAndStageOperation',
+					args: [OperationType.SetSecurityBondsAllowance, client.account.address, 2n, DEFAULT_SELF_OPERATION_TIMEOUT_SECONDS],
+				}),
+		)
+
+		const pendingOperationSlotId = await client.readContract({
+			abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+			address: priceOracle,
+			functionName: 'pendingOperationSlotId',
+			args: [],
+		})
+		assert.strictEqual(pendingOperationSlotId, 1n, 'first queued self operation should keep the auto-execute slot')
+
+		await handleOracleReporting(client, mockWindow, priceOracle, 10n ** 18n)
+		await writeContractAndWait(
+			client,
+			async () =>
+				await client.writeContract({
+					abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+					address: priceOracle,
+					functionName: 'executeStagedOperation',
+					args: [2n],
+				}),
+		)
+
+		const stagedOperation1 = await client.readContract({
+			abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+			address: priceOracle,
+			functionName: 'stagedOperations',
+			args: [1n],
+		})
+		const stagedOperation2 = await client.readContract({
+			abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+			address: priceOracle,
+			functionName: 'stagedOperations',
+			args: [2n],
+		})
+		assert.strictEqual(stagedOperation1[1], addressString(0n), 'pending-slot operation should be consumed after the oracle settles it')
+		assert.strictEqual(stagedOperation2[3], 2n, 'later self operation should retain its requested amount until manual execution')
+		assert.strictEqual(stagedOperation2[2], client.account.address, 'later self operation should still target the initiator vault')
+	})
+
+	test('staged operations can only be executed once', async () => {
+		const ethCost = await getRequestPriceEthCost(client, priceOracle)
+
+		await writeContractAndWait(
+			client,
+			async () =>
+				await client.writeContract({
+					abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+					address: priceOracle,
+					functionName: 'requestPriceIfNeededAndStageOperation',
+					args: [OperationType.Liquidation, client.account.address, 1n, DEFAULT_SELF_OPERATION_TIMEOUT_SECONDS],
+					value: ethCost,
+				}),
+		)
+		await writeContractAndWait(
+			client,
+			async () =>
+				await client.writeContract({
+					abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+					address: priceOracle,
+					functionName: 'requestPriceIfNeededAndStageOperation',
+					args: [OperationType.SetSecurityBondsAllowance, client.account.address, 1n, DEFAULT_SELF_OPERATION_TIMEOUT_SECONDS],
+				}),
+		)
+
+		await handleOracleReporting(client, mockWindow, priceOracle, 10n ** 18n)
+		await writeContractAndWait(
+			client,
+			async () =>
+				await client.writeContract({
+					abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+					address: priceOracle,
+					functionName: 'executeStagedOperation',
+					args: [2n],
+				}),
+		)
+
+		await assert.rejects(
+			async () =>
+				await writeContractAndWait(
+					client,
+					async () =>
+						await client.writeContract({
+							abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+							address: priceOracle,
+							functionName: 'executeStagedOperation',
+							args: [2n],
+						}),
+				),
+			/no such operation or already executed/i,
+		)
+	})
+
+	test('non-liquidation staged operations require the initiator vault as target', async () => {
+		const otherVault = addressString(TEST_ADDRESSES[1])
+		const nonLiquidationOperations = [OperationType.WithdrawRep, OperationType.SetSecurityBondsAllowance]
+
+		for (const operation of nonLiquidationOperations) {
+			await assert.rejects(
+				async () =>
+					await writeContractAndWait(
+						client,
+						async () =>
+							await client.writeContract({
+								abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+								address: priceOracle,
+								functionName: 'requestPriceIfNeededAndStageOperation',
+								args: [operation, otherVault, 1n, DEFAULT_SELF_OPERATION_TIMEOUT_SECONDS],
+							}),
+					),
+				/self operation target must match initiator/i,
+			)
+		}
+	})
+
+	test('staged liquidations expire after their caller-selected validity window', async () => {
+		const ethCost = await getRequestPriceEthCost(client, priceOracle)
+		const liquidationTimeoutSeconds = 60n
+		const targetVault = addressString(TEST_ADDRESSES[1])
+
+		await writeContractAndWait(
+			client,
+			async () =>
+				await client.writeContract({
+					abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+					address: priceOracle,
+					functionName: 'requestPriceIfNeededAndStageOperation',
+					args: [OperationType.Liquidation, targetVault, 1n, liquidationTimeoutSeconds],
+					value: ethCost,
+				}),
+		)
+		await writeContractAndWait(
+			client,
+			async () =>
+				await client.writeContract({
+					abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+					address: priceOracle,
+					functionName: 'requestPriceIfNeededAndStageOperation',
+					args: [OperationType.Liquidation, targetVault, 1n, liquidationTimeoutSeconds],
+				}),
+		)
+
+		await handleOracleReporting(client, mockWindow, priceOracle, 10n ** 18n)
+		await mockWindow.advanceTime(liquidationTimeoutSeconds + 1n)
+		await writeContractAndWait(
+			client,
+			async () =>
+				await client.writeContract({
+					abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+					address: priceOracle,
+					functionName: 'requestPrice',
+					value: ethCost,
+				}),
+		)
+		await handleOracleReporting(client, mockWindow, priceOracle, 10n ** 18n)
+
+		await assert.rejects(
+			async () =>
+				await writeContractAndWait(
+					client,
+					async () =>
+						await client.writeContract({
+							abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+							address: priceOracle,
+							functionName: 'executeStagedOperation',
+							args: [2n],
+						}),
+				),
+			/expired/i,
+		)
+	})
+
+	test('staged self operations expire after their caller-selected validity window', async () => {
+		const ethCost = await getRequestPriceEthCost(client, priceOracle)
+		const selfOperationTimeoutSeconds = 60n
+
+		await writeContractAndWait(
+			client,
+			async () =>
+				await client.writeContract({
+					abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+					address: priceOracle,
+					functionName: 'requestPriceIfNeededAndStageOperation',
+					args: [OperationType.Liquidation, client.account.address, 1n, selfOperationTimeoutSeconds],
+					value: ethCost,
+				}),
+		)
+		await writeContractAndWait(
+			client,
+			async () =>
+				await client.writeContract({
+					abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+					address: priceOracle,
+					functionName: 'requestPriceIfNeededAndStageOperation',
+					args: [OperationType.SetSecurityBondsAllowance, client.account.address, 1n, selfOperationTimeoutSeconds],
+				}),
+		)
+
+		await handleOracleReporting(client, mockWindow, priceOracle, 10n ** 18n)
+		await mockWindow.advanceTime(selfOperationTimeoutSeconds + 1n)
+		await writeContractAndWait(
+			client,
+			async () =>
+				await client.writeContract({
+					abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+					address: priceOracle,
+					functionName: 'requestPrice',
+					value: ethCost,
+				}),
+		)
+		await handleOracleReporting(client, mockWindow, priceOracle, 10n ** 18n)
+
+		await assert.rejects(
+			async () =>
+				await writeContractAndWait(
+					client,
+					async () =>
+						await client.writeContract({
+							abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+							address: priceOracle,
+							functionName: 'executeStagedOperation',
+							args: [2n],
+						}),
+				),
+			/staged operation expired/,
 		)
 	})
 })

--- a/solidity/ts/testsuite/simulator/utils/contracts/peripherals.ts
+++ b/solidity/ts/testsuite/simulator/utils/contracts/peripherals.ts
@@ -21,14 +21,16 @@ export enum OperationType {
 	SetSecurityBondsAllowance = 2,
 }
 
-export const requestPriceIfNeededAndStageOperation = async (client: WriteClient, priceOracleManagerAndOperatorQueuer: Address, operation: OperationType, targetVault: Address, amount: bigint) => {
+const DEFAULT_SELF_OPERATION_VALID_FOR_SECONDS = 24n * 60n * 60n
+
+export const requestPriceIfNeededAndStageOperation = async (client: WriteClient, priceOracleManagerAndOperatorQueuer: Address, operation: OperationType, targetVault: Address, amount: bigint, validForSeconds = DEFAULT_SELF_OPERATION_VALID_FOR_SECONDS) => {
 	const ethCost = await getRequestPriceEthCost(client, priceOracleManagerAndOperatorQueuer)
 	return await writeContractAndWait(client, () =>
 		client.writeContract({
 			abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
 			functionName: 'requestPriceIfNeededAndStageOperation',
 			address: priceOracleManagerAndOperatorQueuer,
-			args: [operation, targetVault, amount],
+			args: [operation, targetVault, amount, validForSeconds],
 			value: ethCost,
 		}),
 	)

--- a/solidity/ts/testsuite/simulator/utils/contracts/peripheralsTestUtils.ts
+++ b/solidity/ts/testsuite/simulator/utils/contracts/peripheralsTestUtils.ts
@@ -2,7 +2,7 @@ import { zeroAddress } from 'viem'
 import type { Address } from 'viem'
 import { AnvilWindowEthereum } from '../../AnvilWindowEthereum'
 import { addressString } from '../bigint'
-import { DAY, GENESIS_REPUTATION_TOKEN, WETH_ADDRESS } from '../constants'
+import { GENESIS_REPUTATION_TOKEN, WETH_ADDRESS } from '../constants'
 import { getInfraContractAddresses, getSecurityPoolAddresses } from './deployPeripherals'
 import { approveToken, contractExists, getERC20Balance } from '../utilities'
 import { WriteClient } from '../viem'
@@ -65,7 +65,7 @@ export const handleOracleReporting = async (client: WriteClient, mockWindow: Anv
 	const stateHash = (await getOpenOracleExtraData(client, pendingReportId)).stateHash
 	await openOracleSubmitInitialReport(client, pendingReportId, amount1, amount2, stateHash)
 
-	await mockWindow.advanceTime(DAY)
+	await mockWindow.advanceTime(BigInt(reportMeta.settlementTime) + 1n)
 
 	await openOracleSettle(client, pendingReportId)
 }

--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -70,6 +70,7 @@ export function App() {
 		environmentBootstrapError,
 		environmentReady,
 		errorMessage: walletErrorMessage,
+		readBackendMessage,
 		hasLoadedDeploymentStatuses,
 		isConnectingWallet,
 		isLoadingDeploymentStatuses,
@@ -78,6 +79,8 @@ export function App() {
 		setDeploymentStatuses,
 		walletBootstrapComplete,
 	} = useOnchainState()
+	const readBackendReady = readBackendMessage === undefined
+	const canReadOnchainData = environmentReady && readBackendReady
 	const baseHookConfig = {
 		accountAddress: accountState.address,
 		onTransactionFailed,
@@ -99,6 +102,7 @@ export function App() {
 		loadingZoltarQuestionCount,
 		loadingZoltarQuestions,
 		loadingZoltarUniverse,
+		loadZoltarQuestionPage,
 		loadZoltarQuestions,
 		marketCreating,
 		marketError,
@@ -126,16 +130,17 @@ export function App() {
 		zoltarMigrationPreparedRepBalance,
 		zoltarMigrationResult,
 		zoltarQuestionCount,
+		zoltarQuestionPage,
 		zoltarQuestions,
 		zoltarUniverse,
 		zoltarUniverseMissing,
-	} = useMarketCreation({ ...baseHookConfig, activeUniverseId, activeZoltarView, autoLoadInitialData: walletBootstrapComplete && environmentReady, deploymentStatuses })
+	} = useMarketCreation({ ...baseHookConfig, activeUniverseId, activeZoltarView, autoLoadInitialData: walletBootstrapComplete && canReadOnchainData, deploymentStatuses })
 	const zoltarUniverseHasForked = zoltarUniverse?.hasForked === true
 	const { checkingDuplicateOriginPool, createPool, duplicateOriginPoolExists, loadMarket, loadMarketById, loadingMarketDetails, marketDetails, poolCreationMarketDetails, resetSecurityPoolCreation, securityPoolCreating, securityPoolError, securityPoolForm, securityPoolResult, setSecurityPoolForm } =
 		useSecurityPoolCreation({
 			...baseHookConfig,
 			deploymentStatuses,
-			enabled: route === 'security-pools',
+			enabled: route === 'security-pools' && canReadOnchainData,
 			zoltarUniverseHasForked,
 		})
 	const {
@@ -156,7 +161,7 @@ export function App() {
 		setSecurityBondAllowance,
 		setSecurityVaultForm,
 		withdrawRep,
-	} = useSecurityVaultOperations({ ...baseHookConfig, enabled: route === 'security-pools', selectedSecurityPoolAddress: securityPoolAddress })
+	} = useSecurityVaultOperations({ ...baseHookConfig, enabled: route === 'security-pools' && canReadOnchainData, selectedSecurityPoolAddress: securityPoolAddress })
 	const {
 		approveToken1,
 		approveToken2,
@@ -180,7 +185,7 @@ export function App() {
 		settleReport,
 		submitInitialReport,
 		wrapWethForInitialReport,
-	} = useOpenOracleOperations({ ...baseHookConfig, enabled: route === 'open-oracle' })
+	} = useOpenOracleOperations({ ...baseHookConfig, enabled: route === 'open-oracle' && canReadOnchainData })
 	const { loadingReportingDetails, loadReporting, onReportOutcome, reportingActiveAction, reportingDetails, reportingError, reportingForm, reportingResult, setReportingForm, withdrawEscalation } = useReportingOperations({ ...baseHookConfig, selectedSecurityPoolAddress: securityPoolAddress })
 	const updateReportingForm = (update: Partial<ReportingFormState>) => {
 		setReportingForm(current => applyReportingFormUpdate(current, update))
@@ -190,26 +195,33 @@ export function App() {
 		checkedSecurityPoolAddress,
 		closeLiquidationModal,
 		hasLoadedSecurityPools,
+		hasLoadedSecurityPoolPage,
 		liquidationAmount,
 		liquidationMaxAmount,
 		liquidationManagerAddress,
 		liquidationModalOpen,
 		liquidationSecurityPoolAddress,
 		liquidationTargetVault,
+		liquidationTimeoutMinutes,
 		loadingSecurityPools,
+		loadingSecurityPoolPage,
+		loadBrowseSecurityPoolPage,
 		loadSecurityPools,
 		openLiquidationModal,
 		queueLiquidation,
 		securityPoolOverviewActiveAction,
 		securityPoolOverviewError,
 		securityPoolOverviewResult,
+		securityPoolBrowseCount,
+		securityPoolPage,
 		securityPools,
 		setLiquidationAmount,
+		setLiquidationTimeoutMinutes,
 	} = useSecurityPoolsOverview(baseHookConfig)
 	const { createCompleteSet, loadingTradingDetails, loadingTradingForkUniverse, migrateShares, redeemCompleteSet, redeemShares, setTradingForm, tradingActiveAction, tradingDetails, tradingError, tradingForm, tradingForkUniverse, tradingResult } = useTradingOperations({
 		...baseHookConfig,
 		deploymentStatuses,
-		enabled: route === 'security-pools',
+		enabled: route === 'security-pools' && canReadOnchainData,
 		selectedSecurityPoolAddress: securityPoolAddress,
 	})
 	const {
@@ -246,7 +258,7 @@ export function App() {
 	const errorMessage = deploymentErrorMessage ?? walletErrorMessage
 	const isMainnet = isSupportedAppChain(accountState.chainId)
 	const wrongNetworkMessage = accountState.address !== undefined && accountState.chainId !== undefined && !isMainnet ? getWrongNetworkMessage() : undefined
-	const augurPlaceHolderDeploymentMissing = environmentReady && augurPlaceHolderDeployed === false
+	const augurPlaceHolderDeploymentMissing = canReadOnchainData && augurPlaceHolderDeployed === false
 	const showDeployTab = augurPlaceHolderDeploymentMissing || (hasLoadedDeploymentStatuses && deploymentStatuses.some(step => !step.deployed))
 	const showAugurPlaceHolderDeploymentWarning = augurPlaceHolderDeploymentMissing
 	const zoltarUniverseState = resolveLoadableValueState({
@@ -254,9 +266,9 @@ export function App() {
 		isMissing: zoltarUniverseMissing,
 		value: zoltarUniverse,
 	})
-	const showZoltarUniverseWarning = environmentReady && zoltarUniverseState === 'missing'
+	const showZoltarUniverseWarning = canReadOnchainData && zoltarUniverseState === 'missing'
 	const showZoltarUniverseForkedWarning = zoltarUniverse?.hasForked === true
-	const disableRouteContent = route !== 'deploy' && (augurPlaceHolderDeploymentMissing || showZoltarUniverseWarning)
+	const disableRouteContent = route !== 'deploy' && (!readBackendReady || augurPlaceHolderDeploymentMissing || showZoltarUniverseWarning)
 	const isRouteContentDisabled = transactionState.value.inFlightCount > 0 || disableRouteContent
 	const universeLabel = formatUniverseCollectionLabel([activeUniverseId])
 	const universePresentation = showZoltarUniverseWarning ? getUniversePresentation(zoltarUniverseState) : undefined
@@ -353,7 +365,7 @@ export function App() {
 	useAppRouteEffects({
 		accountAddress: accountState.address,
 		augurPlaceHolderDeploymentMissing,
-		environmentReady,
+		environmentReady: canReadOnchainData,
 		loadOracleReport: async reportId => await loadOracleReport(reportId),
 		loadSecurityPools: async requestedSecurityPoolAddress => await loadSecurityPools(requestedSecurityPoolAddress),
 		navigate,
@@ -405,6 +417,7 @@ export function App() {
 		onCreateMarket: () => void createMarket(),
 		onForkZoltar: () => void forkZoltar(),
 		onLoadZoltarQuestions: loadZoltarQuestions,
+		onLoadZoltarQuestionPage: loadZoltarQuestionPage,
 		onMigrateInternalRep: () => void migrateInternalRep(),
 		onMarketFormChange: update => setMarketForm(current => ({ ...current, ...update })),
 		onPrepareRepForMigration: () => void prepareRepForMigration(),
@@ -413,6 +426,7 @@ export function App() {
 		onUseQuestionForPool,
 		onZoltarMigrationFormChange: update => setZoltarMigrationForm(current => ({ ...current, ...update })),
 		zoltarQuestionCount,
+		zoltarQuestionPage,
 		zoltarForkApproval,
 		zoltarForkError,
 		zoltarChildUniverseError,
@@ -461,20 +475,27 @@ export function App() {
 			checkedSecurityPoolAddress,
 			closeLiquidationModal: () => closeLiquidationModal(),
 			hasLoadedSecurityPools,
+			hasLoadedSecurityPoolPage,
 			liquidationAmount,
 			liquidationMaxAmount,
 			liquidationManagerAddress,
 			liquidationModalOpen,
 			liquidationSecurityPoolAddress,
 			liquidationTargetVault,
+			liquidationTimeoutMinutes,
 			loadingPoolOracleManager,
+			loadingSecurityPoolPage,
 			loadingSecurityPools,
+			onLoadSecurityPoolPage: (pageIndex: number, pageSize: number) => void loadBrowseSecurityPoolPage(pageIndex, pageSize),
 			onLiquidationAmountChange: setLiquidationAmount,
+			onLiquidationTimeoutMinutesChange: setLiquidationTimeoutMinutes,
 			onLoadPoolOracleManager: (managerAddress: Address) => void loadPoolOracleManager(managerAddress),
 			onOpenLiquidationModal: (managerAddress: Address, selectedSecurityPoolAddress: Address, vaultAddress: Address, maxAmount: bigint | undefined) => openLiquidationModal(managerAddress, selectedSecurityPoolAddress, vaultAddress, maxAmount),
 			onLoadSecurityPools: () => void loadSecurityPools(),
 			onQueueLiquidation: (managerAddress: Address, selectedSecurityPoolAddress: Address) => void queueLiquidation(managerAddress, selectedSecurityPoolAddress),
 			poolOracleManagerDetails,
+			securityPoolBrowseCount,
+			securityPoolPage,
 			securityPoolOverviewActiveAction,
 			securityPoolOverviewError,
 			securityPoolOverviewResult,
@@ -521,7 +542,9 @@ export function App() {
 			liquidationModalOpen,
 			liquidationSecurityPoolAddress,
 			liquidationTargetVault,
+			liquidationTimeoutMinutes,
 			onLiquidationAmountChange: setLiquidationAmount,
+			onLiquidationTimeoutMinutesChange: setLiquidationTimeoutMinutes,
 			onOpenLiquidationModal: (managerAddress: Address, selectedSecurityPoolAddress: Address, vaultAddress: Address, maxAmount: bigint | undefined) => openLiquidationModal(managerAddress, selectedSecurityPoolAddress, vaultAddress, maxAmount),
 			onQueueLiquidation: (managerAddress: Address, selectedSecurityPoolAddress: Address) => void queueLiquidation(managerAddress, selectedSecurityPoolAddress),
 			onExecutePendingPoolOperation: (managerAddress: Address, operationId: bigint) => void executePendingPoolOperation(managerAddress, operationId),
@@ -698,6 +721,7 @@ export function App() {
 				<main>
 					<AppStatusNotices
 						errorMessage={errorMessage}
+						readBackendMessage={readBackendMessage}
 						simulationBootstrapError={environmentBootstrapError}
 						showAugurPlaceHolderDeploymentWarning={showAugurPlaceHolderDeploymentWarning}
 						showZoltarUniverseForkedWarning={showZoltarUniverseForkedWarning}
@@ -708,7 +732,7 @@ export function App() {
 					<GlobalTransactionTray transaction={transactionState.value.active} />
 
 					<fieldset className='route-shell' disabled={isRouteContentDisabled}>
-						<AppRouteContent deploy={deployRouteContentProps} market={marketRouteContentProps} openOracle={openOracleRouteContentProps} route={route} securityPools={securityPoolsRouteContentProps} wrongNetworkMessage={wrongNetworkMessage} />
+						<AppRouteContent deploy={deployRouteContentProps} market={marketRouteContentProps} openOracle={openOracleRouteContentProps} readBackendMessage={readBackendMessage} route={route} securityPools={securityPoolsRouteContentProps} wrongNetworkMessage={wrongNetworkMessage} />
 					</fieldset>
 				</main>
 			</ChainTimestampContext.Provider>

--- a/ui/ts/components/AppRouteContent.tsx
+++ b/ui/ts/components/AppRouteContent.tsx
@@ -11,13 +11,20 @@ type Props = {
 	deploy: ComponentProps<typeof DeploymentRouteContent>
 	market: ComponentProps<typeof MarketSection>
 	openOracle: ComponentProps<typeof OpenOracleSection>
+	readBackendMessage: string | undefined
 	route: AppRoute
 	securityPools: ComponentProps<typeof SecurityPoolsSection>
 	wrongNetworkMessage: string | undefined
 }
 
-export function AppRouteContent({ deploy, market, openOracle, route, securityPools, wrongNetworkMessage }: Props) {
-	if (wrongNetworkMessage !== undefined) return null
+export function shouldRenderRouteContent({ readBackendMessage, route, wrongNetworkMessage }: Pick<Props, 'readBackendMessage' | 'route' | 'wrongNetworkMessage'>) {
+	if (wrongNetworkMessage !== undefined) return false
+	if (route !== 'deploy' && readBackendMessage !== undefined) return false
+	return true
+}
+
+export function AppRouteContent({ deploy, market, openOracle, readBackendMessage, route, securityPools, wrongNetworkMessage }: Props) {
+	if (!shouldRenderRouteContent({ readBackendMessage, route, wrongNetworkMessage })) return null
 
 	switch (route) {
 		case 'deploy':

--- a/ui/ts/components/AppStatusNotices.tsx
+++ b/ui/ts/components/AppStatusNotices.tsx
@@ -6,6 +6,7 @@ import type { NoticeItem } from '../types/components.js'
 
 type AppStatusNoticesProps = {
 	errorMessage: string | undefined
+	readBackendMessage: string | undefined
 	wrongNetworkMessage: string | undefined
 	simulationBootstrapError: string | undefined
 	showAugurPlaceHolderDeploymentWarning: boolean
@@ -13,7 +14,7 @@ type AppStatusNoticesProps = {
 	zoltarUniverse: ZoltarUniverseSummary | undefined
 }
 
-export function AppStatusNotices({ errorMessage, wrongNetworkMessage, simulationBootstrapError, showAugurPlaceHolderDeploymentWarning, showZoltarUniverseForkedWarning, zoltarUniverse }: AppStatusNoticesProps) {
+export function AppStatusNotices({ errorMessage, readBackendMessage, wrongNetworkMessage, simulationBootstrapError, showAugurPlaceHolderDeploymentWarning, showZoltarUniverseForkedWarning, zoltarUniverse }: AppStatusNoticesProps) {
 	const items: NoticeItem[] = []
 	if (simulationBootstrapError !== undefined) items.push({ detail: simulationBootstrapError, id: 'simulation-bootstrap-error', tone: 'blocking', title: 'Simulation bootstrap failed' })
 	if (showZoltarUniverseForkedWarning && zoltarUniverse !== undefined)
@@ -35,6 +36,7 @@ export function AppStatusNotices({ errorMessage, wrongNetworkMessage, simulation
 			tone: 'blocking',
 			title: 'Wrong network',
 		})
+	if (readBackendMessage !== undefined) items.push({ detail: readBackendMessage, id: 'read-backend-mismatch', tone: 'blocking', title: 'Read RPC mismatch' })
 	if (errorMessage !== undefined) items.push({ detail: errorMessage, id: 'app-error', tone: 'blocking', title: 'Error' })
 
 	return <NoticeStack items={items} />

--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -10,6 +10,7 @@ import { ErrorNotice } from './ErrorNotice.js'
 import { FormInput } from './FormInput.js'
 import { LookupFieldRow } from './LookupFieldRow.js'
 import { MetricField } from './MetricField.js'
+import { PaginationControls } from './PaginationControls.js'
 import { RouteWorkflowPanel } from './RouteWorkflowPanel.js'
 import { SectionBlock } from './SectionBlock.js'
 import { TransactionActionButton } from './TransactionActionButton.js'
@@ -1800,13 +1801,7 @@ export function ForkAuctionSection({
 										</div>
 									</button>
 								))}
-								{hasMoreTickSummaries ? (
-									<div className='actions'>
-										<button className='secondary' onClick={() => setLoadedTickPageCount(currentPageCount => currentPageCount + 1)} type='button'>
-											Load More Price Levels
-										</button>
-									</div>
-								) : undefined}
+								{hasMoreTickSummaries ? <PaginationControls hasNextPage={hasMoreTickSummaries} onLoadMore={() => setLoadedTickPageCount(currentPageCount => currentPageCount + 1)} loadMoreLabel='Load More Price Levels' /> : undefined}
 							</div>
 						</div>
 					</div>
@@ -1853,13 +1848,7 @@ export function ForkAuctionSection({
 						})}
 					</div>
 				)}
-				{hasMoreAggregatedAuctionBids ? (
-					<div className='actions'>
-						<button className='secondary' onClick={() => setLoadedAuctionBidPageCount(currentPageCount => currentPageCount + 1)} type='button'>
-							Load More Truth Auction Bids
-						</button>
-					</div>
-				) : undefined}
+				{hasMoreAggregatedAuctionBids ? <PaginationControls hasNextPage={hasMoreAggregatedAuctionBids} onLoadMore={() => setLoadedAuctionBidPageCount(currentPageCount => currentPageCount + 1)} loadMoreLabel='Load More Truth Auction Bids' /> : undefined}
 			</SectionBlock>
 		)
 	})()
@@ -1930,13 +1919,7 @@ export function ForkAuctionSection({
 						})}
 					</div>
 				)}
-				{accountState.address !== undefined && hasMoreViewerBids ? (
-					<div className='actions'>
-						<button className='secondary' onClick={() => setLoadedViewerBidPageCount(currentPageCount => currentPageCount + 1)} type='button'>
-							Load More Of My Bids
-						</button>
-					</div>
-				) : undefined}
+				{accountState.address !== undefined && hasMoreViewerBids ? <PaginationControls hasNextPage={hasMoreViewerBids} onLoadMore={() => setLoadedViewerBidPageCount(currentPageCount => currentPageCount + 1)} loadMoreLabel='Load More Of My Bids' /> : undefined}
 			</SectionBlock>
 		)
 	})()

--- a/ui/ts/components/LiquidationModal.tsx
+++ b/ui/ts/components/LiquidationModal.tsx
@@ -16,11 +16,12 @@ import { assertNever } from '../lib/assert.js'
 import { sameAddress } from '../lib/address.js'
 import { pickFirstReason } from '../lib/actionAvailability.js'
 import { useChainTimestamp } from '../lib/chainTimestamp.js'
-import { formatCurrencyInputBalance } from '../lib/formatters.js'
+import { formatCurrencyInputBalance, formatDuration } from '../lib/formatters.js'
 import { getLiquidationFailureReason, simulateLiquidation } from '../lib/liquidation.js'
-import { tryParseRepAmountInput } from '../lib/marketForm.js'
+import { tryParseBigIntInput, tryParseRepAmountInput } from '../lib/marketForm.js'
 import { getOracleRequestEthGuardMessage } from '../lib/oracleRequestEth.js'
 import { getRepPriceSourceCopy, renderRepPriceSourceLabel, type RepPriceSource } from '../lib/repPriceSource.js'
+import { getStagedOperationTimeoutSeconds } from '../lib/securityVault.js'
 import { getVaultCollateralizationPercent } from '../lib/trading.js'
 import type { SecurityPoolStateModel } from '../lib/securityPoolState.js'
 import type { ListedSecurityPool, OracleManagerDetails, SecurityPoolOverviewActionResult, SecurityPoolVaultSummary } from '../types/contracts.js'
@@ -34,6 +35,7 @@ type LiquidationModalProps = {
 	liquidationManagerAddress: Address | undefined
 	liquidationModalOpen: boolean
 	liquidationSecurityPoolAddress: Address | undefined
+	liquidationTimeoutMinutes: string
 	loadingPoolOracleManager: boolean
 	onLoadPoolOracleManager: (managerAddress: Address) => void
 	onSelectedPoolViewChange: (view: string | undefined) => void
@@ -49,6 +51,7 @@ type LiquidationModalProps = {
 	targetVaultSummary: SecurityPoolVaultSummary | undefined
 	liquidationTargetVault: string
 	onLiquidationAmountChange: (value: string) => void
+	onLiquidationTimeoutMinutesChange: (value: string) => void
 	onQueueLiquidation: (managerAddress: Address, securityPoolAddress: Address) => void
 	walletEthBalance?: bigint | undefined
 }
@@ -148,6 +151,7 @@ export function LiquidationModal({
 	liquidationManagerAddress,
 	liquidationModalOpen,
 	liquidationSecurityPoolAddress,
+	liquidationTimeoutMinutes,
 	loadingPoolOracleManager,
 	liquidationTargetVault,
 	onLoadPoolOracleManager,
@@ -163,6 +167,7 @@ export function LiquidationModal({
 	callerVaultSummary,
 	targetVaultSummary,
 	onLiquidationAmountChange,
+	onLiquidationTimeoutMinutesChange,
 	onQueueLiquidation,
 	walletEthBalance,
 }: LiquidationModalProps) {
@@ -219,6 +224,10 @@ export function LiquidationModal({
 	const liquidationExecutionMode = getLiquidationExecutionMode(currentPoolOracleManagerDetails)
 	const buttonLabels = getLiquidationButtonLabels(currentPoolOracleManagerDetails)
 	const trimmedLiquidationTargetVault = liquidationTargetVault.trim()
+	const liquidationTimeoutDisplayValue = liquidationTimeoutMinutes === '' ? '' : liquidationTimeoutMinutes
+	const liquidationTimeoutSeconds = getStagedOperationTimeoutSeconds(tryParseBigIntInput(liquidationTimeoutDisplayValue))
+	const liquidationTimeoutHelpText =
+		liquidationTimeoutSeconds === undefined ? 'Enter whole minutes. Queued staged operations must stay executable for at least 1 minute after the oracle settlement window completes.' : `This queued staged operation will expire ${formatDuration(liquidationTimeoutSeconds)} after the oracle settlement window completes.`
 	const sameVaultWarning = accountAddress === undefined || trimmedLiquidationTargetVault === '' || !sameAddress(accountAddress, trimmedLiquidationTargetVault) ? undefined : 'Select a target vault that is different from the caller vault.'
 	const liquidationSimulation =
 		targetVaultSummary === undefined || poolOraclePrice === undefined || selectedPool?.securityMultiplier === undefined || liquidationAmountValue === undefined
@@ -258,6 +267,7 @@ export function LiquidationModal({
 		trimmedLiquidationTargetVault === '' ? 'Select a target vault first.' : undefined,
 		sameVaultWarning,
 		liquidationAmount.trim() === '' ? 'Enter a liquidation amount.' : undefined,
+		liquidationExecutionMode === 'queue' && liquidationTimeoutSeconds === undefined ? 'Enter a liquidation timeout of at least 1 minute.' : undefined,
 		directLiquidationReason,
 		queueLiquidationEthGuardMessage,
 	)
@@ -382,7 +392,17 @@ export function LiquidationModal({
 							</button>
 						</div>
 					</label>
+					{liquidationExecutionMode === 'execute' ? null : (
+						<label className='field'>
+							<span>Manual Execution Timeout</span>
+							<div className='field-inline'>
+								<FormInput className='field-inline-input' inputMode='numeric' min='1' pattern='[0-9]*' step='1' value={liquidationTimeoutDisplayValue} onInput={event => onLiquidationTimeoutMinutesChange(event.currentTarget.value)} />
+								<span className='field-inline-action'>minutes</span>
+							</div>
+						</label>
+					)}
 				</div>
+				{liquidationExecutionMode === 'execute' ? null : <p className='detail'>{liquidationTimeoutHelpText}</p>}
 				{liquidationSimulation === undefined ? null : (
 					<section className='entity-card compact'>
 						<div className='entity-card-header'>

--- a/ui/ts/components/MarketQuestionsSection.tsx
+++ b/ui/ts/components/MarketQuestionsSection.tsx
@@ -1,51 +1,90 @@
+import { useEffect, useRef, useState } from 'preact/hooks'
 import { EntityCard } from './EntityCard.js'
 import { LoadingText } from './LoadingText.js'
+import { PaginationControls } from './PaginationControls.js'
 import { Question, getQuestionTitle } from './Question.js'
 import { SectionBlock } from './SectionBlock.js'
 import { StateHint } from './StateHint.js'
-import type { MarketDetails } from '../types/contracts.js'
+import { QUESTION_PAGE_SIZE } from '../lib/pagination.js'
+import type { MarketDetailsPage } from '../types/contracts.js'
+
+function isCurrentQuestionPage(page: MarketDetailsPage | undefined, pageIndex: number, questionCount: bigint | undefined) {
+	return page?.pageIndex === pageIndex && page.pageSize === QUESTION_PAGE_SIZE && (questionCount === undefined || page.questionCount === questionCount)
+}
+
 type MarketQuestionsSectionProps = {
 	hasForked: boolean
-	hasLoadedZoltarQuestions: boolean
 	loadingZoltarQuestionCount: boolean
 	loadingZoltarQuestions: boolean
-	onLoadZoltarQuestions: () => Promise<void>
+	onLoadZoltarQuestionPage: (pageIndex: number, pageSize: number) => Promise<void>
 	onOpenForkTab: () => void
 	onUseQuestionForFork: (questionId: string) => void
 	onUseQuestionForPool: (questionId: string) => void
 	zoltarQuestionCount: bigint | undefined
-	zoltarQuestions: MarketDetails[]
+	zoltarQuestionPage: MarketDetailsPage | undefined
 }
-export function MarketQuestionsSection({ hasForked, hasLoadedZoltarQuestions, loadingZoltarQuestionCount, loadingZoltarQuestions, onLoadZoltarQuestions, onOpenForkTab, onUseQuestionForFork, onUseQuestionForPool, zoltarQuestionCount, zoltarQuestions }: MarketQuestionsSectionProps) {
+export function MarketQuestionsSection({ hasForked, loadingZoltarQuestionCount, loadingZoltarQuestions, onLoadZoltarQuestionPage, onOpenForkTab, onUseQuestionForFork, onUseQuestionForPool, zoltarQuestionCount, zoltarQuestionPage }: MarketQuestionsSectionProps) {
 	const noQuestionsAvailable = zoltarQuestionCount === 0n
+	const [pageIndex, setPageIndex] = useState(0)
+	const [activePageRequestKey, setActivePageRequestKey] = useState<string | undefined>(undefined)
+	const [lastFailedPageRequestKey, setLastFailedPageRequestKey] = useState<string | undefined>(undefined)
+	const lastRequestedPageKeyRef = useRef<string | undefined>(undefined)
+	const currentPageRequestKey = `${pageIndex}:${QUESTION_PAGE_SIZE}:${zoltarQuestionCount?.toString() ?? 'unknown'}`
+	const hasCurrentPageData = isCurrentQuestionPage(zoltarQuestionPage, pageIndex, zoltarQuestionCount)
+	const effectiveQuestionCount = zoltarQuestionPage?.questionCount ?? zoltarQuestionCount
+	const questionPageCount = effectiveQuestionCount === undefined || effectiveQuestionCount === 0n ? 0 : Math.ceil(Number(effectiveQuestionCount) / QUESTION_PAGE_SIZE)
+	const visibleQuestions = hasCurrentPageData && zoltarQuestionPage !== undefined ? zoltarQuestionPage.questions : []
+	const isWaitingForPageData = activePageRequestKey === currentPageRequestKey
+	useEffect(() => {
+		setPageIndex(0)
+	}, [zoltarQuestionCount])
+	useEffect(() => {
+		setLastFailedPageRequestKey(undefined)
+		lastRequestedPageKeyRef.current = undefined
+	}, [currentPageRequestKey])
+	useEffect(() => {
+		if (loadingZoltarQuestionCount) return
+		if (zoltarQuestionCount === undefined || zoltarQuestionCount === 0n) return
+		const pageRequestKey = `${pageIndex}:${QUESTION_PAGE_SIZE}:${zoltarQuestionCount.toString()}`
+		const hasCurrentPageData = isCurrentQuestionPage(zoltarQuestionPage, pageIndex, zoltarQuestionCount)
+		if (hasCurrentPageData) {
+			if (lastFailedPageRequestKey === pageRequestKey) setLastFailedPageRequestKey(undefined)
+			if (activePageRequestKey === pageRequestKey) setActivePageRequestKey(undefined)
+			return
+		}
+		if (lastFailedPageRequestKey === pageRequestKey) return
+		if (activePageRequestKey === pageRequestKey) return
+		if (lastRequestedPageKeyRef.current === pageRequestKey) return
+		lastRequestedPageKeyRef.current = pageRequestKey
+		setActivePageRequestKey(pageRequestKey)
+		void Promise.resolve(onLoadZoltarQuestionPage(pageIndex, QUESTION_PAGE_SIZE))
+			.catch(() => {
+				setLastFailedPageRequestKey(current => (current === undefined ? pageRequestKey : current))
+			})
+			.finally(() => {
+				setActivePageRequestKey(current => (current === pageRequestKey ? undefined : current))
+			})
+	}, [activePageRequestKey, lastFailedPageRequestKey, loadingZoltarQuestionCount, onLoadZoltarQuestionPage, pageIndex, zoltarQuestionCount, zoltarQuestionPage])
+	const hasPreviousPage = pageIndex > 0
+	const hasNextPage = pageIndex + 1 < questionPageCount
 	return (
 		<SectionBlock
 			density='compact'
 			title='Questions'
 			actions={
-				<button
-					className='secondary'
-					onClick={() => {
-						void onLoadZoltarQuestions()
-					}}
-					disabled={loadingZoltarQuestions || noQuestionsAvailable}
-				>
-					{loadingZoltarQuestions ? (
-						<LoadingText>Loading Questions...</LoadingText>
-					) : (
-						(() => {
-							if (noQuestionsAvailable) return 'No Questions'
-							if (hasLoadedZoltarQuestions) return 'Refresh Questions'
-
-							return 'Fetch Questions'
-						})()
-					)}
-				</button>
+				<PaginationControls
+					hasNextPage={hasNextPage}
+					hasPreviousPage={hasPreviousPage}
+					loading={loadingZoltarQuestions}
+					onNextPage={() => setPageIndex(current => current + 1)}
+					onPreviousPage={() => setPageIndex(current => Math.max(0, current - 1))}
+					summary={zoltarQuestionPage === undefined ? undefined : `Page ${pageIndex + 1} of ${Math.max(questionPageCount, 1)}`}
+				/>
 			}
 		>
-			{zoltarQuestions.length === 0 ? (
+			{visibleQuestions.length === 0 ? (
 				(() => {
-					if (loadingZoltarQuestionCount || loadingZoltarQuestions)
+					if (loadingZoltarQuestionCount || loadingZoltarQuestions || isWaitingForPageData)
 						return (
 							<p className='detail'>
 								<LoadingText>Loading questions...</LoadingText>
@@ -63,12 +102,13 @@ export function MarketQuestionsSection({ hasForked, hasLoadedZoltarQuestions, lo
 								title='No questions'
 							/>
 						)
+					if (effectiveQuestionCount !== undefined && effectiveQuestionCount > 0n) return <StateHint presentation={{ key: 'not_checked', badgeLabel: 'Not checked', badgeTone: 'muted', detail: 'Questions for this page have not loaded yet.' }} />
 
 					return undefined
 				})()
 			) : (
 				<div className='entity-card-list'>
-					{zoltarQuestions.map(question => (
+					{visibleQuestions.map(question => (
 						<EntityCard
 							key={question.questionId}
 							title={getQuestionTitle(question)}

--- a/ui/ts/components/MarketSection.tsx
+++ b/ui/ts/components/MarketSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 import { DataGrid } from './DataGrid.js'
 import { ForkZoltarSection } from './ForkZoltarSection.js'
 import { MarketCreateQuestionSection } from './MarketCreateQuestionSection.js'
@@ -12,7 +12,6 @@ import type { MarketSectionProps } from '../types/components.js'
 
 export function MarketSection({
 	accountState,
-	activeUniverseId,
 	activeView,
 	hasLoadedZoltarQuestions,
 	loadingZoltarForkAccess,
@@ -29,7 +28,7 @@ export function MarketSection({
 	onCreateChildUniverseForOutcomeIndex,
 	onCreateMarket,
 	onForkZoltar,
-	onLoadZoltarQuestions,
+	onLoadZoltarQuestionPage,
 	onMarketFormChange,
 	onMigrateInternalRep,
 	onPrepareRepForMigration,
@@ -53,6 +52,7 @@ export function MarketSection({
 	zoltarMigrationPreparedRepBalance,
 	zoltarMigrationResult,
 	zoltarQuestionCount,
+	zoltarQuestionPage,
 	zoltarQuestions,
 	zoltarUniverse,
 	zoltarUniverseState,
@@ -61,7 +61,6 @@ export function MarketSection({
 	const isMainnet = isMainnetChain(accountState.chainId)
 	const view = activeView
 	const showUniverseSummary = view === 'questions' && zoltarUniverse !== undefined
-	const lastAutoLoadedQuestionsUniverseId = useRef<bigint | undefined>(undefined)
 	const [forkModalOpen, setForkModalOpen] = useState(false)
 
 	useEffect(() => {
@@ -70,21 +69,6 @@ export function MarketSection({
 		if (hasForked) return
 		onActiveViewChange('questions')
 	}, [hasForked, onActiveViewChange, view, zoltarUniverse])
-
-	useEffect(() => {
-		if (view !== 'questions') return
-		if (loadingZoltarQuestionCount) return
-		if (zoltarQuestionCount === undefined) return
-		if (zoltarQuestionCount === 0n) return
-		if (loadingZoltarQuestions) return
-		if (hasLoadedZoltarQuestions) return
-		if (lastAutoLoadedQuestionsUniverseId.current === activeUniverseId) return
-		lastAutoLoadedQuestionsUniverseId.current = activeUniverseId
-		void Promise.resolve(onLoadZoltarQuestions()).catch(error => {
-			lastAutoLoadedQuestionsUniverseId.current = undefined
-			console.error('[market] failed to auto-load zoltar questions', error)
-		})
-	}, [activeUniverseId, hasLoadedZoltarQuestions, loadingZoltarQuestionCount, loadingZoltarQuestions, onLoadZoltarQuestions, view, zoltarQuestionCount])
 
 	return (
 		<div className='route-view-flow'>
@@ -131,15 +115,14 @@ export function MarketSection({
 						) : undefined}
 						<MarketQuestionsSection
 							hasForked={hasForked}
-							hasLoadedZoltarQuestions={hasLoadedZoltarQuestions}
+							onLoadZoltarQuestionPage={onLoadZoltarQuestionPage}
 							loadingZoltarQuestionCount={loadingZoltarQuestionCount}
 							loadingZoltarQuestions={loadingZoltarQuestions}
-							onLoadZoltarQuestions={onLoadZoltarQuestions}
 							onOpenForkTab={() => onActiveViewChange('fork')}
 							onUseQuestionForFork={onUseQuestionForFork}
 							onUseQuestionForPool={onUseQuestionForPool}
 							zoltarQuestionCount={zoltarQuestionCount}
-							zoltarQuestions={zoltarQuestions}
+							zoltarQuestionPage={zoltarQuestionPage}
 						/>
 					</>
 				) : undefined}

--- a/ui/ts/components/OpenOracleSection.tsx
+++ b/ui/ts/components/OpenOracleSection.tsx
@@ -14,6 +14,7 @@ import { LookupFieldRow } from './LookupFieldRow.js'
 import { LoadingText } from './LoadingText.js'
 import { MetricField } from './MetricField.js'
 import { OperationModal } from './OperationModal.js'
+import { PaginationControls } from './PaginationControls.js'
 import { ReadOnlyDetailAccordion } from './ReadOnlyDetailAccordion.js'
 import { SectionBlock } from './SectionBlock.js'
 import { StickyObjectContext } from './StickyObjectContext.js'
@@ -869,14 +870,14 @@ export function OpenOracleSection({
 				<div className='workflow-stack route-workflow-stack'>
 					<SectionBlock
 						actions={
-							<div className='actions'>
-								<button className='secondary' type='button' onClick={() => setBrowsePageIndex(current => Math.max(0, current - 1))} disabled={!browseHasPreviousPage || loadingBrowse}>
-									Previous Page
-								</button>
-								<button className='secondary' type='button' onClick={() => setBrowsePageIndex(current => current + 1)} disabled={!browseHasNextPage || loadingBrowse}>
-									Next Page
-								</button>
-							</div>
+							<PaginationControls
+								hasNextPage={browseHasNextPage}
+								hasPreviousPage={browseHasPreviousPage}
+								loading={loadingBrowse}
+								onNextPage={() => setBrowsePageIndex(current => current + 1)}
+								onPreviousPage={() => setBrowsePageIndex(current => Math.max(0, current - 1))}
+								summary={browsePage === undefined ? undefined : `Page ${browsePageIndex + 1} of ${Math.max(browsePageCount, 1)}`}
+							/>
 						}
 						density='compact'
 						title='Browse Reports'

--- a/ui/ts/components/PaginationControls.tsx
+++ b/ui/ts/components/PaginationControls.tsx
@@ -1,0 +1,41 @@
+import type { ComponentChildren } from 'preact'
+
+type PaginationControlsProps = {
+	hasNextPage?: boolean
+	hasPreviousPage?: boolean
+	loading?: boolean
+	loadMoreLabel?: ComponentChildren
+	nextLabel?: ComponentChildren
+	onLoadMore?: () => void
+	onNextPage?: () => void
+	onPreviousPage?: () => void
+	previousLabel?: ComponentChildren
+	summary?: ComponentChildren
+}
+
+export function PaginationControls({ hasNextPage = false, hasPreviousPage = false, loading = false, loadMoreLabel = 'Load More', nextLabel = 'Next Page', onLoadMore, onNextPage, onPreviousPage, previousLabel = 'Previous Page', summary }: PaginationControlsProps) {
+	const hasPageNavigation = onPreviousPage !== undefined || onNextPage !== undefined
+	const hasLoadMore = onLoadMore !== undefined
+	if (!hasPageNavigation && !hasLoadMore && summary === undefined) return undefined
+
+	return (
+		<div className='actions'>
+			{summary === undefined ? undefined : <span className='detail'>{summary}</span>}
+			{onPreviousPage === undefined ? undefined : (
+				<button className='secondary' type='button' onClick={onPreviousPage} disabled={!hasPreviousPage || loading}>
+					{previousLabel}
+				</button>
+			)}
+			{onNextPage === undefined ? undefined : (
+				<button className='secondary' type='button' onClick={onNextPage} disabled={!hasNextPage || loading}>
+					{nextLabel}
+				</button>
+			)}
+			{onLoadMore === undefined ? undefined : (
+				<button className='secondary' type='button' onClick={onLoadMore} disabled={!hasLoadMore || !hasNextPage || loading}>
+					{loadMoreLabel}
+				</button>
+			)}
+		</div>
+	)
+}

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -115,9 +115,11 @@ export function SecurityPoolWorkflowSection({
 	liquidationModalOpen,
 	liquidationSecurityPoolAddress,
 	liquidationTargetVault,
+	liquidationTimeoutMinutes,
 	loadingPoolOracleManager,
 	loadingSecurityPools,
 	onLiquidationAmountChange,
+	onLiquidationTimeoutMinutesChange,
 	onLoadPoolOracleManager,
 	onOpenLiquidationModal,
 	onQueueLiquidation,
@@ -379,6 +381,7 @@ export function SecurityPoolWorkflowSection({
 		isPriceValid: currentPoolOracleManagerDetails?.isPriceValid,
 		resolvedPendingOperationId,
 	})
+	const pendingOperation = currentPoolOracleManagerDetails?.pendingOperation
 	const selectedPoolBrowsePresentation = selectedPool === undefined ? getPoolRegistryPresentation({ mode: 'selection', state: selectedPoolLookupState }) : undefined
 	const selectedVaultLoadNotice = (() => {
 		if (securityVault.loadingSecurityVault)
@@ -897,23 +900,23 @@ export function SecurityPoolWorkflowSection({
 									<SectionBlock density='compact' title='Staged Operations'>
 										<ErrorNotice message={poolOracleManagerError} />
 										<SectionBlock density='compact' headingLevel={4} title='Staged Operations List' variant='embedded'>
-											{currentPoolOracleManagerDetails?.pendingOperation === undefined ? null : (
+											{pendingOperation === undefined ? null : (
 												<WarningSurface as='article' className='warning-entity-card' variant='compact'>
 													<div className='entity-card-header'>
 														<div className='entity-card-copy'>
-															<h3>{getPendingOperationLabel(currentPoolOracleManagerDetails.pendingOperation.operation)}</h3>
+															<h3>{getPendingOperationLabel(pendingOperation.operation)}</h3>
 														</div>
 													</div>
 													<div className='entity-card-body workflow-metric-grid'>
-														<MetricField label='Operation Id'>{currentPoolOracleManagerDetails.pendingOperation.operationId.toString()}</MetricField>
+														<MetricField label='Operation Id'>{pendingOperation.operationId.toString()}</MetricField>
 														<MetricField label='Initiator'>
-															<AddressValue address={currentPoolOracleManagerDetails.pendingOperation.initiatorVault} />
+															<AddressValue address={pendingOperation.initiatorVault} />
 														</MetricField>
 														<MetricField label='Target Vault'>
-															<AddressValue address={currentPoolOracleManagerDetails.pendingOperation.targetVault} />
+															<AddressValue address={pendingOperation.targetVault} />
 														</MetricField>
 														<MetricField label='Amount'>
-															<CurrencyValue value={currentPoolOracleManagerDetails.pendingOperation.amount} />
+															<CurrencyValue value={pendingOperation.amount} />
 														</MetricField>
 													</div>
 												</WarningSurface>
@@ -1013,6 +1016,7 @@ export function SecurityPoolWorkflowSection({
 				liquidationManagerAddress={liquidationManagerAddress}
 				liquidationModalOpen={liquidationModalOpen}
 				liquidationSecurityPoolAddress={liquidationSecurityPoolAddress}
+				liquidationTimeoutMinutes={liquidationTimeoutMinutes}
 				loadingPoolOracleManager={loadingPoolOracleManager}
 				liquidationTargetVault={liquidationTargetVault}
 				onLoadPoolOracleManager={onLoadPoolOracleManager}
@@ -1029,6 +1033,7 @@ export function SecurityPoolWorkflowSection({
 				callerVaultSummary={accountState.address === undefined ? undefined : selectedPool?.vaults.find(vault => sameAddress(vault.vaultAddress, accountState.address))}
 				targetVaultSummary={selectedPool?.vaults.find(vault => sameAddress(vault.vaultAddress, liquidationTargetVault))}
 				onLiquidationAmountChange={onLiquidationAmountChange}
+				onLiquidationTimeoutMinutesChange={onLiquidationTimeoutMinutesChange}
 				onQueueLiquidation={onQueueLiquidation}
 			/>
 		</RouteWorkflowPanel>

--- a/ui/ts/components/SecurityPoolsOverviewSection.tsx
+++ b/ui/ts/components/SecurityPoolsOverviewSection.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'preact/hooks'
+import { useEffect, useRef, useState } from 'preact/hooks'
 import { zeroAddress } from 'viem'
 import { EntityCard } from './EntityCard.js'
 import { ErrorNotice } from './ErrorNotice.js'
 import { FormInput } from './FormInput.js'
 import { LiquidationModal } from './LiquidationModal.js'
-import { LoadingText } from './LoadingText.js'
+import { PaginationControls } from './PaginationControls.js'
 import { Question, getQuestionTitle } from './Question.js'
 import { RouteWorkflowPanel } from './RouteWorkflowPanel.js'
 import { SecurityPoolSummaryMetrics } from './SecurityPoolSummaryMetrics.js'
@@ -14,25 +14,29 @@ import { StateHint } from './StateHint.js'
 import { WorkflowSubsection } from './WorkflowSubsection.js'
 import { sameAddress } from '../lib/address.js'
 import { isMainnetChain } from '../lib/network.js'
+import { SECURITY_POOL_PAGE_SIZE } from '../lib/pagination.js'
 import { getSecurityPoolStatusBadgeLabel } from '../lib/securityPoolLabels.js'
 import { deriveSecurityPoolLifecycleState, evaluateSecurityPoolState, type SecurityPoolLifecycleState } from '../lib/securityPoolState.js'
 import { getPoolRegistryPresentation } from '../lib/userCopy.js'
 import type { SecurityPoolsOverviewSectionProps } from '../types/components.js'
+
 export function SecurityPoolsOverviewSection({
 	accountState,
 	closeLiquidationModal,
-	hasLoadedSecurityPools,
+	hasLoadedSecurityPoolPage,
 	liquidationAmount,
 	liquidationMaxAmount,
 	liquidationManagerAddress,
 	liquidationModalOpen,
 	liquidationSecurityPoolAddress,
 	liquidationTargetVault,
+	liquidationTimeoutMinutes,
 	loadingPoolOracleManager,
-	loadingSecurityPools,
+	loadingSecurityPoolPage,
 	onLiquidationAmountChange,
+	onLiquidationTimeoutMinutesChange,
 	onLoadPoolOracleManager,
-	onLoadSecurityPools,
+	onLoadSecurityPoolPage,
 	onOpenLiquidationModal,
 	onQueueLiquidation,
 	onSelectSecurityPool,
@@ -40,28 +44,51 @@ export function SecurityPoolsOverviewSection({
 	repPerEthPrice,
 	repPerEthSource,
 	repPerEthSourceUrl,
+	securityPoolBrowseCount,
+	securityPoolPage,
 	securityPoolOverviewActiveAction,
 	securityPoolOverviewError,
 	securityPoolOverviewResult,
-	securityPools,
 }: SecurityPoolsOverviewSectionProps) {
 	const isMainnet = isMainnetChain(accountState.chainId)
+	const [pageIndex, setPageIndex] = useState(0)
+	const [activePageRequestKey, setActivePageRequestKey] = useState<string | undefined>(undefined)
 	const [searchText, setSearchText] = useState('')
 	const [systemStateFilter, setSystemStateFilter] = useState<'all' | SecurityPoolLifecycleState>('all')
 	const [vaultFilter, setVaultFilter] = useState<'all' | 'has-vaults' | 'empty'>('all')
-	const parentPoolAddressesWithLoadedChildren = new Set(securityPools.filter(pool => pool.parent !== undefined && pool.parent !== pool.securityPoolAddress).map(pool => pool.parent.toLowerCase()))
+	const loadSecurityPoolPageRef = useRef(onLoadSecurityPoolPage)
+	loadSecurityPoolPageRef.current = onLoadSecurityPoolPage
+	const effectivePoolCount = securityPoolPage?.poolCount ?? securityPoolBrowseCount
+	let poolPageCount: number | undefined
+	if (effectivePoolCount === undefined) {
+		poolPageCount = undefined
+	} else if (effectivePoolCount === 0n) {
+		poolPageCount = 0
+	} else {
+		poolPageCount = Math.ceil(Number(effectivePoolCount) / SECURITY_POOL_PAGE_SIZE)
+	}
+	let resolvedPageIndex = pageIndex
+	if (poolPageCount === 0) {
+		resolvedPageIndex = 0
+	} else if (poolPageCount !== undefined) {
+		resolvedPageIndex = Math.min(pageIndex, poolPageCount - 1)
+	}
+	const currentPageRequestKey = `${resolvedPageIndex}:${SECURITY_POOL_PAGE_SIZE}`
+	const hasCurrentPageData = securityPoolPage?.pageIndex === resolvedPageIndex && securityPoolPage.pageSize === SECURITY_POOL_PAGE_SIZE
+	const pagedSecurityPools = hasCurrentPageData ? securityPoolPage.pools : []
+	const isWaitingForPageData = activePageRequestKey === currentPageRequestKey
 	const registryPresentation = getPoolRegistryPresentation({
-		hasLoaded: hasLoadedSecurityPools,
-		isLoading: loadingSecurityPools,
+		hasLoaded: hasLoadedSecurityPoolPage && hasCurrentPageData,
+		isLoading: loadingSecurityPoolPage || isWaitingForPageData,
 		mode: 'collection',
-		poolCount: securityPools.length,
+		poolCount: pagedSecurityPools.length,
 	})
-	const securityPoolsWithState = securityPools.map(pool => ({
+	const securityPoolsWithState = pagedSecurityPools.map(pool => ({
 		pool,
-		hasKnownForkActivity: pool.hasForkActivity || parentPoolAddressesWithLoadedChildren.has(pool.securityPoolAddress.toLowerCase()),
+		hasKnownForkActivity: pool.hasForkActivity,
 		poolState: evaluateSecurityPoolState({
 			lifecycleState: deriveSecurityPoolLifecycleState({
-				hasForkActivity: pool.hasForkActivity || parentPoolAddressesWithLoadedChildren.has(pool.securityPoolAddress.toLowerCase()),
+				hasForkActivity: pool.hasForkActivity,
 				isChildPool: pool.parent !== zeroAddress,
 				questionOutcome: pool.questionOutcome,
 				systemState: pool.systemState,
@@ -76,6 +103,25 @@ export function SecurityPoolsOverviewSection({
 	const targetVaultSummary = selectedPool?.vaults.find(vault => sameAddress(vault.vaultAddress, liquidationTargetVault))
 	const callerVaultSummary = accountState.address === undefined ? undefined : selectedPool?.vaults.find(vault => sameAddress(vault.vaultAddress, accountState.address))
 	const normalizedSearchText = searchText.trim().toLowerCase()
+	const hasPreviousPage = resolvedPageIndex > 0
+	const hasNextPage = poolPageCount === undefined ? false : resolvedPageIndex + 1 < poolPageCount
+	useEffect(() => {
+		if (resolvedPageIndex === pageIndex) return
+		setPageIndex(resolvedPageIndex)
+	}, [pageIndex, resolvedPageIndex])
+	useEffect(() => {
+		let cancelled = false
+		setActivePageRequestKey(currentPageRequestKey)
+		void Promise.resolve(loadSecurityPoolPageRef.current(resolvedPageIndex, SECURITY_POOL_PAGE_SIZE))
+			.catch(() => undefined)
+			.finally(() => {
+				if (cancelled) return
+				setActivePageRequestKey(current => (current === currentPageRequestKey ? undefined : current))
+			})
+		return () => {
+			cancelled = true
+		}
+	}, [currentPageRequestKey, resolvedPageIndex])
 	const filteredSecurityPools = securityPoolsWithState.filter(({ pool, poolState }) => {
 		const displayState = poolState.lifecycleState
 		if (systemStateFilter !== 'all' && displayState !== systemStateFilter) return false
@@ -91,9 +137,18 @@ export function SecurityPoolsOverviewSection({
 				title='Pool Registry'
 				description='Browse deployed pools, inspect their vaults, and open a selected pool workflow.'
 				actions={
-					<button className='secondary' onClick={onLoadSecurityPools} disabled={loadingSecurityPools}>
-						{loadingSecurityPools ? <LoadingText>Loading pools...</LoadingText> : 'Refresh pools'}
-					</button>
+					<PaginationControls
+						hasNextPage={hasNextPage}
+						hasPreviousPage={hasPreviousPage}
+						loading={loadingSecurityPoolPage}
+						onNextPage={() => {
+							setPageIndex(current => current + 1)
+						}}
+						onPreviousPage={() => {
+							setPageIndex(current => Math.max(0, current - 1))
+						}}
+						summary={securityPoolPage === undefined || poolPageCount === undefined ? undefined : `Page ${resolvedPageIndex + 1} of ${Math.max(poolPageCount, 1)}`}
+					/>
 				}
 			>
 				<ErrorNotice message={securityPoolOverviewError} />
@@ -122,14 +177,14 @@ export function SecurityPoolsOverviewSection({
 						</select>
 					</label>
 				</div>
-				{securityPools.length > 0 ? (
+				{pagedSecurityPools.length > 0 ? (
 					<p className='detail'>
-						{filteredSecurityPools.length.toString()} of {securityPools.length.toString()} pools shown.
+						{filteredSecurityPools.length.toString()} of {pagedSecurityPools.length.toString()} pools shown on this page.
 					</p>
 				) : undefined}
 
 				{(() => {
-					if (securityPools.length === 0) {
+					if (pagedSecurityPools.length === 0) {
 						if (registryPresentation === undefined) return undefined
 
 						return <StateHint presentation={registryPresentation} />
@@ -220,6 +275,7 @@ export function SecurityPoolsOverviewSection({
 				liquidationManagerAddress={liquidationManagerAddress}
 				liquidationModalOpen={liquidationModalOpen}
 				liquidationSecurityPoolAddress={liquidationSecurityPoolAddress}
+				liquidationTimeoutMinutes={liquidationTimeoutMinutes}
 				loadingPoolOracleManager={loadingPoolOracleManager}
 				liquidationTargetVault={liquidationTargetVault}
 				onLoadPoolOracleManager={onLoadPoolOracleManager}
@@ -235,6 +291,7 @@ export function SecurityPoolsOverviewSection({
 				callerVaultSummary={callerVaultSummary}
 				targetVaultSummary={targetVaultSummary}
 				onLiquidationAmountChange={onLiquidationAmountChange}
+				onLiquidationTimeoutMinutesChange={onLiquidationTimeoutMinutesChange}
 				onQueueLiquidation={onQueueLiquidation}
 			/>
 		</RouteWorkflowPanel>

--- a/ui/ts/components/SecurityPoolsSection.tsx
+++ b/ui/ts/components/SecurityPoolsSection.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useRef } from 'preact/hooks'
 import { SecurityPoolSection } from './SecurityPoolSection.js'
 import { SecurityPoolWorkflowSection } from './SecurityPoolWorkflowSection.js'
 import { SecurityPoolsOverviewSection } from './SecurityPoolsOverviewSection.js'
@@ -13,19 +12,6 @@ export function shouldRefreshSelectedPoolDataOnViewOpen({ currentSecurityPoolAdd
 
 export function SecurityPoolsSection({ activeView, createPool, onActiveViewChange, overview, workflow }: SecurityPoolsSectionProps) {
 	const view = activeView
-	const autoLoadedBrowsePools = useRef(false)
-
-	useEffect(() => {
-		if (view !== 'browse') return
-		if (overview.loadingSecurityPools) return
-		if (overview.hasLoadedSecurityPools) return
-		if (autoLoadedBrowsePools.current) return
-		autoLoadedBrowsePools.current = true
-		void Promise.resolve(overview.onLoadSecurityPools()).catch(error => {
-			autoLoadedBrowsePools.current = false
-			console.error('[security-pools] failed to auto-load security pools', error)
-		})
-	}, [overview.hasLoadedSecurityPools, overview.loadingSecurityPools, overview.onLoadSecurityPools, view])
 
 	const openView = (nextView: SecurityPoolsView, nextSecurityPoolAddress?: string) => {
 		onActiveViewChange(nextView)

--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -19,16 +19,18 @@ import { TransactionActionButton } from './TransactionActionButton.js'
 import { VaultMetricGrid } from './VaultMetricGrid.js'
 import { WarningSurface } from './WarningSurface.js'
 import { normalizeAddress, sameAddress } from '../lib/address.js'
-import { formatCurrencyBalance, formatCurrencyInputBalance } from '../lib/formatters.js'
+import { formatCurrencyBalance, formatCurrencyInputBalance, formatDuration } from '../lib/formatters.js'
 import { balanceShortage } from '../lib/inputs.js'
-import { tryParseRepAmountInput } from '../lib/marketForm.js'
+import { tryParseBigIntInput, tryParseRepAmountInput } from '../lib/marketForm.js'
 import { isMainnetChain } from '../lib/network.js'
 import { getSecurityPoolVaultReadinessActions } from '../lib/securityPoolReadiness.js'
 import { getVaultApprovalGuardMessage, getVaultClaimFeesGuardMessage, getVaultDepositGuardMessage, getVaultRedeemRepGuardMessage, getVaultSetSecurityBondAllowanceGuardMessage, getVaultWithdrawGuardMessage } from '../lib/securityVaultGuards.js'
 import { deriveTokenApprovalRequirement } from '../lib/tokenApproval.js'
 import {
+	DEFAULT_STAGED_OPERATION_TIMEOUT_MINUTES,
 	doesLoadedSecurityVaultMatchSelection,
 	getSecurityVaultMaxBondAllowanceAmount,
+	getStagedOperationTimeoutSeconds,
 	getSecurityVaultWithdrawableRepAmount,
 	getSelectedVaultAddress,
 	hasValidSecurityVaultOraclePrice,
@@ -256,6 +258,7 @@ export function SecurityVaultSection({
 		securityBondAllowanceAmount: securityVaultForm.securityBondAllowanceAmount ?? '0',
 		securityPoolAddress: securityVaultForm.securityPoolAddress ?? '',
 		selectedVaultAddress: securityVaultForm.selectedVaultAddress ?? '',
+		stagedOperationTimeoutMinutes: securityVaultForm.stagedOperationTimeoutMinutes ?? DEFAULT_STAGED_OPERATION_TIMEOUT_MINUTES.toString(),
 	}
 	const selectedVaultAddress = getSelectedVaultAddress(normalizedSecurityVaultForm.selectedVaultAddress, accountState.address)
 	const currentSelectedVaultDetails = doesLoadedSecurityVaultMatchSelection({
@@ -271,6 +274,8 @@ export function SecurityVaultSection({
 	const depositAmount = tryParseRepAmountInput(normalizedSecurityVaultForm.depositAmount)
 	const securityBondAllowanceAmount = tryParseRepAmountInput(normalizedSecurityVaultForm.securityBondAllowanceAmount)
 	const withdrawAmount = tryParseRepAmountInput(normalizedSecurityVaultForm.repWithdrawAmount)
+	const stagedOperationTimeoutMinutes = tryParseBigIntInput(normalizedSecurityVaultForm.stagedOperationTimeoutMinutes)
+	const stagedOperationTimeoutSeconds = getStagedOperationTimeoutSeconds(stagedOperationTimeoutMinutes)
 	const securityBondAllowance = currentSelectedVaultDetails?.securityBondAllowance ?? 0n
 	const hasValidOraclePrice = hasValidSecurityVaultOraclePrice(currentSelectedVaultDetails?.managerAddress, oracleManagerDetails)
 	const oraclePriceValidUntilTimestamp = hasValidOraclePrice ? oracleManagerDetails?.priceValidUntilTimestamp : undefined
@@ -320,6 +325,7 @@ export function SecurityVaultSection({
 		securityBondAllowanceAmount,
 		selectedVaultDetailsLoaded: currentSelectedVaultDetails !== undefined,
 		selectedVaultIsOwnedByAccount,
+		stagedOperationTimeoutMinutes,
 		walletEthBalance: accountState.ethBalance,
 	})
 	const depositGuardMessage = getVaultDepositGuardMessage({
@@ -337,6 +343,7 @@ export function SecurityVaultSection({
 		isMainnet,
 		requestPriceEthCost: oracleManagerDetails?.requestPriceEthCost,
 		selectedVaultIsOwnedByAccount,
+		stagedOperationTimeoutMinutes,
 		withdrawAmount: hasWithdrawAmount ? withdrawAmount : undefined,
 		withdrawableRepAmount,
 		walletEthBalance: accountState.ethBalance,
@@ -370,6 +377,31 @@ export function SecurityVaultSection({
 		queuedVaultOperation,
 		securityVaultResult,
 	})
+	const stagedOperationTimeoutHelpText =
+		stagedOperationTimeoutSeconds === undefined
+			? 'Enter whole minutes. Queued self-service operations must stay executable for at least 1 minute after the oracle settlement window completes.'
+			: `This queued self-service operation will expire ${formatDuration(stagedOperationTimeoutSeconds)} after the oracle settlement window completes.`
+	const renderStagedOperationTimeoutField = () => (
+		<>
+			<label className='field'>
+				<span>Manual Execution Timeout</span>
+				<div className='field-inline'>
+					<FormInput
+						className='field-inline-input'
+						inputMode='numeric'
+						min='1'
+						pattern='[0-9]*'
+						step='1'
+						value={normalizedSecurityVaultForm.stagedOperationTimeoutMinutes}
+						onInput={event => onSecurityVaultFormChange({ stagedOperationTimeoutMinutes: event.currentTarget.value })}
+						disabled={!poolCollateralActionsEnabled}
+					/>
+					<span className='field-inline-action'>minutes</span>
+				</div>
+			</label>
+			<p className='detail'>{stagedOperationTimeoutHelpText}</p>
+		</>
+	)
 	const vaultLoadNotice = (() => {
 		if (loadingSecurityVault)
 			return (
@@ -579,6 +611,7 @@ export function SecurityVaultSection({
 								</div>
 							</label>
 						)}
+						{effectiveRepExitMode === 'redeem' ? null : renderStagedOperationTimeoutField()}
 						<RequirementsChecklist
 							items={
 								effectiveRepExitMode === 'redeem'
@@ -596,6 +629,7 @@ export function SecurityVaultSection({
 											{ key: 'owned', label: 'Selected vault is owned by the connected account', resolved: selectedVaultIsOwnedByAccount },
 											{ key: 'oracle', label: 'A valid oracle price is available', resolved: hasValidOraclePrice },
 											{ key: 'withdrawable', label: 'The vault has withdrawable REP', resolved: withdrawableRepAmount !== undefined && withdrawableRepAmount > 0n },
+											{ key: 'timeout', label: 'Manual execution timeout is at least 1 minute', resolved: stagedOperationTimeoutSeconds !== undefined },
 										]
 							}
 						/>
@@ -650,11 +684,13 @@ export function SecurityVaultSection({
 								</button>
 							</div>
 						</label>
+						{renderStagedOperationTimeoutField()}
 						<RequirementsChecklist
 							items={[
 								{ key: 'owned', label: 'Selected vault is owned by the connected account', resolved: selectedVaultIsOwnedByAccount },
 								{ key: 'oracle', label: 'A valid oracle price is available', resolved: hasValidOraclePrice },
 								{ key: 'allowance', label: `Allowance amount is zero or at least ${formatCurrencyBalance(MIN_SECURITY_BOND_ALLOWANCE)} ETH`, resolved: hasValidSecurityBondAllowanceAmount },
+								{ key: 'timeout', label: 'Manual execution timeout is at least 1 minute', resolved: stagedOperationTimeoutSeconds !== undefined },
 							]}
 						/>
 						<div className='actions'>
@@ -783,6 +819,7 @@ export function SecurityVaultSection({
 								</button>
 							</div>
 						</label>
+						{renderStagedOperationTimeoutField()}
 						<div className='actions'>
 							<TransactionActionButton
 								idleLabel='Set Security Bond Allowance'
@@ -841,6 +878,7 @@ export function SecurityVaultSection({
 						</div>
 					</label>
 				)}
+				{effectiveRepExitMode === 'redeem' ? null : renderStagedOperationTimeoutField()}
 				<div className='actions'>
 					<TransactionActionButton
 						idleLabel={repExitActionLabel}

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -79,8 +79,8 @@ import { type ContractRevertReasonParams, type WriteContractClient, readRequired
 import { getInfraContractAddresses, getOpenOracleAddress, getZoltarAddress } from './contracts/deploymentHelpers.js'
 export { getDeploymentSteps, loadDeploymentStatusOracleSnapshot, loadErc20Allowance, loadErc20Balance } from './contracts/deployment.js'
 import { getDeploymentSteps } from './contracts/deployment.js'
-export { createSecurityPool, loadSecurityVaultDetails, originSecurityPoolExists } from './contracts/securityPools.js'
-export { createMarket, loadAllZoltarQuestions, loadMarketDetails, loadZoltarQuestionCount, loadZoltarUniverseSummary } from './contracts/zoltar.js'
+export { createSecurityPool, loadSecurityPoolPage, loadSecurityVaultDetails, originSecurityPoolExists } from './contracts/securityPools.js'
+export { createMarket, loadAllZoltarQuestions, loadMarketDetails, loadZoltarQuestionCount, loadZoltarQuestionPage, loadZoltarUniverseSummary } from './contracts/zoltar.js'
 import { loadMarketDetails } from './contracts/zoltar.js'
 export { readOptionalMulticall } from './contracts/core.js'
 export { getMulticall3Address, getOpenOracleAddress, getZoltarAddress } from './contracts/deploymentHelpers.js'
@@ -1821,12 +1821,12 @@ export async function loadTradingDetails(client: ReadClient, securityPoolAddress
 		universeId,
 	}
 }
-export async function queueSecurityPoolLiquidation(client: WriteClient, managerAddress: Address, targetVault: Address, amount: bigint) {
+export async function queueSecurityPoolLiquidation(client: WriteClient, managerAddress: Address, targetVault: Address, amount: bigint, validForSeconds: bigint) {
 	const callParams = {
 		address: managerAddress,
 		abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
 		functionName: 'requestPriceIfNeededAndStageOperation',
-		args: [LIQUIDATION_OPERATION_TYPE, targetVault, amount],
+		args: [LIQUIDATION_OPERATION_TYPE, targetVault, amount, validForSeconds],
 		value: await loadBufferedOracleRequestEthCost(client, managerAddress),
 	}
 	const { hash, receipt } = await writeContractAndWaitForReceipt(client, () => callParams)
@@ -1866,12 +1866,12 @@ function getShareTokenId(universeId: bigint, outcome: ReportingOutcomeKey) {
 	const universeMask = (1n << 248n) - 1n
 	return ((universeId & universeMask) << 8n) | (getShareMigrationOutcomeValue(outcome) & 255n)
 }
-export async function queueOracleManagerOperation(client: WriteClient, managerAddress: Address, operation: OracleQueueOperation, targetVault: Address, amount: bigint) {
+export async function queueOracleManagerOperation(client: WriteClient, managerAddress: Address, operation: OracleQueueOperation, targetVault: Address, amount: bigint, validForSeconds: bigint) {
 	const callParams = {
 		address: managerAddress,
 		abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
 		functionName: 'requestPriceIfNeededAndStageOperation',
-		args: [getOracleOperationType(operation), targetVault, amount],
+		args: [getOracleOperationType(operation), targetVault, amount, validForSeconds],
 		value: await loadBufferedOracleRequestEthCost(client, managerAddress),
 	}
 	const { hash, receipt } = await writeContractAndWaitForReceipt(client, () => callParams)

--- a/ui/ts/contracts/securityPools.ts
+++ b/ui/ts/contracts/securityPools.ts
@@ -1,11 +1,33 @@
-import { decodeEventLog, encodeAbiParameters, encodeDeployData, getCreate2Address, keccak256, type Address, type TransactionReceipt } from 'viem'
-import { peripherals_SecurityPool_SecurityPool, peripherals_factories_SecurityPoolFactory_SecurityPoolFactory, peripherals_tokens_ShareToken_ShareToken } from '../contractArtifact.js'
+import { decodeEventLog, encodeAbiParameters, encodeDeployData, getCreate2Address, keccak256, parseAbiItem, type Address, type TransactionReceipt } from 'viem'
+import {
+	peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator,
+	peripherals_SecurityPool_SecurityPool,
+	peripherals_SecurityPoolForker_SecurityPoolForker,
+	peripherals_factories_SecurityPoolFactory_SecurityPoolFactory,
+	peripherals_tokens_ShareToken_ShareToken,
+	Zoltar_Zoltar,
+} from '../contractArtifact.js'
 import { isIgnorableLogDecodeError } from '../lib/errors.js'
-import type { SecurityPoolCreationResult, SecurityVaultDetails, WriteClient, ReadClient } from '../types/contracts.js'
-import { writeContractAndWaitForReceipt } from './core.js'
-import { getQuestionIdHex } from './helpers.js'
+import { deriveHasForkActivity } from '../lib/forkAuction.js'
+import type { ListedSecurityPool, SecurityPoolCreationResult, SecurityPoolPage, SecurityVaultDetails, WriteClient, ReadClient } from '../types/contracts.js'
+import { readRequiredMulticall, writeContractAndWaitForReceipt } from './core.js'
+import { getForkOutcomeKey, getQuestionIdHex, getReportingOutcomeKey, getSecurityPoolSystemState, requireSecurityVaultTupleArray } from './helpers.js'
 import { getDeploymentSteps } from './deployment.js'
 import { getInfraContractAddresses, getZoltarAddress } from './deploymentHelpers.js'
+import { loadMarketDetails } from './zoltar.js'
+
+const QUESTION_OUTCOME_ABI = [parseAbiItem('function getQuestionOutcome(address securityPool) view returns (uint8 outcome)')]
+
+type ForkDataTuple = readonly [bigint, Address, bigint, bigint, bigint, boolean, number]
+type SecurityPoolDeploymentQueryResult = {
+	parent: Address
+	priceOracleManagerAndOperatorQueuer: Address
+	questionId: bigint
+	securityMultiplier: bigint
+	securityPool: Address
+	truthAuction: Address
+	universeId: bigint
+}
 
 function getDeploymentStepAddress(id: 'securityPoolFactory' | 'zoltarQuestionData') {
 	const step = getDeploymentSteps().find(candidate => candidate.id === id)
@@ -64,6 +86,102 @@ async function poolOwnershipToRep(client: ReadClient, securityPoolAddress: Addre
 	})
 }
 
+async function getSecurityPoolVaultCount(client: Pick<ReadClient, 'readContract'>, securityPoolAddress: Address) {
+	return await client.readContract({
+		abi: peripherals_SecurityPool_SecurityPool.abi,
+		functionName: 'getVaultCount',
+		address: securityPoolAddress,
+		args: [],
+	})
+}
+
+async function getSecurityPoolVaults(client: Pick<ReadClient, 'readContract'>, securityPoolAddress: Address, startIndex: bigint, count: bigint) {
+	return await client.readContract({
+		abi: peripherals_SecurityPool_SecurityPool.abi,
+		functionName: 'getVaults',
+		address: securityPoolAddress,
+		args: [startIndex, count],
+	})
+}
+
+async function loadSecurityPoolVaultSummaries(
+	client: ReadClient,
+	securityPoolAddress: Address,
+): Promise<{
+	hasLoadedVaults: boolean
+	vaultCount: bigint
+	vaults: ListedSecurityPool['vaults']
+}> {
+	const vaultCount = await getSecurityPoolVaultCount(client, securityPoolAddress)
+	const vaultAddresses = vaultCount === 0n ? [] : await getSecurityPoolVaults(client, securityPoolAddress, 0n, vaultCount)
+	if (vaultAddresses.length === 0) {
+		return {
+			hasLoadedVaults: true,
+			vaultCount,
+			vaults: [],
+		}
+	}
+	const vaultData = requireSecurityVaultTupleArray(
+		await Promise.all(
+			vaultAddresses.map(
+				async vaultAddress =>
+					await client.readContract({
+						abi: peripherals_SecurityPool_SecurityPool.abi,
+						functionName: 'securityVaults',
+						address: securityPoolAddress,
+						args: [vaultAddress],
+					}),
+			),
+		),
+		'security vault tuple',
+	)
+	const poolOwnershipContracts: Array<{
+		index: number
+		poolOwnership: bigint
+	}> = []
+	for (const [index, currentVaultData] of vaultData.entries()) {
+		const [poolOwnership] = currentVaultData
+		if (poolOwnership === 0n) continue
+		poolOwnershipContracts.push({ index, poolOwnership })
+	}
+	const repDeposits = new Map<number, bigint>()
+	if (poolOwnershipContracts.length > 0) {
+		const repDepositResults = await Promise.all(
+			poolOwnershipContracts.map(
+				async ({ poolOwnership }) =>
+					await client.readContract({
+						abi: peripherals_SecurityPool_SecurityPool.abi,
+						functionName: 'poolOwnershipToRep',
+						address: securityPoolAddress,
+						args: [poolOwnership],
+					}),
+			),
+		)
+		for (const [resultIndex, repDepositShare] of repDepositResults.entries()) {
+			const poolOwnershipContract = poolOwnershipContracts[resultIndex]
+			if (poolOwnershipContract === undefined) throw new Error('Unexpected pool ownership contract result')
+			if (typeof repDepositShare !== 'bigint') throw new Error('Unexpected rep deposit result')
+			repDeposits.set(poolOwnershipContract.index, repDepositShare)
+		}
+	}
+	return {
+		hasLoadedVaults: true,
+		vaultCount,
+		vaults: vaultAddresses.map((vaultAddress, index) => {
+			const currentVaultData = vaultData[index]
+			if (currentVaultData === undefined) throw new Error('Unexpected vault data response')
+			const [, securityBondAllowance, unpaidEthFees, , lockedRepInEscalationGame] = currentVaultData
+			return {
+				lockedRepInEscalationGame,
+				repDepositShare: repDeposits.get(index) ?? 0n,
+				securityBondAllowance,
+				unpaidEthFees,
+				vaultAddress,
+			}
+		}),
+	}
+}
+
 export async function createSecurityPool(
 	client: WriteClient,
 	parameters: {
@@ -92,6 +210,146 @@ export async function originSecurityPoolExists(client: Pick<ReadClient, 'getCode
 	const shareTokenAddress = getOriginSecurityPoolShareTokenAddress(questionId, securityMultiplier)
 	const code = await client.getCode({ address: shareTokenAddress })
 	return code !== undefined && code !== '0x'
+}
+
+export async function loadSecurityPoolPage(client: ReadClient, pageIndex: number, pageSize: number): Promise<SecurityPoolPage> {
+	if (!Number.isInteger(pageIndex) || pageIndex < 0) throw new Error('Security pool page index must be a non-negative integer')
+	if (!Number.isInteger(pageSize) || pageSize <= 0) throw new Error('Security pool page size must be a positive integer')
+	const poolCount = await client.readContract({
+		address: getInfraContractAddresses().securityPoolFactory,
+		abi: peripherals_factories_SecurityPoolFactory_SecurityPoolFactory.abi,
+		functionName: 'securityPoolDeploymentCount',
+		args: [],
+	})
+	const startIndex = BigInt(pageIndex * pageSize)
+	if (startIndex >= poolCount) {
+		return {
+			pageIndex,
+			pageSize,
+			poolCount,
+			pools: [],
+		}
+	}
+	const count = poolCount - startIndex < BigInt(pageSize) ? poolCount - startIndex : BigInt(pageSize)
+	const deployments: readonly SecurityPoolDeploymentQueryResult[] = await client.readContract({
+		address: getInfraContractAddresses().securityPoolFactory,
+		abi: peripherals_factories_SecurityPoolFactory_SecurityPoolFactory.abi,
+		functionName: 'securityPoolDeploymentsRange',
+		args: [startIndex, count],
+	})
+	const pools = await Promise.all(
+		deployments.map(async deployment => {
+			const { parent, priceOracleManagerAndOperatorQueuer: managerAddress, questionId, securityMultiplier, securityPool: securityPoolAddress, truthAuction: truthAuctionAddress, universeId } = deployment
+			const [[completeSetCollateralAmount, currentRetentionRate, forkData, lastOraclePrice, lastSettlementTimestamp, questionOutcome, systemStateValue, totalRepDeposit, totalSecurityBondAllowance, universeForkTime], marketDetails, vaultSummaries] = await Promise.all([
+				readRequiredMulticall(client, [
+					{
+						abi: peripherals_SecurityPool_SecurityPool.abi,
+						functionName: 'completeSetCollateralAmount',
+						address: securityPoolAddress,
+						args: [],
+					},
+					{
+						abi: peripherals_SecurityPool_SecurityPool.abi,
+						functionName: 'currentRetentionRate',
+						address: securityPoolAddress,
+						args: [],
+					},
+					{
+						abi: peripherals_SecurityPoolForker_SecurityPoolForker.abi,
+						functionName: 'forkData',
+						address: getInfraContractAddresses().securityPoolForker,
+						args: [securityPoolAddress],
+					},
+					{
+						abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+						functionName: 'lastPrice',
+						address: managerAddress,
+						args: [],
+					},
+					{
+						abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+						functionName: 'lastSettlementTimestamp',
+						address: managerAddress,
+						args: [],
+					},
+					{
+						abi: QUESTION_OUTCOME_ABI,
+						functionName: 'getQuestionOutcome',
+						address: getInfraContractAddresses().securityPoolForker,
+						args: [securityPoolAddress],
+					},
+					{
+						abi: peripherals_SecurityPool_SecurityPool.abi,
+						functionName: 'systemState',
+						address: securityPoolAddress,
+						args: [],
+					},
+					{
+						abi: peripherals_SecurityPool_SecurityPool.abi,
+						functionName: 'getTotalRepBalance',
+						address: securityPoolAddress,
+						args: [],
+					},
+					{
+						abi: peripherals_SecurityPool_SecurityPool.abi,
+						functionName: 'totalSecurityBondAllowance',
+						address: securityPoolAddress,
+						args: [],
+					},
+					{
+						abi: Zoltar_Zoltar.abi,
+						functionName: 'getForkTime',
+						address: getInfraContractAddresses().zoltar,
+						args: [universeId],
+					},
+				]),
+				loadMarketDetails(client, questionId),
+				loadSecurityPoolVaultSummaries(client, securityPoolAddress),
+			])
+			const [, , truthAuctionStartedAt, migratedRep, , forkOwnSecurityPool, forkOutcomeIndex] = forkData as ForkDataTuple
+			const forkOutcome = getForkOutcomeKey(forkOutcomeIndex, parent)
+			const systemState = getSecurityPoolSystemState(systemStateValue)
+			const hasForkActivity = deriveHasForkActivity({
+				forkOutcome,
+				migratedRep,
+				systemState,
+				truthAuctionStartedAt,
+			})
+			return {
+				completeSetCollateralAmount,
+				currentRetentionRate,
+				forkOutcome,
+				forkOwnSecurityPool,
+				hasForkActivity,
+				lastOraclePrice: lastSettlementTimestamp > 0n ? lastOraclePrice : undefined,
+				lastOracleSettlementTimestamp: lastSettlementTimestamp,
+				managerAddress,
+				marketDetails,
+				migratedRep,
+				parent,
+				questionOutcome: getReportingOutcomeKey(questionOutcome),
+				questionId: getQuestionIdHex(questionId),
+				securityMultiplier,
+				securityPoolAddress,
+				systemState,
+				totalRepDeposit,
+				totalSecurityBondAllowance,
+				truthAuctionAddress,
+				truthAuctionStartedAt,
+				universeHasForked: universeForkTime > 0n,
+				universeId,
+				hasLoadedVaults: vaultSummaries.hasLoadedVaults,
+				vaultCount: vaultSummaries.vaultCount,
+				vaults: vaultSummaries.vaults,
+			} satisfies ListedSecurityPool
+		}),
+	)
+	return {
+		pageIndex,
+		pageSize,
+		poolCount,
+		pools,
+	}
 }
 
 export async function loadSecurityVaultDetails(client: ReadClient, securityPoolAddress: Address, vaultAddress: Address): Promise<SecurityVaultDetails | undefined> {

--- a/ui/ts/contracts/zoltar.ts
+++ b/ui/ts/contracts/zoltar.ts
@@ -1,6 +1,6 @@
 import { parseAbiItem, zeroAddress, type Address } from 'viem'
 import { ReputationToken_ReputationToken, Zoltar_Zoltar, ZoltarQuestionData_ZoltarQuestionData } from '../contractArtifact.js'
-import type { MarketCreationResult, MarketDetails, MarketType, QuestionData, ReadClient, WriteClient, ZoltarUniverseSummary } from '../types/contracts.js'
+import type { MarketCreationResult, MarketDetails, MarketDetailsPage, MarketType, QuestionData, ReadClient, WriteClient, ZoltarUniverseSummary } from '../types/contracts.js'
 import { readRequiredMulticall, writeContractAndWait } from './core.js'
 import { getMarketType, getQuestionId, getQuestionIdHex, isStringArray, requireUniverseTupleArray, type UniverseTuple } from './helpers.js'
 import { getDeploymentSteps } from './deployment.js'
@@ -72,6 +72,19 @@ async function loadQuestionIds(client: ReadClient): Promise<bigint[]> {
 	return questionIds
 }
 
+async function loadQuestionIdsPage(client: ReadClient, startIndex: bigint, count: bigint) {
+	if (count === 0n) return []
+	const page = await client.readContract({
+		abi: ZoltarQuestionData_ZoltarQuestionData.abi,
+		functionName: 'getQuestions',
+		address: getDeploymentStepAddress('zoltarQuestionData'),
+		args: [startIndex, count],
+	})
+	if (!Array.isArray(page)) throw new Error('Unexpected question id page response')
+	if (!page.every((questionId): questionId is bigint => typeof questionId === 'bigint')) throw new Error('Unexpected question id page response')
+	return page
+}
+
 export async function loadMarketDetails(client: ReadClient, questionId: bigint): Promise<MarketDetails> {
 	const [question, createdAt] = await readRequiredMulticall(client, [
 		{
@@ -122,6 +135,29 @@ export async function loadZoltarQuestionCount(client: ReadClient) {
 		address: getDeploymentStepAddress('zoltarQuestionData'),
 		args: [],
 	})
+}
+
+export async function loadZoltarQuestionPage(client: ReadClient, pageIndex: number, pageSize: number): Promise<MarketDetailsPage> {
+	if (!Number.isInteger(pageIndex) || pageIndex < 0) throw new Error('Question page index must be a non-negative integer')
+	if (!Number.isInteger(pageSize) || pageSize <= 0) throw new Error('Question page size must be a positive integer')
+	const questionCount = await loadZoltarQuestionCount(client)
+	const startIndex = BigInt(pageIndex * pageSize)
+	if (startIndex >= questionCount) {
+		return {
+			pageIndex,
+			pageSize,
+			questionCount,
+			questions: [],
+		}
+	}
+	const count = questionCount - startIndex < BigInt(pageSize) ? questionCount - startIndex : BigInt(pageSize)
+	const questionIds = await loadQuestionIdsPage(client, startIndex, count)
+	return {
+		pageIndex,
+		pageSize,
+		questionCount,
+		questions: await Promise.all(questionIds.map(async questionId => await loadMarketDetails(client, questionId))),
+	}
 }
 
 export async function loadZoltarUniverseSummary(client: ReadClient, universeId: bigint): Promise<ZoltarUniverseSummary | undefined> {

--- a/ui/ts/hooks/useOnchainState.ts
+++ b/ui/ts/hooks/useOnchainState.ts
@@ -21,6 +21,14 @@ type ChainClock = {
 	currentTimestamp: bigint | undefined
 }
 
+function getExpectedReadChainId(backend: ChainBackend) {
+	return backend.profile.chain.id
+}
+
+function buildReadBackendMismatchMessage(backend: ChainBackend, actualChainId: number) {
+	return `Configured read RPC reports chain ${actualChainId.toString()}, but this app requires ${backend.profile.displayName} (${getExpectedReadChainId(backend).toString()}).`
+}
+
 type LoadWalletStateParameters = {
 	chainIdPromise: Promise<string> | undefined
 	connectedAddress: Address | undefined
@@ -127,6 +135,13 @@ export function useOnchainState() {
 	const nextRefresh = useRequestGuard()
 	const nextChainClockRefresh = useRequestGuard()
 	const errorMessage = useSignal<string | undefined>(undefined)
+	const readBackendMessage = useSignal<string | undefined>(undefined)
+	const readBackendValidated = useSignal(false)
+	const clearChainClock = () => {
+		currentBlockNumber.value = undefined
+		currentTimestamp.value = undefined
+	}
+	const isReadBackendReady = () => readBackendValidated.value && readBackendMessage.value === undefined
 	const setDeploymentStatuses = (update: (current: DeploymentStatus[]) => DeploymentStatus[]) => {
 		const updated = update(deploymentStatuses.value)
 		deploymentStatuses.value = updated
@@ -144,10 +159,42 @@ export function useOnchainState() {
 		const shouldLoadWalletState = options.loadWalletState ?? true
 		const backend = getActiveBackend()
 		const isCurrent = nextRefresh()
+		let connectedAddress: Address | undefined
 		hasInjectedWallet.value = backend.hasWallet()
 		errorMessage.value = undefined
-		backend.setReadTransportMode?.('rpc')
-		void refreshChainClock(backend)
+		readBackendMessage.value = undefined
+		readBackendValidated.value = false
+		if (shouldLoadWalletState) {
+			try {
+				const accounts = await backend.getAccounts()
+				if (!isCurrent()) return
+				connectedAddress = normalizeAccount(accounts[0])
+			} catch (error) {
+				if (!isCurrent()) return
+				walletBootstrapComplete.value = true
+				errorMessage.value = getErrorMessage(error, 'Failed to refresh wallet state')
+				return
+			}
+		}
+		backend.setReadTransportMode?.(connectedAddress === undefined ? 'rpc' : 'provider')
+		if (connectedAddress === undefined) {
+			clearChainClock()
+			try {
+				const readChainId = await backend.createReadClient().getChainId()
+				if (!isCurrent()) return
+				if (readChainId !== getExpectedReadChainId(backend)) {
+					readBackendMessage.value = buildReadBackendMismatchMessage(backend, readChainId)
+					clearChainClock()
+				}
+				readBackendValidated.value = true
+			} catch (error) {
+				if (!isCurrent()) return
+				errorMessage.value = getErrorMessage(error, 'Failed to validate the configured read RPC')
+			}
+		} else {
+			readBackendValidated.value = true
+		}
+		if (isReadBackendReady()) void refreshChainClock(backend)
 
 		if (backend.isBootstrapped === false) {
 			deploymentStatusesLoaded.value = false
@@ -158,7 +205,7 @@ export function useOnchainState() {
 			environmentBootstrapError.value = undefined
 		}
 
-		if (backend.isBootstrapped !== false)
+		if (backend.isBootstrapped !== false && readBackendMessage.value === undefined)
 			void deploymentStatusLoad.track(async () => {
 				try {
 					const snapshot = await loadDeploymentStatusOracleSnapshot(backend.createReadClient())
@@ -176,9 +223,6 @@ export function useOnchainState() {
 
 		await walletStateLoad.track(async () => {
 			try {
-				const accounts = await backend.getAccounts()
-				if (!isCurrent()) return
-				const connectedAddress = normalizeAccount(accounts[0])
 				accountState.value = {
 					address: connectedAddress,
 					chainId: accountState.value.chainId,
@@ -286,7 +330,7 @@ export function useOnchainState() {
 			environmentBootstrapLabel.value = backend.bootstrapLabel
 			environmentBootstrapProgress.value = backend.bootstrapProgress
 			environmentReady.value = backend.isBootstrapped ?? true
-			void refreshChainClock(backend)
+			if (isReadBackendReady()) void refreshChainClock(backend)
 		})
 		const handleWalletChange = () => {
 			void refreshState()
@@ -304,16 +348,18 @@ export function useOnchainState() {
 	useEffect(() => {
 		const backend = getActiveBackend()
 		if (backend.isBootstrapped === false) return
+		if (!isReadBackendReady()) return
 
 		void refreshChainClock(backend)
 		const intervalId = window.setInterval(() => {
+			if (!isReadBackendReady()) return
 			void refreshChainClock(backend)
 		}, CHAIN_CLOCK_POLL_INTERVAL_MILLISECONDS)
 
 		return () => {
 			window.clearInterval(intervalId)
 		}
-	}, [environmentReady.value])
+	}, [environmentReady.value, readBackendMessage.value, readBackendValidated.value])
 
 	return {
 		accountState: accountState.value,
@@ -322,6 +368,7 @@ export function useOnchainState() {
 		currentTimestamp: currentTimestamp.value,
 		deploymentStatuses: deploymentStatuses.value,
 		errorMessage: errorMessage.value,
+		readBackendMessage: readBackendMessage.value,
 		environmentBootstrapError: environmentBootstrapError.value,
 		environmentBootstrapLabel: environmentBootstrapLabel.value,
 		environmentBootstrapProgress: environmentBootstrapProgress.value,

--- a/ui/ts/hooks/usePriceOracleManager.ts
+++ b/ui/ts/hooks/usePriceOracleManager.ts
@@ -32,9 +32,18 @@ export function usePriceOracleManager({ accountAddress, onTransactionFailed, onT
 	const poolOracleManagerError = useSignal<string | undefined>(undefined)
 	const poolPriceOracleResult = useSignal<OpenOracleActionResult | undefined>(undefined)
 	const nextPoolOracleManagerLoad = useRequestGuard()
-	const getPendingTitle = (actionName: OpenOracleActionResult['action']) => (actionName === 'requestPrice' ? 'Requesting price' : 'Executing staged operation')
-	const getSuccessTitle = (actionName: OpenOracleActionResult['action']) => (actionName === 'requestPrice' ? 'Price requested' : 'Staged operation executed')
-	const getFailureTitle = (actionName: OpenOracleActionResult['action']) => (actionName === 'requestPrice' ? 'Price request failed' : 'Staged operation failed')
+	const getPendingTitle = (actionName: OpenOracleActionResult['action']) => {
+		if (actionName === 'requestPrice') return 'Requesting price'
+		return 'Executing staged operation'
+	}
+	const getSuccessTitle = (actionName: OpenOracleActionResult['action']) => {
+		if (actionName === 'requestPrice') return 'Price requested'
+		return 'Staged operation executed'
+	}
+	const getFailureTitle = (actionName: OpenOracleActionResult['action']) => {
+		if (actionName === 'requestPrice') return 'Price request failed'
+		return 'Staged operation failed'
+	}
 
 	const loadPoolOracleManager = async (managerAddress: Address) => {
 		const isCurrent = nextPoolOracleManagerLoad()

--- a/ui/ts/hooks/useSecurityPoolsOverview.ts
+++ b/ui/ts/hooks/useSecurityPoolsOverview.ts
@@ -1,6 +1,6 @@
 import { useSignal } from '@preact/signals'
 import type { Address, Hash } from 'viem'
-import { loadAllSecurityPools, loadOracleManagerDetails, queueSecurityPoolLiquidation } from '../contracts.js'
+import { loadAllSecurityPools, loadOracleManagerDetails, loadSecurityPoolPage, queueSecurityPoolLiquidation } from '../contracts.js'
 import { useLoadController } from './useLoadController.js'
 import { normalizeAddress } from '../lib/address.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
@@ -10,11 +10,12 @@ import type { ActionFeedback } from '../lib/actionFeedback.js'
 import { createLiquidationSuccessPresentation, createLiquidationTransactionIntent, createLiquidationWarningPresentation } from '../lib/transactionPresentations.js'
 import { buildWriteActionConfig, runWriteAction } from '../lib/writeAction.js'
 import { parseAddressInput } from '../lib/inputs.js'
-import { parseRepAmountInput } from '../lib/marketForm.js'
+import { parseBigIntInput, parseRepAmountInput } from '../lib/marketForm.js'
 import { getOracleRequestEthGuardMessage } from '../lib/oracleRequestEth.js'
 import { useRequestGuard } from '../lib/requestGuard.js'
+import { DEFAULT_STAGED_OPERATION_TIMEOUT_MINUTES, getStagedOperationTimeoutSeconds, MIN_STAGED_OPERATION_TIMEOUT_MINUTES } from '../lib/securityVault.js'
 import type { WriteOperationsParameters } from '../types/app.js'
-import type { ListedSecurityPool, SecurityPoolOverviewActionResult } from '../types/contracts.js'
+import type { ListedSecurityPool, SecurityPoolOverviewActionResult, SecurityPoolPage } from '../types/contracts.js'
 
 type UseSecurityPoolsOverviewParameters = {
 	accountAddress: Address | undefined
@@ -30,11 +31,16 @@ export function useSecurityPoolsOverview({ accountAddress, onTransactionFailed, 
 	const liquidationAmount = useSignal('0')
 	const liquidationMaxAmount = useSignal<bigint | undefined>(undefined)
 	const liquidationTargetVault = useSignal('')
+	const liquidationTimeoutMinutes = useSignal(DEFAULT_STAGED_OPERATION_TIMEOUT_MINUTES.toString())
 	const liquidationManagerAddress = useSignal<Address | undefined>(undefined)
 	const liquidationSecurityPoolAddress = useSignal<Address | undefined>(undefined)
 	const liquidationModalOpen = useSignal(false)
+	const securityPoolBrowseCount = useSignal<bigint | undefined>(undefined)
+	const securityPoolPage = useSignal<SecurityPoolPage | undefined>(undefined)
 	const securityPoolsLoad = useLoadController()
+	const securityPoolPageLoad = useLoadController()
 	const hasLoadedSecurityPools = useSignal(false)
+	const hasLoadedSecurityPoolPage = useSignal(false)
 	const checkedSecurityPoolAddress = useSignal<string | undefined>(undefined)
 	const securityPoolOverviewActiveAction = useSignal<SecurityPoolOverviewActionResult['action'] | undefined>(undefined)
 	const securityPoolOverviewFeedback = useSignal<ActionFeedback<SecurityPoolOverviewActionResult['action']> | undefined>(undefined)
@@ -42,6 +48,7 @@ export function useSecurityPoolsOverview({ accountAddress, onTransactionFailed, 
 	const securityPoolOverviewResult = useSignal<SecurityPoolOverviewActionResult | undefined>(undefined)
 	const securityPools = useSignal<ListedSecurityPool[]>([])
 	const nextSecurityPoolsLoad = useRequestGuard()
+	const nextSecurityPoolPageLoad = useRequestGuard()
 
 	const loadSecurityPools = async (securityPoolAddress?: string) => {
 		const normalizedCheckedAddress = normalizeAddress(securityPoolAddress)
@@ -68,6 +75,26 @@ export function useSecurityPoolsOverview({ accountAddress, onTransactionFailed, 
 		})
 	}
 
+	const loadBrowseSecurityPoolPage = async (pageIndex: number, pageSize: number) => {
+		const isCurrent = nextSecurityPoolPageLoad()
+		await securityPoolPageLoad.run({
+			isCurrent,
+			onStart: () => {
+				if (!isCurrent()) return
+				securityPoolOverviewError.value = undefined
+			},
+			load: async () => await loadSecurityPoolPage(createConnectedReadClient(), pageIndex, pageSize),
+			onSuccess: page => {
+				hasLoadedSecurityPoolPage.value = true
+				securityPoolBrowseCount.value = page.poolCount
+				securityPoolPage.value = page
+			},
+			onError: error => {
+				securityPoolOverviewError.value = getErrorMessage(error, 'Failed to load security pool registry page')
+			},
+		})
+	}
+
 	const openLiquidationModal = (managerAddress: Address, securityPoolAddress: Address, vaultAddress: Address, maxAmount: bigint | undefined) => {
 		securityPoolOverviewError.value = undefined
 		securityPoolOverviewFeedback.value = undefined
@@ -76,6 +103,7 @@ export function useSecurityPoolsOverview({ accountAddress, onTransactionFailed, 
 		liquidationMaxAmount.value = maxAmount
 		liquidationSecurityPoolAddress.value = securityPoolAddress
 		liquidationTargetVault.value = vaultAddress
+		liquidationTimeoutMinutes.value = DEFAULT_STAGED_OPERATION_TIMEOUT_MINUTES.toString()
 		liquidationModalOpen.value = true
 	}
 
@@ -124,7 +152,11 @@ export function useSecurityPoolsOverview({ accountAddress, onTransactionFailed, 
 					if (liquidationGuardMessage !== undefined) throw new Error(liquidationGuardMessage)
 					const targetVault = parseAddressInput(liquidationTargetVault.value, 'Target vault')
 					const amount = parseRepAmountInput(liquidationAmount.value, 'Liquidation amount')
-					return await queueSecurityPoolLiquidation(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), managerAddress, targetVault, amount)
+					const timeoutMinutes = parseBigIntInput(liquidationTimeoutMinutes.value, 'Liquidation timeout')
+					if (timeoutMinutes < MIN_STAGED_OPERATION_TIMEOUT_MINUTES) throw new Error('Liquidation timeout must be at least 1 minute')
+					const validForSeconds = getStagedOperationTimeoutSeconds(timeoutMinutes)
+					if (validForSeconds === undefined) throw new Error('Liquidation timeout must be at least 1 minute')
+					return await queueSecurityPoolLiquidation(createWalletWriteClient(walletAddress, { onTransactionSubmitted }), managerAddress, targetVault, amount, validForSeconds)
 				},
 				'Failed to queue liquidation',
 				async result => {
@@ -153,20 +185,29 @@ export function useSecurityPoolsOverview({ accountAddress, onTransactionFailed, 
 		liquidationManagerAddress: liquidationManagerAddress.value,
 		liquidationModalOpen: liquidationModalOpen.value,
 		liquidationTargetVault: liquidationTargetVault.value,
+		liquidationTimeoutMinutes: liquidationTimeoutMinutes.value,
 		checkedSecurityPoolAddress: checkedSecurityPoolAddress.value,
 		hasLoadedSecurityPools: hasLoadedSecurityPools.value,
+		hasLoadedSecurityPoolPage: hasLoadedSecurityPoolPage.value,
 		liquidationSecurityPoolAddress: liquidationSecurityPoolAddress.value,
+		loadingSecurityPoolPage: securityPoolPageLoad.isLoading.value,
 		loadingSecurityPools: securityPoolsLoad.isLoading.value,
 		closeLiquidationModal,
+		loadBrowseSecurityPoolPage,
 		openLiquidationModal,
 		queueLiquidation,
 		securityPoolOverviewActiveAction: securityPoolOverviewActiveAction.value,
 		securityPoolOverviewError: securityPoolOverviewError.value,
 		securityPoolOverviewFeedback: securityPoolOverviewFeedback.value,
 		securityPoolOverviewResult: securityPoolOverviewResult.value,
+		securityPoolBrowseCount: securityPoolBrowseCount.value,
+		securityPoolPage: securityPoolPage.value,
 		securityPools: securityPools.value,
 		setLiquidationAmount: (value: string) => {
 			liquidationAmount.value = value
+		},
+		setLiquidationTimeoutMinutes: (value: string) => {
+			liquidationTimeoutMinutes.value = value
 		},
 		setLiquidationTargetVault: (value: string) => {
 			liquidationTargetVault.value = value

--- a/ui/ts/hooks/useSecurityVaultOperations.ts
+++ b/ui/ts/hooks/useSecurityVaultOperations.ts
@@ -13,10 +13,10 @@ import { getErrorMessage, isRecoverableContractReadError } from '../lib/errors.j
 import { createErrorActionFeedback, createPendingActionFeedback, createSuccessActionFeedback, createWarningActionFeedback } from '../lib/actionFeedback.js'
 import type { ActionFeedback } from '../lib/actionFeedback.js'
 import { parseAddressInput } from '../lib/inputs.js'
-import { getDefaultSecurityVaultFormState, parseRepAmountInput } from '../lib/marketForm.js'
+import { getDefaultSecurityVaultFormState, parseBigIntInput, parseRepAmountInput } from '../lib/marketForm.js'
 import { getOracleRequestEthGuardMessage } from '../lib/oracleRequestEth.js'
 import { requireDefined } from '../lib/required.js'
-import { doesLoadedSecurityVaultMatchSelection, getSelectedVaultAddress, MIN_SECURITY_BOND_ALLOWANCE } from '../lib/securityVault.js'
+import { doesLoadedSecurityVaultMatchSelection, getSelectedVaultAddress, getStagedOperationTimeoutSeconds, MIN_SECURITY_BOND_ALLOWANCE, MIN_STAGED_OPERATION_TIMEOUT_MINUTES } from '../lib/securityVault.js'
 import { createSecurityVaultSuccessPresentation, createSecurityVaultTransactionIntent, createSecurityVaultWarningPresentation } from '../lib/transactionPresentations.js'
 import { buildWriteActionConfig, runWriteAction } from '../lib/writeAction.js'
 import { useRequestGuard } from '../lib/requestGuard.js'
@@ -127,6 +127,13 @@ export function useSecurityVaultOperations({ accountAddress, enabled, onTransact
 		return parseAddressInput(selectedVaultAddress, 'Selected vault address')
 	}
 	const resolveSecurityVaultPoolAddress = () => parseAddressInput(effectiveSecurityPoolAddressInput, 'Security pool address')
+	const resolveStagedOperationValidForSeconds = () => {
+		const timeoutMinutes = parseBigIntInput(securityVaultForm.value.stagedOperationTimeoutMinutes ?? '', 'Staged operation timeout')
+		if (timeoutMinutes < MIN_STAGED_OPERATION_TIMEOUT_MINUTES) throw new Error('Staged operation timeout must be at least 1 minute')
+		const timeoutSeconds = getStagedOperationTimeoutSeconds(timeoutMinutes)
+		if (timeoutSeconds === undefined) throw new Error('Staged operation timeout must be at least 1 minute')
+		return timeoutSeconds
+	}
 
 	useEffect(() => {
 		if (!enabled) {
@@ -321,7 +328,7 @@ export function useSecurityVaultOperations({ accountAddress, enabled, onTransact
 					walletEthBalance,
 				})
 				if (setBondAllowanceGuardMessage !== undefined) throw new Error(setBondAllowanceGuardMessage)
-				const result = await queueOracleManagerOperation(createWalletWriteClient(vaultAddress, { onTransactionSubmitted }), details.managerAddress, 'setSecurityBondsAllowance', vaultAddress, amount)
+				const result = await queueOracleManagerOperation(createWalletWriteClient(vaultAddress, { onTransactionSubmitted }), details.managerAddress, 'setSecurityBondsAllowance', vaultAddress, amount, resolveStagedOperationValidForSeconds())
 				return {
 					action: 'queueSetSecurityBondAllowance',
 					hash: result.hash,
@@ -383,7 +390,7 @@ export function useSecurityVaultOperations({ accountAddress, enabled, onTransact
 					walletEthBalance,
 				})
 				if (withdrawRepGuardMessage !== undefined) throw new Error(withdrawRepGuardMessage)
-				const result = await queueOracleManagerOperation(createWalletWriteClient(vaultAddress, { onTransactionSubmitted }), details.managerAddress, 'withdrawRep', vaultAddress, amount)
+				const result = await queueOracleManagerOperation(createWalletWriteClient(vaultAddress, { onTransactionSubmitted }), details.managerAddress, 'withdrawRep', vaultAddress, amount, resolveStagedOperationValidForSeconds())
 				return {
 					action: 'queueWithdrawRep',
 					hash: result.hash,

--- a/ui/ts/hooks/useZoltarUniverse.ts
+++ b/ui/ts/hooks/useZoltarUniverse.ts
@@ -1,7 +1,7 @@
 import { useSignal } from '@preact/signals'
 import { useLayoutEffect, useRef } from 'preact/hooks'
 import type { Address, Hash } from 'viem'
-import { createZoltarChildUniverse, loadAllZoltarQuestions, loadZoltarQuestionCount, loadZoltarUniverseSummary } from '../contracts.js'
+import { createZoltarChildUniverse, loadAllZoltarQuestions, loadZoltarQuestionCount, loadZoltarQuestionPage, loadZoltarUniverseSummary } from '../contracts.js'
 import { useLoadController } from './useLoadController.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
 import { formatRefreshErrorMessage, formatWriteErrorMessage } from '../lib/errors.js'
@@ -12,7 +12,18 @@ import { hasDeployedStep } from '../lib/marketCreation.js'
 import { useRequestGuard } from '../lib/requestGuard.js'
 import { requireWallet } from '../lib/walletGuard.js'
 import type { WriteOperationsParameters } from '../types/app.js'
-import type { DeploymentStatus, MarketDetails, ZoltarChildUniverseActionResult, ZoltarUniverseSummary } from '../types/contracts.js'
+import type { DeploymentStatus, MarketDetails, MarketDetailsPage, ZoltarChildUniverseActionResult, ZoltarUniverseSummary } from '../types/contracts.js'
+
+function buildQuestionPageFromQuestions(questions: MarketDetails[], currentPage: MarketDetailsPage): MarketDetailsPage {
+	const questionCount = BigInt(questions.length)
+	const startIndex = currentPage.pageIndex * currentPage.pageSize
+	return {
+		pageIndex: currentPage.pageIndex,
+		pageSize: currentPage.pageSize,
+		questionCount,
+		questions: questions.slice(startIndex, startIndex + currentPage.pageSize),
+	}
+}
 
 type UseZoltarUniverseParameters = {
 	accountAddress: Address | undefined
@@ -35,6 +46,7 @@ export function useZoltarUniverse({ accountAddress, activeUniverseId, autoLoadIn
 	const zoltarUniverseResolvedId = useSignal<bigint | undefined>(undefined)
 	const hasLoadedZoltarQuestions = useSignal(false)
 	const zoltarQuestionCount = useSignal<bigint | undefined>(undefined)
+	const zoltarQuestionPage = useSignal<MarketDetailsPage | undefined>(undefined)
 	const zoltarQuestions = useSignal<MarketDetails[]>([])
 	const zoltarUniverse = useSignal<ZoltarUniverseSummary | undefined>(undefined)
 	const zoltarChildUniverseError = useSignal<string | undefined>(undefined)
@@ -54,6 +66,7 @@ export function useZoltarUniverse({ accountAddress, activeUniverseId, autoLoadIn
 		zoltarChildUniversePendingOutcomeIndex.value = undefined
 		hasLoadedZoltarQuestions.value = false
 		zoltarQuestionCount.value = undefined
+		zoltarQuestionPage.value = undefined
 		zoltarQuestions.value = []
 	}
 
@@ -145,6 +158,45 @@ export function useZoltarUniverse({ accountAddress, activeUniverseId, autoLoadIn
 				if (!isMounted.current) return
 				zoltarQuestions.value = questions
 				hasLoadedZoltarQuestions.value = true
+				const currentQuestionPage = zoltarQuestionPage.value
+				if (currentQuestionPage !== undefined) {
+					zoltarQuestionPage.value = buildQuestionPageFromQuestions(questions, currentQuestionPage)
+				}
+			},
+			onError: error => {
+				loadError = loadError ?? error
+			},
+		})
+
+		await Promise.allSettled([countTask, questionsTask])
+		if (loadError !== undefined) throw loadError
+	}
+
+	const loadQuestionsPage = async (pageIndex: number, pageSize: number): Promise<void> => {
+		if (!isMounted.current) return
+		const isCountCurrent = nextQuestionCountLoad()
+		const isQuestionsCurrent = nextQuestionsLoad()
+		const readClient = createConnectedReadClient()
+		let loadError: unknown
+
+		const countTask = questionCountLoad.run({
+			isCurrent: isCountCurrent,
+			load: async () => await loadZoltarQuestionCount(readClient),
+			onSuccess: questionCount => {
+				if (!isMounted.current) return
+				zoltarQuestionCount.value = questionCount
+			},
+			onError: error => {
+				loadError = loadError ?? error
+			},
+		})
+
+		const questionsTask = questionsLoad.run({
+			isCurrent: isQuestionsCurrent,
+			load: async () => await loadZoltarQuestionPage(readClient, pageIndex, pageSize),
+			onSuccess: page => {
+				if (!isMounted.current) return
+				zoltarQuestionPage.value = page
 			},
 			onError: error => {
 				loadError = loadError ?? error
@@ -229,12 +281,14 @@ export function useZoltarUniverse({ accountAddress, activeUniverseId, autoLoadIn
 		loadingZoltarQuestions: questionsLoad.isLoading.value,
 		loadingZoltarUniverse: universeLoad.isLoading.value,
 		loadZoltarQuestionCount: loadZoltarQuestionCountData,
+		loadZoltarQuestionPage: loadQuestionsPage,
 		loadZoltarQuestions: loadQuestions,
 		loadZoltarUniverse,
 		zoltarChildUniverseFeedback: zoltarChildUniverseFeedback.value,
 		refreshZoltarUniverse,
 		zoltarChildUniverseError: zoltarChildUniverseError.value,
 		zoltarChildUniversePendingOutcomeIndex: zoltarChildUniversePendingOutcomeIndex.value,
+		zoltarQuestionPage: zoltarQuestionPage.value,
 		zoltarQuestionCount: zoltarQuestionCount.value,
 		zoltarQuestions: zoltarQuestions.value,
 		zoltarUniverse: zoltarUniverseLoadedId.value === activeUniverseId ? zoltarUniverse.value : undefined,

--- a/ui/ts/lib/marketForm.ts
+++ b/ui/ts/lib/marketForm.ts
@@ -36,6 +36,7 @@ export function getDefaultSecurityVaultFormState(): SecurityVaultFormState {
 		repWithdrawAmount: '0',
 		selectedVaultAddress: '',
 		securityPoolAddress: '',
+		stagedOperationTimeoutMinutes: '30',
 	}
 }
 

--- a/ui/ts/lib/pagination.ts
+++ b/ui/ts/lib/pagination.ts
@@ -1,0 +1,2 @@
+export const QUESTION_PAGE_SIZE = 10
+export const SECURITY_POOL_PAGE_SIZE = 6

--- a/ui/ts/lib/securityVault.ts
+++ b/ui/ts/lib/securityVault.ts
@@ -6,6 +6,8 @@ import { sameAddress } from './address.js'
 export const MIN_SECURITY_VAULT_REP_DEPOSIT = 10n * 10n ** 18n
 export const MIN_SECURITY_BOND_ALLOWANCE = 1n * 10n ** 18n
 export const ORACLE_MANAGER_PRICE_VALID_FOR_SECONDS = 60n * 60n
+export const DEFAULT_STAGED_OPERATION_TIMEOUT_MINUTES = 30n
+export const MIN_STAGED_OPERATION_TIMEOUT_MINUTES = 1n
 const PRICE_PRECISION = 10n ** 18n
 
 export function getSelectedVaultAddress(selectedVaultAddress: string | undefined, accountAddress: Address | undefined) {
@@ -107,6 +109,11 @@ export function getSecurityVaultMaxBondAllowanceAmount({
 export function getOracleManagerPriceValidUntilTimestamp(lastSettlementTimestamp: bigint | undefined) {
 	if (lastSettlementTimestamp === undefined || lastSettlementTimestamp === 0n) return undefined
 	return lastSettlementTimestamp + ORACLE_MANAGER_PRICE_VALID_FOR_SECONDS
+}
+
+export function getStagedOperationTimeoutSeconds(timeoutMinutes: bigint | undefined) {
+	if (timeoutMinutes === undefined || timeoutMinutes < MIN_STAGED_OPERATION_TIMEOUT_MINUTES) return undefined
+	return timeoutMinutes * 60n
 }
 
 export function hasValidSecurityVaultOraclePrice(managerAddress: Address | undefined, oracleManagerDetails: Pick<OracleManagerDetails, 'isPriceValid' | 'managerAddress'> | undefined) {

--- a/ui/ts/lib/securityVaultGuards.ts
+++ b/ui/ts/lib/securityVaultGuards.ts
@@ -1,7 +1,7 @@
 import type { Address } from 'viem'
 import { formatCurrencyBalance } from './formatters.js'
 import { getOracleRequestEthGuardMessage } from './oracleRequestEth.js'
-import { MIN_SECURITY_BOND_ALLOWANCE, MIN_SECURITY_VAULT_REP_DEPOSIT } from './securityVault.js'
+import { MIN_SECURITY_BOND_ALLOWANCE, MIN_SECURITY_VAULT_REP_DEPOSIT, MIN_STAGED_OPERATION_TIMEOUT_MINUTES } from './securityVault.js'
 
 export function getVaultApprovalGuardMessage({ accountAddress, isMainnet, selectedVaultDetailsLoaded, selectedVaultIsOwnedByAccount }: { accountAddress: Address | undefined; isMainnet: boolean; selectedVaultDetailsLoaded: boolean; selectedVaultIsOwnedByAccount: boolean }) {
 	if (accountAddress === undefined) return 'Connect wallet to continue.'
@@ -44,6 +44,7 @@ export function getVaultWithdrawGuardMessage({
 	isMainnet,
 	requestPriceEthCost,
 	selectedVaultIsOwnedByAccount,
+	stagedOperationTimeoutMinutes,
 	withdrawAmount,
 	withdrawableRepAmount,
 	walletEthBalance,
@@ -53,6 +54,7 @@ export function getVaultWithdrawGuardMessage({
 	isMainnet: boolean
 	requestPriceEthCost: bigint | undefined
 	selectedVaultIsOwnedByAccount: boolean
+	stagedOperationTimeoutMinutes: bigint | undefined
 	withdrawAmount: bigint | undefined
 	withdrawableRepAmount: bigint | undefined
 	walletEthBalance: bigint | undefined
@@ -64,6 +66,7 @@ export function getVaultWithdrawGuardMessage({
 	if (withdrawAmount === undefined || withdrawAmount <= 0n) return 'Enter a valid REP withdraw amount.'
 	if (withdrawableRepAmount === undefined || withdrawableRepAmount <= 0n) return 'No REP is currently withdrawable from this vault.'
 	if (withdrawAmount > withdrawableRepAmount) return `Reduce the withdrawal to ${formatCurrencyBalance(withdrawableRepAmount)} REP or less.`
+	if (stagedOperationTimeoutMinutes === undefined || stagedOperationTimeoutMinutes < MIN_STAGED_OPERATION_TIMEOUT_MINUTES) return 'Enter a staged operation timeout of at least 1 minute.'
 	const ethGuardMessage = getOracleRequestEthGuardMessage({
 		actionLabel: 'queue this REP withdrawal',
 		requestPriceEthCost,
@@ -81,6 +84,7 @@ export function getVaultSetSecurityBondAllowanceGuardMessage({
 	securityBondAllowanceAmount,
 	selectedVaultDetailsLoaded,
 	selectedVaultIsOwnedByAccount,
+	stagedOperationTimeoutMinutes,
 	walletEthBalance,
 }: {
 	hasValidOraclePrice: boolean
@@ -90,6 +94,7 @@ export function getVaultSetSecurityBondAllowanceGuardMessage({
 	securityBondAllowanceAmount: bigint | undefined
 	selectedVaultDetailsLoaded: boolean
 	selectedVaultIsOwnedByAccount: boolean
+	stagedOperationTimeoutMinutes: bigint | undefined
 	walletEthBalance: bigint | undefined
 }) {
 	if (!selectedVaultIsOwnedByAccount) return 'Select your own vault to set the security bond allowance.'
@@ -99,6 +104,7 @@ export function getVaultSetSecurityBondAllowanceGuardMessage({
 	if (securityBondAllowanceAmount === undefined || securityBondAllowanceAmount < 0n) return 'Enter a valid security bond allowance.'
 	if (securityBondAllowanceAmount !== 0n && securityBondAllowanceAmount < MIN_SECURITY_BOND_ALLOWANCE) return `Enter at least ${formatCurrencyBalance(MIN_SECURITY_BOND_ALLOWANCE)} ETH for a non-zero allowance.`
 	if (maxSecurityBondAllowanceAmount !== undefined && securityBondAllowanceAmount > maxSecurityBondAllowanceAmount) return `Reduce the security bond allowance to ${formatCurrencyBalance(maxSecurityBondAllowanceAmount)} ETH or less.`
+	if (stagedOperationTimeoutMinutes === undefined || stagedOperationTimeoutMinutes < MIN_STAGED_OPERATION_TIMEOUT_MINUTES) return 'Enter a staged operation timeout of at least 1 minute.'
 	const ethGuardMessage = getOracleRequestEthGuardMessage({
 		actionLabel: 'queue this bond allowance update',
 		requestPriceEthCost,

--- a/ui/ts/lib/transactionPresentations.tsx
+++ b/ui/ts/lib/transactionPresentations.tsx
@@ -349,20 +349,32 @@ export function createLiquidationWarningPresentation(result: SecurityPoolOvervie
 }
 
 export function createPoolOracleTransactionIntent(actionName: 'executeStagedOperation' | 'requestPrice') {
+	let submittedTitle = 'Executing Staged Operation'
+	let submittedDetail = 'Staged-operation transaction submitted.'
+	if (actionName === 'requestPrice') {
+		submittedTitle = 'Requesting Price'
+		submittedDetail = 'Price request transaction submitted.'
+	}
 	return buildIntent({
 		action: actionName,
 		source: 'pool-oracle',
-		submittedTitle: actionName === 'requestPrice' ? 'Requesting Price' : 'Executing Staged Operation',
-		submittedDetail: actionName === 'requestPrice' ? 'Price request transaction submitted.' : 'Staged-operation transaction submitted.',
+		submittedTitle,
+		submittedDetail,
 	})
 }
 
 export function createPoolOracleSuccessPresentation(result: OpenOracleActionResult) {
+	let detail = 'The staged oracle-manager operation was executed successfully.'
+	let title = 'Staged Operation Executed'
+	if (result.action === 'requestPrice') {
+		detail = 'A new oracle price was requested successfully.'
+		title = 'Price Requested'
+	}
 	return buildPresentation({
-		detail: result.action === 'requestPrice' ? 'A new oracle price was requested successfully.' : 'The staged oracle-manager operation was executed successfully.',
+		detail,
 		hash: result.hash,
 		rows: [{ label: 'Action', value: humanizeAction(result.action) }],
-		title: result.action === 'requestPrice' ? 'Price Requested' : 'Staged Operation Executed',
+		title,
 		tone: 'success',
 	})
 }

--- a/ui/ts/simulation/bootstrap.ts
+++ b/ui/ts/simulation/bootstrap.ts
@@ -52,6 +52,7 @@ const SECURITY_POOL_X2_PRIMARY_REP_DEPOSIT = 12_000n * 10n ** 18n
 const SECURITY_POOL_X2_PRIMARY_SECURITY_BOND_ALLOWANCE = 1_000n * 10n ** 18n
 const SECURITY_POOL_X2_SECONDARY_REP_DEPOSIT = SECURITY_POOL_REP_DEPOSIT
 const SECURITY_POOL_X2_SECONDARY_SECURITY_BOND_ALLOWANCE = SECURITY_BOND_ALLOWANCE
+const STAGED_SELF_OPERATION_TIMEOUT_SECONDS = 30n * 60n
 const SECURITY_POOL_X2_AUCTION_EXTRA_REP_DEPOSIT = 20_000_000n * 10n ** 18n
 const SECURITY_POOL_X2_AUCTION_BID_PRICES = [getTruthAuctionPriceAtTick(12n), getTruthAuctionPriceAtTick(10n), getTruthAuctionPriceAtTick(8n)] as const
 const SECURITY_POOL_X2_AUCTION_BID_AMOUNTS = [3n * 10n ** 18n, 4n * 10n ** 18n, 5n * 10n ** 18n, 6n * 10n ** 18n, 3n * 10n ** 18n, 4n * 10n ** 18n, 5n * 10n ** 18n, 3n * 10n ** 18n, 4n * 10n ** 18n, 5n * 10n ** 18n] as const
@@ -428,7 +429,7 @@ async function configureSecurityBondAllowance({
 	securityBondAllowance: bigint
 }) {
 	const writeClient = createWriteClient(accountAddress)
-	const queueResult = await queueOracleManagerOperation(writeClient, managerAddress, 'setSecurityBondsAllowance', accountAddress, securityBondAllowance)
+	const queueResult = await queueOracleManagerOperation(writeClient, managerAddress, 'setSecurityBondsAllowance', accountAddress, securityBondAllowance, STAGED_SELF_OPERATION_TIMEOUT_SECONDS)
 	if (queueResult.stagedExecution?.success === false) throw new Error(queueResult.stagedExecution.errorMessage ?? `Failed to seed security bond allowance for ${accountAddress}`)
 	let updatedVault = await loadRequiredSecurityVault(readClient, securityPoolAddress, accountAddress, accountAddress)
 	if (updatedVault.securityBondAllowance !== securityBondAllowance) {
@@ -487,7 +488,7 @@ async function settleSeededOracleReport({
 	securityBondAllowance: bigint
 }) {
 	const writeClient = createWriteClient(accountAddress)
-	await queueOracleManagerOperation(writeClient, managerAddress, 'setSecurityBondsAllowance', accountAddress, securityBondAllowance)
+	await queueOracleManagerOperation(writeClient, managerAddress, 'setSecurityBondsAllowance', accountAddress, securityBondAllowance, STAGED_SELF_OPERATION_TIMEOUT_SECONDS)
 	await onProgressStep(`Configuring oracle manager for ${poolLabel}`)
 
 	const oracleManagerDetails = await loadOracleManagerDetails(readClient, managerAddress)

--- a/ui/ts/tests/appRouteContent.test.ts
+++ b/ui/ts/tests/appRouteContent.test.ts
@@ -1,0 +1,22 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { shouldRenderRouteContent } from '../components/AppRouteContent.js'
+
+describe('AppRouteContent', () => {
+	test('does not render route content when the connected wallet is on the wrong network', () => {
+		expect(shouldRenderRouteContent({ readBackendMessage: undefined, route: 'zoltar', wrongNetworkMessage: 'Switch to Ethereum mainnet.' })).toBe(false)
+	})
+
+	test('does not render route content when the configured read RPC is on the wrong chain', () => {
+		expect(shouldRenderRouteContent({ readBackendMessage: 'Configured read RPC reports chain 11155111, but this app requires Ethereum Mainnet (1).', route: 'zoltar', wrongNetworkMessage: undefined })).toBe(false)
+	})
+
+	test('renders route content when both wallet and read backend are ready', () => {
+		expect(shouldRenderRouteContent({ readBackendMessage: undefined, route: 'zoltar', wrongNetworkMessage: undefined })).toBe(true)
+	})
+
+	test('keeps deploy route content available when the configured read RPC is on the wrong chain', () => {
+		expect(shouldRenderRouteContent({ readBackendMessage: 'Configured read RPC reports chain 11155111, but this app requires Ethereum Mainnet (1).', route: 'deploy', wrongNetworkMessage: undefined })).toBe(true)
+	})
+})

--- a/ui/ts/tests/appStatusNotices.test.tsx
+++ b/ui/ts/tests/appStatusNotices.test.tsx
@@ -27,6 +27,7 @@ describe('AppStatusNotices', () => {
 		const renderedComponent = await renderIntoDocument(
 			h(AppStatusNotices, {
 				errorMessage: undefined,
+				readBackendMessage: undefined,
 				showAugurPlaceHolderDeploymentWarning: false,
 				showZoltarUniverseForkedWarning: false,
 				simulationBootstrapError: undefined,
@@ -45,6 +46,7 @@ describe('AppStatusNotices', () => {
 		const renderedComponent = await renderIntoDocument(
 			h(AppStatusNotices, {
 				errorMessage: undefined,
+				readBackendMessage: undefined,
 				showAugurPlaceHolderDeploymentWarning: false,
 				showZoltarUniverseForkedWarning: false,
 				simulationBootstrapError: undefined,
@@ -63,6 +65,7 @@ describe('AppStatusNotices', () => {
 		const renderedComponent = await renderIntoDocument(
 			h(AppStatusNotices, {
 				errorMessage: undefined,
+				readBackendMessage: undefined,
 				showAugurPlaceHolderDeploymentWarning: false,
 				showZoltarUniverseForkedWarning: false,
 				simulationBootstrapError: 'Anvil boot failed',
@@ -77,10 +80,30 @@ describe('AppStatusNotices', () => {
 		expect(documentQueries.getByText('Anvil boot failed')).not.toBeNull()
 	})
 
+	test('shows a read RPC mismatch notice', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(AppStatusNotices, {
+				errorMessage: undefined,
+				readBackendMessage: 'Configured read RPC reports chain 11155111, but this app requires Ethereum Mainnet (1).',
+				showAugurPlaceHolderDeploymentWarning: false,
+				showZoltarUniverseForkedWarning: false,
+				simulationBootstrapError: undefined,
+				wrongNetworkMessage: undefined,
+				zoltarUniverse: undefined,
+			}),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByText('Read RPC mismatch')).not.toBeNull()
+		expect(documentQueries.getByText('Configured read RPC reports chain 11155111, but this app requires Ethereum Mainnet (1).')).not.toBeNull()
+	})
+
 	test('shows deployment setup and custom wrong-network guidance together', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(AppStatusNotices, {
 				errorMessage: 'Top-level error',
+				readBackendMessage: undefined,
 				showAugurPlaceHolderDeploymentWarning: true,
 				showZoltarUniverseForkedWarning: false,
 				simulationBootstrapError: undefined,
@@ -103,6 +126,7 @@ describe('AppStatusNotices', () => {
 		const renderedComponent = await renderIntoDocument(
 			h(AppStatusNotices, {
 				errorMessage: undefined,
+				readBackendMessage: undefined,
 				showAugurPlaceHolderDeploymentWarning: false,
 				showZoltarUniverseForkedWarning: true,
 				simulationBootstrapError: undefined,

--- a/ui/ts/tests/contracts.test.ts
+++ b/ui/ts/tests/contracts.test.ts
@@ -2,7 +2,20 @@
 
 import { describe, expect, test } from 'bun:test'
 import { decodeFunctionData, getAddress, zeroAddress, type Address, type Hash, type Hex } from 'viem'
-import { getOpenOracleAddress, loadAllSecurityPools, loadEscalationDeposits, loadForkAuctionDetails, loadTruthAuctionActiveTickPage, loadTruthAuctionBidderBidPage, loadTruthAuctionTickBidPage, loadTruthAuctionTickPage, loadTruthAuctionTickSummary, migrateSharesFromUniverse, settleOracleReport } from '../contracts.js'
+import {
+	getOpenOracleAddress,
+	loadAllSecurityPools,
+	loadEscalationDeposits,
+	loadForkAuctionDetails,
+	loadSecurityPoolPage,
+	loadTruthAuctionActiveTickPage,
+	loadTruthAuctionBidderBidPage,
+	loadTruthAuctionTickBidPage,
+	loadTruthAuctionTickPage,
+	loadTruthAuctionTickSummary,
+	migrateSharesFromUniverse,
+	settleOracleReport,
+} from '../contracts.js'
 import { getForkOutcomeKey } from '../contracts/helpers.js'
 import { peripherals_openOracle_OpenOracle_OpenOracle, peripherals_tokens_ShareToken_ShareToken } from '../contractArtifact.js'
 import type { ReadClient } from '../types/contracts.js'
@@ -204,6 +217,69 @@ describe('contracts helpers', () => {
 		expect(pool.parent).toBe(zeroAddress)
 		expect(pool.forkOutcome).toBe('none')
 		expect(pool.hasForkActivity).toBe(false)
+	})
+
+	test('loadSecurityPoolPage does not infer parent fork activity from other pools on the same page', async () => {
+		const questionId = 1n
+		const questionTuple = ['Question', 'Description', 1n, 2n, 2n, 0n, 100n, ''] as const
+		const parentSecurityPoolAddress = getAddress('0x00000000000000000000000000000000000000d1')
+		const childSecurityPoolAddress = getAddress('0x00000000000000000000000000000000000000d2')
+		const client = createMockLoaderClient({
+			getBlock: async () => createBlockWithTimestamp(0n),
+			multicall: async request => {
+				const contracts = request.contracts
+				const firstContract = contracts[0]
+				if (getContractFunctionName(firstContract) === 'completeSetCollateralAmount') {
+					const contractAddress = Reflect.get(firstContract, 'address')
+					if (typeof contractAddress !== 'string') throw new Error('Expected security pool address')
+					if (getAddress(contractAddress) === parentSecurityPoolAddress) return [0n, 10n, [0n, zeroAddress, 0n, 0n, 0n, false, 0], 0n, 0n, 3n, 0n, 0n, 0n, 1n]
+					if (getAddress(contractAddress) === childSecurityPoolAddress) return [0n, 10n, [0n, zeroAddress, 0n, 0n, 0n, false, 0], 0n, 0n, 3n, 0n, 0n, 0n, 1n]
+				}
+				if (getContractFunctionName(firstContract) === 'questions') return [questionTuple, 1n]
+				throw new Error(`Unexpected multicall contract: ${getContractFunctionName(firstContract)}`)
+			},
+			readContract: async request => {
+				if (request.functionName === 'securityPoolDeploymentCount') return 2n
+				if (request.functionName === 'securityPoolDeploymentsRange') {
+					return [
+						{
+							completeSetCollateralAmount: 0n,
+							currentRetentionRate: 0n,
+							parent: zeroAddress,
+							priceOracleManagerAndOperatorQueuer: zeroAddress,
+							questionId,
+							securityMultiplier: 2n,
+							securityPool: parentSecurityPoolAddress,
+							shareToken: shareTokenAddress,
+							truthAuction: zeroAddress,
+							universeId: 1n,
+						},
+						{
+							completeSetCollateralAmount: 0n,
+							currentRetentionRate: 0n,
+							parent: parentSecurityPoolAddress,
+							priceOracleManagerAndOperatorQueuer: zeroAddress,
+							questionId,
+							securityMultiplier: 2n,
+							securityPool: childSecurityPoolAddress,
+							shareToken: shareTokenAddress,
+							truthAuction: zeroAddress,
+							universeId: 2n,
+						},
+					]
+				}
+				if (request.functionName === 'getVaultCount') return 0n
+				if (request.functionName === 'getOutcomeLabels') return ['Yes', 'No']
+				throw new Error(`Unexpected readContract function: ${request.functionName}`)
+			},
+		})
+
+		const page = await loadSecurityPoolPage(client, 0, 2)
+		const parentPool = page.pools.find(pool => pool.securityPoolAddress === parentSecurityPoolAddress)
+		if (parentPool === undefined) throw new Error('Expected parent security pool on the loaded page')
+
+		expect(parentPool.hasForkActivity).toBe(false)
+		expect(parentPool.universeHasForked).toBe(true)
 	})
 
 	test('loadAllSecurityPools defers vault detail loading for unselected pools in selected mode', async () => {

--- a/ui/ts/tests/liquidationModal.test.tsx
+++ b/ui/ts/tests/liquidationModal.test.tsx
@@ -139,9 +139,11 @@ describe('LiquidationModal', () => {
 				liquidationModalOpen
 				liquidationSecurityPoolAddress={zeroAddress}
 				liquidationTargetVault={defaultTargetVaultAddress}
+				liquidationTimeoutMinutes='30'
 				loadingPoolOracleManager={false}
 				onLoadPoolOracleManager={() => undefined}
 				onLiquidationAmountChange={() => undefined}
+				onLiquidationTimeoutMinutesChange={() => undefined}
 				onQueueLiquidation={() => undefined}
 				onSelectedPoolViewChange={() => undefined}
 				repPerEthPrice={1n * 10n ** 18n}
@@ -186,6 +188,29 @@ describe('LiquidationModal', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		expectTransactionButtonDisabled(document.body, 'Queue Liquidation')
+	})
+
+	test('defaults queued liquidation timeout copy to 30 minutes', async () => {
+		const renderedComponent = await renderLiquidationModal({
+			currentPoolOracleManagerDetails: createOracleManagerDetails({
+				isPriceValid: false,
+			}),
+		})
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(document.body.textContent?.includes('This queued staged operation will expire 30m after the oracle settlement window completes.')).toBe(true)
+	})
+
+	test('requires a queued liquidation timeout of at least 1 minute', async () => {
+		const renderedComponent = await renderLiquidationModal({
+			currentPoolOracleManagerDetails: createOracleManagerDetails({
+				isPriceValid: false,
+			}),
+			liquidationTimeoutMinutes: '0',
+		})
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expectTransactionButtonDisabled(document.body, 'Queue Liquidation', 'Enter a liquidation timeout of at least 1 minute.')
 	})
 
 	test('traps focus while open and restores it when closed', async () => {
@@ -245,10 +270,12 @@ describe('LiquidationModal', () => {
 					liquidationManagerAddress={zeroAddress}
 					liquidationModalOpen
 					liquidationSecurityPoolAddress={zeroAddress}
+					liquidationTimeoutMinutes='30'
 					loadingPoolOracleManager={false}
 					liquidationTargetVault={zeroAddress}
 					onLoadPoolOracleManager={() => undefined}
 					onLiquidationAmountChange={setLiquidationAmount}
+					onLiquidationTimeoutMinutesChange={() => undefined}
 					onQueueLiquidation={() => undefined}
 					onSelectedPoolViewChange={() => undefined}
 					repPerEthPrice={1n * 10n ** 18n}
@@ -459,9 +486,11 @@ describe('LiquidationModal', () => {
 					liquidationModalOpen={liquidationModalOpen}
 					liquidationSecurityPoolAddress={zeroAddress}
 					liquidationTargetVault={defaultTargetVaultAddress}
+					liquidationTimeoutMinutes='30'
 					loadingPoolOracleManager={false}
 					onLoadPoolOracleManager={() => undefined}
 					onLiquidationAmountChange={() => undefined}
+					onLiquidationTimeoutMinutesChange={() => undefined}
 					onQueueLiquidation={() => {
 						setLiquidationModalOpen(false)
 						setSecurityPoolOverviewResult({
@@ -551,9 +580,11 @@ describe('LiquidationModal', () => {
 					liquidationModalOpen={liquidationModalOpen}
 					liquidationSecurityPoolAddress={zeroAddress}
 					liquidationTargetVault={defaultTargetVaultAddress}
+					liquidationTimeoutMinutes='30'
 					loadingPoolOracleManager={false}
 					onLoadPoolOracleManager={() => undefined}
 					onLiquidationAmountChange={() => undefined}
+					onLiquidationTimeoutMinutesChange={() => undefined}
 					onQueueLiquidation={() => {
 						setLiquidationModalOpen(false)
 						setSecurityPoolOverviewError('Liquidation execution reverted')
@@ -656,9 +687,11 @@ describe('LiquidationModal', () => {
 					liquidationModalOpen
 					liquidationSecurityPoolAddress={zeroAddress}
 					liquidationTargetVault={defaultTargetVaultAddress}
+					liquidationTimeoutMinutes='30'
 					loadingPoolOracleManager={false}
 					onLoadPoolOracleManager={() => undefined}
 					onLiquidationAmountChange={() => undefined}
+					onLiquidationTimeoutMinutesChange={() => undefined}
 					onQueueLiquidation={() => undefined}
 					onSelectedPoolViewChange={() => undefined}
 					repPerEthPrice={1n * 10n ** 18n}
@@ -851,9 +884,11 @@ describe('LiquidationModal', () => {
 					liquidationModalOpen
 					liquidationSecurityPoolAddress={zeroAddress}
 					liquidationTargetVault={defaultTargetVaultAddress}
+					liquidationTimeoutMinutes='30'
 					loadingPoolOracleManager={false}
 					onLoadPoolOracleManager={() => undefined}
 					onLiquidationAmountChange={setLiquidationAmount}
+					onLiquidationTimeoutMinutesChange={() => undefined}
 					onQueueLiquidation={() => undefined}
 					onSelectedPoolViewChange={() => undefined}
 					repPerEthPrice={3n * 10n ** 18n}

--- a/ui/ts/tests/marketForm.test.ts
+++ b/ui/ts/tests/marketForm.test.ts
@@ -24,6 +24,7 @@ describe('market form defaults and conversion helpers', () => {
 		expect(getDefaultSecurityPoolFormState().currentRetentionRate).toBe('10')
 		expect(getDefaultSecurityPoolFormState().securityMultiplier).toBe('2')
 		expect(getDefaultSecurityVaultFormState().depositAmount).toBe('0')
+		expect(getDefaultSecurityVaultFormState().stagedOperationTimeoutMinutes).toBe('30')
 		expect(getDefaultReportingFormState().selectedOutcome).toBeUndefined()
 		expect(getDefaultReportingFormState().selectedWithdrawDepositIndexesByOutcome).toEqual({ invalid: [], yes: [], no: [] })
 		expect(getDefaultTradingFormState().selectedShareOutcome).toBe('yes')

--- a/ui/ts/tests/marketSection.test.tsx
+++ b/ui/ts/tests/marketSection.test.tsx
@@ -89,6 +89,7 @@ function createMarketSectionProps(overrides: Partial<MarketSectionProps> = {}): 
 		onCreateChildUniverseForOutcomeIndex: () => undefined,
 		onCreateMarket: () => undefined,
 		onForkZoltar: () => undefined,
+		onLoadZoltarQuestionPage: async () => undefined,
 		onLoadZoltarQuestions: async () => undefined,
 		onMarketFormChange: () => undefined,
 		onMigrateInternalRep: () => undefined,
@@ -117,6 +118,7 @@ function createMarketSectionProps(overrides: Partial<MarketSectionProps> = {}): 
 		zoltarMigrationPreparedRepBalance: 0n,
 		zoltarMigrationResult: undefined,
 		zoltarQuestionCount: 0n,
+		zoltarQuestionPage: undefined,
 		zoltarQuestions: [],
 		zoltarUniverse: createZoltarUniverse(),
 		zoltarUniverseState: 'ready',
@@ -158,10 +160,9 @@ describe('MarketSection', () => {
 		const calls: string[] = []
 		const initialProps = createMarketSectionProps({
 			activeUniverseId: 7n,
-			hasLoadedZoltarQuestions: false,
 			loadingZoltarQuestions: false,
-			onLoadZoltarQuestions: async () => {
-				calls.push('load')
+			onLoadZoltarQuestionPage: async (pageIndex, pageSize) => {
+				calls.push(`${pageIndex}:${pageSize}`)
 			},
 			zoltarQuestionCount: 3n,
 			zoltarUniverse: createZoltarUniverse({ universeId: 7n }),
@@ -169,21 +170,56 @@ describe('MarketSection', () => {
 
 		const renderedComponent = await renderIntoDocument(h(MarketSection, initialProps))
 		cleanupRenderedComponent = renderedComponent.cleanup
-		expect(calls).toEqual(['load'])
+		expect(within(document.body).getByText('Loading questions...')).not.toBeNull()
+		await waitFor(() => {
+			expect(calls).toEqual(['0:10'])
+		})
 
 		await act(() => {
 			render(
 				h(MarketSection, {
 					...initialProps,
-					onLoadZoltarQuestions: async () => {
-						calls.push('rerender')
+					onLoadZoltarQuestionPage: async (pageIndex, pageSize) => {
+						calls.push(`rerender:${pageIndex}:${pageSize}`)
 					},
 				}),
 				renderedComponent.container,
 			)
 		})
 
-		expect(calls).toEqual(['load'])
+		expect(calls).toEqual(['0:10'])
+	})
+
+	test('stops showing a loading state when a requested question page fails to load', async () => {
+		const failedPageLoad = createDeferred<void>()
+		const initialProps = createMarketSectionProps({
+			onLoadZoltarQuestionPage: async (pageIndex, pageSize) => {
+				if (pageIndex === 1 && pageSize === 10) return await failedPageLoad.promise
+			},
+			zoltarQuestionCount: 12n,
+			zoltarQuestionPage: {
+				pageIndex: 0,
+				pageSize: 10,
+				questionCount: 12n,
+				questions: [createBinaryForkQuestion()],
+			},
+		})
+		const renderedComponent = await renderIntoDocument(h(MarketSection, initialProps))
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		const nextPageButton = documentQueries.getByRole('button', { name: 'Next Page' })
+		await act(() => {
+			fireEvent.click(nextPageButton)
+		})
+		expect(documentQueries.getByText('Loading questions...')).not.toBeNull()
+
+		void failedPageLoad.promise.catch(() => undefined)
+		failedPageLoad.reject(new Error('page load failed'))
+		await waitFor(() => {
+			expect(documentQueries.queryByText('Loading questions...')).toBeNull()
+			expect(documentQueries.getByText('Questions for this page have not loaded yet.')).not.toBeNull()
+		})
 	})
 
 	test('does not auto-load questions while the question count is unresolved', async () => {
@@ -192,7 +228,7 @@ describe('MarketSection', () => {
 			h(
 				MarketSection,
 				createMarketSectionProps({
-					onLoadZoltarQuestions: async () => {
+					onLoadZoltarQuestionPage: async () => {
 						calls.push('load')
 					},
 					zoltarQuestionCount: undefined,
@@ -210,7 +246,7 @@ describe('MarketSection', () => {
 			h(
 				MarketSection,
 				createMarketSectionProps({
-					onLoadZoltarQuestions: async () => {
+					onLoadZoltarQuestionPage: async () => {
 						calls.push('load')
 					},
 					zoltarQuestionCount: 0n,
@@ -228,11 +264,16 @@ describe('MarketSection', () => {
 			h(
 				MarketSection,
 				createMarketSectionProps({
-					hasLoadedZoltarQuestions: true,
-					onLoadZoltarQuestions: async () => {
+					onLoadZoltarQuestionPage: async () => {
 						calls.push('load')
 					},
 					zoltarQuestionCount: 3n,
+					zoltarQuestionPage: {
+						pageIndex: 0,
+						pageSize: 10,
+						questionCount: 3n,
+						questions: [createBinaryForkQuestion()],
+					},
 				}),
 			),
 		)
@@ -246,8 +287,8 @@ describe('MarketSection', () => {
 		const initialProps = createMarketSectionProps({
 			activeUniverseId: 12n,
 			loadingZoltarQuestionCount: true,
-			onLoadZoltarQuestions: async () => {
-				calls.push('load')
+			onLoadZoltarQuestionPage: async (pageIndex, pageSize) => {
+				calls.push(`${pageIndex}:${pageSize}`)
 			},
 			zoltarQuestionCount: undefined,
 			zoltarUniverse: undefined,
@@ -272,15 +313,17 @@ describe('MarketSection', () => {
 			)
 		})
 
-		expect(calls).toEqual(['load'])
+		await waitFor(() => {
+			expect(calls).toEqual(['0:10'])
+		})
 	})
 
 	test('does not auto-load questions again on rerender when the active universe id is unchanged', async () => {
 		const calls: string[] = []
 		const initialProps = createMarketSectionProps({
 			activeUniverseId: 13n,
-			onLoadZoltarQuestions: async () => {
-				calls.push('load')
+			onLoadZoltarQuestionPage: async (pageIndex, pageSize) => {
+				calls.push(`${pageIndex}:${pageSize}`)
 			},
 			zoltarQuestionCount: 3n,
 			zoltarUniverse: undefined,
@@ -289,7 +332,9 @@ describe('MarketSection', () => {
 
 		const renderedComponent = await renderIntoDocument(h(MarketSection, initialProps))
 		cleanupRenderedComponent = renderedComponent.cleanup
-		expect(calls).toEqual(['load'])
+		await waitFor(() => {
+			expect(calls).toEqual(['0:10'])
+		})
 
 		await act(() => {
 			render(
@@ -297,8 +342,8 @@ describe('MarketSection', () => {
 					MarketSection,
 					createMarketSectionProps({
 						...initialProps,
-						onLoadZoltarQuestions: async () => {
-							calls.push('rerender')
+						onLoadZoltarQuestionPage: async (pageIndex, pageSize) => {
+							calls.push(`rerender:${pageIndex}:${pageSize}`)
 						},
 					}),
 				),
@@ -306,36 +351,52 @@ describe('MarketSection', () => {
 			)
 		})
 
-		expect(calls).toEqual(['load'])
+		expect(calls).toEqual(['0:10'])
 	})
 
-	test('retries question auto-load when the previous automatic load fails', async () => {
+	test('retries question auto-load when the user leaves and re-enters the failed page', async () => {
 		const calls: string[] = []
 		const initialLoad = createDeferred<void>()
+		const firstPageQuestion = createBinaryForkQuestion()
+		const secondPageQuestion = {
+			...createBinaryForkQuestion(),
+			questionId: '0x02',
+			title: 'Second page question',
+		}
 		const renderedComponent = await renderIntoDocument(
 			h(
 				MarketSection,
 				createMarketSectionProps({
 					activeUniverseId: 9n,
-					hasLoadedZoltarQuestions: false,
 					loadingZoltarQuestions: false,
-					onLoadZoltarQuestions: async () => {
-						calls.push('load')
-						return await initialLoad.promise
+					onLoadZoltarQuestionPage: async (pageIndex, pageSize) => {
+						calls.push(`load:${pageIndex}:${pageSize}`)
+						if (pageIndex === 1 && pageSize === 10) return await initialLoad.promise
 					},
-					zoltarQuestionCount: 3n,
+					zoltarQuestionCount: 12n,
+					zoltarQuestionPage: {
+						pageIndex: 0,
+						pageSize: 10,
+						questionCount: 12n,
+						questions: [firstPageQuestion],
+					},
 					zoltarUniverse: undefined,
 					zoltarUniverseState: 'unknown',
 				}),
 			),
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
-		await waitFor(() => {
-			expect(calls).toEqual(['load'])
+
+		const documentQueries = within(document.body)
+		await act(() => {
+			fireEvent.click(documentQueries.getByRole('button', { name: 'Next Page' }))
 		})
 		await act(async () => {
 			initialLoad.reject(new Error('temporary failure'))
 			await expect(initialLoad.promise).rejects.toThrow('temporary failure')
+		})
+		await waitFor(() => {
+			expect(calls).toEqual(['load:1:10'])
 		})
 
 		await act(() => {
@@ -344,12 +405,17 @@ describe('MarketSection', () => {
 					MarketSection,
 					createMarketSectionProps({
 						activeUniverseId: 9n,
-						hasLoadedZoltarQuestions: false,
 						loadingZoltarQuestions: false,
-						onLoadZoltarQuestions: async () => {
-							calls.push('retry')
+						onLoadZoltarQuestionPage: async (pageIndex, pageSize) => {
+							calls.push(`retry:${pageIndex}:${pageSize}`)
 						},
-						zoltarQuestionCount: 3n,
+						zoltarQuestionCount: 12n,
+						zoltarQuestionPage: {
+							pageIndex: 0,
+							pageSize: 10,
+							questionCount: 12n,
+							questions: [firstPageQuestion],
+						},
 						zoltarUniverse: undefined,
 						zoltarUniverseState: 'unknown',
 					}),
@@ -358,7 +424,125 @@ describe('MarketSection', () => {
 			)
 		})
 
-		expect(calls).toEqual(['load', 'retry'])
+		await act(() => {
+			fireEvent.click(documentQueries.getByRole('button', { name: 'Previous Page' }))
+		})
+		await act(() => {
+			render(
+				h(
+					MarketSection,
+					createMarketSectionProps({
+						activeUniverseId: 9n,
+						loadingZoltarQuestions: false,
+						onLoadZoltarQuestionPage: async (pageIndex, pageSize) => {
+							calls.push(`retry:${pageIndex}:${pageSize}`)
+						},
+						zoltarQuestionCount: 12n,
+						zoltarQuestionPage: {
+							pageIndex: 0,
+							pageSize: 10,
+							questionCount: 12n,
+							questions: [firstPageQuestion],
+						},
+						zoltarUniverse: undefined,
+						zoltarUniverseState: 'unknown',
+					}),
+				),
+				renderedComponent.container,
+			)
+		})
+		await act(() => {
+			fireEvent.click(documentQueries.getByRole('button', { name: 'Next Page' }))
+		})
+		await act(() => {
+			render(
+				h(
+					MarketSection,
+					createMarketSectionProps({
+						activeUniverseId: 9n,
+						loadingZoltarQuestions: false,
+						onLoadZoltarQuestionPage: async (pageIndex, pageSize) => {
+							calls.push(`retry:${pageIndex}:${pageSize}`)
+						},
+						zoltarQuestionCount: 12n,
+						zoltarQuestionPage: {
+							pageIndex: 1,
+							pageSize: 10,
+							questionCount: 12n,
+							questions: [secondPageQuestion],
+						},
+						zoltarUniverse: undefined,
+						zoltarUniverseState: 'unknown',
+					}),
+				),
+				renderedComponent.container,
+			)
+		})
+
+		await waitFor(() => {
+			expect(calls).toEqual(['load:1:10', 'retry:1:10'])
+		})
+	})
+
+	test('invalidates stale paged question data when the question count changes', async () => {
+		const calls: string[] = []
+		const initialProps = createMarketSectionProps({
+			onLoadZoltarQuestionPage: async () => undefined,
+			zoltarQuestionCount: 1n,
+			zoltarQuestionPage: {
+				pageIndex: 0,
+				pageSize: 10,
+				questionCount: 1n,
+				questions: [createBinaryForkQuestion()],
+			},
+		})
+		const renderedComponent = await renderIntoDocument(h(MarketSection, initialProps))
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await act(() => {
+			render(
+				h(
+					MarketSection,
+					createMarketSectionProps({
+						...initialProps,
+						onLoadZoltarQuestionPage: async (pageIndex, pageSize) => {
+							calls.push(`${pageIndex}:${pageSize}`)
+						},
+						zoltarQuestionCount: 2n,
+					}),
+				),
+				renderedComponent.container,
+			)
+		})
+
+		await waitFor(() => {
+			expect(calls).toEqual(['0:10'])
+		})
+	})
+
+	test('shows a not-yet-loaded question state instead of rendering an empty page', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				MarketSection,
+				createMarketSectionProps({
+					loadingZoltarQuestionCount: false,
+					loadingZoltarQuestions: false,
+					onLoadZoltarQuestionPage: async () => undefined,
+					zoltarQuestionCount: 3n,
+					zoltarQuestionPage: {
+						pageIndex: 1,
+						pageSize: 10,
+						questionCount: 3n,
+						questions: [],
+					},
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.queryByText('No questions were returned for the selected page.')).toBeNull()
+		expect(documentQueries.getByText('Loading questions...')).not.toBeNull()
 	})
 
 	test('does not render redundant universe summary cards for questions view', async () => {

--- a/ui/ts/tests/openOracle.test.ts
+++ b/ui/ts/tests/openOracle.test.ts
@@ -49,6 +49,7 @@ const genesisUniverse = 0n
 const securityMultiplier = 2n
 const MAX_RETENTION_RATE = 999_999_996_848_000_000n
 const reportedRepEthPrice = 10n
+const DEFAULT_SELF_OPERATION_TIMEOUT_SECONDS = 30n * 60n
 const outcomes = ['Yes', 'No']
 
 function createQuoteClient(amountOut: bigint): Parameters<typeof loadOpenOracleInitialReportPrice>[0] {
@@ -986,7 +987,7 @@ describe('Open Oracle helpers', () => {
 	})
 
 	test('queueOracleManagerOperation returns queued operation metadata for the pending slot', async () => {
-		const result = await queueOracleManagerOperation(uiWriteClient, managerAddress, 'setSecurityBondsAllowance', client.account.address, 0n)
+		const result = await queueOracleManagerOperation(uiWriteClient, managerAddress, 'setSecurityBondsAllowance', client.account.address, 0n, DEFAULT_SELF_OPERATION_TIMEOUT_SECONDS)
 
 		expect(result.queuedOperation).toBeDefined()
 		expect(result.queuedOperation?.isPendingSlot).toBe(true)
@@ -995,9 +996,9 @@ describe('Open Oracle helpers', () => {
 		expect(result.stagedExecution).toBeUndefined()
 	})
 
-	test('queueOracleManagerOperation preserves incremental ids when another pending slot already exists', async () => {
-		const firstResult = await queueOracleManagerOperation(uiWriteClient, managerAddress, 'setSecurityBondsAllowance', client.account.address, 0n)
-		const secondResult = await queueOracleManagerOperation(uiWriteClient, managerAddress, 'withdrawRep', client.account.address, 1n)
+	test('queueOracleManagerOperation preserves incremental ids when another pending slot already exists for a liquidation target vault', async () => {
+		const firstResult = await queueOracleManagerOperation(uiWriteClient, managerAddress, 'setSecurityBondsAllowance', client.account.address, 0n, DEFAULT_SELF_OPERATION_TIMEOUT_SECONDS)
+		const secondResult = await queueOracleManagerOperation(uiWriteClient, managerAddress, 'liquidation', addressString(TEST_ADDRESSES[1]), 1n, DEFAULT_SELF_OPERATION_TIMEOUT_SECONDS)
 		const details = await loadOracleManagerDetails(uiReadClient, managerAddress)
 		const firstOperationId = firstResult.queuedOperation?.operationId
 		if (firstOperationId === undefined) throw new Error('Expected the first queued operation id to be defined')

--- a/ui/ts/tests/securityPoolWorkflowSection.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection.test.tsx
@@ -307,9 +307,11 @@ function createSecurityPoolWorkflowProps(overrides: Partial<SecurityPoolWorkflow
 		liquidationModalOpen: false,
 		liquidationSecurityPoolAddress: undefined,
 		liquidationTargetVault: '',
+		liquidationTimeoutMinutes: '30',
 		loadingPoolOracleManager: false,
 		loadingSecurityPools: false,
 		onLiquidationAmountChange: () => undefined,
+		onLiquidationTimeoutMinutesChange: () => undefined,
 		onLoadPoolOracleManager: () => undefined,
 		onOpenLiquidationModal: () => undefined,
 		onQueueLiquidation: () => undefined,
@@ -2199,6 +2201,37 @@ describe('SecurityPoolWorkflowSection', () => {
 		expect(documentQueries.getByText('Withdraw REP')).not.toBeNull()
 		expect(documentQueries.getByText('7')).not.toBeNull()
 		expect(documentQueries.queryByText('Pending Price Request')).toBeNull()
+	})
+
+	test('does not show staged-operation cancellation actions', async () => {
+		const walletAddress = getAddress('0x00000000000000000000000000000000000000a1')
+		const targetVault = getAddress('0x00000000000000000000000000000000000000a2')
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					accountState: createAccountState({ address: walletAddress }),
+					checkedSecurityPoolAddress: zeroAddress,
+					poolOracleManagerDetails: createOracleManagerDetails({
+						pendingOperation: {
+							amount: 1n,
+							initiatorVault: walletAddress,
+							operation: 'liquidation',
+							operationId: 9n,
+							targetVault,
+						},
+						pendingOperationSlotId: 9n,
+					}),
+					securityPoolAddress: zeroAddress,
+					securityPools: [createSelectedPool()],
+					selectedPoolView: 'staged-operations',
+				})}
+				showHeader={false}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.queryByRole('button', { name: 'Cancel Staged Operation' })).toBeNull()
 	})
 
 	test('blocks staged-operation execution after the selected pool has ended', async () => {

--- a/ui/ts/tests/securityPoolsOverviewSection.test.tsx
+++ b/ui/ts/tests/securityPoolsOverviewSection.test.tsx
@@ -1,11 +1,12 @@
 /// <reference types="bun-types" />
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { within } from '@testing-library/dom'
+import { waitFor, within } from '@testing-library/dom'
+import { render } from 'preact'
 import { SecurityPoolsOverviewSection } from '../components/SecurityPoolsOverviewSection.js'
 import { deriveHasForkActivity } from '../lib/forkAuction.js'
 import type { AccountState } from '../types/app.js'
-import type { ListedSecurityPool, MarketDetails } from '../types/contracts.js'
+import type { ListedSecurityPool, MarketDetails, SecurityPoolPage } from '../types/contracts.js'
 import type { SecurityPoolsOverviewSectionProps } from '../types/components.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
@@ -20,6 +21,16 @@ function createAccountState(overrides: Partial<AccountState> = {}): AccountState
 		wethBalance: 0n,
 		...overrides,
 	}
+}
+
+function createDeferred<T>() {
+	let resolve: (value: T) => void = () => undefined
+	let reject: (reason?: unknown) => void = () => undefined
+	const promise = new Promise<T>((promiseResolve, promiseReject) => {
+		resolve = promiseResolve
+		reject = promiseReject
+	})
+	return { promise, reject, resolve }
 }
 
 function createMarketDetails(overrides: Partial<MarketDetails> = {}): MarketDetails {
@@ -77,21 +88,34 @@ function createSecurityPool(overrides: Partial<ListedSecurityPool> = {}): Listed
 }
 
 function createProps(overrides: Partial<SecurityPoolsOverviewSectionProps> = {}): SecurityPoolsOverviewSectionProps {
+	const defaultPools = [createSecurityPool()]
+	const securityPools = overrides.securityPools ?? defaultPools
+	const defaultPage: SecurityPoolPage = {
+		pageIndex: 0,
+		pageSize: 6,
+		poolCount: BigInt(securityPools.length),
+		pools: securityPools,
+	}
 	return {
 		accountState: createAccountState(),
 		checkedSecurityPoolAddress: undefined,
 		closeLiquidationModal: () => undefined,
 		hasLoadedSecurityPools: true,
+		hasLoadedSecurityPoolPage: true,
 		liquidationAmount: '',
 		liquidationMaxAmount: undefined,
 		liquidationManagerAddress: undefined,
 		liquidationModalOpen: false,
 		liquidationSecurityPoolAddress: undefined,
 		liquidationTargetVault: '',
+		liquidationTimeoutMinutes: '30',
 		loadingPoolOracleManager: false,
+		loadingSecurityPoolPage: false,
 		loadingSecurityPools: false,
 		onLiquidationAmountChange: () => undefined,
+		onLiquidationTimeoutMinutesChange: () => undefined,
 		onLoadPoolOracleManager: () => undefined,
+		onLoadSecurityPoolPage: () => undefined,
 		onLoadSecurityPools: () => undefined,
 		onOpenLiquidationModal: () => undefined,
 		onQueueLiquidation: () => undefined,
@@ -100,10 +124,12 @@ function createProps(overrides: Partial<SecurityPoolsOverviewSectionProps> = {})
 		repPerEthPrice: undefined,
 		repPerEthSource: undefined,
 		repPerEthSourceUrl: undefined,
+		securityPoolBrowseCount: overrides.securityPoolPage?.poolCount ?? BigInt(securityPools.length),
+		securityPoolPage: overrides.securityPoolPage ?? defaultPage,
 		securityPoolOverviewActiveAction: undefined,
 		securityPoolOverviewError: undefined,
 		securityPoolOverviewResult: undefined,
-		securityPools: [createSecurityPool()],
+		securityPools,
 		...overrides,
 	}
 }
@@ -276,8 +302,51 @@ describe('SecurityPoolsOverviewSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		expect(documentQueries.getByRole('button', { name: 'Refresh pools' })).not.toBeNull()
+		expect(documentQueries.queryByRole('button', { name: 'Refresh pools' })).toBeNull()
 		expect(documentQueries.queryByText('Refresh pools to check again.')).toBeNull()
+	})
+
+	test('shows a loading browse state before the first registry page loads', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolsOverviewSection
+				{...createProps({
+					hasLoadedSecurityPoolPage: false,
+					loadingSecurityPoolPage: false,
+					securityPoolPage: undefined,
+					securityPools: [],
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByText('Refreshing pools.')).not.toBeNull()
+		expect(documentQueries.queryByText('None yet')).toBeNull()
+	})
+
+	test('does not infer browse page count from selected-pool cache before the first registry page loads', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolsOverviewSection
+				{...createProps({
+					hasLoadedSecurityPoolPage: false,
+					loadingSecurityPoolPage: false,
+					securityPoolBrowseCount: undefined,
+					securityPoolPage: undefined,
+					securityPools: [
+						createSecurityPool({
+							marketDetails: createMarketDetails({ title: 'Selected-pool cache entry' }),
+							securityPoolAddress: '0x0000000000000000000000000000000000000abc',
+						}),
+					],
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.queryByText('Page 1 of 1')).toBeNull()
+		expect(documentQueries.queryByText('Selected-pool cache entry')).toBeNull()
+		expect(documentQueries.getByText('Refreshing pools.')).not.toBeNull()
 	})
 
 	test('filters the registry by the derived Ended state', async () => {
@@ -313,6 +382,98 @@ describe('SecurityPoolsOverviewSection', () => {
 		expect(documentQueries.getAllByText('Ended pool').length).toBeGreaterThan(0)
 	})
 
+	test('clamps the current page when the loaded pool count shrinks', async () => {
+		const loadPageCalls: Array<{ pageIndex: number; pageSize: number }> = []
+		const initialProps = createProps({
+			onLoadSecurityPoolPage: (pageIndex, pageSize) => {
+				loadPageCalls.push({ pageIndex, pageSize })
+			},
+			securityPoolPage: {
+				pageIndex: 0,
+				pageSize: 6,
+				poolCount: 12n,
+				pools: [
+					createSecurityPool({
+						marketDetails: createMarketDetails({ title: 'Paged pool' }),
+						securityPoolAddress: '0x0000000000000000000000000000000000000300',
+					}),
+				],
+			},
+		})
+		const renderedComponent = await renderIntoDocument(<SecurityPoolsOverviewSection {...initialProps} />)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		const nextPageButton = documentQueries.getByRole('button', { name: 'Next Page' })
+		await act(() => {
+			nextPageButton.dispatchEvent(new window.MouseEvent('click', { bubbles: true }))
+		})
+		expect(documentQueries.getByText('Page 2 of 2')).not.toBeNull()
+
+		const shrunkProps = createProps({
+			onLoadSecurityPoolPage: initialProps.onLoadSecurityPoolPage,
+			securityPoolPage: {
+				pageIndex: 0,
+				pageSize: 6,
+				poolCount: 1n,
+				pools: [
+					createSecurityPool({
+						marketDetails: createMarketDetails({ title: 'Shrunk pool' }),
+						securityPoolAddress: '0x0000000000000000000000000000000000000301',
+					}),
+				],
+			},
+		})
+		await act(() => {
+			render(<SecurityPoolsOverviewSection {...shrunkProps} />, renderedComponent.container)
+		})
+
+		expect(documentQueries.getByText('Page 1 of 1')).not.toBeNull()
+		expect(loadPageCalls.some(call => call.pageIndex === 0)).toBe(true)
+	})
+
+	test('stops showing a loading state when a requested registry page fails to load', async () => {
+		const failedPageLoad = createDeferred<void>()
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolsOverviewSection
+				{...createProps({
+					onLoadSecurityPoolPage: async pageIndex => {
+						if (pageIndex === 1) return await failedPageLoad.promise
+					},
+					securityPoolPage: {
+						pageIndex: 0,
+						pageSize: 6,
+						poolCount: 12n,
+						pools: [
+							createSecurityPool({
+								marketDetails: createMarketDetails({ title: 'Paged pool' }),
+								securityPoolAddress: '0x0000000000000000000000000000000000000400',
+							}),
+						],
+					},
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		const nextPageButton = documentQueries.getByRole('button', { name: 'Next Page' })
+		await act(() => {
+			nextPageButton.dispatchEvent(new window.MouseEvent('click', { bubbles: true }))
+		})
+		expect(documentQueries.getByText('Refreshing pools.')).not.toBeNull()
+
+		void failedPageLoad.promise.catch(() => undefined)
+		failedPageLoad.reject(new Error('page load failed'))
+		await act(async () => {
+			await failedPageLoad.promise.catch(() => undefined)
+		})
+		await waitFor(() => {
+			expect(documentQueries.queryByText('Refreshing pools.')).toBeNull()
+			expect(documentQueries.getByText('Refresh pools')).not.toBeNull()
+		})
+	})
+
 	test('shows a deferred vault placeholder when browse mode has not loaded vault details yet', async () => {
 		const renderedComponent = await renderIntoDocument(
 			<SecurityPoolsOverviewSection
@@ -337,5 +498,39 @@ describe('SecurityPoolsOverviewSection', () => {
 		const poolCardQueries = within(poolCard)
 		expect(poolCardQueries.getByText('Open this pool to load 2 vaults.')).not.toBeNull()
 		expect(poolCardQueries.queryByText('No vaults in this pool yet.')).toBeNull()
+	})
+
+	test('renders browse-mode vault previews when the paged pool data includes loaded vaults', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolsOverviewSection
+				{...createProps({
+					securityPools: [
+						createSecurityPool({
+							marketDetails: createMarketDetails({ title: 'Pool with preview vaults' }),
+							securityPoolAddress: '0x0000000000000000000000000000000000000500',
+							vaultCount: 1n,
+							vaults: [
+								{
+									lockedRepInEscalationGame: 0n,
+									repDepositShare: 10n,
+									securityBondAllowance: 5n,
+									unpaidEthFees: 0n,
+									vaultAddress: '0x0000000000000000000000000000000000000501',
+								},
+							],
+						}),
+					],
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		const poolCard = documentQueries.getByRole('heading', { name: 'Pool with preview vaults' }).closest('.entity-card')
+		if (!(poolCard instanceof HTMLElement)) throw new Error('Expected pool card')
+		const poolCardQueries = within(poolCard)
+		expect(poolCardQueries.queryByText('Open this pool to load 1 vault.')).toBeNull()
+		expect(poolCardQueries.getByRole('button', { name: 'Copy address 0x0000000000000000000000000000000000000501' })).not.toBeNull()
+		expect(poolCardQueries.getByRole('button', { name: 'Liquidate Vault' })).not.toBeNull()
 	})
 })

--- a/ui/ts/tests/securityPoolsSection.test.ts
+++ b/ui/ts/tests/securityPoolsSection.test.ts
@@ -9,7 +9,7 @@ import { getAddress, zeroAddress, zeroHash } from 'viem'
 import { SecurityPoolsSection, shouldRefreshSelectedPoolDataOnViewOpen } from '../components/SecurityPoolsSection.js'
 import { deriveHasForkActivity } from '../lib/forkAuction.js'
 import type { AccountState } from '../types/app.js'
-import type { ListedSecurityPool, MarketDetails, OracleManagerDetails } from '../types/contracts.js'
+import type { ListedSecurityPool, MarketDetails, OracleManagerDetails, SecurityPoolPage } from '../types/contracts.js'
 import type { ForkAuctionRouteContentProps, ReportingRouteContentProps, SecurityPoolRouteContentProps, SecurityPoolsOverviewRouteContentProps, SecurityPoolsSectionProps, SecurityPoolWorkflowRouteContentProps, SecurityVaultRouteContentProps, TradingRouteContentProps } from '../types/components.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
@@ -247,9 +247,11 @@ function createWorkflowProps(overrides: Partial<SecurityPoolWorkflowRouteContent
 		liquidationModalOpen: false,
 		liquidationSecurityPoolAddress: undefined,
 		liquidationTargetVault: '',
+		liquidationTimeoutMinutes: '30',
 		loadingPoolOracleManager: false,
 		loadingSecurityPools: false,
 		onLiquidationAmountChange: () => undefined,
+		onLiquidationTimeoutMinutesChange: () => undefined,
 		onLoadPoolOracleManager: () => undefined,
 		onOpenLiquidationModal: () => undefined,
 		onQueueLiquidation: () => undefined,
@@ -280,21 +282,37 @@ function createWorkflowProps(overrides: Partial<SecurityPoolWorkflowRouteContent
 }
 
 function createOverviewProps(overrides: Partial<SecurityPoolsOverviewRouteContentProps> = {}): SecurityPoolsOverviewRouteContentProps {
+	const securityPools = overrides.securityPools ?? []
+	const securityPoolPage: SecurityPoolPage | undefined =
+		overrides.securityPoolPage ??
+		(securityPools.length === 0
+			? undefined
+			: {
+					pageIndex: 0,
+					pageSize: 6,
+					poolCount: BigInt(securityPools.length),
+					pools: securityPools,
+				})
 	return {
 		accountState: createAccountState(),
 		checkedSecurityPoolAddress: undefined,
 		closeLiquidationModal: () => undefined,
 		hasLoadedSecurityPools: false,
+		hasLoadedSecurityPoolPage: securityPoolPage !== undefined,
 		liquidationAmount: '',
 		liquidationMaxAmount: undefined,
 		liquidationManagerAddress: undefined,
 		liquidationModalOpen: false,
 		liquidationSecurityPoolAddress: undefined,
 		liquidationTargetVault: '',
+		liquidationTimeoutMinutes: '30',
 		loadingPoolOracleManager: false,
+		loadingSecurityPoolPage: false,
 		loadingSecurityPools: false,
 		onLiquidationAmountChange: () => undefined,
+		onLiquidationTimeoutMinutesChange: () => undefined,
 		onLoadPoolOracleManager: () => undefined,
+		onLoadSecurityPoolPage: () => undefined,
 		onLoadSecurityPools: () => undefined,
 		onOpenLiquidationModal: () => undefined,
 		onQueueLiquidation: () => undefined,
@@ -302,10 +320,12 @@ function createOverviewProps(overrides: Partial<SecurityPoolsOverviewRouteConten
 		repPerEthPrice: undefined,
 		repPerEthSource: undefined,
 		repPerEthSourceUrl: undefined,
+		securityPoolBrowseCount: securityPoolPage?.poolCount,
+		securityPoolPage,
 		securityPoolOverviewActiveAction: undefined,
 		securityPoolOverviewError: undefined,
 		securityPoolOverviewResult: undefined,
-		securityPools: [],
+		securityPools,
 		...overrides,
 	}
 }
@@ -494,27 +514,27 @@ void describe('SecurityPoolsSection', () => {
 		const calls: string[] = []
 		const initialProps = createSecurityPoolsSectionProps({
 			overview: createOverviewProps({
-				hasLoadedSecurityPools: false,
-				loadingSecurityPools: false,
-				onLoadSecurityPools: () => {
-					calls.push('load')
+				hasLoadedSecurityPoolPage: false,
+				loadingSecurityPoolPage: false,
+				onLoadSecurityPoolPage: (pageIndex, pageSize) => {
+					calls.push(`${pageIndex}:${pageSize}`)
 				},
 			}),
 		})
 
 		const renderedComponent = await renderIntoDocument(h(SecurityPoolsSection, initialProps))
 		cleanupRenderedComponent = renderedComponent.cleanup
-		expect(calls).toEqual(['load'])
+		expect(calls).toEqual(['0:6'])
 
 		await act(() => {
 			render(
 				h(SecurityPoolsSection, {
 					...initialProps,
 					overview: createOverviewProps({
-						hasLoadedSecurityPools: false,
-						loadingSecurityPools: false,
-						onLoadSecurityPools: () => {
-							calls.push('rerender')
+						hasLoadedSecurityPoolPage: false,
+						loadingSecurityPoolPage: false,
+						onLoadSecurityPoolPage: (pageIndex, pageSize) => {
+							calls.push(`rerender:${pageIndex}:${pageSize}`)
 						},
 					}),
 				}),
@@ -522,7 +542,7 @@ void describe('SecurityPoolsSection', () => {
 			)
 		})
 
-		expect(calls).toEqual(['load'])
+		expect(calls).toEqual(['0:6'])
 	})
 
 	void test('openView opens and refreshes selected pool data when navigating from create mode', async () => {

--- a/ui/ts/tests/securityVaultGuards.test.ts
+++ b/ui/ts/tests/securityVaultGuards.test.ts
@@ -65,6 +65,7 @@ describe('security vault guards', () => {
 				isMainnet: true,
 				requestPriceEthCost: undefined,
 				selectedVaultIsOwnedByAccount: true,
+				stagedOperationTimeoutMinutes: 30n,
 				withdrawAmount: 1n,
 				withdrawableRepAmount: 1n,
 				walletEthBalance: 1n,
@@ -78,6 +79,7 @@ describe('security vault guards', () => {
 				isMainnet: true,
 				requestPriceEthCost: undefined,
 				selectedVaultIsOwnedByAccount: true,
+				stagedOperationTimeoutMinutes: 30n,
 				withdrawAmount: 10_000n * 10n ** 18n,
 				withdrawableRepAmount: 2_500n * 10n ** 18n,
 				walletEthBalance: 1n,
@@ -93,6 +95,7 @@ describe('security vault guards', () => {
 				securityBondAllowanceAmount: undefined,
 				selectedVaultDetailsLoaded: true,
 				selectedVaultIsOwnedByAccount: true,
+				stagedOperationTimeoutMinutes: 30n,
 				walletEthBalance: 1n,
 			}),
 		).toBe('Enter a valid security bond allowance.')
@@ -106,6 +109,7 @@ describe('security vault guards', () => {
 				securityBondAllowanceAmount: 0n,
 				selectedVaultDetailsLoaded: true,
 				selectedVaultIsOwnedByAccount: true,
+				stagedOperationTimeoutMinutes: 30n,
 				walletEthBalance: 1n,
 			}),
 		).toBeUndefined()
@@ -119,6 +123,7 @@ describe('security vault guards', () => {
 				securityBondAllowanceAmount: 5n * 10n ** 17n,
 				selectedVaultDetailsLoaded: true,
 				selectedVaultIsOwnedByAccount: true,
+				stagedOperationTimeoutMinutes: 30n,
 				walletEthBalance: 1n,
 			}),
 		).toBe('Enter at least 1 ETH for a non-zero allowance.')
@@ -132,6 +137,7 @@ describe('security vault guards', () => {
 				securityBondAllowanceAmount: 6n * 10n ** 18n,
 				selectedVaultDetailsLoaded: true,
 				selectedVaultIsOwnedByAccount: true,
+				stagedOperationTimeoutMinutes: 30n,
 				walletEthBalance: 1n,
 			}),
 		).toBe('Reduce the security bond allowance to 5 ETH or less.')
@@ -206,6 +212,7 @@ describe('security vault guards', () => {
 				isMainnet: true,
 				requestPriceEthCost: 10n * ETH,
 				selectedVaultIsOwnedByAccount: true,
+				stagedOperationTimeoutMinutes: 30n,
 				withdrawAmount: 1n * ETH,
 				withdrawableRepAmount: 5n * ETH,
 				walletEthBalance: 5n * ETH,
@@ -221,6 +228,7 @@ describe('security vault guards', () => {
 				securityBondAllowanceAmount: 0n,
 				selectedVaultDetailsLoaded: true,
 				selectedVaultIsOwnedByAccount: true,
+				stagedOperationTimeoutMinutes: 30n,
 				walletEthBalance: 5n * ETH,
 			}),
 		).toBe('Need 7 more ETH in this wallet to queue this bond allowance update.')

--- a/ui/ts/tests/securityVaultSection.test.tsx
+++ b/ui/ts/tests/securityVaultSection.test.tsx
@@ -207,6 +207,19 @@ describe('SecurityVaultSection', () => {
 		expectTransactionButtonEnabled(document.body, 'Set Security Bond Allowance')
 	})
 
+	test('defaults queued self-service timeout copy to 30 minutes when the form has no explicit timeout', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<SecurityVaultSection
+				{...createSecurityVaultSectionProps({
+					oracleManagerDetails: createOracleManagerDetails(),
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(document.body.textContent?.includes('This queued self-service operation will expire 30m after the oracle settlement window completes.')).toBe(true)
+	})
+
 	test('blocks non-zero security bond allowances below the minimum', async () => {
 		const renderedComponent = await renderIntoDocument(
 			<SecurityVaultSection

--- a/ui/ts/tests/simulationBootstrap.test.ts
+++ b/ui/ts/tests/simulationBootstrap.test.ts
@@ -353,7 +353,7 @@ function createMockedBootstrapDependencies({ accounts, scenario, profile }: { ac
 				universeId: 0n,
 			} as never
 		}),
-		queueOracleManagerOperation: mock(async (_client: never, managerAddress: Address, operation: string, targetVault: Address, amount: bigint) => {
+		queueOracleManagerOperation: mock(async (_client: never, managerAddress: Address, operation: string, targetVault: Address, amount: bigint, _validForSeconds: bigint) => {
 			state.callLog.queueOracleManagerOperation += 1
 			if (operation === 'setSecurityBondsAllowance') {
 				pendingOperations[managerAddress] = {

--- a/ui/ts/tests/useOnchainState.integration.test.tsx
+++ b/ui/ts/tests/useOnchainState.integration.test.tsx
@@ -8,7 +8,7 @@ import type { Address } from 'viem'
 import { getAddress } from 'viem'
 import type { ChainBackend, ReadClient } from '../lib/chainBackend.js'
 import { getDeploymentSteps } from '../contracts.js'
-import { MAINNET_NETWORK_PROFILE, type NetworkProfile } from '../lib/networkProfile.js'
+import { MAINNET_NETWORK_PROFILE, createSimulationProfile, type NetworkProfile } from '../lib/networkProfile.js'
 import { installActiveEnvironmentForTesting, resetActiveEnvironmentForTesting } from '../lib/activeEnvironment.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
@@ -43,6 +43,7 @@ function createReadClient({ ethBalance = 0n, blockNumber = 10n, blockTimestamp =
 	return {
 		getBalance: async () => ethBalance,
 		getBlock: async () => ({ number: blockNumber, timestamp: blockTimestamp }),
+		getChainId: async () => 1,
 		readContract: async () => 0n,
 		getCode: async () => '0x',
 	} as unknown as ReadClient
@@ -241,6 +242,81 @@ describe('useOnchainState (integration)', () => {
 		expect(requireHookState(hookState).currentTimestamp).toBe(200n)
 		expect(loadDeploymentStatusOracleSnapshot).toHaveBeenCalledTimes(1)
 		expect(loadErc20Balance).toHaveBeenCalledTimes(1)
+
+		resetEnvironment()
+	})
+
+	test('surfaces a blocking error when the configured read RPC is on the wrong chain', async () => {
+		const loadDeploymentStatusOracleSnapshot = mock(async () => ({
+			augurPlaceHolderDeployed: false,
+			deploymentStatuses,
+		}))
+		mock.module('../contracts.js', () => ({
+			getDeploymentSteps,
+			loadDeploymentStatusOracleSnapshot,
+			loadErc20Balance: mock(async () => 0n),
+		}))
+
+		const { useOnchainState } = await import(`../hooks/useOnchainState.js?case=${crypto.randomUUID()}`)
+		const wrongChainReadClient = {
+			...createReadClient(),
+			getBlock: async () => ({ number: 999n, timestamp: 1234n }),
+			getChainId: async () => 11155111,
+		} as ReadClient
+		const { backend, subscriptionState } = createBackend({ hasWallet: false, readClient: wrongChainReadClient })
+		const resetEnvironment = installActiveEnvironmentForTesting(backend)
+		let hookState: UseOnchainStateState | undefined
+		const Harness = createHarness(useOnchainState, state => {
+			hookState = state
+		})
+		const renderedComponent = await renderIntoDocument(h(Harness, {}))
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await waitFor(() => expect(requireHookState(hookState).readBackendMessage).toBe('Configured read RPC reports chain 11155111, but this app requires Ethereum Mainnet (1).'))
+		expect(requireHookState(hookState).currentBlockNumber).toBeUndefined()
+		expect(requireHookState(hookState).currentTimestamp).toBeUndefined()
+		await act(async () => {
+			subscriptionState.stateHandler?.()
+			await Promise.resolve()
+		})
+		expect(requireHookState(hookState).currentBlockNumber).toBeUndefined()
+		expect(requireHookState(hookState).currentTimestamp).toBeUndefined()
+		expect(loadDeploymentStatusOracleSnapshot).not.toHaveBeenCalled()
+
+		resetEnvironment()
+	})
+
+	test('uses the active backend label when surfacing a read-RPC chain mismatch', async () => {
+		const loadDeploymentStatusOracleSnapshot = mock(async () => ({
+			augurPlaceHolderDeployed: false,
+			deploymentStatuses,
+		}))
+		mock.module('../contracts.js', () => ({
+			getDeploymentSteps,
+			loadDeploymentStatusOracleSnapshot,
+			loadErc20Balance: mock(async () => 0n),
+		}))
+
+		const { useOnchainState } = await import(`../hooks/useOnchainState.js?case=${crypto.randomUUID()}`)
+		const wrongChainReadClient = {
+			...createReadClient(),
+			getChainId: async () => 11155111,
+		} as ReadClient
+		const profile = createSimulationProfile({
+			genesisRepTokenAddress: getAddress('0x00000000000000000000000000000000000000f1'),
+			wethAddress: getAddress('0x00000000000000000000000000000000000000f2'),
+		})
+		const { backend } = createBackend({ hasWallet: false, profile, readClient: wrongChainReadClient })
+		const resetEnvironment = installActiveEnvironmentForTesting(backend)
+		let hookState: UseOnchainStateState | undefined
+		const Harness = createHarness(useOnchainState, state => {
+			hookState = state
+		})
+		const renderedComponent = await renderIntoDocument(h(Harness, {}))
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await waitFor(() => expect(requireHookState(hookState).readBackendMessage).toBe('Configured read RPC reports chain 11155111, but this app requires Browser Simulation (1337).'))
+		expect(loadDeploymentStatusOracleSnapshot).not.toHaveBeenCalled()
 
 		resetEnvironment()
 	})
@@ -663,6 +739,7 @@ describe('useOnchainState (integration)', () => {
 		const renderedComponent = await renderIntoDocument(h(Harness, {}))
 		cleanupRenderedComponent = renderedComponent.cleanup
 
+		await waitFor(() => expect(requireHookState(hookState).augurPlaceHolderDeployed).toBe(false))
 		const deployButton = within(document.body).getByRole('button', { name: 'Mark deployments deployed' })
 		await act(async () => {
 			fireEvent.click(deployButton)

--- a/ui/ts/tests/zoltar.test.ts
+++ b/ui/ts/tests/zoltar.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, test } from 'bun:test'
 import { getAddress } from 'viem'
-import { loadMarketDetails, loadZoltarUniverseSummary } from '../contracts/zoltar.js'
+import { loadMarketDetails, loadZoltarQuestionPage, loadZoltarUniverseSummary } from '../contracts/zoltar.js'
 
 const QUESTION_TUPLE_BINARY = ['Binary question', 'desc', 1n, 2n, 0n, 0n, 100n, '']
 const QUESTION_TUPLE_SCALAR = ['Scalar question', 'desc', 1n, 2n, 100n, -10n, 10n, 'units']
@@ -71,6 +71,27 @@ describe('zoltar contract helpers', () => {
 		expect(market.marketType).toBe('binary')
 		expect(market.outcomeLabels).toEqual(outcomeLabels)
 		expect(readContractCalls).toEqual(['getOutcomeLabels'])
+	})
+
+	test('loadZoltarQuestionPage loads only the requested page of questions', async () => {
+		const client = createReadClient({
+			multicallResponses: [
+				[QUESTION_TUPLE_BINARY, 1n],
+				[QUESTION_TUPLE_SCALAR, 1n],
+			],
+			readContractHandlers: {
+				getQuestionCount: async () => 5n,
+				getQuestions: async () => [101n, 102n],
+				getOutcomeLabels: async () => ['Yes', 'No'],
+			},
+		})
+
+		const page = await loadZoltarQuestionPage(client, 1, 2)
+
+		expect(page.questionCount).toBe(5n)
+		expect(page.pageIndex).toBe(1)
+		expect(page.pageSize).toBe(2)
+		expect(page.questions.map(question => question.questionId)).toEqual(['0x65', '0x66'])
 	})
 
 	test('loadZoltarUniverseSummary returns a non-forked universe summary for an active universe', async () => {

--- a/ui/ts/types/app.ts
+++ b/ui/ts/types/app.ts
@@ -46,6 +46,7 @@ export type SecurityVaultFormState = {
 	repWithdrawAmount: string
 	selectedVaultAddress: string
 	securityPoolAddress: string
+	stagedOperationTimeoutMinutes?: string
 }
 
 export type OpenOracleFormState = {

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -9,6 +9,7 @@ import type {
 	ListedSecurityPool,
 	MarketCreationResult,
 	MarketDetails,
+	MarketDetailsPage,
 	OpenOracleActionResult,
 	OpenOracleReportDetails,
 	OracleManagerDetails,
@@ -17,6 +18,7 @@ import type {
 	ReportingDetails,
 	ReportingOutcomeKey,
 	SecurityPoolCreationResult,
+	SecurityPoolPage,
 	SecurityPoolOverviewActionResult,
 	SecurityPoolVaultSummary,
 	SecurityVaultActionResult,
@@ -323,11 +325,13 @@ export type MarketRouteContentProps = {
 	loadingZoltarUniverse: boolean
 	zoltarUniverseState: LoadableValueState
 	onLoadZoltarQuestions: () => Promise<void>
+	onLoadZoltarQuestionPage: (pageIndex: number, pageSize: number) => Promise<void>
 	onMarketFormChange: (update: Partial<MarketFormState>) => void
 	onUseQuestionForFork: (questionId: string) => void
 	onUseQuestionForPool: (questionId: string) => void
 	onZoltarMigrationFormChange: (update: Partial<ZoltarMigrationFormState>) => void
 	zoltarQuestionCount: bigint | undefined
+	zoltarQuestionPage: MarketDetailsPage | undefined
 	zoltarForkApproval: TokenApprovalState
 	zoltarForkError: string | undefined
 	loadingZoltarForkAccess: boolean
@@ -382,11 +386,13 @@ type LiquidationControlsProps = {
 	liquidationManagerAddress: Address | undefined
 	liquidationModalOpen: boolean
 	liquidationSecurityPoolAddress: Address | undefined
+	liquidationTimeoutMinutes: string
 	loadingPoolOracleManager: boolean
 	securityPoolOverviewActiveAction: SecurityPoolOverviewActionResult['action'] | undefined
 	securityPoolOverviewError: string | undefined
 	liquidationTargetVault: string
 	onLiquidationAmountChange: (value: string) => void
+	onLiquidationTimeoutMinutesChange: (value: string) => void
 	onLoadPoolOracleManager: (managerAddress: Address) => void
 	onOpenLiquidationModal: (managerAddress: Address, securityPoolAddress: Address, vaultAddress: Address, maxAmount: bigint | undefined) => void
 	onQueueLiquidation: (managerAddress: Address, securityPoolAddress: Address) => void
@@ -397,11 +403,16 @@ export type SecurityPoolsOverviewRouteContentProps = {
 	accountState: AccountState
 	checkedSecurityPoolAddress: string | undefined
 	hasLoadedSecurityPools: boolean
+	hasLoadedSecurityPoolPage: boolean
+	loadingSecurityPoolPage: boolean
 	loadingSecurityPools: boolean
+	onLoadSecurityPoolPage: (pageIndex: number, pageSize: number) => void
 	onSelectSecurityPool?: (securityPoolAddress: string) => void
 	onLoadSecurityPools: () => void
 	securityPoolOverviewError: string | undefined
 	securityPoolOverviewResult: SecurityPoolOverviewActionResult | undefined
+	securityPoolBrowseCount: bigint | undefined
+	securityPoolPage: SecurityPoolPage | undefined
 	securityPools: ListedSecurityPool[]
 } & LiquidationControlsProps &
 	RepPerEthPriceProps
@@ -420,9 +431,11 @@ export type SecurityPoolWorkflowRouteContentProps = {
 	liquidationModalOpen: boolean
 	liquidationSecurityPoolAddress: Address | undefined
 	liquidationTargetVault: string
+	liquidationTimeoutMinutes: string
 	loadingPoolOracleManager: boolean
 	loadingSecurityPools: boolean
 	onLiquidationAmountChange: (value: string) => void
+	onLiquidationTimeoutMinutesChange: (value: string) => void
 	onLoadPoolOracleManager: (managerAddress: Address) => void
 	onOpenLiquidationModal: (managerAddress: Address, securityPoolAddress: Address, vaultAddress: Address, maxAmount: bigint | undefined) => void
 	onQueueLiquidation: (managerAddress: Address, securityPoolAddress: Address) => void

--- a/ui/ts/types/contracts.ts
+++ b/ui/ts/types/contracts.ts
@@ -130,6 +130,13 @@ export type MarketDetails = QuestionData & {
 	questionId: string
 }
 
+export type MarketDetailsPage = {
+	pageIndex: number
+	pageSize: number
+	questionCount: bigint
+	questions: MarketDetails[]
+}
+
 export type SecurityPoolCreationResult = {
 	deployPoolHash: Hash
 	questionId: string
@@ -277,6 +284,13 @@ export type ListedSecurityPool = {
 	vaultCount: bigint
 	hasLoadedVaults?: boolean
 	vaults: SecurityPoolVaultSummary[]
+}
+
+export type SecurityPoolPage = {
+	pageIndex: number
+	pageSize: number
+	poolCount: bigint
+	pools: ListedSecurityPool[]
 }
 
 export type SecurityPoolVaultSummary = {


### PR DESCRIPTION
## Summary
- Added `SelfOperation` replay-protection and expiry handling in `solidity/contracts/peripherals/SecurityPoolOracleCoordinator.sol`.
  - Tracks per-vault self-operation nonces.
  - Replaces older queued self-operations for the same vault in the pending auto-execute slot.
  - Adds `cancelSelfOperations()` to invalidate stale queued self-operations for a vault.
  - Enforces nonce match and 7-day validity window when executing staged self-operations.
- Extended oracle security test coverage in `solidity/ts/tests/priceOracleSecurity.test.ts` for:
  - Superseding self-operations.
  - `cancelSelfOperations` behavior.
  - Expiry of staged self-operations.
- Reworked question and pool browsing to use paginated data flow instead of full-list loads.
  - Introduced reusable `PaginationControls` component.
  - Updated `MarketQuestionsSection.tsx` and `OpenOracleSection.tsx` to use unified pagination UI.
  - Updated `ForkAuctionSection.tsx` load-more flows to use shared pagination controls.
- Added security pool page-aware loading in `SecurityPoolsOverviewSection.tsx` and integrated page props in `MarketSection.tsx`/`App.tsx` so pagination state is propagated from hooks.
- Added new/updated contract and hook interfaces to support nonce/page metadata and cancellation action wiring, including:
  - `ui/ts/contracts/{zoltar.ts,securityPools.ts}
  - `ui/ts/hooks/{usePriceOracleManager.ts,useOnchainState.ts,useSecurityPoolsOverview.ts,useZoltarUniverse.ts}
  - `ui/ts/types/{components.ts,contracts.ts}`
- Added cancel action for pending self-operations in security pool workflow UI (`SecurityPoolWorkflowSection.tsx`) and surfaced read-backend mismatch notice in `AppStatusNotices.tsx`.

## Testing
- Not run (per request): full checks were not executed in this response.
- Not run: `bun run tsc`
- Not run: `bun run test`
- Not run: `bun run format`
- Not run: `bun run check`
- Not run: `bun run knip`