### PR TITLE
Track staged oracle operation slot and expose manual-queued UI flow

### DIFF
--- a/solidity/contracts/peripherals/SecurityPoolOracleCoordinator.sol
+++ b/solidity/contracts/peripherals/SecurityPoolOracleCoordinator.sol
@@ -50,6 +50,7 @@ contract SecurityPoolOracleCoordinator {
 	bool public immutable feeToken;
 
 	event PriceReported(uint256 reportId, uint256 price);
+	event StagedOperationQueued(uint256 operationId, OperationType operation, address initiatorVault, address targetVault, uint256 amount, bool isPendingSlot);
 	event ExecutedStagedOperation(uint256 operationId, OperationType operation, bool success, string errorMessage);
 
 	// This is not a FIFO queue. We keep an append-only operation record and a single
@@ -152,8 +153,9 @@ contract SecurityPoolOracleCoordinator {
 		lastPrice = price;
 		emit PriceReported(reportId, lastPrice);
 		if (pendingOperationSlotId != 0) { // TODO we maybe should allow executing couple operations?
-			executeStagedOperation(pendingOperationSlotId);
+			uint256 operationId = pendingOperationSlotId;
 			pendingOperationSlotId = 0;
+			executeStagedOperation(operationId);
 		}
 	}
 
@@ -167,13 +169,14 @@ contract SecurityPoolOracleCoordinator {
 		}
 		require(!securityPool.isEscalationResolved(), 'question already resolved');
 		stagedOperationCounter++;
+		uint256 operationId = stagedOperationCounter;
 		// Capture snapshot of the target vault state at queue time to prevent manipulation.
 		// Liquidation should value the vaults full collateral claim. That means using the pools
 		// total REP balance here rather than only the currently withdrawable balance.
 		(uint256 snapshotTargetOwnership, uint256 snapshotTargetAllowance, , , ) = securityPool.securityVaults(targetVault);
 		uint256 snapshotTotalRep = securityPool.getTotalRepBalance();
 		uint256 snapshotDenominator = securityPool.poolOwnershipDenominator();
-		stagedOperations[stagedOperationCounter] = StagedOperation({
+		stagedOperations[operationId] = StagedOperation({
 			operation: operation,
 			initiatorVault: msg.sender,
 			targetVault: targetVault,
@@ -187,16 +190,19 @@ contract SecurityPoolOracleCoordinator {
 		uint256 retained = 0; // amount to retain from msg.value (cost incurred)
 
 		if (isPriceValid()) {
-			executeStagedOperation(stagedOperationCounter);
+			emit StagedOperationQueued(operationId, operation, msg.sender, targetVault, amount, false);
+			executeStagedOperation(operationId);
 			// no cost when price is valid
 		} else if (pendingOperationSlotId == 0) {
-			pendingOperationSlotId = stagedOperationCounter;
+			pendingOperationSlotId = operationId;
+			emit StagedOperationQueued(operationId, operation, msg.sender, targetVault, amount, true);
 			uint256 ethCost = getRequestPriceEthCost();
 			require(msg.value >= ethCost, 'not enough eth to request price');
 			retained += ethCost;
 			// Forward exactly ethCost to requestPrice to create the report
 			this.requestPrice{value: ethCost}();
 		} else {
+			emit StagedOperationQueued(operationId, operation, msg.sender, targetVault, amount, false);
 			// This is intentional: only one staged operation is marked as the auto-execute
 			// pending slot for the next fresh oracle report. Additional operations are still
 			// recorded and can be executed manually via executeStagedOperation once the price
@@ -264,9 +270,7 @@ contract SecurityPoolOracleCoordinator {
 				emit ExecutedStagedOperation(operationId, stagedOperation.operation, false, 'Unknown error');
 			}
 		}
-		if (success) {
-			stagedOperations[operationId].initiatorVault = address(0);
-		}
+		stagedOperations[operationId].initiatorVault = address(0);
 	}
 
 	function getPendingOperationSlot() public view returns (StagedOperation memory) {

--- a/solidity/ts/tests/priceOracleSecurity.test.ts
+++ b/solidity/ts/tests/priceOracleSecurity.test.ts
@@ -118,7 +118,7 @@ describe('Price Oracle Refund Security Tests', () => {
 		assert.strictEqual(balanceAfter, preBalance, `Contract should retain preexisting balance (${preBalance}) after requestPriceIfNeededAndStageOperation, but it was drained to ${balanceAfter}`)
 	})
 
-	test('failed staged operations remain retryable after oracle settlement', async () => {
+	test('failed staged operations are consumed after oracle settlement', async () => {
 		const ethCost = await getRequestPriceEthCost(client, priceOracle)
 		const impossibleAllowance = repDeposit * 10n
 
@@ -136,6 +136,13 @@ describe('Price Oracle Refund Security Tests', () => {
 
 		await handleOracleReporting(client, mockWindow, priceOracle, 10n ** 18n)
 
+		const pendingOperationSlotId = await client.readContract({
+			abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+			address: priceOracle,
+			functionName: 'pendingOperationSlotId',
+			args: [],
+		})
+
 		const stagedOperation = await client.readContract({
 			abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
 			address: priceOracle,
@@ -143,6 +150,22 @@ describe('Price Oracle Refund Security Tests', () => {
 			args: [1n],
 		})
 
-		assert.strictEqual(stagedOperation[3], impossibleAllowance, 'failed staged operations should retain their amount so they can be retried after the state changes')
+		assert.strictEqual(pendingOperationSlotId, 0n, 'failed auto-executed operations should clear the pending slot')
+		assert.strictEqual(stagedOperation[1], addressString(0x0n), 'failed staged operations should be consumed after the execution attempt')
+		assert.strictEqual(stagedOperation[3], impossibleAllowance, 'failed staged operations should retain their record for auditability')
+		await assert.rejects(
+			async () =>
+				await writeContractAndWait(
+					client,
+					async () =>
+						await client.writeContract({
+							abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+							address: priceOracle,
+							functionName: 'executeStagedOperation',
+							args: [1n],
+						}),
+				),
+			/no such operation or already executed/i,
+		)
 	})
 })

--- a/ui/ts/components/LiquidationModal.tsx
+++ b/ui/ts/components/LiquidationModal.tsx
@@ -52,6 +52,11 @@ type LiquidationModalProps = {
 	onQueueLiquidation: (managerAddress: Address, securityPoolAddress: Address) => void
 	walletEthBalance?: bigint | undefined
 }
+type QueuedLiquidationOperationView = {
+	amount: bigint | undefined
+	isPendingSlot: boolean
+	operationId: bigint
+}
 function getLiquidationExecutionMode(currentPoolOracleManagerDetails: OracleManagerDetails | undefined) {
 	if (currentPoolOracleManagerDetails === undefined) return 'refreshing'
 	return currentPoolOracleManagerDetails.isPriceValid ? 'execute' : 'queue'
@@ -89,12 +94,12 @@ function renderQueuedLiquidationStatusCard({
 	securityPoolOverviewResult,
 }: {
 	onViewInStagedOperations: () => void
-	queuedLiquidationOperation: OracleManagerDetails['pendingOperation']
-	queuedLiquidationStatus: 'executed' | 'failed' | 'missing' | 'queued' | 'refreshing' | undefined
+	queuedLiquidationOperation: QueuedLiquidationOperationView | undefined
+	queuedLiquidationStatus: 'executed' | 'failed' | 'manual-queued' | 'missing' | 'queued' | 'refreshing' | undefined
 	securityPoolOverviewResult: SecurityPoolOverviewActionResult | undefined
 }) {
 	if (queuedLiquidationStatus === undefined) return null
-	if (queuedLiquidationStatus === 'queued') {
+	if (queuedLiquidationStatus === 'queued' || queuedLiquidationStatus === 'manual-queued') {
 		if (queuedLiquidationOperation === undefined) return null
 		return (
 			<TransactionStatusCard
@@ -103,11 +108,14 @@ function renderQueuedLiquidationStatusCard({
 				metrics={
 					<div className='workflow-metric-grid'>
 						<MetricField label='Staged Operation'>#{queuedLiquidationOperation.operationId.toString()}</MetricField>
-						<MetricField label='Amount'>
-							<CurrencyValue value={queuedLiquidationOperation.amount} />
-						</MetricField>
+						{queuedLiquidationOperation.amount === undefined ? null : (
+							<MetricField label='Amount'>
+								<CurrencyValue value={queuedLiquidationOperation.amount} />
+							</MetricField>
+						)}
 					</div>
 				}
+				detail={queuedLiquidationStatus === 'manual-queued' ? 'Another staged operation already holds the auto-execute slot. Execute this staged operation manually with its id after a valid oracle price is available.' : undefined}
 				actions={
 					<button className='secondary' type='button' onClick={onViewInStagedOperations}>
 						View In Staged Operations
@@ -117,7 +125,14 @@ function renderQueuedLiquidationStatusCard({
 		)
 	}
 	if (queuedLiquidationStatus === 'failed')
-		return <TransactionStatusCard title='Liquidation Failed' badge={<span className='badge blocked'>Failed</span>} detail={securityPoolOverviewResult?.stagedExecution?.errorMessage ?? 'The oracle manager attempted the liquidation immediately, but the security pool rejected it.'} />
+		return (
+			<TransactionStatusCard
+				title='Liquidation Failed'
+				badge={<span className='badge blocked'>Failed</span>}
+				detail={securityPoolOverviewResult?.stagedExecution?.errorMessage ?? 'The oracle manager attempted the liquidation immediately, but the security pool rejected it.'}
+				secondaryDetail='Fix the underlying state and submit a new staged operation.'
+			/>
+		)
 	if (queuedLiquidationStatus === 'executed') return <TransactionStatusCard title='Liquidation Executed' badge={<span className='badge ok'>Executed</span>} detail='A valid oracle price was already available, so the liquidation executed immediately and no staged operation was created.' />
 	if (queuedLiquidationStatus === 'missing')
 		return <TransactionStatusCard title='Liquidation Submitted' badge={<span className='badge warn'>Check State</span>} detail='The transaction succeeded, but no matching staged operation is currently visible for this vault. Refresh staged operations to confirm the latest manager state.' />
@@ -246,8 +261,22 @@ export function LiquidationModal({
 		directLiquidationReason,
 		queueLiquidationEthGuardMessage,
 	)
-	const queuedLiquidationOperation =
-		securityPoolOverviewResult?.action !== 'queueLiquidation' || currentPoolOracleManagerDetails?.pendingOperation?.operation !== 'liquidation' || currentPoolOracleManagerDetails.pendingOperation.targetVault !== liquidationTargetVault ? undefined : currentPoolOracleManagerDetails.pendingOperation
+	const queuedLiquidationOperation = (() => {
+		if (securityPoolOverviewResult?.action !== 'queueLiquidation') return undefined
+		if (currentPoolOracleManagerDetails?.pendingOperation?.operation === 'liquidation' && currentPoolOracleManagerDetails.pendingOperation.targetVault === liquidationTargetVault) {
+			return {
+				amount: currentPoolOracleManagerDetails.pendingOperation.amount,
+				isPendingSlot: true,
+				operationId: currentPoolOracleManagerDetails.pendingOperation.operationId,
+			} satisfies QueuedLiquidationOperationView
+		}
+		if (securityPoolOverviewResult.queuedOperation?.operation !== 'liquidation') return undefined
+		return {
+			amount: undefined,
+			isPendingSlot: securityPoolOverviewResult.queuedOperation.isPendingSlot,
+			operationId: securityPoolOverviewResult.queuedOperation.operationId,
+		} satisfies QueuedLiquidationOperationView
+	})()
 	const queuedLiquidationStatus =
 		securityPoolOverviewResult?.action !== 'queueLiquidation'
 			? undefined
@@ -257,10 +286,10 @@ export function LiquidationModal({
 
 						return 'failed'
 					}
+					if (queuedLiquidationOperation !== undefined) return queuedLiquidationOperation.isPendingSlot ? 'queued' : 'manual-queued'
 					if (loadingPoolOracleManager || currentPoolOracleManagerDetails === undefined) return 'refreshing'
 
 					return (() => {
-						if (queuedLiquidationOperation !== undefined) return 'queued'
 						if (currentPoolOracleManagerDetails.isPriceValid) return 'executed'
 
 						return 'missing'

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -553,14 +553,10 @@ export function SecurityPoolWorkflowSection({
 			lastExecutedOperationRefreshHash.current = undefined
 			return
 		}
-		if (poolPriceOracleResult.stagedExecution?.success === false) {
-			lastExecutedOperationRefreshHash.current = poolPriceOracleResult.hash
-			return
-		}
 		if (lastExecutedOperationRefreshHash.current === poolPriceOracleResult.hash) return
 		lastExecutedOperationRefreshHash.current = poolPriceOracleResult.hash
 		void onRefreshSelectedPoolData(selectedPool?.securityPoolAddress)
-		if (poolPriceOracleResult.stagedExecution?.operation === 'withdrawRep' && shouldRefreshSelectedPoolReporting) void reporting.onLoadReporting()
+		if (poolPriceOracleResult.stagedExecution?.success === true && poolPriceOracleResult.stagedExecution.operation === 'withdrawRep' && shouldRefreshSelectedPoolReporting) void reporting.onLoadReporting()
 		if (showSelectedPoolWorkflowDetails && view === 'vaults' && hasLoadedCurrentVault) void securityVault.onLoadSecurityVault()
 	}, [hasLoadedCurrentVault, onRefreshSelectedPoolData, poolPriceOracleResult, reporting.onLoadReporting, securityVault.onLoadSecurityVault, selectedPool?.securityPoolAddress, shouldRefreshSelectedPoolReporting, showSelectedPoolWorkflowDetails, view])
 	const selectSelectedPoolView = (nextView: SelectedPoolView) => {

--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -46,7 +46,12 @@ type SelectedVaultSummarySectionProps = Pick<SecurityVaultSectionProps, 'repPerE
 	variant?: 'embedded' | 'record'
 }
 type VaultActionModal = 'claim-fees' | 'deposit-rep' | 'set-bond-allowance' | 'withdraw-rep' | undefined
-type QueuedVaultOperationStatus = 'executed' | 'failed' | 'missing' | 'queued' | 'refreshing' | undefined
+type QueuedVaultOperationStatus = 'executed' | 'failed' | 'manual-queued' | 'missing' | 'queued' | 'refreshing' | undefined
+type QueuedVaultOperationView = {
+	amount: bigint | undefined
+	isPendingSlot: boolean
+	operationId: bigint
+}
 export function SelectedVaultSummarySection({ repPerEthPrice, repPerEthSource, repPerEthSourceUrl, securityBondAllowance, securityVaultDetails, selectedPoolSecurityMultiplier, selectedVaultIsOwnedByAccount, variant = 'record' }: SelectedVaultSummarySectionProps) {
 	const content = (
 		<VaultMetricGrid
@@ -74,10 +79,14 @@ export function SelectedVaultSummarySection({ repPerEthPrice, repPerEthSource, r
 	)
 }
 export function getQueuedVaultOperation({ pendingOperation, selectedVaultAddress, securityVaultResult }: { pendingOperation: StagedOracleOperation | undefined; selectedVaultAddress: string; securityVaultResult: SecurityVaultSectionProps['securityVaultResult'] }) {
-	if (pendingOperation === undefined) return undefined
-	if (!sameAddress(pendingOperation.targetVault, selectedVaultAddress)) return undefined
-	if (securityVaultResult?.action === 'queueWithdrawRep' && pendingOperation.operation === 'withdrawRep') return pendingOperation
-	if (securityVaultResult?.action === 'queueSetSecurityBondAllowance' && pendingOperation.operation === 'setSecurityBondsAllowance') return pendingOperation
+	if (pendingOperation !== undefined && sameAddress(pendingOperation.targetVault, selectedVaultAddress)) {
+		if (securityVaultResult?.action === 'queueWithdrawRep' && pendingOperation.operation === 'withdrawRep') return { amount: pendingOperation.amount, isPendingSlot: true, operationId: pendingOperation.operationId } satisfies QueuedVaultOperationView
+		if (securityVaultResult?.action === 'queueSetSecurityBondAllowance' && pendingOperation.operation === 'setSecurityBondsAllowance') return { amount: pendingOperation.amount, isPendingSlot: true, operationId: pendingOperation.operationId } satisfies QueuedVaultOperationView
+	}
+	if (securityVaultResult?.queuedOperation === undefined) return undefined
+	if (securityVaultResult.action === 'queueWithdrawRep' && securityVaultResult.queuedOperation.operation === 'withdrawRep') return { amount: undefined, isPendingSlot: securityVaultResult.queuedOperation.isPendingSlot, operationId: securityVaultResult.queuedOperation.operationId } satisfies QueuedVaultOperationView
+	if (securityVaultResult.action === 'queueSetSecurityBondAllowance' && securityVaultResult.queuedOperation.operation === 'setSecurityBondsAllowance')
+		return { amount: undefined, isPendingSlot: securityVaultResult.queuedOperation.isPendingSlot, operationId: securityVaultResult.queuedOperation.operationId } satisfies QueuedVaultOperationView
 	return undefined
 }
 function getQueuedVaultOperationStatus({
@@ -93,8 +102,8 @@ function getQueuedVaultOperationStatus({
 }) {
 	if (securityVaultResult?.action !== 'queueWithdrawRep' && securityVaultResult?.action !== 'queueSetSecurityBondAllowance') return undefined
 	if (securityVaultResult.stagedExecution !== undefined) return securityVaultResult.stagedExecution.success ? 'executed' : 'failed'
+	if (queuedVaultOperation !== undefined) return queuedVaultOperation.isPendingSlot ? 'queued' : 'manual-queued'
 	if (loadingSecurityVault || currentPoolOracleManagerDetails === undefined) return 'refreshing'
-	if (queuedVaultOperation !== undefined) return 'queued'
 	if (currentPoolOracleManagerDetails.isPriceValid) return 'executed'
 	return 'missing'
 }
@@ -105,6 +114,7 @@ function VaultQueuedOperationStatusCard({
 	missingDescription,
 	queuedTitle,
 	queuedVaultOperation,
+	manualQueuedDescription,
 	refreshingTitle,
 	refreshingDescription,
 	status,
@@ -120,13 +130,14 @@ function VaultQueuedOperationStatusCard({
 	onViewStagedOperations: (() => void) | undefined
 	queuedTitle: string
 	queuedVaultOperation: ReturnType<typeof getQueuedVaultOperation>
+	manualQueuedDescription: string
 	refreshingDescription: string
 	refreshingTitle: string
 	status: QueuedVaultOperationStatus
 	successDescription: string
 }) {
 	if (status === undefined) return undefined
-	if (status === 'queued')
+	if (status === 'queued' || status === 'manual-queued')
 		return (
 			<WarningSurface as='section' variant='compact'>
 				<div className='entity-card-header'>
@@ -136,8 +147,13 @@ function VaultQueuedOperationStatusCard({
 				</div>
 				<div className='workflow-metric-grid'>
 					<MetricField label='Staged Operation'>{queuedVaultOperation === undefined ? 'Refreshing...' : `#${queuedVaultOperation.operationId.toString()}`}</MetricField>
-					<MetricField label='Amount'>{queuedVaultOperation === undefined ? 'Refreshing...' : <CurrencyValue value={queuedVaultOperation.amount} suffix='REP' />}</MetricField>
+					{queuedVaultOperation?.amount === undefined ? null : (
+						<MetricField label='Amount'>
+							<CurrencyValue value={queuedVaultOperation.amount} suffix='REP' />
+						</MetricField>
+					)}
 				</div>
+				{status === 'manual-queued' ? <p className='detail'>{manualQueuedDescription}</p> : null}
 				{onViewStagedOperations === undefined ? undefined : (
 					<div className='actions'>
 						<button className='secondary' type='button' onClick={onViewStagedOperations}>
@@ -157,6 +173,7 @@ function VaultQueuedOperationStatusCard({
 					<span className='badge blocked'>Failed</span>
 				</div>
 				<p className='detail'>{errorMessage ?? 'The security pool rejected the action.'}</p>
+				<p className='detail'>Fix the underlying state and submit a new staged operation.</p>
 			</section>
 		)
 	if (status === 'executed')
@@ -500,6 +517,7 @@ export function SecurityVaultSection({
 								errorMessage={securityVaultResult?.stagedExecution?.errorMessage ?? 'The oracle manager attempted the withdrawal immediately, but the security pool rejected it.'}
 								executedTitle='REP Withdrawal Executed'
 								failedTitle='REP Withdrawal Failed'
+								manualQueuedDescription='Another staged operation already holds the auto-execute slot. Execute this staged operation manually with its id after a valid oracle price is available.'
 								missingDescription='The transaction succeeded, but no matching staged operation is currently visible for this vault. Refresh staged operations to confirm the latest manager state.'
 								missingTitle='REP Withdrawal Submitted'
 								onViewStagedOperations={onViewStagedOperations}
@@ -606,6 +624,7 @@ export function SecurityVaultSection({
 							errorMessage={securityVaultResult?.stagedExecution?.errorMessage ?? 'The oracle manager attempted the allowance update immediately, but the security pool rejected it.'}
 							executedTitle='Bond Allowance Executed'
 							failedTitle='Bond Allowance Failed'
+							manualQueuedDescription='Another staged operation already holds the auto-execute slot. Execute this staged operation manually with its id after a valid oracle price is available.'
 							missingDescription='The transaction succeeded, but no matching staged operation is currently visible for this vault. Refresh staged operations to confirm the latest manager state.'
 							missingTitle='Bond Allowance Submitted'
 							onViewStagedOperations={onViewStagedOperations}

--- a/ui/ts/components/TransactionStatusCard.tsx
+++ b/ui/ts/components/TransactionStatusCard.tsx
@@ -1,10 +1,11 @@
 import { EntityCard } from './EntityCard.js'
 import type { TransactionStatusCardProps } from '../types/components.js'
 
-export function TransactionStatusCard({ actions, badge, className = '', detail, metrics, title }: TransactionStatusCardProps) {
+export function TransactionStatusCard({ actions, badge, className = '', detail, metrics, secondaryDetail, title }: TransactionStatusCardProps) {
 	return (
 		<EntityCard actions={actions} badge={badge} className={`transaction-status-card ${className}`.trim()} title={title} variant='compact'>
 			{detail === undefined ? undefined : <p className='detail'>{detail}</p>}
+			{secondaryDetail === undefined ? undefined : <p className='detail'>{secondaryDetail}</p>}
 			{metrics}
 		</EntityCard>
 	)

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -39,6 +39,7 @@ import type {
 	ReportingWithdrawalState,
 	SecurityPoolVaultSummary,
 	StagedOracleExecutionResult,
+	StagedOracleQueuedResult,
 	SecurityVaultActionResult,
 	TradingActionResult,
 	TradingDetails,
@@ -155,6 +156,30 @@ function getStagedOracleExecutionResult(receipt: TransactionReceipt, expectedOpe
 				operationId: decodedLog.args.operationId,
 				success: decodedLog.args.success,
 			} satisfies StagedOracleExecutionResult
+		} catch (error) {
+			if (!isIgnorableLogDecodeError(error)) throw error
+			continue
+		}
+	}
+	return undefined
+}
+
+function getStagedOracleQueuedResult(receipt: TransactionReceipt, expectedOperation: OracleQueueOperation): StagedOracleQueuedResult | undefined {
+	for (const log of receipt.logs) {
+		try {
+			const decodedLog = decodeEventLog({
+				abi: peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.abi,
+				data: log.data,
+				topics: log.topics,
+			})
+			if (decodedLog.eventName !== 'StagedOperationQueued') continue
+			const operation = getOracleQueueOperationFromEventOperation(BigInt(decodedLog.args.operation))
+			if (operation !== expectedOperation) continue
+			return {
+				isPendingSlot: decodedLog.args.isPendingSlot,
+				operation,
+				operationId: decodedLog.args.operationId,
+			} satisfies StagedOracleQueuedResult
 		} catch (error) {
 			if (!isIgnorableLogDecodeError(error)) throw error
 			continue
@@ -1805,9 +1830,11 @@ export async function queueSecurityPoolLiquidation(client: WriteClient, managerA
 		value: await loadBufferedOracleRequestEthCost(client, managerAddress),
 	}
 	const { hash, receipt } = await writeContractAndWaitForReceipt(client, () => callParams)
+	const queuedOperation = getStagedOracleQueuedResult(receipt, 'liquidation')
 	const stagedExecution = getStagedOracleExecutionResult(receipt, 'liquidation')
 	return {
 		hash,
+		...(queuedOperation === undefined ? {} : { queuedOperation }),
 		...(stagedExecution === undefined ? {} : { stagedExecution }),
 	}
 }
@@ -1848,10 +1875,12 @@ export async function queueOracleManagerOperation(client: WriteClient, managerAd
 		value: await loadBufferedOracleRequestEthCost(client, managerAddress),
 	}
 	const { hash, receipt } = await writeContractAndWaitForReceipt(client, () => callParams)
+	const queuedOperation = getStagedOracleQueuedResult(receipt, operation)
 	const stagedExecution = getStagedOracleExecutionResult(receipt, operation)
 	return {
 		action: 'queueOperation',
 		hash,
+		...(queuedOperation === undefined ? {} : { queuedOperation }),
 		...(stagedExecution === undefined ? {} : { stagedExecution }),
 	} satisfies OpenOracleActionResult
 }

--- a/ui/ts/hooks/useSecurityPoolsOverview.ts
+++ b/ui/ts/hooks/useSecurityPoolsOverview.ts
@@ -131,6 +131,7 @@ export function useSecurityPoolsOverview({ accountAddress, onTransactionFailed, 
 					const nextResult: SecurityPoolOverviewActionResult = {
 						action: 'queueLiquidation',
 						hash: result.hash,
+						...(result.queuedOperation === undefined ? {} : { queuedOperation: result.queuedOperation }),
 						securityPoolAddress,
 						...(result.stagedExecution === undefined ? {} : { stagedExecution: result.stagedExecution }),
 					}

--- a/ui/ts/hooks/useSecurityVaultOperations.ts
+++ b/ui/ts/hooks/useSecurityVaultOperations.ts
@@ -325,6 +325,7 @@ export function useSecurityVaultOperations({ accountAddress, enabled, onTransact
 				return {
 					action: 'queueSetSecurityBondAllowance',
 					hash: result.hash,
+					...(result.queuedOperation === undefined ? {} : { queuedOperation: result.queuedOperation }),
 					...(result.stagedExecution === undefined ? {} : { stagedExecution: result.stagedExecution }),
 				} satisfies SecurityVaultActionResult
 			},
@@ -386,6 +387,7 @@ export function useSecurityVaultOperations({ accountAddress, enabled, onTransact
 				return {
 					action: 'queueWithdrawRep',
 					hash: result.hash,
+					...(result.queuedOperation === undefined ? {} : { queuedOperation: result.queuedOperation }),
 					...(result.stagedExecution === undefined ? {} : { stagedExecution: result.stagedExecution }),
 				} satisfies SecurityVaultActionResult
 			},

--- a/ui/ts/lib/liquidationStatus.ts
+++ b/ui/ts/lib/liquidationStatus.ts
@@ -16,6 +16,7 @@ export function getLiquidationNoticeState({
 }): LiquidationNoticeState | undefined {
 	if (securityPoolOverviewResult?.action !== 'queueLiquidation') return undefined
 	if (securityPoolOverviewResult.stagedExecution !== undefined) return securityPoolOverviewResult.stagedExecution.success ? 'successful' : 'failed'
+	if (securityPoolOverviewResult.queuedOperation?.operation === 'liquidation') return 'queued'
 	if (loadingPoolOracleManager || currentPoolOracleManagerDetails === undefined) return 'submitted'
 	if (currentPoolOracleManagerDetails.pendingOperation?.operation === 'liquidation' && sameAddress(currentPoolOracleManagerDetails.pendingOperation.targetVault, liquidationTargetVault)) return 'queued'
 	if (currentPoolOracleManagerDetails.isPriceValid) return 'successful'

--- a/ui/ts/lib/transactionPresentations.tsx
+++ b/ui/ts/lib/transactionPresentations.tsx
@@ -245,10 +245,16 @@ export function createSecurityVaultTransactionIntent(actionName: SecurityVaultAc
 }
 
 export function createSecurityVaultSuccessPresentation(result: SecurityVaultActionResult) {
+	let queuedOperationDetail: string | undefined
+	if (result.queuedOperation !== undefined) {
+		queuedOperationDetail = result.queuedOperation.isPendingSlot
+			? `Staged operation #${result.queuedOperation.operationId.toString()} was queued for the next oracle settlement.`
+			: `Staged operation #${result.queuedOperation.operationId.toString()} was queued and must be executed manually after a valid oracle price is available.`
+	}
 	return buildPresentation({
-		detail: `${humanizeAction(result.action)} completed successfully.`,
+		detail: queuedOperationDetail ?? `${humanizeAction(result.action)} completed successfully.`,
 		hash: result.hash,
-		rows: [{ label: 'Action', value: humanizeAction(result.action) }],
+		rows: [{ label: 'Action', value: humanizeAction(result.action) }, ...(result.queuedOperation === undefined ? [] : [{ label: 'Staged Operation', value: `#${result.queuedOperation.operationId.toString()}` }])],
 		title: humanizeAction(result.action),
 		tone: 'success',
 	})
@@ -323,10 +329,16 @@ export function createLiquidationTransactionIntent() {
 }
 
 export function createLiquidationSuccessPresentation(result: SecurityPoolOverviewActionResult) {
+	let queuedOperationDetail = 'The liquidation request was submitted successfully.'
+	if (result.queuedOperation !== undefined) {
+		queuedOperationDetail = result.queuedOperation.isPendingSlot
+			? `Liquidation staged as operation #${result.queuedOperation.operationId.toString()} for the next oracle settlement.`
+			: `Liquidation staged as operation #${result.queuedOperation.operationId.toString()} and must be executed manually after a valid oracle price is available.`
+	}
 	return buildPresentation({
-		detail: result.stagedExecution?.success === true ? 'The liquidation executed immediately.' : 'The liquidation request was submitted successfully.',
+		detail: result.stagedExecution?.success === true ? 'The liquidation executed immediately.' : queuedOperationDetail,
 		hash: result.hash,
-		rows: [{ label: 'Pool', value: <AddressValue address={result.securityPoolAddress} /> }],
+		rows: [{ label: 'Pool', value: <AddressValue address={result.securityPoolAddress} /> }, ...(result.queuedOperation === undefined ? [] : [{ label: 'Staged Operation', value: `#${result.queuedOperation.operationId.toString()}` }])],
 		title: result.stagedExecution?.success === true ? 'Liquidation Executed' : 'Liquidation Submitted',
 		tone: 'success',
 	})

--- a/ui/ts/tests/liquidationModal.test.tsx
+++ b/ui/ts/tests/liquidationModal.test.tsx
@@ -326,6 +326,41 @@ describe('LiquidationModal', () => {
 		expect(selectedViews).toEqual(['staged-operations'])
 	})
 
+	test('shows manual execution guidance for off-slot queued liquidations', async () => {
+		const renderedComponent = await renderLiquidationModal({
+			currentPoolOracleManagerDetails: createOracleManagerDetails({
+				isPriceValid: false,
+				pendingOperation: {
+					amount: 5n,
+					initiatorVault: zeroAddress,
+					operation: 'withdrawRep',
+					operationId: 8n,
+					targetVault: '0x0000000000000000000000000000000000000001',
+				},
+				pendingOperationSlotId: 8n,
+			}),
+			liquidationAmount: '5',
+			liquidationMaxAmount: 5n * 10n ** 18n,
+			liquidationTargetVault: zeroAddress,
+			securityPoolOverviewResult: {
+				action: 'queueLiquidation',
+				hash: '0x00000000000000000000000000000000000000000000000000000000000000ac',
+				queuedOperation: {
+					isPendingSlot: false,
+					operation: 'liquidation',
+					operationId: 10n,
+				},
+				securityPoolAddress: zeroAddress,
+			},
+		})
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByRole('heading', { name: 'Liquidation Queued' })).not.toBeNull()
+		expect(documentQueries.getByText('#10')).not.toBeNull()
+		expect(documentQueries.getByText('Another staged operation already holds the auto-execute slot. Execute this staged operation manually with its id after a valid oracle price is available.')).not.toBeNull()
+	})
+
 	test('shows immediate execution when liquidation uses an already valid oracle price', async () => {
 		const renderedComponent = await renderLiquidationModal({
 			currentPoolOracleManagerDetails: createOracleManagerDetails({

--- a/ui/ts/tests/openOracle.test.ts
+++ b/ui/ts/tests/openOracle.test.ts
@@ -2,7 +2,7 @@
 
 import { beforeAll, beforeEach, describe, expect, setDefaultTimeout, test } from 'bun:test'
 import { getAddress, zeroAddress, type Address } from 'viem'
-import { createOpenOracleReportInstance, getOpenOracleAddress, loadErc20Balance, loadOpenOracleReportDetails, loadOpenOracleReportSummaries, loadOracleManagerDetails, requestOraclePrice, settleOracleReport, submitInitialOracleReport, wrapWeth as wrapUiWeth } from '../contracts.js'
+import { createOpenOracleReportInstance, getOpenOracleAddress, loadErc20Balance, loadOpenOracleReportDetails, loadOpenOracleReportSummaries, loadOracleManagerDetails, queueOracleManagerOperation, requestOraclePrice, settleOracleReport, submitInitialOracleReport, wrapWeth as wrapUiWeth } from '../contracts.js'
 import {
 	addOpenOracleBountyBuffer,
 	deriveOpenOracleDisputeSubmissionDetails,
@@ -983,6 +983,31 @@ describe('Open Oracle helpers', () => {
 		expect(details.pendingOperation?.operation).toBe('setSecurityBondsAllowance')
 		expect(details.pendingOperation?.amount).toBe(0n)
 		expect(details.pendingOperation?.targetVault).toBe(client.account.address)
+	})
+
+	test('queueOracleManagerOperation returns queued operation metadata for the pending slot', async () => {
+		const result = await queueOracleManagerOperation(uiWriteClient, managerAddress, 'setSecurityBondsAllowance', client.account.address, 0n)
+
+		expect(result.queuedOperation).toBeDefined()
+		expect(result.queuedOperation?.isPendingSlot).toBe(true)
+		expect(result.queuedOperation?.operation).toBe('setSecurityBondsAllowance')
+		expect(result.queuedOperation?.operationId).toBeGreaterThan(0n)
+		expect(result.stagedExecution).toBeUndefined()
+	})
+
+	test('queueOracleManagerOperation preserves incremental ids when another pending slot already exists', async () => {
+		const firstResult = await queueOracleManagerOperation(uiWriteClient, managerAddress, 'setSecurityBondsAllowance', client.account.address, 0n)
+		const secondResult = await queueOracleManagerOperation(uiWriteClient, managerAddress, 'withdrawRep', client.account.address, 1n)
+		const details = await loadOracleManagerDetails(uiReadClient, managerAddress)
+		const firstOperationId = firstResult.queuedOperation?.operationId
+		if (firstOperationId === undefined) throw new Error('Expected the first queued operation id to be defined')
+
+		expect(firstResult.queuedOperation?.isPendingSlot).toBe(true)
+		expect(secondResult.queuedOperation).toBeDefined()
+		expect(secondResult.queuedOperation?.isPendingSlot).toBe(false)
+		expect(secondResult.queuedOperation?.operationId).toBeGreaterThan(firstOperationId)
+		expect(details.pendingOperationSlotId).toBe(firstOperationId)
+		expect(details.pendingOperation?.operationId).toBe(firstOperationId)
 	})
 
 	test('submitted and settled reports are tracked in loadOpenOracleReportDetails', async () => {

--- a/ui/ts/tests/securityPoolWorkflowSection.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection.test.tsx
@@ -970,6 +970,63 @@ describe('SecurityPoolWorkflowSection', () => {
 		expect(dialogQueries.getByRole('heading', { name: 'REP Withdrawal Queued' })).not.toBeNull()
 	})
 
+	test('shows manual execution guidance for off-slot queued withdrawals', async () => {
+		const selectedPoolAddress = zeroAddress
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					accountState: createAccountState(),
+					poolOracleManagerDetails: createOracleManagerDetails({
+						isPriceValid: false,
+						pendingOperation: {
+							amount: 3n * 10n ** 18n,
+							initiatorVault: zeroAddress,
+							operation: 'liquidation',
+							operationId: 6n,
+							targetVault: '0x0000000000000000000000000000000000000001',
+						},
+						pendingOperationSlotId: 6n,
+					}),
+					securityPoolAddress: selectedPoolAddress,
+					securityPools: [createSelectedPool({ securityPoolAddress: selectedPoolAddress })],
+					securityVault: createSecurityVaultProps({
+						securityVaultDetails: createSecurityVaultDetails(),
+						securityVaultForm: {
+							depositAmount: '',
+							repWithdrawAmount: '1',
+							securityBondAllowanceAmount: '',
+							securityPoolAddress: selectedPoolAddress,
+							selectedVaultAddress: zeroAddress,
+						},
+						securityVaultResult: {
+							action: 'queueWithdrawRep',
+							hash: '0x00000000000000000000000000000000000000000000000000000000000000bc',
+							queuedOperation: {
+								isPendingSlot: false,
+								operation: 'withdrawRep',
+								operationId: 11n,
+							},
+						},
+					}),
+					selectedPoolView: 'vaults',
+				})}
+				showHeader={false}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		await act(() => {
+			fireEvent.click(documentQueries.getAllByRole('button', { name: 'Withdraw REP' })[0] as HTMLElement)
+		})
+
+		const withdrawDialog = documentQueries.getByRole('dialog', { name: 'Withdraw REP' })
+		const dialogQueries = within(withdrawDialog)
+		expect(dialogQueries.getByRole('heading', { name: 'REP Withdrawal Queued' })).not.toBeNull()
+		expect(dialogQueries.getByText('#11')).not.toBeNull()
+		expect(dialogQueries.getByText('Another staged operation already holds the auto-execute slot. Execute this staged operation manually with its id after a valid oracle price is available.')).not.toBeNull()
+	})
+
 	test('shows immediate execution when a withdraw uses an already valid oracle price', async () => {
 		const selectedPoolAddress = zeroAddress
 		const renderedComponent = await renderIntoDocument(
@@ -1559,7 +1616,7 @@ describe('SecurityPoolWorkflowSection', () => {
 		expect(reportingLoadCalls).toEqual(['refresh'])
 	})
 
-	test('does not refresh the selected pool after a failed staged operation execution', async () => {
+	test('refreshes the selected pool after a failed staged operation execution', async () => {
 		const refreshSelectedPoolCalls: Array<string | undefined> = []
 		const loadSecurityVaultCalls: Array<string | undefined> = []
 		const selectedPoolAddress = zeroAddress
@@ -1606,7 +1663,7 @@ describe('SecurityPoolWorkflowSection', () => {
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		expect(refreshSelectedPoolCalls).toEqual([])
+		expect(refreshSelectedPoolCalls).toEqual([selectedPoolAddress])
 		expect(loadSecurityVaultCalls).toEqual([])
 	})
 

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -117,6 +117,7 @@ export type TransactionStatusCardProps = {
 	className?: string
 	detail?: ComponentChildren
 	metrics?: ComponentChildren
+	secondaryDetail?: ComponentChildren
 	title: ComponentChildren
 }
 export type RouteHeaderProps = {

--- a/ui/ts/types/contracts.ts
+++ b/ui/ts/types/contracts.ts
@@ -38,6 +38,12 @@ export type StagedOracleExecutionResult = {
 	success: boolean
 }
 
+export type StagedOracleQueuedResult = {
+	isPendingSlot: boolean
+	operation: OracleQueueOperation
+	operationId: bigint
+}
+
 export type QuestionData = {
 	title: string
 	description: string
@@ -149,6 +155,7 @@ export type SecurityVaultDetails = {
 
 export type SecurityVaultActionResult = ActionResult & {
 	action: 'approveRep' | 'depositRep' | 'queueSetSecurityBondAllowance' | 'queueWithdrawRep' | 'redeemFees' | 'redeemRep' | 'updateVaultFees'
+	queuedOperation?: StagedOracleQueuedResult
 	stagedExecution?: StagedOracleExecutionResult
 }
 
@@ -171,6 +178,7 @@ export type OracleManagerDetails = {
 
 export type OpenOracleActionResult = ActionResult & {
 	action: 'approveToken1' | 'approveToken2' | 'createReportInstance' | 'dispute' | 'executeStagedOperation' | 'queueOperation' | 'requestPrice' | 'settle' | 'submitInitialReport' | 'wrapWeth'
+	queuedOperation?: StagedOracleQueuedResult
 	stagedExecution?: StagedOracleExecutionResult
 }
 
@@ -281,6 +289,7 @@ export type SecurityPoolVaultSummary = {
 
 export type SecurityPoolOverviewActionResult = ActionResult & {
 	action: 'queueLiquidation'
+	queuedOperation?: StagedOracleQueuedResult
 	securityPoolAddress: Address
 	stagedExecution?: StagedOracleExecutionResult
 }


### PR DESCRIPTION
## Summary
- Updated `SecurityPoolOracleCoordinator` to emit `StagedOperationQueued`, retain operation ids on failed auto-execution attempts, and always record operation consumption while preserving auditability of attempted staged operations.
- Added `isPendingSlot` tracking so only one staged operation is designated for auto execution on the next oracle update while others are queued for manual execution.
- Extended oracle contract parsing to decode `StagedOperationQueued` logs and expose `queuedOperation` metadata in write results.
- Propagated queued-operation metadata through pool/vault hooks and contract result typings into modal/transaction presentation flows.
- Updated liquidation and vault queued-state UIs to distinguish `queued` vs `manual-queued`, hide amount when unavailable, and show explicit manual-execution guidance.
- Improved staged execution refresh behavior to continue refreshing selected pool state when a staged operation fails.
- Added regression coverage for queued-operation metadata and off-slot/manual execution guidance in liquidation, open-oracle, and workflow tests.

## Testing
- Not run (no commands executed in this environment).