### PR TITLE
Refine openOracle coordinator callback flow and simplify fee handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"generate:ui": "bun run generate:shared-js && bun run ui:shared && bun run generate:ui-vendor",
 		"setup": "bun install --frozen-lockfile && cd ui && bun install --frozen-lockfile && cd .. && bun run setup-contracts && bun run shared:build && bun run ui:vendor && cd ui && bun run build && bun run build:tests",
 		"setup-contracts": "cd solidity && bun run setup",
-		"compile-contracts": "cd solidity && bun x tsc --project tsconfig-compile.json && node ./js/compile.js && cd .. && bun run generate:ui-contract-artifact",
+		"compile-contracts": "cd solidity && bun x tsc --project tsconfig-compile.json && bun ./js/compile.js && cd .. && bun run generate:ui-contract-artifact",
 		"generate": "bun run generate:contracts && bun run generate:ui",
 		"tsc:app": "bun x tsc --noEmit",
 		"tsc:scripts": "bun x tsc --project tsconfig.scripts.json --noEmit",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"generate:ui": "bun run generate:shared-js && bun run ui:shared && bun run generate:ui-vendor",
 		"setup": "bun install --frozen-lockfile && cd ui && bun install --frozen-lockfile && cd .. && bun run setup-contracts && bun run shared:build && bun run ui:vendor && cd ui && bun run build && bun run build:tests",
 		"setup-contracts": "cd solidity && bun run setup",
-		"compile-contracts": "cd solidity && bun x tsc --project tsconfig-compile.json && bun run ./js/compile.js && cd .. && bun run generate:ui-contract-artifact",
+		"compile-contracts": "cd solidity && bun x tsc --project tsconfig-compile.json && node ./js/compile.js && cd .. && bun run generate:ui-contract-artifact",
 		"generate": "bun run generate:contracts && bun run generate:ui",
 		"tsc:app": "bun x tsc --noEmit",
 		"tsc:scripts": "bun x tsc --project tsconfig.scripts.json --noEmit",

--- a/shared/ts/deploymentAddresses.ts
+++ b/shared/ts/deploymentAddresses.ts
@@ -36,6 +36,10 @@ type InfraContractAddressConfig = {
 	securityPoolUtilsBytecode: Hex
 	uniformPriceDualCapBatchAuctionFactoryBytecode: Hex
 	zeroSalt: Hex
+	openOracleCreate2Inputs?: {
+		proxyDeployerAddress: Address
+		salt: Hex
+	}
 	getZoltarAddress: () => Address
 	getZoltarQuestionDataAddress: () => Address
 }
@@ -101,7 +105,7 @@ export function createInfraContractAddressHelper(config: InfraContractAddressCon
 		const addresses = {
 			multicall3: getProxyDeployerCreate2Address(config.proxyDeployerAddress, config.zeroSalt, config.multicall3Bytecode),
 			securityPoolUtils: getProxyDeployerCreate2Address(config.proxyDeployerAddress, config.zeroSalt, config.securityPoolUtilsBytecode),
-			openOracle: getProxyDeployerCreate2Address(config.proxyDeployerAddress, config.zeroSalt, config.openOracleBytecode),
+			openOracle: getProxyDeployerCreate2Address(config.openOracleCreate2Inputs?.proxyDeployerAddress ?? config.proxyDeployerAddress, config.openOracleCreate2Inputs?.salt ?? config.zeroSalt, config.openOracleBytecode),
 			zoltarQuestionData: config.getZoltarQuestionDataAddress(),
 			zoltar: config.getZoltarAddress(),
 			shareTokenFactory: getProxyDeployerCreate2Address(config.proxyDeployerAddress, config.zeroSalt, config.getShareTokenFactoryByteCode(config.getZoltarAddress())),

--- a/solidity/contracts/peripherals/SecurityPoolOracleCoordinator.sol
+++ b/solidity/contracts/peripherals/SecurityPoolOracleCoordinator.sol
@@ -8,6 +8,7 @@ import { ISecurityPool } from './interfaces/ISecurityPool.sol';
 
 // price oracle
 uint256 constant PRICE_VALID_FOR_SECONDS = 1 hours;
+uint256 constant PRICE_PRECISION = 1e18;
 
 enum OperationType {
 	Liquidation,
@@ -47,9 +48,7 @@ contract SecurityPoolOracleCoordinator {
 	uint16 public immutable multiplier;
 	bool public immutable timeType;
 	bool public immutable trackDisputes;
-	bool public immutable keepFee;
 	address public immutable protocolFeeRecipient;
-	bool public immutable feeToken;
 
 	event PriceReported(uint256 reportId, uint256 price);
 	event StagedOperationQueued(uint256 operationId, OperationType operation, address initiatorVault, address targetVault, uint256 amount, bool isPendingSlot);
@@ -74,9 +73,7 @@ contract SecurityPoolOracleCoordinator {
 		uint16 _multiplier,
 		bool _timeType,
 		bool _trackDisputes,
-		bool _keepFee,
-		address _protocolFeeRecipient,
-		bool _feeToken
+		address _protocolFeeRecipient
 	) {
 		reputationToken = _reputationToken;
 		openOracle = _openOracle;
@@ -91,9 +88,7 @@ contract SecurityPoolOracleCoordinator {
 		multiplier = _multiplier;
 		timeType = _timeType;
 		trackDisputes = _trackDisputes;
-		keepFee = _keepFee;
 		protocolFeeRecipient = _protocolFeeRecipient;
-		feeToken = _feeToken;
 	}
 
 	function setSecurityPool(ISecurityPool _securityPool) public {
@@ -107,20 +102,23 @@ contract SecurityPoolOracleCoordinator {
 	}
 
 	function getRequestPriceEthCost() public view returns (uint256) {
-		// https://github.com/j0i0m0b0o/openOracleBase/blob/feeTokenChange/src/OpenOracle.sol#L100
 		uint256 ethCost = block.basefee * 4 * (gasConsumedSettlement + gasConsumedOpenOracleReportPrice) + 101;
 		return ethCost;
 	}
 	function requestPrice() public payable {
 		require(pendingReportId == 0, 'Already pending request');
-		// https://github.com/j0i0m0b0o/openOracleBase/blob/feeTokenChange/src/OpenOracle.sol#L100
 		uint256 ethCost = getRequestPriceEthCost();
 		require(msg.value >= ethCost, 'not big enough eth bounty');
+		uint256 escalationHalt = reputationToken.totalSupply() / 100000;
+		uint256 settlerReward = block.basefee * 2 * gasConsumedOpenOracleReportPrice;
+		require(exactToken1Report <= type(uint128).max, 'exactToken1Report too large');
+		require(escalationHalt <= type(uint128).max, 'escalation halt too large');
+		require(settlerReward <= type(uint96).max, 'settler reward too large');
 
 		OpenOracle.CreateReportParams memory reportparams = OpenOracle.CreateReportParams({
-			exactToken1Report: exactToken1Report,
-			escalationHalt: reputationToken.totalSupply() / 100000, // amount of token1 past which escalation stops but disputes can still happen
-			settlerReward: block.basefee * 2 * gasConsumedOpenOracleReportPrice, // eth paid to settler in wei
+			exactToken1Report: uint128(exactToken1Report),
+			escalationHalt: uint128(escalationHalt), // amount of token1 past which escalation stops but disputes can still happen
+			settlerReward: uint96(settlerReward), // eth paid to settler in wei
 			token1Address: address(reputationToken), // address of token1 in the oracle report instance
 			settlementTime: settlementTime,
 			disputeDelay: disputeDelay,
@@ -131,11 +129,8 @@ contract SecurityPoolOracleCoordinator {
 			multiplier: multiplier,
 			timeType: timeType,
 			trackDisputes: trackDisputes,
-			keepFee: keepFee,
 			callbackContract: address(this), // contract address for settle to call back into
-			callbackSelector: this.openOracleReportPrice.selector, // method in the callbackContract you want called.
-			protocolFeeRecipient: protocolFeeRecipient,
-			feeToken: feeToken
+			protocolFeeRecipient: protocolFeeRecipient
 		});
 
 		pendingReportId = openOracle.createReportInstance{value: ethCost}(reportparams);
@@ -147,12 +142,12 @@ contract SecurityPoolOracleCoordinator {
 			require(sent, 'failed to refund excess');
 		}
 	}
-	function openOracleReportPrice(uint256 reportId, uint256 price, uint256, address, address) external {
+	function openOracleCallback(uint256 reportId, uint256 amount1, uint256 amount2, uint256, address, address) external {
 		require(msg.sender == address(openOracle), 'only open oracle can call');
 		require(reportId == pendingReportId, 'not report created by us');
 		pendingReportId = 0;
 		lastSettlementTimestamp = block.timestamp;
-		lastPrice = price;
+		lastPrice = amount2 == 0 ? 0 : (amount1 * PRICE_PRECISION) / amount2;
 		emit PriceReported(reportId, lastPrice);
 		if (pendingOperationSlotId != 0) { // TODO we maybe should allow executing couple operations?
 			uint256 operationId = pendingOperationSlotId;

--- a/solidity/contracts/peripherals/factories/PriceOracleManagerAndOperatorQueuerFactory.sol
+++ b/solidity/contracts/peripherals/factories/PriceOracleManagerAndOperatorQueuerFactory.sol
@@ -20,9 +20,7 @@ contract PriceOracleManagerAndOperatorQueuerFactory {
 	uint16 public immutable multiplier;
 	bool public immutable timeType;
 	bool public immutable trackDisputes;
-	bool public immutable keepFee;
 	address public immutable protocolFeeRecipient;
-	bool public immutable feeToken;
 
 	constructor(
 		IWeth9 _weth,
@@ -36,9 +34,7 @@ contract PriceOracleManagerAndOperatorQueuerFactory {
 		uint16 _multiplier,
 		bool _timeType,
 		bool _trackDisputes,
-		bool _keepFee,
-		address _protocolFeeRecipient,
-		bool _feeToken
+		address _protocolFeeRecipient
 	) {
 		weth = _weth;
 		gasConsumedOpenOracleReportPrice = _gasConsumedOpenOracleReportPrice;
@@ -51,9 +47,7 @@ contract PriceOracleManagerAndOperatorQueuerFactory {
 		multiplier = _multiplier;
 		timeType = _timeType;
 		trackDisputes = _trackDisputes;
-		keepFee = _keepFee;
 		protocolFeeRecipient = _protocolFeeRecipient;
-		feeToken = _feeToken;
 	}
 
 	function deployPriceOracleManagerAndOperatorQueuer(OpenOracle _openOracle, ReputationToken _reputationToken, bytes32 salt) external returns (SecurityPoolOracleCoordinator) {
@@ -71,9 +65,7 @@ contract PriceOracleManagerAndOperatorQueuerFactory {
 			multiplier,
 			timeType,
 			trackDisputes,
-			keepFee,
-			protocolFeeRecipient,
-			feeToken
+			protocolFeeRecipient
 		);
 	}
 }

--- a/solidity/contracts/peripherals/openOracle/OpenOracle.sol
+++ b/solidity/contracts/peripherals/openOracle/OpenOracle.sol
@@ -1,43 +1,62 @@
 // SPDX-License-Identifier: MIT
-// copied from https://github.com/j0i0m0b0o/openOracleBase
-pragma solidity 0.8.35;
+pragma solidity 0.8.28;
 
-import {ReentrancyGuard} from "./openzeppelin/contracts/utils/ReentrancyGuard.sol";
-import {IERC20} from "./openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {SafeERC20} from "./openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 /**
  * @title OpenOracle
  * @notice A trust-free price oracle that uses an escalating auction mechanism
  * @dev This contract enables price discovery through economic incentives where
- *      expiration serves as evidence of a good price with appropriate parameters
+ *      expiration serves as evidence of a good price with appropriate parameters.
+ *      Participants are responsible for validating report instance parameters before participation
+ *      and unsafe parameter sets including but not limited to settlementTime too high and callbackGasLimit too high
+ *      will result in lost funds.
  * @author OpenOracle Team
  * @custom:version 0.1.6
- * @custom:documentation https://openprices.gitbook.io/openoracle-docs
+ * @custom:documentation https://docs.openoracle.org
  */
+
 contract OpenOracle is ReentrancyGuard {
     using SafeERC20 for IERC20;
 
     // Custom errors for gas optimization
-    error InvalidInput(string parameter);
-    error InsufficientAmount(string resource);
-    error AlreadyProcessed(string action);
-    error InvalidTiming(string action);
-    error OutOfBounds(string parameter);
     error TokensCannotBeSame();
     error NoReportToDispute();
     error EthTransferFailed();
-    error CallToArbSysFailed();
-    error InvalidAmount2(string parameter);
-    error InvalidStateHash(string parameter);
+    error InvalidAmount1();
+    error InvalidAmount2();
+    error InvalidStateHash();
     error InvalidGasLimit();
+    error SettleTooEarly();
+    error AlreadySettled();
+    error ExactToken1CannotBeZero();
+    error SettleVsDisputeDelayTiming();
+    error MsgValueTooLow();
+    error MsgValueTooHigh();
+    error FeesTooHigh();
+    error MultiplierTooLow();
+    error ReportAlreadySubmitted();
+    error InvalidReportId();
+    error AddressCannotBeZero();
+    error InvalidAmount2Expected();
+    error InvalidTokenToSwap();
+    error NoReportYet();
+    error EscalationHalted();
+    error AmountsCannotBeZero();
+    error DisputeTooLate();
+    error DisputeTooEarly();
+    error NewPriceInsideFeeBoundary();
+    error ReportNotSettled();
 
     // Constants
-    uint256 public constant PRICE_PRECISION = 1e18;
+    uint256 public constant PRICE_PRECISION = 1e30;
     uint256 public constant PERCENTAGE_PRECISION = 1e7;
     uint256 public constant MULTIPLIER_PRECISION = 100;
-    uint256 public constant SETTLEMENT_WINDOW = 60; // 60 seconds for testing
-    uint256 public constant SETTLEMENT_WINDOW_BLOCKS = 1350; // 5 minutes @ 4.5 blocks per second on Arbitrum
+    bytes4 internal constant CALLBACK_SELECTOR =
+        bytes4(keccak256("openOracleCallback(uint256,uint256,uint256,uint256,address,address)"));
 
     // State variables
     uint256 public nextReportId = 1;
@@ -50,8 +69,8 @@ contract OpenOracle is ReentrancyGuard {
     mapping(uint256 => mapping(uint256 => disputeRecord)) public disputeHistory;
 
     struct disputeRecord {
-        uint256 amount1;
-        uint256 amount2;
+        uint128 amount1;
+        uint128 amount2;
         address tokenToSwap;
         uint48 reportTimestamp;
     }
@@ -61,19 +80,15 @@ contract OpenOracle is ReentrancyGuard {
         address callbackContract;
         uint32 numReports;
         uint32 callbackGasLimit;
-        bytes4 callbackSelector;
         address protocolFeeRecipient;
         bool trackDisputes;
-        bool keepFee;
-        bool feeToken;
     }
 
-    // Type declarations
     struct ReportMeta {
-        uint256 exactToken1Report;
-        uint256 escalationHalt;
-        uint256 fee;
-        uint256 settlerReward;
+        uint128 exactToken1Report;
+        uint128 escalationHalt;
+        uint96 fee;
+        uint96 settlerReward;
         address token1;
         uint48 settlementTime;
         address token2;
@@ -85,23 +100,19 @@ contract OpenOracle is ReentrancyGuard {
     }
 
     struct ReportStatus {
-        uint256 currentAmount1;
-        uint256 currentAmount2;
-        uint256 price;
+        uint128 currentAmount1;
+        uint128 currentAmount2;
         address payable currentReporter;
         uint48 reportTimestamp;
         uint48 settlementTimestamp;
         address payable initialReporter;
         uint48 lastReportOppoTime;
-        bool disputeOccurred;
-        bool isDistributed;
     }
 
-    //initial reporter reward is paid to the initial reporter and is msg.value - settlerReward
     struct CreateReportParams {
-        uint256 exactToken1Report; // initial oracle liquidity in token1
-        uint256 escalationHalt; // amount of token1 past which escalation stops but disputes can still happen
-        uint256 settlerReward; // eth paid to settler in wei
+        uint128 exactToken1Report; // initial oracle liquidity in token1
+        uint128 escalationHalt; // amount of token1 at which escalation stops but disputes can still happen
+        uint96 settlerReward; // eth paid to settler in wei
         address token1Address; // address of token1 in the oracle report instance
         uint48 settlementTime; // report instance can settle if no disputes within this timeframe
         uint24 disputeDelay; // time disputes must wait after every new report
@@ -109,86 +120,55 @@ contract OpenOracle is ReentrancyGuard {
         address token2Address; // address of token2 in the oracle report instance
         uint32 callbackGasLimit; // gas the settlement callback must use
         uint24 feePercentage; // fee paid to previous reporter. 1000 = 0.01%
-        uint16 multiplier; // amount by which newAmount1 must increase versus old amount1. 140 = 1.4x
+        uint16 multiplier; // amount by which newAmount1 must increase versus old amount1. 140 = 1.4x. 100 = no escalation.
         bool timeType; // true for block timestamp, false for block number
         bool trackDisputes; // true keeps a readable dispute history for smart contracts
-        bool keepFee; // true means initial reporter keeps the initial reporter reward if disputed. if false, it goes to protocolFeeRecipient if disputed
         address callbackContract; // contract address for settle to call back into
-        bytes4 callbackSelector; // method in the callbackContract you want called.
         address protocolFeeRecipient; // address that receives protocol fees and initial reporter rewards if keepFee set to false
-        bool feeToken; //if true, protocol fees + fees paid to previous reporter are in tokenToSwap. if false, in not(tokenToSwap)
-    } //typically if feeToken true, fees are paid in less valuable token, if false, fees paid in more valuable token
+    }
 
     // Events
     event ReportInstanceCreated(
         uint256 indexed reportId,
         address indexed token1Address,
         address indexed token2Address,
-        uint256 feePercentage,
-        uint256 multiplier,
-        uint256 exactToken1Report,
-        uint256 ethFee,
         address creator,
-        uint256 settlementTime,
-        uint256 escalationHalt,
-        uint256 disputeDelay,
-        uint256 protocolFee,
-        uint256 settlerReward,
+        address protocolFeeRecipient,
+        uint128 exactToken1Report,
+        uint128 escalationHalt,
+        uint96 settlerReward,
+        uint96 reporterFee,
+        uint48 settlementTime,
+        uint24 disputeDelay,
+        uint24 feePercentage,
+        uint24 protocolFee,
+        uint16 multiplier,
         bool timeType,
-        address callbackContract,
-        bytes4 callbackSelector,
         bool trackDisputes,
-        uint256 callbackGasLimit,
-        bool keepFee,
+        address callbackContract,
+        uint32 callbackGasLimit,
         bytes32 stateHash,
-        uint256 blockTimestamp,
-        bool feeToken
+        uint256 blockTimestamp
     );
 
     event InitialReportSubmitted(
         uint256 indexed reportId,
-        address reporter,
-        uint256 amount1,
-        uint256 amount2,
-        address indexed token1Address,
-        address indexed token2Address,
-        uint256 swapFee,
-        uint256 protocolFee,
-        uint256 settlementTime,
-        uint256 disputeDelay,
-        uint256 escalationHalt,
-        bool timeType,
-        address callbackContract,
-        bytes4 callbackSelector,
-        bool trackDisputes,
-        uint256 callbackGasLimit,
-        bytes32 stateHash,
-        uint256 blockTimestamp
+        address indexed reporter,
+        uint128 amount1,
+        uint128 amount2,
+        uint48 reportTimestamp
     );
 
     event ReportDisputed(
         uint256 indexed reportId,
-        address disputer,
-        uint256 newAmount1,
-        uint256 newAmount2,
-        address indexed token1Address,
-        address indexed token2Address,
-        uint256 swapFee,
-        uint256 protocolFee,
-        uint256 settlementTime,
-        uint256 disputeDelay,
-        uint256 escalationHalt,
-        bool timeType,
-        address callbackContract,
-        bytes4 callbackSelector,
-        bool trackDisputes,
-        uint256 callbackGasLimit,
-        bytes32 stateHash,
-        uint256 blockTimestamp
+        address indexed disputer,
+        address indexed tokenToSwap,
+        uint128 newAmount1,
+        uint128 newAmount2,
+        uint48 reportTimestamp
     );
 
-    event ReportSettled(uint256 indexed reportId, uint256 price, uint256 settlementTimestamp, uint256 blockTimestamp);
-
+    event ReportSettled(uint256 indexed reportId, uint256 amount1, uint256 amount2, uint256 settlementTimestamp, uint256 blockTimestamp);
     event SettlementCallbackExecuted(uint256 indexed reportId, address indexed callbackContract, bool success);
 
     constructor() ReentrancyGuard() {}
@@ -197,12 +177,11 @@ contract OpenOracle is ReentrancyGuard {
      * @notice Withdraws accumulated protocol fees for a specific token
      * @param tokenToGet The token address to withdraw fees for
      */
-    function getProtocolFees(address tokenToGet) external nonReentrant returns (uint256) {
+    function getProtocolFees(address tokenToGet) external {
         uint256 amount = protocolFees[msg.sender][tokenToGet];
         if (amount > 0) {
             protocolFees[msg.sender][tokenToGet] = 0;
             _transferTokens(tokenToGet, address(this), msg.sender, amount);
-            return amount;
         }
     }
 
@@ -222,71 +201,60 @@ contract OpenOracle is ReentrancyGuard {
     /**
      * @notice Settles a report after the settlement time has elapsed
      * @param reportId The unique identifier for the report to settle
-     * @return price The final settled price
-     * @return settlementTimestamp The timestamp when the report was settled
      */
-    function settle(uint256 reportId) external nonReentrant returns (uint256 price, uint256 settlementTimestamp) {
+    function settle(uint256 reportId) external nonReentrant {
         ReportStatus storage status = reportStatus[reportId];
         ReportMeta storage meta = reportMeta[reportId];
 
+        if (status.settlementTimestamp != 0) revert AlreadySettled();
+
         if (meta.timeType) {
-            if (block.timestamp < status.reportTimestamp + meta.settlementTime) {
-                revert InvalidTiming("settlement");
-            }
+            if (block.timestamp < status.reportTimestamp + meta.settlementTime) revert SettleTooEarly();
         } else {
-            if (_getBlockNumber() < status.reportTimestamp + meta.settlementTime) {
-                revert InvalidTiming("settlement");
-            }
+            if (_getBlockNumber() < status.reportTimestamp + meta.settlementTime) revert SettleTooEarly();
         }
 
-        if (status.reportTimestamp == 0) revert InvalidInput("no initial report");
-
-        if (status.isDistributed) {
-            return status.isDistributed ? (status.price, status.settlementTimestamp) : (0, 0);
-        }
+        if (status.reportTimestamp == 0) revert NoReportYet();
 
         uint256 settlerReward = meta.settlerReward;
         uint256 reporterReward = meta.fee;
+        uint128 currentAmount1 = status.currentAmount1;
+        uint128 currentAmount2 = status.currentAmount2;
+        address payable currentReporter = status.currentReporter;
+        address token1 = meta.token1;
+        address token2 = meta.token2;
 
-        status.isDistributed = true;
         status.settlementTimestamp = meta.timeType ? uint48(block.timestamp) : _getBlockNumber();
-        emit ReportSettled(reportId, status.price, status.settlementTimestamp, block.timestamp);
+        emit ReportSettled(reportId, currentAmount1, currentAmount2, status.settlementTimestamp, block.timestamp);
 
         extraReportData storage extra = extraData[reportId];
+        address callbackContract = extra.callbackContract;
+        uint32 callbackGasLimit = extra.callbackGasLimit;
 
-        _transferTokens(meta.token1, address(this), status.currentReporter, status.currentAmount1);
-        _transferTokens(meta.token2, address(this), status.currentReporter, status.currentAmount2);
+        _transferTokens(token1, address(this), currentReporter, currentAmount1);
+        _transferTokens(token2, address(this), currentReporter, currentAmount2);
 
-        if (extra.callbackContract != address(0) && extra.callbackSelector != bytes4(0)) {
+        if (callbackContract != address(0)) {
             // Prepare callback data
             bytes memory callbackData = abi.encodeWithSelector(
-                extra.callbackSelector, reportId, status.price, status.settlementTimestamp, meta.token1, meta.token2
+                CALLBACK_SELECTOR, reportId, currentAmount1, currentAmount2, status.settlementTimestamp, token1, token2
             );
 
             // Execute callback with gas limit. Revert if not enough gas supplied to attempt callback fully.
             // Using low-level call to handle failures gracefully
-            if (gasleft() < ((64 * extra.callbackGasLimit + 62) / 63) + 100000) revert InvalidGasLimit();
-            (bool success,) = extra.callbackContract.call{gas: extra.callbackGasLimit}(callbackData);
+
+            (bool success,) = callbackContract.call{gas: callbackGasLimit}(callbackData);
+            if (gasleft() < callbackGasLimit / 63) {
+                revert InvalidGasLimit();
+            }
 
             // Emit event regardless of bool success
-            emit SettlementCallbackExecuted(reportId, extra.callbackContract, success);
+            emit SettlementCallbackExecuted(reportId, callbackContract, success);
         }
 
         // other external calls below (check-effect-interaction pattern)
-
-        if (status.disputeOccurred) {
-            if (extraData[reportId].keepFee) {
-                _sendEth(status.initialReporter, reporterReward);
-            } else {
-                accruedProtocolFees[extra.protocolFeeRecipient] += reporterReward;
-            }
-        } else {
-            _sendEth(status.initialReporter, reporterReward);
-        }
-
+        _sendEth(status.initialReporter, reporterReward);
         _sendEth(payable(msg.sender), settlerReward);
-
-        return status.isDistributed ? (status.price, status.settlementTimestamp) : (0, 0);
     }
 
     /**
@@ -297,35 +265,35 @@ contract OpenOracle is ReentrancyGuard {
      */
     function getSettlementData(uint256 reportId) external view returns (uint256 price, uint256 settlementTimestamp) {
         ReportStatus storage status = reportStatus[reportId];
-        if (!status.isDistributed) revert AlreadyProcessed("not settled");
-        return (status.price, status.settlementTimestamp);
+        if (status.settlementTimestamp == 0) revert ReportNotSettled();
+        return (Math.mulDiv(status.currentAmount1, PRICE_PRECISION, status.currentAmount2), status.settlementTimestamp);
     }
 
     /**
-     * @notice Creates a new report instance for price discovery. Backwards-compatible (timeType true)
+     * @notice Creates a new report instance for price discovery. Hard-codes certain oracle parameters.
      * @param token1Address Address of the first token
      * @param token2Address Address of the second token
-     * @param exactToken1Report Exact amount of token1 required for reports
+     * @param exactToken1Report Exact amount of token1 required for the initial report
      * @param feePercentage Fee in thousandths of basis points (3000 = 3bps)
      * @param multiplier Multiplier in percentage points (110 = 1.1x)
      * @param settlementTime Time in seconds before report can be settled
-     * @param escalationHalt Threshold where multiplier drops to 100
+     * @param escalationHalt Threshold at which multiplier drops to 100
      * @param disputeDelay Delay in seconds before disputes are allowed
      * @param protocolFee Protocol fee in thousandths of basis points
      * @param settlerReward Reward for settling the report in wei
-     * @return reportId The unique identifier for the created report
+     * @return reportId The unique identifier for the created report instance
      */
     function createReportInstance(
         address token1Address,
         address token2Address,
-        uint256 exactToken1Report,
+        uint128 exactToken1Report,
         uint24 feePercentage,
         uint16 multiplier,
         uint48 settlementTime,
-        uint256 escalationHalt,
+        uint128 escalationHalt,
         uint24 disputeDelay,
         uint24 protocolFee,
-        uint256 settlerReward
+        uint96 settlerReward
     ) external payable returns (uint256 reportId) {
         CreateReportParams memory params = CreateReportParams({
             token1Address: token1Address,
@@ -340,77 +308,100 @@ contract OpenOracle is ReentrancyGuard {
             settlerReward: settlerReward,
             timeType: true,
             callbackContract: address(0),
-            callbackSelector: bytes4(0),
             trackDisputes: false,
             callbackGasLimit: 0,
-            keepFee: true,
-            protocolFeeRecipient: msg.sender,
-            feeToken: true
+            protocolFeeRecipient: msg.sender
         });
         return _createReportInstance(params);
     }
 
-    //new function. full control over timeType. true = seconds, false = blocks
-    // not backwards compatible to previous createReportInstance (different function argument order!!)
+    /**
+     * @notice Creates a new report instance for price discovery.
+     * @param params Report creation parameters:
+     *   - token1Address: Address of the first token
+     *   - token2Address: Address of the second token
+     *   - exactToken1Report: Exact amount of token1 required for the initial report.
+     *   - feePercentage: Fee in thousandths of basis points (3000 = 0.03%)
+     *   - multiplier: Dispute amount1 multiplier in percentage points (110 = 1.1x). newAmount1 = oldAmount1 * multipier / 100
+     *   - settlementTime: Time before report can be settled
+     *   - escalationHalt: Threshold at which multiplier disappears and newAmount1 = oldAmount1 + 1
+     *   - disputeDelay: Delay in time before disputes are allowed
+     *   - protocolFee: Protocol fee in thousandths of basis points (3000 = 0.03%)
+     *   - settlerReward: Reward for settling the report in wei
+     *   - timeType: If true: time in seconds, if false: blocks
+     *   - callbackContract: Settle calls back into this address (callback signature is fixed: openOracleCallback(uint256 reportId, uint256 currentAmount1, uint256 currentAmount2, uint256 settlementTimestamp, address token1, address token2))
+     *   - trackDisputes: Optional dispute tracking for smart contracts
+     *   - callbackGasLimit: How much gas the callback must use. Must be safely < block gas limit or funds will be stuck
+     *   - protocolFeeRecipient: Address that receives accrued protocol fees & initial reporter reward if keepFee false
+     * @dev Initial reporter reward is msg.value in wei minus settlerReward
+     * @return reportId The unique identifier for the created report instance
+     */
     function createReportInstance(CreateReportParams calldata params) external payable returns (uint256 reportId) {
         return _createReportInstance(params);
     }
 
     function _createReportInstance(CreateReportParams memory params) internal returns (uint256 reportId) {
-        if (msg.value <= 100) revert InsufficientAmount("fee");
-        if (params.exactToken1Report == 0) revert InvalidInput("token amount");
+        if (params.exactToken1Report == 0) revert ExactToken1CannotBeZero();
         if (params.token1Address == params.token2Address) revert TokensCannotBeSame();
-        if (params.settlementTime < params.disputeDelay) revert InvalidTiming("settlement vs dispute delay");
-        if (msg.value <= params.settlerReward) revert InsufficientAmount("settler reward fee");
-        if (params.feePercentage == 0) revert InvalidInput("feePercentage 0");
-        if (params.feePercentage + params.protocolFee > 1e7) revert InvalidInput("sum of fees");
+        if (params.settlementTime < params.disputeDelay) revert SettleVsDisputeDelayTiming();
+
+        if (msg.value < params.settlerReward) revert MsgValueTooLow();
+        if (params.feePercentage + params.protocolFee > 1e7) revert FeesTooHigh();
+        if (params.multiplier < MULTIPLIER_PRECISION) revert MultiplierTooLow();
+
         reportId = nextReportId++;
 
         ReportMeta storage meta = reportMeta[reportId];
         meta.token1 = params.token1Address;
         meta.token2 = params.token2Address;
         meta.exactToken1Report = params.exactToken1Report;
-        meta.feePercentage = params.feePercentage;
+
+        if (params.feePercentage > 0) meta.feePercentage = params.feePercentage;
         meta.multiplier = params.multiplier;
         meta.settlementTime = params.settlementTime;
-        meta.fee = msg.value - params.settlerReward;
+
+        uint96 reporterFee;
+        if (msg.value > params.settlerReward) {
+            if (msg.value > type(uint96).max) revert MsgValueTooHigh();
+            reporterFee = uint96(msg.value) - params.settlerReward;
+            meta.fee = reporterFee;
+        }
+
         meta.escalationHalt = params.escalationHalt;
-        meta.disputeDelay = params.disputeDelay;
-        meta.protocolFee = params.protocolFee;
+
+        if (params.disputeDelay > 0) meta.disputeDelay = params.disputeDelay;
+        if (params.protocolFee > 0) meta.protocolFee = params.protocolFee;
         meta.settlerReward = params.settlerReward;
         meta.timeType = params.timeType;
 
         extraReportData storage extra = extraData[reportId];
         extra.callbackContract = params.callbackContract;
-        extra.callbackSelector = params.callbackSelector;
-        extra.trackDisputes = params.trackDisputes;
+        if (params.trackDisputes == true) extra.trackDisputes = params.trackDisputes;
         extra.callbackGasLimit = params.callbackGasLimit;
-        extra.keepFee = params.keepFee;
-        extra.protocolFeeRecipient = params.protocolFeeRecipient;
-        extra.feeToken = params.feeToken;
-
+        if (params.protocolFeeRecipient != address(0)) extra.protocolFeeRecipient = params.protocolFeeRecipient;
+        
         bytes32 stateHash = keccak256(
-            abi.encodePacked(
-                keccak256(abi.encodePacked(params.timeType)),
-                keccak256(abi.encodePacked(params.settlementTime)),
-                keccak256(abi.encodePacked(params.disputeDelay)),
-                keccak256(abi.encodePacked(params.callbackContract)),
-                keccak256(abi.encodePacked(params.callbackSelector)),
-                keccak256(abi.encodePacked(params.callbackGasLimit)),
-                keccak256(abi.encodePacked(params.keepFee)),
-                keccak256(abi.encodePacked(params.feePercentage)),
-                keccak256(abi.encodePacked(params.protocolFee)),
-                keccak256(abi.encodePacked(params.settlerReward)),
-                keccak256(abi.encodePacked(meta.fee)),
-                keccak256(abi.encodePacked(params.trackDisputes)),
-                keccak256(abi.encodePacked(params.multiplier)),
-                keccak256(abi.encodePacked(params.escalationHalt)),
-                keccak256(abi.encodePacked(params.feeToken)),
-                keccak256(abi.encodePacked(msg.sender)),
-                keccak256(abi.encodePacked(_getBlockNumber())),
-                keccak256(abi.encodePacked(uint48(block.timestamp)))
-            )
-        );
+            abi.encode(
+                params.timeType,
+                params.settlementTime,
+                params.disputeDelay,
+                params.callbackContract,
+                params.callbackGasLimit,
+                params.feePercentage,
+                params.protocolFee,
+                params.settlerReward,
+                reporterFee,
+                params.trackDisputes,
+                params.multiplier,
+                params.escalationHalt,
+                params.protocolFeeRecipient,
+                params.token1Address,
+                params.token2Address,
+                params.exactToken1Report,
+                msg.sender,
+                _getBlockNumber(),
+                uint48(block.timestamp))
+            );
 
         extra.stateHash = stateHash;
 
@@ -418,102 +409,96 @@ contract OpenOracle is ReentrancyGuard {
             reportId,
             params.token1Address,
             params.token2Address,
-            params.feePercentage,
-            params.multiplier,
-            params.exactToken1Report,
-            msg.value,
             msg.sender,
-            params.settlementTime,
+            params.protocolFeeRecipient,
+            params.exactToken1Report,
             params.escalationHalt,
-            params.disputeDelay,
-            params.protocolFee,
             params.settlerReward,
+            reporterFee,
+            params.settlementTime,
+            params.disputeDelay,
+            params.feePercentage,
+            params.protocolFee,
+            params.multiplier,
             params.timeType,
-            params.callbackContract,
-            params.callbackSelector,
             params.trackDisputes,
+            params.callbackContract,
             params.callbackGasLimit,
-            params.keepFee,
             stateHash,
-            block.timestamp,
-            params.feeToken
+            block.timestamp
         );
+
         return reportId;
     }
 
     /**
-     * @notice Submits the initial price report for a given report ID
+     * @notice Submits the initial price report for a given report ID. Amounts use smallest unit for a given ERC-20.
      * @param reportId The unique identifier for the report
      * @param amount1 Amount of token1 (must equal exactToken1Report)
-     * @param amount2 Amount of token2 for the price ratio
-     * @dev Tokens are pulled from msg.sender and will be returned to msg.sender when settled
+     * @param amount2 Choose the amount of token2 that equals amount1 in value
+     * @dev Tokens are pulled from msg.sender and will be returned to msg.sender when settled or disputed
      */
-    function submitInitialReport(uint256 reportId, uint256 amount1, uint256 amount2, bytes32 stateHash) external {
+    function submitInitialReport(uint256 reportId, uint128 amount1, uint128 amount2, bytes32 stateHash) external {
         _submitInitialReport(reportId, amount1, amount2, stateHash, msg.sender);
     }
 
     /**
-     * @notice Submits the initial price report with a custom reporter address
+     * @notice Submits the initial price report with a custom reporter address. Amounts use smallest unit for a given ERC-20.
      * @param reportId The unique identifier for the report
      * @param amount1 Amount of token1 (must equal exactToken1Report)
-     * @param amount2 Amount of token2 for the price ratio
-     * @param reporter The address that will receive tokens back when settled
+     * @param amount2 Choose the amount of token2 that equals amount1 in value
+     * @param reporter The address that will receive tokens back when settled or disputed
      * @dev Tokens are pulled from msg.sender but will be returned to reporter address
      * @dev This overload enables contracts to submit reports on behalf of users
      */
     function submitInitialReport(
         uint256 reportId,
-        uint256 amount1,
-        uint256 amount2,
+        uint128 amount1,
+        uint128 amount2,
         bytes32 stateHash,
         address reporter
     ) external {
         _submitInitialReport(reportId, amount1, amount2, stateHash, reporter);
     }
 
-    /**
-     * @notice Submits the initial price report for a given report ID
-     * @param reportId The unique identifier for the report
-     * @param amount1 Amount of token1 (must equal exactToken1Report)
-     * @param amount2 Amount of token2 for the price ratio
-     * @param reporter The address that will receive tokens back when settled
-     */
     function _submitInitialReport(
         uint256 reportId,
-        uint256 amount1,
-        uint256 amount2,
+        uint128 amount1,
+        uint128 amount2,
         bytes32 stateHash,
         address reporter
     ) internal {
-        if (reportStatus[reportId].currentReporter != address(0)) revert AlreadyProcessed("report submitted");
+        if (reportStatus[reportId].currentReporter != address(0)) {
+            revert ReportAlreadySubmitted();
+        }
 
         ReportMeta storage meta = reportMeta[reportId];
         ReportStatus storage status = reportStatus[reportId];
         extraReportData storage extra = extraData[reportId];
+        bool trackDisputes = extra.trackDisputes;
 
-        if (reportId >= nextReportId) revert InvalidInput("report id");
-        if (amount1 != meta.exactToken1Report) revert InvalidInput("token1 amount");
-        if (amount2 == 0) revert InvalidInput("token2 amount");
-        // Temporarily disabled because `eth_simulate` changes the state hash while testing in
-        // Interceptor, so this validation must stay commented out for that flow.
-        // if (extra.stateHash != stateHash) revert InvalidStateHash("state hash");
-        if (reporter == address(0)) revert InvalidInput("reporter address");
+        if (reportId >= nextReportId) revert InvalidReportId();
+        if (amount1 != meta.exactToken1Report) revert InvalidAmount1();
+        if (amount2 == 0) revert InvalidAmount2();
+        if (extra.stateHash != stateHash) revert InvalidStateHash();
+        if (reporter == address(0) || reporter == address(this)) revert AddressCannotBeZero();
 
         _transferTokens(meta.token1, msg.sender, address(this), amount1);
         _transferTokens(meta.token2, msg.sender, address(this), amount2);
 
+        uint48 reportTimestamp = meta.timeType ? uint48(block.timestamp) : _getBlockNumber();
         status.currentAmount1 = amount1;
         status.currentAmount2 = amount2;
         status.currentReporter = payable(reporter);
         status.initialReporter = payable(reporter);
-        status.reportTimestamp = meta.timeType ? uint48(block.timestamp) : _getBlockNumber();
-        status.price = (amount1 * PRICE_PRECISION) / amount2;
+        status.reportTimestamp = reportTimestamp;
         status.lastReportOppoTime = meta.timeType ? _getBlockNumber() : uint48(block.timestamp);
 
-        if (extra.trackDisputes) {
-            disputeHistory[reportId][0].amount1 = amount1;
-            disputeHistory[reportId][0].amount2 = amount2;
-            disputeHistory[reportId][0].reportTimestamp = status.reportTimestamp;
+        if (trackDisputes) {
+            disputeRecord storage initialRecord = disputeHistory[reportId][0];
+            initialRecord.amount1 = amount1;
+            initialRecord.amount2 = amount2;
+            initialRecord.reportTimestamp = reportTimestamp;
             extra.numReports = 1;
         }
 
@@ -522,129 +507,119 @@ contract OpenOracle is ReentrancyGuard {
             reporter,
             amount1,
             amount2,
-            meta.token1,
-            meta.token2,
-            meta.feePercentage,
-            meta.protocolFee,
-            meta.settlementTime,
-            meta.disputeDelay,
-            meta.escalationHalt,
-            meta.timeType,
-            extra.callbackContract,
-            extra.callbackSelector,
-            extra.trackDisputes,
-            extra.callbackGasLimit,
-            stateHash,
-            block.timestamp
+            reportTimestamp
         );
+
     }
 
-    //backwards-compatible function
+    /**
+     * @notice Disputes an existing report. Amounts use smallest unit for a given ERC-20.
+     * @param reportId The unique identifier for the report instance to dispute
+     * @param tokenToSwap Token being swapped (token1 or token2). Disputer should choose token whose amount is lower valued
+     * @param newAmount1 New amount of token1 after the dispute. Must respect contract escalation rules
+     * @param newAmount2 New amount of token2 after the dispute. Choose the amount of token2 that equals newAmount1 in value
+     * @param amt2Expected currentAmount2 of the report instance you are disputing (not newAmount2)
+     * @param stateHash state hash of the report instance you are disputing
+     * @dev Tokens are pulled from msg.sender and will be returned to msg.sender when settled or disputed
+     */
     function disputeAndSwap(
         uint256 reportId,
         address tokenToSwap,
-        uint256 newAmount1,
-        uint256 newAmount2,
-        uint256 amt2Expected,
+        uint128 newAmount1,
+        uint128 newAmount2,
+        uint128 amt2Expected,
         bytes32 stateHash
     ) external nonReentrant {
         _disputeAndSwap(reportId, tokenToSwap, newAmount1, newAmount2, msg.sender, amt2Expected, stateHash);
     }
 
+    /**
+     * @notice Disputes an existing report with a custom disputer address. Amounts use smallest unit for a given ERC-20.
+     * @param reportId The unique identifier for the report instance to dispute
+     * @param tokenToSwap Token being swapped (token1 or token2). Disputer should choose token whose amount is lower valued
+     * @param newAmount1 New amount of token1 after the dispute. Must respect contract escalation rules
+     * @param newAmount2 New amount of token2 after the dispute. Choose the amount of token2 that equals newAmount1 in value
+     * @param disputer The address that will receive tokens back when settled or disputed
+     * @param amt2Expected currentAmount2 of the report instance you are disputing (not newAmount2)
+     * @param stateHash state hash of the report instance you are disputing
+     * @dev Tokens are pulled from msg.sender but will be returned to disputer address
+     * @dev This overload enables contracts to submit disputes on behalf of users
+     */
     function disputeAndSwap(
         uint256 reportId,
         address tokenToSwap,
-        uint256 newAmount1,
-        uint256 newAmount2,
+        uint128 newAmount1,
+        uint128 newAmount2,
         address disputer,
-        uint256 amt2Expected,
+        uint128 amt2Expected,
         bytes32 stateHash
     ) external nonReentrant {
         _disputeAndSwap(reportId, tokenToSwap, newAmount1, newAmount2, disputer, amt2Expected, stateHash);
     }
 
-    /**
-     * @notice Disputes an existing report and swaps tokens to update the price
-     * @param reportId The unique identifier for the report to dispute
-     * @param tokenToSwap The token being swapped (token1 or token2)
-     * @param newAmount1 New amount of token1 after the dispute
-     * @param newAmount2 New amount of token2 after the dispute
-     */
     function _disputeAndSwap(
         uint256 reportId,
         address tokenToSwap,
-        uint256 newAmount1,
-        uint256 newAmount2,
+        uint128 newAmount1,
+        uint128 newAmount2,
         address disputer,
-        uint256 amt2Expected,
+        uint128 amt2Expected,
         bytes32 stateHash
     ) internal {
-        _preValidate(
-            newAmount1,
-            reportStatus[reportId].currentAmount1,
-            reportMeta[reportId].multiplier,
-            reportMeta[reportId].escalationHalt
-        );
-
         ReportMeta storage meta = reportMeta[reportId];
         ReportStatus storage status = reportStatus[reportId];
+        extraReportData storage extra = extraData[reportId];
+
+        _preValidate(
+            newAmount1,
+            status.currentAmount1,
+            meta.multiplier,
+            meta.escalationHalt
+        );
 
         _validateDispute(reportId, tokenToSwap, newAmount1, newAmount2, meta, status);
-        if (status.currentAmount2 != amt2Expected) revert InvalidAmount2("amount2 doesn't match expectation");
-        // Temporarily disabled because `eth_simulate` changes the state hash while testing in
-        // Interceptor, so this validation must stay commented out for that flow.
-        // if (stateHash != extraData[reportId].stateHash) revert InvalidStateHash("state hash");
-        if (disputer == address(0)) revert InvalidInput("disputer address");
+        if (status.currentAmount2 != amt2Expected) revert InvalidAmount2Expected();
+        if (stateHash != extra.stateHash) revert InvalidStateHash();
+        if (disputer == address(0) || disputer == address(this)) revert AddressCannotBeZero();
 
-        address protocolFeeRecipient = extraData[reportId].protocolFeeRecipient;
-        bool feeToken = extraData[reportId].feeToken;
-
+        bool trackDisputes = extra.trackDisputes;
         if (tokenToSwap == meta.token1) {
-            _handleToken1Swap(meta, status, newAmount2, disputer, protocolFeeRecipient, feeToken);
+            _handleToken1Swap(meta, status, newAmount2, disputer, extra.protocolFeeRecipient, newAmount1);
         } else if (tokenToSwap == meta.token2) {
-            _handleToken2Swap(meta, status, newAmount2, protocolFeeRecipient, feeToken);
+            _handleToken2Swap(meta, status, newAmount2, extra.protocolFeeRecipient, newAmount1);
         } else {
-            revert InvalidInput("token to swap");
+            revert InvalidTokenToSwap();
         }
 
         // Update the report status after the dispute and swap
-        status.currentAmount1 = newAmount1;
-        status.currentAmount2 = newAmount2;
-        status.currentReporter = payable(disputer);
-        status.reportTimestamp = meta.timeType ? uint48(block.timestamp) : _getBlockNumber();
-        status.price = (newAmount1 * PRICE_PRECISION) / newAmount2;
-        status.disputeOccurred = true;
-        status.lastReportOppoTime = meta.timeType ? _getBlockNumber() : uint48(block.timestamp);
+        {
+            uint48 reportTimestamp = meta.timeType ? uint48(block.timestamp) : _getBlockNumber();
+            status.currentAmount1 = newAmount1;
+            status.currentAmount2 = newAmount2;
+            status.currentReporter = payable(disputer);
+            status.reportTimestamp = reportTimestamp;
+            status.lastReportOppoTime = meta.timeType ? _getBlockNumber() : uint48(block.timestamp);
 
-        if (extraData[reportId].trackDisputes) {
-            uint32 nextIndex = extraData[reportId].numReports;
-            disputeHistory[reportId][nextIndex].amount1 = newAmount1;
-            disputeHistory[reportId][nextIndex].amount2 = newAmount2;
-            disputeHistory[reportId][nextIndex].reportTimestamp = status.reportTimestamp;
-            disputeHistory[reportId][nextIndex].tokenToSwap = tokenToSwap;
-            extraData[reportId].numReports = nextIndex + 1;
+            if (trackDisputes) {
+                uint32 nextIndex = extra.numReports;
+                disputeRecord storage record = disputeHistory[reportId][nextIndex];
+                record.amount1 = newAmount1;
+                record.amount2 = newAmount2;
+                record.reportTimestamp = reportTimestamp;
+                record.tokenToSwap = tokenToSwap;
+                extra.numReports = nextIndex + 1;
+            }
         }
 
         emit ReportDisputed(
             reportId,
             disputer,
+            tokenToSwap,
             newAmount1,
             newAmount2,
-            meta.token1,
-            meta.token2,
-            meta.feePercentage,
-            meta.protocolFee,
-            meta.settlementTime,
-            meta.disputeDelay,
-            meta.escalationHalt,
-            meta.timeType,
-            extraData[reportId].callbackContract,
-            extraData[reportId].callbackSelector,
-            extraData[reportId].trackDisputes,
-            extraData[reportId].callbackGasLimit,
-            stateHash,
-            block.timestamp
+            status.reportTimestamp
         );
+
     }
 
     function _preValidate(uint256 newAmount1, uint256 oldAmount1, uint256 multiplier, uint256 escalationHalt)
@@ -655,15 +630,18 @@ contract OpenOracle is ReentrancyGuard {
 
         if (escalationHalt > oldAmount1) {
             expectedAmount1 = (oldAmount1 * multiplier) / MULTIPLIER_PRECISION;
+            if (expectedAmount1 > escalationHalt) {
+                expectedAmount1 = escalationHalt;
+            }
         } else {
             expectedAmount1 = oldAmount1 + 1;
         }
 
         if (newAmount1 != expectedAmount1) {
             if (escalationHalt <= oldAmount1) {
-                revert OutOfBounds("escalation halted");
+                revert EscalationHalted();
             } else {
-                revert InvalidInput("new amount");
+                revert InvalidAmount1();
             }
         }
     }
@@ -679,38 +657,34 @@ contract OpenOracle is ReentrancyGuard {
         ReportMeta storage meta,
         ReportStatus storage status
     ) internal view {
-        if (reportId >= nextReportId) revert InvalidInput("report id");
-        if (newAmount1 == 0 || newAmount2 == 0) revert InvalidInput("token amounts");
+        if (reportId >= nextReportId) revert InvalidReportId();
+        if (newAmount1 == 0 || newAmount2 == 0) revert AmountsCannotBeZero();
         if (status.currentReporter == address(0)) revert NoReportToDispute();
         if (meta.timeType) {
-            if (block.timestamp > status.reportTimestamp + meta.settlementTime) {
-                revert InvalidTiming("dispute period expired");
-            }
+            if (block.timestamp > status.reportTimestamp + meta.settlementTime) revert DisputeTooLate();
         } else {
-            if (_getBlockNumber() > status.reportTimestamp + meta.settlementTime) {
-                revert InvalidTiming("dispute period expired");
-            }
+            if (_getBlockNumber() > status.reportTimestamp + meta.settlementTime) revert DisputeTooLate();
         }
-        if (status.isDistributed) revert AlreadyProcessed("report settled");
-        if (tokenToSwap != meta.token1 && tokenToSwap != meta.token2) revert InvalidInput("token to swap");
+        if (status.settlementTimestamp != 0) revert AlreadySettled();
+        if (tokenToSwap != meta.token1 && tokenToSwap != meta.token2) revert InvalidTokenToSwap();
         if (meta.timeType) {
-            if (block.timestamp < status.reportTimestamp + meta.disputeDelay) revert InvalidTiming("dispute too early");
+            if (block.timestamp < status.reportTimestamp + meta.disputeDelay) revert DisputeTooEarly();
         } else {
-            if (_getBlockNumber() < status.reportTimestamp + meta.disputeDelay) {
-                revert InvalidTiming("dispute too early");
-            }
+            if (_getBlockNumber() < status.reportTimestamp + meta.disputeDelay) revert DisputeTooEarly();
         }
 
-        uint256 oldAmount1 = status.currentAmount1;
-        uint256 oldPrice = (oldAmount1 * PRICE_PRECISION) / status.currentAmount2;
         uint256 feeSum = uint256(meta.feePercentage) + uint256(meta.protocolFee);
-        uint256 feeBoundary = (oldPrice * feeSum) / PERCENTAGE_PRECISION;
-        uint256 lowerBoundary = (oldPrice * PERCENTAGE_PRECISION) / (PERCENTAGE_PRECISION + feeSum);
-        uint256 upperBoundary = oldPrice + feeBoundary;
-        uint256 newPrice = (newAmount1 * PRICE_PRECISION) / newAmount2;
+        if (feeSum > 0){
+            uint256 oldAmount1 = status.currentAmount1;
+            uint256 oldPrice = Math.mulDiv(oldAmount1, PRICE_PRECISION, status.currentAmount2);
+            uint256 feeBoundary = Math.mulDiv(oldPrice, feeSum, PERCENTAGE_PRECISION);
+            uint256 lowerBoundary = Math.mulDiv(oldPrice, PERCENTAGE_PRECISION, PERCENTAGE_PRECISION + feeSum);
+            uint256 upperBoundary = oldPrice + feeBoundary;
+            uint256 newPrice = Math.mulDiv(newAmount1, PRICE_PRECISION, newAmount2);
 
-        if (newPrice >= lowerBoundary && newPrice <= upperBoundary) {
-            revert OutOfBounds("price within boundaries");
+            if (newPrice >= lowerBoundary && newPrice <= upperBoundary) {
+                revert NewPriceInsideFeeBoundary();
+            }
         }
     }
 
@@ -723,64 +697,33 @@ contract OpenOracle is ReentrancyGuard {
         uint256 newAmount2,
         address disputer,
         address protocolFeeRecipient,
-        bool feeToken
+        uint256 newAmount1
     ) internal {
         uint256 oldAmount1 = status.currentAmount1;
         uint256 oldAmount2 = status.currentAmount2;
+        address token1 = meta.token1;
+        address token2 = meta.token2;
+        uint256 fee = (oldAmount1 * meta.feePercentage) / PERCENTAGE_PRECISION;
+        uint256 protocolFee = (oldAmount1 * meta.protocolFee) / PERCENTAGE_PRECISION;
 
-        if (feeToken) {
-            uint256 fee = (oldAmount1 * meta.feePercentage) / PERCENTAGE_PRECISION;
-            uint256 protocolFee = (oldAmount1 * meta.protocolFee) / PERCENTAGE_PRECISION;
+        if (protocolFee > 0) protocolFees[protocolFeeRecipient][token1] += protocolFee;
 
-            protocolFees[protocolFeeRecipient][meta.token1] += protocolFee;
+        uint256 requiredToken1Contribution = newAmount1;
 
-            uint256 requiredToken1Contribution = meta.escalationHalt > oldAmount1
-                ? (oldAmount1 * meta.multiplier) / MULTIPLIER_PRECISION
-                : oldAmount1 + 1;
+        uint256 netToken2Contribution = newAmount2 >= oldAmount2 ? newAmount2 - oldAmount2 : 0;
+        uint256 netToken2Receive = newAmount2 < oldAmount2 ? oldAmount2 - newAmount2 : 0;
 
-            uint256 netToken2Contribution = newAmount2 >= oldAmount2 ? newAmount2 - oldAmount2 : 0;
-            uint256 netToken2Receive = newAmount2 < oldAmount2 ? oldAmount2 - newAmount2 : 0;
-
-            if (netToken2Contribution > 0) {
-                IERC20(meta.token2).safeTransferFrom(msg.sender, address(this), netToken2Contribution);
-            }
-
-            if (netToken2Receive > 0) {
-                IERC20(meta.token2).safeTransfer(disputer, netToken2Receive);
-            }
-
-            IERC20(meta.token1).safeTransferFrom(
-                msg.sender, address(this), requiredToken1Contribution + oldAmount1 + fee + protocolFee
-            );
-            IERC20(meta.token1).safeTransfer(status.currentReporter, 2 * oldAmount1 + fee);
-        } else {
-            uint256 fee = (oldAmount2 * meta.feePercentage) / PERCENTAGE_PRECISION;
-            uint256 protocolFee = (oldAmount2 * meta.protocolFee) / PERCENTAGE_PRECISION;
-
-            protocolFees[protocolFeeRecipient][meta.token2] += protocolFee;
-
-            uint256 requiredToken1Contribution = meta.escalationHalt > oldAmount1
-                ? (oldAmount1 * meta.multiplier) / MULTIPLIER_PRECISION
-                : oldAmount1 + 1;
-
-            uint256 netToken2Contribution =
-                newAmount2 + protocolFee + fee >= oldAmount2 ? newAmount2 + protocolFee + fee - oldAmount2 : 0;
-            uint256 netToken2Receive =
-                newAmount2 + protocolFee + fee < oldAmount2 ? oldAmount2 - newAmount2 - protocolFee - fee : 0;
-
-            if (netToken2Contribution > 0) {
-                IERC20(meta.token2).safeTransferFrom(msg.sender, address(this), netToken2Contribution);
-            }
-
-            if (netToken2Receive > 0) {
-                IERC20(meta.token2).safeTransfer(disputer, netToken2Receive);
-            }
-
-            IERC20(meta.token1).safeTransferFrom(msg.sender, address(this), requiredToken1Contribution + oldAmount1);
-
-            IERC20(meta.token1).safeTransfer(status.currentReporter, 2 * oldAmount1);
-            IERC20(meta.token2).safeTransfer(status.currentReporter, fee);
+        if (netToken2Contribution > 0) {
+            IERC20(token2).safeTransferFrom(msg.sender, address(this), netToken2Contribution);
         }
+
+        if (netToken2Receive > 0) {
+            IERC20(token2).safeTransfer(disputer, netToken2Receive);
+        }
+
+        IERC20(token1).safeTransferFrom(msg.sender, address(this), requiredToken1Contribution + oldAmount1 + fee + protocolFee);
+
+        _transferTokens(token1, address(this), status.currentReporter, 2 * oldAmount1 + fee);
     }
 
     /**
@@ -791,53 +734,29 @@ contract OpenOracle is ReentrancyGuard {
         ReportStatus storage status,
         uint256 newAmount2,
         address protocolFeeRecipient,
-        bool feeToken
+        uint256 newAmount1
     ) internal {
         uint256 oldAmount1 = status.currentAmount1;
         uint256 oldAmount2 = status.currentAmount2;
+        address token1 = meta.token1;
+        address token2 = meta.token2;
+        uint256 fee = (oldAmount2 * meta.feePercentage) / PERCENTAGE_PRECISION;
+        uint256 protocolFee = (oldAmount2 * meta.protocolFee) / PERCENTAGE_PRECISION;
 
-        if (feeToken) {
-            uint256 fee = (oldAmount2 * meta.feePercentage) / PERCENTAGE_PRECISION;
-            uint256 protocolFee = (oldAmount2 * meta.protocolFee) / PERCENTAGE_PRECISION;
+        if (protocolFee > 0) protocolFees[protocolFeeRecipient][token2] += protocolFee;
 
-            protocolFees[protocolFeeRecipient][meta.token2] += protocolFee;
+        uint256 requiredToken1Contribution = newAmount1;
 
-            uint256 requiredToken1Contribution = meta.escalationHalt > oldAmount1
-                ? (oldAmount1 * meta.multiplier) / MULTIPLIER_PRECISION
-                : oldAmount1 + 1;
+        uint256 netToken1Contribution =
+            requiredToken1Contribution > (oldAmount1) ? requiredToken1Contribution - (oldAmount1) : 0;
 
-            uint256 netToken1Contribution =
-                requiredToken1Contribution > (oldAmount1) ? requiredToken1Contribution - (oldAmount1) : 0;
-
-            if (netToken1Contribution > 0) {
-                IERC20(meta.token1).safeTransferFrom(msg.sender, address(this), netToken1Contribution);
-            }
-
-            IERC20(meta.token2).safeTransferFrom(msg.sender, address(this), newAmount2 + oldAmount2 + fee + protocolFee);
-            IERC20(meta.token2).safeTransfer(status.currentReporter, 2 * oldAmount2 + fee);
-        } else {
-            uint256 fee = (oldAmount1 * meta.feePercentage) / PERCENTAGE_PRECISION;
-            uint256 protocolFee = (oldAmount1 * meta.protocolFee) / PERCENTAGE_PRECISION;
-
-            protocolFees[protocolFeeRecipient][meta.token1] += protocolFee;
-
-            uint256 requiredToken1Contribution = meta.escalationHalt > oldAmount1
-                ? (oldAmount1 * meta.multiplier) / MULTIPLIER_PRECISION
-                : oldAmount1 + 1;
-
-            requiredToken1Contribution += fee + protocolFee;
-            uint256 netToken1Contribution =
-                requiredToken1Contribution > (oldAmount1) ? requiredToken1Contribution - (oldAmount1) : 0;
-
-            if (netToken1Contribution > 0) {
-                IERC20(meta.token1).safeTransferFrom(msg.sender, address(this), netToken1Contribution);
-            }
-
-            IERC20(meta.token2).safeTransferFrom(msg.sender, address(this), newAmount2 + oldAmount2);
-            IERC20(meta.token2).safeTransfer(status.currentReporter, 2 * oldAmount2);
-
-            IERC20(meta.token1).safeTransfer(status.currentReporter, fee);
+        if (netToken1Contribution > 0) {
+            IERC20(token1).safeTransferFrom(msg.sender, address(this), netToken1Contribution);
         }
+
+        IERC20(token2).safeTransferFrom(msg.sender, address(this), newAmount2 + oldAmount2 + fee + protocolFee);
+
+        _transferTokens(token2, address(this), status.currentReporter, 2 * oldAmount2 + fee);
     }
 
     /**
@@ -847,7 +766,18 @@ contract OpenOracle is ReentrancyGuard {
         if (amount == 0) return; // Gas optimization: skip zero transfers
 
         if (from == address(this)) {
-            IERC20(token).safeTransfer(to, amount);
+
+            (bool success, bytes memory returndata) = token.call(
+                    abi.encodeWithSelector(IERC20.transfer.selector, to, amount)
+                );
+
+            if (success && ((returndata.length > 0 && abi.decode(returndata, (bool))) || 
+                (returndata.length == 0 && address(token).code.length > 0))) {
+               return;
+            }
+
+            protocolFees[to][token] += amount;
+
         } else {
             IERC20(token).safeTransferFrom(from, to, amount);
         }
@@ -859,12 +789,9 @@ contract OpenOracle is ReentrancyGuard {
     function _sendEth(address payable recipient, uint256 amount) internal {
         if (amount == 0) return; // Gas optimization: skip zero transfers
 
-        (bool success,) = recipient.call{value: amount}("");
+        (bool success,) = recipient.call{value: amount, gas: 40000}("");
         if (!success) {
-            (bool success2,) = payable(address(0)).call{value: amount}("");
-            if (!success2) {
-                //do nothing so at least erc20 can move
-            }
+            accruedProtocolFees[recipient] += amount;
         }
     }
 
@@ -872,11 +799,6 @@ contract OpenOracle is ReentrancyGuard {
      * @dev Gets the current block number (returns L1 block number for L1 deployment)
      */
     function _getBlockNumber() internal view returns (uint48) {
-        uint256 id;
-        assembly {
-            id := chainid()
-        }
-
         return uint48(block.number);
     }
 }

--- a/solidity/contracts/peripherals/openOracle/openzeppelin/contracts/interfaces/IERC1363.sol
+++ b/solidity/contracts/peripherals/openOracle/openzeppelin/contracts/interfaces/IERC1363.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts (last updated v5.4.0) (interfaces/IERC1363.sol)
+// OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC1363.sol)
 
-pragma solidity >=0.6.2;
+pragma solidity ^0.8.20;
 
 import {IERC20} from "./IERC20.sol";
 import {IERC165} from "./IERC165.sol";

--- a/solidity/contracts/peripherals/openOracle/openzeppelin/contracts/interfaces/IERC165.sol
+++ b/solidity/contracts/peripherals/openOracle/openzeppelin/contracts/interfaces/IERC165.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts (last updated v5.4.0) (interfaces/IERC165.sol)
+// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC165.sol)
 
-pragma solidity >=0.4.16;
+pragma solidity ^0.8.20;
 
 import {IERC165} from "../utils/introspection/IERC165.sol";

--- a/solidity/contracts/peripherals/openOracle/openzeppelin/contracts/interfaces/IERC20.sol
+++ b/solidity/contracts/peripherals/openOracle/openzeppelin/contracts/interfaces/IERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts (last updated v5.4.0) (interfaces/IERC20.sol)
+// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC20.sol)
 
-pragma solidity >=0.4.16;
+pragma solidity ^0.8.20;
 
 import {IERC20} from "../token/ERC20/IERC20.sol";

--- a/solidity/contracts/peripherals/openOracle/openzeppelin/contracts/token/ERC20/IERC20.sol
+++ b/solidity/contracts/peripherals/openOracle/openzeppelin/contracts/token/ERC20/IERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts (last updated v5.4.0) (token/ERC20/IERC20.sol)
+// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/IERC20.sol)
 
-pragma solidity >=0.4.16;
+pragma solidity ^0.8.20;
 
 /**
  * @dev Interface of the ERC-20 standard as defined in the ERC.

--- a/solidity/contracts/peripherals/openOracle/openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
+++ b/solidity/contracts/peripherals/openOracle/openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
@@ -31,9 +31,7 @@ library SafeERC20 {
      * non-reverting calls are assumed to be successful.
      */
     function safeTransfer(IERC20 token, address to, uint256 value) internal {
-        if (!_safeTransfer(token, to, value, true)) {
-            revert SafeERC20FailedOperation(address(token));
-        }
+        _callOptionalReturn(token, abi.encodeCall(token.transfer, (to, value)));
     }
 
     /**
@@ -41,23 +39,21 @@ library SafeERC20 {
      * calling contract. If `token` returns no value, non-reverting calls are assumed to be successful.
      */
     function safeTransferFrom(IERC20 token, address from, address to, uint256 value) internal {
-        if (!_safeTransferFrom(token, from, to, value, true)) {
-            revert SafeERC20FailedOperation(address(token));
-        }
+        _callOptionalReturn(token, abi.encodeCall(token.transferFrom, (from, to, value)));
     }
 
     /**
      * @dev Variant of {safeTransfer} that returns a bool instead of reverting if the operation is not successful.
      */
     function trySafeTransfer(IERC20 token, address to, uint256 value) internal returns (bool) {
-        return _safeTransfer(token, to, value, false);
+        return _callOptionalReturnBool(token, abi.encodeCall(token.transfer, (to, value)));
     }
 
     /**
      * @dev Variant of {safeTransferFrom} that returns a bool instead of reverting if the operation is not successful.
      */
     function trySafeTransferFrom(IERC20 token, address from, address to, uint256 value) internal returns (bool) {
-        return _safeTransferFrom(token, from, to, value, false);
+        return _callOptionalReturnBool(token, abi.encodeCall(token.transferFrom, (from, to, value)));
     }
 
     /**
@@ -103,15 +99,17 @@ library SafeERC20 {
      * set here.
      */
     function forceApprove(IERC20 token, address spender, uint256 value) internal {
-        if (!_safeApprove(token, spender, value, false)) {
-            if (!_safeApprove(token, spender, 0, true)) revert SafeERC20FailedOperation(address(token));
-            if (!_safeApprove(token, spender, value, true)) revert SafeERC20FailedOperation(address(token));
+        bytes memory approvalCall = abi.encodeCall(token.approve, (spender, value));
+
+        if (!_callOptionalReturnBool(token, approvalCall)) {
+            _callOptionalReturn(token, abi.encodeCall(token.approve, (spender, 0)));
+            _callOptionalReturn(token, approvalCall);
         }
     }
 
     /**
      * @dev Performs an {ERC1363} transferAndCall, with a fallback to the simple {ERC20} transfer if the target has no
-     * code. This can be used to implement an {ERC721}-like safe transfer that relies on {ERC1363} checks when
+     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when
      * targeting contracts.
      *
      * Reverts if the returned value is other than `true`.
@@ -126,7 +124,7 @@ library SafeERC20 {
 
     /**
      * @dev Performs an {ERC1363} transferFromAndCall, with a fallback to the simple {ERC20} transferFrom if the target
-     * has no code. This can be used to implement an {ERC721}-like safe transfer that relies on {ERC1363} checks when
+     * has no code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when
      * targeting contracts.
      *
      * Reverts if the returned value is other than `true`.
@@ -151,7 +149,7 @@ library SafeERC20 {
      * targeting contracts.
      *
      * NOTE: When the recipient address (`to`) has no code (i.e. is an EOA), this function behaves as {forceApprove}.
-     * Oppositely, when the recipient address (`to`) has code, this function only attempts to call {ERC1363-approveAndCall}
+     * Opposedly, when the recipient address (`to`) has code, this function only attempts to call {ERC1363-approveAndCall}
      * once without retrying, and relies on the returned value to be true.
      *
      * Reverts if the returned value is other than `true`.
@@ -165,116 +163,50 @@ library SafeERC20 {
     }
 
     /**
-     * @dev Imitates a Solidity `token.transfer(to, value)` call, relaxing the requirement on the return value: the
-     * return value is optional (but if data is returned, it must not be false).
-     *
+     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
+     * on the return value: the return value is optional (but if data is returned, it must not be false).
      * @param token The token targeted by the call.
-     * @param to The recipient of the tokens
-     * @param value The amount of token to transfer
-     * @param bubble Behavior switch if the transfer call reverts: bubble the revert reason or return a false boolean.
+     * @param data The call data (encoded using abi.encode or one of its variants).
+     *
+     * This is a variant of {_callOptionalReturnBool} that reverts if call fails to meet the requirements.
      */
-    function _safeTransfer(IERC20 token, address to, uint256 value, bool bubble) private returns (bool success) {
-        bytes4 selector = IERC20.transfer.selector;
-
+    function _callOptionalReturn(IERC20 token, bytes memory data) private {
+        uint256 returnSize;
+        uint256 returnValue;
         assembly ("memory-safe") {
-            let fmp := mload(0x40)
-            mstore(0x00, selector)
-            mstore(0x04, and(to, shr(96, not(0))))
-            mstore(0x24, value)
-            success := call(gas(), token, 0, 0x00, 0x44, 0x00, 0x20)
-            // if call success and return is true, all is good.
-            // otherwise (not success or return is not true), we need to perform further checks
-            if iszero(and(success, eq(mload(0x00), 1))) {
-                // if the call was a failure and bubble is enabled, bubble the error
-                if and(iszero(success), bubble) {
-                    returndatacopy(fmp, 0x00, returndatasize())
-                    revert(fmp, returndatasize())
-                }
-                // if the return value is not true, then the call is only successful if:
-                // - the token address has code
-                // - the returndata is empty
-                success := and(success, and(iszero(returndatasize()), gt(extcodesize(token), 0)))
+            let success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)
+            // bubble errors
+            if iszero(success) {
+                let ptr := mload(0x40)
+                returndatacopy(ptr, 0, returndatasize())
+                revert(ptr, returndatasize())
             }
-            mstore(0x40, fmp)
+            returnSize := returndatasize()
+            returnValue := mload(0)
+        }
+
+        if (returnSize == 0 ? address(token).code.length == 0 : returnValue != 1) {
+            revert SafeERC20FailedOperation(address(token));
         }
     }
 
     /**
-     * @dev Imitates a Solidity `token.transferFrom(from, to, value)` call, relaxing the requirement on the return
-     * value: the return value is optional (but if data is returned, it must not be false).
-     *
+     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
+     * on the return value: the return value is optional (but if data is returned, it must not be false).
      * @param token The token targeted by the call.
-     * @param from The sender of the tokens
-     * @param to The recipient of the tokens
-     * @param value The amount of token to transfer
-     * @param bubble Behavior switch if the transfer call reverts: bubble the revert reason or return a false boolean.
-     */
-    function _safeTransferFrom(
-        IERC20 token,
-        address from,
-        address to,
-        uint256 value,
-        bool bubble
-    ) private returns (bool success) {
-        bytes4 selector = IERC20.transferFrom.selector;
-
-        assembly ("memory-safe") {
-            let fmp := mload(0x40)
-            mstore(0x00, selector)
-            mstore(0x04, and(from, shr(96, not(0))))
-            mstore(0x24, and(to, shr(96, not(0))))
-            mstore(0x44, value)
-            success := call(gas(), token, 0, 0x00, 0x64, 0x00, 0x20)
-            // if call success and return is true, all is good.
-            // otherwise (not success or return is not true), we need to perform further checks
-            if iszero(and(success, eq(mload(0x00), 1))) {
-                // if the call was a failure and bubble is enabled, bubble the error
-                if and(iszero(success), bubble) {
-                    returndatacopy(fmp, 0x00, returndatasize())
-                    revert(fmp, returndatasize())
-                }
-                // if the return value is not true, then the call is only successful if:
-                // - the token address has code
-                // - the returndata is empty
-                success := and(success, and(iszero(returndatasize()), gt(extcodesize(token), 0)))
-            }
-            mstore(0x40, fmp)
-            mstore(0x60, 0)
-        }
-    }
-
-    /**
-     * @dev Imitates a Solidity `token.approve(spender, value)` call, relaxing the requirement on the return value:
-     * the return value is optional (but if data is returned, it must not be false).
+     * @param data The call data (encoded using abi.encode or one of its variants).
      *
-     * @param token The token targeted by the call.
-     * @param spender The spender of the tokens
-     * @param value The amount of token to transfer
-     * @param bubble Behavior switch if the transfer call reverts: bubble the revert reason or return a false boolean.
+     * This is a variant of {_callOptionalReturn} that silently catches all reverts and returns a bool instead.
      */
-    function _safeApprove(IERC20 token, address spender, uint256 value, bool bubble) private returns (bool success) {
-        bytes4 selector = IERC20.approve.selector;
-
+    function _callOptionalReturnBool(IERC20 token, bytes memory data) private returns (bool) {
+        bool success;
+        uint256 returnSize;
+        uint256 returnValue;
         assembly ("memory-safe") {
-            let fmp := mload(0x40)
-            mstore(0x00, selector)
-            mstore(0x04, and(spender, shr(96, not(0))))
-            mstore(0x24, value)
-            success := call(gas(), token, 0, 0x00, 0x44, 0x00, 0x20)
-            // if call success and return is true, all is good.
-            // otherwise (not success or return is not true), we need to perform further checks
-            if iszero(and(success, eq(mload(0x00), 1))) {
-                // if the call was a failure and bubble is enabled, bubble the error
-                if and(iszero(success), bubble) {
-                    returndatacopy(fmp, 0x00, returndatasize())
-                    revert(fmp, returndatasize())
-                }
-                // if the return value is not true, then the call is only successful if:
-                // - the token address has code
-                // - the returndata is empty
-                success := and(success, and(iszero(returndatasize()), gt(extcodesize(token), 0)))
-            }
-            mstore(0x40, fmp)
+            success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)
+            returnSize := returndatasize()
+            returnValue := mload(0)
         }
+        return success && (returnSize == 0 ? address(token).code.length > 0 : returnValue == 1);
     }
 }

--- a/solidity/contracts/peripherals/openOracle/openzeppelin/contracts/utils/Panic.sol
+++ b/solidity/contracts/peripherals/openOracle/openzeppelin/contracts/utils/Panic.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.1.0) (utils/Panic.sol)
+
+pragma solidity ^0.8.20;
+
+/**
+ * @dev Helper library for emitting standardized panic codes.
+ *
+ * ```solidity
+ * contract Example {
+ *      using Panic for uint256;
+ *
+ *      // Use any of the declared internal constants
+ *      function foo() { Panic.GENERIC.panic(); }
+ *
+ *      // Alternatively
+ *      function foo() { Panic.panic(Panic.GENERIC); }
+ * }
+ * ```
+ *
+ * Follows the list from https://github.com/ethereum/solidity/blob/v0.8.24/libsolutil/ErrorCodes.h[libsolutil].
+ *
+ * _Available since v5.1._
+ */
+// slither-disable-next-line unused-state
+library Panic {
+    /// @dev generic / unspecified error
+    uint256 internal constant GENERIC = 0x00;
+    /// @dev used by the assert() builtin
+    uint256 internal constant ASSERT = 0x01;
+    /// @dev arithmetic underflow or overflow
+    uint256 internal constant UNDER_OVERFLOW = 0x11;
+    /// @dev division or modulo by zero
+    uint256 internal constant DIVISION_BY_ZERO = 0x12;
+    /// @dev enum conversion error
+    uint256 internal constant ENUM_CONVERSION_ERROR = 0x21;
+    /// @dev invalid encoding in storage
+    uint256 internal constant STORAGE_ENCODING_ERROR = 0x22;
+    /// @dev empty array pop
+    uint256 internal constant EMPTY_ARRAY_POP = 0x31;
+    /// @dev array out of bounds access
+    uint256 internal constant ARRAY_OUT_OF_BOUNDS = 0x32;
+    /// @dev resource error (too large allocation or too large array)
+    uint256 internal constant RESOURCE_ERROR = 0x41;
+    /// @dev calling invalid internal function
+    uint256 internal constant INVALID_INTERNAL_FUNCTION = 0x51;
+
+    /// @dev Reverts with a panic code. Recommended to use with
+    /// the internal constants with predefined codes.
+    function panic(uint256 code) internal pure {
+        assembly ("memory-safe") {
+            mstore(0x00, 0x4e487b71)
+            mstore(0x20, code)
+            revert(0x1c, 0x24)
+        }
+    }
+}

--- a/solidity/contracts/peripherals/openOracle/openzeppelin/contracts/utils/ReentrancyGuard.sol
+++ b/solidity/contracts/peripherals/openOracle/openzeppelin/contracts/utils/ReentrancyGuard.sol
@@ -3,8 +3,6 @@
 
 pragma solidity ^0.8.20;
 
-import {StorageSlot} from "./StorageSlot.sol";
-
 /**
  * @dev Contract module that helps prevent reentrant calls to a function.
  *
@@ -23,19 +21,8 @@ import {StorageSlot} from "./StorageSlot.sol";
  * TIP: If you would like to learn more about reentrancy and alternative ways
  * to protect against it, check out our blog post
  * https://blog.openzeppelin.com/reentrancy-after-istanbul/[Reentrancy After Istanbul].
- *
- * IMPORTANT: Deprecated. This storage-based reentrancy guard will be removed and replaced
- * by the {ReentrancyGuardTransient} variant in v6.0.
- *
- * @custom:stateless
  */
 abstract contract ReentrancyGuard {
-    using StorageSlot for bytes32;
-
-    // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.ReentrancyGuard")) - 1)) & ~bytes32(uint256(0xff))
-    bytes32 private constant REENTRANCY_GUARD_STORAGE =
-        0x9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f00;
-
     // Booleans are more expensive than uint256 or any type that takes up a full
     // word because each write operation emits an extra SLOAD to first read the
     // slot's contents, replace the bits taken up by the boolean, and then write
@@ -50,13 +37,15 @@ abstract contract ReentrancyGuard {
     uint256 private constant NOT_ENTERED = 1;
     uint256 private constant ENTERED = 2;
 
+    uint256 private _status;
+
     /**
      * @dev Unauthorized reentrant call.
      */
     error ReentrancyGuardReentrantCall();
 
     constructor() {
-        _reentrancyGuardStorageSlot().getUint256Slot().value = NOT_ENTERED;
+        _status = NOT_ENTERED;
     }
 
     /**
@@ -72,37 +61,20 @@ abstract contract ReentrancyGuard {
         _nonReentrantAfter();
     }
 
-    /**
-     * @dev A `view` only version of {nonReentrant}. Use to block view functions
-     * from being called, preventing reading from inconsistent contract state.
-     *
-     * CAUTION: This is a "view" modifier and does not change the reentrancy
-     * status. Use it only on view functions. For payable or non-payable functions,
-     * use the standard {nonReentrant} modifier instead.
-     */
-    modifier nonReentrantView() {
-        _nonReentrantBeforeView();
-        _;
-    }
-
-    function _nonReentrantBeforeView() private view {
-        if (_reentrancyGuardEntered()) {
-            revert ReentrancyGuardReentrantCall();
-        }
-    }
-
     function _nonReentrantBefore() private {
         // On the first call to nonReentrant, _status will be NOT_ENTERED
-        _nonReentrantBeforeView();
+        if (_status == ENTERED) {
+            revert ReentrancyGuardReentrantCall();
+        }
 
         // Any calls to nonReentrant after this point will fail
-        _reentrancyGuardStorageSlot().getUint256Slot().value = ENTERED;
+        _status = ENTERED;
     }
 
     function _nonReentrantAfter() private {
         // By storing the original value once again, a refund is triggered (see
         // https://eips.ethereum.org/EIPS/eip-2200)
-        _reentrancyGuardStorageSlot().getUint256Slot().value = NOT_ENTERED;
+        _status = NOT_ENTERED;
     }
 
     /**
@@ -110,10 +82,6 @@ abstract contract ReentrancyGuard {
      * `nonReentrant` function in the call stack.
      */
     function _reentrancyGuardEntered() internal view returns (bool) {
-        return _reentrancyGuardStorageSlot().getUint256Slot().value == ENTERED;
-    }
-
-    function _reentrancyGuardStorageSlot() internal pure virtual returns (bytes32) {
-        return REENTRANCY_GUARD_STORAGE;
+        return _status == ENTERED;
     }
 }

--- a/solidity/contracts/peripherals/openOracle/openzeppelin/contracts/utils/introspection/IERC165.sol
+++ b/solidity/contracts/peripherals/openOracle/openzeppelin/contracts/utils/introspection/IERC165.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts (last updated v5.4.0) (utils/introspection/IERC165.sol)
+// OpenZeppelin Contracts (last updated v5.1.0) (utils/introspection/IERC165.sol)
 
-pragma solidity >=0.4.16;
+pragma solidity ^0.8.20;
 
 /**
  * @dev Interface of the ERC-165 standard, as defined in the

--- a/solidity/contracts/peripherals/openOracle/openzeppelin/contracts/utils/math/Math.sol
+++ b/solidity/contracts/peripherals/openOracle/openzeppelin/contracts/utils/math/Math.sol
@@ -1,0 +1,749 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.3.0) (utils/math/Math.sol)
+
+pragma solidity ^0.8.20;
+
+import {Panic} from "../Panic.sol";
+import {SafeCast} from "./SafeCast.sol";
+
+/**
+ * @dev Standard math utilities missing in the Solidity language.
+ */
+library Math {
+    enum Rounding {
+        Floor, // Toward negative infinity
+        Ceil, // Toward positive infinity
+        Trunc, // Toward zero
+        Expand // Away from zero
+    }
+
+    /**
+     * @dev Return the 512-bit addition of two uint256.
+     *
+     * The result is stored in two 256 variables such that sum = high * 2²⁵⁶ + low.
+     */
+    function add512(uint256 a, uint256 b) internal pure returns (uint256 high, uint256 low) {
+        assembly ("memory-safe") {
+            low := add(a, b)
+            high := lt(low, a)
+        }
+    }
+
+    /**
+     * @dev Return the 512-bit multiplication of two uint256.
+     *
+     * The result is stored in two 256 variables such that product = high * 2²⁵⁶ + low.
+     */
+    function mul512(uint256 a, uint256 b) internal pure returns (uint256 high, uint256 low) {
+        // 512-bit multiply [high low] = x * y. Compute the product mod 2²⁵⁶ and mod 2²⁵⁶ - 1, then use
+        // the Chinese Remainder Theorem to reconstruct the 512 bit result. The result is stored in two 256
+        // variables such that product = high * 2²⁵⁶ + low.
+        assembly ("memory-safe") {
+            let mm := mulmod(a, b, not(0))
+            low := mul(a, b)
+            high := sub(sub(mm, low), lt(mm, low))
+        }
+    }
+
+    /**
+     * @dev Returns the addition of two unsigned integers, with a success flag (no overflow).
+     */
+    function tryAdd(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {
+        unchecked {
+            uint256 c = a + b;
+            success = c >= a;
+            result = c * SafeCast.toUint(success);
+        }
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, with a success flag (no overflow).
+     */
+    function trySub(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {
+        unchecked {
+            uint256 c = a - b;
+            success = c <= a;
+            result = c * SafeCast.toUint(success);
+        }
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, with a success flag (no overflow).
+     */
+    function tryMul(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {
+        unchecked {
+            uint256 c = a * b;
+            assembly ("memory-safe") {
+                // Only true when the multiplication doesn't overflow
+                // (c / a == b) || (a == 0)
+                success := or(eq(div(c, a), b), iszero(a))
+            }
+            // equivalent to: success ? c : 0
+            result = c * SafeCast.toUint(success);
+        }
+    }
+
+    /**
+     * @dev Returns the division of two unsigned integers, with a success flag (no division by zero).
+     */
+    function tryDiv(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {
+        unchecked {
+            success = b > 0;
+            assembly ("memory-safe") {
+                // The `DIV` opcode returns zero when the denominator is 0.
+                result := div(a, b)
+            }
+        }
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers, with a success flag (no division by zero).
+     */
+    function tryMod(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {
+        unchecked {
+            success = b > 0;
+            assembly ("memory-safe") {
+                // The `MOD` opcode returns zero when the denominator is 0.
+                result := mod(a, b)
+            }
+        }
+    }
+
+    /**
+     * @dev Unsigned saturating addition, bounds to `2²⁵⁶ - 1` instead of overflowing.
+     */
+    function saturatingAdd(uint256 a, uint256 b) internal pure returns (uint256) {
+        (bool success, uint256 result) = tryAdd(a, b);
+        return ternary(success, result, type(uint256).max);
+    }
+
+    /**
+     * @dev Unsigned saturating subtraction, bounds to zero instead of overflowing.
+     */
+    function saturatingSub(uint256 a, uint256 b) internal pure returns (uint256) {
+        (, uint256 result) = trySub(a, b);
+        return result;
+    }
+
+    /**
+     * @dev Unsigned saturating multiplication, bounds to `2²⁵⁶ - 1` instead of overflowing.
+     */
+    function saturatingMul(uint256 a, uint256 b) internal pure returns (uint256) {
+        (bool success, uint256 result) = tryMul(a, b);
+        return ternary(success, result, type(uint256).max);
+    }
+
+    /**
+     * @dev Branchless ternary evaluation for `a ? b : c`. Gas costs are constant.
+     *
+     * IMPORTANT: This function may reduce bytecode size and consume less gas when used standalone.
+     * However, the compiler may optimize Solidity ternary operations (i.e. `a ? b : c`) to only compute
+     * one branch when needed, making this function more expensive.
+     */
+    function ternary(bool condition, uint256 a, uint256 b) internal pure returns (uint256) {
+        unchecked {
+            // branchless ternary works because:
+            // b ^ (a ^ b) == a
+            // b ^ 0 == b
+            return b ^ ((a ^ b) * SafeCast.toUint(condition));
+        }
+    }
+
+    /**
+     * @dev Returns the largest of two numbers.
+     */
+    function max(uint256 a, uint256 b) internal pure returns (uint256) {
+        return ternary(a > b, a, b);
+    }
+
+    /**
+     * @dev Returns the smallest of two numbers.
+     */
+    function min(uint256 a, uint256 b) internal pure returns (uint256) {
+        return ternary(a < b, a, b);
+    }
+
+    /**
+     * @dev Returns the average of two numbers. The result is rounded towards
+     * zero.
+     */
+    function average(uint256 a, uint256 b) internal pure returns (uint256) {
+        // (a + b) / 2 can overflow.
+        return (a & b) + (a ^ b) / 2;
+    }
+
+    /**
+     * @dev Returns the ceiling of the division of two numbers.
+     *
+     * This differs from standard division with `/` in that it rounds towards infinity instead
+     * of rounding towards zero.
+     */
+    function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {
+        if (b == 0) {
+            // Guarantee the same behavior as in a regular Solidity division.
+            Panic.panic(Panic.DIVISION_BY_ZERO);
+        }
+
+        // The following calculation ensures accurate ceiling division without overflow.
+        // Since a is non-zero, (a - 1) / b will not overflow.
+        // The largest possible result occurs when (a - 1) / b is type(uint256).max,
+        // but the largest value we can obtain is type(uint256).max - 1, which happens
+        // when a = type(uint256).max and b = 1.
+        unchecked {
+            return SafeCast.toUint(a > 0) * ((a - 1) / b + 1);
+        }
+    }
+
+    /**
+     * @dev Calculates floor(x * y / denominator) with full precision. Throws if result overflows a uint256 or
+     * denominator == 0.
+     *
+     * Original credit to Remco Bloemen under MIT license (https://xn--2-umb.com/21/muldiv) with further edits by
+     * Uniswap Labs also under MIT license.
+     */
+    function mulDiv(uint256 x, uint256 y, uint256 denominator) internal pure returns (uint256 result) {
+        unchecked {
+            (uint256 high, uint256 low) = mul512(x, y);
+
+            // Handle non-overflow cases, 256 by 256 division.
+            if (high == 0) {
+                // Solidity will revert if denominator == 0, unlike the div opcode on its own.
+                // The surrounding unchecked block does not change this fact.
+                // See https://docs.soliditylang.org/en/latest/control-structures.html#checked-or-unchecked-arithmetic.
+                return low / denominator;
+            }
+
+            // Make sure the result is less than 2²⁵⁶. Also prevents denominator == 0.
+            if (denominator <= high) {
+                Panic.panic(ternary(denominator == 0, Panic.DIVISION_BY_ZERO, Panic.UNDER_OVERFLOW));
+            }
+
+            ///////////////////////////////////////////////
+            // 512 by 256 division.
+            ///////////////////////////////////////////////
+
+            // Make division exact by subtracting the remainder from [high low].
+            uint256 remainder;
+            assembly ("memory-safe") {
+                // Compute remainder using mulmod.
+                remainder := mulmod(x, y, denominator)
+
+                // Subtract 256 bit number from 512 bit number.
+                high := sub(high, gt(remainder, low))
+                low := sub(low, remainder)
+            }
+
+            // Factor powers of two out of denominator and compute largest power of two divisor of denominator.
+            // Always >= 1. See https://cs.stackexchange.com/q/138556/92363.
+
+            uint256 twos = denominator & (0 - denominator);
+            assembly ("memory-safe") {
+                // Divide denominator by twos.
+                denominator := div(denominator, twos)
+
+                // Divide [high low] by twos.
+                low := div(low, twos)
+
+                // Flip twos such that it is 2²⁵⁶ / twos. If twos is zero, then it becomes one.
+                twos := add(div(sub(0, twos), twos), 1)
+            }
+
+            // Shift in bits from high into low.
+            low |= high * twos;
+
+            // Invert denominator mod 2²⁵⁶. Now that denominator is an odd number, it has an inverse modulo 2²⁵⁶ such
+            // that denominator * inv ≡ 1 mod 2²⁵⁶. Compute the inverse by starting with a seed that is correct for
+            // four bits. That is, denominator * inv ≡ 1 mod 2⁴.
+            uint256 inverse = (3 * denominator) ^ 2;
+
+            // Use the Newton-Raphson iteration to improve the precision. Thanks to Hensel's lifting lemma, this also
+            // works in modular arithmetic, doubling the correct bits in each step.
+            inverse *= 2 - denominator * inverse; // inverse mod 2⁸
+            inverse *= 2 - denominator * inverse; // inverse mod 2¹⁶
+            inverse *= 2 - denominator * inverse; // inverse mod 2³²
+            inverse *= 2 - denominator * inverse; // inverse mod 2⁶⁴
+            inverse *= 2 - denominator * inverse; // inverse mod 2¹²⁸
+            inverse *= 2 - denominator * inverse; // inverse mod 2²⁵⁶
+
+            // Because the division is now exact we can divide by multiplying with the modular inverse of denominator.
+            // This will give us the correct result modulo 2²⁵⁶. Since the preconditions guarantee that the outcome is
+            // less than 2²⁵⁶, this is the final result. We don't need to compute the high bits of the result and high
+            // is no longer required.
+            result = low * inverse;
+            return result;
+        }
+    }
+
+    /**
+     * @dev Calculates x * y / denominator with full precision, following the selected rounding direction.
+     */
+    function mulDiv(uint256 x, uint256 y, uint256 denominator, Rounding rounding) internal pure returns (uint256) {
+        return mulDiv(x, y, denominator) + SafeCast.toUint(unsignedRoundsUp(rounding) && mulmod(x, y, denominator) > 0);
+    }
+
+    /**
+     * @dev Calculates floor(x * y >> n) with full precision. Throws if result overflows a uint256.
+     */
+    function mulShr(uint256 x, uint256 y, uint8 n) internal pure returns (uint256 result) {
+        unchecked {
+            (uint256 high, uint256 low) = mul512(x, y);
+            if (high >= 1 << n) {
+                Panic.panic(Panic.UNDER_OVERFLOW);
+            }
+            return (high << (256 - n)) | (low >> n);
+        }
+    }
+
+    /**
+     * @dev Calculates x * y >> n with full precision, following the selected rounding direction.
+     */
+    function mulShr(uint256 x, uint256 y, uint8 n, Rounding rounding) internal pure returns (uint256) {
+        return mulShr(x, y, n) + SafeCast.toUint(unsignedRoundsUp(rounding) && mulmod(x, y, 1 << n) > 0);
+    }
+
+    /**
+     * @dev Calculate the modular multiplicative inverse of a number in Z/nZ.
+     *
+     * If n is a prime, then Z/nZ is a field. In that case all elements are inversible, except 0.
+     * If n is not a prime, then Z/nZ is not a field, and some elements might not be inversible.
+     *
+     * If the input value is not inversible, 0 is returned.
+     *
+     * NOTE: If you know for sure that n is (big) a prime, it may be cheaper to use Fermat's little theorem and get the
+     * inverse using `Math.modExp(a, n - 2, n)`. See {invModPrime}.
+     */
+    function invMod(uint256 a, uint256 n) internal pure returns (uint256) {
+        unchecked {
+            if (n == 0) return 0;
+
+            // The inverse modulo is calculated using the Extended Euclidean Algorithm (iterative version)
+            // Used to compute integers x and y such that: ax + ny = gcd(a, n).
+            // When the gcd is 1, then the inverse of a modulo n exists and it's x.
+            // ax + ny = 1
+            // ax = 1 + (-y)n
+            // ax ≡ 1 (mod n) # x is the inverse of a modulo n
+
+            // If the remainder is 0 the gcd is n right away.
+            uint256 remainder = a % n;
+            uint256 gcd = n;
+
+            // Therefore the initial coefficients are:
+            // ax + ny = gcd(a, n) = n
+            // 0a + 1n = n
+            int256 x = 0;
+            int256 y = 1;
+
+            while (remainder != 0) {
+                uint256 quotient = gcd / remainder;
+
+                (gcd, remainder) = (
+                    // The old remainder is the next gcd to try.
+                    remainder,
+                    // Compute the next remainder.
+                    // Can't overflow given that (a % gcd) * (gcd // (a % gcd)) <= gcd
+                    // where gcd is at most n (capped to type(uint256).max)
+                    gcd - remainder * quotient
+                );
+
+                (x, y) = (
+                    // Increment the coefficient of a.
+                    y,
+                    // Decrement the coefficient of n.
+                    // Can overflow, but the result is casted to uint256 so that the
+                    // next value of y is "wrapped around" to a value between 0 and n - 1.
+                    x - y * int256(quotient)
+                );
+            }
+
+            if (gcd != 1) return 0; // No inverse exists.
+            return ternary(x < 0, n - uint256(-x), uint256(x)); // Wrap the result if it's negative.
+        }
+    }
+
+    /**
+     * @dev Variant of {invMod}. More efficient, but only works if `p` is known to be a prime greater than `2`.
+     *
+     * From https://en.wikipedia.org/wiki/Fermat%27s_little_theorem[Fermat's little theorem], we know that if p is
+     * prime, then `a**(p-1) ≡ 1 mod p`. As a consequence, we have `a * a**(p-2) ≡ 1 mod p`, which means that
+     * `a**(p-2)` is the modular multiplicative inverse of a in Fp.
+     *
+     * NOTE: this function does NOT check that `p` is a prime greater than `2`.
+     */
+    function invModPrime(uint256 a, uint256 p) internal view returns (uint256) {
+        unchecked {
+            return Math.modExp(a, p - 2, p);
+        }
+    }
+
+    /**
+     * @dev Returns the modular exponentiation of the specified base, exponent and modulus (b ** e % m)
+     *
+     * Requirements:
+     * - modulus can't be zero
+     * - underlying staticcall to precompile must succeed
+     *
+     * IMPORTANT: The result is only valid if the underlying call succeeds. When using this function, make
+     * sure the chain you're using it on supports the precompiled contract for modular exponentiation
+     * at address 0x05 as specified in https://eips.ethereum.org/EIPS/eip-198[EIP-198]. Otherwise,
+     * the underlying function will succeed given the lack of a revert, but the result may be incorrectly
+     * interpreted as 0.
+     */
+    function modExp(uint256 b, uint256 e, uint256 m) internal view returns (uint256) {
+        (bool success, uint256 result) = tryModExp(b, e, m);
+        if (!success) {
+            Panic.panic(Panic.DIVISION_BY_ZERO);
+        }
+        return result;
+    }
+
+    /**
+     * @dev Returns the modular exponentiation of the specified base, exponent and modulus (b ** e % m).
+     * It includes a success flag indicating if the operation succeeded. Operation will be marked as failed if trying
+     * to operate modulo 0 or if the underlying precompile reverted.
+     *
+     * IMPORTANT: The result is only valid if the success flag is true. When using this function, make sure the chain
+     * you're using it on supports the precompiled contract for modular exponentiation at address 0x05 as specified in
+     * https://eips.ethereum.org/EIPS/eip-198[EIP-198]. Otherwise, the underlying function will succeed given the lack
+     * of a revert, but the result may be incorrectly interpreted as 0.
+     */
+    function tryModExp(uint256 b, uint256 e, uint256 m) internal view returns (bool success, uint256 result) {
+        if (m == 0) return (false, 0);
+        assembly ("memory-safe") {
+            let ptr := mload(0x40)
+            // | Offset    | Content    | Content (Hex)                                                      |
+            // |-----------|------------|--------------------------------------------------------------------|
+            // | 0x00:0x1f | size of b  | 0x0000000000000000000000000000000000000000000000000000000000000020 |
+            // | 0x20:0x3f | size of e  | 0x0000000000000000000000000000000000000000000000000000000000000020 |
+            // | 0x40:0x5f | size of m  | 0x0000000000000000000000000000000000000000000000000000000000000020 |
+            // | 0x60:0x7f | value of b | 0x<.............................................................b> |
+            // | 0x80:0x9f | value of e | 0x<.............................................................e> |
+            // | 0xa0:0xbf | value of m | 0x<.............................................................m> |
+            mstore(ptr, 0x20)
+            mstore(add(ptr, 0x20), 0x20)
+            mstore(add(ptr, 0x40), 0x20)
+            mstore(add(ptr, 0x60), b)
+            mstore(add(ptr, 0x80), e)
+            mstore(add(ptr, 0xa0), m)
+
+            // Given the result < m, it's guaranteed to fit in 32 bytes,
+            // so we can use the memory scratch space located at offset 0.
+            success := staticcall(gas(), 0x05, ptr, 0xc0, 0x00, 0x20)
+            result := mload(0x00)
+        }
+    }
+
+    /**
+     * @dev Variant of {modExp} that supports inputs of arbitrary length.
+     */
+    function modExp(bytes memory b, bytes memory e, bytes memory m) internal view returns (bytes memory) {
+        (bool success, bytes memory result) = tryModExp(b, e, m);
+        if (!success) {
+            Panic.panic(Panic.DIVISION_BY_ZERO);
+        }
+        return result;
+    }
+
+    /**
+     * @dev Variant of {tryModExp} that supports inputs of arbitrary length.
+     */
+    function tryModExp(
+        bytes memory b,
+        bytes memory e,
+        bytes memory m
+    ) internal view returns (bool success, bytes memory result) {
+        if (_zeroBytes(m)) return (false, new bytes(0));
+
+        uint256 mLen = m.length;
+
+        // Encode call args in result and move the free memory pointer
+        result = abi.encodePacked(b.length, e.length, mLen, b, e, m);
+
+        assembly ("memory-safe") {
+            let dataPtr := add(result, 0x20)
+            // Write result on top of args to avoid allocating extra memory.
+            success := staticcall(gas(), 0x05, dataPtr, mload(result), dataPtr, mLen)
+            // Overwrite the length.
+            // result.length > returndatasize() is guaranteed because returndatasize() == m.length
+            mstore(result, mLen)
+            // Set the memory pointer after the returned data.
+            mstore(0x40, add(dataPtr, mLen))
+        }
+    }
+
+    /**
+     * @dev Returns whether the provided byte array is zero.
+     */
+    function _zeroBytes(bytes memory byteArray) private pure returns (bool) {
+        for (uint256 i = 0; i < byteArray.length; ++i) {
+            if (byteArray[i] != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @dev Returns the square root of a number. If the number is not a perfect square, the value is rounded
+     * towards zero.
+     *
+     * This method is based on Newton's method for computing square roots; the algorithm is restricted to only
+     * using integer operations.
+     */
+    function sqrt(uint256 a) internal pure returns (uint256) {
+        unchecked {
+            // Take care of easy edge cases when a == 0 or a == 1
+            if (a <= 1) {
+                return a;
+            }
+
+            // In this function, we use Newton's method to get a root of `f(x) := x² - a`. It involves building a
+            // sequence x_n that converges toward sqrt(a). For each iteration x_n, we also define the error between
+            // the current value as `ε_n = | x_n - sqrt(a) |`.
+            //
+            // For our first estimation, we consider `e` the smallest power of 2 which is bigger than the square root
+            // of the target. (i.e. `2**(e-1) ≤ sqrt(a) < 2**e`). We know that `e ≤ 128` because `(2¹²⁸)² = 2²⁵⁶` is
+            // bigger than any uint256.
+            //
+            // By noticing that
+            // `2**(e-1) ≤ sqrt(a) < 2**e → (2**(e-1))² ≤ a < (2**e)² → 2**(2*e-2) ≤ a < 2**(2*e)`
+            // we can deduce that `e - 1` is `log2(a) / 2`. We can thus compute `x_n = 2**(e-1)` using a method similar
+            // to the msb function.
+            uint256 aa = a;
+            uint256 xn = 1;
+
+            if (aa >= (1 << 128)) {
+                aa >>= 128;
+                xn <<= 64;
+            }
+            if (aa >= (1 << 64)) {
+                aa >>= 64;
+                xn <<= 32;
+            }
+            if (aa >= (1 << 32)) {
+                aa >>= 32;
+                xn <<= 16;
+            }
+            if (aa >= (1 << 16)) {
+                aa >>= 16;
+                xn <<= 8;
+            }
+            if (aa >= (1 << 8)) {
+                aa >>= 8;
+                xn <<= 4;
+            }
+            if (aa >= (1 << 4)) {
+                aa >>= 4;
+                xn <<= 2;
+            }
+            if (aa >= (1 << 2)) {
+                xn <<= 1;
+            }
+
+            // We now have x_n such that `x_n = 2**(e-1) ≤ sqrt(a) < 2**e = 2 * x_n`. This implies ε_n ≤ 2**(e-1).
+            //
+            // We can refine our estimation by noticing that the middle of that interval minimizes the error.
+            // If we move x_n to equal 2**(e-1) + 2**(e-2), then we reduce the error to ε_n ≤ 2**(e-2).
+            // This is going to be our x_0 (and ε_0)
+            xn = (3 * xn) >> 1; // ε_0 := | x_0 - sqrt(a) | ≤ 2**(e-2)
+
+            // From here, Newton's method give us:
+            // x_{n+1} = (x_n + a / x_n) / 2
+            //
+            // One should note that:
+            // x_{n+1}² - a = ((x_n + a / x_n) / 2)² - a
+            //              = ((x_n² + a) / (2 * x_n))² - a
+            //              = (x_n⁴ + 2 * a * x_n² + a²) / (4 * x_n²) - a
+            //              = (x_n⁴ + 2 * a * x_n² + a² - 4 * a * x_n²) / (4 * x_n²)
+            //              = (x_n⁴ - 2 * a * x_n² + a²) / (4 * x_n²)
+            //              = (x_n² - a)² / (2 * x_n)²
+            //              = ((x_n² - a) / (2 * x_n))²
+            //              ≥ 0
+            // Which proves that for all n ≥ 1, sqrt(a) ≤ x_n
+            //
+            // This gives us the proof of quadratic convergence of the sequence:
+            // ε_{n+1} = | x_{n+1} - sqrt(a) |
+            //         = | (x_n + a / x_n) / 2 - sqrt(a) |
+            //         = | (x_n² + a - 2*x_n*sqrt(a)) / (2 * x_n) |
+            //         = | (x_n - sqrt(a))² / (2 * x_n) |
+            //         = | ε_n² / (2 * x_n) |
+            //         = ε_n² / | (2 * x_n) |
+            //
+            // For the first iteration, we have a special case where x_0 is known:
+            // ε_1 = ε_0² / | (2 * x_0) |
+            //     ≤ (2**(e-2))² / (2 * (2**(e-1) + 2**(e-2)))
+            //     ≤ 2**(2*e-4) / (3 * 2**(e-1))
+            //     ≤ 2**(e-3) / 3
+            //     ≤ 2**(e-3-log2(3))
+            //     ≤ 2**(e-4.5)
+            //
+            // For the following iterations, we use the fact that, 2**(e-1) ≤ sqrt(a) ≤ x_n:
+            // ε_{n+1} = ε_n² / | (2 * x_n) |
+            //         ≤ (2**(e-k))² / (2 * 2**(e-1))
+            //         ≤ 2**(2*e-2*k) / 2**e
+            //         ≤ 2**(e-2*k)
+            xn = (xn + a / xn) >> 1; // ε_1 := | x_1 - sqrt(a) | ≤ 2**(e-4.5)  -- special case, see above
+            xn = (xn + a / xn) >> 1; // ε_2 := | x_2 - sqrt(a) | ≤ 2**(e-9)    -- general case with k = 4.5
+            xn = (xn + a / xn) >> 1; // ε_3 := | x_3 - sqrt(a) | ≤ 2**(e-18)   -- general case with k = 9
+            xn = (xn + a / xn) >> 1; // ε_4 := | x_4 - sqrt(a) | ≤ 2**(e-36)   -- general case with k = 18
+            xn = (xn + a / xn) >> 1; // ε_5 := | x_5 - sqrt(a) | ≤ 2**(e-72)   -- general case with k = 36
+            xn = (xn + a / xn) >> 1; // ε_6 := | x_6 - sqrt(a) | ≤ 2**(e-144)  -- general case with k = 72
+
+            // Because e ≤ 128 (as discussed during the first estimation phase), we know have reached a precision
+            // ε_6 ≤ 2**(e-144) < 1. Given we're operating on integers, then we can ensure that xn is now either
+            // sqrt(a) or sqrt(a) + 1.
+            return xn - SafeCast.toUint(xn > a / xn);
+        }
+    }
+
+    /**
+     * @dev Calculates sqrt(a), following the selected rounding direction.
+     */
+    function sqrt(uint256 a, Rounding rounding) internal pure returns (uint256) {
+        unchecked {
+            uint256 result = sqrt(a);
+            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && result * result < a);
+        }
+    }
+
+    /**
+     * @dev Return the log in base 2 of a positive value rounded towards zero.
+     * Returns 0 if given 0.
+     */
+    function log2(uint256 x) internal pure returns (uint256 r) {
+        // If value has upper 128 bits set, log2 result is at least 128
+        r = SafeCast.toUint(x > 0xffffffffffffffffffffffffffffffff) << 7;
+        // If upper 64 bits of 128-bit half set, add 64 to result
+        r |= SafeCast.toUint((x >> r) > 0xffffffffffffffff) << 6;
+        // If upper 32 bits of 64-bit half set, add 32 to result
+        r |= SafeCast.toUint((x >> r) > 0xffffffff) << 5;
+        // If upper 16 bits of 32-bit half set, add 16 to result
+        r |= SafeCast.toUint((x >> r) > 0xffff) << 4;
+        // If upper 8 bits of 16-bit half set, add 8 to result
+        r |= SafeCast.toUint((x >> r) > 0xff) << 3;
+        // If upper 4 bits of 8-bit half set, add 4 to result
+        r |= SafeCast.toUint((x >> r) > 0xf) << 2;
+
+        // Shifts value right by the current result and use it as an index into this lookup table:
+        //
+        // | x (4 bits) |  index  | table[index] = MSB position |
+        // |------------|---------|-----------------------------|
+        // |    0000    |    0    |        table[0] = 0         |
+        // |    0001    |    1    |        table[1] = 0         |
+        // |    0010    |    2    |        table[2] = 1         |
+        // |    0011    |    3    |        table[3] = 1         |
+        // |    0100    |    4    |        table[4] = 2         |
+        // |    0101    |    5    |        table[5] = 2         |
+        // |    0110    |    6    |        table[6] = 2         |
+        // |    0111    |    7    |        table[7] = 2         |
+        // |    1000    |    8    |        table[8] = 3         |
+        // |    1001    |    9    |        table[9] = 3         |
+        // |    1010    |   10    |        table[10] = 3        |
+        // |    1011    |   11    |        table[11] = 3        |
+        // |    1100    |   12    |        table[12] = 3        |
+        // |    1101    |   13    |        table[13] = 3        |
+        // |    1110    |   14    |        table[14] = 3        |
+        // |    1111    |   15    |        table[15] = 3        |
+        //
+        // The lookup table is represented as a 32-byte value with the MSB positions for 0-15 in the last 16 bytes.
+        assembly ("memory-safe") {
+            r := or(r, byte(shr(r, x), 0x0000010102020202030303030303030300000000000000000000000000000000))
+        }
+    }
+
+    /**
+     * @dev Return the log in base 2, following the selected rounding direction, of a positive value.
+     * Returns 0 if given 0.
+     */
+    function log2(uint256 value, Rounding rounding) internal pure returns (uint256) {
+        unchecked {
+            uint256 result = log2(value);
+            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 1 << result < value);
+        }
+    }
+
+    /**
+     * @dev Return the log in base 10 of a positive value rounded towards zero.
+     * Returns 0 if given 0.
+     */
+    function log10(uint256 value) internal pure returns (uint256) {
+        uint256 result = 0;
+        unchecked {
+            if (value >= 10 ** 64) {
+                value /= 10 ** 64;
+                result += 64;
+            }
+            if (value >= 10 ** 32) {
+                value /= 10 ** 32;
+                result += 32;
+            }
+            if (value >= 10 ** 16) {
+                value /= 10 ** 16;
+                result += 16;
+            }
+            if (value >= 10 ** 8) {
+                value /= 10 ** 8;
+                result += 8;
+            }
+            if (value >= 10 ** 4) {
+                value /= 10 ** 4;
+                result += 4;
+            }
+            if (value >= 10 ** 2) {
+                value /= 10 ** 2;
+                result += 2;
+            }
+            if (value >= 10 ** 1) {
+                result += 1;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * @dev Return the log in base 10, following the selected rounding direction, of a positive value.
+     * Returns 0 if given 0.
+     */
+    function log10(uint256 value, Rounding rounding) internal pure returns (uint256) {
+        unchecked {
+            uint256 result = log10(value);
+            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 10 ** result < value);
+        }
+    }
+
+    /**
+     * @dev Return the log in base 256 of a positive value rounded towards zero.
+     * Returns 0 if given 0.
+     *
+     * Adding one to the result gives the number of pairs of hex symbols needed to represent `value` as a hex string.
+     */
+    function log256(uint256 x) internal pure returns (uint256 r) {
+        // If value has upper 128 bits set, log2 result is at least 128
+        r = SafeCast.toUint(x > 0xffffffffffffffffffffffffffffffff) << 7;
+        // If upper 64 bits of 128-bit half set, add 64 to result
+        r |= SafeCast.toUint((x >> r) > 0xffffffffffffffff) << 6;
+        // If upper 32 bits of 64-bit half set, add 32 to result
+        r |= SafeCast.toUint((x >> r) > 0xffffffff) << 5;
+        // If upper 16 bits of 32-bit half set, add 16 to result
+        r |= SafeCast.toUint((x >> r) > 0xffff) << 4;
+        // Add 1 if upper 8 bits of 16-bit half set, and divide accumulated result by 8
+        return (r >> 3) | SafeCast.toUint((x >> r) > 0xff);
+    }
+
+    /**
+     * @dev Return the log in base 256, following the selected rounding direction, of a positive value.
+     * Returns 0 if given 0.
+     */
+    function log256(uint256 value, Rounding rounding) internal pure returns (uint256) {
+        unchecked {
+            uint256 result = log256(value);
+            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 1 << (result << 3) < value);
+        }
+    }
+
+    /**
+     * @dev Returns whether a provided rounding mode is considered rounding up for unsigned integers.
+     */
+    function unsignedRoundsUp(Rounding rounding) internal pure returns (bool) {
+        return uint8(rounding) % 2 == 1;
+    }
+}

--- a/solidity/contracts/peripherals/openOracle/openzeppelin/contracts/utils/math/SafeCast.sol
+++ b/solidity/contracts/peripherals/openOracle/openzeppelin/contracts/utils/math/SafeCast.sol
@@ -1,0 +1,1162 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.1.0) (utils/math/SafeCast.sol)
+// This file was procedurally generated from scripts/generate/templates/SafeCast.js.
+
+pragma solidity ^0.8.20;
+
+/**
+ * @dev Wrappers over Solidity's uintXX/intXX/bool casting operators with added overflow
+ * checks.
+ *
+ * Downcasting from uint256/int256 in Solidity does not revert on overflow. This can
+ * easily result in undesired exploitation or bugs, since developers usually
+ * assume that overflows raise errors. `SafeCast` restores this intuition by
+ * reverting the transaction when such an operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeCast {
+    /**
+     * @dev Value doesn't fit in an uint of `bits` size.
+     */
+    error SafeCastOverflowedUintDowncast(uint8 bits, uint256 value);
+
+    /**
+     * @dev An int value doesn't fit in an uint of `bits` size.
+     */
+    error SafeCastOverflowedIntToUint(int256 value);
+
+    /**
+     * @dev Value doesn't fit in an int of `bits` size.
+     */
+    error SafeCastOverflowedIntDowncast(uint8 bits, int256 value);
+
+    /**
+     * @dev An uint value doesn't fit in an int of `bits` size.
+     */
+    error SafeCastOverflowedUintToInt(uint256 value);
+
+    /**
+     * @dev Returns the downcasted uint248 from uint256, reverting on
+     * overflow (when the input is greater than largest uint248).
+     *
+     * Counterpart to Solidity's `uint248` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 248 bits
+     */
+    function toUint248(uint256 value) internal pure returns (uint248) {
+        if (value > type(uint248).max) {
+            revert SafeCastOverflowedUintDowncast(248, value);
+        }
+        return uint248(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint240 from uint256, reverting on
+     * overflow (when the input is greater than largest uint240).
+     *
+     * Counterpart to Solidity's `uint240` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 240 bits
+     */
+    function toUint240(uint256 value) internal pure returns (uint240) {
+        if (value > type(uint240).max) {
+            revert SafeCastOverflowedUintDowncast(240, value);
+        }
+        return uint240(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint232 from uint256, reverting on
+     * overflow (when the input is greater than largest uint232).
+     *
+     * Counterpart to Solidity's `uint232` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 232 bits
+     */
+    function toUint232(uint256 value) internal pure returns (uint232) {
+        if (value > type(uint232).max) {
+            revert SafeCastOverflowedUintDowncast(232, value);
+        }
+        return uint232(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint224 from uint256, reverting on
+     * overflow (when the input is greater than largest uint224).
+     *
+     * Counterpart to Solidity's `uint224` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 224 bits
+     */
+    function toUint224(uint256 value) internal pure returns (uint224) {
+        if (value > type(uint224).max) {
+            revert SafeCastOverflowedUintDowncast(224, value);
+        }
+        return uint224(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint216 from uint256, reverting on
+     * overflow (when the input is greater than largest uint216).
+     *
+     * Counterpart to Solidity's `uint216` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 216 bits
+     */
+    function toUint216(uint256 value) internal pure returns (uint216) {
+        if (value > type(uint216).max) {
+            revert SafeCastOverflowedUintDowncast(216, value);
+        }
+        return uint216(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint208 from uint256, reverting on
+     * overflow (when the input is greater than largest uint208).
+     *
+     * Counterpart to Solidity's `uint208` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 208 bits
+     */
+    function toUint208(uint256 value) internal pure returns (uint208) {
+        if (value > type(uint208).max) {
+            revert SafeCastOverflowedUintDowncast(208, value);
+        }
+        return uint208(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint200 from uint256, reverting on
+     * overflow (when the input is greater than largest uint200).
+     *
+     * Counterpart to Solidity's `uint200` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 200 bits
+     */
+    function toUint200(uint256 value) internal pure returns (uint200) {
+        if (value > type(uint200).max) {
+            revert SafeCastOverflowedUintDowncast(200, value);
+        }
+        return uint200(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint192 from uint256, reverting on
+     * overflow (when the input is greater than largest uint192).
+     *
+     * Counterpart to Solidity's `uint192` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 192 bits
+     */
+    function toUint192(uint256 value) internal pure returns (uint192) {
+        if (value > type(uint192).max) {
+            revert SafeCastOverflowedUintDowncast(192, value);
+        }
+        return uint192(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint184 from uint256, reverting on
+     * overflow (when the input is greater than largest uint184).
+     *
+     * Counterpart to Solidity's `uint184` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 184 bits
+     */
+    function toUint184(uint256 value) internal pure returns (uint184) {
+        if (value > type(uint184).max) {
+            revert SafeCastOverflowedUintDowncast(184, value);
+        }
+        return uint184(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint176 from uint256, reverting on
+     * overflow (when the input is greater than largest uint176).
+     *
+     * Counterpart to Solidity's `uint176` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 176 bits
+     */
+    function toUint176(uint256 value) internal pure returns (uint176) {
+        if (value > type(uint176).max) {
+            revert SafeCastOverflowedUintDowncast(176, value);
+        }
+        return uint176(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint168 from uint256, reverting on
+     * overflow (when the input is greater than largest uint168).
+     *
+     * Counterpart to Solidity's `uint168` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 168 bits
+     */
+    function toUint168(uint256 value) internal pure returns (uint168) {
+        if (value > type(uint168).max) {
+            revert SafeCastOverflowedUintDowncast(168, value);
+        }
+        return uint168(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint160 from uint256, reverting on
+     * overflow (when the input is greater than largest uint160).
+     *
+     * Counterpart to Solidity's `uint160` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 160 bits
+     */
+    function toUint160(uint256 value) internal pure returns (uint160) {
+        if (value > type(uint160).max) {
+            revert SafeCastOverflowedUintDowncast(160, value);
+        }
+        return uint160(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint152 from uint256, reverting on
+     * overflow (when the input is greater than largest uint152).
+     *
+     * Counterpart to Solidity's `uint152` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 152 bits
+     */
+    function toUint152(uint256 value) internal pure returns (uint152) {
+        if (value > type(uint152).max) {
+            revert SafeCastOverflowedUintDowncast(152, value);
+        }
+        return uint152(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint144 from uint256, reverting on
+     * overflow (when the input is greater than largest uint144).
+     *
+     * Counterpart to Solidity's `uint144` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 144 bits
+     */
+    function toUint144(uint256 value) internal pure returns (uint144) {
+        if (value > type(uint144).max) {
+            revert SafeCastOverflowedUintDowncast(144, value);
+        }
+        return uint144(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint136 from uint256, reverting on
+     * overflow (when the input is greater than largest uint136).
+     *
+     * Counterpart to Solidity's `uint136` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 136 bits
+     */
+    function toUint136(uint256 value) internal pure returns (uint136) {
+        if (value > type(uint136).max) {
+            revert SafeCastOverflowedUintDowncast(136, value);
+        }
+        return uint136(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint128 from uint256, reverting on
+     * overflow (when the input is greater than largest uint128).
+     *
+     * Counterpart to Solidity's `uint128` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 128 bits
+     */
+    function toUint128(uint256 value) internal pure returns (uint128) {
+        if (value > type(uint128).max) {
+            revert SafeCastOverflowedUintDowncast(128, value);
+        }
+        return uint128(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint120 from uint256, reverting on
+     * overflow (when the input is greater than largest uint120).
+     *
+     * Counterpart to Solidity's `uint120` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 120 bits
+     */
+    function toUint120(uint256 value) internal pure returns (uint120) {
+        if (value > type(uint120).max) {
+            revert SafeCastOverflowedUintDowncast(120, value);
+        }
+        return uint120(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint112 from uint256, reverting on
+     * overflow (when the input is greater than largest uint112).
+     *
+     * Counterpart to Solidity's `uint112` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 112 bits
+     */
+    function toUint112(uint256 value) internal pure returns (uint112) {
+        if (value > type(uint112).max) {
+            revert SafeCastOverflowedUintDowncast(112, value);
+        }
+        return uint112(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint104 from uint256, reverting on
+     * overflow (when the input is greater than largest uint104).
+     *
+     * Counterpart to Solidity's `uint104` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 104 bits
+     */
+    function toUint104(uint256 value) internal pure returns (uint104) {
+        if (value > type(uint104).max) {
+            revert SafeCastOverflowedUintDowncast(104, value);
+        }
+        return uint104(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint96 from uint256, reverting on
+     * overflow (when the input is greater than largest uint96).
+     *
+     * Counterpart to Solidity's `uint96` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 96 bits
+     */
+    function toUint96(uint256 value) internal pure returns (uint96) {
+        if (value > type(uint96).max) {
+            revert SafeCastOverflowedUintDowncast(96, value);
+        }
+        return uint96(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint88 from uint256, reverting on
+     * overflow (when the input is greater than largest uint88).
+     *
+     * Counterpart to Solidity's `uint88` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 88 bits
+     */
+    function toUint88(uint256 value) internal pure returns (uint88) {
+        if (value > type(uint88).max) {
+            revert SafeCastOverflowedUintDowncast(88, value);
+        }
+        return uint88(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint80 from uint256, reverting on
+     * overflow (when the input is greater than largest uint80).
+     *
+     * Counterpart to Solidity's `uint80` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 80 bits
+     */
+    function toUint80(uint256 value) internal pure returns (uint80) {
+        if (value > type(uint80).max) {
+            revert SafeCastOverflowedUintDowncast(80, value);
+        }
+        return uint80(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint72 from uint256, reverting on
+     * overflow (when the input is greater than largest uint72).
+     *
+     * Counterpart to Solidity's `uint72` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 72 bits
+     */
+    function toUint72(uint256 value) internal pure returns (uint72) {
+        if (value > type(uint72).max) {
+            revert SafeCastOverflowedUintDowncast(72, value);
+        }
+        return uint72(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint64 from uint256, reverting on
+     * overflow (when the input is greater than largest uint64).
+     *
+     * Counterpart to Solidity's `uint64` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 64 bits
+     */
+    function toUint64(uint256 value) internal pure returns (uint64) {
+        if (value > type(uint64).max) {
+            revert SafeCastOverflowedUintDowncast(64, value);
+        }
+        return uint64(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint56 from uint256, reverting on
+     * overflow (when the input is greater than largest uint56).
+     *
+     * Counterpart to Solidity's `uint56` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 56 bits
+     */
+    function toUint56(uint256 value) internal pure returns (uint56) {
+        if (value > type(uint56).max) {
+            revert SafeCastOverflowedUintDowncast(56, value);
+        }
+        return uint56(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint48 from uint256, reverting on
+     * overflow (when the input is greater than largest uint48).
+     *
+     * Counterpart to Solidity's `uint48` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 48 bits
+     */
+    function toUint48(uint256 value) internal pure returns (uint48) {
+        if (value > type(uint48).max) {
+            revert SafeCastOverflowedUintDowncast(48, value);
+        }
+        return uint48(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint40 from uint256, reverting on
+     * overflow (when the input is greater than largest uint40).
+     *
+     * Counterpart to Solidity's `uint40` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 40 bits
+     */
+    function toUint40(uint256 value) internal pure returns (uint40) {
+        if (value > type(uint40).max) {
+            revert SafeCastOverflowedUintDowncast(40, value);
+        }
+        return uint40(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint32 from uint256, reverting on
+     * overflow (when the input is greater than largest uint32).
+     *
+     * Counterpart to Solidity's `uint32` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 32 bits
+     */
+    function toUint32(uint256 value) internal pure returns (uint32) {
+        if (value > type(uint32).max) {
+            revert SafeCastOverflowedUintDowncast(32, value);
+        }
+        return uint32(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint24 from uint256, reverting on
+     * overflow (when the input is greater than largest uint24).
+     *
+     * Counterpart to Solidity's `uint24` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 24 bits
+     */
+    function toUint24(uint256 value) internal pure returns (uint24) {
+        if (value > type(uint24).max) {
+            revert SafeCastOverflowedUintDowncast(24, value);
+        }
+        return uint24(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint16 from uint256, reverting on
+     * overflow (when the input is greater than largest uint16).
+     *
+     * Counterpart to Solidity's `uint16` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 16 bits
+     */
+    function toUint16(uint256 value) internal pure returns (uint16) {
+        if (value > type(uint16).max) {
+            revert SafeCastOverflowedUintDowncast(16, value);
+        }
+        return uint16(value);
+    }
+
+    /**
+     * @dev Returns the downcasted uint8 from uint256, reverting on
+     * overflow (when the input is greater than largest uint8).
+     *
+     * Counterpart to Solidity's `uint8` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 8 bits
+     */
+    function toUint8(uint256 value) internal pure returns (uint8) {
+        if (value > type(uint8).max) {
+            revert SafeCastOverflowedUintDowncast(8, value);
+        }
+        return uint8(value);
+    }
+
+    /**
+     * @dev Converts a signed int256 into an unsigned uint256.
+     *
+     * Requirements:
+     *
+     * - input must be greater than or equal to 0.
+     */
+    function toUint256(int256 value) internal pure returns (uint256) {
+        if (value < 0) {
+            revert SafeCastOverflowedIntToUint(value);
+        }
+        return uint256(value);
+    }
+
+    /**
+     * @dev Returns the downcasted int248 from int256, reverting on
+     * overflow (when the input is less than smallest int248 or
+     * greater than largest int248).
+     *
+     * Counterpart to Solidity's `int248` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 248 bits
+     */
+    function toInt248(int256 value) internal pure returns (int248 downcasted) {
+        downcasted = int248(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(248, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int240 from int256, reverting on
+     * overflow (when the input is less than smallest int240 or
+     * greater than largest int240).
+     *
+     * Counterpart to Solidity's `int240` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 240 bits
+     */
+    function toInt240(int256 value) internal pure returns (int240 downcasted) {
+        downcasted = int240(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(240, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int232 from int256, reverting on
+     * overflow (when the input is less than smallest int232 or
+     * greater than largest int232).
+     *
+     * Counterpart to Solidity's `int232` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 232 bits
+     */
+    function toInt232(int256 value) internal pure returns (int232 downcasted) {
+        downcasted = int232(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(232, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int224 from int256, reverting on
+     * overflow (when the input is less than smallest int224 or
+     * greater than largest int224).
+     *
+     * Counterpart to Solidity's `int224` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 224 bits
+     */
+    function toInt224(int256 value) internal pure returns (int224 downcasted) {
+        downcasted = int224(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(224, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int216 from int256, reverting on
+     * overflow (when the input is less than smallest int216 or
+     * greater than largest int216).
+     *
+     * Counterpart to Solidity's `int216` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 216 bits
+     */
+    function toInt216(int256 value) internal pure returns (int216 downcasted) {
+        downcasted = int216(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(216, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int208 from int256, reverting on
+     * overflow (when the input is less than smallest int208 or
+     * greater than largest int208).
+     *
+     * Counterpart to Solidity's `int208` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 208 bits
+     */
+    function toInt208(int256 value) internal pure returns (int208 downcasted) {
+        downcasted = int208(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(208, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int200 from int256, reverting on
+     * overflow (when the input is less than smallest int200 or
+     * greater than largest int200).
+     *
+     * Counterpart to Solidity's `int200` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 200 bits
+     */
+    function toInt200(int256 value) internal pure returns (int200 downcasted) {
+        downcasted = int200(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(200, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int192 from int256, reverting on
+     * overflow (when the input is less than smallest int192 or
+     * greater than largest int192).
+     *
+     * Counterpart to Solidity's `int192` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 192 bits
+     */
+    function toInt192(int256 value) internal pure returns (int192 downcasted) {
+        downcasted = int192(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(192, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int184 from int256, reverting on
+     * overflow (when the input is less than smallest int184 or
+     * greater than largest int184).
+     *
+     * Counterpart to Solidity's `int184` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 184 bits
+     */
+    function toInt184(int256 value) internal pure returns (int184 downcasted) {
+        downcasted = int184(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(184, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int176 from int256, reverting on
+     * overflow (when the input is less than smallest int176 or
+     * greater than largest int176).
+     *
+     * Counterpart to Solidity's `int176` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 176 bits
+     */
+    function toInt176(int256 value) internal pure returns (int176 downcasted) {
+        downcasted = int176(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(176, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int168 from int256, reverting on
+     * overflow (when the input is less than smallest int168 or
+     * greater than largest int168).
+     *
+     * Counterpart to Solidity's `int168` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 168 bits
+     */
+    function toInt168(int256 value) internal pure returns (int168 downcasted) {
+        downcasted = int168(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(168, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int160 from int256, reverting on
+     * overflow (when the input is less than smallest int160 or
+     * greater than largest int160).
+     *
+     * Counterpart to Solidity's `int160` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 160 bits
+     */
+    function toInt160(int256 value) internal pure returns (int160 downcasted) {
+        downcasted = int160(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(160, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int152 from int256, reverting on
+     * overflow (when the input is less than smallest int152 or
+     * greater than largest int152).
+     *
+     * Counterpart to Solidity's `int152` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 152 bits
+     */
+    function toInt152(int256 value) internal pure returns (int152 downcasted) {
+        downcasted = int152(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(152, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int144 from int256, reverting on
+     * overflow (when the input is less than smallest int144 or
+     * greater than largest int144).
+     *
+     * Counterpart to Solidity's `int144` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 144 bits
+     */
+    function toInt144(int256 value) internal pure returns (int144 downcasted) {
+        downcasted = int144(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(144, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int136 from int256, reverting on
+     * overflow (when the input is less than smallest int136 or
+     * greater than largest int136).
+     *
+     * Counterpart to Solidity's `int136` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 136 bits
+     */
+    function toInt136(int256 value) internal pure returns (int136 downcasted) {
+        downcasted = int136(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(136, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int128 from int256, reverting on
+     * overflow (when the input is less than smallest int128 or
+     * greater than largest int128).
+     *
+     * Counterpart to Solidity's `int128` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 128 bits
+     */
+    function toInt128(int256 value) internal pure returns (int128 downcasted) {
+        downcasted = int128(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(128, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int120 from int256, reverting on
+     * overflow (when the input is less than smallest int120 or
+     * greater than largest int120).
+     *
+     * Counterpart to Solidity's `int120` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 120 bits
+     */
+    function toInt120(int256 value) internal pure returns (int120 downcasted) {
+        downcasted = int120(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(120, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int112 from int256, reverting on
+     * overflow (when the input is less than smallest int112 or
+     * greater than largest int112).
+     *
+     * Counterpart to Solidity's `int112` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 112 bits
+     */
+    function toInt112(int256 value) internal pure returns (int112 downcasted) {
+        downcasted = int112(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(112, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int104 from int256, reverting on
+     * overflow (when the input is less than smallest int104 or
+     * greater than largest int104).
+     *
+     * Counterpart to Solidity's `int104` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 104 bits
+     */
+    function toInt104(int256 value) internal pure returns (int104 downcasted) {
+        downcasted = int104(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(104, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int96 from int256, reverting on
+     * overflow (when the input is less than smallest int96 or
+     * greater than largest int96).
+     *
+     * Counterpart to Solidity's `int96` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 96 bits
+     */
+    function toInt96(int256 value) internal pure returns (int96 downcasted) {
+        downcasted = int96(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(96, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int88 from int256, reverting on
+     * overflow (when the input is less than smallest int88 or
+     * greater than largest int88).
+     *
+     * Counterpart to Solidity's `int88` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 88 bits
+     */
+    function toInt88(int256 value) internal pure returns (int88 downcasted) {
+        downcasted = int88(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(88, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int80 from int256, reverting on
+     * overflow (when the input is less than smallest int80 or
+     * greater than largest int80).
+     *
+     * Counterpart to Solidity's `int80` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 80 bits
+     */
+    function toInt80(int256 value) internal pure returns (int80 downcasted) {
+        downcasted = int80(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(80, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int72 from int256, reverting on
+     * overflow (when the input is less than smallest int72 or
+     * greater than largest int72).
+     *
+     * Counterpart to Solidity's `int72` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 72 bits
+     */
+    function toInt72(int256 value) internal pure returns (int72 downcasted) {
+        downcasted = int72(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(72, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int64 from int256, reverting on
+     * overflow (when the input is less than smallest int64 or
+     * greater than largest int64).
+     *
+     * Counterpart to Solidity's `int64` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 64 bits
+     */
+    function toInt64(int256 value) internal pure returns (int64 downcasted) {
+        downcasted = int64(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(64, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int56 from int256, reverting on
+     * overflow (when the input is less than smallest int56 or
+     * greater than largest int56).
+     *
+     * Counterpart to Solidity's `int56` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 56 bits
+     */
+    function toInt56(int256 value) internal pure returns (int56 downcasted) {
+        downcasted = int56(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(56, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int48 from int256, reverting on
+     * overflow (when the input is less than smallest int48 or
+     * greater than largest int48).
+     *
+     * Counterpart to Solidity's `int48` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 48 bits
+     */
+    function toInt48(int256 value) internal pure returns (int48 downcasted) {
+        downcasted = int48(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(48, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int40 from int256, reverting on
+     * overflow (when the input is less than smallest int40 or
+     * greater than largest int40).
+     *
+     * Counterpart to Solidity's `int40` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 40 bits
+     */
+    function toInt40(int256 value) internal pure returns (int40 downcasted) {
+        downcasted = int40(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(40, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int32 from int256, reverting on
+     * overflow (when the input is less than smallest int32 or
+     * greater than largest int32).
+     *
+     * Counterpart to Solidity's `int32` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 32 bits
+     */
+    function toInt32(int256 value) internal pure returns (int32 downcasted) {
+        downcasted = int32(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(32, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int24 from int256, reverting on
+     * overflow (when the input is less than smallest int24 or
+     * greater than largest int24).
+     *
+     * Counterpart to Solidity's `int24` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 24 bits
+     */
+    function toInt24(int256 value) internal pure returns (int24 downcasted) {
+        downcasted = int24(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(24, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int16 from int256, reverting on
+     * overflow (when the input is less than smallest int16 or
+     * greater than largest int16).
+     *
+     * Counterpart to Solidity's `int16` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 16 bits
+     */
+    function toInt16(int256 value) internal pure returns (int16 downcasted) {
+        downcasted = int16(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(16, value);
+        }
+    }
+
+    /**
+     * @dev Returns the downcasted int8 from int256, reverting on
+     * overflow (when the input is less than smallest int8 or
+     * greater than largest int8).
+     *
+     * Counterpart to Solidity's `int8` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 8 bits
+     */
+    function toInt8(int256 value) internal pure returns (int8 downcasted) {
+        downcasted = int8(value);
+        if (downcasted != value) {
+            revert SafeCastOverflowedIntDowncast(8, value);
+        }
+    }
+
+    /**
+     * @dev Converts an unsigned uint256 into a signed int256.
+     *
+     * Requirements:
+     *
+     * - input must be less than or equal to maxInt256.
+     */
+    function toInt256(uint256 value) internal pure returns (int256) {
+        // Note: Unsafe cast below is okay because `type(int256).max` is guaranteed to be positive
+        if (value > uint256(type(int256).max)) {
+            revert SafeCastOverflowedUintToInt(value);
+        }
+        return int256(value);
+    }
+
+    /**
+     * @dev Cast a boolean (false or true) to a uint256 (0 or 1) with no jump.
+     */
+    function toUint(bool b) internal pure returns (uint256 u) {
+        assembly ("memory-safe") {
+            u := iszero(iszero(b))
+        }
+    }
+}

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -7,7 +7,7 @@
 		"ensure-contract-artifacts": "bun ../scripts/ensure-contract-artifacts.mts",
 		"setup": "bun install --frozen-lockfile && bun run compile-contracts",
 		"generate:contract-artifacts": "bun run compile-contracts",
-		"compile-contracts": "bun tsc --project tsconfig-compile.json && bun run ./js/compile.js && cd .. && bun run generate:ui-contract-artifact",
+		"compile-contracts": "bun tsc --project tsconfig-compile.json && node ./js/compile.js && cd .. && bun run generate:ui-contract-artifact",
 		"gas-costs": "bun tsc && bun run ./js/gas-costs.js",
 		"test": "bun run ensure-contract-artifacts && bun tsc && bun test --timeout 300000 ./js/tests/"
 	},

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -7,7 +7,7 @@
 		"ensure-contract-artifacts": "bun ../scripts/ensure-contract-artifacts.mts",
 		"setup": "bun install --frozen-lockfile && bun run compile-contracts",
 		"generate:contract-artifacts": "bun run compile-contracts",
-		"compile-contracts": "bun tsc --project tsconfig-compile.json && node ./js/compile.js && cd .. && bun run generate:ui-contract-artifact",
+		"compile-contracts": "bun tsc --project tsconfig-compile.json && bun ./js/compile.js && cd .. && bun run generate:ui-contract-artifact",
 		"gas-costs": "bun tsc && bun run ./js/gas-costs.js",
 		"test": "bun run ensure-contract-artifacts && bun tsc && bun test --timeout 300000 ./js/tests/"
 	},

--- a/solidity/ts/compile.ts
+++ b/solidity/ts/compile.ts
@@ -75,7 +75,7 @@ const mainCompilerSettings = {
 	viaIR: true,
 	optimizer: {
 		enabled: true,
-		runs: 190,
+		runs: 200,
 	},
 	outputSelection: {
 		'*': {

--- a/solidity/ts/compile.ts
+++ b/solidity/ts/compile.ts
@@ -1,9 +1,9 @@
+import { createHash } from 'crypto'
 import { promises as fs } from 'fs'
 import * as path from 'path'
 import solc from 'solc'
 import * as funtypes from 'funtypes'
 import * as url from 'url'
-import { createHash } from 'crypto'
 
 const directoryOfThisFile = path.dirname(url.fileURLToPath(import.meta.url))
 const CONTRACT_PATH_APP = path.join(directoryOfThisFile, '..', 'ts', 'types', 'contractArtifact.ts')
@@ -11,6 +11,13 @@ const CONTRACT_PATH_RUNTIME = path.join(directoryOfThisFile, '..', 'types', 'con
 const HASH_CACHE_PATH = path.join(process.cwd(), '.contract-hash.json')
 const ARTIFACTS_DIR = path.join(process.cwd(), 'artifacts')
 const ARTIFACTS_JSON = path.join(ARTIFACTS_DIR, 'Contracts.json')
+const OPEN_ORACLE_LOCAL_PATH = 'contracts/peripherals/openOracle/OpenOracle.sol'
+const OPEN_ORACLE_LOCAL_VENDOR_PREFIX = 'contracts/peripherals/openOracle/openzeppelin/contracts/'
+const OPEN_ORACLE_UPSTREAM_PATH = 'src/OpenOracleL1.sol'
+const OPEN_ORACLE_IMPORT_PREFIX = '@openzeppelin/contracts/'
+const OPEN_ORACLE_EXACT_PRAGMA = 'pragma solidity 0.8.28;'
+const OPEN_ORACLE_MAIN_PASS_PRAGMA = 'pragma solidity >=0.8.28 <0.9.0;'
+const OPEN_ORACLE_SOLC_VERSION = 'v0.8.28+commit.7893614a'
 
 const CompileError = funtypes.ReadonlyObject({
 	severity: funtypes.String,
@@ -42,7 +49,6 @@ const AbiEntry = funtypes.ReadonlyPartial({
 	outputs: funtypes.ReadonlyArray(AbiParameter),
 })
 
-// Contract data may have abi and evm optional (if compilation failed for that contract)
 const ContractData = funtypes.ReadonlyPartial({
 	abi: funtypes.ReadonlyArray(AbiEntry),
 	evm: funtypes.ReadonlyPartial({
@@ -65,27 +71,63 @@ const HashCache = funtypes.ReadonlyPartial({
 	hash: funtypes.String,
 })
 
+const mainCompilerSettings = {
+	viaIR: true,
+	optimizer: {
+		enabled: true,
+		runs: 190,
+	},
+	outputSelection: {
+		'*': {
+			'*': ['abi', 'evm.bytecode.object', 'evm.bytecode.opcodes', 'evm.bytecode.sourceMap', 'evm.deployedBytecode.object', 'evm.deployedBytecode.opcodes', 'evm.deployedBytecode.sourceMap'],
+		},
+	},
+}
+
+const openOracleCompilerSettings = {
+	viaIR: true,
+	optimizer: {
+		enabled: true,
+		runs: 50000,
+	},
+	outputSelection: mainCompilerSettings.outputSelection,
+	evmVersion: 'cancun',
+}
+
+type SolcCompiler = {
+	compile(input: string): string
+	version(): string
+}
+
+let openOracleCompilerPromise: Promise<SolcCompiler> | undefined
+
 class CompilationError extends Error {
 	errors: string[]
+
 	constructor(errors: string[]) {
 		super('compilation error')
 		this.name = 'CompilationError'
 		this.errors = errors
 	}
+
 	override toString() {
 		const unescape = (str: string) => str.replace(/\\n/g, '\n').replace(/\\t/g, '\t')
-		return `${this.name}: ${this.message}\n errors:\n${this.errors.map((e, i) => `  [${i}] ${unescape(e)}`).join('\n')}`
+		return `${this.name}: ${this.message}\n errors:\n${this.errors.map((error, index) => `  [${index}] ${unescape(error)}`).join('\n')}`
 	}
 }
 
-async function exists(path: string) {
+async function exists(filePath: string) {
 	try {
-		await fs.stat(path)
+		await fs.stat(filePath)
 		return true
 	} catch (error) {
-		if (!(error instanceof Error) || !('code' in error) || error.code !== 'ENOENT') throw error
-		return false
+		if (hasNodeErrorCode(error, 'ENOENT')) return false
+		throw error
 	}
+}
+
+function hasNodeErrorCode(error: unknown, code: string): boolean {
+	return isObjectRecord(error) && error['code'] === code
 }
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
@@ -96,36 +138,54 @@ function isCompileError(value: unknown): value is { severity: string; formattedM
 	return isObjectRecord(value) && typeof value['severity'] === 'string' && typeof value['formattedMessage'] === 'string'
 }
 
-// Compiler settings that affect output - must be included in hash
-const compilerSettings = {
-	viaIR: true,
-	optimizer: {
-		enabled: true,
-		runs: 1,
-		details: {
-			inliner: true,
-		},
-	},
-	outputSelection: {
-		'*': {
-			'*': ['abi', 'evm.bytecode.object', 'evm.bytecode.opcodes', 'evm.bytecode.sourceMap', 'evm.deployedBytecode.object', 'evm.deployedBytecode.opcodes', 'evm.deployedBytecode.sourceMap'],
-		},
-	},
+function isFuntypesValidationError(error: unknown): error is Error {
+	return error instanceof Error && error.name === 'ValidationError'
+}
+
+function getCompilerVersion(compiler: SolcCompiler): string {
+	return compiler.version()
+}
+
+async function loadOpenOracleCompiler(): Promise<SolcCompiler> {
+	if (openOracleCompilerPromise) return openOracleCompilerPromise
+
+	openOracleCompilerPromise = new Promise((resolve, reject) => {
+		solc.loadRemoteVersion(OPEN_ORACLE_SOLC_VERSION, (error, compiler) => {
+			if (error !== undefined && error !== null) {
+				reject(error)
+				return
+			}
+			if (compiler === undefined || typeof compiler.compile !== 'function' || typeof compiler.version !== 'function') {
+				reject(new Error(`Failed to load ${OPEN_ORACLE_SOLC_VERSION}`))
+				return
+			}
+			resolve(compiler)
+		})
+	})
+
+	return openOracleCompilerPromise
 }
 
 async function computeContractHash(sourceFiles: Map<string, string>): Promise<string> {
 	const hasher = createHash('sha256')
 
-	// Include compiler version to detect solc upgrades
-	if (!('version' in solc) || typeof solc.version !== 'function') throw new Error('solc.version is unavailable')
-	hasher.update(solc.version())
+	hasher.update(getCompilerVersion(solc))
+	hasher.update('\n')
+	hasher.update(OPEN_ORACLE_SOLC_VERSION)
+	hasher.update('\n')
+	hasher.update(
+		JSON.stringify({
+			mainCompilerSettings,
+			openOracleCompilerSettings,
+			openOracleLocalPath: OPEN_ORACLE_LOCAL_PATH,
+			openOracleLocalVendorPrefix: OPEN_ORACLE_LOCAL_VENDOR_PREFIX,
+			openOracleUpstreamPath: OPEN_ORACLE_UPSTREAM_PATH,
+			openOracleImportPrefix: OPEN_ORACLE_IMPORT_PREFIX,
+			openOracleMainPassPragma: OPEN_ORACLE_MAIN_PASS_PRAGMA,
+		}),
+	)
 	hasher.update('\n')
 
-	// Include compiler settings in the hash
-	hasher.update(JSON.stringify(compilerSettings))
-	hasher.update('\n')
-
-	// Hash all source files
 	const sortedPaths = Array.from(sourceFiles.keys()).sort()
 	for (const relativePath of sortedPaths) {
 		hasher.update(relativePath)
@@ -133,6 +193,7 @@ async function computeContractHash(sourceFiles: Map<string, string>): Promise<st
 		hasher.update(sourceFiles.get(relativePath) ?? '')
 		hasher.update('\n')
 	}
+
 	return hasher.digest('hex')
 }
 
@@ -144,9 +205,10 @@ async function loadHashCache(): Promise<{ hash: string | undefined }> {
 			return { hash: parsed.hash }
 		}
 	} catch (error) {
-		if (error instanceof SyntaxError || (error instanceof Error && (('code' in error && error.code === 'ENOENT') || error.name === 'ZodError'))) return { hash: undefined }
-		// ignore
+		if (error instanceof SyntaxError || hasNodeErrorCode(error, 'ENOENT') || isFuntypesValidationError(error)) return { hash: undefined }
+		throw error
 	}
+
 	return { hash: undefined }
 }
 
@@ -156,14 +218,9 @@ async function saveHashCache(contractHash: string): Promise<void> {
 }
 
 const getAllFiles = async (dirPath: string, baseDir?: string, fileList: string[] = [], visited?: Set<string>): Promise<string[]> => {
-	// Set base directory on first call and resolve to absolute canonical path (resolve symlinks)
 	if (!baseDir) baseDir = await fs.realpath(dirPath)
-	// Initialize visited set on first call
 	const visitedSet = visited ?? new Set<string>()
-
-	// Get canonical path of current directory to detect cycles
 	const canonicalDir = await fs.realpath(dirPath)
-	// Skip if already visited (symlink loop detection)
 	if (visitedSet.has(canonicalDir)) return fileList
 	visitedSet.add(canonicalDir)
 
@@ -171,28 +228,22 @@ const getAllFiles = async (dirPath: string, baseDir?: string, fileList: string[]
 	for (const file of files) {
 		const filePath = path.join(dirPath, file.name)
 
-		// Resolve symbolic links to their target for security check and recursion
 		let targetPath = filePath
 		if (file.isSymbolicLink()) {
 			targetPath = await fs.realpath(filePath)
-		} else {
-			// For regular files/directories, just use absolute path (no need to resolve symlinks in parent chain again)
-			// Since dirPath is already resolved (canonical), filePath is already absolute.
-			// We'll use filePath for security check and recursion for non-symlinks.
-			targetPath = filePath
 		}
 
-		// Security check: ensure targetPath is within baseDir
 		const relative = path.relative(baseDir, targetPath)
 		if (relative.startsWith('..') || path.isAbsolute(relative)) throw new Error(`Path traversal detected: ${filePath} resolves outside allowed directory`)
 
-		// Recurse into directories (including symlinked directories that passed the check)
 		if (file.isDirectory() || (file.isSymbolicLink() && (await fs.stat(targetPath)).isDirectory())) {
 			await getAllFiles(targetPath, baseDir, fileList, visitedSet)
-		} else {
-			fileList.push(filePath)
+			continue
 		}
+
+		fileList.push(filePath)
 	}
+
 	return fileList
 }
 
@@ -211,17 +262,142 @@ const copySolidityContractArtifact = async (contractLocation: string) => {
 			contractData,
 		}))
 	})
-	if (new Set(contracts.map(x => x.contractName)).size !== contracts.length) throw new Error('duplicated contract name!')
+	if (new Set(contracts.map(contract => contract.contractName)).size !== contracts.length) throw new Error('duplicated contract name!')
 	const typescriptString = contracts.map(contract => `export const ${contract.contractName} = ${JSON.stringify(contract.contractData, null, 4)} as const`).join('\r\n\r\n')
 	await fs.mkdir(path.dirname(CONTRACT_PATH_RUNTIME), { recursive: true })
 	await fs.writeFile(CONTRACT_PATH_APP, typescriptString)
 	await fs.writeFile(CONTRACT_PATH_RUNTIME, `${typescriptString}\n`)
 }
 
+function buildSourceObject(sources: Map<string, string>) {
+	const sourceObject: { [key: string]: { content: string } } = {}
+	for (const [sourcePath, content] of sources) {
+		sourceObject[sourcePath] = { content }
+	}
+	return sourceObject
+}
+
+function addOpenOracleImportAliases(targetSources: Map<string, string>, sourceFiles: Map<string, string>) {
+	for (const [sourcePath, content] of sourceFiles) {
+		if (!sourcePath.startsWith(OPEN_ORACLE_LOCAL_VENDOR_PREFIX)) continue
+		const aliasedPath = `${OPEN_ORACLE_IMPORT_PREFIX}${sourcePath.slice(OPEN_ORACLE_LOCAL_VENDOR_PREFIX.length)}`
+		targetSources.set(aliasedPath, content)
+	}
+}
+
+function createMainCompilerSources(sourceFiles: Map<string, string>) {
+	const mainSources = new Map(sourceFiles)
+	const openOracleSource = sourceFiles.get(OPEN_ORACLE_LOCAL_PATH)
+	if (openOracleSource === undefined) throw new Error(`Missing ${OPEN_ORACLE_LOCAL_PATH}`)
+	if (!openOracleSource.includes(OPEN_ORACLE_EXACT_PRAGMA)) throw new Error(`Expected ${OPEN_ORACLE_LOCAL_PATH} to include ${OPEN_ORACLE_EXACT_PRAGMA}`)
+	mainSources.set(OPEN_ORACLE_LOCAL_PATH, openOracleSource.replace(OPEN_ORACLE_EXACT_PRAGMA, OPEN_ORACLE_MAIN_PASS_PRAGMA))
+	addOpenOracleImportAliases(mainSources, sourceFiles)
+	return mainSources
+}
+
+function createOpenOracleCompilerSources(sourceFiles: Map<string, string>) {
+	const openOracleSource = sourceFiles.get(OPEN_ORACLE_LOCAL_PATH)
+	if (openOracleSource === undefined) throw new Error(`Missing ${OPEN_ORACLE_LOCAL_PATH}`)
+	const openOracleSources = new Map<string, string>([[OPEN_ORACLE_UPSTREAM_PATH, openOracleSource]])
+	for (const [sourcePath, content] of sourceFiles) {
+		if (!sourcePath.startsWith(OPEN_ORACLE_LOCAL_VENDOR_PREFIX)) continue
+		const remappedPath = `${OPEN_ORACLE_IMPORT_PREFIX}${sourcePath.slice(OPEN_ORACLE_LOCAL_VENDOR_PREFIX.length)}`
+		openOracleSources.set(remappedPath, content)
+	}
+	return openOracleSources
+}
+
+function compileSourceMap(label: string, compiler: SolcCompiler, sources: Map<string, string>, settings: Record<string, unknown>) {
+	const input = {
+		language: 'Solidity',
+		sources: buildSourceObject(sources),
+		settings,
+	}
+
+	console.time(`${label} compilation`)
+	const output = compiler.compile(JSON.stringify(input))
+	console.timeEnd(`${label} compilation`)
+
+	const result = CompileResult.parse(JSON.parse(output))
+	const diagnostics = Array.isArray(result.errors) ? result.errors : []
+	const errors: string[] = []
+	const warnings: string[] = []
+
+	for (const diagnostic of diagnostics) {
+		if (!isCompileError(diagnostic)) continue
+		if (diagnostic.severity === 'error') errors.push(diagnostic.formattedMessage)
+		if (diagnostic.severity === 'warning') warnings.push(diagnostic.formattedMessage)
+	}
+
+	if (errors.length > 0) throw new CompilationError(errors.map(error => `${label}: ${error}`))
+	if (warnings.length > 0) warnings.forEach(warning => console.warn(`${label}: ${warning}`))
+
+	return result
+}
+
+function isTemporaryCompilerSourcePath(sourcePath: string) {
+	return sourcePath === OPEN_ORACLE_UPSTREAM_PATH || sourcePath.startsWith(OPEN_ORACLE_IMPORT_PREFIX)
+}
+
+function isReplacedLocalOracleSourcePath(sourcePath: string) {
+	return sourcePath === OPEN_ORACLE_LOCAL_PATH || sourcePath.startsWith(OPEN_ORACLE_LOCAL_VENDOR_PREFIX)
+}
+
+function remapOpenOracleSourcePath(sourcePath: string): string | undefined {
+	if (sourcePath === OPEN_ORACLE_UPSTREAM_PATH) return OPEN_ORACLE_LOCAL_PATH
+	return undefined
+}
+
+function mergeCompileSources(mainSources: unknown, openOracleSources: unknown) {
+	const mergedSources: Record<string, unknown> = {}
+
+	if (isObjectRecord(mainSources)) {
+		for (const [sourcePath, sourceData] of Object.entries(mainSources)) {
+			if (isTemporaryCompilerSourcePath(sourcePath) || isReplacedLocalOracleSourcePath(sourcePath)) continue
+			mergedSources[sourcePath] = sourceData
+		}
+	}
+
+	if (isObjectRecord(openOracleSources)) {
+		for (const [sourcePath, sourceData] of Object.entries(openOracleSources)) {
+			const remappedPath = remapOpenOracleSourcePath(sourcePath)
+			if (remappedPath === undefined) continue
+			mergedSources[remappedPath] = sourceData
+		}
+	}
+
+	return Object.keys(mergedSources).length > 0 ? mergedSources : undefined
+}
+
+function mergeCompileResults(mainResult: funtypes.Static<typeof CompileResult>, openOracleResult: funtypes.Static<typeof CompileResult>) {
+	const mergedContracts: Record<string, Record<string, unknown>> = {}
+
+	if (mainResult.contracts) {
+		for (const [sourcePath, contractFile] of Object.entries(mainResult.contracts)) {
+			if (isTemporaryCompilerSourcePath(sourcePath) || isReplacedLocalOracleSourcePath(sourcePath)) continue
+			if (!isObjectRecord(contractFile)) throw new Error(`Invalid contract output for ${sourcePath}`)
+			mergedContracts[sourcePath] = contractFile
+		}
+	}
+
+	if (openOracleResult.contracts) {
+		for (const [sourcePath, contractFile] of Object.entries(openOracleResult.contracts)) {
+			const remappedPath = remapOpenOracleSourcePath(sourcePath)
+			if (remappedPath === undefined) continue
+			if (!isObjectRecord(contractFile)) throw new Error(`Invalid contract output for ${sourcePath}`)
+			mergedContracts[remappedPath] = contractFile
+		}
+	}
+
+	return {
+		contracts: mergedContracts,
+		sources: mergeCompileSources(mainResult.sources, openOracleResult.sources),
+	}
+}
+
 const compileContracts = async () => {
 	console.log('Computing contract hash...')
 
-	// Load all source files once
 	const files = await getAllFiles('contracts')
 	const sources = new Map<string, string>()
 	for (const file of files) {
@@ -229,21 +405,17 @@ const compileContracts = async () => {
 		sources.set(relativePath, await fs.readFile(file, 'utf8'))
 	}
 
-	// Compute hash from loaded sources (no additional I/O)
 	const currentContractHash = await computeContractHash(sources)
 	const cache = await loadHashCache()
-
-	// Determine if recompilation is needed
 	let needsRecompilation = !(cache.hash === currentContractHash && (await exists(ARTIFACTS_JSON)))
 
 	if (!needsRecompilation) {
 		console.log('No changes detected in Solidity contracts. Skipping recompilation.')
-		// Validate artifact file exists, is accessible, and contains valid data
 		try {
 			const artifactContent = await fs.readFile(ARTIFACTS_JSON, 'utf8')
 			CompileResult.parse(JSON.parse(artifactContent))
 		} catch (error) {
-			if (!(error instanceof SyntaxError) && !(error instanceof Error && (('code' in error && error.code === 'ENOENT') || error.name === 'ZodError'))) throw error
+			if (!(error instanceof SyntaxError) && !hasNodeErrorCode(error, 'ENOENT') && !isFuntypesValidationError(error)) throw error
 			console.log('Artifact file is missing, inaccessible, or corrupted, recompiling...')
 			needsRecompilation = true
 		}
@@ -251,45 +423,17 @@ const compileContracts = async () => {
 
 	if (needsRecompilation) {
 		console.log('Changes detected or first run. Compiling Solidity contracts...')
-
-		// Convert Map to object for solc input
-		const sourcesObj: { [key: string]: { content: string } } = {}
-		for (const [key, value] of sources) {
-			sourcesObj[key] = { content: value }
-		}
-
-		const input = {
-			language: 'Solidity',
-			sources: sourcesObj,
-			settings: compilerSettings,
-		}
-
-		console.time('solc compilation')
-		const output = solc.compile(JSON.stringify(input))
-		console.timeEnd('solc compilation')
-
-		const result = CompileResult.parse(JSON.parse(output))
-		const diagnostics = Array.isArray(result.errors) ? result.errors : []
-		const errors: string[] = []
-		const warnings: string[] = []
-		for (const diagnostic of diagnostics) {
-			if (!isCompileError(diagnostic)) continue
-			if (diagnostic.severity === 'error') errors.push(diagnostic.formattedMessage)
-			if (diagnostic.severity === 'warning') warnings.push(diagnostic.formattedMessage)
-		}
-		if (errors.length) throw new CompilationError(errors)
-
-		if (warnings.length > 0) warnings.forEach(warning => console.warn(warning))
+		const openOracleCompiler = await loadOpenOracleCompiler()
+		const mainResult = compileSourceMap('main contracts', solc, createMainCompilerSources(sources), mainCompilerSettings)
+		const openOracleResult = compileSourceMap('OpenOracle', openOracleCompiler, createOpenOracleCompilerSources(sources), openOracleCompilerSettings)
+		const mergedResult = CompileResult.parse(mergeCompileResults(mainResult, openOracleResult))
 
 		if (!(await exists(ARTIFACTS_DIR))) await fs.mkdir(ARTIFACTS_DIR, { recursive: false })
-		await fs.writeFile(ARTIFACTS_JSON, output)
-
-		// Save updated hash after successful compilation
+		await fs.writeFile(ARTIFACTS_JSON, JSON.stringify(mergedResult))
 		await saveHashCache(currentContractHash)
 		console.log('Compilation complete. Hash cache updated.')
 	}
 
-	// Always regenerate TypeScript artifact to reflect any changes in the generation logic
 	await copySolidityContractArtifact(ARTIFACTS_JSON)
 	console.log('TypeScript artifact generated.')
 }
@@ -300,6 +444,5 @@ compileContracts().catch((error: unknown) => {
 	} else {
 		console.error(error)
 	}
-	debugger
 	process.exit(1)
 })

--- a/solidity/ts/tests/deploymentStatusOracle.test.ts
+++ b/solidity/ts/tests/deploymentStatusOracle.test.ts
@@ -14,6 +14,8 @@ import { PROXY_DEPLOYER_ADDRESS } from '../testsuite/simulator/utils/constants'
 setDefaultTimeout(TEST_TIMEOUT_MS)
 
 const MULTICALL3_BYTECODE = `0x${peripherals_Multicall3_Multicall3.evm.bytecode.object}` satisfies Hex
+const OPEN_ORACLE_CREATE2_DEPLOYER_ADDRESS = '0x4e59b44847b379578588920ca78fbf26c0b4956c'
+const OPEN_ORACLE_CREATE2_SALT = '0xf5b91b18c7242605256d8b307d4a5bd3d398aa87a1d89917c9fa68c624e8399a' satisfies Hex
 
 describe('Deployment Status Oracle Test Suite', () => {
 	const { getAnvilWindowEthereum } = useIsolatedAnvilNode()
@@ -24,6 +26,14 @@ describe('Deployment Status Oracle Test Suite', () => {
 		const hash = await client.sendTransaction({
 			to: addressString(PROXY_DEPLOYER_ADDRESS),
 			data: bytecode,
+		})
+		await client.waitForTransactionReceipt({ hash })
+	}
+
+	const deployOpenOracle = async () => {
+		const hash = await client.sendTransaction({
+			to: OPEN_ORACLE_CREATE2_DEPLOYER_ADDRESS,
+			data: `${OPEN_ORACLE_CREATE2_SALT}${peripherals_openOracle_OpenOracle_OpenOracle.evm.bytecode.object}` as Hex,
 		})
 		await client.waitForTransactionReceipt({ hash })
 	}
@@ -48,7 +58,7 @@ describe('Deployment Status Oracle Test Suite', () => {
 
 		await deployViaProxy(MULTICALL3_BYTECODE)
 		await deployViaProxy(`0x${ScalarOutcomes_ScalarOutcomes.evm.bytecode.object}`)
-		await deployViaProxy(`0x${peripherals_openOracle_OpenOracle_OpenOracle.evm.bytecode.object}`)
+		await deployOpenOracle()
 
 		const deploymentMask = await loadDeploymentStatusOracleMask(client)
 
@@ -57,7 +67,7 @@ describe('Deployment Status Oracle Test Suite', () => {
 
 	test('ensureInfraDeployed repairs an out-of-order partial deployment', async () => {
 		await deployViaProxy(`0x${peripherals_SecurityPoolUtils_SecurityPoolUtils.evm.bytecode.object}`)
-		await deployViaProxy(`0x${peripherals_openOracle_OpenOracle_OpenOracle.evm.bytecode.object}`)
+		await deployOpenOracle()
 		await deployViaProxy(`0x${peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory.evm.bytecode.object}`)
 		await deployViaProxy(`0x${ScalarOutcomes_ScalarOutcomes.evm.bytecode.object}`)
 

--- a/solidity/ts/testsuite/simulator/utils/contracts/deployPeripherals.ts
+++ b/solidity/ts/testsuite/simulator/utils/contracts/deployPeripherals.ts
@@ -30,6 +30,8 @@ import { objectEntries } from '../typescript'
 import { getRepTokenAddress } from './zoltar'
 
 const ZERO_SALT: Hex = toHex(0, { size: 32 })
+const OPEN_ORACLE_CREATE2_DEPLOYER_ADDRESS = '0x4e59b44847b379578588920ca78fbf26c0b4956c' satisfies Address
+const OPEN_ORACLE_CREATE2_SALT = '0xf5b91b18c7242605256d8b307d4a5bd3d398aa87a1d89917c9fa68c624e8399a' satisfies Hex
 const MULTICALL3_BYTECODE = `0x${peripherals_Multicall3_Multicall3.evm.bytecode.object}` satisfies Hex
 const MAINNET_WETH_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' satisfies Address
 const ORACLE_REPORT_GAS = 100000n
@@ -42,9 +44,7 @@ const ORACLE_FEE_PERCENTAGE = 10000
 const ORACLE_MULTIPLIER = 140
 const ORACLE_TIME_TYPE = true
 const ORACLE_TRACK_DISPUTES = false
-const ORACLE_KEEP_FEE = false
 const ORACLE_PROTOCOL_FEE_RECIPIENT = addressString(0x0n)
-const ORACLE_FEE_TOKEN = true
 
 const getSecurityPoolUtilsAddress = () => getCreate2Address({ bytecode: `0x${peripherals_SecurityPoolUtils_SecurityPoolUtils.evm.bytecode.object}`, from: addressString(PROXY_DEPLOYER_ADDRESS), salt: ZERO_SALT })
 
@@ -66,8 +66,8 @@ function getPriceOracleManagerAndOperatorQueuerFactoryByteCode(): Hex {
 	return concatHex([
 		`0x${peripherals_factories_PriceOracleManagerAndOperatorQueuerFactory_PriceOracleManagerAndOperatorQueuerFactory.evm.bytecode.object}`,
 		encodeAbiParameters(
-			[{ type: 'address' }, { type: 'uint256' }, { type: 'uint32' }, { type: 'uint256' }, { type: 'uint48' }, { type: 'uint24' }, { type: 'uint24' }, { type: 'uint24' }, { type: 'uint16' }, { type: 'bool' }, { type: 'bool' }, { type: 'bool' }, { type: 'address' }, { type: 'bool' }],
-			[MAINNET_WETH_ADDRESS, ORACLE_REPORT_GAS, ORACLE_SETTLEMENT_GAS, ORACLE_EXACT_TOKEN1_REPORT, ORACLE_SETTLEMENT_TIME, ORACLE_DISPUTE_DELAY, ORACLE_PROTOCOL_FEE, ORACLE_FEE_PERCENTAGE, ORACLE_MULTIPLIER, ORACLE_TIME_TYPE, ORACLE_TRACK_DISPUTES, ORACLE_KEEP_FEE, ORACLE_PROTOCOL_FEE_RECIPIENT, ORACLE_FEE_TOKEN],
+			[{ type: 'address' }, { type: 'uint256' }, { type: 'uint32' }, { type: 'uint256' }, { type: 'uint48' }, { type: 'uint24' }, { type: 'uint24' }, { type: 'uint24' }, { type: 'uint16' }, { type: 'bool' }, { type: 'bool' }, { type: 'address' }],
+			[MAINNET_WETH_ADDRESS, ORACLE_REPORT_GAS, ORACLE_SETTLEMENT_GAS, ORACLE_EXACT_TOKEN1_REPORT, ORACLE_SETTLEMENT_TIME, ORACLE_DISPUTE_DELAY, ORACLE_PROTOCOL_FEE, ORACLE_FEE_PERCENTAGE, ORACLE_MULTIPLIER, ORACLE_TIME_TYPE, ORACLE_TRACK_DISPUTES, ORACLE_PROTOCOL_FEE_RECIPIENT],
 		),
 	])
 }
@@ -151,6 +151,10 @@ export const { getInfraContractAddresses } = createInfraContractAddressHelper({
 	getZoltarQuestionDataAddress,
 	multicall3Bytecode: MULTICALL3_BYTECODE,
 	openOracleBytecode: `0x${peripherals_openOracle_OpenOracle_OpenOracle.evm.bytecode.object}`,
+	openOracleCreate2Inputs: {
+		proxyDeployerAddress: OPEN_ORACLE_CREATE2_DEPLOYER_ADDRESS,
+		salt: OPEN_ORACLE_CREATE2_SALT,
+	},
 	priceOracleManagerAndOperatorQueuerFactoryBytecode: getPriceOracleManagerAndOperatorQueuerFactoryByteCode(),
 	proxyDeployerAddress: addressString(PROXY_DEPLOYER_ADDRESS),
 	scalarOutcomesBytecode: `0x${ScalarOutcomes_ScalarOutcomes.evm.bytecode.object}`,
@@ -165,6 +169,8 @@ export const { getDeploymentStatusOracleAddress } = createDeploymentStatusOracle
 	zeroSalt: ZERO_SALT,
 })
 
+const getOpenOracleCreate2DeploymentBytecode = (): Hex => concatHex([OPEN_ORACLE_CREATE2_SALT, `0x${peripherals_openOracle_OpenOracle_OpenOracle.evm.bytecode.object}`])
+
 export const { getSecurityPoolAddresses } = createSecurityPoolAddressHelper({
 	getEscalationGameInitCode: securityPool =>
 		encodeDeployData({
@@ -177,42 +183,8 @@ export const { getSecurityPoolAddresses } = createSecurityPoolAddressHelper({
 		concatHex([
 			`0x${peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator.evm.bytecode.object}`,
 			encodeAbiParameters(
-				[
-					{ type: 'address' },
-					{ type: 'address' },
-					{ type: 'address' },
-					{ type: 'uint256' },
-					{ type: 'uint32' },
-					{ type: 'uint256' },
-					{ type: 'uint48' },
-					{ type: 'uint24' },
-					{ type: 'uint24' },
-					{ type: 'uint24' },
-					{ type: 'uint16' },
-					{ type: 'bool' },
-					{ type: 'bool' },
-					{ type: 'bool' },
-					{ type: 'address' },
-					{ type: 'bool' },
-				],
-				[
-					openOracle,
-					repToken,
-					MAINNET_WETH_ADDRESS,
-					ORACLE_REPORT_GAS,
-					ORACLE_SETTLEMENT_GAS,
-					ORACLE_EXACT_TOKEN1_REPORT,
-					ORACLE_SETTLEMENT_TIME,
-					ORACLE_DISPUTE_DELAY,
-					ORACLE_PROTOCOL_FEE,
-					ORACLE_FEE_PERCENTAGE,
-					ORACLE_MULTIPLIER,
-					ORACLE_TIME_TYPE,
-					ORACLE_TRACK_DISPUTES,
-					ORACLE_KEEP_FEE,
-					ORACLE_PROTOCOL_FEE_RECIPIENT,
-					ORACLE_FEE_TOKEN,
-				],
+				[{ type: 'address' }, { type: 'address' }, { type: 'address' }, { type: 'uint256' }, { type: 'uint32' }, { type: 'uint256' }, { type: 'uint48' }, { type: 'uint24' }, { type: 'uint24' }, { type: 'uint24' }, { type: 'uint16' }, { type: 'bool' }, { type: 'bool' }, { type: 'address' }],
+				[openOracle, repToken, MAINNET_WETH_ADDRESS, ORACLE_REPORT_GAS, ORACLE_SETTLEMENT_GAS, ORACLE_EXACT_TOKEN1_REPORT, ORACLE_SETTLEMENT_TIME, ORACLE_DISPUTE_DELAY, ORACLE_PROTOCOL_FEE, ORACLE_FEE_PERCENTAGE, ORACLE_MULTIPLIER, ORACLE_TIME_TYPE, ORACLE_TRACK_DISPUTES, ORACLE_PROTOCOL_FEE_RECIPIENT],
 			),
 		]),
 	getRepTokenAddress,
@@ -306,16 +278,21 @@ export async function ensureInfraDeployed(client: WriteClient): Promise<void> {
 		await client.waitForTransactionReceipt({ hash })
 	}
 
+	const deployOpenOracle = async () => {
+		const hash = await client.sendTransaction({ to: OPEN_ORACLE_CREATE2_DEPLOYER_ADDRESS, data: getOpenOracleCreate2DeploymentBytecode() })
+		await client.waitForTransactionReceipt({ hash })
+	}
+
 	await ensureDeploymentStatusOracleDeployed(client)
 	const existence = await getInfraDeployedInformation(client)
 
-	if (!existence.multicall3) await deployBytecode(MULTICALL3_BYTECODE)
-	if (!existence.uniformPriceDualCapBatchAuctionFactory) await deployBytecode(`0x${peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory.evm.bytecode.object}`)
-	if (!existence.scalarOutcomes) await deployBytecode(`0x${ScalarOutcomes_ScalarOutcomes.evm.bytecode.object}`)
-	if (!existence.securityPoolUtils) await deployBytecode(`0x${peripherals_SecurityPoolUtils_SecurityPoolUtils.evm.bytecode.object}`)
-	if (!existence.openOracle) await deployBytecode(`0x${peripherals_openOracle_OpenOracle_OpenOracle.evm.bytecode.object}`)
-	if (!existence.zoltarQuestionData) await deployBytecode(getZoltarQuestionDataByteCode())
-	if (!existence.zoltar) {
+	if (!existence['multicall3']) await deployBytecode(MULTICALL3_BYTECODE)
+	if (!existence['uniformPriceDualCapBatchAuctionFactory']) await deployBytecode(`0x${peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory.evm.bytecode.object}`)
+	if (!existence['scalarOutcomes']) await deployBytecode(`0x${ScalarOutcomes_ScalarOutcomes.evm.bytecode.object}`)
+	if (!existence['securityPoolUtils']) await deployBytecode(`0x${peripherals_SecurityPoolUtils_SecurityPoolUtils.evm.bytecode.object}`)
+	if (!existence['openOracle']) await deployOpenOracle()
+	if (!existence['zoltarQuestionData']) await deployBytecode(getZoltarQuestionDataByteCode())
+	if (!existence['zoltar']) {
 		const initCode = encodeDeployData({
 			abi: Zoltar_Zoltar.abi,
 			bytecode: `0x${Zoltar_Zoltar.evm.bytecode.object}`,
@@ -323,11 +300,11 @@ export async function ensureInfraDeployed(client: WriteClient): Promise<void> {
 		})
 		await deployBytecode(initCode)
 	}
-	if (!existence.shareTokenFactory) await deployBytecode(getShareTokenFactoryByteCode(getZoltarAddress()))
-	if (!existence.priceOracleManagerAndOperatorQueuerFactory) await deployBytecode(getPriceOracleManagerAndOperatorQueuerFactoryByteCode())
-	if (!existence.securityPoolForker) await deployBytecode(getSecurityPoolForkerByteCode(contractAddresses.zoltar))
-	if (!existence.escalationGameFactory) await deployBytecode(getEscalationGameFactoryByteCode())
-	if (!existence.securityPoolFactory)
+	if (!existence['shareTokenFactory']) await deployBytecode(getShareTokenFactoryByteCode(getZoltarAddress()))
+	if (!existence['priceOracleManagerAndOperatorQueuerFactory']) await deployBytecode(getPriceOracleManagerAndOperatorQueuerFactoryByteCode())
+	if (!existence['securityPoolForker']) await deployBytecode(getSecurityPoolForkerByteCode(contractAddresses.zoltar))
+	if (!existence['escalationGameFactory']) await deployBytecode(getEscalationGameFactoryByteCode())
+	if (!existence['securityPoolFactory'])
 		await deployBytecode(
 			getSecurityPoolFactoryByteCode({
 				escalationGameFactory: contractAddresses.escalationGameFactory,

--- a/solidity/ts/testsuite/simulator/utils/contracts/peripherals.ts
+++ b/solidity/ts/testsuite/simulator/utils/contracts/peripherals.ts
@@ -62,15 +62,12 @@ interface ExtraReportData {
 	callbackContract: Address
 	numReports: number
 	callbackGasLimit: number
-	callbackSelector: Hex
 	protocolFeeRecipient: Address
 	trackDisputes: boolean
-	keepFee: boolean
-	feeToken: boolean
 }
 
-function isOpenOracleExtraData(value: ReadContractReturnType): value is readonly [Hex, Address, bigint, bigint, Hex, Address, boolean, boolean, boolean] {
-	return Array.isArray(value) && value.length === 9
+function isOpenOracleExtraData(value: ReadContractReturnType): value is readonly [Hex, Address, bigint, bigint, Address, boolean] {
+	return Array.isArray(value) && value.length === 6
 }
 
 export const getOpenOracleExtraData = async (client: ReadClient, extraDataId: bigint): Promise<ExtraReportData> => {
@@ -83,18 +80,15 @@ export const getOpenOracleExtraData = async (client: ReadClient, extraDataId: bi
 
 	if (!isOpenOracleExtraData(result)) throw new Error('OpenOracle extraData returned an unexpected shape')
 
-	const [stateHash, callbackContract, numReports, callbackGasLimit, callbackSelector, protocolFeeRecipient, trackDisputes, keepFee, feeToken] = result
+	const [stateHash, callbackContract, numReports, callbackGasLimit, protocolFeeRecipient, trackDisputes] = result
 
 	return {
 		stateHash,
 		callbackContract,
 		numReports: Number(numReports),
 		callbackGasLimit: Number(callbackGasLimit),
-		callbackSelector,
 		protocolFeeRecipient,
 		trackDisputes,
-		keepFee,
-		feeToken,
 	}
 }
 

--- a/solidity/ts/testsuite/simulator/utils/utilities.ts
+++ b/solidity/ts/testsuite/simulator/utils/utilities.ts
@@ -13,6 +13,8 @@ const TOKEN_AMOUNT_TO_MINT = 100000000n * 10n ** 18n
 const ETH_AMOUNT_TO_MINT = 10n ** 30n
 const DEFAULT_APPROVAL_AMOUNT = 1000000000000000000000000000000n
 const PROXY_DEPLOYER_BYTECODE = '0x60003681823780368234f58015156014578182fd5b80825250506014600cf3'
+const OPEN_ORACLE_CREATE2_DEPLOYER_ADDRESS = '0x4e59b44847b379578588920ca78fbf26c0b4956c'
+const OPEN_ORACLE_CREATE2_DEPLOYER_BYTECODE = '0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3'
 
 function hexToBytes(value: string) {
 	const result = new Uint8Array((value.length - 2) / 2)
@@ -89,6 +91,11 @@ export const setupTestAccounts = async (anvilWindowEthereum: AnvilWindowEthereum
 	await anvilWindowEthereum.addStateOverrides({
 		[addressString(PROXY_DEPLOYER_ADDRESS)]: {
 			code: hexToBytes(proxyDeployerBytecode),
+		},
+	})
+	await anvilWindowEthereum.addStateOverrides({
+		[OPEN_ORACLE_CREATE2_DEPLOYER_ADDRESS]: {
+			code: hexToBytes(OPEN_ORACLE_CREATE2_DEPLOYER_BYTECODE),
 		},
 	})
 

--- a/solidity/ts/types/index.d.ts
+++ b/solidity/ts/types/index.d.ts
@@ -90,4 +90,12 @@ declare module 'solc' {
 	}
 	type ReadCallback = (path: string) => { contents?: string; error?: string }
 	function compile(input: string, readCallback?: ReadCallback): string
+	function version(): string
+	function loadRemoteVersion(version: string, callback: (error: Error | undefined, compiler: { compile(input: string, readCallback?: ReadCallback): string; version(): string } | undefined) => void): void
+	const solc: {
+		readonly compile: typeof compile
+		readonly version: typeof version
+		readonly loadRemoteVersion: typeof loadRemoteVersion
+	}
+	export default solc
 }

--- a/ui/ts/components/OpenOracleSection.tsx
+++ b/ui/ts/components/OpenOracleSection.tsx
@@ -48,6 +48,7 @@ import type { OpenOracleFormState } from '../types/app.js'
 import type { OpenOracleReportDetails, OpenOracleReportSummary, OpenOracleReportSummaryPage } from '../types/contracts.js'
 import type { OpenOracleSectionProps } from '../types/components.js'
 const BROWSE_PAGE_SIZE = 10
+const OPEN_ORACLE_PRICE_UNITS = 30
 type SelectedReportModal = 'dispute' | 'initial-report' | 'settle' | undefined
 type BrowseStatusFilter = 'all' | 'Awaiting Initial Report' | 'Pending' | 'Disputed' | 'Settled'
 function getEffectiveOpenOracleReportDetails(report: OpenOracleReportDetails | undefined, currentTimestamp: bigint | undefined, currentBlockNumber: bigint | undefined) {
@@ -125,7 +126,7 @@ function renderReportSummaryCard(report: OpenOracleReportSummary, onSelectReport
 						<AddressValue address={report.token1} /> / <AddressValue address={report.token2} />
 					</>,
 				)}
-				{renderReportField('Current Price', <CurrencyValue value={report.price} suffix={`${report.token1Symbol} / ${report.token2Symbol}`} copyable={false} />)}
+				{renderReportField('Current Price', <CurrencyValue value={report.price} suffix={`${report.token1Symbol} / ${report.token2Symbol}`} units={OPEN_ORACLE_PRICE_UNITS} copyable={false} />)}
 				{renderReportField('Current Reporter', report.currentReporter === zeroAddress ? 'None' : <AddressValue address={report.currentReporter} />)}
 				{renderReportField('Current Amount1', <CurrencyValue value={report.currentAmount1} suffix={report.token1Symbol} units={report.token1Decimals} copyable={false} />)}
 				{renderReportField('Current Amount2', <CurrencyValue value={report.currentAmount2} suffix={report.token2Symbol} units={report.token2Decimals} copyable={false} />)}
@@ -525,7 +526,7 @@ function renderReportDetailsCard(
 					{ label: 'Stage', value: stage.label },
 					{ label: 'Token Pair', value: `${openOracleReportDetails.token1Symbol} / ${openOracleReportDetails.token2Symbol}` },
 					{ label: 'Reporter', value: openOracleReportDetails.currentReporter === zeroAddress ? 'None' : <AddressValue address={openOracleReportDetails.currentReporter} /> },
-					{ label: 'Price', value: <CurrencyValue value={openOracleReportDetails.price} suffix={`${openOracleReportDetails.token1Symbol} / ${openOracleReportDetails.token2Symbol}`} copyable={false} /> },
+					{ label: 'Price', value: <CurrencyValue value={openOracleReportDetails.price} suffix={`${openOracleReportDetails.token1Symbol} / ${openOracleReportDetails.token2Symbol}`} units={OPEN_ORACLE_PRICE_UNITS} copyable={false} /> },
 				]}
 			/>
 			<LifecycleStageBanner stage={stage} />
@@ -542,7 +543,7 @@ function renderReportDetailsCard(
 					{renderReportField('Report ID', openOracleReportDetails.reportId.toString())}
 					{renderReportField('Oracle Address', <AddressValue address={openOracleReportDetails.openOracleAddress} />)}
 					{renderReportField('Current Reporter', openOracleReportDetails.currentReporter === zeroAddress ? 'None (awaiting initial report)' : <AddressValue address={openOracleReportDetails.currentReporter} />)}
-					{renderReportField('Current Price', <CurrencyValue value={openOracleReportDetails.price} suffix={`${openOracleReportDetails.token1Symbol} / ${openOracleReportDetails.token2Symbol}`} copyable={false} />)}
+					{renderReportField('Current Price', <CurrencyValue value={openOracleReportDetails.price} suffix={`${openOracleReportDetails.token1Symbol} / ${openOracleReportDetails.token2Symbol}`} units={OPEN_ORACLE_PRICE_UNITS} copyable={false} />)}
 					{renderReportField('Settlement Timestamp', <TimestampValue currentTimestamp={openOracleReportDetails.currentTime} timestamp={openOracleReportDetails.settlementTimestamp} zeroText='Not settled' />)}
 				</DataGrid>
 			</SectionBlock>
@@ -588,7 +589,7 @@ function renderReportDetailsCard(
 						},
 						{
 							label: 'Price',
-							value: <CurrencyValue value={openOracleReportDetails.price} suffix={`${openOracleReportDetails.token1Symbol} / ${openOracleReportDetails.token2Symbol}`} copyable={false} />,
+							value: <CurrencyValue value={openOracleReportDetails.price} suffix={`${openOracleReportDetails.token1Symbol} / ${openOracleReportDetails.token2Symbol}`} units={OPEN_ORACLE_PRICE_UNITS} copyable={false} />,
 						},
 						{
 							label: 'Fee',
@@ -616,7 +617,7 @@ function renderReportDetailsCard(
 							value: openOracleReportDetails.disputeOccurred ? 'Yes' : 'No',
 						},
 						{
-							label: 'Distributed',
+							label: 'Settled',
 							value: openOracleReportDetails.isDistributed ? 'Yes' : 'No',
 						},
 						{
@@ -666,10 +667,6 @@ function renderReportDetailsCard(
 							value: openOracleReportDetails.callbackContract === zeroAddress ? 'None' : <AddressValue address={openOracleReportDetails.callbackContract} />,
 						},
 						{
-							label: 'Callback Selector',
-							value: openOracleReportDetails.callbackSelector === '0x00000000' ? 'None' : openOracleReportDetails.callbackSelector,
-						},
-						{
 							label: 'Callback Gas Limit',
 							value: openOracleReportDetails.callbackGasLimit === 0 ? 'None' : openOracleReportDetails.callbackGasLimit.toString(),
 						},
@@ -680,14 +677,6 @@ function renderReportDetailsCard(
 						{
 							label: 'Track Disputes',
 							value: openOracleReportDetails.trackDisputes ? 'Yes' : 'No',
-						},
-						{
-							label: 'Keep Fee',
-							value: openOracleReportDetails.keepFee ? 'Yes' : 'No',
-						},
-						{
-							label: 'Fee Token',
-							value: openOracleReportDetails.feeToken ? openOracleReportDetails.token1Symbol : 'ETH',
 						},
 						{
 							label: 'Number of Reports',

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -68,6 +68,7 @@ import {
 	isBigintTriple,
 	requireEscalationGameTuple,
 	requireOpenOracleExtraDataTuple,
+	requireOpenOracleExtraDataTupleArray,
 	requireOpenOracleReportMetaTuple,
 	requireOpenOracleReportMetaTupleArray,
 	requireOpenOracleReportStatusTuple,
@@ -832,7 +833,7 @@ export async function loadOpenOracleReportSummaries(client: ReadClient, pageInde
 		reportIds.push(reportId)
 		if (reportId === pageStartId) break
 	}
-	const [metaResults, statusResults] = await Promise.all([
+	const [metaResults, statusResults, extraResults] = await Promise.all([
 		readRequiredMulticall(
 			client,
 			reportIds.map(reportId => ({
@@ -851,9 +852,19 @@ export async function loadOpenOracleReportSummaries(client: ReadClient, pageInde
 				args: [reportId],
 			})),
 		),
+		readRequiredMulticall(
+			client,
+			reportIds.map(reportId => ({
+				abi: peripherals_openOracle_OpenOracle_OpenOracle.abi,
+				functionName: 'extraData',
+				address: openOracleAddress,
+				args: [reportId],
+			})),
+		),
 	])
 	const metas = requireOpenOracleReportMetaTupleArray(metaResults, 'open oracle report metas')
 	const statuses = requireOpenOracleReportStatusTupleArray(statusResults, 'open oracle report statuses')
+	const extras = requireOpenOracleExtraDataTupleArray(extraResults, 'open oracle report extras')
 	const tokenAddresses = new Set<Address>()
 	for (const meta of metas) {
 		if (meta[4] !== zeroAddress) tokenAddresses.add(meta[4])
@@ -899,7 +910,8 @@ export async function loadOpenOracleReportSummaries(client: ReadClient, pageInde
 	const reports = reportIds.map((reportId, index) => {
 		const meta = metas[index]
 		const status = statuses[index]
-		if (meta === undefined || status === undefined) throw new Error('Unexpected oracle report summary response')
+		const extra = extras[index]
+		if (meta === undefined || status === undefined || extra === undefined) throw new Error('Unexpected oracle report summary response')
 		const token1Metadata = tokenMetadata.get(meta[4])
 		const token2Metadata = tokenMetadata.get(meta[6])
 		if (token1Metadata === undefined || token2Metadata === undefined) throw new Error('Unexpected oracle token metadata response')
@@ -907,7 +919,7 @@ export async function loadOpenOracleReportSummaries(client: ReadClient, pageInde
 			currentAmount1: status[0],
 			currentAmount2: status[1],
 			currentReporter: status[2],
-			disputeOccurred: hasOpenOracleDisputeOccurred(status[2], status[5], 0n),
+			disputeOccurred: hasOpenOracleDisputeOccurred(status[2], status[5], BigInt(extra[2])),
 			exactToken1Report: meta[0],
 			isDistributed: BigInt(status[4]) > 0n,
 			price: calculateOpenOraclePrice(status[0], status[1]),

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -89,6 +89,7 @@ const MIGRATION_TIME_LENGTH = 4838400n
 const TRUTH_AUCTION_TIME_LENGTH = 604800n
 const QUESTION_OUTCOME_ABI = [parseAbiItem('function getQuestionOutcome(address securityPool) view returns (uint8 outcome)')]
 const CONTRACT_PAGE_SIZE = 30n
+const OPEN_ORACLE_PRICE_UNITS = 30n
 type ReadWriteContractClient<TReceipt extends Pick<TransactionReceipt, 'status'> = TransactionReceipt> = Pick<ReadClient, 'readContract'> & WriteContractClient<TReceipt>
 type ForkDataTuple = readonly [bigint, Address, bigint, bigint, bigint, boolean, number]
 type AuctionClearingTuple = readonly [boolean, bigint, bigint, bigint]
@@ -691,6 +692,16 @@ function resolveOracleQueueOperation(operation: bigint | number): OracleQueueOpe
 			throw new Error(`Unknown oracle operation: ${operation}`)
 	}
 }
+
+function calculateOpenOraclePrice(amount1: bigint, amount2: bigint) {
+	return amount2 === 0n ? 0n : (amount1 * 10n ** OPEN_ORACLE_PRICE_UNITS) / amount2
+}
+
+function hasOpenOracleDisputeOccurred(currentReporter: Address, initialReporter: Address, numReports: bigint) {
+	if (numReports > 1n) return true
+	if (currentReporter === zeroAddress || initialReporter === zeroAddress) return false
+	return !sameAddress(currentReporter, initialReporter)
+}
 export async function loadOpenOracleReportDetails(client: ReadClient, openOracleAddress: Address, reportId: bigint): Promise<import('./types/contracts.js').OpenOracleReportDetails> {
 	const [[meta, status, extra], block] = await Promise.all([
 		readRequiredMulticall(client, [
@@ -765,23 +776,20 @@ export async function loadOpenOracleReportDetails(client: ReadClient, openOracle
 		disputeDelay: BigInt(reportMeta[11]),
 		currentAmount1: reportStatus[0],
 		currentAmount2: reportStatus[1],
-		price: reportStatus[2],
-		currentReporter: reportStatus[3],
-		reportTimestamp: BigInt(reportStatus[4]),
-		settlementTimestamp: BigInt(reportStatus[5]),
-		initialReporter: reportStatus[6],
-		disputeOccurred: reportStatus[8],
-		isDistributed: reportStatus[9],
+		price: calculateOpenOraclePrice(reportStatus[0], reportStatus[1]),
+		currentReporter: reportStatus[2],
+		reportTimestamp: BigInt(reportStatus[3]),
+		settlementTimestamp: BigInt(reportStatus[4]),
+		initialReporter: reportStatus[5],
+		disputeOccurred: hasOpenOracleDisputeOccurred(reportStatus[2], reportStatus[5], BigInt(reportExtra[2])),
+		isDistributed: BigInt(reportStatus[4]) > 0n,
 		stateHash: reportExtra[0],
 		callbackContract: reportExtra[1],
 		numReports: BigInt(reportExtra[2]),
 		callbackGasLimit: Number(reportExtra[3]),
-		callbackSelector: reportExtra[4],
-		protocolFeeRecipient: reportExtra[5],
-		trackDisputes: reportExtra[6],
-		keepFee: reportExtra[7],
-		feeToken: reportExtra[8],
-		lastReportOppoTime: BigInt(reportStatus[7]),
+		protocolFeeRecipient: reportExtra[4],
+		trackDisputes: reportExtra[5],
+		lastReportOppoTime: BigInt(reportStatus[6]),
 		token1Decimals: Number(token1Decimals),
 		token2Decimals: Number(token2Decimals),
 		token1Symbol: String(token1Symbol),
@@ -898,14 +906,14 @@ export async function loadOpenOracleReportSummaries(client: ReadClient, pageInde
 		return {
 			currentAmount1: status[0],
 			currentAmount2: status[1],
-			currentReporter: status[3],
-			disputeOccurred: status[8],
+			currentReporter: status[2],
+			disputeOccurred: hasOpenOracleDisputeOccurred(status[2], status[5], 0n),
 			exactToken1Report: meta[0],
-			isDistributed: status[9],
-			price: status[2],
+			isDistributed: BigInt(status[4]) > 0n,
+			price: calculateOpenOraclePrice(status[0], status[1]),
 			reportId,
-			reportTimestamp: BigInt(status[4]),
-			settlementTimestamp: BigInt(status[5]),
+			reportTimestamp: BigInt(status[3]),
+			settlementTimestamp: BigInt(status[4]),
 			token1: meta[4],
 			token2: meta[6],
 			token1Decimals: token1Metadata.decimals,

--- a/ui/ts/contracts/deployment.ts
+++ b/ui/ts/contracts/deployment.ts
@@ -1,13 +1,15 @@
 import { encodeDeployData, getAddress, type Address, type Hash, type Hex } from 'viem'
 import { ABIS } from '../abis.js'
 import { createDeploymentStatusOracleAddressHelper } from '../shared/deploymentAddresses.js'
-import { DeploymentStatusOracle_DeploymentStatusOracle, ScalarOutcomes_ScalarOutcomes, peripherals_SecurityPoolUtils_SecurityPoolUtils, peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory, peripherals_openOracle_OpenOracle_OpenOracle } from '../contractArtifact.js'
+import { DeploymentStatusOracle_DeploymentStatusOracle, ScalarOutcomes_ScalarOutcomes, peripherals_SecurityPoolUtils_SecurityPoolUtils, peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory } from '../contractArtifact.js'
 import {
 	MULTICALL3_BYTECODE,
+	OPEN_ORACLE_CREATE2_DEPLOYER_ADDRESS,
 	PROXY_DEPLOYER_ADDRESS,
 	ZERO_SALT,
 	getEscalationGameFactoryByteCode,
 	getInfraContractAddresses,
+	getOpenOracleCreate2DeploymentBytecode,
 	getPriceOracleManagerAndOperatorQueuerFactoryByteCode,
 	getSecurityPoolFactoryByteCode,
 	getSecurityPoolForkerByteCode,
@@ -21,6 +23,7 @@ import { getGenesisReputationTokenAddress } from '../lib/universe.js'
 const PROXY_DEPLOYER_SIGNER = getAddress('0x4c8d290a1b368ac4728d83a9e8321fc3af2b39b1')
 const PROXY_DEPLOYER_RAW_TRANSACTION = '0xf87e8085174876e800830186a08080ad601f80600e600039806000f350fe60003681823780368234f58015156014578182fd5b80825250506014600cf31ba02222222222222222222222222222222222222222222222222222222222222222a02222222222222222222222222222222222222222222222222222222222222222' satisfies Hex
 const PROXY_DEPLOYER_RUNTIME_CODE = '0x60003681823780368234f58015156014578182fd5b80825250506014600cf3' satisfies Hex
+const OPEN_ORACLE_CREATE2_DEPLOYER_RUNTIME_CODE = '0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3' satisfies Hex
 const ZERO_HASH = '0x0000000000000000000000000000000000000000000000000000000000000000' satisfies Hash
 const FUND_PROXY_DEPLOYER_SIGNER_AMOUNT = 10000000000000000n
 
@@ -89,6 +92,15 @@ async function deployViaProxy(client: WriteClient, bytecode: Hex) {
 	return hash
 }
 
+async function deployOpenOracleViaCreate2(client: WriteClient) {
+	const hash = await client.sendTransaction({
+		to: OPEN_ORACLE_CREATE2_DEPLOYER_ADDRESS,
+		data: getOpenOracleCreate2DeploymentBytecode(),
+	})
+	await client.waitForTransactionReceipt({ hash })
+	return hash
+}
+
 async function ensureProxyDeployerDeployed(client: WriteClient) {
 	const code = await client.getCode({ address: PROXY_DEPLOYER_ADDRESS })
 	if (code !== undefined && code !== '0x') return undefined
@@ -111,6 +123,19 @@ async function ensureProxyDeployerDeployed(client: WriteClient) {
 	})
 	await client.waitForTransactionReceipt({ hash: deployHash })
 	return deployHash
+}
+
+async function ensureOpenOracleCreate2DeployerDeployed(client: WriteClient) {
+	const code = await client.getCode({ address: OPEN_ORACLE_CREATE2_DEPLOYER_ADDRESS })
+	if (code !== undefined && code !== '0x') return undefined
+	if (client.installSimulationProxyDeployer !== undefined) {
+		await client.installSimulationProxyDeployer({
+			address: OPEN_ORACLE_CREATE2_DEPLOYER_ADDRESS,
+			runtimeCode: OPEN_ORACLE_CREATE2_DEPLOYER_RUNTIME_CODE,
+		})
+		return ZERO_HASH
+	}
+	throw new Error(`OpenOracle CREATE2 deployer missing at ${OPEN_ORACLE_CREATE2_DEPLOYER_ADDRESS}`)
 }
 
 async function loadDeploymentStatusOracleMask(client: Pick<ReadClient, 'readContract'>): Promise<bigint> {
@@ -177,8 +202,11 @@ export function getDeploymentSteps(): DeploymentStep[] {
 			id: 'openOracle',
 			label: 'OpenOracle',
 			address: addresses.openOracle,
-			dependencies: ['proxyDeployer'],
-			deploy: async client => await deployViaProxy(client, `0x${peripherals_openOracle_OpenOracle_OpenOracle.evm.bytecode.object}`),
+			dependencies: [],
+			deploy: async client => {
+				await ensureOpenOracleCreate2DeployerDeployed(client)
+				return await deployOpenOracleViaCreate2(client)
+			},
 		},
 		{
 			id: 'zoltarQuestionData',

--- a/ui/ts/contracts/deploymentHelpers.ts
+++ b/ui/ts/contracts/deploymentHelpers.ts
@@ -18,6 +18,8 @@ import {
 
 export const PROXY_DEPLOYER_ADDRESS = bigintToAddress(0x7a0d94f55792c434d74a40883c6ed8545e406d12n)
 export const ZERO_SALT = toHex(0, { size: 32 })
+export const OPEN_ORACLE_CREATE2_DEPLOYER_ADDRESS = bigintToAddress(0x4e59b44847b379578588920ca78fbf26c0b4956cn)
+const OPEN_ORACLE_CREATE2_SALT = '0xf5b91b18c7242605256d8b307d4a5bd3d398aa87a1d89917c9fa68c624e8399a' satisfies Hex
 export const MULTICALL3_BYTECODE = `0x${peripherals_Multicall3_Multicall3.evm.bytecode.object}` satisfies Hex
 const MAINNET_WETH_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' satisfies Address
 const ORACLE_REPORT_GAS = 100000n
@@ -30,9 +32,7 @@ const ORACLE_FEE_PERCENTAGE = 10000
 const ORACLE_MULTIPLIER = 140
 const ORACLE_TIME_TYPE = true
 const ORACLE_TRACK_DISPUTES = false
-const ORACLE_KEEP_FEE = false
 const ORACLE_PROTOCOL_FEE_RECIPIENT = bigintToAddress(0x0n)
-const ORACLE_FEE_TOKEN = true
 
 const getSecurityPoolUtilsAddress = () =>
 	getCreate2Address({
@@ -76,8 +76,8 @@ export const getPriceOracleManagerAndOperatorQueuerFactoryByteCode = () =>
 	concatHex([
 		`0x${peripherals_factories_PriceOracleManagerAndOperatorQueuerFactory_PriceOracleManagerAndOperatorQueuerFactory.evm.bytecode.object}`,
 		encodeAbiParameters(
-			[{ type: 'address' }, { type: 'uint256' }, { type: 'uint32' }, { type: 'uint256' }, { type: 'uint48' }, { type: 'uint24' }, { type: 'uint24' }, { type: 'uint24' }, { type: 'uint16' }, { type: 'bool' }, { type: 'bool' }, { type: 'bool' }, { type: 'address' }, { type: 'bool' }],
-			[MAINNET_WETH_ADDRESS, ORACLE_REPORT_GAS, ORACLE_SETTLEMENT_GAS, ORACLE_EXACT_TOKEN1_REPORT, ORACLE_SETTLEMENT_TIME, ORACLE_DISPUTE_DELAY, ORACLE_PROTOCOL_FEE, ORACLE_FEE_PERCENTAGE, ORACLE_MULTIPLIER, ORACLE_TIME_TYPE, ORACLE_TRACK_DISPUTES, ORACLE_KEEP_FEE, ORACLE_PROTOCOL_FEE_RECIPIENT, ORACLE_FEE_TOKEN],
+			[{ type: 'address' }, { type: 'uint256' }, { type: 'uint32' }, { type: 'uint256' }, { type: 'uint48' }, { type: 'uint24' }, { type: 'uint24' }, { type: 'uint24' }, { type: 'uint16' }, { type: 'bool' }, { type: 'bool' }, { type: 'address' }],
+			[MAINNET_WETH_ADDRESS, ORACLE_REPORT_GAS, ORACLE_SETTLEMENT_GAS, ORACLE_EXACT_TOKEN1_REPORT, ORACLE_SETTLEMENT_TIME, ORACLE_DISPUTE_DELAY, ORACLE_PROTOCOL_FEE, ORACLE_FEE_PERCENTAGE, ORACLE_MULTIPLIER, ORACLE_TIME_TYPE, ORACLE_TRACK_DISPUTES, ORACLE_PROTOCOL_FEE_RECIPIENT],
 		),
 	])
 
@@ -142,6 +142,10 @@ export const { getInfraContractAddresses } = createInfraContractAddressHelper({
 	getZoltarQuestionDataAddress,
 	multicall3Bytecode: MULTICALL3_BYTECODE,
 	openOracleBytecode: `0x${peripherals_openOracle_OpenOracle_OpenOracle.evm.bytecode.object}`,
+	openOracleCreate2Inputs: {
+		proxyDeployerAddress: OPEN_ORACLE_CREATE2_DEPLOYER_ADDRESS,
+		salt: OPEN_ORACLE_CREATE2_SALT,
+	},
 	priceOracleManagerAndOperatorQueuerFactoryBytecode: getPriceOracleManagerAndOperatorQueuerFactoryByteCode(),
 	proxyDeployerAddress: PROXY_DEPLOYER_ADDRESS,
 	scalarOutcomesBytecode: `0x${ScalarOutcomes_ScalarOutcomes.evm.bytecode.object}`,
@@ -149,6 +153,10 @@ export const { getInfraContractAddresses } = createInfraContractAddressHelper({
 	uniformPriceDualCapBatchAuctionFactoryBytecode: `0x${peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory.evm.bytecode.object}`,
 	zeroSalt: ZERO_SALT,
 })
+
+export function getOpenOracleCreate2DeploymentBytecode() {
+	return concatHex([OPEN_ORACLE_CREATE2_SALT, `0x${peripherals_openOracle_OpenOracle_OpenOracle.evm.bytecode.object}`])
+}
 
 export function getOpenOracleAddress() {
 	return getInfraContractAddresses().openOracle

--- a/ui/ts/contracts/helpers.ts
+++ b/ui/ts/contracts/helpers.ts
@@ -143,6 +143,11 @@ export function requireOpenOracleExtraDataTuple(value: unknown, context: string)
 	throw new Error(`Unexpected ${context} response`)
 }
 
+export function requireOpenOracleExtraDataTupleArray(value: unknown, context: string): OpenOracleExtraDataTuple[] {
+	if (Array.isArray(value) && value.every(isOpenOracleExtraDataTuple)) return value
+	throw new Error(`Unexpected ${context} response`)
+}
+
 export function getQuestionId(questionData: QuestionData, outcomeOptions: readonly string[]) {
 	return BigInt(
 		keccak256(

--- a/ui/ts/contracts/helpers.ts
+++ b/ui/ts/contracts/helpers.ts
@@ -7,8 +7,8 @@ type SecurityVaultTuple = readonly [bigint, bigint, bigint, bigint, bigint]
 export type UniverseTuple = readonly [bigint, bigint, bigint, Address, bigint]
 type EscalationGameTuple = readonly [bigint, bigint, bigint, bigint, bigint, [bigint, bigint, bigint], IntegerLike, bigint, IntegerLike, bigint, boolean]
 type OpenOracleReportMetaTuple = readonly [bigint, bigint, bigint, bigint, Address, IntegerLike, Address, boolean, IntegerLike, IntegerLike, IntegerLike, IntegerLike]
-type OpenOracleReportStatusTuple = readonly [bigint, bigint, bigint, Address, IntegerLike, IntegerLike, Address, IntegerLike, boolean, boolean]
-type OpenOracleExtraDataTuple = readonly [Hex, Address, IntegerLike, IntegerLike, Hex, Address, boolean, boolean, boolean]
+type OpenOracleReportStatusTuple = readonly [bigint, bigint, Address, IntegerLike, IntegerLike, Address, IntegerLike]
+type OpenOracleExtraDataTuple = readonly [Hex, Address, IntegerLike, IntegerLike, Address, boolean]
 
 export function bigintToAddress(value: bigint): Address {
 	return getAddress(`0x${value.toString(16).padStart(40, '0')}`)
@@ -121,20 +121,7 @@ export function requireOpenOracleReportMetaTupleArray(value: unknown, context: s
 }
 
 function isOpenOracleReportStatusTuple(value: unknown): value is OpenOracleReportStatusTuple {
-	return (
-		Array.isArray(value) &&
-		value.length === 10 &&
-		typeof value[0] === 'bigint' &&
-		typeof value[1] === 'bigint' &&
-		typeof value[2] === 'bigint' &&
-		typeof value[3] === 'string' &&
-		isIntegerLike(value[4]) &&
-		isIntegerLike(value[5]) &&
-		typeof value[6] === 'string' &&
-		isIntegerLike(value[7]) &&
-		typeof value[8] === 'boolean' &&
-		typeof value[9] === 'boolean'
-	)
+	return Array.isArray(value) && value.length === 7 && typeof value[0] === 'bigint' && typeof value[1] === 'bigint' && typeof value[2] === 'string' && isIntegerLike(value[3]) && isIntegerLike(value[4]) && typeof value[5] === 'string' && isIntegerLike(value[6])
 }
 
 export function requireOpenOracleReportStatusTuple(value: unknown, context: string): OpenOracleReportStatusTuple {
@@ -148,19 +135,7 @@ export function requireOpenOracleReportStatusTupleArray(value: unknown, context:
 }
 
 function isOpenOracleExtraDataTuple(value: unknown): value is OpenOracleExtraDataTuple {
-	return (
-		Array.isArray(value) &&
-		value.length === 9 &&
-		typeof value[0] === 'string' &&
-		typeof value[1] === 'string' &&
-		isIntegerLike(value[2]) &&
-		isIntegerLike(value[3]) &&
-		typeof value[4] === 'string' &&
-		typeof value[5] === 'string' &&
-		typeof value[6] === 'boolean' &&
-		typeof value[7] === 'boolean' &&
-		typeof value[8] === 'boolean'
-	)
+	return Array.isArray(value) && value.length === 6 && typeof value[0] === 'string' && typeof value[1] === 'string' && isIntegerLike(value[2]) && isIntegerLike(value[3]) && typeof value[4] === 'string' && typeof value[5] === 'boolean'
 }
 
 export function requireOpenOracleExtraDataTuple(value: unknown, context: string): OpenOracleExtraDataTuple {

--- a/ui/ts/lib/openOracle.ts
+++ b/ui/ts/lib/openOracle.ts
@@ -7,11 +7,11 @@ import { formatCurrencyBalance, formatCurrencyInputBalance, formatDuration } fro
 import { tryParseBigIntInput } from './marketForm.js'
 import { deriveTokenApprovalRequirement, formatTokenApprovalUnavailableMessage, type TokenApprovalRequirement } from './tokenApproval.js'
 import { getWethAddress, isRepPricingEnabled, quoteBestExactInputWithSource, quoteBestV3ExactInputWithSource, quoteExactInput } from './uniswapQuoter.js'
-const OPEN_ORACLE_PRICE_PRECISION = 10n ** 18n
+const OPEN_ORACLE_PRICE_PRECISION = 10n ** 30n
 const OPEN_ORACLE_BOUNTY_BUFFER_NUMERATOR = 12n
 const OPEN_ORACLE_BOUNTY_BUFFER_DENOMINATOR = 10n
 const OPEN_ORACLE_PERCENTAGE_PRECISION = 10n ** 7n
-const OPEN_ORACLE_MULTIPLIER_PRECISION = 10n ** 4n
+const OPEN_ORACLE_MULTIPLIER_PRECISION = 100n
 type OpenOracleReportStatus = 'Awaiting Initial Report' | 'Pending' | 'Disputed' | 'Settled'
 export type OpenOracleSelectedReportActionMode = 'initial-report' | 'dispute' | 'settle' | 'read-only'
 export type OpenOracleInitialReportPriceSource = 'Uniswap V4' | 'Uniswap V3' | 'MOCK' | 'Manual override' | 'Unavailable'
@@ -88,11 +88,11 @@ export function formatOpenOracleInitialReportWriteErrorMessage(error: unknown, f
 	const normalizedDetail = detail?.toLowerCase()
 	if (normalizedDetail === undefined) return 'Transaction failed while submitting the initial report. Reload the report and try again.'
 	if (genericMessage === detail) return detail
-	if (normalizedDetail.includes('report submitted')) return 'This report already has an initial report.'
-	if (normalizedDetail.includes('report id')) return 'This report is no longer valid. Reload it before submitting the initial report again.'
-	if (normalizedDetail.includes('token1 amount')) return 'The required token1 amount changed on-chain. Reload the report before submitting the initial report again.'
-	if (normalizedDetail.includes('token2 amount')) return 'The selected price produces an invalid token2 amount for the initial report.'
-	if (normalizedDetail.includes('state hash')) return 'This report changed on-chain. Reload the report before submitting the initial report again.'
+	if (normalizedDetail.includes('report submitted') || normalizedDetail.includes('reportalreadysubmitted') || normalizedDetail.includes('0xcc0220a9')) return 'This report already has an initial report.'
+	if (normalizedDetail.includes('report id') || normalizedDetail.includes('invalidreportid')) return 'This report is no longer valid. Reload it before submitting the initial report again.'
+	if (normalizedDetail.includes('token1 amount') || normalizedDetail.includes('invalidamount1')) return 'The required token1 amount changed on-chain. Reload the report before submitting the initial report again.'
+	if (normalizedDetail.includes('token2 amount') || normalizedDetail.includes('invalidamount2')) return 'The selected price produces an invalid token2 amount for the initial report.'
+	if (normalizedDetail.includes('state hash') || normalizedDetail.includes('invalidstatehash') || normalizedDetail.includes('0x937d7862')) return 'This report changed on-chain. Reload the report before submitting the initial report again.'
 	if (
 		normalizedDetail.includes('allowance') ||
 		normalizedDetail.includes('balance') ||
@@ -114,9 +114,9 @@ export function formatOpenOracleSettleWriteErrorMessage(error: unknown, fallback
 	if (normalizedDetail === undefined) return 'Transaction failed while settling the report. Reload the report and try again.'
 	if (genericMessage === detail) return detail
 	if (normalizedDetail.includes('0x98bdb2e0') || normalizedDetail.includes('invalidgaslimit') || normalizedDetail.includes('invalid gas limit')) return 'This report requires a higher settlement gas limit because it executes a callback on settlement. Retry with the updated UI.'
-	if (normalizedDetail.includes('settlement')) return 'This report is not ready to settle yet.'
-	if (normalizedDetail.includes('report settled')) return 'This report is already settled.'
-	if (normalizedDetail.includes('no initial report')) return 'Submit an initial report before settling this report.'
+	if (normalizedDetail.includes('settletooearly') || normalizedDetail.includes('settlement')) return 'This report is not ready to settle yet.'
+	if (normalizedDetail.includes('alreadysettled') || normalizedDetail.includes('report settled')) return 'This report is already settled.'
+	if (normalizedDetail.includes('noreportyet') || normalizedDetail.includes('no initial report')) return 'Submit an initial report before settling this report.'
 	return `Transaction failed while settling the report. Reason: ${detail}`
 }
 export function formatOpenOracleDisputeWriteErrorMessage(error: unknown, fallbackMessage = 'Failed to dispute report') {
@@ -126,10 +126,10 @@ export function formatOpenOracleDisputeWriteErrorMessage(error: unknown, fallbac
 	const normalizedDetail = detail?.toLowerCase()
 	if (normalizedDetail === undefined) return 'Transaction failed while disputing the report. Reload the report and try again.'
 	if (genericMessage === detail) return detail
-	if (normalizedDetail.includes('dispute too early')) return 'This report is not ready to dispute yet.'
-	if (normalizedDetail.includes('dispute period expired')) return 'Dispute window closed. Settle Report instead.'
-	if (normalizedDetail.includes('report settled')) return 'This report is already settled.'
-	if (normalizedDetail.includes('no report to dispute')) return 'Submit an initial report before disputing this report.'
+	if (normalizedDetail.includes('disputetooearly') || normalizedDetail.includes('dispute too early')) return 'This report is not ready to dispute yet.'
+	if (normalizedDetail.includes('disputetoolate') || normalizedDetail.includes('dispute period expired')) return 'Dispute window closed. Settle Report instead.'
+	if (normalizedDetail.includes('alreadysettled') || normalizedDetail.includes('report settled')) return 'This report is already settled.'
+	if (normalizedDetail.includes('noreporttodispute') || normalizedDetail.includes('no report to dispute')) return 'Submit an initial report before disputing this report.'
 	return `Transaction failed while disputing the report. Reason: ${detail}`
 }
 export function getOpenOracleCreateGuardMessage({ ethValueInput, isMainnet, settlerRewardInput, walletConnected, walletEthBalance }: { ethValueInput: string; isMainnet: boolean; settlerRewardInput: string; walletConnected: boolean; walletEthBalance: bigint | undefined }) {
@@ -139,8 +139,7 @@ export function getOpenOracleCreateGuardMessage({ ethValueInput, isMainnet, sett
 	if (ethValue === undefined) return 'Enter a valid ETH value to send.'
 	const settlerReward = tryParseBigIntInput(settlerRewardInput)
 	if (settlerReward === undefined) return 'Enter a valid settler reward.'
-	if (ethValue <= 100n) return 'ETH value to send must be greater than 100 wei.'
-	if (ethValue <= settlerReward) return 'ETH value to send must exceed the settler reward.'
+	if (ethValue < settlerReward) return 'ETH value to send must be at least the settler reward.'
 	if (walletEthBalance === undefined) return 'Loading wallet ETH balance.'
 	if (ethValue > walletEthBalance) return `Need ${formatCurrencyBalance(ethValue - walletEthBalance)} more ETH in this wallet to create the selected Open Oracle game.`
 	return undefined
@@ -284,10 +283,10 @@ function calculateOpenOracleToken2Amount(token1Amount: bigint, price: bigint) {
 	return (token1Amount * OPEN_ORACLE_PRICE_PRECISION) / price
 }
 function tryParseOpenOraclePriceInput(value: string) {
-	return tryParseDecimalInput(value)
+	return tryParseDecimalInput(value, 30)
 }
 export function formatOpenOraclePriceInput(price: bigint | undefined) {
-	return price === undefined ? '' : formatCurrencyInputBalance(price)
+	return price === undefined ? '' : formatCurrencyInputBalance(price, 30)
 }
 function resolveOpenOracleTokenLabel({ fallbackLabel, tokenAddress, tokenSymbol }: { fallbackLabel: string; tokenAddress: string | undefined; tokenSymbol: string | undefined }) {
 	const resolvedSymbol = tokenSymbol?.trim()
@@ -358,35 +357,21 @@ function formatOpenOracleDisputeBalanceStatusUnavailableMessage({ reason, tokenL
 function formatOpenOracleDisputeInsufficientBalanceMessage({ available, required, tokenDecimals, tokenLabel }: { available: bigint; required: bigint; tokenDecimals: number | undefined; tokenLabel: string }) {
 	return `Insufficient ${tokenLabel} balance for this dispute. Need ${formatCurrencyBalance(required, tokenDecimals ?? 18)}, wallet has ${formatCurrencyBalance(available, tokenDecimals ?? 18)}.`
 }
-function resolveOpenOracleDisputeToken1Contribution({ feeToken, feePercentage, oldAmount1, protocolFee, requiredToken1Contribution, tokenToSwap }: { feePercentage: bigint; feeToken: boolean; oldAmount1: bigint; protocolFee: bigint; requiredToken1Contribution: bigint; tokenToSwap: 'token1' | 'token2' }) {
+function resolveOpenOracleDisputeToken1Contribution({ feePercentage, oldAmount1, protocolFee, requiredToken1Contribution, tokenToSwap }: { feePercentage: bigint; oldAmount1: bigint; protocolFee: bigint; requiredToken1Contribution: bigint; tokenToSwap: 'token1' | 'token2' }) {
 	if (tokenToSwap === 'token1') {
-		if (feeToken) {
-			const fee = (oldAmount1 * feePercentage) / OPEN_ORACLE_PERCENTAGE_PRECISION
-			const protocolFeeAmount = (oldAmount1 * protocolFee) / OPEN_ORACLE_PERCENTAGE_PRECISION
-			return requiredToken1Contribution + oldAmount1 + fee + protocolFeeAmount
-		}
-		return requiredToken1Contribution + oldAmount1
+		const fee = (oldAmount1 * feePercentage) / OPEN_ORACLE_PERCENTAGE_PRECISION
+		const protocolFeeAmount = (oldAmount1 * protocolFee) / OPEN_ORACLE_PERCENTAGE_PRECISION
+		return requiredToken1Contribution + oldAmount1 + fee + protocolFeeAmount
 	}
-	if (feeToken) return requiredToken1Contribution > oldAmount1 ? requiredToken1Contribution - oldAmount1 : 0n
-	const fee = (oldAmount1 * feePercentage) / OPEN_ORACLE_PERCENTAGE_PRECISION
-	const protocolFeeAmount = (oldAmount1 * protocolFee) / OPEN_ORACLE_PERCENTAGE_PRECISION
-	const totalContribution = requiredToken1Contribution + fee + protocolFeeAmount
-	return totalContribution > oldAmount1 ? totalContribution - oldAmount1 : 0n
+	return requiredToken1Contribution > oldAmount1 ? requiredToken1Contribution - oldAmount1 : 0n
 }
-function resolveOpenOracleDisputeToken2Contribution({ feeToken, feePercentage, newAmount2, oldAmount2, protocolFee, tokenToSwap }: { feePercentage: bigint; feeToken: boolean; newAmount2: bigint; oldAmount2: bigint; protocolFee: bigint; tokenToSwap: 'token1' | 'token2' }) {
+function resolveOpenOracleDisputeToken2Contribution({ feePercentage, newAmount2, oldAmount2, protocolFee, tokenToSwap }: { feePercentage: bigint; newAmount2: bigint; oldAmount2: bigint; protocolFee: bigint; tokenToSwap: 'token1' | 'token2' }) {
 	if (tokenToSwap === 'token1') {
-		if (feeToken) return newAmount2 >= oldAmount2 ? newAmount2 - oldAmount2 : 0n
-		const fee = (oldAmount2 * feePercentage) / OPEN_ORACLE_PERCENTAGE_PRECISION
-		const protocolFeeAmount = (oldAmount2 * protocolFee) / OPEN_ORACLE_PERCENTAGE_PRECISION
-		const totalContribution = newAmount2 + fee + protocolFeeAmount
-		return totalContribution >= oldAmount2 ? totalContribution - oldAmount2 : 0n
+		return newAmount2 >= oldAmount2 ? newAmount2 - oldAmount2 : 0n
 	}
-	if (feeToken) {
-		const fee = (oldAmount2 * feePercentage) / OPEN_ORACLE_PERCENTAGE_PRECISION
-		const protocolFeeAmount = (oldAmount2 * protocolFee) / OPEN_ORACLE_PERCENTAGE_PRECISION
-		return newAmount2 + oldAmount2 + fee + protocolFeeAmount
-	}
-	return newAmount2 + oldAmount2
+	const fee = (oldAmount2 * feePercentage) / OPEN_ORACLE_PERCENTAGE_PRECISION
+	const protocolFeeAmount = (oldAmount2 * protocolFee) / OPEN_ORACLE_PERCENTAGE_PRECISION
+	return newAmount2 + oldAmount2 + fee + protocolFeeAmount
 }
 export async function loadOpenOracleInitialReportPriceResult(client: Parameters<typeof quoteExactInput>[0], token1: Parameters<typeof quoteExactInput>[1], token2: Parameters<typeof quoteExactInput>[2], token1Amount: bigint): Promise<OpenOracleInitialReportPriceLoadResult> {
 	if (!isRepPricingEnabled())
@@ -682,25 +667,7 @@ export function deriveOpenOracleDisputeSubmissionDetails({
 	reportDetails:
 		| Pick<
 				OpenOracleReportDetails,
-				| 'currentAmount1'
-				| 'currentAmount2'
-				| 'currentBlockNumber'
-				| 'currentReporter'
-				| 'currentTime'
-				| 'disputeDelay'
-				| 'escalationHalt'
-				| 'feePercentage'
-				| 'feeToken'
-				| 'isDistributed'
-				| 'multiplier'
-				| 'protocolFee'
-				| 'reportTimestamp'
-				| 'settlementTime'
-				| 'timeType'
-				| 'token1'
-				| 'token1Symbol'
-				| 'token2'
-				| 'token2Symbol'
+				'currentAmount1' | 'currentAmount2' | 'currentBlockNumber' | 'currentReporter' | 'currentTime' | 'disputeDelay' | 'escalationHalt' | 'feePercentage' | 'isDistributed' | 'multiplier' | 'protocolFee' | 'reportTimestamp' | 'settlementTime' | 'timeType' | 'token1' | 'token1Symbol' | 'token2' | 'token2Symbol'
 		  >
 		| undefined
 	token1AllowanceError: string | undefined
@@ -725,7 +692,14 @@ export function deriveOpenOracleDisputeSubmissionDetails({
 	let expectedNewAmount1: bigint | undefined
 	let newAmount1: bigint | undefined
 	let newAmount2: bigint | undefined
-	if (reportDetails !== undefined) expectedNewAmount1 = reportDetails.escalationHalt > reportDetails.currentAmount1 ? (reportDetails.currentAmount1 * reportDetails.multiplier) / OPEN_ORACLE_MULTIPLIER_PRECISION : reportDetails.currentAmount1 + 1n
+	if (reportDetails !== undefined)
+		expectedNewAmount1 =
+			reportDetails.escalationHalt > reportDetails.currentAmount1
+				? (() => {
+						const multiplied = (reportDetails.currentAmount1 * reportDetails.multiplier) / OPEN_ORACLE_MULTIPLIER_PRECISION
+						return multiplied > reportDetails.escalationHalt ? reportDetails.escalationHalt : multiplied
+					})()
+				: reportDetails.currentAmount1 + 1n
 	newAmount1 = tryParseBigIntInput(disputeNewAmount1Input)
 	newAmount2 = tryParseBigIntInput(disputeNewAmount2Input)
 	const token1ContributionAmount =
@@ -733,7 +707,6 @@ export function deriveOpenOracleDisputeSubmissionDetails({
 			? undefined
 			: resolveOpenOracleDisputeToken1Contribution({
 					feePercentage: reportDetails.feePercentage,
-					feeToken: reportDetails.feeToken,
 					oldAmount1: reportDetails.currentAmount1,
 					protocolFee: reportDetails.protocolFee,
 					requiredToken1Contribution: expectedNewAmount1,
@@ -744,7 +717,6 @@ export function deriveOpenOracleDisputeSubmissionDetails({
 			? undefined
 			: resolveOpenOracleDisputeToken2Contribution({
 					feePercentage: reportDetails.feePercentage,
-					feeToken: reportDetails.feeToken,
 					newAmount2,
 					oldAmount2: reportDetails.currentAmount2,
 					protocolFee: reportDetails.protocolFee,

--- a/ui/ts/tests/contracts.test.ts
+++ b/ui/ts/tests/contracts.test.ts
@@ -7,6 +7,7 @@ import {
 	loadAllSecurityPools,
 	loadEscalationDeposits,
 	loadForkAuctionDetails,
+	loadOpenOracleReportSummaries,
 	loadSecurityPoolPage,
 	loadTruthAuctionActiveTickPage,
 	loadTruthAuctionBidderBidPage,
@@ -18,6 +19,7 @@ import {
 } from '../contracts.js'
 import { getForkOutcomeKey } from '../contracts/helpers.js'
 import { peripherals_openOracle_OpenOracle_OpenOracle, peripherals_tokens_ShareToken_ShareToken } from '../contractArtifact.js'
+import { getOpenOracleReportStatus } from '../lib/openOracle.js'
 import type { ReadClient } from '../types/contracts.js'
 
 const securityPoolAddress = getAddress('0x00000000000000000000000000000000000000a1')
@@ -25,6 +27,8 @@ const alternateSecurityPoolAddress = getAddress('0x00000000000000000000000000000
 const shareTokenAddress = getAddress('0x00000000000000000000000000000000000000b2')
 const vaultAddress = getAddress('0x00000000000000000000000000000000000000c1')
 const truthAuctionAddress = getAddress('0x00000000000000000000000000000000000000f6')
+const token1Address = getAddress('0x00000000000000000000000000000000000000d1')
+const token2Address = getAddress('0x00000000000000000000000000000000000000d2')
 const transactionHash = '0x00000000000000000000000000000000000000000000000000000000000000c3' satisfies Hash
 
 type MockWriteClient = Parameters<typeof migrateSharesFromUniverse>[0]
@@ -170,6 +174,42 @@ describe('contracts helpers', () => {
 
 		expect(details.truthAuctionStartedAt).toBe(1n)
 		expect(details.migrationEndsAt).toBe(forkTime + 4_838_400n)
+	})
+
+	test('loadOpenOracleReportSummaries keeps reports disputed when dispute history returns to the initial reporter', async () => {
+		const initialReporter = getAddress('0x00000000000000000000000000000000000000e1')
+		const client = createMockLoaderClient({
+			getBlock: async () => createBlockWithTimestamp(0n),
+			multicall: async request => {
+				const contracts = request.contracts
+				const firstContract = contracts[0]
+				const functionName = getContractFunctionName(firstContract)
+				if (functionName === 'reportMeta') {
+					return [[100n, 0n, 0n, 0n, token1Address, 0, token2Address, true, 0, 0, 0, 0]]
+				}
+				if (functionName === 'reportStatus') {
+					return [[100n, 10n, initialReporter, 1, 0, initialReporter, 0]]
+				}
+				if (functionName === 'extraData') {
+					return [['0x0000000000000000000000000000000000000000000000000000000000000000', zeroAddress, 2, 0, zeroAddress, false]]
+				}
+				if (functionName === 'decimals') return [18n, 18n]
+				if (functionName === 'symbol') return ['REP', 'WETH']
+				throw new Error(`Unexpected multicall contract: ${functionName}`)
+			},
+			readContract: async request => {
+				if (request.functionName === 'nextReportId') return 2n
+				throw new Error(`Unexpected readContract function: ${request.functionName}`)
+			},
+		})
+
+		const page = await loadOpenOracleReportSummaries(client, 0, 10)
+		const [report] = page.reports
+		if (report === undefined) throw new Error('Expected one open oracle report summary')
+
+		expect(report.currentReporter).toBe(initialReporter)
+		expect(report.disputeOccurred).toBe(true)
+		expect(getOpenOracleReportStatus(report)).toBe('Disputed')
 	})
 
 	test('loadAllSecurityPools keeps the default root-pool fork outcome unset and inactive', async () => {

--- a/ui/ts/tests/contractsHelpers.test.ts
+++ b/ui/ts/tests/contractsHelpers.test.ts
@@ -84,22 +84,12 @@ describe('contracts helpers', () => {
 		expect(requireOpenOracleReportMetaTupleArray(oneValidMetaTuple, 'oracle meta')).toEqual(oneValidMetaTuple)
 		expect(() => requireOpenOracleReportMetaTupleArray([[1n, 2n] as never], 'oracle meta')).toThrow('Unexpected oracle meta response')
 
-		const validStatusTuple: [bigint, bigint, bigint, `0x${string}`, bigint, bigint, `0x${string}`, bigint, boolean, boolean] = [1n, 2n, 3n, getAddress('0x00000000000000000000000000000000000000d4'), 1n, 2n, getAddress('0x00000000000000000000000000000000000000e5'), 3n, true, false]
+		const validStatusTuple: [bigint, bigint, `0x${string}`, bigint, bigint, `0x${string}`, bigint] = [1n, 2n, getAddress('0x00000000000000000000000000000000000000d4'), 1n, 2n, getAddress('0x00000000000000000000000000000000000000e5'), 3n]
 		expect(requireOpenOracleReportStatusTuple(validStatusTuple, 'oracle status')).toEqual(validStatusTuple)
 		expect(requireOpenOracleReportStatusTupleArray([validStatusTuple], 'oracle status')).toEqual([validStatusTuple])
 		expect(() => requireOpenOracleReportStatusTupleArray([[1n, 2n] as never], 'oracle status')).toThrow('Unexpected oracle status response')
 
-		const validExtraData: [`0x${string}`, `0x${string}`, bigint, bigint, `0x${string}`, `0x${string}`, boolean, boolean, boolean] = [
-			'0x00000000000000000000000000000000000000f6',
-			getAddress('0x00000000000000000000000000000000000000f7'),
-			1n,
-			2n,
-			getAddress('0x00000000000000000000000000000000000000f6'),
-			zeroAddress,
-			true,
-			false,
-			true,
-		]
+		const validExtraData: [`0x${string}`, `0x${string}`, bigint, bigint, `0x${string}`, boolean] = ['0x00000000000000000000000000000000000000f6', getAddress('0x00000000000000000000000000000000000000f7'), 1n, 2n, getAddress('0x00000000000000000000000000000000000000f6'), false]
 		expect(requireOpenOracleExtraDataTuple(validExtraData, 'oracle extra data')).toEqual(validExtraData)
 		expect(() => requireOpenOracleExtraDataTuple(['0x00', zeroAddress, 1] as never, 'oracle extra data')).toThrow('Unexpected oracle extra data response')
 	})

--- a/ui/ts/tests/openOracle.test.ts
+++ b/ui/ts/tests/openOracle.test.ts
@@ -146,7 +146,6 @@ function createDisputeSubmissionPreview(overrides: Partial<Parameters<typeof der
 			disputeDelay: 10n,
 			escalationHalt: 200n,
 			feePercentage: 1_000_000n,
-			feeToken: false,
 			isDistributed: false,
 			multiplier: 20_000n,
 			protocolFee: 500_000n,
@@ -284,7 +283,7 @@ describe('Open Oracle helpers', () => {
 	test('initial report price helpers derive a Uniswap default price and preserve quote failure metadata', async () => {
 		const quote = await loadOpenOracleInitialReportPrice(createQuoteClient(25n), getAddress('0x00000000000000000000000000000000000000a1'), getAddress('0x00000000000000000000000000000000000000a2'), 100n)
 		expect(quote).toEqual({
-			price: 4_000_000_000_000_000_000n,
+			price: 4_000_000_000_000_000_000_000_000_000_000n,
 			priceSource: 'Uniswap V4',
 			token2Amount: 25n,
 		})
@@ -324,7 +323,7 @@ describe('Open Oracle helpers', () => {
 		fallbackClient.simulateContract = simulateContract
 
 		await expect(loadOpenOracleInitialReportPrice(fallbackClient, REP_ADDRESS, WETH_ADDRESS, 100n * 10n ** 18n)).resolves.toEqual({
-			price: 500_000_000_000_000_000_000n,
+			price: 500_000_000_000_000_000_000_000_000_000_000n,
 			priceSource: 'Uniswap V3',
 			token2Amount: 200_000_000_000_000_000n,
 		})
@@ -341,7 +340,7 @@ describe('Open Oracle helpers', () => {
 		fallbackClient.simulateContract = simulateContract
 
 		await expect(loadOpenOracleInitialReportPrice(fallbackClient, USDC_ADDRESS, WETH_ADDRESS, 100n)).resolves.toEqual({
-			price: 2_000_000_000_000_000_000n,
+			price: 2_000_000_000_000_000_000_000_000_000_000n,
 			priceSource: 'Uniswap V3',
 			token2Amount: 50n,
 		})
@@ -354,7 +353,7 @@ describe('Open Oracle helpers', () => {
 
 		expect(preview.priceSource).toBe('Uniswap V4')
 		expect(preview.priceSourceUrl).toBe('https://app.uniswap.org/explore/pools/ethereum/0xpool')
-		expect(preview.price).toBe(4_000_000_000_000_000_000n)
+		expect(preview.price).toBe(4_000_000_000_000_000_000_000_000_000_000n)
 		expect(preview.amount1).toBe(100n)
 		expect(preview.amount2).toBe(25n)
 		expect(preview.token2Approval.neededAmount).toBe(1n)
@@ -365,12 +364,10 @@ describe('Open Oracle helpers', () => {
 		})
 	})
 
-	test('dispute submission helper computes token contributions across both swap directions and fee-token modes', () => {
+	test('dispute submission helper computes token contributions across both swap directions', () => {
 		const cases = [
-			{ disputeTokenToSwap: 'token1' as const, feeToken: false, expectedToken1Contribution: 300n, expectedToken2Contribution: 37n },
-			{ disputeTokenToSwap: 'token1' as const, feeToken: true, expectedToken1Contribution: 315n, expectedToken2Contribution: 30n },
-			{ disputeTokenToSwap: 'token2' as const, feeToken: false, expectedToken1Contribution: 115n, expectedToken2Contribution: 130n },
-			{ disputeTokenToSwap: 'token2' as const, feeToken: true, expectedToken1Contribution: 100n, expectedToken2Contribution: 137n },
+			{ disputeTokenToSwap: 'token1' as const, expectedToken1Contribution: 315n, expectedToken2Contribution: 30n },
+			{ disputeTokenToSwap: 'token2' as const, expectedToken1Contribution: 100n, expectedToken2Contribution: 137n },
 		]
 
 		for (const testCase of cases) {
@@ -385,7 +382,6 @@ describe('Open Oracle helpers', () => {
 					disputeDelay: 10n,
 					escalationHalt: 200n,
 					feePercentage: 1_000_000n,
-					feeToken: testCase.feeToken,
 					isDistributed: false,
 					multiplier: 20_000n,
 					protocolFee: 500_000n,
@@ -478,7 +474,7 @@ describe('Open Oracle helpers', () => {
 		})
 
 		expect(preview.priceSource).toBe('Manual override')
-		expect(preview.price).toBe(4_000_000_000_000_000_000n)
+		expect(preview.price).toBe(4_000_000_000_000_000_000_000_000_000_000n)
 		expect(preview.blockMessage).toEqual({
 			kind: 'visible',
 			message: 'XYZ approval required',
@@ -1065,12 +1061,10 @@ describe('Open Oracle helpers', () => {
 		const stateHash = (await getOpenOracleExtraData(client, reportId)).stateHash
 		await submitInitialOracleReport(uiWriteClient, openOracleAddress, reportId, amount1, amount2, stateHash)
 
-		await expect(submitInitialOracleReport(uiWriteClient, openOracleAddress, reportId, amount1, amount2, stateHash)).rejects.toThrow(/report submitted/i)
+		await expect(submitInitialOracleReport(uiWriteClient, openOracleAddress, reportId, amount1, amount2, stateHash)).rejects.toThrow(/0xcc0220a9|reportalreadysubmitted|custom error/i)
 	})
 
-	// Temporarily disabled because `eth_simulate` changes the state hash while testing in
-	// Interceptor, so this validation must stay commented out for that flow.
-	test('submitInitialOracleReport accepts an invalid state hash', async () => {
+	test('submitInitialOracleReport rejects an invalid state hash', async () => {
 		await requestOraclePrice(uiWriteClient, managerAddress)
 
 		const reportId = (await loadOracleManagerDetails(uiReadClient, managerAddress)).pendingReportId
@@ -1087,12 +1081,7 @@ describe('Open Oracle helpers', () => {
 		const stateHash = (await getOpenOracleExtraData(client, reportId)).stateHash
 		const invalidStateHash = stateHash === '0x0000000000000000000000000000000000000000000000000000000000000000' ? '0x0000000000000000000000000000000000000000000000000000000000000001' : '0x0000000000000000000000000000000000000000000000000000000000000000'
 
-		await submitInitialOracleReport(uiWriteClient, openOracleAddress, reportId, amount1, amount2, invalidStateHash)
-
-		const reportDetails = await loadOpenOracleReportDetails(uiReadClient, openOracleAddress, reportId)
-		expect(reportDetails.currentAmount1).toBe(amount1)
-		expect(reportDetails.currentAmount2).toBe(amount2)
-		expect(getOpenOracleReportStatus(reportDetails)).toBe('Pending')
+		await expect(submitInitialOracleReport(uiWriteClient, openOracleAddress, reportId, amount1, amount2, invalidStateHash)).rejects.toThrow(/0x937d7862|invalidstatehash|custom error/i)
 	})
 
 	test('ui wrapWeth helper deposits ETH into WETH and reports the wrap action', async () => {

--- a/ui/ts/tests/openOracleRouteSection.test.tsx
+++ b/ui/ts/tests/openOracleRouteSection.test.tsx
@@ -133,7 +133,6 @@ function createOpenOracleReportDetails(overrides: Partial<OpenOracleReportDetail
 	return {
 		callbackContract: zeroAddress,
 		callbackGasLimit: 0,
-		callbackSelector: '0x00000000',
 		currentBlockNumber: 0n,
 		currentAmount1: 0n,
 		currentAmount2: 0n,
@@ -145,10 +144,8 @@ function createOpenOracleReportDetails(overrides: Partial<OpenOracleReportDetail
 		exactToken1Report: 10n ** 18n,
 		fee: 10n ** 15n,
 		feePercentage: 1000000000000000n,
-		feeToken: false,
 		initialReporter: zeroAddress,
 		isDistributed: false,
-		keepFee: false,
 		lastReportOppoTime: 0n,
 		multiplier: 2n * 10n ** 18n,
 		numReports: 0n,

--- a/ui/ts/tests/openOracleSection.test.tsx
+++ b/ui/ts/tests/openOracleSection.test.tsx
@@ -145,7 +145,6 @@ function createOpenOracleReportDetails(overrides: Partial<OpenOracleReportDetail
 	return {
 		callbackContract: zeroAddress,
 		callbackGasLimit: 0,
-		callbackSelector: '0x00000000',
 		currentBlockNumber: 0n,
 		currentAmount1: 0n,
 		currentAmount2: 0n,
@@ -157,10 +156,8 @@ function createOpenOracleReportDetails(overrides: Partial<OpenOracleReportDetail
 		exactToken1Report: 10n ** 18n,
 		fee: 10n ** 15n,
 		feePercentage: 1000000000000000n,
-		feeToken: false,
 		initialReporter: zeroAddress,
 		isDistributed: false,
-		keepFee: false,
 		lastReportOppoTime: 0n,
 		multiplier: 2n * 10n ** 18n,
 		numReports: 0n,

--- a/ui/ts/tests/useOpenOracleOperations.test.tsx
+++ b/ui/ts/tests/useOpenOracleOperations.test.tsx
@@ -23,7 +23,6 @@ function createOpenOracleReportDetails(overrides: Partial<OpenOracleReportDetail
 	return {
 		callbackContract: zeroAddress,
 		callbackGasLimit: 0,
-		callbackSelector: '0x00000000',
 		currentAmount1: 100n,
 		currentAmount2: 25n,
 		currentBlockNumber: 10n,
@@ -35,10 +34,8 @@ function createOpenOracleReportDetails(overrides: Partial<OpenOracleReportDetail
 		exactToken1Report: 100n,
 		fee: 0n,
 		feePercentage: 0n,
-		feeToken: false,
 		initialReporter: zeroAddress,
 		isDistributed: false,
-		keepFee: false,
 		lastReportOppoTime: 0n,
 		multiplier: 1n,
 		numReports: 0n,

--- a/ui/ts/types/contracts.ts
+++ b/ui/ts/types/contracts.ts
@@ -244,12 +244,9 @@ export type OpenOracleReportDetails = {
 	isDistributed: boolean
 	stateHash: Hex
 	callbackContract: Address
-	callbackSelector: Hex
 	callbackGasLimit: number
 	protocolFeeRecipient: Address
 	trackDisputes: boolean
-	keepFee: boolean
-	feeToken: boolean
 	numReports: bigint
 	lastReportOppoTime: bigint
 	token1Decimals: number


### PR DESCRIPTION
## Summary
- Updated Oracle integration to use a single OpenOracle callback path (`openOracleCallback`) and removed legacy callback selector wiring.
- Refined oracle report creation params for `SecurityPoolOracleCoordinator`/`PriceOracleManagerAndOperatorQueuerFactory` by dropping `keepFee`/`feeToken` fields and standardizing coordinator settlement behavior.
- Modernized OpenOracle integration in Solidity (`OpenOracle.sol`) with tighter types, new validation/revert semantics, fixed callback selector, and updated settlement/token flow.
- Added optional Create2 override inputs for openOracle address derivation and updated deployment/test plumbing accordingly.
- Adjusted UI contract adapters/helpers and tests to consume the updated OpenOracle report/callback contract metadata.
- Updated dependency invocation (`compile-contracts`) and supporting math/SafeCast/OpenZeppelin interface updates reflected in the diff.

## Testing
- Not run (not requested).
- Recommended checks:
  - `bun run tsc` or `cd ui && bun x tsc --project tsconfig.json` (UI-only fallback)
  - `bun run test`
  - `bun run format`
  - `bun run check`
  - `bun run knip`