### PR TITLE
Use bigint-safe ratio, pagination, and formatting helpers in UI

### DIFF
--- a/ui/ts/components/CollateralizationCircle.tsx
+++ b/ui/ts/components/CollateralizationCircle.tsx
@@ -1,8 +1,8 @@
 import type { CollateralizationCircleProps } from '../types/components.js'
-import { formatCollateralizationCompactPercentLabel, getCollateralizationVisualPercent, getToneRatioThreshold } from '../lib/visualMetrics.js'
+import { formatCollateralizationCompactPercentLabel, getCollateralizationVisualPercent, getToneRatioThreshold, getVisualRatio } from '../lib/visualMetrics.js'
 
 export function CollateralizationCircle({ collateralizationPercent, className = '', label = 'Collateralization', size = 'medium', successThreshold = 1, targetCollateralizationPercent, tone, warningThreshold = 0.65 }: CollateralizationCircleProps) {
-	const toneRatio = collateralizationPercent === undefined || targetCollateralizationPercent === undefined || targetCollateralizationPercent <= 0n ? undefined : Number(collateralizationPercent) / Number(targetCollateralizationPercent)
+	const toneRatio = getVisualRatio({ value: collateralizationPercent, maxValue: targetCollateralizationPercent })
 	const resolvedTone =
 		tone ??
 		getToneRatioThreshold({

--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -33,6 +33,7 @@ import { deriveSecurityPoolForkStage, deriveSecurityPoolLifecycleState, evaluate
 import { getCurrentSelectedPoolForkAuctionDetails, shouldReloadSelectedPoolDetails } from '../lib/securityPoolWorkflow.js'
 import { getCurrentForkWorkflowSelectionStage, type ForkWorkflowSelectionStage } from '../lib/securityPoolWorkflow.js'
 import { writeSecurityPoolQueryParam, writeUniverseQueryParam } from '../lib/urlParams.js'
+import { getVisualRatio } from '../lib/visualMetrics.js'
 import type { ImportedEscalationDeposit, ListedSecurityPool, ReadClient, ReportingOutcomeKey, TruthAuctionBidView, TruthAuctionMetrics, TruthAuctionTickSummary } from '../types/contracts.js'
 import type { ForkAuctionSectionProps } from '../types/components.js'
 const UNKNOWN_VALUE = '—'
@@ -271,9 +272,7 @@ function getFinalizeTruthAuctionGuardMessage({ currentTimestamp, truthAuction, t
 }
 
 function clampPercentage(value: bigint, maxValue: bigint) {
-	if (value <= 0n || maxValue <= 0n) return 0
-	const boundedValue = value > maxValue ? maxValue : value
-	return Number((boundedValue * 10000n) / maxValue) / 100
+	return (getVisualRatio({ value, maxValue }) ?? 0) * 100
 }
 
 function getTruthAuctionWinningThresholdPrice(truthAuction: TruthAuctionMetrics | undefined) {

--- a/ui/ts/components/MarketQuestionsSection.tsx
+++ b/ui/ts/components/MarketQuestionsSection.tsx
@@ -5,7 +5,7 @@ import { PaginationControls } from './PaginationControls.js'
 import { Question, getQuestionTitle } from './Question.js'
 import { SectionBlock } from './SectionBlock.js'
 import { StateHint } from './StateHint.js'
-import { QUESTION_PAGE_SIZE } from '../lib/pagination.js'
+import { formatPaginationSummary, getHasNextPaginationPage, getPaginationPageCount, QUESTION_PAGE_SIZE } from '../lib/pagination.js'
 import type { MarketDetailsPage } from '../types/contracts.js'
 
 function isCurrentQuestionPage(page: MarketDetailsPage | undefined, pageIndex: number, questionCount: bigint | undefined) {
@@ -32,7 +32,7 @@ export function MarketQuestionsSection({ hasForked, loadingZoltarQuestionCount, 
 	const currentPageRequestKey = `${pageIndex}:${QUESTION_PAGE_SIZE}:${zoltarQuestionCount?.toString() ?? 'unknown'}`
 	const hasCurrentPageData = isCurrentQuestionPage(zoltarQuestionPage, pageIndex, zoltarQuestionCount)
 	const effectiveQuestionCount = zoltarQuestionPage?.questionCount ?? zoltarQuestionCount
-	const questionPageCount = effectiveQuestionCount === undefined || effectiveQuestionCount === 0n ? 0 : Math.ceil(Number(effectiveQuestionCount) / QUESTION_PAGE_SIZE)
+	const questionPageCount = getPaginationPageCount(effectiveQuestionCount, QUESTION_PAGE_SIZE)
 	const visibleQuestions = hasCurrentPageData && zoltarQuestionPage !== undefined ? zoltarQuestionPage.questions : []
 	const isWaitingForPageData = activePageRequestKey === currentPageRequestKey
 	useEffect(() => {
@@ -66,7 +66,7 @@ export function MarketQuestionsSection({ hasForked, loadingZoltarQuestionCount, 
 			})
 	}, [activePageRequestKey, lastFailedPageRequestKey, loadingZoltarQuestionCount, onLoadZoltarQuestionPage, pageIndex, zoltarQuestionCount, zoltarQuestionPage])
 	const hasPreviousPage = pageIndex > 0
-	const hasNextPage = pageIndex + 1 < questionPageCount
+	const hasNextPage = getHasNextPaginationPage(pageIndex, questionPageCount)
 	return (
 		<SectionBlock
 			density='compact'
@@ -78,7 +78,7 @@ export function MarketQuestionsSection({ hasForked, loadingZoltarQuestionCount, 
 					loading={loadingZoltarQuestions}
 					onNextPage={() => setPageIndex(current => current + 1)}
 					onPreviousPage={() => setPageIndex(current => Math.max(0, current - 1))}
-					summary={zoltarQuestionPage === undefined ? undefined : `Page ${pageIndex + 1} of ${Math.max(questionPageCount, 1)}`}
+					summary={zoltarQuestionPage === undefined ? undefined : formatPaginationSummary(pageIndex, questionPageCount)}
 				/>
 			}
 		>

--- a/ui/ts/components/OpenOracleSection.tsx
+++ b/ui/ts/components/OpenOracleSection.tsx
@@ -41,6 +41,7 @@ import {
 } from '../lib/openOracle.js'
 import { getOpenOracleReadinessActions } from '../lib/openOracleReadiness.js'
 import { getOpenOracleStagePresentation } from '../lib/openOracleStage.js'
+import { formatPaginationSummary, getHasNextPaginationPage, getPaginationPageCount } from '../lib/pagination.js'
 import { loadOpenOracleReportSummaries } from '../contracts.js'
 import { isMainnetChain } from '../lib/network.js'
 import { getReportPresentation } from '../lib/userCopy.js'
@@ -832,9 +833,9 @@ export function OpenOracleSection({
 	const loadingBrowse = browseLoad.isLoading.value
 	const normalizedBrowseSearchText = browseSearchText.trim().toLowerCase()
 	const browseReportCount = browsePage?.reportCount ?? 0n
-	const browsePageCount = browsePage === undefined || browseReportCount === 0n ? 0 : Math.ceil(Number(browseReportCount) / BROWSE_PAGE_SIZE)
+	const browsePageCount = browsePage === undefined ? undefined : getPaginationPageCount(browseReportCount, BROWSE_PAGE_SIZE)
 	const browseHasPreviousPage = browsePageIndex > 0
-	const browseHasNextPage = browsePage !== undefined && browsePageIndex + 1 < browsePageCount
+	const browseHasNextPage = getHasNextPaginationPage(browsePageIndex, browsePageCount)
 	const filteredBrowseReports =
 		browsePage?.reports.filter(report => {
 			const status = getOpenOracleReportStatus(report)
@@ -865,7 +866,7 @@ export function OpenOracleSection({
 								loading={loadingBrowse}
 								onNextPage={() => setBrowsePageIndex(current => current + 1)}
 								onPreviousPage={() => setBrowsePageIndex(current => Math.max(0, current - 1))}
-								summary={browsePage === undefined ? undefined : `Page ${browsePageIndex + 1} of ${Math.max(browsePageCount, 1)}`}
+								summary={browsePage === undefined ? undefined : formatPaginationSummary(browsePageIndex, browsePageCount)}
 							/>
 						}
 						density='compact'

--- a/ui/ts/components/SecurityPoolSummaryMetrics.tsx
+++ b/ui/ts/components/SecurityPoolSummaryMetrics.tsx
@@ -8,7 +8,7 @@ import { ProgressMeter } from './ProgressMeter.js'
 import { UniverseLink } from './UniverseLink.js'
 import { openInterestFeePerYearBigint } from '../lib/retentionRate.js'
 import { getPoolCollateralizationPercent } from '../lib/trading.js'
-import { getToneRatioThreshold } from '../lib/visualMetrics.js'
+import { getToneRatioThreshold, getVisualRatio } from '../lib/visualMetrics.js'
 import type { ListedSecurityPool } from '../types/contracts.js'
 
 type SecurityPoolSummaryMetricsProps = {
@@ -117,7 +117,7 @@ export function SecurityPoolSummaryMetrics({
 							</span>
 						}
 						tone={getToneRatioThreshold({
-							ratio: pool.totalSecurityBondAllowance === 0n ? undefined : Number(pool.completeSetCollateralAmount) / Number(pool.totalSecurityBondAllowance),
+							ratio: getVisualRatio({ value: pool.completeSetCollateralAmount, maxValue: pool.totalSecurityBondAllowance }),
 							successThreshold: 0.6,
 							warningThreshold: 0.85,
 						})}

--- a/ui/ts/components/SecurityPoolsOverviewSection.tsx
+++ b/ui/ts/components/SecurityPoolsOverviewSection.tsx
@@ -19,13 +19,13 @@ import { StateHint } from './StateHint.js'
 import { UniverseLink } from './UniverseLink.js'
 import { sameAddress } from '../lib/address.js'
 import { isMainnetChain } from '../lib/network.js'
-import { SECURITY_POOL_PAGE_SIZE } from '../lib/pagination.js'
+import { formatPaginationSummary, getHasNextPaginationPage, getPaginationPageCount, resolvePaginationPageIndex, SECURITY_POOL_PAGE_SIZE } from '../lib/pagination.js'
 import { openInterestFeePerYearBigint } from '../lib/retentionRate.js'
 import { getSecurityPoolStatusBadgeLabel } from '../lib/securityPoolLabels.js'
 import { deriveSecurityPoolLifecycleState, evaluateSecurityPoolState, type SecurityPoolLifecycleState } from '../lib/securityPoolState.js'
 import { getPoolCollateralizationPercent, getVaultCollateralizationPercent } from '../lib/trading.js'
 import { getPoolRegistryPresentation } from '../lib/userCopy.js'
-import { getToneRatioThreshold } from '../lib/visualMetrics.js'
+import { getToneRatioThreshold, getVisualRatio } from '../lib/visualMetrics.js'
 import type { SecurityPoolsOverviewSectionProps } from '../types/components.js'
 
 export function SecurityPoolsOverviewSection({
@@ -67,20 +67,8 @@ export function SecurityPoolsOverviewSection({
 	const loadSecurityPoolPageRef = useRef(onLoadSecurityPoolPage)
 	loadSecurityPoolPageRef.current = onLoadSecurityPoolPage
 	const effectivePoolCount = securityPoolPage?.poolCount ?? securityPoolBrowseCount
-	let poolPageCount: number | undefined
-	if (effectivePoolCount === undefined) {
-		poolPageCount = undefined
-	} else if (effectivePoolCount === 0n) {
-		poolPageCount = 0
-	} else {
-		poolPageCount = Math.ceil(Number(effectivePoolCount) / SECURITY_POOL_PAGE_SIZE)
-	}
-	let resolvedPageIndex = pageIndex
-	if (poolPageCount === 0) {
-		resolvedPageIndex = 0
-	} else if (poolPageCount !== undefined) {
-		resolvedPageIndex = Math.min(pageIndex, poolPageCount - 1)
-	}
+	const poolPageCount = getPaginationPageCount(effectivePoolCount, SECURITY_POOL_PAGE_SIZE)
+	const resolvedPageIndex = resolvePaginationPageIndex(pageIndex, poolPageCount)
 	const currentPageRequestKey = `${resolvedPageIndex}:${SECURITY_POOL_PAGE_SIZE}`
 	const hasCurrentPageData = securityPoolPage?.pageIndex === resolvedPageIndex && securityPoolPage.pageSize === SECURITY_POOL_PAGE_SIZE
 	const pagedSecurityPools = hasCurrentPageData ? securityPoolPage.pools : []
@@ -112,7 +100,7 @@ export function SecurityPoolsOverviewSection({
 	const callerVaultSummary = accountState.address === undefined ? undefined : selectedPool?.vaults.find(vault => sameAddress(vault.vaultAddress, accountState.address))
 	const normalizedSearchText = searchText.trim().toLowerCase()
 	const hasPreviousPage = resolvedPageIndex > 0
-	const hasNextPage = poolPageCount === undefined ? false : resolvedPageIndex + 1 < poolPageCount
+	const hasNextPage = getHasNextPaginationPage(resolvedPageIndex, poolPageCount)
 	useEffect(() => {
 		if (resolvedPageIndex === pageIndex) return
 		setPageIndex(resolvedPageIndex)
@@ -155,7 +143,7 @@ export function SecurityPoolsOverviewSection({
 						onPreviousPage={() => {
 							setPageIndex(current => Math.max(0, current - 1))
 						}}
-						summary={securityPoolPage === undefined || poolPageCount === undefined ? undefined : `Page ${resolvedPageIndex + 1} of ${Math.max(poolPageCount, 1)}`}
+						summary={securityPoolPage === undefined ? undefined : formatPaginationSummary(resolvedPageIndex, poolPageCount)}
 					/>
 				}
 			>
@@ -279,7 +267,7 @@ export function SecurityPoolsOverviewSection({
 																</span>
 															}
 															tone={getToneRatioThreshold({
-																ratio: pool.totalSecurityBondAllowance === 0n ? undefined : Number(pool.completeSetCollateralAmount) / Number(pool.totalSecurityBondAllowance),
+																ratio: getVisualRatio({ value: pool.completeSetCollateralAmount, maxValue: pool.totalSecurityBondAllowance }),
 																successThreshold: 0.6,
 																warningThreshold: 0.85,
 															})}

--- a/ui/ts/components/TruthAuctionDepthChart.tsx
+++ b/ui/ts/components/TruthAuctionDepthChart.tsx
@@ -1,6 +1,7 @@
 import { useRef } from 'preact/hooks'
 import { CurrencyValue } from './CurrencyValue.js'
 import { formatCurrencyInputBalance, formatRoundedCurrencyBalance } from '../lib/formatters.js'
+import { getVisualRatio } from '../lib/visualMetrics.js'
 
 type TruthAuctionDisposition = {
 	label: string
@@ -25,7 +26,6 @@ type TruthAuctionDepthChartProps = {
 
 const CHART_WIDTH = 560
 const CHART_HEIGHT = 180
-const DEPTH_RATIO_SCALE = 1_000_000n
 const CHART_PADDING = {
 	bottom: 22,
 	left: 6,
@@ -39,8 +39,7 @@ function formatTruthAuctionPriceLabel(price: bigint) {
 }
 
 function getDepthRatio(value: bigint, maxDepth: bigint) {
-	if (value <= 0n || maxDepth <= 0n) return 0
-	return Number((value * DEPTH_RATIO_SCALE) / maxDepth) / Number(DEPTH_RATIO_SCALE)
+	return getVisualRatio({ value, maxValue: maxDepth }) ?? 0
 }
 
 function getMarkerClassName(point: TruthAuctionDepthPoint, clearingTick: bigint | undefined) {

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -1114,12 +1114,13 @@ export async function loadOracleManagerDetails(client: ReadClient, managerAddres
 	}
 }
 function resolveOracleQueueOperation(operation: bigint | number): OracleQueueOperation {
-	switch (Number(operation)) {
-		case 0:
+	const operationValue = typeof operation === 'bigint' ? operation : BigInt(operation)
+	switch (operationValue) {
+		case 0n:
 			return 'liquidation'
-		case 1:
+		case 1n:
 			return 'withdrawRep'
-		case 2:
+		case 2n:
 			return 'setSecurityBondsAllowance'
 		default:
 			throw new Error(`Unknown oracle operation: ${operation}`)

--- a/ui/ts/lib/formatters.ts
+++ b/ui/ts/lib/formatters.ts
@@ -70,6 +70,16 @@ function formatUtcTimestamp(timestamp: bigint) {
 	return `${date.getUTCFullYear()}-${formatTimestampPart(date.getUTCMonth() + 1)}-${formatTimestampPart(date.getUTCDate())} ${formatTimestampPart(date.getUTCHours())}:${formatTimestampPart(date.getUTCMinutes())}:${formatTimestampPart(date.getUTCSeconds())} UTC`
 }
 
+function getEffectiveRoundedDecimals(absoluteValue: bigint, units: number, decimals: number) {
+	if (absoluteValue === 0n) return decimals
+
+	const base = 10n ** BigInt(units)
+	if (absoluteValue >= base) return decimals
+
+	const leadingFractionalZeroCount = units - absoluteValue.toString().length
+	return Math.max(decimals, leadingFractionalZeroCount + 2)
+}
+
 export function formatCurrencyBalance(value: bigint | undefined, units: number = 18) {
 	if (value === undefined) return '—'
 	assertInteger(units, 'Units')
@@ -92,10 +102,7 @@ export function formatRoundedCurrencyBalance(value: bigint | undefined, units: n
 	const absoluteValue = isNegative ? -value : value
 	const prefix = isNegative ? '-' : ''
 
-	// For tiny values between 0 and 1, extend decimal places to show 2 significant figures.
-	// floatValue is used only for order-of-magnitude detection; bigint arithmetic handles rounding.
-	const floatValue = Number(absoluteValue) / 10 ** units
-	const effectiveDecimals = floatValue > 0 && floatValue < 1 ? Math.max(decimals, Math.ceil(-Math.log10(floatValue)) + 1) : decimals
+	const effectiveDecimals = getEffectiveRoundedDecimals(absoluteValue, units, decimals)
 
 	const scale = 10n ** BigInt(effectiveDecimals)
 	const base = 10n ** BigInt(units)

--- a/ui/ts/lib/openOracle.ts
+++ b/ui/ts/lib/openOracle.ts
@@ -262,13 +262,33 @@ export function getOpenOracleSettleAvailability(report: Pick<OpenOracleReportDet
 		message: undefined,
 	}
 }
+
+function formatGroupedInteger(value: bigint) {
+	return value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+}
+
+function formatScaledBigInt(value: bigint, scale: bigint, minimumFractionDigits = 0, groupInteger = false) {
+	const isNegative = value < 0n
+	const absoluteValue = isNegative ? -value : value
+	const integerPart = absoluteValue / scale
+	const fractionPart = absoluteValue % scale
+	const scaleDigits = scale.toString().length - 1
+	let fractionText = fractionPart.toString().padStart(scaleDigits, '0').replace(/0+$/, '')
+	while (fractionText.length < minimumFractionDigits) {
+		fractionText += '0'
+	}
+
+	const integerText = groupInteger ? formatGroupedInteger(integerPart) : integerPart.toString()
+	return `${isNegative ? '-' : ''}${integerText}${fractionText === '' ? '' : `.${fractionText}`}`
+}
+
 export function formatOpenOracleFeePercentage(feePercentage: bigint | undefined) {
 	if (feePercentage === undefined) return '—'
-	return `${(Number(feePercentage) / 100000).toLocaleString(undefined, { maximumFractionDigits: 6 })}%`
+	return `${formatScaledBigInt(feePercentage, 100_000n, 0, true)}%`
 }
 export function formatOpenOracleMultiplier(multiplier: bigint | undefined) {
 	if (multiplier === undefined) return '—'
-	return `${(Number(multiplier) / 100).toFixed(2)}x`
+	return `${formatScaledBigInt(multiplier, 100n, 2)}x`
 }
 export function addOpenOracleBountyBuffer(requiredBounty: bigint) {
 	if (requiredBounty <= 0n) return requiredBounty

--- a/ui/ts/lib/pagination.ts
+++ b/ui/ts/lib/pagination.ts
@@ -1,2 +1,39 @@
 export const QUESTION_PAGE_SIZE = 10
 export const SECURITY_POOL_PAGE_SIZE = 6
+
+function getPageSizeBigInt(pageSize: number) {
+	if (!Number.isSafeInteger(pageSize) || pageSize <= 0) throw new RangeError('Page size must be a positive safe integer')
+	return BigInt(pageSize)
+}
+
+export function getPaginationPageCount(itemCount: bigint | undefined, pageSize: number) {
+	if (itemCount === undefined) return undefined
+	if (itemCount < 0n) throw new RangeError('Pagination count must be non-negative')
+	if (itemCount === 0n) return 0n
+
+	const pageSizeBigInt = getPageSizeBigInt(pageSize)
+	return (itemCount + pageSizeBigInt - 1n) / pageSizeBigInt
+}
+
+export function getHasNextPaginationPage(pageIndex: number, pageCount: bigint | undefined) {
+	if (pageCount === undefined) return false
+	return BigInt(pageIndex) + 1n < pageCount
+}
+
+export function resolvePaginationPageIndex(pageIndex: number, pageCount: bigint | undefined) {
+	if (pageCount === undefined) return pageIndex
+	if (pageCount === 0n) return 0
+
+	const lastPageIndex = pageCount - 1n
+	if (BigInt(pageIndex) <= lastPageIndex) return pageIndex
+	if (lastPageIndex > BigInt(Number.MAX_SAFE_INTEGER)) return pageIndex
+	return Number(lastPageIndex)
+}
+
+export function formatPaginationSummary(pageIndex: number, pageCount: bigint | undefined) {
+	if (pageCount === undefined) return undefined
+
+	const currentPage = BigInt(pageIndex) + 1n
+	const displayedPageCount = pageCount === 0n ? 1n : pageCount
+	return `Page ${currentPage.toString()} of ${displayedPageCount.toString()}`
+}

--- a/ui/ts/lib/scalarOutcome.ts
+++ b/ui/ts/lib/scalarOutcome.ts
@@ -1,4 +1,5 @@
 import { parseDecimalInput } from './decimal.js'
+import { getVisualRatio } from './visualMetrics.js'
 
 type ScalarQuestionDetails = {
 	answerUnit: string
@@ -63,11 +64,11 @@ function splitScalarOutcomeIndex(outcomeIndex: bigint) {
 export function getScalarSliderProgress(tickIndex: bigint, numTicks: bigint) {
 	if (numTicks <= 0n) throw new Error('Scalar question numTicks must be positive')
 	if (tickIndex < 0n || tickIndex > numTicks) throw new Error('Tick index is out of range')
-	return Number((tickIndex * 100n) / numTicks)
+	return Math.floor((getVisualRatio({ value: tickIndex, maxValue: numTicks }) ?? 0) * 100)
 }
 
 export function getScalarSliderFillWidth(tickIndex: bigint, numTicks: bigint) {
-	const fraction = Number(tickIndex) / Number(numTicks)
+	const fraction = getVisualRatio({ value: tickIndex, maxValue: numTicks }) ?? 0
 	return `calc(${fraction * 100}% - ${fraction}rem + 0.5rem)`
 }
 

--- a/ui/ts/lib/visualMetrics.ts
+++ b/ui/ts/lib/visualMetrics.ts
@@ -1,5 +1,7 @@
 import { formatRoundedCurrencyBalance } from './formatters.js'
 
+const VISUAL_RATIO_SCALE = 1_000_000n
+
 export function clampVisualRatio(value: number | undefined) {
 	if (value === undefined || Number.isNaN(value) || !Number.isFinite(value)) return 0
 	if (value < 0) return 0
@@ -9,7 +11,11 @@ export function clampVisualRatio(value: number | undefined) {
 
 export function getVisualRatio({ value, maxValue }: { value: bigint | undefined; maxValue: bigint | undefined }) {
 	if (value === undefined || maxValue === undefined || maxValue <= 0n) return undefined
-	return clampVisualRatio(Number(value) / Number(maxValue))
+	if (value <= 0n) return 0
+	if (value >= maxValue) return 1
+
+	const scaledRatio = (value * VISUAL_RATIO_SCALE) / maxValue
+	return Number(scaledRatio) / Number(VISUAL_RATIO_SCALE)
 }
 
 function formatCollateralizationPercentLabel(value: bigint | undefined, decimals: number = 0) {

--- a/ui/ts/tests/openOracle.test.ts
+++ b/ui/ts/tests/openOracle.test.ts
@@ -821,7 +821,9 @@ describe('Open Oracle helpers', () => {
 
 	test('open oracle fee and multiplier formatters render human values', () => {
 		expect(formatOpenOracleFeePercentage(10_000n)).toBe('0.1%')
+		expect(formatOpenOracleFeePercentage(BigInt(Number.MAX_SAFE_INTEGER) * 100_000n + 12_345n)).toBe('9,007,199,254,740,991.12345%')
 		expect(formatOpenOracleMultiplier(140n)).toBe('1.40x')
+		expect(formatOpenOracleMultiplier(BigInt(Number.MAX_SAFE_INTEGER) * 100n + 1n)).toBe('9007199254740991.01x')
 	})
 
 	test('oracle bounty buffer adds a 20% headroom and rounds up', () => {

--- a/ui/ts/tests/pagination.test.ts
+++ b/ui/ts/tests/pagination.test.ts
@@ -1,0 +1,25 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { formatPaginationSummary, getHasNextPaginationPage, getPaginationPageCount, resolvePaginationPageIndex } from '../lib/pagination.js'
+
+void describe('pagination helpers', () => {
+	void test('computes page counts with bigint arithmetic above Number.MAX_SAFE_INTEGER', () => {
+		const itemCount = BigInt(Number.MAX_SAFE_INTEGER) * 10n + 1n
+
+		expect(getPaginationPageCount(itemCount, 10)).toBe(9_007_199_254_740_992n)
+		expect(formatPaginationSummary(0, getPaginationPageCount(itemCount, 10))).toBe('Page 1 of 9007199254740992')
+	})
+
+	void test('compares next-page state without converting page counts to numbers', () => {
+		const pageCount = BigInt(Number.MAX_SAFE_INTEGER) + 1n
+
+		expect(getHasNextPaginationPage(Number.MAX_SAFE_INTEGER, pageCount)).toBe(false)
+		expect(getHasNextPaginationPage(Number.MAX_SAFE_INTEGER - 1, pageCount)).toBe(true)
+	})
+
+	void test('clamps loaded indexes only when the last page is representable as a safe number', () => {
+		expect(resolvePaginationPageIndex(3, 2n)).toBe(1)
+		expect(resolvePaginationPageIndex(3, BigInt(Number.MAX_SAFE_INTEGER) + 2n)).toBe(3)
+	})
+})

--- a/ui/ts/tests/visualMetrics.test.ts
+++ b/ui/ts/tests/visualMetrics.test.ts
@@ -1,0 +1,17 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { getVisualRatio } from '../lib/visualMetrics.js'
+
+void describe('visual metric helpers', () => {
+	void test('computes bounded ratios without converting unbounded operands to numbers', () => {
+		const value = 3n * BigInt(Number.MAX_SAFE_INTEGER) ** 2n
+		const maxValue = 5n * BigInt(Number.MAX_SAFE_INTEGER) ** 2n
+
+		expect(getVisualRatio({ value, maxValue })).toBe(0.6)
+	})
+
+	void test('clamps visual ratios at one for values above the maximum', () => {
+		expect(getVisualRatio({ value: 10n ** 80n, maxValue: 1n })).toBe(1)
+	})
+})


### PR DESCRIPTION
## Summary
- Added bigint-safe ratio utilities to replace number-based math in visual metrics and pagination flows (`visualMetrics`, `pagination`, `scalarOutcome`, collateralization/auction/security pool components).
- Replaced unsafe `Number(...)` conversions in multiple UI components with bounded ratio helpers to avoid precision loss on large on-chain values.
- Introduced bigint-safe pagination helpers for page count, next-page checks, index clamping, and summary rendering, and wired them into Market Questions, Open Oracle, and Security Pools screens.
- Updated `formatOpenOracleFeePercentage`/`formatOpenOracleMultiplier` to use integer-scaled formatting (supports large values) and added regression tests.
- Added focused tests for new bigint-safe helpers in `ui/ts/tests/pagination.test.ts` and `ui/ts/tests/visualMetrics.test.ts`.
- Improved robustness in `resolveOracleQueueOperation` by comparing oracle operation values as `bigint` directly.

## Testing
- Not run (not requested in this step).
- New test coverage added in:
  - `ui/ts/tests/openOracle.test.ts`
  - `ui/ts/tests/pagination.test.ts`
  - `ui/ts/tests/visualMetrics.test.ts`
- Suggested follow-up checks:
  1. Run `bun run tsc`
  2. Run `bun run test`
  3. Run `bun run format`
  4. Run `bun run check`
  5. Run `bun run knip`

Base branch: `main`
Head branch: `t3code/bfeb9d4d`