### PR TITLE
Clamp paginated reads to remaining array bounds

### DIFF
--- a/solidity/contracts/Zoltar.sol
+++ b/solidity/contracts/Zoltar.sol
@@ -125,7 +125,7 @@ contract Zoltar {
 
 	function getDeployedChildUniverses(uint248 universeId, uint256 startIndex, uint256 count) external view returns (uint256[] memory outcomeIndexes, uint248[] memory childUniverseIds, Universe[] memory childUniverses) {
 		uint256[] storage deployedOutcomeIndexes = deployedChildOutcomeIndexes[universeId];
-		uint256 iterateUntil = startIndex + count > deployedOutcomeIndexes.length ? deployedOutcomeIndexes.length : startIndex + count;
+		uint256 iterateUntil = _sliceEnd(startIndex, count, deployedOutcomeIndexes.length);
 		if (iterateUntil <= startIndex) return (new uint256[](0), new uint248[](0), new Universe[](0));
 		uint256 resultLength = iterateUntil - startIndex;
 		outcomeIndexes = new uint256[](resultLength);
@@ -138,6 +138,13 @@ contract Zoltar {
 			childUniverseIds[resultIndex] = childUniverseId;
 			childUniverses[resultIndex] = universes[childUniverseId];
 		}
+	}
+
+	function _sliceEnd(uint256 startIndex, uint256 count, uint256 total) internal pure returns (uint256) {
+		if (startIndex >= total || count == 0) return startIndex;
+		uint256 availableCount = total - startIndex;
+		if (count >= availableCount) return total;
+		return startIndex + count;
 	}
 
 	// stores rep in the migration balance for a universe

--- a/solidity/contracts/ZoltarQuestionData.sol
+++ b/solidity/contracts/ZoltarQuestionData.sol
@@ -56,7 +56,7 @@ contract ZoltarQuestionData {
 	}
 
 	function getQuestions(uint256 startIndex, uint256 numberOfEntries) external view returns (uint256[] memory returnQuestionIds) {
-		uint256 iterateUntil = startIndex + numberOfEntries > questionIds.length ? questionIds.length : startIndex + numberOfEntries;
+		uint256 iterateUntil = _sliceEnd(startIndex, numberOfEntries, questionIds.length);
 		if (iterateUntil <= startIndex) return new uint256[](0);
 		returnQuestionIds = new uint256[](iterateUntil - startIndex);
 		for (uint256 i = startIndex; i < iterateUntil; i++) {
@@ -78,12 +78,19 @@ contract ZoltarQuestionData {
 	}
 
 	function getOutcomeLabels(uint256 questionId, uint256 startIndex, uint256 numberOfEntries) external view returns (string[] memory returnOutcomeLabels) {
-		uint256 iterateUntil = startIndex + numberOfEntries > outcomeLabels[questionId].length ? outcomeLabels[questionId].length : startIndex + numberOfEntries;
+		uint256 iterateUntil = _sliceEnd(startIndex, numberOfEntries, outcomeLabels[questionId].length);
 		if (iterateUntil <= startIndex) return new string[](0);
 		returnOutcomeLabels = new string[](iterateUntil - startIndex);
 		for (uint256 i = startIndex; i < iterateUntil; i++) {
 			returnOutcomeLabels[i - startIndex] = outcomeLabels[questionId][i];
 		}
+	}
+
+	function _sliceEnd(uint256 startIndex, uint256 count, uint256 total) internal pure returns (uint256) {
+		if (startIndex >= total || count == 0) return startIndex;
+		uint256 availableCount = total - startIndex;
+		if (count >= availableCount) return total;
+		return startIndex + count;
 	}
 
 	function isMalformedAnswerOption(uint256 questionId, uint256 answer) external view returns (bool) {

--- a/solidity/contracts/peripherals/EscalationGame.sol
+++ b/solidity/contracts/peripherals/EscalationGame.sol
@@ -569,9 +569,8 @@ contract EscalationGame {
 	function getProofConsumedCarriedDepositIndexesByOutcome(BinaryOutcomes.BinaryOutcome outcome, uint256 startIndex, uint256 numberOfEntries) external view returns (uint256[] memory parentDepositIndexes) {
 		if (outcome == BinaryOutcomes.BinaryOutcome.None) return new uint256[](0);
 		uint256[] storage consumedIndexes = outcomeState[uint8(outcome)].proofConsumedDepositIndexes;
-		if (startIndex >= consumedIndexes.length || numberOfEntries == 0) return new uint256[](0);
-		uint256 endIndex = startIndex + numberOfEntries;
-		if (endIndex > consumedIndexes.length) endIndex = consumedIndexes.length;
+		uint256 endIndex = _sliceEnd(startIndex, numberOfEntries, consumedIndexes.length);
+		if (endIndex <= startIndex) return new uint256[](0);
 		parentDepositIndexes = new uint256[](endIndex - startIndex);
 		for (uint256 index = startIndex; index < endIndex; index++) {
 			parentDepositIndexes[index - startIndex] = consumedIndexes[index];
@@ -716,7 +715,7 @@ contract EscalationGame {
 	function getDepositsByOutcome(BinaryOutcomes.BinaryOutcome outcome, uint256 startIndex, uint256 numberOfEntries) external view returns (Deposit[] memory returnDeposits) {
 		if (outcome == BinaryOutcomes.BinaryOutcome.None) return new Deposit[](0);
 		Deposit[] storage outcomeDeposits = outcomeState[uint8(outcome)].deposits;
-		uint256 iterateUntil = startIndex + numberOfEntries > outcomeDeposits.length ? outcomeDeposits.length : startIndex + numberOfEntries;
+		uint256 iterateUntil = _sliceEnd(startIndex, numberOfEntries, outcomeDeposits.length);
 		if (iterateUntil <= startIndex) return new Deposit[](0);
 		returnDeposits = new Deposit[](iterateUntil - startIndex);
 		for (uint256 index = startIndex; index < iterateUntil; index++) {
@@ -752,6 +751,13 @@ contract EscalationGame {
 			if (state.sourcePrincipal > state.sourcePrincipalClaimed || state.childRep > state.childRepClaimed) return true;
 		}
 		return false;
+	}
+
+	function _sliceEnd(uint256 startIndex, uint256 count, uint256 total) internal pure returns (uint256) {
+		if (startIndex >= total || count == 0) return startIndex;
+		uint256 availableCount = total - startIndex;
+		if (count >= availableCount) return total;
+		return startIndex + count;
 	}
 
 	function _encodeLocalDepositRef(uint8 outcomeIndex, uint256 depositIndex) private pure returns (uint256) {

--- a/solidity/contracts/peripherals/UniformPriceDualCapBatchAuction.sol
+++ b/solidity/contracts/peripherals/UniformPriceDualCapBatchAuction.sol
@@ -400,9 +400,9 @@ contract UniformPriceDualCapBatchAuction {
 
 	function _sliceEnd(uint256 offset, uint256 limit, uint256 total) internal pure returns (uint256) {
 		if (limit == 0 || offset >= total) return offset;
-		uint256 end = offset + limit;
-		if (end < offset || end > total) return total;
-		return end;
+		uint256 availableCount = total - offset;
+		if (limit >= availableCount) return total;
+		return offset + limit;
 	}
 
 	function _compute(uint256 nodeId, uint256 accEth, int256 lastValidTick, uint256 lastValidEth, uint256 lastValidEthAtTick) internal view returns (bool, int256, uint256, uint256) {

--- a/solidity/ts/tests/escalationGame.test.ts
+++ b/solidity/ts/tests/escalationGame.test.ts
@@ -18,6 +18,7 @@ import { isIgnorableLogDecodeError } from './logDecodeErrors'
 
 const ESCALATION_TIME_LENGTH = 4233600n
 const NULLIFIER_DEPTH = 64
+const MAX_UINT256 = 2n ** 256n - 1n
 
 setDefaultTimeout(TEST_TIMEOUT_MS)
 
@@ -90,7 +91,7 @@ describe('Escalation Game Test Suite', () => {
 					abi: ReputationToken_ReputationToken.abi,
 					address: getRepTokenAddress(0n),
 					functionName: 'approve',
-					args: [testSecurityPoolAddress, 2n ** 256n - 1n],
+					args: [testSecurityPoolAddress, MAX_UINT256],
 				}),
 		)
 		const escalationGameDeploymentHash = await client.sendTransaction({
@@ -218,6 +219,14 @@ describe('Escalation Game Test Suite', () => {
 			address: escalationGameAddress,
 			functionName: 'getCarryLeafPageByOutcome',
 			args: [outcome, startNodeId, maxEntries],
+		})
+
+	const readProofConsumedCarriedDepositIndexes = async (escalationGameAddress: Address, outcome: QuestionOutcome, startIndex: bigint, numberOfEntries: bigint) =>
+		await client.readContract({
+			abi: peripherals_EscalationGame_EscalationGame.abi,
+			address: escalationGameAddress,
+			functionName: 'getProofConsumedCarriedDepositIndexesByOutcome',
+			args: [outcome, startIndex, numberOfEntries],
 		})
 
 	type PeakArray = Awaited<ReturnType<typeof readCarryPeaks>>
@@ -513,11 +522,20 @@ describe('Escalation Game Test Suite', () => {
 
 		const deposits = await getEscalationGameDeposits(client, escalationGame, QuestionOutcome.Yes)
 		const depositPage = deposits.slice(1, 6)
+		const maxCountDepositPage = await client.readContract({
+			abi: peripherals_EscalationGame_EscalationGame.abi,
+			address: escalationGame,
+			functionName: 'getDepositsByOutcome',
+			args: [QuestionOutcome.Yes, 1n, MAX_UINT256],
+		})
 
 		assert.strictEqual(depositPage.length, 1, 'deposit paging should return only the remaining entries')
 		assert.strictEqual(depositPage[0]?.amount, reportBond * 2n, 'paged deposit should retain its amount')
 		assert.strictEqual(depositPage[0]?.depositor, client.account.address, 'paged deposit should retain its depositor')
 		assert.strictEqual(depositPage[0]?.depositIndex, 1n, 'paged deposit should retain its index')
+		assert.strictEqual(maxCountDepositPage.length, 1, 'max-count deposit paging should return only the remaining entries')
+		assert.strictEqual(maxCountDepositPage[0]?.amount, reportBond * 2n, 'max-count paged deposit should retain its amount')
+		assert.strictEqual(maxCountDepositPage[0]?.depositor, client.account.address, 'max-count paged deposit should retain its depositor')
 	})
 
 	test('claimDepositForWinning reverts when outcome is None', async () => {
@@ -676,6 +694,8 @@ describe('Escalation Game Test Suite', () => {
 
 		const remainingCarryTotal = await readCarryTotal(child.escalationGameAddress, QuestionOutcome.Yes)
 		assert.strictEqual(remainingCarryTotal, 0n)
+		const consumedIndexes = await readProofConsumedCarriedDepositIndexes(child.escalationGameAddress, QuestionOutcome.Yes, 0n, MAX_UINT256)
+		assert.deepStrictEqual(consumedIndexes, [0n, 1n], 'max-count proof-consumed paging should return all consumed inherited indexes')
 	})
 
 	test('fork carry proof settlement rejects reusing the same carried proof twice', async () => {

--- a/solidity/ts/tests/questionData.test.ts
+++ b/solidity/ts/tests/questionData.test.ts
@@ -12,6 +12,8 @@ import { combineUint256FromTwoWithInvalid, createQuestion, getAnswerOptionName, 
 import { areEqualArrays } from '../testsuite/simulator/utils/array-utils'
 import { ZoltarQuestionData_ZoltarQuestionData } from '../types/contractArtifact'
 
+const MAX_UINT256 = 2n ** 256n - 1n
+
 setDefaultTimeout(TEST_TIMEOUT_MS)
 
 describe('Question Data', () => {
@@ -380,15 +382,23 @@ describe('Question Data', () => {
 		}
 		const firstOutcomes = sortStringArrayByKeccak(['Alpha', 'Beta', 'Gamma'])
 		const secondOutcomes = ['Yes', 'No']
+		const secondQuestion = { ...question, title: 'Paged Question 2' }
 		await createQuestion(client, question, firstOutcomes)
-		await createQuestion(client, { ...question, title: 'Paged Question 2' }, secondOutcomes)
+		await createQuestion(client, secondQuestion, secondOutcomes)
 		const firstQuestionId = getQuestionId(question, firstOutcomes)
+		const secondQuestionId = getQuestionId(secondQuestion, secondOutcomes)
 
 		const rawQuestionPage = await client.readContract({
 			abi: ZoltarQuestionData_ZoltarQuestionData.abi,
 			functionName: 'getQuestions',
 			address: getInfraContractAddresses().zoltarQuestionData,
 			args: [1n, 5n],
+		})
+		const maxCountQuestionPage = await client.readContract({
+			abi: ZoltarQuestionData_ZoltarQuestionData.abi,
+			functionName: 'getQuestions',
+			address: getInfraContractAddresses().zoltarQuestionData,
+			args: [0n, MAX_UINT256],
 		})
 
 		const rawOutcomePage = await client.readContract({
@@ -397,10 +407,18 @@ describe('Question Data', () => {
 			address: getInfraContractAddresses().zoltarQuestionData,
 			args: [firstQuestionId, 1n, 5n],
 		})
+		const maxCountOutcomePage = await client.readContract({
+			abi: ZoltarQuestionData_ZoltarQuestionData.abi,
+			functionName: 'getOutcomeLabels',
+			address: getInfraContractAddresses().zoltarQuestionData,
+			args: [firstQuestionId, 1n, MAX_UINT256],
+		})
 		const questionPage = rawQuestionPage.filter(questionId => questionId !== 0n)
 		const outcomePage = rawOutcomePage.filter(label => label !== '')
 
 		assert.deepStrictEqual(questionPage.length, 1, 'question paging should return only the remaining ids')
 		assert.deepStrictEqual(outcomePage, [firstOutcomes[1], firstOutcomes[2]], 'outcome paging should return only the remaining labels')
+		assert.deepStrictEqual(maxCountQuestionPage, [firstQuestionId, secondQuestionId], 'question paging should clamp max count to available ids')
+		assert.deepStrictEqual(maxCountOutcomePage, [firstOutcomes[1], firstOutcomes[2]], 'outcome paging should clamp max count to available labels')
 	})
 })

--- a/solidity/ts/tests/zoltar.test.ts
+++ b/solidity/ts/tests/zoltar.test.ts
@@ -31,6 +31,7 @@ import { formatScalarOutcomeLabel, getScalarOutcomeIndex } from '../testsuite/si
 
 // Forker deposit fractions: deposit is 5% of total supply (1/20), and 20% of that deposit is burned (1/5 of deposit)
 const FORKER_DEPOSIT_FRACTION = 20n
+const MAX_UINT256 = 2n ** 256n - 1n
 
 setDefaultTimeout(TEST_TIMEOUT_MS)
 
@@ -298,6 +299,12 @@ describe('Contract Test Suite', () => {
 			address: getZoltarAddress(),
 			args: [genesisUniverse, 2n, 2n],
 		})
+		const maxCountPage = await client.readContract({
+			abi: Zoltar_Zoltar.abi,
+			functionName: 'getDeployedChildUniverses',
+			address: getZoltarAddress(),
+			args: [genesisUniverse, 1n, MAX_UINT256],
+		})
 		const emptyPage = await client.readContract({
 			abi: Zoltar_Zoltar.abi,
 			functionName: 'getDeployedChildUniverses',
@@ -316,6 +323,14 @@ describe('Contract Test Suite', () => {
 		assert.deepStrictEqual(secondPage[0], [3n], 'second page should include the remaining child outcome')
 		assert.deepStrictEqual(secondPage[1], [getChildUniverseId(genesisUniverse, 3)], 'second page child id should match the deployed child')
 		assert.strictEqual(secondPage[2][0]?.forkingOutcomeIndex, 3n, 'second page child universe should retain the outcome index')
+
+		assert.deepStrictEqual(maxCountPage[0], [1n, 3n], 'max-count paging should clamp to the remaining child outcomes')
+		assert.deepStrictEqual(maxCountPage[1], [getChildUniverseId(genesisUniverse, 1), getChildUniverseId(genesisUniverse, 3)], 'max-count paging should return matching child ids')
+		assert.deepStrictEqual(
+			maxCountPage[2].map(child => child.parentUniverseId),
+			[genesisUniverse, genesisUniverse],
+			'max-count child universes should point back to genesis',
+		)
 
 		assert.deepStrictEqual(emptyPage[0], [], 'out of range paging should return no outcome indexes')
 		assert.deepStrictEqual(emptyPage[1], [], 'out of range paging should return no child universe ids')


### PR DESCRIPTION
## Summary
- Updated Solidity paginated read functions to clamp end indexes with a shared `_sliceEnd` helper, preventing overflow/over-read when `count` exceeds available items in `Zoltar`, `ZoltarQuestionData`, and `EscalationGame`.
- Kept the same pagination behavior for zero-count/out-of-range inputs by returning empty results.
- Simplified `UniformPriceDualCapBatchAuction._sliceEnd` to use remaining-item logic consistent with the new clamping behavior.
- Added regression coverage for max-count pagination in existing tests:
  - `solidity/ts/tests/zoltar.test.ts` (`getDeployedChildUniverses`)
  - `solidity/ts/tests/questionData.test.ts` (`getQuestions`, `getOutcomeLabels`)
  - `solidity/ts/tests/escalationGame.test.ts` (`getDepositsByOutcome`, `getProofConsumedCarriedDepositIndexesByOutcome`)
- Introduced `MAX_UINT256` test constants to simulate oversized pagination requests and verify clamped responses.

## Testing
- `solidity/ts/tests/zoltar.test.ts` — added assertions for max-count pagination clamping.
- `solidity/ts/tests/questionData.test.ts` — added assertions for max-count `getQuestions` and `getOutcomeLabels` clamping.
- `solidity/ts/tests/escalationGame.test.ts` — added assertions for max-count `getDepositsByOutcome` and proof-consumed index pagination clamping.
- Not run: test suite / typecheck / format checks not executed in this pass.