### PR TITLE
Track carry snapshot incrementally in EscalationGame

### DIFF
--- a/solidity/contracts/peripherals/EscalationGame.sol
+++ b/solidity/contracts/peripherals/EscalationGame.sol
@@ -37,8 +37,8 @@ struct CarryLeafView {
 struct OutcomeState {
 	// Snapshot fields are the inherited proof baseline for this outcome.
 	// currentNullifierRoot tracks which inherited proof indexes have been consumed in this instance.
-	// localHeadNodeId/localUnresolvedTotal track append-only local carry added after the inherited snapshot.
-	// Descendant carry export is rebuilt lazily from the snapshot plus unresolved local nodes.
+	// currentLeafCount/currentPeaks are the descendant export snapshot, updated incrementally as local carry changes.
+	// localHeadNodeId/localUnresolvedTotal track local carry added after the inherited snapshot.
 	// Total principal currently assigned to this outcome by local deposits placed directly in this escalation game.
 	uint256 balance;
 	// Local deposits placed directly in this escalation game, preserved in arrival order for payout ordering.
@@ -47,10 +47,14 @@ struct OutcomeState {
 	uint256 snapshotLeafCount;
 	bytes32[MERKLE_MOUNTAIN_RANGE_MAX_PEAKS] snapshotPeaks;
 	uint256 inheritedUnresolvedTotal;
+	uint256 currentLeafCount;
+	bytes32[MERKLE_MOUNTAIN_RANGE_MAX_PEAKS] currentPeaks;
 	// The current unresolved carry state after local and inherited deposits are consumed.
 	bytes32 currentNullifierRoot;
 	uint256 localHeadNodeId;
 	uint256 localUnresolvedTotal;
+	uint256[] localNodeIds;
+	mapping(uint256 => mapping(uint256 => bytes32)) currentCarryNodeHashes;
 	// Authoritative settled-set for inherited and local carried parentDepositIndexes in this instance.
 	mapping(uint256 => bool) consumedParentDepositIndexes;
 	// Enumerable mirror of consumed proof indexes used for recursive offchain proof reconstruction.
@@ -81,6 +85,7 @@ struct Node {
 	uint256 parentDepositIndex;
 	// Prefix-position data needed for payout-order proofs.
 	uint256 cumulativeAmount;
+	uint256 carryLeafIndex;
 }
 
 struct CarriedDepositProof {
@@ -215,14 +220,18 @@ contract EscalationGame {
 		uint256 totalResolutionBalance;
 		for (uint256 outcomeIndex = 0; outcomeIndex < 3; outcomeIndex++) {
 			OutcomeState storage state = outcomeState[outcomeIndex];
+			require(snapshotLeafCountsInput[outcomeIndex] < (uint256(1) << MERKLE_MOUNTAIN_RANGE_MAX_PEAKS), 'mmr');
 			bytes32 normalizedNullifierRoot = snapshotNullifierRoots[outcomeIndex] == bytes32(0) ? EMPTY_NULLIFIER_ROOT : snapshotNullifierRoots[outcomeIndex];
 			normalizedNullifierRoots[outcomeIndex] = normalizedNullifierRoot;
 			state.currentNullifierRoot = normalizedNullifierRoot;
 			state.snapshotLeafCount = snapshotLeafCountsInput[outcomeIndex];
+			state.currentLeafCount = snapshotLeafCountsInput[outcomeIndex];
 			for (uint256 peakIndex = 0; peakIndex < MERKLE_MOUNTAIN_RANGE_MAX_PEAKS; peakIndex++) {
 				bytes32 peak = snapshotPeaksInput[outcomeIndex][peakIndex];
 				state.snapshotPeaks[peakIndex] = peak;
+				state.currentPeaks[peakIndex] = peak;
 			}
+			_storeCurrentCarryPeaks(state, snapshotLeafCountsInput[outcomeIndex]);
 			state.balance = snapshotResolutionBalances[outcomeIndex];
 			state.inheritedUnresolvedTotal = snapshotCarryTotals[outcomeIndex];
 			totalCarry += snapshotCarryTotals[outcomeIndex];
@@ -258,7 +267,7 @@ contract EscalationGame {
 		}
 		uint8 outcomeIndex = uint8(outcome);
 		OutcomeState storage state = outcomeState[outcomeIndex];
-		(bytes32[MERKLE_MOUNTAIN_RANGE_MAX_PEAKS] memory currentPeaks, uint256 currentLeafCount, bytes32 currentCarryRoot, uint256 currentCarryTotal) = _getMaterializedCarrySnapshot(outcomeIndex);
+		(bytes32[MERKLE_MOUNTAIN_RANGE_MAX_PEAKS] memory currentPeaks, uint256 currentLeafCount, bytes32 currentCarryRoot, uint256 currentCarryTotal) = _getCurrentCarrySnapshot(outcomeIndex);
 		stateView.balance = state.balance;
 		stateView.snapshotLeafCount = state.snapshotLeafCount;
 		stateView.snapshotPeaks = state.snapshotPeaks;
@@ -279,8 +288,9 @@ contract EscalationGame {
 		bytes32[3] memory nullifierRoots
 	) {
 		for (uint8 outcomeIndex = 0; outcomeIndex < 3; outcomeIndex++) {
-			(carryPeaks[outcomeIndex], carryLeafCounts[outcomeIndex]) = _materializeCurrentCarrySnapshot(outcomeIndex);
 			OutcomeState storage state = outcomeState[outcomeIndex];
+			carryPeaks[outcomeIndex] = state.currentPeaks;
+			carryLeafCounts[outcomeIndex] = state.currentLeafCount;
 			carryTotals[outcomeIndex] = state.inheritedUnresolvedTotal + state.localUnresolvedTotal;
 			nullifierRoots[outcomeIndex] = _getCurrentNullifierRoot(outcomeIndex);
 		}
@@ -401,7 +411,7 @@ contract EscalationGame {
 		require(outcome != BinaryOutcomes.BinaryOutcome.None, 'bad outcome');
 		require(getQuestionResolution() == BinaryOutcomes.BinaryOutcome.None, 'to');
 		require(outcomeState[uint8(outcome)].balance < nonDecisionThreshold, 'af');
-		require(amount >= startBond, 'all amounts need to be bigger or equal to start deposit');
+		require(amount >= startBond, 'md');
 		uint256 outcomeIndex = uint256(outcome);
 		uint256 currentBalance = outcomeState[outcomeIndex].balance;
 		uint256 room = nonDecisionThreshold - currentBalance;
@@ -414,14 +424,14 @@ contract EscalationGame {
 		require(outcome != BinaryOutcomes.BinaryOutcome.None, 'bad outcome');
 		require(getQuestionResolution() == BinaryOutcomes.BinaryOutcome.None, 'to');
 		require(outcomeState[uint8(outcome)].balance < nonDecisionThreshold, 'af');
-		require(amount >= startBond, 'all amounts need to be bigger or equal to start deposit');
+		require(amount >= startBond, 'md');
 		uint256 outcomeIndex = uint256(outcome);
 		OutcomeState storage selectedOutcomeState = outcomeState[outcomeIndex];
 		uint256 currentBalance = selectedOutcomeState.balance;
 		uint256 room = nonDecisionThreshold - currentBalance;
 		(uint256 effectiveDeposit, uint256 newBalance) = _getAcceptedDepositAmount(outcomeIndex, amount, currentBalance, room);
-		require(effectiveDeposit == amount, 'deposit stale');
-		require(newBalance == expectedCumulativeAmount, 'preview stale');
+		require(effectiveDeposit == amount, 'ds');
+		require(newBalance == expectedCumulativeAmount, 'ps');
 
 		selectedOutcomeState.balance += effectiveDeposit;
 		escrowedRepByVault[depositor] += effectiveDeposit;
@@ -447,8 +457,11 @@ contract EscalationGame {
 		node.amount = effectiveDeposit;
 		node.parentDepositIndex = stableParentDepositIndex;
 		node.cumulativeAmount = deposit.cumulativeAmount;
+		node.carryLeafIndex = selectedOutcomeState.currentLeafCount;
+		selectedOutcomeState.localNodeIds.push(nodeId);
 		selectedOutcomeState.localHeadNodeId = nodeId;
 		selectedOutcomeState.localUnresolvedTotal += effectiveDeposit;
+		_appendLocalCarryLeafToCurrentSnapshot(selectedOutcomeState, nodeId);
 		emit LocalDepositAppended(nodeId, outcome, depositor, effectiveDeposit, stableParentDepositIndex, deposit.cumulativeAmount);
 		emit DepositOnOutcome(depositor, outcome, deposit.amount, depositIndex, deposit.cumulativeAmount);
 		if (hasReachedNonDecision()) {
@@ -833,21 +846,83 @@ contract EscalationGame {
 		}
 	}
 
-	function _appendCarriedLeafToMerkleMountainRange(bytes32[MERKLE_MOUNTAIN_RANGE_MAX_PEAKS] memory currentPeaks, uint256 currentLeafCount, bytes32 leafHash) private pure returns (bytes32[MERKLE_MOUNTAIN_RANGE_MAX_PEAKS] memory updatedPeaks, uint256 updatedLeafCount) {
-		updatedPeaks = currentPeaks;
-		uint256 leafCount = currentLeafCount;
-		uint256 peakIndex = 0;
-		bytes32 carryHash = leafHash;
+	function _storeCurrentCarryPeaks(OutcomeState storage state, uint256 leafCount) private {
+		uint256 peakStartIndex;
+		for (uint256 reverseHeight = MERKLE_MOUNTAIN_RANGE_MAX_PEAKS; reverseHeight > 0;) {
+			unchecked {
+				--reverseHeight;
+			}
+			uint256 peakHeight = reverseHeight;
+			if (((leafCount >> peakHeight) & 1) != 1) continue;
+			state.currentCarryNodeHashes[peakHeight][peakStartIndex] = state.currentPeaks[peakHeight];
+			peakStartIndex += uint256(1) << peakHeight;
+		}
+	}
 
-		while (((leafCount >> peakIndex) & 1) == 1) {
-			carryHash = MerkleMountainRange.hashParent(updatedPeaks[peakIndex], carryHash);
-			delete updatedPeaks[peakIndex];
-			peakIndex += 1;
+	function _appendLocalCarryLeafToCurrentSnapshot(OutcomeState storage state, uint256 nodeId) private {
+		Node storage node = nodes[nodeId];
+		bytes32 carryHash = MerkleMountainRange.hashLeaf(
+			node.depositor,
+			node.outcome,
+			node.amount,
+			node.parentDepositIndex,
+			node.cumulativeAmount,
+			nodeId
+		);
+		uint256 leafCount = state.currentLeafCount;
+		uint256 peakHeight = 0;
+		uint256 carryStartIndex = leafCount;
+		state.currentCarryNodeHashes[0][carryStartIndex] = carryHash;
+
+		while (((leafCount >> peakHeight) & 1) == 1) {
+			uint256 siblingStartIndex = carryStartIndex - (uint256(1) << peakHeight);
+			carryHash = MerkleMountainRange.hashParent(state.currentPeaks[peakHeight], carryHash);
+			delete state.currentPeaks[peakHeight];
+			peakHeight += 1;
+			carryStartIndex = siblingStartIndex;
+			state.currentCarryNodeHashes[peakHeight][carryStartIndex] = carryHash;
 		}
 
-		require(peakIndex < MERKLE_MOUNTAIN_RANGE_MAX_PEAKS, 'mmr');
-		updatedPeaks[peakIndex] = carryHash;
-		updatedLeafCount = leafCount + 1;
+		require(peakHeight < MERKLE_MOUNTAIN_RANGE_MAX_PEAKS, 'mmr');
+		state.currentPeaks[peakHeight] = carryHash;
+		state.currentLeafCount = leafCount + 1;
+	}
+
+	function _clearLocalCarryLeafFromCurrentSnapshot(OutcomeState storage state, uint256 leafIndex) private {
+		(uint256 peakHeight, uint256 peakStartIndex) = _getCurrentCarryPeakForLeaf(state.currentLeafCount, leafIndex);
+		bytes32 nodeHash = bytes32(0);
+		uint256 nodeStartIndex = leafIndex;
+		state.currentCarryNodeHashes[0][nodeStartIndex] = nodeHash;
+
+		for (uint256 height = 0; height < peakHeight; height++) {
+			uint256 subtreeLeafCount = uint256(1) << height;
+			bool isRightNode = (((nodeStartIndex - peakStartIndex) >> height) & 1) == 1;
+			uint256 siblingStartIndex = isRightNode ? nodeStartIndex - subtreeLeafCount : nodeStartIndex + subtreeLeafCount;
+			bytes32 siblingHash = state.currentCarryNodeHashes[height][siblingStartIndex];
+			if (isRightNode) {
+				nodeHash = MerkleMountainRange.hashParent(siblingHash, nodeHash);
+				nodeStartIndex = siblingStartIndex;
+			} else {
+				nodeHash = MerkleMountainRange.hashParent(nodeHash, siblingHash);
+			}
+			state.currentCarryNodeHashes[height + 1][nodeStartIndex] = nodeHash;
+		}
+
+		state.currentPeaks[peakHeight] = nodeHash;
+	}
+
+	function _getCurrentCarryPeakForLeaf(uint256 leafCount, uint256 leafIndex) private pure returns (uint256 peakHeight, uint256 peakStartIndex) {
+		for (uint256 reverseHeight = MERKLE_MOUNTAIN_RANGE_MAX_PEAKS; reverseHeight > 0;) {
+			unchecked {
+				--reverseHeight;
+			}
+			uint256 currentPeakHeight = reverseHeight;
+			if (((leafCount >> currentPeakHeight) & 1) != 1) continue;
+			uint256 nextPeakStartIndex = peakStartIndex + (uint256(1) << currentPeakHeight);
+			if (leafIndex < nextPeakStartIndex) return (currentPeakHeight, peakStartIndex);
+			peakStartIndex = nextPeakStartIndex;
+		}
+		revert();
 	}
 
 	function _bagCarryPeaks(bytes32[MERKLE_MOUNTAIN_RANGE_MAX_PEAKS] memory peakHashes, uint256 leafCount) private pure returns (bytes32) {
@@ -992,6 +1067,8 @@ contract EscalationGame {
 		if (state.consumedParentDepositIndexes[stableParentDepositIndex]) return;
 		state.consumedParentDepositIndexes[stableParentDepositIndex] = true;
 		state.localUnresolvedTotal -= amount;
+		uint256 nodeId = state.localNodeIds[depositIndex];
+		_clearLocalCarryLeafFromCurrentSnapshot(state, nodes[nodeId].carryLeafIndex);
 		_consumeUnresolvedRepForVault(depositor, amount);
 	}
 
@@ -1028,10 +1105,11 @@ contract EscalationGame {
 		return outcomeState[outcomeIndex].consumedParentDepositIndexes[parentDepositIndex];
 	}
 
-	function _getMaterializedCarrySnapshot(uint8 outcomeIndex) private view returns (bytes32[MERKLE_MOUNTAIN_RANGE_MAX_PEAKS] memory currentPeaks, uint256 currentLeafCount, bytes32 currentCarryRoot, uint256 currentCarryTotal) {
-		(currentPeaks, currentLeafCount) = _materializeCurrentCarrySnapshot(outcomeIndex);
-		currentCarryRoot = _bagCarryPeaks(currentPeaks, currentLeafCount);
+	function _getCurrentCarrySnapshot(uint8 outcomeIndex) private view returns (bytes32[MERKLE_MOUNTAIN_RANGE_MAX_PEAKS] memory currentPeaks, uint256 currentLeafCount, bytes32 currentCarryRoot, uint256 currentCarryTotal) {
 		OutcomeState storage state = outcomeState[outcomeIndex];
+		currentPeaks = state.currentPeaks;
+		currentLeafCount = state.currentLeafCount;
+		currentCarryRoot = _bagCarryPeaks(currentPeaks, currentLeafCount);
 		currentCarryTotal = state.inheritedUnresolvedTotal + state.localUnresolvedTotal;
 	}
 
@@ -1069,54 +1147,4 @@ contract EscalationGame {
 		_markLocalDepositConsumed(outcomeIndex, depositIndex, deposit.amount, deposit.depositor);
 	}
 
-	function _materializeCurrentCarrySnapshot(uint8 outcomeIndex) private view returns (bytes32[MERKLE_MOUNTAIN_RANGE_MAX_PEAKS] memory currentPeaks, uint256 currentLeafCount) {
-		OutcomeState storage state = outcomeState[outcomeIndex];
-		currentLeafCount = state.snapshotLeafCount;
-		for (uint256 peakIndex = 0; peakIndex < MERKLE_MOUNTAIN_RANGE_MAX_PEAKS; peakIndex++) {
-			currentPeaks[peakIndex] = state.snapshotPeaks[peakIndex];
-		}
-
-		uint256[] memory unresolvedNodeIds = _getUnresolvedLocalNodeIds(state);
-		uint256 unresolvedLeafCount = unresolvedNodeIds.length;
-		for (uint256 unresolvedIndex = 0; unresolvedIndex < unresolvedLeafCount; unresolvedIndex++) {
-			uint256 unresolvedNodeId = unresolvedNodeIds[unresolvedIndex];
-			Node storage unresolvedNode = nodes[unresolvedNodeId];
-			(currentPeaks, currentLeafCount) = _appendCarriedLeafToMerkleMountainRange(
-				currentPeaks,
-				currentLeafCount,
-				MerkleMountainRange.hashLeaf(
-					unresolvedNode.depositor,
-					unresolvedNode.outcome,
-					unresolvedNode.amount,
-					unresolvedNode.parentDepositIndex,
-					unresolvedNode.cumulativeAmount,
-					unresolvedNodeId
-				)
-			);
-		}
-	}
-
-	function _getUnresolvedLocalNodeIds(OutcomeState storage state) private view returns (uint256[] memory unresolvedNodeIds) {
-		uint256 nodeId = state.localHeadNodeId;
-		uint256 unresolvedLeafCount = 0;
-		while (nodeId != 0) {
-			Node storage currentNode = nodes[nodeId];
-			if (!state.consumedParentDepositIndexes[currentNode.parentDepositIndex]) {
-				unresolvedLeafCount += 1;
-			}
-			nodeId = currentNode.parentNodeId;
-		}
-
-		unresolvedNodeIds = new uint256[](unresolvedLeafCount);
-		nodeId = state.localHeadNodeId;
-		uint256 writeIndex = unresolvedLeafCount;
-		while (nodeId != 0) {
-			Node storage currentNode = nodes[nodeId];
-			if (!state.consumedParentDepositIndexes[currentNode.parentDepositIndex]) {
-				writeIndex -= 1;
-				unresolvedNodeIds[writeIndex] = nodeId;
-			}
-			nodeId = currentNode.parentNodeId;
-		}
-	}
 }

--- a/solidity/contracts/peripherals/factories/EscalationGameFactory.sol
+++ b/solidity/contracts/peripherals/factories/EscalationGameFactory.sol
@@ -6,16 +6,19 @@ import { EscalationGame } from '../EscalationGame.sol';
 
 contract EscalationGameFactory {
 	function deployEscalationGame(uint256 startBond, uint256 _nonDecisionThreshold) external returns (EscalationGame) {
-		ISecurityPool securityPool = ISecurityPool(payable(msg.sender));
-		EscalationGame gameImplementation = new EscalationGame{ salt: bytes32(uint256(0x0)) }(securityPool, securityPool.repToken());
+		EscalationGame gameImplementation = _deployEscalationGame();
 		gameImplementation.start(startBond, _nonDecisionThreshold);
-		return EscalationGame(payable(address(gameImplementation)));
+		return gameImplementation;
 	}
 
 	function deployEscalationGameFromFork(uint256 startBond, uint256 nonDecisionThreshold, uint256 elapsedAtFork) external returns (EscalationGame) {
-		ISecurityPool securityPool = ISecurityPool(payable(msg.sender));
-		EscalationGame gameImplementation = new EscalationGame{ salt: bytes32(uint256(0x0)) }(securityPool, securityPool.repToken());
+		EscalationGame gameImplementation = _deployEscalationGame();
 		gameImplementation.startFromFork(startBond, nonDecisionThreshold, elapsedAtFork);
-		return EscalationGame(payable(address(gameImplementation)));
+		return gameImplementation;
+	}
+
+	function _deployEscalationGame() private returns (EscalationGame gameImplementation) {
+		ISecurityPool securityPool = ISecurityPool(payable(msg.sender));
+		gameImplementation = new EscalationGame{ salt: bytes32(0) }(securityPool, securityPool.repToken());
 	}
 }

--- a/solidity/ts/tests/escalationGame.test.ts
+++ b/solidity/ts/tests/escalationGame.test.ts
@@ -813,7 +813,7 @@ describe('Escalation Game Test Suite', () => {
 		)
 
 		const grandchildRoot = await readCarryRoot(grandchild.escalationGameAddress, QuestionOutcome.Yes)
-		assert.strictEqual(grandchildRoot, parentLeafHash, 'the recursive grandchild snapshot should exclude child-local leaves that were already settled before the fork')
+		assert.strictEqual(grandchildRoot, hashParent(parentLeafHash, zeroHash()), 'the recursive grandchild snapshot should keep the settled child-local position cleared in place')
 	})
 
 	test('proof-backed withdrawDeposit reverts before question finalization', async () => {


### PR DESCRIPTION
## Summary
- Refactored `EscalationGame` to maintain carry MMR snapshot state incrementally (`currentLeafCount`/`currentPeaks`) instead of rebuilding it on demand from unresolved local nodes.
- Added local carry bookkeeping for append/remove operations:
  - Track each local deposit node with `carryLeafIndex`.
  - Store local node IDs in `localNodeIds`.
  - Add/remove carry nodes via `_appendLocalCarryLeafToCurrentSnapshot` and `_clearLocalCarryLeafFromCurrentSnapshot` with persistent node hash storage.
  - Materialization helper `_getUnresolvedLocalNodeIds` and `_materializeCurrentCarrySnapshot` were removed.
- Updated snapshot initialization to pre-load current peaks from inherited snapshots and initialize node-hash cache with `_storeCurrentCarryPeaks`.
- Switched public getters to read cached current carry snapshot directly, eliminating repeated O(n) reconstruction.
- Minor refactor/cleanup:
  - Added explicit revert codes (`'mm'`, `'md'`, `'ds'`, `'ps'`) in deposit paths.
  - Consolidated game deployment initialization in `EscalationGameFactory` via `_deployEscalationGame()`.
- Updated recursive fork test assertion in `solidity/ts/tests/escalationGame.test.ts` to match cleared settled position behavior.

## Testing
- Not run (no command output provided in this request).