### PR TITLE
Refactor fork migration and escalation flows for immutable state and cleaner accounting

### DIFF
--- a/solidity/contracts/Zoltar.sol
+++ b/solidity/contracts/Zoltar.sol
@@ -40,7 +40,7 @@ contract Zoltar {
 
 	uint256 public immutable forkThresholdDivisor;
 	uint256 public immutable forkBurnDivisor;
-	ZoltarQuestionData public zoltarQuestionData;
+	ZoltarQuestionData public immutable zoltarQuestionData;
 
 	constructor(ZoltarQuestionData _zoltarQuestionData, uint256 _forkThresholdDivisor, uint256 _forkBurnDivisor) {
 		require(_forkThresholdDivisor > 1, 'fork threshold divisor');

--- a/solidity/contracts/peripherals/EscalationGame.sol
+++ b/solidity/contracts/peripherals/EscalationGame.sol
@@ -190,33 +190,29 @@ contract EscalationGame {
 	}
 
 	function start(uint256 _startBond, uint256 _nonDecisionThreshold) external {
-		require(owner == msg.sender, 'os');
-		require(activationTime == 0, 'as');
-		require(_nonDecisionThreshold > _startBond, 'te');
-		require(_startBond > 0, 'sb');
-		require(_startBond >= 1e18, 's1');
-		require(_nonDecisionThreshold >= 1e18, 't1');
+		_initializeStartParams(_startBond, _nonDecisionThreshold);
 		activationTime = block.timestamp + activationDelay;
-		nonDecisionThreshold = _nonDecisionThreshold;
-		startBond = _startBond;
-		lnRatioScaled = _computeLnRatioScaled(_startBond, _nonDecisionThreshold);
 		emit GameStarted(activationTime, startBond, nonDecisionThreshold);
 	}
 
 	function startFromFork(uint256 _startBond, uint256 _nonDecisionThreshold, uint256 elapsedAtFork) external {
+		_initializeStartParams(_startBond, _nonDecisionThreshold);
+		require(elapsedAtFork <= ESCALATION_TIME_LENGTH, 'it');
+		forkContinuation = true;
+		forkElapsedAtStart = elapsedAtFork;
+		emit GameContinuedFromFork(startBond, nonDecisionThreshold, elapsedAtFork);
+	}
+
+	function _initializeStartParams(uint256 _startBond, uint256 _nonDecisionThreshold) private {
 		require(owner == msg.sender, 'os');
 		require(activationTime == 0, 'as');
 		require(_nonDecisionThreshold > _startBond, 'te');
 		require(_startBond > 0, 'sb');
 		require(_startBond >= 1e18, 's1');
 		require(_nonDecisionThreshold >= 1e18, 't1');
-		require(elapsedAtFork <= ESCALATION_TIME_LENGTH, 'it');
-		forkContinuation = true;
-		forkElapsedAtStart = elapsedAtFork;
 		startBond = _startBond;
 		nonDecisionThreshold = _nonDecisionThreshold;
 		lnRatioScaled = _computeLnRatioScaled(_startBond, _nonDecisionThreshold);
-		emit GameContinuedFromFork(startBond, nonDecisionThreshold, elapsedAtFork);
 	}
 
 	function initializeForkCarrySnapshot(
@@ -432,43 +428,82 @@ contract EscalationGame {
 	}
 
 	function getQuestionResolution() public view returns (BinaryOutcomes.BinaryOutcome outcome) {
+		(uint256 invalidBalance, uint256 yesBalance, uint256 noBalance) = _getOutcomeBalances();
 		uint256 currentTotalCost = totalCost();
-		uint8 invalidOver = outcomeState[0].balance >= currentTotalCost ? 1 : 0;
-		uint8 yesOver = outcomeState[1].balance >= currentTotalCost ? 1 : 0;
-		uint8 noOver = outcomeState[2].balance >= currentTotalCost ? 1 : 0;
-		if (invalidOver + yesOver + noOver >= 2) return BinaryOutcomes.BinaryOutcome.None;
-		if (outcomeState[0].balance == 0 && outcomeState[1].balance == 0 && outcomeState[2].balance == 0)
+		if (_countBalancesAtLeast(invalidBalance, yesBalance, noBalance, currentTotalCost) >= 2)
+			return BinaryOutcomes.BinaryOutcome.None;
+		if (_allOutcomeBalancesEmpty(invalidBalance, yesBalance, noBalance))
 			return BinaryOutcomes.BinaryOutcome.Invalid;
-		if (outcomeState[0].balance > outcomeState[1].balance && outcomeState[0].balance > outcomeState[2].balance)
-			return BinaryOutcomes.BinaryOutcome.Invalid;
-		if (outcomeState[1].balance > outcomeState[0].balance && outcomeState[1].balance > outcomeState[2].balance)
-			return BinaryOutcomes.BinaryOutcome.Yes;
-		return BinaryOutcomes.BinaryOutcome.No;
+		return _strictLeadingOutcome(invalidBalance, yesBalance, noBalance);
 	}
 
 	function hasReachedNonDecision() public view returns (bool) {
-		uint8 invalidOver = outcomeState[0].balance >= nonDecisionThreshold ? 1 : 0;
-		uint8 yesOver = outcomeState[1].balance >= nonDecisionThreshold ? 1 : 0;
-		uint8 noOver = outcomeState[2].balance >= nonDecisionThreshold ? 1 : 0;
-		return invalidOver + yesOver + noOver >= 2;
+		(uint256 invalidBalance, uint256 yesBalance, uint256 noBalance) = _getOutcomeBalances();
+		return _countBalancesAtLeast(invalidBalance, yesBalance, noBalance, nonDecisionThreshold) >= 2;
 	}
 
 	function getBindingCapital() public view returns (uint256) {
+		(uint256 invalidBalance, uint256 yesBalance, uint256 noBalance) = _getOutcomeBalances();
+		return _medianBalance(invalidBalance, yesBalance, noBalance);
+	}
+
+	function _getOutcomeBalances()
+		private
+		view
+		returns (uint256 invalidBalance, uint256 yesBalance, uint256 noBalance)
+	{
+		invalidBalance = outcomeState[0].balance;
+		yesBalance = outcomeState[1].balance;
+		noBalance = outcomeState[2].balance;
+	}
+
+	function _countBalancesAtLeast(
+		uint256 invalidBalance,
+		uint256 yesBalance,
+		uint256 noBalance,
+		uint256 threshold
+	) private pure returns (uint8 count) {
+		if (invalidBalance >= threshold) count += 1;
+		if (yesBalance >= threshold) count += 1;
+		if (noBalance >= threshold) count += 1;
+	}
+
+	function _allOutcomeBalancesEmpty(
+		uint256 invalidBalance,
+		uint256 yesBalance,
+		uint256 noBalance
+	) private pure returns (bool) {
+		return invalidBalance == 0 && yesBalance == 0 && noBalance == 0;
+	}
+
+	function _strictLeadingOutcome(
+		uint256 invalidBalance,
+		uint256 yesBalance,
+		uint256 noBalance
+	) private pure returns (BinaryOutcomes.BinaryOutcome) {
+		if (invalidBalance > yesBalance && invalidBalance > noBalance) return BinaryOutcomes.BinaryOutcome.Invalid;
+		if (yesBalance > invalidBalance && yesBalance > noBalance) return BinaryOutcomes.BinaryOutcome.Yes;
+		return BinaryOutcomes.BinaryOutcome.No;
+	}
+
+	function _medianBalance(
+		uint256 invalidBalance,
+		uint256 yesBalance,
+		uint256 noBalance
+	) private pure returns (uint256) {
 		if (
-			(outcomeState[0].balance >= outcomeState[1].balance &&
-				outcomeState[0].balance <= outcomeState[2].balance) ||
-			(outcomeState[0].balance >= outcomeState[2].balance && outcomeState[0].balance <= outcomeState[1].balance)
+			(invalidBalance >= yesBalance && invalidBalance <= noBalance) ||
+			(invalidBalance >= noBalance && invalidBalance <= yesBalance)
 		) {
-			return outcomeState[0].balance;
+			return invalidBalance;
 		}
 		if (
-			(outcomeState[1].balance >= outcomeState[0].balance &&
-				outcomeState[1].balance <= outcomeState[2].balance) ||
-			(outcomeState[1].balance >= outcomeState[2].balance && outcomeState[1].balance <= outcomeState[0].balance)
+			(yesBalance >= invalidBalance && yesBalance <= noBalance) ||
+			(yesBalance >= noBalance && yesBalance <= invalidBalance)
 		) {
-			return outcomeState[1].balance;
+			return yesBalance;
 		}
-		return outcomeState[2].balance;
+		return noBalance;
 	}
 
 	function previewDepositOnOutcome(

--- a/solidity/contracts/peripherals/EscalationGameForker.sol
+++ b/solidity/contracts/peripherals/EscalationGameForker.sol
@@ -25,7 +25,7 @@ contract EscalationGameForker is SecurityPoolForkerVaultMigrationBase {
 		ISecurityPool parent,
 		address vault,
 		BinaryOutcomes.BinaryOutcome outcomeIndex,
-		uint256[] memory depositIndexes
+		uint256[] calldata depositIndexes
 	) public {
 		EscalationGame escalationGame = parent.escalationGame();
 		require(address(escalationGame) != address(0x0), 'e4');
@@ -101,7 +101,7 @@ contract EscalationGameForker is SecurityPoolForkerVaultMigrationBase {
 		EscalationGame escalationGame,
 		address vault,
 		BinaryOutcomes.BinaryOutcome outcomeIndex,
-		uint256[] memory depositIndexes,
+		uint256[] calldata depositIndexes,
 		bool ownFork,
 		bool payWallet
 	) private returns (uint256 totalRepMigrated) {
@@ -128,105 +128,74 @@ contract EscalationGameForker is SecurityPoolForkerVaultMigrationBase {
 		EscalationGame parentEscalationGame = parent.escalationGame();
 		require(address(parentEscalationGame) != address(0x0), 'mpe');
 		if (parentForkData.ownFork) {
-			parent.updateVaultFees(vault);
-			ISecurityPool ownForkChild = childrenByPoolAndOutcome[parent][childOutcomeIndex];
-			if (address(ownForkChild) != address(0x0)) {
-				require(ownForkChild.systemState() == SystemState.ForkMigration, 'cap');
-			} else {
-				require(
-					block.timestamp <= zoltar.getForkTime(parent.universeId()) + SecurityPoolUtils.MIGRATION_TIME,
-					'mwc'
-				);
-				ownForkChild = _getOrDeployChildPool(parent, childOutcomeIndex);
-			}
-			uint256[3] memory ownForkSourcePrincipalByOutcome;
-			uint256[3] memory ownForkCurrentRepByOutcome;
-			if (parentEscalationGame.forkContinuation()) {
-				(
-					uint256[3] memory forkedSourcePrincipalByOutcome,
-					uint256[3] memory forkedChildRepByOutcome
-				) = parentEscalationGame.exportForkedEscrowByOutcomeWithoutTransfer(vault);
-				_addOutcomeAmounts(ownForkSourcePrincipalByOutcome, forkedSourcePrincipalByOutcome);
-				_addOutcomeAmounts(ownForkCurrentRepByOutcome, forkedChildRepByOutcome);
-			}
-			if (_sumOutcomeAmounts(ownForkCurrentRepByOutcome) == 0) {
-				ownForkSourcePrincipalByOutcome = parentEscalationGame
-					.exportVaultUnresolvedDepositAmountsWithoutTransfer(vault);
-				ownForkCurrentRepByOutcome = ownForkSourcePrincipalByOutcome;
-			}
-			uint256 ownForkCurrentRepToTransfer = _sumOutcomeAmounts(ownForkCurrentRepByOutcome);
-			if (ownForkCurrentRepToTransfer == 0) return _hasMoreUnresolvedMigration(parentEscalationGame, vault);
-			require(ownForkCurrentRepToTransfer > 0, 'ef');
-			uint256 ownForkChildRepToTransfer = _previewOwnForkEscalationRep(parent, ownForkCurrentRepToTransfer);
-			ownForkChildRepToTransfer = _capOwnForkEscalationChildRep(
-				parent,
-				childOutcomeIndex,
-				ownForkChildRepToTransfer
-			);
-			if (ownForkChildRepToTransfer == 0) return _hasMoreUnresolvedMigration(parentEscalationGame, vault);
-			EscalationGame ownForkChildEscalationGame = ownForkChild.escalationGame();
-			SecurityPoolMigrationProxy ownForkMigrationProxy = migrationProxyByPool[parent];
-			require(address(ownForkChildEscalationGame) != address(0x0), 'mce');
-			require(address(ownForkMigrationProxy) != address(0x0), 'mp');
-			// Continuation forks do not replay parent unresolved deposits into child local state.
-			// The child inherits the parent carry snapshot in `_initializeChildForkedEscalationGameIfNeeded`
-			// and receives only the REP backing via forked-escrow accounting below.
-			// Own-fork unresolved migration uses an aggregate fork conversion rate. Any dust
-			// from floor rounding remains unallocated as protocol residual.
-			_splitMigrationRepToChild(parent, childOutcomeIndex, ownForkChildRepToTransfer, true, true);
-			ownForkMigrationProxy.sweepChildRep(
-				address(ownForkChildEscalationGame),
-				ownForkChild.repToken(),
-				ownForkChildRepToTransfer
-			);
-			_migrateVaultUnlockedState(parent, ownForkChild, vault);
-			_recordForkedEscrowByOriginalOutcome(
-				ownForkChildEscalationGame,
-				vault,
-				ownForkSourcePrincipalByOutcome,
-				ownForkCurrentRepByOutcome,
-				ownForkCurrentRepToTransfer,
-				ownForkChildRepToTransfer
-			);
-			(
-				uint256 ownForkChildPoolOwnership,
-				uint256 ownForkChildSecurityBondAllowance,
-				,
-				uint256 ownForkChildFeeIndex
-			) = ownForkChild.securityVaults(vault);
-			ownForkChild.configureVault(
-				vault,
-				ownForkChildPoolOwnership,
-				ownForkChildSecurityBondAllowance,
-				ownForkChildFeeIndex
-			);
-			return _hasMoreUnresolvedMigration(parentEscalationGame, vault);
+			return _migrateOwnForkUnresolvedEscalation(parent, parentEscalationGame, vault, childOutcomeIndex);
 		}
+		return _migrateExternalForkUnresolvedEscalation(parent, parentEscalationGame, vault, childOutcomeIndex);
+	}
 
+	function _migrateOwnForkUnresolvedEscalation(
+		ISecurityPool parent,
+		EscalationGame parentEscalationGame,
+		address vault,
+		uint8 childOutcomeIndex
+	) private returns (bool moreToMigrate) {
+		parent.updateVaultFees(vault);
+		ISecurityPool child = _getOrDeployOwnForkMigrationChild(parent, childOutcomeIndex);
+		(uint256[3] memory sourcePrincipalByOutcome, uint256[3] memory currentRepByOutcome) = _exportUnresolvedRep(
+			parentEscalationGame,
+			vault,
+			address(0x0),
+			false
+		);
+		uint256 currentRepToTransfer = _sumOutcomeAmounts(currentRepByOutcome);
+		if (currentRepToTransfer == 0) return _hasMoreUnresolvedMigration(parentEscalationGame, vault);
+		require(currentRepToTransfer > 0, 'ef');
+		uint256 childRepToTransfer = _previewOwnForkEscalationRep(parent, currentRepToTransfer);
+		childRepToTransfer = _capOwnForkEscalationChildRep(parent, childOutcomeIndex, childRepToTransfer);
+		if (childRepToTransfer == 0) return _hasMoreUnresolvedMigration(parentEscalationGame, vault);
+		(EscalationGame childEscalationGame, SecurityPoolMigrationProxy migrationProxy) = _loadChildEscalationAndProxy(
+			parent,
+			child
+		);
+		// Continuation forks do not replay parent unresolved deposits into child local state.
+		// The child inherits the parent carry snapshot in `_initializeChildForkedEscalationGameIfNeeded`
+		// and receives only the REP backing via forked-escrow accounting below.
+		// Own-fork unresolved migration uses an aggregate fork conversion rate. Any dust
+		// from floor rounding remains unallocated as protocol residual.
+		_splitMigrationRepToChild(parent, childOutcomeIndex, childRepToTransfer, true, true);
+		migrationProxy.sweepChildRep(address(childEscalationGame), child.repToken(), childRepToTransfer);
+		_migrateVaultUnlockedState(parent, child, vault);
+		_recordForkedEscrowAndRefreshVault(
+			childEscalationGame,
+			child,
+			vault,
+			sourcePrincipalByOutcome,
+			currentRepByOutcome,
+			currentRepToTransfer,
+			childRepToTransfer
+		);
+		return _hasMoreUnresolvedMigration(parentEscalationGame, vault);
+	}
+
+	function _migrateExternalForkUnresolvedEscalation(
+		ISecurityPool parent,
+		EscalationGame parentEscalationGame,
+		address vault,
+		uint8 childOutcomeIndex
+	) private returns (bool moreToMigrate) {
 		parent.updateVaultFees(vault);
 		ISecurityPool child = _getOrDeployChildPool(parent, childOutcomeIndex);
-		EscalationGame childEscalationGame = child.escalationGame();
-		SecurityPoolMigrationProxy migrationProxy = migrationProxyByPool[parent];
-		require(address(childEscalationGame) != address(0x0), 'mce');
-		require(address(migrationProxy) != address(0x0), 'mp');
+		(EscalationGame childEscalationGame, SecurityPoolMigrationProxy migrationProxy) = _loadChildEscalationAndProxy(
+			parent,
+			child
+		);
 		require(child.systemState() == SystemState.ForkMigration, 'cap');
-		uint256[3] memory sourcePrincipalByOutcome;
-		uint256[3] memory currentRepByOutcome;
-		if (parentEscalationGame.forkContinuation()) {
-			(
-				uint256[3] memory forkedSourcePrincipalByOutcome,
-				uint256[3] memory forkedChildRepByOutcome
-			) = parentEscalationGame.exportForkedEscrowByOutcome(vault, address(migrationProxy));
-			_addOutcomeAmounts(sourcePrincipalByOutcome, forkedSourcePrincipalByOutcome);
-			_addOutcomeAmounts(currentRepByOutcome, forkedChildRepByOutcome);
-		}
-		if (_sumOutcomeAmounts(currentRepByOutcome) == 0) {
-			sourcePrincipalByOutcome = parentEscalationGame.exportVaultUnresolvedDepositAmounts(
-				vault,
-				address(migrationProxy)
-			);
-			currentRepByOutcome = sourcePrincipalByOutcome;
-		}
+		(uint256[3] memory sourcePrincipalByOutcome, uint256[3] memory currentRepByOutcome) = _exportUnresolvedRep(
+			parentEscalationGame,
+			vault,
+			address(migrationProxy),
+			true
+		);
 		uint256 childRepToTransfer = _sumOutcomeAmounts(currentRepByOutcome);
 		if (childRepToTransfer == 0) return _hasMoreUnresolvedMigration(parentEscalationGame, vault);
 		require(childRepToTransfer > 0, 'ef');
@@ -237,22 +206,93 @@ contract EscalationGameForker is SecurityPoolForkerVaultMigrationBase {
 		_splitMigrationRepToChild(parent, childOutcomeIndex, childRepToTransfer, false, false);
 		migrationProxy.sweepChildRep(address(childEscalationGame), child.repToken(), childRepToTransfer);
 		_migrateVaultUnlockedState(parent, child, vault);
-		_recordForkedEscrowByOriginalOutcome(
+		_recordForkedEscrowAndRefreshVault(
 			childEscalationGame,
+			child,
 			vault,
 			sourcePrincipalByOutcome,
 			currentRepByOutcome,
 			childRepToTransfer,
 			childRepToTransfer
 		);
-		(
-			uint256 childCurrentPoolOwnership,
-			uint256 childCurrentSecurityBondAllowance,
-			,
-			uint256 childCurrentFeeIndex
-		) = child.securityVaults(vault);
-		child.configureVault(vault, childCurrentPoolOwnership, childCurrentSecurityBondAllowance, childCurrentFeeIndex);
 		return _hasMoreUnresolvedMigration(parentEscalationGame, vault);
+	}
+
+	function _getOrDeployOwnForkMigrationChild(
+		ISecurityPool parent,
+		uint8 childOutcomeIndex
+	) private returns (ISecurityPool child) {
+		child = childrenByPoolAndOutcome[parent][childOutcomeIndex];
+		if (address(child) != address(0x0)) {
+			require(child.systemState() == SystemState.ForkMigration, 'cap');
+			return child;
+		}
+		require(block.timestamp <= zoltar.getForkTime(parent.universeId()) + SecurityPoolUtils.MIGRATION_TIME, 'mwc');
+		child = _getOrDeployChildPool(parent, childOutcomeIndex);
+	}
+
+	function _loadChildEscalationAndProxy(
+		ISecurityPool parent,
+		ISecurityPool child
+	) private view returns (EscalationGame childEscalationGame, SecurityPoolMigrationProxy migrationProxy) {
+		childEscalationGame = child.escalationGame();
+		migrationProxy = migrationProxyByPool[parent];
+		require(address(childEscalationGame) != address(0x0), 'mce');
+		require(address(migrationProxy) != address(0x0), 'mp');
+	}
+
+	function _exportUnresolvedRep(
+		EscalationGame parentEscalationGame,
+		address vault,
+		address repReceiver,
+		bool transferRep
+	) private returns (uint256[3] memory sourcePrincipalByOutcome, uint256[3] memory currentRepByOutcome) {
+		if (parentEscalationGame.forkContinuation()) {
+			if (transferRep) {
+				(
+					uint256[3] memory forkedSourcePrincipalByOutcome,
+					uint256[3] memory forkedChildRepByOutcome
+				) = parentEscalationGame.exportForkedEscrowByOutcome(vault, repReceiver);
+				_addOutcomeAmounts(sourcePrincipalByOutcome, forkedSourcePrincipalByOutcome);
+				_addOutcomeAmounts(currentRepByOutcome, forkedChildRepByOutcome);
+			} else {
+				(
+					uint256[3] memory forkedSourcePrincipalByOutcome,
+					uint256[3] memory forkedChildRepByOutcome
+				) = parentEscalationGame.exportForkedEscrowByOutcomeWithoutTransfer(vault);
+				_addOutcomeAmounts(sourcePrincipalByOutcome, forkedSourcePrincipalByOutcome);
+				_addOutcomeAmounts(currentRepByOutcome, forkedChildRepByOutcome);
+			}
+		}
+		if (_sumOutcomeAmounts(currentRepByOutcome) != 0) return (sourcePrincipalByOutcome, currentRepByOutcome);
+		if (transferRep) {
+			sourcePrincipalByOutcome = parentEscalationGame.exportVaultUnresolvedDepositAmounts(vault, repReceiver);
+		} else {
+			sourcePrincipalByOutcome = parentEscalationGame.exportVaultUnresolvedDepositAmountsWithoutTransfer(vault);
+		}
+		currentRepByOutcome = sourcePrincipalByOutcome;
+	}
+
+	function _recordForkedEscrowAndRefreshVault(
+		EscalationGame childEscalationGame,
+		ISecurityPool child,
+		address vault,
+		uint256[3] memory sourcePrincipalByOutcome,
+		uint256[3] memory currentRepByOutcome,
+		uint256 totalCurrentRep,
+		uint256 totalChildRep
+	) private {
+		_recordForkedEscrowByOriginalOutcome(
+			childEscalationGame,
+			vault,
+			sourcePrincipalByOutcome,
+			currentRepByOutcome,
+			totalCurrentRep,
+			totalChildRep
+		);
+		(uint256 childPoolOwnership, uint256 childSecurityBondAllowance, , uint256 childFeeIndex) = child
+			.securityVaults(vault);
+		child.configureVault(vault, childPoolOwnership, childSecurityBondAllowance, childFeeIndex);
 	}
 
 	function _hasMoreUnresolvedMigration(

--- a/solidity/contracts/peripherals/SecurityPool.sol
+++ b/solidity/contracts/peripherals/SecurityPool.sol
@@ -39,10 +39,10 @@ contract SecurityPool is ISecurityPool {
 	OpenOracle public immutable openOracle;
 	EscalationGameFactory public immutable escalationGameFactory;
 	EscalationGame public escalationGame;
-	ZoltarQuestionData public questionData;
-	address public securityPoolForker;
+	ZoltarQuestionData public immutable questionData;
+	address public immutable securityPoolForker;
 	address public immutable truthAuction;
-	ISecurityPoolFactory public securityPoolFactory;
+	ISecurityPoolFactory public immutable securityPoolFactory;
 
 	uint256 public totalSecurityBondAllowance;
 	uint256 public completeSetCollateralAmount; // amount of eth that is backing complete sets, `address(this).balance - completeSetCollateralAmount` are the fees belonging to REP pool holders
@@ -126,7 +126,7 @@ contract SecurityPool is ISecurityPool {
 		uint256 _initialEscalationGameDeposit,
 		address _truthAuction
 	) {
-		require(_initialEscalationGameDeposit > 0, 'initial escalation deposit');
+		require(_initialEscalationGameDeposit > 0);
 		universeId = _universeId;
 		securityPoolFactory = _securityPoolFactory;
 		questionId = _questionId;
@@ -261,6 +261,7 @@ contract SecurityPool is ISecurityPool {
 	}
 
 	function redeemFees(address vault) external {
+		updateVaultFees(vault);
 		uint256 fees = securityVaults[vault].unpaidEthFees;
 		securityVaults[vault].unpaidEthFees = 0;
 		totalFeesOwedToVaults -= fees;
@@ -325,10 +326,6 @@ contract SecurityPool is ISecurityPool {
 	function poolOwnershipToRep(uint256 poolOwnership) public view returns (uint256) {
 		if (poolOwnershipDenominator == 0) return 0;
 		return (poolOwnership * getTotalRepBalance()) / poolOwnershipDenominator;
-	}
-
-	function getAvailableRepBalance() public view returns (uint256) {
-		return repToken.balanceOf(address(this));
 	}
 
 	function getTotalRepBalance() public view returns (uint256) {
@@ -509,6 +506,7 @@ contract SecurityPool is ISecurityPool {
 		require(systemState == SystemState.Operational, 'not operational');
 		BinaryOutcomes.BinaryOutcome outcome = ISecurityPoolForker(securityPoolForker).getQuestionOutcome(this);
 		require(outcome != BinaryOutcomes.BinaryOutcome.None, 'question not final');
+		updateCollateralAmount();
 		uint256 tokenId = shareToken.getTokenId(universeId, outcome);
 		uint256 amount = shareToken.burnTokenId(tokenId, msg.sender);
 		uint256 ethValue = sharesToCash(amount);
@@ -539,7 +537,7 @@ contract SecurityPool is ISecurityPool {
 		emit RedeemRep(msg.sender, vault, repAmount);
 	}
 
-	function withdrawForkedEscalationDeposits(QuestionOutcome outcome, CarriedDepositProof[] memory proofs) external {
+	function withdrawForkedEscalationDeposits(QuestionOutcome outcome, CarriedDepositProof[] calldata proofs) external {
 		require(address(escalationGame) != address(0x0), 'missing escalation');
 		require(systemState == SystemState.Operational, 'not operational');
 		BinaryOutcomes.BinaryOutcome questionOutcome = ISecurityPoolForker(securityPoolForker).getQuestionOutcome(this);
@@ -618,7 +616,7 @@ contract SecurityPool is ISecurityPool {
 
 	function withdrawFromEscalationGame(
 		BinaryOutcomes.BinaryOutcome outcome,
-		uint256[] memory depositIndexes
+		uint256[] calldata depositIndexes
 	) external {
 		require(address(escalationGame) != address(0x0), 'missing escalation');
 		require(systemState == SystemState.Operational, 'not operational');

--- a/solidity/contracts/peripherals/SecurityPoolForker.sol
+++ b/solidity/contracts/peripherals/SecurityPoolForker.sol
@@ -83,16 +83,9 @@ contract SecurityPoolForker is SecurityPoolForkerVaultMigrationBase {
 		ISecurityPool securityPool
 	) public view returns (uint256 vaultRepAtFork, uint256 unallocatedEscrowChildRep, uint256 escrowSourceRepAtFork) {
 		SecurityPoolForkerForkData storage repBuckets = forkDataByPool[securityPool];
-		uint256 escrowChildRepUsed;
-		for (uint8 outcomeIndex = 0; outcomeIndex < 3; outcomeIndex++) {
-			escrowChildRepUsed += ownForkChildRepAllocationByPoolAndOutcome[securityPool][outcomeIndex]
-				.escrowChildRepUsed;
-		}
 		return (
 			repBuckets.vaultRepAtFork,
-			repBuckets.escalationChildRepAtFork > escrowChildRepUsed
-				? repBuckets.escalationChildRepAtFork - escrowChildRepUsed
-				: 0,
+			_unallocatedEscrowChildRep(securityPool, repBuckets),
 			repBuckets.escalationSourceRepAtFork
 		);
 	}
@@ -111,18 +104,27 @@ contract SecurityPoolForker is SecurityPoolForkerVaultMigrationBase {
 		)
 	{
 		SecurityPoolForkerForkData storage data = forkDataByPool[securityPool];
+		return (
+			data.ownFork,
+			data.auctionableRepAtFork,
+			data.vaultRepAtFork,
+			_unallocatedEscrowChildRep(securityPool, data),
+			data.escalationSourceRepAtFork
+		);
+	}
+
+	function _unallocatedEscrowChildRep(
+		ISecurityPool securityPool,
+		SecurityPoolForkerForkData storage data
+	) private view returns (uint256) {
 		uint256 escrowChildRepUsed;
 		for (uint8 outcomeIndex = 0; outcomeIndex < 3; outcomeIndex++) {
 			escrowChildRepUsed += ownForkChildRepAllocationByPoolAndOutcome[securityPool][outcomeIndex]
 				.escrowChildRepUsed;
 		}
-		return (
-			data.ownFork,
-			data.auctionableRepAtFork,
-			data.vaultRepAtFork,
-			data.escalationChildRepAtFork > escrowChildRepUsed ? data.escalationChildRepAtFork - escrowChildRepUsed : 0,
-			data.escalationSourceRepAtFork
-		);
+		uint256 escalationChildRepAtFork = data.escalationChildRepAtFork;
+		if (escalationChildRepAtFork <= escrowChildRepUsed) return 0;
+		return escalationChildRepAtFork - escrowChildRepUsed;
 	}
 
 	constructor(Zoltar _zoltar) SecurityPoolForkerVaultMigrationBase(_zoltar) {
@@ -294,7 +296,7 @@ contract SecurityPoolForker is SecurityPoolForkerVaultMigrationBase {
 		// TODO: we could pay the caller basefee*2 out of Open interest. We have to reward caller
 	}
 
-	function migrateRepToZoltar(ISecurityPool securityPool, uint256[] memory outcomeIndices) public {
+	function migrateRepToZoltar(ISecurityPool securityPool, uint256[] calldata outcomeIndices) external {
 		SecurityPoolMigrationProxy migrationProxy = migrationProxyByPool[securityPool];
 		require(address(migrationProxy) != address(0x0), 'e3');
 		require(securityPool.systemState() == SystemState.PoolForked, 'parent pool not forked');
@@ -338,8 +340,8 @@ contract SecurityPoolForker is SecurityPoolForkerVaultMigrationBase {
 		ISecurityPool,
 		address vault,
 		BinaryOutcomes.BinaryOutcome,
-		uint256[] memory
-	) public {
+		uint256[] calldata
+	) external {
 		require(msg.sender == vault, 'ov');
 		_delegateEscalationGameForker();
 	}
@@ -479,8 +481,10 @@ contract SecurityPoolForker is SecurityPoolForkerVaultMigrationBase {
 		ISecurityPool securityPool,
 		SecurityPoolForkerForkData storage data
 	) private returns (uint256 repPurchased) {
-		data.truthAuction.finalize();
-		repPurchased = data.truthAuction.totalRepPurchased();
+		if (data.truthAuction.auctionStarted() != 0) {
+			data.truthAuction.finalize();
+			repPurchased = data.truthAuction.totalRepPurchased();
+		}
 		securityPool.setSystemState(SystemState.Operational);
 	}
 
@@ -609,8 +613,8 @@ contract SecurityPoolForker is SecurityPoolForkerVaultMigrationBase {
 	function claimAuctionProceeds(
 		ISecurityPool securityPool,
 		address vault,
-		IUniformPriceDualCapBatchAuction.TickIndex[] memory tickIndices
-	) public {
+		IUniformPriceDualCapBatchAuction.TickIndex[] calldata tickIndices
+	) external {
 		_claimAuctionProceeds(securityPool, vault, tickIndices);
 	}
 
@@ -620,9 +624,9 @@ contract SecurityPoolForker is SecurityPoolForkerVaultMigrationBase {
 	function settleAuctionBids(
 		ISecurityPool securityPool,
 		address vault,
-		IUniformPriceDualCapBatchAuction.TickIndex[] memory claimTickIndices,
-		IUniformPriceDualCapBatchAuction.TickIndex[] memory refundTickIndices
-	) public {
+		IUniformPriceDualCapBatchAuction.TickIndex[] calldata claimTickIndices,
+		IUniformPriceDualCapBatchAuction.TickIndex[] calldata refundTickIndices
+	) external {
 		require(claimTickIndices.length > 0 || refundTickIndices.length > 0, 'f7');
 		if (forkDataByPool[securityPool].truthAuction.finalized()) {
 			IUniformPriceDualCapBatchAuction.TickIndex[]
@@ -639,7 +643,7 @@ contract SecurityPoolForker is SecurityPoolForkerVaultMigrationBase {
 			return;
 		}
 		require(claimTickIndices.length == 0, 'f8');
-		claimableRefundsForSettlement(securityPool, refundTickIndices);
+		_refundLosingAuctionBidsForSettlement(securityPool, vault, refundTickIndices);
 	}
 
 	function _claimAuctionProceeds(
@@ -679,11 +683,12 @@ contract SecurityPoolForker is SecurityPoolForkerVaultMigrationBase {
 		}
 	}
 
-	function claimableRefundsForSettlement(
+	function _refundLosingAuctionBidsForSettlement(
 		ISecurityPool securityPool,
-		IUniformPriceDualCapBatchAuction.TickIndex[] memory tickIndices
+		address vault,
+		IUniformPriceDualCapBatchAuction.TickIndex[] calldata tickIndices
 	) private {
-		forkDataByPool[securityPool].truthAuction.refundLosingBids(tickIndices);
+		forkDataByPool[securityPool].truthAuction.refundLosingBidsFor(vault, tickIndices);
 	}
 
 	function getQuestionOutcome(

--- a/solidity/contracts/peripherals/UniformPriceDualCapBatchAuction.sol
+++ b/solidity/contracts/peripherals/UniformPriceDualCapBatchAuction.sol
@@ -113,6 +113,8 @@ contract UniformPriceDualCapBatchAuction {
 	function finalize() external {
 		require(!finalized, 'already finalized');
 		require(msg.sender == owner, 'Only owner can finalize');
+		require(auctionStarted != 0, 'not started');
+		require(block.timestamp >= auctionStarted + AUCTION_TIME, 'auction active');
 
 		(bool hitCap, int256 foundTick, uint256 accumulatedEth, uint256 ethAtClearingTick) = computeClearing();
 		finalized = true;
@@ -158,7 +160,7 @@ contract UniformPriceDualCapBatchAuction {
 
 	function withdrawBids(
 		address withdrawFor,
-		IUniformPriceDualCapBatchAuction.TickIndex[] memory tickIndices
+		IUniformPriceDualCapBatchAuction.TickIndex[] calldata tickIndices
 	) external returns (uint256 totalFilledRep, uint256 totalEthRefund) {
 		require(finalized, 'not finalized');
 		// The owner is expected to be the coordinating forker contract for truth auctions,
@@ -228,8 +230,25 @@ contract UniformPriceDualCapBatchAuction {
 		}
 	}
 
-	function refundLosingBids(IUniformPriceDualCapBatchAuction.TickIndex[] memory tickIndices) external {
+	function refundLosingBids(IUniformPriceDualCapBatchAuction.TickIndex[] calldata tickIndices) external {
+		_refundLosingBids(msg.sender, tickIndices);
+	}
+
+	function refundLosingBidsFor(
+		address bidder,
+		IUniformPriceDualCapBatchAuction.TickIndex[] calldata tickIndices
+	) external {
+		require(msg.sender == owner, 'Only owner can call');
+		_refundLosingBids(bidder, tickIndices);
+	}
+
+	function _refundLosingBids(
+		address bidder,
+		IUniformPriceDualCapBatchAuction.TickIndex[] calldata tickIndices
+	) private {
 		require(!finalized, 'already finalized');
+		require(auctionStarted != 0, 'not started');
+		require(bidder != address(0x0), 'invalid bidder');
 
 		(bool hitCap, int256 foundTick, , ) = computeClearing();
 		require(hitCap, 'no clearing yet');
@@ -243,7 +262,7 @@ contract UniformPriceDualCapBatchAuction {
 			require(tick < foundTick, 'cannot withdraw binding bid');
 
 			Bid storage bid = bidsAtTick[tick][index];
-			require(bid.bidder == msg.sender, 'not bidder');
+			require(bid.bidder == bidder, 'not bidder');
 			require(bid.ethAmount > 0 && !bid.claimed, 'already withdrawn');
 
 			uint256 originalEth = bid.ethAmount;
@@ -258,10 +277,10 @@ contract UniformPriceDualCapBatchAuction {
 		}
 
 		// Send ETH back to user
-		(bool sent, ) = payable(msg.sender).call{ value: totalEthToRefund }('');
+		(bool sent, ) = payable(bidder).call{ value: totalEthToRefund }('');
 		require(sent, 'transfer failed');
 
-		emit RefundLosingBids(msg.sender, tickIndices, totalEthToRefund);
+		emit RefundLosingBids(bidder, tickIndices, totalEthToRefund);
 	}
 
 	function tickToPrice(int256 tick) public pure returns (uint256 price) {

--- a/solidity/contracts/peripherals/factories/SecurityPoolDeployer.sol
+++ b/solidity/contracts/peripherals/factories/SecurityPoolDeployer.sol
@@ -19,7 +19,6 @@ contract SecurityPoolDeployer {
 
 	function deploy(
 		address securityPoolForker,
-		ISecurityPoolFactory securityPoolFactory,
 		ZoltarQuestionData questionData,
 		EscalationGameFactory escalationGameFactory,
 		SecurityPoolOracleCoordinator priceOracleManagerAndOperatorQueuer,
@@ -33,14 +32,14 @@ contract SecurityPoolDeployer {
 		uint256 initialEscalationGameDeposit,
 		address truthAuction
 	) external returns (ISecurityPool securityPool) {
-		require(msg.sender == factory, 'only factory');
+		require(msg.sender == factory);
 
 		securityPool = ISecurityPool(
 			payable(
 				address(
 					new SecurityPool{ salt: bytes32(uint256(0)) }(
 						securityPoolForker,
-						securityPoolFactory,
+						ISecurityPoolFactory(factory),
 						questionData,
 						escalationGameFactory,
 						priceOracleManagerAndOperatorQueuer,

--- a/solidity/contracts/peripherals/factories/SecurityPoolFactory.sol
+++ b/solidity/contracts/peripherals/factories/SecurityPoolFactory.sol
@@ -17,15 +17,15 @@ import { ISecurityPoolForker } from '../interfaces/ISecurityPoolForker.sol';
 import { SecurityPoolDeployer } from './SecurityPoolDeployer.sol';
 
 contract SecurityPoolFactory is ISecurityPoolFactory {
-	ShareTokenFactory shareTokenFactory;
-	UniformPriceDualCapBatchAuctionFactory uniformPriceDualCapBatchAuctionFactory;
-	PriceOracleManagerAndOperatorQueuerFactory priceOracleManagerAndOperatorQueuerFactory;
-	Zoltar zoltar;
-	OpenOracle openOracle;
-	EscalationGameFactory escalationGameFactory;
-	ZoltarQuestionData questionData;
-	ISecurityPoolForker securityPoolForker;
-	SecurityPoolDeployer securityPoolDeployer;
+	ShareTokenFactory immutable shareTokenFactory;
+	UniformPriceDualCapBatchAuctionFactory immutable uniformPriceDualCapBatchAuctionFactory;
+	PriceOracleManagerAndOperatorQueuerFactory immutable priceOracleManagerAndOperatorQueuerFactory;
+	Zoltar immutable zoltar;
+	OpenOracle immutable openOracle;
+	EscalationGameFactory immutable escalationGameFactory;
+	ZoltarQuestionData immutable questionData;
+	ISecurityPoolForker immutable securityPoolForker;
+	SecurityPoolDeployer immutable securityPoolDeployer;
 	uint256 public immutable initialEscalationGameDeposit;
 	SecurityPoolDeployment[] private securityPoolDeployments;
 
@@ -112,7 +112,7 @@ contract SecurityPoolFactory is ISecurityPoolFactory {
 			completeSetCollateralAmount,
 			address(truthAuction)
 		);
-		securityPoolDeployments.push(
+		_recordSecurityPoolDeployment(
 			SecurityPoolDeployment(
 				securityPool,
 				truthAuction,
@@ -125,19 +125,6 @@ contract SecurityPoolFactory is ISecurityPoolFactory {
 				currentRetentionRate,
 				completeSetCollateralAmount
 			)
-		);
-
-		emit DeploySecurityPool(
-			securityPool,
-			truthAuction,
-			priceOracleManagerAndOperatorQueuer,
-			shareToken,
-			parent,
-			universeId,
-			questionId,
-			securityMultiplier,
-			currentRetentionRate,
-			completeSetCollateralAmount
 		);
 	}
 
@@ -155,8 +142,10 @@ contract SecurityPoolFactory is ISecurityPoolFactory {
 		require(outcomes.length == 2, 'need 2 outcomes');
 		require(keccak256(bytes(outcomes[0])) == keccak256(bytes('Yes')), 'first != Yes');
 		require(keccak256(bytes(outcomes[1])) == keccak256(bytes('No')), 'second != No');
+		require(zoltar.getForkTime(universeId) == 0, 'universe forked');
 
 		ReputationToken reputationToken = zoltar.getRepToken(universeId);
+		require(address(reputationToken) != address(0x0), 'universe missing');
 		bytes32 securityPoolSalt = keccak256(abi.encode(address(0x0), universeId, questionId, securityMultiplier));
 		SecurityPoolOracleCoordinator priceOracleManagerAndOperatorQueuer = priceOracleManagerAndOperatorQueuerFactory
 			.deployPriceOracleManagerAndOperatorQueuer(openOracle, reputationToken, securityPoolSalt);
@@ -177,7 +166,7 @@ contract SecurityPoolFactory is ISecurityPoolFactory {
 		);
 
 		shareToken.authorize(securityPool);
-		securityPoolDeployments.push(
+		_recordSecurityPoolDeployment(
 			SecurityPoolDeployment(
 				securityPool,
 				UniformPriceDualCapBatchAuction(address(0)),
@@ -191,18 +180,21 @@ contract SecurityPoolFactory is ISecurityPoolFactory {
 				0
 			)
 		);
+	}
 
+	function _recordSecurityPoolDeployment(SecurityPoolDeployment memory deployment) private {
+		securityPoolDeployments.push(deployment);
 		emit DeploySecurityPool(
-			securityPool,
-			UniformPriceDualCapBatchAuction(address(0)),
-			priceOracleManagerAndOperatorQueuer,
-			shareToken,
-			ISecurityPool(payable(address(0))),
-			universeId,
-			questionId,
-			securityMultiplier,
-			currentRetentionRate,
-			0
+			deployment.securityPool,
+			deployment.truthAuction,
+			deployment.priceOracleManagerAndOperatorQueuer,
+			deployment.shareToken,
+			deployment.parent,
+			deployment.universeId,
+			deployment.questionId,
+			deployment.securityMultiplier,
+			deployment.currentRetentionRate,
+			deployment.completeSetCollateralAmount
 		);
 	}
 
@@ -219,7 +211,6 @@ contract SecurityPoolFactory is ISecurityPoolFactory {
 	) private returns (ISecurityPool securityPool) {
 		securityPool = securityPoolDeployer.deploy(
 			address(securityPoolForker),
-			this,
 			questionData,
 			escalationGameFactory,
 			priceOracleManagerAndOperatorQueuer,

--- a/solidity/contracts/peripherals/interfaces/ISecurityPool.sol
+++ b/solidity/contracts/peripherals/interfaces/ISecurityPool.sol
@@ -68,7 +68,6 @@ interface ISecurityPool {
 
 	function repToPoolOwnership(uint256 repAmount) external view returns (uint256);
 	function poolOwnershipToRep(uint256 poolOwnership) external view returns (uint256);
-	function getAvailableRepBalance() external view returns (uint256);
 	function getTotalRepBalance() external view returns (uint256);
 	function isEscalationResolved() external view returns (bool);
 	function initialEscalationGameDeposit() external view returns (uint256);
@@ -83,7 +82,7 @@ interface ISecurityPool {
 	function performWithdrawRep(address vault, uint256 repAmount) external;
 	function depositRep(uint256 repAmount) external;
 	function redeemRep(address vault) external;
-	function withdrawForkedEscalationDeposits(QuestionOutcome outcome, CarriedDepositProof[] memory proofs) external;
+	function withdrawForkedEscalationDeposits(QuestionOutcome outcome, CarriedDepositProof[] calldata proofs) external;
 	function performLiquidation(
 		address callerVault,
 		address targetVaultAddress,

--- a/solidity/contracts/peripherals/interfaces/ISecurityPoolForker.sol
+++ b/solidity/contracts/peripherals/interfaces/ISecurityPoolForker.sol
@@ -22,7 +22,7 @@ interface ISecurityPoolForker {
 			uint256 escrowSourceRepAtFork
 		);
 	function initiateSecurityPoolFork(ISecurityPool securityPool) external;
-	function migrateRepToZoltar(ISecurityPool securityPool, uint256[] memory outcomeIndices) external;
+	function migrateRepToZoltar(ISecurityPool securityPool, uint256[] calldata outcomeIndices) external;
 	function createChildUniverse(ISecurityPool securityPool, uint8 outcomeIndex) external;
 	function migrateVault(ISecurityPool securityPool, uint8 outcomeIndex) external;
 	function migrateVaultWithUnresolvedEscalation(
@@ -34,7 +34,7 @@ interface ISecurityPoolForker {
 		ISecurityPool securityPool,
 		address vault,
 		BinaryOutcomes.BinaryOutcome outcomeIndex,
-		uint256[] memory depositIndexes
+		uint256[] calldata depositIndexes
 	) external;
 	function startTruthAuction(ISecurityPool securityPool) external;
 	function finalizeTruthAuction(ISecurityPool securityPool) external;
@@ -42,13 +42,13 @@ interface ISecurityPoolForker {
 	function claimAuctionProceeds(
 		ISecurityPool securityPool,
 		address vault,
-		IUniformPriceDualCapBatchAuction.TickIndex[] memory tickIndices
+		IUniformPriceDualCapBatchAuction.TickIndex[] calldata tickIndices
 	) external;
 	function settleAuctionBids(
 		ISecurityPool securityPool,
 		address vault,
-		IUniformPriceDualCapBatchAuction.TickIndex[] memory claimTickIndices,
-		IUniformPriceDualCapBatchAuction.TickIndex[] memory refundTickIndices
+		IUniformPriceDualCapBatchAuction.TickIndex[] calldata claimTickIndices,
+		IUniformPriceDualCapBatchAuction.TickIndex[] calldata refundTickIndices
 	) external;
 	function getQuestionOutcome(
 		ISecurityPool securityPool

--- a/solidity/contracts/peripherals/interfaces/IShareToken.sol
+++ b/solidity/contracts/peripherals/interfaces/IShareToken.sol
@@ -25,10 +25,10 @@ interface IShareToken {
 	) external pure returns (uint256 _tokenId);
 	function getTokenIds(
 		uint248 _universeId,
-		BinaryOutcomes.BinaryOutcome[] memory _outcomes
+		BinaryOutcomes.BinaryOutcome[] calldata _outcomes
 	) external pure returns (uint256[] memory _tokenIds);
 	function unpackTokenId(
 		uint256 _tokenId
 	) external pure returns (uint248 _universe, BinaryOutcomes.BinaryOutcome _outcome);
-	function migrate(uint256 fromId, uint256[] memory targetOutcomeIndexes) external;
+	function migrate(uint256 fromId, uint256[] calldata targetOutcomeIndexes) external;
 }

--- a/solidity/contracts/peripherals/interfaces/IUniformPriceDualCapBatchAuction.sol
+++ b/solidity/contracts/peripherals/interfaces/IUniformPriceDualCapBatchAuction.sol
@@ -70,6 +70,8 @@ interface IUniformPriceDualCapBatchAuction {
 
 	function refundLosingBids(TickIndex[] calldata tickIndices) external;
 
+	function refundLosingBidsFor(address bidder, TickIndex[] calldata tickIndices) external;
+
 	function tickToPrice(int256 tick) external pure returns (uint256 price);
 	function activeTickCount() external view returns (uint256);
 	function getTickSummary(int256 tick) external view returns (TickSummary memory);

--- a/solidity/contracts/peripherals/tokens/ShareToken.sol
+++ b/solidity/contracts/peripherals/tokens/ShareToken.sol
@@ -141,8 +141,8 @@ contract ShareToken is ERC1155, IShareToken {
 
 	function getTokenIds(
 		uint248 _universeId,
-		BinaryOutcomes.BinaryOutcome[] memory _outcomes
-	) public pure returns (uint256[] memory _tokenIds) {
+		BinaryOutcomes.BinaryOutcome[] calldata _outcomes
+	) external pure returns (uint256[] memory _tokenIds) {
 		return TokenId.getTokenIds(_universeId, _outcomes);
 	}
 
@@ -152,7 +152,7 @@ contract ShareToken is ERC1155, IShareToken {
 		return TokenId.unpackTokenId(_tokenId);
 	}
 
-	function migrate(uint256 fromId, uint256[] memory targetOutcomeIndexes) external {
+	function migrate(uint256 fromId, uint256[] calldata targetOutcomeIndexes) external {
 		uint248 universeId = getUniverseId(fromId);
 		require(universeHasForked(universeId), 'Universe has not forked');
 		require(targetOutcomeIndexes.length > 0, 'No target outcomes');

--- a/solidity/contracts/peripherals/tokens/TokenId.sol
+++ b/solidity/contracts/peripherals/tokens/TokenId.sol
@@ -19,7 +19,7 @@ library TokenId {
 
 	function getTokenIds(
 		uint248 _universeId,
-		BinaryOutcomes.BinaryOutcome[] memory _outcomes
+		BinaryOutcomes.BinaryOutcome[] calldata _outcomes
 	) internal pure returns (uint256[] memory _tokenIds) {
 		_tokenIds = new uint256[](_outcomes.length);
 		for (uint256 _i = 0; _i < _outcomes.length; _i++) {

--- a/solidity/ts/tests/auction.test.ts
+++ b/solidity/ts/tests/auction.test.ts
@@ -310,6 +310,8 @@ describe('Auction', () => {
 		await deployUniformPriceDualCapBatchAuction(client, ownerClient.account.address)
 		const localAuctionAddress = getUniformPriceDualCapBatchAuctionAddress(ownerClient.account.address)
 		const bidAmount = 1n * ATTOETH_PER_ETH
+		await startAuction(ownerClient, localAuctionAddress, height * bidAmount + bidAmount, 1n)
+		await mockWindow.advanceTime(AUCTION_TIME + 1n)
 
 		await mockWindow.addStateOverrides({
 			[localAuctionAddress]: {
@@ -346,6 +348,16 @@ describe('Auction', () => {
 	// ============ Test Suites ============
 
 	describe('Lifecycle & Finalization', () => {
+		test('finalize rejects before the auction starts or ends', async () => {
+			await assert.rejects(async () => await finalize(client, auctionAddress), /not started/)
+
+			const raiseCap = DEFAULT_ETH_RAISE_CAP * ATTOETH_PER_ETH
+			await setupStandardAuction(client, auctionAddress)
+			await submitBid(client, auctionAddress, tickForPrice(PRICE_PRECISION), raiseCap)
+
+			await assert.rejects(async () => await finalize(client, auctionAddress), /auction active/)
+		})
+
 		test('can start auction and make a single bid that finalizes', async () => {
 			const raiseCap = DEFAULT_ETH_RAISE_CAP * ATTOETH_PER_ETH
 			await setupStandardAuction(client, auctionAddress)
@@ -555,6 +567,7 @@ describe('Auction', () => {
 			const clearingAfterRefund = await computeClearing(client, auctionAddress)
 			const expectedEthRaised = clearingAfterRefund.accumulatedEth
 
+			await mockWindow.advanceTime(AUCTION_TIME + 1n)
 			await finalize(client, auctionAddress)
 			strictEqualTypeSafe(await getEthRaised(client, auctionAddress), expectedEthRaised, 'raised amount mismatch')
 			strictEqualTypeSafe(await isFinalized(client, auctionAddress), true, 'Did not finalize')
@@ -694,6 +707,7 @@ describe('Auction', () => {
 
 			await submitBid(alice, auctionAddress, tickForPrice(price), 1n * 10n ** 18n)
 
+			await mockWindow.advanceTime(AUCTION_TIME + 1n)
 			await finalize(client, auctionAddress)
 
 			const clearing = await computeClearing(client, auctionAddress)
@@ -723,6 +737,7 @@ describe('Auction', () => {
 			strictEqualTypeSafe(clearingPre.hitCap, false, 'hitCap should be false (underfunded)')
 
 			// Finalize the auction
+			await mockWindow.advanceTime(AUCTION_TIME + 1n)
 			await finalize(client, auctionAddress)
 
 			// Verify total REP purchased equals maxRepBeingSold (all rep sold)
@@ -758,6 +773,7 @@ describe('Auction', () => {
 			const aliceEth = (maxRepBeingSold * tickToPrice(thresholdTick)) / PRICE_PRECISION
 
 			await submitBid(alice, auctionAddress, thresholdTick, aliceEth)
+			await mockWindow.advanceTime(AUCTION_TIME + 1n)
 			await finalize(client, auctionAddress)
 
 			const totalRep = await getTotalRepPurchased(client, auctionAddress)
@@ -1383,11 +1399,13 @@ describe('Auction', () => {
 			if (expected.hitCap) {
 				strictEqualTypeSafe(clearing.foundTick, expected.foundTick, `${c.name}: foundTick mismatch`)
 				strictEqualTypeSafe(clearing.accumulatedEth, expected.accumulatedEth, `${c.name}: accumulatedEth mismatch`)
+				await mockWindow.advanceTime(AUCTION_TIME + 1n)
 				await finalize(client, auctionAddress)
 				await assertFairPayoutForUser(client, auctionAddress, client.account.address, fairPayoutBids, clearing.foundTick)
 			} else {
 				assert.strictEqual(clearing.hitCap, false, `${c.name}: expected no clearing price`)
 				// Finalize anyway to clear the contract balance
+				await mockWindow.advanceTime(AUCTION_TIME + 1n)
 				await finalize(client, auctionAddress)
 			}
 

--- a/solidity/ts/tests/peripherals.test.ts
+++ b/solidity/ts/tests/peripherals.test.ts
@@ -35,6 +35,7 @@ import {
 	migrateRepToZoltar,
 	migrateVault,
 	migrateVaultWithUnresolvedEscalation,
+	settleAuctionBids,
 	startTruthAuction,
 } from '../testsuite/simulator/utils/contracts/securityPoolForker'
 import { getEscalationGameDeposits, getEscalationGameOutcomeState, getEscalationGameTotalCost, getNonDecisionThreshold, getQuestionResolution, getStartBond } from '../testsuite/simulator/utils/contracts/escalationGame'
@@ -47,10 +48,10 @@ import {
 	depositToEscalationGame,
 	getCompleteSetCollateralAmount,
 	getCurrentRetentionRate,
-	getAvailableRepBalance,
 	getPoolOwnershipDenominator,
 	getRepToken,
 	getShareTokenSupply,
+	getTotalRepBalance,
 	getAwaitingForkContinuation,
 	getActiveVaultCount,
 	getActiveVaults,
@@ -226,7 +227,7 @@ describe('Peripherals Contract Test Suite', () => {
 		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
 	}
 
-	const setupFinalizedTruthAuctionWithMixedBids = async () => {
+	const setupTruthAuctionWithMixedBids = async (finalizeAuction: boolean) => {
 		const endTime = await getQuestionEndDate(client, questionId)
 		await mockWindow.setTime(endTime + 10000n)
 
@@ -263,8 +264,10 @@ describe('Peripherals Contract Test Suite', () => {
 		const losingTick = await participateAuction(losingBidder, yesSecurityPool.truthAuction, repAtFork, losingEth)
 		const winningTick = await participateAuction(winningBidder, yesSecurityPool.truthAuction, repAtFork / 4n, expectedEthToBuy)
 
-		await mockWindow.advanceTime(7n * DAY + DAY)
-		await finalizeTruthAuction(client, yesSecurityPool.securityPool)
+		if (finalizeAuction) {
+			await mockWindow.advanceTime(7n * DAY + DAY)
+			await finalizeTruthAuction(client, yesSecurityPool.securityPool)
+		}
 
 		return {
 			yesSecurityPool,
@@ -277,6 +280,8 @@ describe('Peripherals Contract Test Suite', () => {
 			winningTick,
 		}
 	}
+
+	const setupFinalizedTruthAuctionWithMixedBids = async () => await setupTruthAuctionWithMixedBids(true)
 
 	const initializePeripheralsBaseline = async () => {
 		mockWindow = getAnvilWindowEthereum()
@@ -621,12 +626,12 @@ describe('Peripherals Contract Test Suite', () => {
 		await depositToEscalationGame(attackerClient, securityPoolAddresses.securityPool, QuestionOutcome.Yes, lockedDeposit)
 		await manipulatePriceOracle(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer)
 
-		const availableRepBeforeWithdrawal = await getAvailableRepBalance(client, securityPoolAddresses.securityPool)
+		const availableRepBeforeWithdrawal = await getTotalRepBalance(client, securityPoolAddresses.securityPool)
 		const aliceWalletRepBeforeWithdrawal = await getERC20Balance(client, addressString(GENESIS_REPUTATION_TOKEN), client.account.address)
 
 		await requestPriceIfNeededAndStageOperation(client, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.WithdrawRep, client.account.address, repDeposit)
 
-		const availableRepAfterWithdrawal = await getAvailableRepBalance(client, securityPoolAddresses.securityPool)
+		const availableRepAfterWithdrawal = await getTotalRepBalance(client, securityPoolAddresses.securityPool)
 		const aliceWalletRepAfterWithdrawal = await getERC20Balance(client, addressString(GENESIS_REPUTATION_TOKEN), client.account.address)
 		const aliceVaultAfterWithdrawal = await getSecurityVault(client, securityPoolAddresses.securityPool, client.account.address)
 		const attackerVaultAfterWithdrawal = await getSecurityVault(client, securityPoolAddresses.securityPool, attackerClient.account.address)
@@ -701,7 +706,7 @@ describe('Peripherals Contract Test Suite', () => {
 
 		await approveAndDepositRep(secondVault, repDeposit, questionId)
 
-		const totalRepBeforeEscrow = await getAvailableRepBalance(client, securityPoolAddresses.securityPool)
+		const totalRepBeforeEscrow = await getTotalRepBalance(client, securityPoolAddresses.securityPool)
 		const poolOwnershipDenominator = await getPoolOwnershipDenominator(client, securityPoolAddresses.securityPool)
 		const vaultBeforeEscrow = await getSecurityVault(client, securityPoolAddresses.securityPool, client.account.address)
 		const ownershipToEscrow = (escrowAmount * poolOwnershipDenominator + totalRepBeforeEscrow - 1n) / totalRepBeforeEscrow
@@ -1938,7 +1943,7 @@ describe('Peripherals Contract Test Suite', () => {
 		const vaultBefore = await getSecurityVault(client, securityPoolAddresses.securityPool, client.account.address)
 		const snapshotTargetOwnership = vaultBefore.repDepositShare
 		const snapshotTargetAllowance = vaultBefore.securityBondAllowance
-		const snapshotTotalRep = await getAvailableRepBalance(client, securityPoolAddresses.securityPool)
+		const snapshotTotalRep = await getTotalRepBalance(client, securityPoolAddresses.securityPool)
 		const snapshotDenominator = await getPoolOwnershipDenominator(client, securityPoolAddresses.securityPool)
 
 		const snapshotExpectedRepDeposit = (snapshotTargetOwnership * snapshotTotalRep) / snapshotDenominator
@@ -2042,7 +2047,7 @@ describe('Peripherals Contract Test Suite', () => {
 		const secondVault = await getSecurityVault(client, securityPoolAddresses.securityPool, secondVaultClient.account.address)
 		const firstVaultTotalClaim = await getVaultRepClaim(client.account.address)
 		const secondVaultTotalClaim = await getVaultRepClaim(secondVaultClient.account.address)
-		const availableRepBalance = await getAvailableRepBalance(client, securityPoolAddresses.securityPool)
+		const availableRepBalance = await getTotalRepBalance(client, securityPoolAddresses.securityPool)
 
 		strictEqualTypeSafe(firstVaultTotalClaim, repDeposit - lockedDeposit, 'locking REP should remove the committed principal from the vault claim')
 		strictEqualTypeSafe(secondVaultTotalClaim, repDeposit, 'locking REP should not reduce another vaults total collateral claim')
@@ -2186,21 +2191,50 @@ describe('Peripherals Contract Test Suite', () => {
 		const secondWinningShares = ensureDefined(secondHolderShares[1], 'second holder winning shares missing')
 		const initialCollateral = await getCompleteSetCollateralAmount(client, securityPoolAddresses.securityPool)
 		const initialShareSupply = await getShareTokenSupply(client, securityPoolAddresses.securityPool)
-		const firstWinningCashValue = await sharesToCash(client, securityPoolAddresses.securityPool, firstWinningShares)
+		const initialFeesOwed = await getTotalFeesOwedToVaults(client, securityPoolAddresses.securityPool)
 		assert.ok(initialCollateral > 0n, 'collateral should be positive before finalization')
 		strictEqualTypeSafe(initialShareSupply, firstWinningShares + secondWinningShares, 'share supply should equal the minted winning-share balances')
 
 		await finalizeQuestionAsYesWithoutFork()
+		const firstHolderBalanceBeforeRedemption = await getETHBalance(client, firstHolder.account.address)
 		await redeemShares(firstHolder, securityPoolAddresses.securityPool)
 
-		approximatelyEqual(await getCompleteSetCollateralAmount(client, securityPoolAddresses.securityPool), initialCollateral - firstWinningCashValue, 10n, 'collateral should shrink after first winning redemption')
+		const collateralAfterFirstRedemption = await getCompleteSetCollateralAmount(client, securityPoolAddresses.securityPool)
+		const feesAfterFirstRedemption = await getTotalFeesOwedToVaults(client, securityPoolAddresses.securityPool)
+		const firstHolderPayout = (await getETHBalance(client, firstHolder.account.address)) - firstHolderBalanceBeforeRedemption
+		const feeDelta = feesAfterFirstRedemption - initialFeesOwed
+
+		assert.ok(feeDelta > 0n, 'first redemption should accrue open-interest fees')
+		strictEqualTypeSafe(collateralAfterFirstRedemption + firstHolderPayout + feeDelta, initialCollateral, 'collateral should shrink by fees and first winning redemption')
 		strictEqualTypeSafe(await getShareTokenSupply(client, securityPoolAddresses.securityPool), initialShareSupply - firstWinningShares, 'share supply should shrink after first winning redemption')
-		approximatelyEqual(await sharesToCash(client, securityPoolAddresses.securityPool, secondWinningShares), initialCollateral - firstWinningCashValue, 10n, 'remaining winning shares should not be double counted')
+		approximatelyEqual(await sharesToCash(client, securityPoolAddresses.securityPool, secondWinningShares), collateralAfterFirstRedemption, 10n, 'remaining winning shares should not be double counted')
 
 		await redeemShares(secondHolder, securityPoolAddresses.securityPool)
 
 		strictEqualTypeSafe(await getCompleteSetCollateralAmount(client, securityPoolAddresses.securityPool), 0n, 'collateral should be empty after all winning shares are redeemed')
 		strictEqualTypeSafe(await getShareTokenSupply(client, securityPoolAddresses.securityPool), 0n, 'share supply should be empty after all winning shares are redeemed')
+	})
+
+	test('redeemShares accrues open-interest fees before paying winning shares', async () => {
+		const securityPoolAllowance = repDeposit / 4n
+		await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, securityPoolAllowance)
+
+		const openInterestHolder = createWriteClient(mockWindow, TEST_ADDRESSES[3], 0)
+		const openInterestAmount = 10n * 10n ** 18n
+		await createCompleteSet(openInterestHolder, securityPoolAddresses.securityPool, openInterestAmount)
+		const balanceBefore = await getETHBalance(client, openInterestHolder.account.address)
+
+		await finalizeQuestionAsYesWithoutFork()
+		await redeemShares(openInterestHolder, securityPoolAddresses.securityPool)
+
+		const balanceAfter = await getETHBalance(client, openInterestHolder.account.address)
+		const feesOwed = await getTotalFeesOwedToVaults(client, securityPoolAddresses.securityPool)
+		const payout = balanceAfter - balanceBefore
+
+		assert.ok(feesOwed > 0n, 'redeemShares should accrue fees before paying winning shares')
+		assert.ok(payout < openInterestAmount, 'winner payout should be net of accrued fees')
+		approximatelyEqual(payout + feesOwed, openInterestAmount, 1000n, 'payout plus fees should conserve open interest')
+		strictEqualTypeSafe(await getCompleteSetCollateralAmount(client, securityPoolAddresses.securityPool), 0n, 'all collateral should be consumed after sole winning redemption')
 	})
 
 	test('sharesToCash returns zero for stale non-winning shares after all winning shares are redeemed', async () => {
@@ -3747,6 +3781,22 @@ describe('Peripherals Contract Test Suite', () => {
 		strictEqualTypeSafe(vaultCountAfterClaim, vaultCountBeforeClaim, 'zero-REP finalized claim should not create a new vault')
 	})
 
+	test('settleAuctionBids can refund a losing bid before truth auction finalization', async () => {
+		const { yesSecurityPool, losingBidder, losingEth, losingTick } = await setupTruthAuctionWithMixedBids(false)
+		const thirdParty = createWriteClient(mockWindow, TEST_ADDRESSES[5], 0)
+		const thirdPartyBalanceBeforeSettlement = await getETHBalance(client, thirdParty.account.address)
+		const losingBidderBalanceBeforeSettlement = await getETHBalance(client, losingBidder.account.address)
+
+		strictEqualTypeSafe(await getSystemState(client, yesSecurityPool.securityPool), SystemState.ForkTruthAuction, 'setup should leave the child pool in an active truth auction')
+		await settleAuctionBids(thirdParty, yesSecurityPool.securityPool, losingBidder.account.address, [], [{ tick: losingTick, bidIndex: 0n }])
+
+		const thirdPartyBalanceAfterSettlement = await getETHBalance(client, thirdParty.account.address)
+		const losingBidderBalanceAfterSettlement = await getETHBalance(client, losingBidder.account.address)
+
+		strictEqualTypeSafe(losingBidderBalanceAfterSettlement - losingBidderBalanceBeforeSettlement, losingEth, 'pre-finalization settlement should refund losing-bid ETH to the bidder')
+		strictEqualTypeSafe(thirdPartyBalanceAfterSettlement, thirdPartyBalanceBeforeSettlement, 'pre-finalization settlement should not redirect refunded ETH to the caller')
+	})
+
 	test('claimAuctionProceeds preserves winner accounting when a finalized losing refund is settled first', async () => {
 		const { yesSecurityPool, expectedEthToBuy, losingBidder, losingTick, winningBidder, winningTick } = await setupFinalizedTruthAuctionWithMixedBids()
 		const forkData = await getSecurityPoolForkerForkData(client, yesSecurityPool.securityPool)
@@ -4047,6 +4097,27 @@ describe('Peripherals Contract Test Suite', () => {
 
 		// Attempt to deploy security pool with non-existent question should fail
 		await assert.rejects(deployOriginSecurityPool(client, genesisUniverse, nonExistentQuestionId, securityMultiplier, MAX_RETENTION_RATE))
+	})
+
+	test('cannot deploy origin security pool in an already-forked universe', async () => {
+		const forkSourceQuestionData = {
+			...questionData,
+			title: `factory fork source ${await mockWindow.getTime()}`,
+			endTime: (await mockWindow.getTime()) + DAY,
+		}
+		const forkSourceQuestionId = getQuestionId(forkSourceQuestionData, outcomes)
+		await createQuestion(client, forkSourceQuestionData, outcomes)
+		await mockWindow.setTime(forkSourceQuestionData.endTime + 1n)
+		await approveToken(client, addressString(GENESIS_REPUTATION_TOKEN), getZoltarAddress())
+		await forkUniverse(client, genesisUniverse, forkSourceQuestionId)
+
+		await assert.rejects(deployOriginSecurityPool(client, genesisUniverse, questionId, securityMultiplier, MAX_RETENTION_RATE), /universe forked/)
+	})
+
+	test('cannot deploy origin security pool in a missing universe', async () => {
+		const missingUniverseId = 999999n
+
+		await assert.rejects(deployOriginSecurityPool(client, missingUniverseId, questionId, securityMultiplier, MAX_RETENTION_RATE), /universe missing/)
 	})
 
 	test('can fork security pool using separate initiate and migrate calls with multiple migrations', async () => {

--- a/solidity/ts/testsuite/simulator/utils/contracts/securityPool.ts
+++ b/solidity/ts/testsuite/simulator/utils/contracts/securityPool.ts
@@ -265,10 +265,10 @@ export const getRepToken = async (client: ReadClient, securityPoolAddress: Addre
 		args: [],
 	})
 
-export const getAvailableRepBalance = async (client: ReadClient, securityPoolAddress: Address) =>
+export const getTotalRepBalance = async (client: ReadClient, securityPoolAddress: Address) =>
 	await client.readContract({
 		abi: peripherals_SecurityPool_SecurityPool.abi,
-		functionName: 'getAvailableRepBalance',
+		functionName: 'getTotalRepBalance',
 		address: securityPoolAddress,
 		args: [],
 	})

--- a/solidity/ts/testsuite/simulator/utils/contracts/securityPoolForker.ts
+++ b/solidity/ts/testsuite/simulator/utils/contracts/securityPoolForker.ts
@@ -97,6 +97,16 @@ export const claimAuctionProceeds = async (client: WriteClient, securityPoolAddr
 		}),
 	)
 
+export const settleAuctionBids = async (client: WriteClient, securityPoolAddress: Address, vault: Address, claimTickIndices: readonly { tick: bigint; bidIndex: bigint }[], refundTickIndices: readonly { tick: bigint; bidIndex: bigint }[]) =>
+	await writeContractAndWait(client, () =>
+		client.writeContract({
+			abi: peripherals_SecurityPoolForker_SecurityPoolForker.abi,
+			functionName: 'settleAuctionBids',
+			address: getInfraContractAddresses().securityPoolForker,
+			args: [securityPoolAddress, vault, claimTickIndices, refundTickIndices],
+		}),
+	)
+
 export const forkZoltarWithOwnEscalationGame = async (client: WriteClient, securityPoolAddress: Address) =>
 	await writeContractAndWait(client, () =>
 		client.writeContract({


### PR DESCRIPTION
## Summary
- Refactored fork migration and escalation paths to reduce duplicated logic and make ownership/child-setup behavior explicit, including extracted helpers in `EscalationGameForker` and `SecurityPoolForker`.
- Marked key contract references as `immutable` (`Zoltar`, `SecurityPool`, and `SecurityPoolFactory` dependencies) and removed redundant mutable storage where safe.
- Consolidated escalation outcome logic in `EscalationGame` with helper functions for balance counting, empty checks, strict leader selection, and median balance calculation.
- Split escalation fork migration into explicit own-fork vs external-fork flows and centralized unresolved-rep export/recording logic.
- Updated auction refund semantics in `UniformPriceDualCapBatchAuction` to support bidder-specific refunds for settlement flows and enforced safer finalization timing checks.
- Simplified fork factory/deployer interfaces and params (`calldata` for arrays), removed unused `getAvailableRepBalance` from interface/implementation, and added early validation guards for fork deployment setup.

## Testing
- Not run (`bun run tsc`) — not executed in this context.
- Not run (`bun run test`) — not executed in this context.
- Not run (`bun run format`) — not executed in this context.
- Not run (`bun run check`) — not executed in this context.
- Not run (`bun run knip`) — not executed in this context.
- Note: per repo QA policy, these checks should be run before merging `t3code/b93f7fed` into `main` before final PR submission.