### PR TITLE
Refactor UI sections to shared Badge and MetricGrid components

### DIFF
--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -1355,13 +1355,15 @@ button.currency-value.copyable:hover:not(:disabled) {
 	background: var(--success-soft);
 }
 
-.badge.pending {
+.badge.pending,
+.badge.warning {
 	color: var(--warning);
 	border-color: var(--warning-border);
 	background: var(--warning-soft);
 }
 
-.badge.blocked {
+.badge.blocked,
+.badge.danger {
 	color: var(--danger);
 	border-color: var(--danger-border);
 	background: var(--danger-soft);

--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -1198,48 +1198,6 @@ button.currency-value.copyable:hover:not(:disabled) {
 	overflow-x: auto;
 }
 
-.tab-link {
-	flex: 0 0 auto;
-	display: inline-flex;
-	align-items: center;
-	justify-content: flex-start;
-	border-radius: 0;
-	padding: 0.58rem 0.82rem;
-	background: transparent;
-	color: var(--muted);
-	text-decoration: none;
-	text-align: left;
-	white-space: nowrap;
-	border: 1px solid transparent;
-	font-size: var(--font-tab);
-	line-height: 1;
-	font-weight: 600;
-	letter-spacing: 0.09em;
-	text-transform: uppercase;
-	transition:
-		background 140ms ease,
-		color 140ms ease,
-		border-color 140ms ease;
-}
-
-.tab-link:hover {
-	border-color: var(--interactive-border);
-	background: var(--interactive-bg);
-}
-
-.tab-link.active {
-	background: var(--interactive-bg-hover);
-	color: var(--text);
-	border-color: var(--interactive-border);
-	box-shadow: 0 1px 0 0 rgba(56, 213, 255, 0.4);
-}
-
-.tab-link.disabled {
-	opacity: 0.42;
-	cursor: not-allowed;
-	pointer-events: none;
-}
-
 .subtab-nav {
 	display: flex;
 	flex-wrap: wrap;
@@ -1247,48 +1205,6 @@ button.currency-value.copyable:hover:not(:disabled) {
 	margin-top: 1rem;
 	padding: 0 0 0.75rem;
 	border-bottom: 1px solid var(--border-default);
-}
-
-.subtab-link {
-	flex: 0 0 auto;
-	display: inline-flex;
-	align-items: center;
-	justify-content: flex-start;
-	border: 1px solid var(--control-border);
-	border-radius: 0;
-	padding: 0.62rem 0.9rem;
-	background: var(--surface-sunken);
-	color: var(--muted);
-	font: inherit;
-	font-size: var(--font-subtab);
-	line-height: 1;
-	font-weight: 600;
-	letter-spacing: 0.08em;
-	text-transform: uppercase;
-}
-
-.subtab-link:hover {
-	background: var(--interactive-bg);
-	border-color: var(--interactive-border);
-	color: var(--text);
-}
-
-.subtab-link:disabled {
-	opacity: 0.45;
-	cursor: not-allowed;
-}
-
-.subtab-link.active:disabled {
-	opacity: 1;
-	background: var(--interactive-bg-hover);
-	border-color: var(--interactive-border);
-	color: var(--text);
-}
-
-.subtab-link.active {
-	background: var(--interactive-bg-hover);
-	border-color: var(--interactive-border);
-	color: var(--text);
 }
 
 .contract-panel-header {
@@ -1486,11 +1402,6 @@ button.currency-value.copyable:hover:not(:disabled) {
 	border: 0;
 	background: transparent;
 	box-shadow: none;
-}
-
-.market-subtab-nav .subtab-link {
-	flex: 1 1 10rem;
-	justify-content: center;
 }
 
 .workflow-stack {
@@ -3730,8 +3641,7 @@ strong.metric-value-danger {
 
 .field input:focus,
 .field select:focus,
-.field textarea:focus,
-.tab-link:focus-visible {
+.field textarea:focus {
 	outline: none;
 	border-color: var(--accent);
 	box-shadow: 0 0 0 3px rgba(56, 213, 255, 0.12);

--- a/ui/ts/components/Badge.tsx
+++ b/ui/ts/components/Badge.tsx
@@ -7,15 +7,8 @@ type BadgeProps = {
 	tone?: BadgeTone
 }
 
-function getBadgeToneClass(tone: BadgeTone) {
-	if (tone === 'danger') return 'blocked'
-	if (tone === 'warning') return 'pending'
-	return tone
-}
-
 export function Badge({ children, className = '', tone = 'muted' }: BadgeProps) {
-	const toneClass = getBadgeToneClass(tone)
-	const classes = ['badge', toneClass, className].filter(Boolean).join(' ')
+	const classes = ['badge', tone, className].filter(Boolean).join(' ')
 
 	return <span className={classes}>{children}</span>
 }

--- a/ui/ts/components/Badge.tsx
+++ b/ui/ts/components/Badge.tsx
@@ -1,0 +1,21 @@
+import type { ComponentChildren } from 'preact'
+import type { BadgeTone } from '../types/components.js'
+
+type BadgeProps = {
+	children: ComponentChildren
+	className?: string
+	tone?: BadgeTone
+}
+
+function getBadgeToneClass(tone: BadgeTone) {
+	if (tone === 'danger') return 'blocked'
+	if (tone === 'warning') return 'pending'
+	return tone
+}
+
+export function Badge({ children, className = '', tone = 'muted' }: BadgeProps) {
+	const toneClass = getBadgeToneClass(tone)
+	const classes = ['badge', toneClass, className].filter(Boolean).join(' ')
+
+	return <span className={classes}>{children}</span>
+}

--- a/ui/ts/components/ChildUniversesSection.tsx
+++ b/ui/ts/components/ChildUniversesSection.tsx
@@ -1,4 +1,5 @@
 import type { ComponentChildren } from 'preact'
+import { Badge } from './Badge.js'
 import { EntityCard } from './EntityCard.js'
 import { TransactionActionButton } from './TransactionActionButton.js'
 import { UniverseLink } from './UniverseLink.js'
@@ -25,6 +26,10 @@ type ChildUniversesSectionProps = {
 	renderBody: (child: ZoltarChildUniverseSummary) => ComponentChildren
 	renderBadge?: (child: ZoltarChildUniverseSummary) => ComponentChildren
 	renderTitle?: (child: ZoltarChildUniverseSummary) => ComponentChildren
+}
+
+export function ChildUniverseStatusBadge({ child }: { child: ZoltarChildUniverseSummary }) {
+	return <Badge tone={child.exists ? 'ok' : 'pending'}>{child.exists ? 'Exists' : 'Not deployed'}</Badge>
 }
 
 export function ChildUniversesSection({ action, childUniverses, emptyMessage, headerSubtitle, headerTitle, renderBody, renderBadge, renderTitle }: ChildUniversesSectionProps) {

--- a/ui/ts/components/DeploymentSection.tsx
+++ b/ui/ts/components/DeploymentSection.tsx
@@ -1,10 +1,11 @@
-import type { DeploymentSectionProps } from '../types/components.js'
+import type { BadgeTone, DeploymentSectionProps } from '../types/components.js'
+import { Badge } from './Badge.js'
 import { SectionBlock } from './SectionBlock.js'
 import { TransactionActionButton } from './TransactionActionButton.js'
 import { getDeploymentStepAvailability, getPrerequisiteLabel } from '../lib/deployment.js'
 
 type StepStatus = {
-	badgeClass: string
+	badgeTone: BadgeTone
 	label: string | undefined
 	detail: string
 	buttonLabel: string
@@ -13,7 +14,7 @@ type StepStatus = {
 function getStepStatus(stepDeployed: boolean, prerequisiteLabel: string | undefined, isBusy: boolean, accountAddress: string | undefined, isMainnet: boolean): StepStatus {
 	if (stepDeployed)
 		return {
-			badgeClass: 'ok',
+			badgeTone: 'ok',
 			detail: 'Code found at expected address.',
 			label: 'Deployed',
 			buttonLabel: 'Deployed',
@@ -21,7 +22,7 @@ function getStepStatus(stepDeployed: boolean, prerequisiteLabel: string | undefi
 
 	if (isBusy)
 		return {
-			badgeClass: 'pending',
+			badgeTone: 'pending',
 			detail: 'Deployment in progress.',
 			label: 'Deploying...',
 			buttonLabel: 'Deploying...',
@@ -30,20 +31,20 @@ function getStepStatus(stepDeployed: boolean, prerequisiteLabel: string | undefi
 	if (prerequisiteLabel === undefined) {
 		if (accountAddress === undefined)
 			return {
-				badgeClass: 'pending',
+				badgeTone: 'pending',
 				detail: 'Connect wallet to continue.',
 				label: 'Not Deployed',
 				buttonLabel: 'Deploy',
 			}
 		if (!isMainnet)
 			return {
-				badgeClass: 'pending',
+				badgeTone: 'pending',
 				detail: 'Switch to Ethereum mainnet.',
 				label: 'Not Deployed',
 				buttonLabel: 'Deploy',
 			}
 		return {
-			badgeClass: 'pending',
+			badgeTone: 'pending',
 			detail: 'Can deploy now.',
 			label: 'Not Deployed',
 			buttonLabel: 'Deploy',
@@ -51,7 +52,7 @@ function getStepStatus(stepDeployed: boolean, prerequisiteLabel: string | undefi
 	}
 
 	return {
-		badgeClass: 'blocked',
+		badgeTone: 'blocked',
 		detail: `Waiting for ${prerequisiteLabel}.`,
 		label: 'Waiting',
 		buttonLabel: 'Deploy',
@@ -79,7 +80,7 @@ export function DeploymentSection({ title, steps, allSteps, accountAddress, busy
 						<div className='contract-row' key={step.id}>
 							<div className='contract-copy'>
 								<div className='contract-topline'>
-									{stepStatus.label === undefined ? undefined : <span className={`badge ${stepStatus.badgeClass}`}>{stepStatus.label}</span>}
+									{stepStatus.label === undefined ? undefined : <Badge tone={stepStatus.badgeTone}>{stepStatus.label}</Badge>}
 									<h3>{step.label}</h3>
 								</div>
 								<p className='address'>{step.address}</p>

--- a/ui/ts/components/EscalationSide.tsx
+++ b/ui/ts/components/EscalationSide.tsx
@@ -1,4 +1,5 @@
 import { CurrencyValue } from './CurrencyValue.js'
+import { Badge } from './Badge.js'
 import type { EscalationDeposit } from '../types/contracts.js'
 
 type EscalationSideDisplay = {
@@ -48,8 +49,8 @@ export function EscalationSide({ bindingCapital, chartScaleMax, disabled = false
 						<span className='panel-label'>{side.label}</span>
 						{isLeading || isSelected ? (
 							<div className='escalation-side-badges'>
-								{isSelected ? <span className='badge escalation-side-selected-badge'>Selected</span> : undefined}
-								{isLeading ? <span className='badge ok'>Leading</span> : undefined}
+								{isSelected ? <Badge className='escalation-side-selected-badge'>Selected</Badge> : undefined}
+								{isLeading ? <Badge tone='ok'>Leading</Badge> : undefined}
 							</div>
 						) : undefined}
 					</div>

--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -3,12 +3,14 @@ import { useEffect, useRef, useState } from 'preact/hooks'
 import type { ComponentChildren } from 'preact'
 import { type Address, zeroAddress } from 'viem'
 import { AddressValue } from './AddressValue.js'
+import { Badge } from './Badge.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { EscalationDepositSelectionList } from './EscalationDepositSelectionList.js'
 import { EnumDropdown } from './EnumDropdown.js'
 import { ErrorNotice } from './ErrorNotice.js'
 import { FormInput } from './FormInput.js'
 import { LookupFieldRow } from './LookupFieldRow.js'
+import { MetricGrid } from './MetricGrid.js'
 import { MetricField } from './MetricField.js'
 import { PaginationControls } from './PaginationControls.js'
 import { ReadOnlyDetailAccordion } from './ReadOnlyDetailAccordion.js'
@@ -194,13 +196,13 @@ function getForkWorkflowSeparatorClassName({ currentStage, stage }: { currentSta
 }
 function renderWorkflowMetricGrid(metrics: DisplayMetric[]) {
 	return (
-		<div className='workflow-metric-grid'>
+		<MetricGrid>
 			{metrics.map(metric => (
 				<MetricField key={metric.label} label={metric.label}>
 					{metric.value}
 				</MetricField>
 			))}
-		</div>
+		</MetricGrid>
 	)
 }
 
@@ -1130,7 +1132,7 @@ export function ForkAuctionSection({
 		effectiveTruthAuctionStartedAt,
 		migrationEndsAt: forkAuctionDetails?.migrationEndsAt,
 	})
-	const migrationStatusBadge = <span className={`badge ${migrationStateBadge.tone}`}>{migrationStateBadge.label}</span>
+	const migrationStatusBadge = <Badge tone={migrationStateBadge.tone}>{migrationStateBadge.label}</Badge>
 	const fullTruthAuctionReadClient = isFullReadClient(truthAuctionReadClient) ? truthAuctionReadClient : undefined
 	const onStartTruthAuctionSubmit = () => {
 		setIsStartTruthAuctionInProgressState(true)
@@ -1756,7 +1758,7 @@ export function ForkAuctionSection({
 
 		return <TimestampValue {...(effectiveCurrentTimestamp === undefined ? {} : { currentTimestamp: effectiveCurrentTimestamp })} timestamp={forkAuctionDetails.migrationEndsAt} />
 	})()
-	const truthAuctionStateBadgeElement = <span className={`badge ${truthAuctionStateBadge.tone}`}>{truthAuctionStateBadge.label}</span>
+	const truthAuctionStateBadgeElement = <Badge tone={truthAuctionStateBadge.tone}>{truthAuctionStateBadge.label}</Badge>
 	const auctionStatusMetrics: DisplayMetric[] = [
 		{ label: 'Truth Auction Address', value: renderAddress(auctionTruthAuctionAddress) },
 		{ label: 'Started', value: startedDisplay },

--- a/ui/ts/components/GlobalTransactionTray.tsx
+++ b/ui/ts/components/GlobalTransactionTray.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'preact/hooks'
+import { Badge } from './Badge.js'
 import { TransactionHashLink } from './TransactionHashLink.js'
-import type { GlobalTransactionPresentation } from '../types/components.js'
+import type { BadgeTone, GlobalTransactionPresentation } from '../types/components.js'
 
 type GlobalTransactionTrayProps = {
 	transaction: GlobalTransactionPresentation | undefined
@@ -12,12 +13,12 @@ function getDismissKey(transaction: GlobalTransactionPresentation | undefined) {
 	return transaction?.dismissKey ?? transaction?.hash
 }
 
-function getTransactionBadge(tone: GlobalTransactionPresentation['tone']) {
-	if (tone === 'awaiting-wallet') return { className: 'pending', label: 'Awaiting Wallet' }
-	if (tone === 'pending') return { className: 'pending', label: 'Pending' }
-	if (tone === 'success') return { className: 'ok', label: 'Confirmed' }
-	if (tone === 'error') return { className: 'warn', label: 'Failed' }
-	return { className: 'warn', label: 'Attention' }
+function getTransactionBadge(tone: GlobalTransactionPresentation['tone']): { label: string; tone: BadgeTone } {
+	if (tone === 'awaiting-wallet') return { tone: 'pending', label: 'Awaiting Wallet' }
+	if (tone === 'pending') return { tone: 'pending', label: 'Pending' }
+	if (tone === 'success') return { tone: 'ok', label: 'Confirmed' }
+	if (tone === 'error') return { tone: 'danger', label: 'Failed' }
+	return { tone: 'warning', label: 'Attention' }
 }
 
 export function GlobalTransactionTray({ transaction }: GlobalTransactionTrayProps) {
@@ -54,7 +55,7 @@ export function GlobalTransactionTray({ transaction }: GlobalTransactionTrayProp
 			<div className='global-transaction-notice' role='status' aria-live='polite'>
 				<div className='global-transaction-notice-copy'>
 					<div className='global-transaction-notice-header'>
-						<span className={`badge ${badge.className}`}>{badge.label}</span>
+						<Badge tone={badge.tone}>{badge.label}</Badge>
 						<strong>{transaction.title}</strong>
 					</div>
 					{!showDetail ? undefined : <div className='global-transaction-notice-detail'>{transaction.detail}</div>}

--- a/ui/ts/components/LiquidationModal.tsx
+++ b/ui/ts/components/LiquidationModal.tsx
@@ -2,11 +2,13 @@ import { useEffect, useRef } from 'preact/hooks'
 import type { Address } from 'viem'
 import { AddressInfo } from './AddressInfo.js'
 import { AddressValue } from './AddressValue.js'
+import { Badge } from './Badge.js'
 import { CollateralizationMetricField } from './CollateralizationMetricField.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { DataGrid } from './DataGrid.js'
 import { ErrorNotice } from './ErrorNotice.js'
 import { FormInput } from './FormInput.js'
+import { MetricGrid } from './MetricGrid.js'
 import { MetricField } from './MetricField.js'
 import { OpenOraclePriceValue } from './OpenOraclePriceValue.js'
 import { TransactionActionButton } from './TransactionActionButton.js'
@@ -107,16 +109,16 @@ function renderQueuedLiquidationStatusCard({
 		return (
 			<TransactionStatusCard
 				title='Liquidation Queued'
-				badge={<span className='badge warn'>Queued</span>}
+				badge={<Badge tone='warning'>Queued</Badge>}
 				metrics={
-					<div className='workflow-metric-grid'>
+					<MetricGrid>
 						<MetricField label='Staged Operation'>#{queuedLiquidationOperation.operationId.toString()}</MetricField>
 						{queuedLiquidationOperation.amount === undefined ? null : (
 							<MetricField label='Amount'>
 								<CurrencyValue value={queuedLiquidationOperation.amount} />
 							</MetricField>
 						)}
-					</div>
+					</MetricGrid>
 				}
 				detail={queuedLiquidationStatus === 'manual-queued' ? 'Another staged operation already holds the auto-execute slot. Execute this staged operation manually with its id after a valid oracle price is available.' : undefined}
 				actions={
@@ -131,15 +133,15 @@ function renderQueuedLiquidationStatusCard({
 		return (
 			<TransactionStatusCard
 				title='Liquidation Failed'
-				badge={<span className='badge blocked'>Failed</span>}
+				badge={<Badge tone='blocked'>Failed</Badge>}
 				detail={securityPoolOverviewResult?.stagedExecution?.errorMessage ?? 'The oracle manager attempted the liquidation immediately, but the security pool rejected it.'}
 				secondaryDetail='Fix the underlying state and submit a new staged operation.'
 			/>
 		)
-	if (queuedLiquidationStatus === 'executed') return <TransactionStatusCard title='Liquidation Executed' badge={<span className='badge ok'>Executed</span>} detail='A valid oracle price was already available, so the liquidation executed immediately and no staged operation was created.' />
+	if (queuedLiquidationStatus === 'executed') return <TransactionStatusCard title='Liquidation Executed' badge={<Badge tone='ok'>Executed</Badge>} detail='A valid oracle price was already available, so the liquidation executed immediately and no staged operation was created.' />
 	if (queuedLiquidationStatus === 'missing')
-		return <TransactionStatusCard title='Liquidation Submitted' badge={<span className='badge warn'>Check State</span>} detail='The transaction succeeded, but no matching staged operation is currently visible for this vault. Refresh staged operations to confirm the latest manager state.' />
-	return <TransactionStatusCard title='Refreshing Liquidation State' badge={<span className='badge muted'>Refreshing</span>} detail='Refreshing the oracle manager to determine whether the liquidation was queued or executed immediately.' />
+		return <TransactionStatusCard title='Liquidation Submitted' badge={<Badge tone='warning'>Check State</Badge>} detail='The transaction succeeded, but no matching staged operation is currently visible for this vault. Refresh staged operations to confirm the latest manager state.' />
+	return <TransactionStatusCard title='Refreshing Liquidation State' badge={<Badge tone='muted'>Refreshing</Badge>} detail='Refreshing the oracle manager to determine whether the liquidation was queued or executed immediately.' />
 }
 export function LiquidationModal({
 	accountAddress,
@@ -410,7 +412,7 @@ export function LiquidationModal({
 								<h4>Caller Vault After Liquidation</h4>
 							</div>
 						</div>
-						<div className='workflow-metric-grid'>
+						<MetricGrid>
 							<MetricField label='REP Collateral'>
 								<CurrencyValue value={liquidationSimulation.callerAfter.repDepositShare} suffix='REP' />
 							</MetricField>
@@ -429,7 +431,7 @@ export function LiquidationModal({
 							<MetricField label='Rep Moved'>
 								<CurrencyValue value={liquidationSimulation.repToMove} suffix='REP' />
 							</MetricField>
-						</div>
+						</MetricGrid>
 					</section>
 				)}
 				<div className='actions liquidation-modal-actions'>

--- a/ui/ts/components/MarketOverviewSection.tsx
+++ b/ui/ts/components/MarketOverviewSection.tsx
@@ -6,7 +6,7 @@ import { CurrencyValue } from './CurrencyValue.js'
 import { ChildUniverseDetails } from './ChildUniverseDetails.js'
 import { DataGrid } from './DataGrid.js'
 import { EntityCard } from './EntityCard.js'
-import { ChildUniversesSection } from './ChildUniversesSection.js'
+import { ChildUniversesSection, ChildUniverseStatusBadge } from './ChildUniversesSection.js'
 import { Question } from './Question.js'
 import { MetricField } from './MetricField.js'
 import { ScalarDeploymentSection } from './ScalarDeploymentSection.js'
@@ -115,7 +115,7 @@ export function MarketOverviewSection({ accountAddress, isMainnet, loadingZoltar
 								pending: zoltarChildUniversePendingOutcomeIndex === child.outcomeIndex,
 								pendingLabel: 'Opening...',
 							})}
-							renderBadge={child => <span className={`badge ${child.exists ? 'ok' : 'pending'}`}>{child.exists ? 'Exists' : 'Not deployed'}</span>}
+							renderBadge={child => <ChildUniverseStatusBadge child={child} />}
 							renderBody={child => <ChildUniverseDetails child={child} />}
 						/>
 					)}

--- a/ui/ts/components/MetricGrid.tsx
+++ b/ui/ts/components/MetricGrid.tsx
@@ -1,0 +1,20 @@
+import { DataGrid } from './DataGrid.js'
+import type { MetricGridProps } from '../types/components.js'
+
+const metricGridVariantClassNames = {
+	context: 'selected-pool-context-grid',
+	default: 'workflow-metric-grid',
+	question: 'question-summary-grid',
+	summary: 'overview-summary-grid',
+	vault: 'workflow-vault-grid',
+} as const
+
+export function MetricGrid({ children, className = '', columns = 'auto', dense = false, variant = 'default' }: MetricGridProps) {
+	const classes = [metricGridVariantClassNames[variant], className].filter(Boolean).join(' ')
+
+	return (
+		<DataGrid className={classes} columns={columns} dense={dense}>
+			{children}
+		</DataGrid>
+	)
+}

--- a/ui/ts/components/OpenOracleSection.tsx
+++ b/ui/ts/components/OpenOracleSection.tsx
@@ -3,8 +3,8 @@ import type { ComponentChildren } from 'preact'
 import { zeroAddress } from 'viem'
 import { ActionLauncherCard } from './ActionLauncherCard.js'
 import { AddressValue } from './AddressValue.js'
+import { Badge } from './Badge.js'
 import { CurrencyValue } from './CurrencyValue.js'
-import { DataGrid } from './DataGrid.js'
 import { EntityCard } from './EntityCard.js'
 import { EnumDropdown, type EnumDropdownOption } from './EnumDropdown.js'
 import { ErrorNotice } from './ErrorNotice.js'
@@ -12,6 +12,7 @@ import { FormInput } from './FormInput.js'
 import { LifecycleStageBanner } from './LifecycleStageBanner.js'
 import { LookupFieldRow } from './LookupFieldRow.js'
 import { LoadingText } from './LoadingText.js'
+import { MetricGrid } from './MetricGrid.js'
 import { MetricField } from './MetricField.js'
 import { OperationModal } from './OperationModal.js'
 import { PaginationControls } from './PaginationControls.js'
@@ -89,7 +90,7 @@ function renderReportSection(
 ) {
 	return (
 		<SectionBlock headingLevel={4} title={title} variant='embedded'>
-			<DataGrid className='question-summary-grid'>{fields.map(field => renderReportField(field.label, field.value))}</DataGrid>
+			<MetricGrid variant='question'>{fields.map(field => renderReportField(field.label, field.value))}</MetricGrid>
 		</SectionBlock>
 	)
 }
@@ -111,7 +112,7 @@ function renderReportSummaryCard(report: OpenOracleReportSummary, onSelectReport
 			key={report.reportId.toString()}
 			className='compact'
 			title={`Report #${report.reportId.toString()}`}
-			badge={<span className={`badge ${statusTone}`}>{status}</span>}
+			badge={<Badge tone={statusTone}>{status}</Badge>}
 			actions={
 				<div className='actions'>
 					<button className='secondary' type='button' onClick={() => onSelectReport(report.reportId)}>
@@ -120,7 +121,7 @@ function renderReportSummaryCard(report: OpenOracleReportSummary, onSelectReport
 				</div>
 			}
 		>
-			<DataGrid className='question-summary-grid'>
+			<MetricGrid variant='question'>
 				{renderReportField(
 					'Token Pair',
 					<>
@@ -133,7 +134,7 @@ function renderReportSummaryCard(report: OpenOracleReportSummary, onSelectReport
 				{renderReportField('Current Amount2', <CurrencyValue value={report.currentAmount2} suffix={report.token2Symbol} units={report.token2Decimals} copyable={false} />)}
 				{renderReportField('Report Timestamp', <TimestampValue timestamp={report.reportTimestamp} zeroText='Awaiting initial report' />)}
 				{renderReportField('Settlement Timestamp', <TimestampValue timestamp={report.settlementTimestamp} zeroText='Not settled' />)}
-			</DataGrid>
+			</MetricGrid>
 		</EntityCard>
 	)
 }
@@ -538,15 +539,15 @@ function renderReportDetailsCard(
 					))}
 				</div>
 			</SectionBlock>
-			<SectionBlock badge={<span className={`badge ${statusTone}`}>{status}</span>} title='Selected Report'>
+			<SectionBlock badge={<Badge tone={statusTone}>{status}</Badge>} title='Selected Report'>
 				{reportControls}
-				<DataGrid className='question-summary-grid'>
+				<MetricGrid variant='question'>
 					{renderReportField('Report ID', openOracleReportDetails.reportId.toString())}
 					{renderReportField('Oracle Address', <AddressValue address={openOracleReportDetails.openOracleAddress} />)}
 					{renderReportField('Current Reporter', openOracleReportDetails.currentReporter === zeroAddress ? 'None (awaiting initial report)' : <AddressValue address={openOracleReportDetails.currentReporter} />)}
 					{renderReportField('Current Price', <CurrencyValue value={openOracleReportDetails.price} suffix={`${openOracleReportDetails.token1Symbol} / ${openOracleReportDetails.token2Symbol}`} units={OPEN_ORACLE_PRICE_UNITS} copyable={false} />)}
 					{renderReportField('Settlement Timestamp', <TimestampValue currentTimestamp={openOracleReportDetails.currentTime} timestamp={openOracleReportDetails.settlementTimestamp} zeroText='Not settled' />)}
-				</DataGrid>
+				</MetricGrid>
 			</SectionBlock>
 			<div className='report-detail-stack'>
 				<ReadOnlyDetailAccordion defaultOpen title='Identity'>

--- a/ui/ts/components/OverviewPanels.tsx
+++ b/ui/ts/components/OverviewPanels.tsx
@@ -1,5 +1,6 @@
 import { RouteHeader } from './RouteHeader.js'
 import { AddressValue } from './AddressValue.js'
+import { Badge } from './Badge.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { DataGrid } from './DataGrid.js'
 import { MetricField } from './MetricField.js'
@@ -51,7 +52,7 @@ export function OverviewPanels({
 			<article className='overview-panel overview-wallet-panel'>
 				<RouteHeader
 					actions={accountState.address === undefined ? <TransactionActionButton idleLabel='Connect wallet' pendingLabel='Connecting...' onClick={onConnect} pending={isConnectingWallet} /> : undefined}
-					badge={universeHasForked ? <span className='badge warn'>Forked</span> : undefined}
+					badge={universeHasForked ? <Badge tone='warning'>Forked</Badge> : undefined}
 					description={operationsHeaderDescription}
 					eyebrow='Operations'
 					title='Augur PLACEHOLDER'

--- a/ui/ts/components/Question.tsx
+++ b/ui/ts/components/Question.tsx
@@ -1,5 +1,5 @@
-import { DataGrid } from './DataGrid.js'
 import { LoadingText } from './LoadingText.js'
+import { MetricGrid } from './MetricGrid.js'
 import { MetricField } from './MetricField.js'
 import { OutcomeChipRow } from './OutcomeChipRow.js'
 import { TimestampValue } from './TimestampValue.js'
@@ -151,7 +151,7 @@ export function Question({ className = '', loading = false, question, showTitle 
 			) : (
 				<p className='detail'>{description}</p>
 			)}
-			<DataGrid className='question-summary-grid'>{summaryFields.map(renderQuestionSummaryField)}</DataGrid>
+			<MetricGrid variant='question'>{summaryFields.map(renderQuestionSummaryField)}</MetricGrid>
 		</div>
 	)
 }

--- a/ui/ts/components/RouteWorkflowPanel.tsx
+++ b/ui/ts/components/RouteWorkflowPanel.tsx
@@ -1,17 +1,10 @@
 import type { RouteWorkflowPanelProps } from '../types/components.js'
+import { SectionBlock } from './SectionBlock.js'
 
 export function RouteWorkflowPanel({ children, className = '', description, showHeader = true, title }: RouteWorkflowPanelProps) {
 	return (
-		<section className={['panel', 'market-panel', className].filter(Boolean).join(' ')}>
-			{showHeader ? (
-				<div className='market-header'>
-					<div>
-						<h2>{title}</h2>
-						{description === undefined ? undefined : <p className='detail'>{description}</p>}
-					</div>
-				</div>
-			) : undefined}
+		<SectionBlock className={['panel', 'market-panel', className].filter(Boolean).join(' ')} description={showHeader ? description : undefined} headingLevel={2} title={showHeader ? title : undefined}>
 			<div className='workflow-stack route-workflow-stack'>{children}</div>
-		</section>
+		</SectionBlock>
 	)
 }

--- a/ui/ts/components/ScalarDeploymentSection.tsx
+++ b/ui/ts/components/ScalarDeploymentSection.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'preact/hooks'
 import type { Address } from 'viem'
-import { ChildUniversesSection } from './ChildUniversesSection.js'
+import { ChildUniversesSection, ChildUniverseStatusBadge } from './ChildUniversesSection.js'
 import { ChildUniverseDetails } from './ChildUniverseDetails.js'
 import { ChildUniverseDeploymentModal } from './ChildUniverseDeploymentModal.js'
 import { ErrorNotice } from './ErrorNotice.js'
@@ -66,13 +66,7 @@ export function ScalarDeploymentSection({ accountAddress, childUniverses, hasFor
 	}, [questionDetails.numTicks, scalarOutcomeTick, selectedScalarTick])
 	return (
 		<WorkflowSubsection badge={<span className='detail'>Scalar forks can deploy one outcome universe at a time.</span>} title='Child Universes'>
-			<ChildUniversesSection
-				childUniverses={childUniverses}
-				emptyMessage='No deployed child universes yet.'
-				headerTitle='Existing Child Universes'
-				renderBadge={child => <span className={`badge ${child.exists ? 'ok' : 'pending'}`}>{child.exists ? 'Exists' : 'Not deployed'}</span>}
-				renderBody={child => <ChildUniverseDetails child={child} />}
-			/>
+			<ChildUniversesSection childUniverses={childUniverses} emptyMessage='No deployed child universes yet.' headerTitle='Existing Child Universes' renderBadge={child => <ChildUniverseStatusBadge child={child} />} renderBody={child => <ChildUniverseDetails child={child} />} />
 			<ScalarOutcomePicker
 				action={
 					<TransactionActionButton
@@ -128,13 +122,7 @@ export function ScalarDeploymentSection({ accountAddress, childUniverses, hasFor
 				title='Create Child Universe'
 			>
 				{selectedScalarChild === undefined ? undefined : (
-					<ChildUniversesSection
-						childUniverses={[selectedScalarChild]}
-						emptyMessage='No child universe selected.'
-						headerTitle='Selected Child Universe'
-						renderBadge={child => <span className={`badge ${child.exists ? 'ok' : 'pending'}`}>{child.exists ? 'Exists' : 'Not deployed'}</span>}
-						renderBody={child => <ChildUniverseDetails child={child} />}
-					/>
+					<ChildUniversesSection childUniverses={[selectedScalarChild]} emptyMessage='No child universe selected.' headerTitle='Selected Child Universe' renderBadge={child => <ChildUniverseStatusBadge child={child} />} renderBody={child => <ChildUniverseDetails child={child} />} />
 				)}
 			</ChildUniverseDeploymentModal>
 			<ErrorNotice message={scalarDeployError} />

--- a/ui/ts/components/SectionBlock.tsx
+++ b/ui/ts/components/SectionBlock.tsx
@@ -1,7 +1,13 @@
 import type { SectionBlockProps } from '../types/components.js'
 
+function getSectionBlockHeadingTag(headingLevel: SectionBlockProps['headingLevel']) {
+	if (headingLevel === 2) return 'h2'
+	if (headingLevel === 4) return 'h4'
+	return 'h3'
+}
+
 export function SectionBlock({ actions, badge, children, className = '', description, density = 'balanced', headingLevel = 3, title, tone = 'default', variant = 'default' }: SectionBlockProps) {
-	const HeadingTag = headingLevel === 4 ? 'h4' : 'h3'
+	const HeadingTag = getSectionBlockHeadingTag(headingLevel)
 	const classes = ['section-block', `tone-${tone}`, `density-${density}`, variant, className].filter(Boolean).join(' ')
 
 	return (

--- a/ui/ts/components/SecurityPoolSummaryMetrics.tsx
+++ b/ui/ts/components/SecurityPoolSummaryMetrics.tsx
@@ -1,6 +1,7 @@
 import type { ComponentChildren } from 'preact'
 import { AddressValue } from './AddressValue.js'
 import { CurrencyValue } from './CurrencyValue.js'
+import { MetricGrid } from './MetricGrid.js'
 import { MetricField } from './MetricField.js'
 import { CollateralizationCircle } from './CollateralizationCircle.js'
 import { OpenOraclePriceValue } from './OpenOraclePriceValue.js'
@@ -9,12 +10,14 @@ import { UniverseLink } from './UniverseLink.js'
 import { openInterestFeePerYearBigint } from '../lib/retentionRate.js'
 import { getPoolCollateralizationPercent } from '../lib/trading.js'
 import { getToneRatioThreshold, getVisualRatio } from '../lib/visualMetrics.js'
+import type { MetricGridVariant } from '../types/components.js'
 import type { ListedSecurityPool } from '../types/contracts.js'
 
 type SecurityPoolSummaryMetricsProps = {
 	children?: ComponentChildren
 	className?: string
 	currentTimestamp?: bigint | undefined
+	metricVariant?: MetricGridVariant
 	pool: ListedSecurityPool
 	repPerEthPrice: bigint | undefined
 	repPerEthSource: 'mock' | 'v3' | 'v4' | undefined
@@ -28,8 +31,9 @@ type SecurityPoolSummaryMetricsProps = {
 
 export function SecurityPoolSummaryMetrics({
 	children,
-	className = 'workflow-metric-grid',
+	className = '',
 	currentTimestamp,
+	metricVariant = 'default',
 	pool,
 	repPerEthPrice,
 	repPerEthSource: _repPerEthSource,
@@ -45,7 +49,7 @@ export function SecurityPoolSummaryMetrics({
 
 	if (variant === 'embedded')
 		return (
-			<div className={className}>
+			<MetricGrid className={className} variant={metricVariant}>
 				{showPoolAddress ? (
 					<MetricField label='Pool Address'>
 						<AddressValue address={pool.securityPoolAddress} />
@@ -70,7 +74,7 @@ export function SecurityPoolSummaryMetrics({
 					<CurrencyValue value={pool.completeSetCollateralAmount} suffix='ETH' /> / <CurrencyValue value={pool.totalSecurityBondAllowance} suffix='ETH' />
 				</MetricField>
 				{children}
-			</div>
+			</MetricGrid>
 		)
 
 	return (

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -2,6 +2,7 @@ import type { ComponentChildren } from 'preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { getAddress, zeroAddress } from 'viem'
 import { AddressValue } from './AddressValue.js'
+import { Badge } from './Badge.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { CollateralizationCircle } from './CollateralizationCircle.js'
 import { ErrorNotice } from './ErrorNotice.js'
@@ -10,6 +11,7 @@ import { ForkAuctionSection } from './ForkAuctionSection.js'
 import { LiquidationModal } from './LiquidationModal.js'
 import { LookupFieldRow } from './LookupFieldRow.js'
 import { LoadingText } from './LoadingText.js'
+import { MetricGrid } from './MetricGrid.js'
 import { MetricField } from './MetricField.js'
 import { OpenOraclePriceValue } from './OpenOraclePriceValue.js'
 import { getQuestionTitle, Question } from './Question.js'
@@ -107,7 +109,7 @@ function getPendingOperationLabel(operation: 'liquidation' | 'setSecurityBondsAl
 function getSecurityPoolStatusBadgeTone(systemState: SecurityPoolLifecycleState | undefined) {
 	if (systemState === 'operational') return 'ok'
 	if (systemState === undefined) return 'muted'
-	return 'warn'
+	return 'warning'
 }
 export function SecurityPoolWorkflowSection({
 	accountState,
@@ -473,7 +475,7 @@ export function SecurityPoolWorkflowSection({
 		selectedPoolSummaryContent = (
 			<div className='selected-pool-context-summary'>
 				<div className='selected-pool-context-overview'>
-					<SecurityPoolSummaryMetrics className='selected-pool-context-grid' pool={selectedPoolSummaryPool} repPerEthPrice={repPerEthPrice} repPerEthSource={repPerEthSource} repPerEthSourceUrl={repPerEthSourceUrl} showTotalBacking>
+					<SecurityPoolSummaryMetrics metricVariant='context' pool={selectedPoolSummaryPool} repPerEthPrice={repPerEthPrice} repPerEthSource={repPerEthSource} repPerEthSourceUrl={repPerEthSourceUrl} showTotalBacking>
 						{selectedPoolSummaryPool.parent === zeroAddress ? undefined : (
 							<MetricField label='Parent Pool'>
 								<SecurityPoolLink securityPoolAddress={selectedPoolSummaryPool.parent} selectedPoolView={selectedPoolView} universeId={selectedPoolParentPool?.universeId} />
@@ -697,56 +699,13 @@ export function SecurityPoolWorkflowSection({
 		if (poolPriceOracleResult.stagedExecution?.success === true && poolPriceOracleResult.stagedExecution.operation === 'withdrawRep' && shouldRefreshSelectedPoolReporting) void reporting.onLoadReporting()
 		if (showSelectedPoolWorkflowDetails && view === 'vaults' && hasLoadedCurrentVault) void securityVault.onLoadSecurityVault()
 	}, [hasLoadedCurrentVault, onRefreshSelectedPoolData, poolPriceOracleResult, reporting.onLoadReporting, securityVault.onLoadSecurityVault, selectedPool?.securityPoolAddress, shouldRefreshSelectedPoolReporting, showSelectedPoolWorkflowDetails, view])
-	const selectSelectedPoolView = (nextView: SelectedPoolView) => {
-		onSelectedPoolViewChange(hasSelectedPoolAddress ? nextView : undefined)
-	}
-	const moveSelectedPoolView = (currentView: SelectedPoolView, direction: 'next' | 'previous' | 'first' | 'last') => {
-		if (selectedPoolWorkflowGuardMessage !== undefined) return undefined
-		const enabledViews = SELECTED_POOL_VIEWS
-		if (enabledViews.length === 0) return undefined
-		if (direction === 'first') return enabledViews[0]
-		if (direction === 'last') return enabledViews[enabledViews.length - 1]
-		const currentIndex = enabledViews.indexOf(currentView)
-		if (currentIndex === -1) return enabledViews[0]
-		const nextIndex = direction === 'next' ? (currentIndex + 1) % enabledViews.length : (currentIndex - 1 + enabledViews.length) % enabledViews.length
-		return enabledViews[nextIndex]
-	}
-	const handleSelectedPoolViewKeyDown = (currentView: SelectedPoolView, event: KeyboardEvent) => {
-		const navigationKey = (() => {
-			if (event.key === 'ArrowDown' || event.key === 'ArrowRight') return 'next'
-			if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') return 'previous'
-			if (event.key === 'Home') return 'first'
-			if (event.key === 'End') return 'last'
-			return undefined
-		})()
-		if (navigationKey === undefined) return
-		const nextView = moveSelectedPoolView(currentView, navigationKey)
-		if (nextView === undefined) return
-		event.preventDefault()
-		selectSelectedPoolView(nextView)
-		const nextTab = document.getElementById(`selected-pool-view-${nextView}`)
-		if (nextTab instanceof HTMLElement) nextTab.focus()
-	}
-	const renderSelectedPoolViewTab = (selectedPoolUiView: SelectedPoolView) => {
-		return (
-			<button
-				aria-label={getSelectedPoolViewLabel(selectedPoolUiView)}
-				key={selectedPoolUiView}
-				aria-selected={view === selectedPoolUiView}
-				className={`view-tab ${view === selectedPoolUiView ? 'active' : ''}`.trim()}
-				disabled={selectedPoolWorkflowGuardMessage !== undefined}
-				id={`selected-pool-view-${selectedPoolUiView}`}
-				onClick={() => selectSelectedPoolView(selectedPoolUiView)}
-				onKeyDown={event => handleSelectedPoolViewKeyDown(selectedPoolUiView, event)}
-				role='tab'
-				tabIndex={view === selectedPoolUiView ? 0 : -1}
-				title={selectedPoolWorkflowGuardMessage}
-				type='button'
-			>
-				{getSelectedPoolViewLabel(selectedPoolUiView)}
-			</button>
-		)
-	}
+	const selectedPoolViewOptions = SELECTED_POOL_VIEWS.map(selectedPoolUiView => ({
+		disabled: selectedPoolWorkflowGuardMessage !== undefined,
+		id: `selected-pool-view-${selectedPoolUiView}`,
+		label: getSelectedPoolViewLabel(selectedPoolUiView),
+		...(selectedPoolWorkflowGuardMessage === undefined ? {} : { reason: selectedPoolWorkflowGuardMessage }),
+		value: selectedPoolUiView,
+	}))
 	return (
 		<RouteWorkflowPanel showHeader={showHeader} title='Selected Pool'>
 			<StickyObjectContext
@@ -754,13 +713,13 @@ export function SecurityPoolWorkflowSection({
 					? {}
 					: {
 							badge: (
-								<span className={`badge ${getSecurityPoolStatusBadgeTone(selectedPoolStateModel.lifecycleState)}`}>
+								<Badge tone={getSecurityPoolStatusBadgeTone(selectedPoolStateModel.lifecycleState)}>
 									{getSecurityPoolStatusBadgeLabel({
 										hasForkActivity: selectedPoolSummaryPool.hasForkActivity,
 										questionOutcome: selectedPoolSummaryPool.questionOutcome,
 										lifecycleState: selectedPoolStateModel.lifecycleState,
 									})}
-								</span>
+								</Badge>
 							),
 						})}
 				sticky={false}
@@ -797,14 +756,19 @@ export function SecurityPoolWorkflowSection({
 			<section className='selected-pool-workspace'>
 				<div className='selected-pool-workspace-grid'>
 					<div className='selected-pool-workflow-rail'>
-						<div aria-label='Selected pool views' className='selected-pool-workflow-nav view-tabs' data-orientation='vertical' data-size='compact' role='tablist'>
-							<div className='selected-pool-workflow-group' role='group' aria-label='Primary pool workflows'>
-								{SELECTED_POOL_PRIMARY_VIEWS.map(renderSelectedPoolViewTab)}
-							</div>
-							<div className='selected-pool-workflow-group selected-pool-workflow-group-secondary' role='group' aria-label='Additional pool workflows'>
-								{SELECTED_POOL_SECONDARY_VIEWS.map(renderSelectedPoolViewTab)}
-							</div>
-						</div>
+						<ViewTabs
+							ariaLabel='Selected pool views'
+							className='selected-pool-workflow-nav'
+							groups={[
+								{ ariaLabel: 'Primary pool workflows', className: 'selected-pool-workflow-group', values: SELECTED_POOL_PRIMARY_VIEWS },
+								{ ariaLabel: 'Additional pool workflows', className: 'selected-pool-workflow-group selected-pool-workflow-group-secondary', values: SELECTED_POOL_SECONDARY_VIEWS },
+							]}
+							orientation='vertical'
+							size='compact'
+							value={view}
+							onChange={nextView => onSelectedPoolViewChange(hasSelectedPoolAddress ? nextView : undefined)}
+							options={selectedPoolViewOptions}
+						/>
 					</div>
 
 					<div className='selected-pool-workflow-content'>
@@ -887,7 +851,7 @@ export function SecurityPoolWorkflowSection({
 															</div>
 														)
 													}}
-													renderBadge={vault => (selectedVaultAddress !== '' && sameCaseInsensitiveText(selectedVaultAddress, vault.vaultAddress) ? <span className='badge ok'>Selected</span> : undefined)}
+													renderBadge={vault => (selectedVaultAddress !== '' && sameCaseInsensitiveText(selectedVaultAddress, vault.vaultAddress) ? <Badge tone='ok'>Selected</Badge> : undefined)}
 													repPerEthPrice={repPerEthPrice}
 													repPerEthSource={repPerEthSource}
 													repPerEthSourceUrl={repPerEthSourceUrl}
@@ -993,7 +957,7 @@ export function SecurityPoolWorkflowSection({
 															{currentPoolOracleManagerDetails?.pendingOperationSlotId === operation.operationId ? <p className='detail'>Auto-exec slot</p> : <p className='detail'>Manual execution</p>}
 														</div>
 													</div>
-													<div className='entity-card-body workflow-metric-grid'>
+													<MetricGrid className='entity-card-body'>
 														<MetricField label='Operation Id'>{operation.operationId.toString()}</MetricField>
 														<MetricField label='Initiator'>
 															<AddressValue address={operation.initiatorVault} />
@@ -1004,7 +968,7 @@ export function SecurityPoolWorkflowSection({
 														<MetricField label='Amount'>
 															<CurrencyValue value={operation.amount} />
 														</MetricField>
-													</div>
+													</MetricGrid>
 												</WarningSurface>
 											))}
 											{activeStagedOperationCount > BigInt(stagedOperations.length) ? (
@@ -1051,7 +1015,7 @@ export function SecurityPoolWorkflowSection({
 
 								{view === 'price-oracle' && loadedSelectedPool !== undefined ? (
 									<SectionBlock density='compact' title='Open Oracle'>
-										<div className='workflow-metric-grid'>
+										<MetricGrid>
 											<MetricField label='Open Oracle Price' valueTagName='span'>
 												<OpenOraclePriceValue
 													currentTimestamp={currentTimestamp}
@@ -1072,7 +1036,7 @@ export function SecurityPoolWorkflowSection({
 													</button>
 												</MetricField>
 											)}
-										</div>
+										</MetricGrid>
 										<ErrorNotice message={poolOracleManagerError} />
 										<div className='actions'>
 											<button className='secondary' onClick={() => onLoadPoolOracleManager(loadedSelectedPool.managerAddress)} disabled={loadingPoolOracleManager}>

--- a/ui/ts/components/SecurityPoolsOverviewSection.tsx
+++ b/ui/ts/components/SecurityPoolsOverviewSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { zeroAddress } from 'viem'
 import { AddressValue } from './AddressValue.js'
+import { Badge } from './Badge.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { EntityCard } from './EntityCard.js'
 import { ErrorNotice } from './ErrorNotice.js'
@@ -212,13 +213,13 @@ export function SecurityPoolsOverviewSection({
 										}
 										variant='record'
 										badge={
-											<span className={`badge ${badgeTone}`}>
+											<Badge tone={badgeTone}>
 												{getSecurityPoolStatusBadgeLabel({
 													hasForkActivity: hasKnownForkActivity,
 													questionOutcome: pool.questionOutcome,
 													lifecycleState: displayState,
 												})}
-											</span>
+											</Badge>
 										}
 										actions={
 											onSelectSecurityPool === undefined ? undefined : (

--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { AddressValue } from './AddressValue.js'
 import { ActionLauncherCard } from './ActionLauncherCard.js'
+import { Badge } from './Badge.js'
 import { CurrencyValue } from './CurrencyValue.js'
 import { EntityCard } from './EntityCard.js'
 import { ErrorNotice } from './ErrorNotice.js'
@@ -8,6 +9,7 @@ import { FormInput } from './FormInput.js'
 import { CollateralizationCircle } from './CollateralizationCircle.js'
 import { LookupFieldRow } from './LookupFieldRow.js'
 import { LoadingText } from './LoadingText.js'
+import { MetricGrid } from './MetricGrid.js'
 import { MetricField } from './MetricField.js'
 import { OperationModal } from './OperationModal.js'
 import { RequirementsChecklist } from './RequirementsChecklist.js'
@@ -110,7 +112,7 @@ export function SelectedVaultSummarySection({ repPerEthPrice, repPerEthSource, r
 			</SectionBlock>
 		)
 	return (
-		<EntityCard badge={<span className={`badge ${selectedVaultIsOwnedByAccount ? 'ok' : 'muted'}`}>{selectedVaultIsOwnedByAccount ? 'Owned' : 'Read only'}</span>} title='Selected Vault' variant='record'>
+		<EntityCard badge={<Badge tone={selectedVaultIsOwnedByAccount ? 'ok' : 'muted'}>{selectedVaultIsOwnedByAccount ? 'Owned' : 'Read only'}</Badge>} title='Selected Vault' variant='record'>
 			{gridContent}
 		</EntityCard>
 	)
@@ -182,14 +184,14 @@ function VaultQueuedOperationStatusCard({
 						<h4>{queuedTitle}</h4>
 					</div>
 				</div>
-				<div className='workflow-metric-grid'>
+				<MetricGrid>
 					<MetricField label='Staged Operation'>{queuedVaultOperation === undefined ? 'Refreshing...' : `#${queuedVaultOperation.operationId.toString()}`}</MetricField>
 					{queuedVaultOperation?.amount === undefined ? null : (
 						<MetricField label='Amount'>
 							<CurrencyValue value={queuedVaultOperation.amount} suffix='REP' />
 						</MetricField>
 					)}
-				</div>
+				</MetricGrid>
 				{status === 'manual-queued' ? <p className='detail'>{manualQueuedDescription}</p> : null}
 				{onViewStagedOperations === undefined ? undefined : (
 					<div className='actions'>
@@ -207,7 +209,7 @@ function VaultQueuedOperationStatusCard({
 					<div>
 						<h4>{failedTitle}</h4>
 					</div>
-					<span className='badge blocked'>Failed</span>
+					<Badge tone='blocked'>Failed</Badge>
 				</div>
 				<p className='detail'>{errorMessage ?? 'The security pool rejected the action.'}</p>
 				<p className='detail'>Fix the underlying state and submit a new staged operation.</p>
@@ -220,7 +222,7 @@ function VaultQueuedOperationStatusCard({
 					<div>
 						<h4>{executedTitle}</h4>
 					</div>
-					<span className='badge ok'>Executed</span>
+					<Badge tone='ok'>Executed</Badge>
 				</div>
 				<p className='detail'>{successDescription}</p>
 			</section>
@@ -242,7 +244,7 @@ function VaultQueuedOperationStatusCard({
 				<div>
 					<h4>{refreshingTitle}</h4>
 				</div>
-				<span className='badge muted'>Refreshing</span>
+				<Badge tone='muted'>Refreshing</Badge>
 			</div>
 			<p className='detail'>{refreshingDescription}</p>
 		</section>
@@ -532,11 +534,11 @@ export function SecurityVaultSection({
 								</button>
 							</div>
 						</label>
-						<div className='workflow-metric-grid'>
+						<MetricGrid>
 							<MetricField label='Wallet REP'>
 								<CurrencyValue value={securityVaultRepBalance} suffix='REP' />
 							</MetricField>
-						</div>
+						</MetricGrid>
 						<TokenApprovalControl
 							actionLabel='depositing REP'
 							allowanceError={securityVaultRepApproval.error}
@@ -605,7 +607,7 @@ export function SecurityVaultSection({
 							selectedVaultIsOwnedByAccount={selectedVaultIsOwnedByAccount}
 							variant='embedded'
 						/>
-						<div className='workflow-metric-grid'>
+						<MetricGrid>
 							<MetricField label={effectiveRepExitMode === 'redeem' ? 'Redeemable REP' : 'Withdrawable REP'}>
 								{(() => {
 									if (effectiveRepExitMode === 'redeem') {
@@ -625,7 +627,7 @@ export function SecurityVaultSection({
 							) : (
 								<MetricField label='Price Valid Until'>{oraclePriceValidUntilTimestamp === undefined ? 'Unavailable' : <TimestampValue timestamp={oraclePriceValidUntilTimestamp} />}</MetricField>
 							)}
-						</div>
+						</MetricGrid>
 						{effectiveRepExitMode === 'redeem' ? null : (
 							<label className='field'>
 								<span>REP Withdraw Amount</span>
@@ -703,12 +705,12 @@ export function SecurityVaultSection({
 							status={securityVaultResult?.action === 'queueSetSecurityBondAllowance' ? queuedVaultOperationStatus : undefined}
 							successDescription='A valid oracle price was already available, so the new bond allowance executed immediately and no staged operation was created.'
 						/>
-						<div className='workflow-metric-grid'>
+						<MetricGrid>
 							<MetricField label='Current Bond Allowance'>
 								<CurrencyValue value={currentSelectedVaultDetails.securityBondAllowance} suffix='ETH' />
 							</MetricField>
 							<MetricField label='Price Valid Until'>{oraclePriceValidUntilTimestamp === undefined ? 'Unavailable' : <TimestampValue timestamp={oraclePriceValidUntilTimestamp} />}</MetricField>
-						</div>
+						</MetricGrid>
 						<label className='field'>
 							<span>Security Bond Allowance Amount</span>
 							<div className='field-inline'>
@@ -745,10 +747,10 @@ export function SecurityVaultSection({
 			</OperationModal>
 
 			<OperationModal isOpen={vaultActionModal === 'claim-fees'} onClose={() => setVaultActionModal(undefined)} title='Claim Fees' description='Confirm the claimable fee balance before submitting the fee redemption for this vault.'>
-				<div className='workflow-metric-grid'>
+				<MetricGrid>
 					<MetricField label='Claimable Fees'>{currentSelectedVaultDetails === undefined ? '—' : <CurrencyValue value={currentSelectedVaultDetails.unpaidEthFees} suffix='ETH' />}</MetricField>
 					<MetricField label='Vault'>{selectedVaultAddress === undefined ? 'None selected' : <AddressValue address={selectedVaultAddress} />}</MetricField>
-				</div>
+				</MetricGrid>
 				<RequirementsChecklist
 					items={[
 						{ key: 'owned', label: 'Selected vault is owned by the connected account', resolved: selectedVaultIsOwnedByAccount },

--- a/ui/ts/components/SimulationBanner.tsx
+++ b/ui/ts/components/SimulationBanner.tsx
@@ -10,6 +10,8 @@ import { getSimulationScenarioDescription, getSimulationScenarioLabel, SIMULATIO
 import { deleteSavedSimulationState, getSavedSimulationStateStorageSummary, persistSavedSimulationState, removeCorruptedSavedSimulationStates, type SavedSimulationStateRecord, type SavedSimulationStateStorageSummary } from '../simulation/savedStates.js'
 import { OperationModal } from './OperationModal.js'
 import { TimestampValue } from './TimestampValue.js'
+import { Badge } from './Badge.js'
+import type { BadgeTone } from '../types/components.js'
 
 const SIMULATION_TIME_PRESETS = [
 	{ label: '+1 hour', seconds: 60n * 60n },
@@ -61,21 +63,21 @@ function hasSavedSimulationStateRoute() {
 	return stateId !== null && stateId.trim() !== ''
 }
 
-function getScenarioStatus(parameters: { bootstrapError: string | undefined; isBootstrapped: boolean }) {
+function getScenarioStatus(parameters: { bootstrapError: string | undefined; isBootstrapped: boolean }): { badgeTone: BadgeTone; label: string } {
 	if (parameters.bootstrapError !== undefined) {
 		return {
-			badgeClassName: 'error',
+			badgeTone: 'blocked',
 			label: 'Error',
 		}
 	}
 	if (parameters.isBootstrapped) {
 		return {
-			badgeClassName: 'ok',
+			badgeTone: 'ok',
 			label: 'Ready',
 		}
 	}
 	return {
-		badgeClassName: 'pending',
+		badgeTone: 'pending',
 		label: 'Bootstrapping',
 	}
 }
@@ -218,7 +220,7 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 				<div className='contract-row simulation-banner-row'>
 					<div className='contract-copy'>
 						<div className='contract-topline'>
-							<span className={`badge ${scenarioStatus.badgeClassName}`}>{scenarioStatus.label}</span>
+							<Badge tone={scenarioStatus.badgeTone}>{scenarioStatus.label}</Badge>
 							<h3>Scenario</h3>
 						</div>
 						<p className='detail'>{scenarioDetail}</p>
@@ -269,7 +271,7 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 				<div className='contract-row simulation-banner-row'>
 					<div className='contract-copy'>
 						<div className='contract-topline'>
-							<span className='badge ok'>Active</span>
+							<Badge tone='ok'>Active</Badge>
 							<h3>QA account</h3>
 						</div>
 					</div>

--- a/ui/ts/components/TokenApprovalControl.tsx
+++ b/ui/ts/components/TokenApprovalControl.tsx
@@ -4,6 +4,7 @@ import { CurrencyValue } from './CurrencyValue.js'
 import { ErrorNotice } from './ErrorNotice.js'
 import { FormInput } from './FormInput.js'
 import { LoadingText } from './LoadingText.js'
+import { MetricGrid } from './MetricGrid.js'
 import { MetricField } from './MetricField.js'
 import { TransactionActionButton } from './TransactionActionButton.js'
 import { formatCurrencyBalance } from '../lib/formatters.js'
@@ -112,14 +113,14 @@ export function TokenApprovalControl({ actionLabel, allowanceError, allowanceLoa
 	})
 	return (
 		<div className='form-grid'>
-			<div className='workflow-metric-grid'>
+			<MetricGrid>
 				<MetricField label={`Required ${tokenSymbol}`}>
 					<CurrencyValue value={requiredAmount} units={tokenUnits} suffix={tokenSymbol} copyable={false} />
 				</MetricField>
 				<MetricField label={`Approved ${tokenSymbol}`}>
 					<ApprovedAmountValue loading={allowanceLoading} value={approvedAmount} requiredAmount={requiredAmount} units={tokenUnits} suffix={tokenSymbol} copyable={false} />
 				</MetricField>
-			</div>
+			</MetricGrid>
 
 			<label className='field approval-amount-field'>
 				<span className='approval-amount-label'>{`${tokenSymbol} Approval Amount`}</span>

--- a/ui/ts/components/TradingSection.tsx
+++ b/ui/ts/components/TradingSection.tsx
@@ -5,6 +5,7 @@ import { CurrencyValue } from './CurrencyValue.js'
 import { EnumDropdown } from './EnumDropdown.js'
 import { ErrorNotice } from './ErrorNotice.js'
 import { FormInput } from './FormInput.js'
+import { MetricGrid } from './MetricGrid.js'
 import { MetricField } from './MetricField.js'
 import { OperationModal } from './OperationModal.js'
 import { RankedBarList } from './RankedBarList.js'
@@ -320,14 +321,14 @@ export function TradingSection({
 
 			<OperationModal description='Review available capacity and confirm the complete-set mint amount before submitting.' isOpen={activeModal === 'mint'} onClose={() => setActiveModal(undefined)} title='Mint Complete Sets'>
 				{selectedPool === undefined ? undefined : (
-					<div className='workflow-metric-grid'>
+					<MetricGrid>
 						<MetricField label='Bond Allowance In Use'>
 							<CurrencyValue value={selectedPool.totalSecurityBondAllowance} suffix='ETH' />
 						</MetricField>
 						<MetricField label='REP Backing'>
 							<CurrencyValue value={selectedPool.totalRepDeposit} suffix='REP' />
 						</MetricField>
-					</div>
+					</MetricGrid>
 				)}
 				<label className='field'>
 					<span>Mint Complete Sets Amount</span>

--- a/ui/ts/components/VaultMetricGrid.tsx
+++ b/ui/ts/components/VaultMetricGrid.tsx
@@ -5,6 +5,17 @@ import type { VaultMetricGridProps } from '../types/components.js'
 import { CollateralizationCircle } from './CollateralizationCircle.js'
 import { getVaultCollateralizationPercent } from '../lib/trading.js'
 
+function VaultPrimaryMetric({ className, label, suffix, value }: { className?: string; label: string; suffix: string; value: bigint | undefined }) {
+	return (
+		<div className={className}>
+			<span>{label}</span>
+			<strong>
+				<CurrencyValue value={value} suffix={suffix} />
+			</strong>
+		</div>
+	)
+}
+
 export function VaultMetricGrid({ className = '', layout = 'grid', escalationEscrowedRep, priceValidUntilTimestamp, repDepositShare, repPerEthPrice, selectedPoolSecurityMultiplier, securityBondAllowance }: VaultMetricGridProps) {
 	const collateralizationPercent = getVaultCollateralizationPercent(repDepositShare, securityBondAllowance, repPerEthPrice)
 	const targetCollateralizationPercent = selectedPoolSecurityMultiplier === undefined ? undefined : selectedPoolSecurityMultiplier * 100n * 10n ** 18n
@@ -13,20 +24,10 @@ export function VaultMetricGrid({ className = '', layout = 'grid', escalationEsc
 		return (
 			<div className={['vault-preview-strip', className].filter(Boolean).join(' ')}>
 				<div className='vault-preview-strip-head'>
-					<div className='vault-preview-allowance'>
-						<span>Security Bond Allowance</span>
-						<strong>
-							<CurrencyValue value={securityBondAllowance} suffix='ETH' />
-						</strong>
-					</div>
+					<VaultPrimaryMetric className='vault-preview-allowance' label='Security Bond Allowance' value={securityBondAllowance} suffix='ETH' />
 				</div>
 				<div className='vault-preview-side-metrics'>
-					<div>
-						<span>REP Collateral</span>
-						<strong>
-							<CurrencyValue value={repDepositShare} suffix='REP' />
-						</strong>
-					</div>
+					<VaultPrimaryMetric label='REP Collateral' value={repDepositShare} suffix='REP' />
 				</div>
 				<div className='vault-preview-meta'>
 					{escalationEscrowedRep === undefined ? null : (
@@ -47,19 +48,9 @@ export function VaultMetricGrid({ className = '', layout = 'grid', escalationEsc
 		<div className={['vault-detail-stage', className].filter(Boolean).join(' ')}>
 			<div className='vault-detail-hero'>
 				<CollateralizationCircle className='vault-detail-collateralization' collateralizationPercent={collateralizationPercent} size='medium' targetCollateralizationPercent={targetCollateralizationPercent} />
-				<div className='vault-detail-hero-primary'>
-					<span>Security Bond Allowance</span>
-					<strong>
-						<CurrencyValue value={securityBondAllowance} suffix='ETH' />
-					</strong>
-				</div>
+				<VaultPrimaryMetric className='vault-detail-hero-primary' label='Security Bond Allowance' value={securityBondAllowance} suffix='ETH' />
 				<div className='vault-detail-hero-secondary'>
-					<div>
-						<span>REP Collateral</span>
-						<strong>
-							<CurrencyValue value={repDepositShare} suffix='REP' />
-						</strong>
-					</div>
+					<VaultPrimaryMetric label='REP Collateral' value={repDepositShare} suffix='REP' />
 				</div>
 			</div>
 			<div className='vault-detail-meta'>

--- a/ui/ts/components/ViewTabs.tsx
+++ b/ui/ts/components/ViewTabs.tsx
@@ -1,7 +1,35 @@
-import type { ViewTabsProps } from '../types/components.js'
-export function ViewTabs<TValue extends string>({ ariaLabel, className = '', onChange, options, orientation = 'horizontal', size = 'default', value, variant = 'subroute' }: ViewTabsProps<TValue>) {
+import type { ViewTabOption, ViewTabsProps } from '../types/components.js'
+
+type IndexedViewTabOption<TValue extends string> = {
+	index: number
+	option: ViewTabOption<TValue>
+}
+
+type ViewTabGroup<TValue extends string> = {
+	ariaLabel: string
+	className?: string
+	options: IndexedViewTabOption<TValue>[]
+}
+
+function buildGroupedOptions<TValue extends string>(groups: ViewTabsProps<TValue>['groups'], indexedOptions: IndexedViewTabOption<TValue>[]): ViewTabGroup<TValue>[] | undefined {
+	if (groups === undefined) return undefined
+	const optionsByValue = new Map(indexedOptions.map(option => [option.option.value, option]))
+	return groups.map(group => {
+		const groupedOptions = group.values.flatMap(groupValue => {
+			const option = optionsByValue.get(groupValue)
+			return option === undefined ? [] : [option]
+		})
+		if (group.className === undefined) return { ariaLabel: group.ariaLabel, options: groupedOptions }
+		return { ariaLabel: group.ariaLabel, className: group.className, options: groupedOptions }
+	})
+}
+
+export function ViewTabs<TValue extends string>({ ariaLabel, className = '', groups, onChange, options, orientation = 'horizontal', size = 'default', value, variant = 'subroute' }: ViewTabsProps<TValue>) {
+	const indexedOptions = options.map((option, index) => ({ index, option }))
+	const groupedOptions = buildGroupedOptions(groups, indexedOptions)
+	const renderedOptions = groupedOptions === undefined ? indexedOptions : groupedOptions.flatMap(group => group.options)
 	const moveSelection = (currentIndex: number, direction: 'next' | 'previous' | 'first' | 'last') => {
-		const enabledOptions = options.map((option, index) => ({ ...option, index })).filter(option => option.disabled !== true)
+		const enabledOptions = renderedOptions.filter(({ option }) => option.disabled !== true)
 		if (enabledOptions.length === 0) return undefined
 		if (direction === 'first') return enabledOptions[0]
 		if (direction === 'last') return enabledOptions[enabledOptions.length - 1]
@@ -26,42 +54,51 @@ export function ViewTabs<TValue extends string>({ ariaLabel, className = '', onC
 		const targetOption = moveSelection(currentIndex, navigationKey)
 		if (targetOption === undefined) return
 		event.preventDefault()
-		onChange(targetOption.value)
-		const nextTabId = targetOption.id ?? `${ariaLabel.toLowerCase().replaceAll(/[^a-z0-9]+/g, '-')}-${String(targetOption.value).toLowerCase()}-tab`
+		onChange(targetOption.option.value)
+		const nextTabId = targetOption.option.id ?? `${ariaLabel.toLowerCase().replaceAll(/[^a-z0-9]+/g, '-')}-${String(targetOption.option.value).toLowerCase()}-tab`
 		const nextTab = document.getElementById(nextTabId)
 		if (nextTab instanceof HTMLElement) nextTab.focus()
 	}
+	const renderOption = (option: ViewTabOption<TValue>, index: number) => {
+		const active = option.value === value
+		const tabId = option.id ?? `${ariaLabel.toLowerCase().replaceAll(/[^a-z0-9]+/g, '-')}-${String(option.value).toLowerCase()}-tab`
+		const commonProps = {
+			className: `view-tab ${active ? 'active' : ''}`.trim(),
+			id: tabId,
+			role: 'tab',
+			'aria-controls': option.panelId,
+			'aria-selected': active,
+			tabIndex: active ? 0 : -1,
+			title: option.reason,
+			onClick: () => {
+				if (option.disabled) return
+				onChange(option.value)
+			},
+			onKeyDown: (event: KeyboardEvent) => handleKeyDown(index, event),
+		} as const
+		if (option.href !== undefined && option.disabled !== true)
+			return (
+				<a key={option.value} {...commonProps} href={option.href}>
+					{option.label}
+				</a>
+			)
+		return (
+			<button key={option.value} {...commonProps} type='button' disabled={option.disabled}>
+				{option.label}
+			</button>
+		)
+	}
+	const renderOptions = () => {
+		if (groupedOptions === undefined) return renderedOptions.map(({ index, option }) => renderOption(option, index))
+		return groupedOptions.map(group => (
+			<div key={group.ariaLabel} className={group.className} role='group' aria-label={group.ariaLabel}>
+				{group.options.map(({ index, option }) => renderOption(option, index))}
+			</div>
+		))
+	}
 	return (
 		<div className={`view-tabs ${variant} ${className}`.trim()} data-orientation={orientation} data-size={size} role='tablist' aria-label={ariaLabel}>
-			{options.map((option, index) => {
-				const active = option.value === value
-				const tabId = option.id ?? `${ariaLabel.toLowerCase().replaceAll(/[^a-z0-9]+/g, '-')}-${String(option.value).toLowerCase()}-tab`
-				const commonProps = {
-					className: `view-tab ${active ? 'active' : ''}`.trim(),
-					id: tabId,
-					role: 'tab',
-					'aria-controls': option.panelId,
-					'aria-selected': active,
-					tabIndex: active ? 0 : -1,
-					title: option.reason,
-					onClick: () => {
-						if (option.disabled) return
-						onChange(option.value)
-					},
-					onKeyDown: (event: KeyboardEvent) => handleKeyDown(index, event),
-				} as const
-				if (option.href !== undefined && option.disabled !== true)
-					return (
-						<a key={option.value} {...commonProps} href={option.href}>
-							{option.label}
-						</a>
-					)
-				return (
-					<button key={option.value} {...commonProps} type='button' disabled={option.disabled}>
-						{option.label}
-					</button>
-				)
-			})}
+			{renderOptions()}
 		</div>
 	)
 }

--- a/ui/ts/components/ViewTabs.tsx
+++ b/ui/ts/components/ViewTabs.tsx
@@ -14,10 +14,14 @@ type ViewTabGroup<TValue extends string> = {
 function buildGroupedOptions<TValue extends string>(groups: ViewTabsProps<TValue>['groups'], indexedOptions: IndexedViewTabOption<TValue>[]): ViewTabGroup<TValue>[] | undefined {
 	if (groups === undefined) return undefined
 	const optionsByValue = new Map(indexedOptions.map(option => [option.option.value, option]))
+	const renderedValues = new Set<TValue>()
 	return groups.map(group => {
 		const groupedOptions = group.values.flatMap(groupValue => {
+			if (renderedValues.has(groupValue)) return []
 			const option = optionsByValue.get(groupValue)
-			return option === undefined ? [] : [option]
+			if (option === undefined) return []
+			renderedValues.add(groupValue)
+			return [option]
 		})
 		if (group.className === undefined) return { ariaLabel: group.ariaLabel, options: groupedOptions }
 		return { ariaLabel: group.ariaLabel, className: group.className, options: groupedOptions }

--- a/ui/ts/lib/openOracle.ts
+++ b/ui/ts/lib/openOracle.ts
@@ -166,14 +166,14 @@ export function getOpenOracleReportStatus(report: Pick<OpenOracleReportSummary, 
 	if (report.disputeOccurred) return 'Disputed'
 	return 'Pending'
 }
-export function getOpenOracleReportStatusTone(status: OpenOracleReportStatus): 'blocked' | 'muted' | 'error' | 'ok' {
+export function getOpenOracleReportStatusTone(status: OpenOracleReportStatus): 'blocked' | 'danger' | 'muted' | 'ok' {
 	switch (status) {
 		case 'Awaiting Initial Report':
 			return 'blocked'
 		case 'Pending':
 			return 'muted'
 		case 'Disputed':
-			return 'error'
+			return 'danger'
 		case 'Settled':
 			return 'ok'
 		default:

--- a/ui/ts/tests/transactionStatusCard.test.tsx
+++ b/ui/ts/tests/transactionStatusCard.test.tsx
@@ -4,6 +4,8 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { within } from './testUtils/queries'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
+import { Badge } from '../components/Badge.js'
+import { MetricGrid } from '../components/MetricGrid.js'
 import { TransactionStatusCard } from '../components/TransactionStatusCard.js'
 
 describe('TransactionStatusCard', () => {
@@ -23,7 +25,7 @@ describe('TransactionStatusCard', () => {
 	})
 
 	test('renders title, badge, and detail', async () => {
-		const renderedComponent = await renderIntoDocument(<TransactionStatusCard title='Liquidation Submitted' badge={<span className='badge warn'>Check State</span>} detail='Refresh staged operations.' />)
+		const renderedComponent = await renderIntoDocument(<TransactionStatusCard title='Liquidation Submitted' badge={<Badge tone='warning'>Check State</Badge>} detail='Refresh staged operations.' />)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
@@ -36,12 +38,12 @@ describe('TransactionStatusCard', () => {
 		const renderedComponent = await renderIntoDocument(
 			<TransactionStatusCard
 				title='REP Withdrawal Queued'
-				badge={<span className='badge warn'>Queued</span>}
+				badge={<Badge tone='warning'>Queued</Badge>}
 				metrics={
-					<div className='workflow-metric-grid'>
+					<MetricGrid>
 						<div>Staged Operation</div>
 						<div>#7</div>
-					</div>
+					</MetricGrid>
 				}
 			/>,
 		)
@@ -56,7 +58,7 @@ describe('TransactionStatusCard', () => {
 		const renderedComponent = await renderIntoDocument(
 			<TransactionStatusCard
 				title='Bond Allowance Queued'
-				badge={<span className='badge warn'>Queued</span>}
+				badge={<Badge tone='warning'>Queued</Badge>}
 				actions={
 					<button className='secondary' type='button'>
 						View In Staged Operations

--- a/ui/ts/tests/viewTabs.test.tsx
+++ b/ui/ts/tests/viewTabs.test.tsx
@@ -165,4 +165,26 @@ describe('ViewTabs', () => {
 		expect(selectedValue).toBe('reports')
 		expect(document.activeElement).toBe(reportsTab)
 	})
+
+	test('renders duplicate grouped values only once', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<ViewTabs
+				ariaLabel='Duplicate Grouped Tabs'
+				value='overview'
+				onChange={() => undefined}
+				groups={[
+					{ ariaLabel: 'Primary tabs', values: ['overview', 'reports'] },
+					{ ariaLabel: 'Repeated tabs', values: ['reports'] },
+				]}
+				options={[
+					{ label: 'Overview', value: 'overview' },
+					{ label: 'Reports', value: 'reports' },
+				]}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const reportsTabs = within(document.body).getAllByRole('tab', { name: 'Reports' })
+		expect(reportsTabs).toHaveLength(1)
+	})
 })

--- a/ui/ts/tests/viewTabs.test.tsx
+++ b/ui/ts/tests/viewTabs.test.tsx
@@ -130,4 +130,39 @@ describe('ViewTabs', () => {
 		expect(overviewLink.tagName).toBe('A')
 		expect(overviewLink.getAttribute('href')).toBe('#/overview')
 	})
+
+	test('uses rendered grouped options for keyboard navigation', async () => {
+		let selectedValue = 'overview'
+		const renderedComponent = await renderIntoDocument(
+			<ViewTabs
+				ariaLabel='Grouped Tabs'
+				value={selectedValue}
+				onChange={value => {
+					selectedValue = value
+				}}
+				groups={[
+					{ ariaLabel: 'Primary tabs', values: ['overview'] },
+					{ ariaLabel: 'Secondary tabs', values: ['reports'] },
+				]}
+				options={[
+					{ label: 'Overview', value: 'overview' },
+					{ label: 'Hidden', value: 'hidden' },
+					{ label: 'Reports', value: 'reports' },
+				]}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const overviewTab = within(document.body).getByRole('tab', { name: 'Overview' })
+		const reportsTab = within(document.body).getByRole('tab', { name: 'Reports' })
+		expect(within(document.body).queryByRole('tab', { name: 'Hidden' })).toBeNull()
+
+		overviewTab.focus()
+		await act(() => {
+			fireEvent.keyDown(overviewTab, { key: 'ArrowRight' })
+		})
+
+		expect(selectedValue).toBe('reports')
+		expect(document.activeElement).toBe(reportsTab)
+	})
 })

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -51,6 +51,8 @@ export type ActionAvailability = {
 
 export type NoticeTone = 'blocking' | 'warning' | 'pending' | 'success'
 
+export type BadgeTone = 'blocked' | 'danger' | 'muted' | 'ok' | 'pending' | 'warning'
+
 export type NoticeItem = {
 	detail: ComponentChildren
 	id: string
@@ -138,7 +140,7 @@ export type SectionBlockProps = {
 	className?: string
 	description?: ComponentChildren
 	density?: 'balanced' | 'compact'
-	headingLevel?: 3 | 4
+	headingLevel?: 2 | 3 | 4
 	title?: ComponentChildren
 	tone?: 'critical' | 'default' | 'muted'
 	variant?: 'default' | 'embedded'
@@ -157,6 +159,16 @@ export type DataGridProps = {
 	className?: string
 	columns?: 2 | 3 | 4 | 'auto'
 	dense?: boolean
+}
+
+export type MetricGridVariant = 'context' | 'default' | 'question' | 'summary' | 'vault'
+
+export type MetricGridProps = {
+	children: ComponentChildren
+	className?: string
+	columns?: 2 | 3 | 4 | 'auto'
+	dense?: boolean
+	variant?: MetricGridVariant
 }
 
 export type ProgressMeterProps = {
@@ -258,6 +270,11 @@ export type ViewTabOption<TValue extends string> = {
 export type ViewTabsProps<TValue extends string> = {
 	ariaLabel: string
 	className?: string
+	groups?: Array<{
+		ariaLabel: string
+		className?: string
+		values: readonly TValue[]
+	}>
 	onChange: (value: TValue) => void
 	orientation?: 'horizontal' | 'vertical'
 	options: ViewTabOption<TValue>[]

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -270,6 +270,7 @@ export type ViewTabOption<TValue extends string> = {
 export type ViewTabsProps<TValue extends string> = {
 	ariaLabel: string
 	className?: string
+	/** When provided, only grouped values are rendered. Duplicate values render at their first grouped position. */
 	groups?: Array<{
 		ariaLabel: string
 		className?: string


### PR DESCRIPTION
## Summary
- Added reusable `Badge` component (`ui/ts/components/Badge.tsx`) and migrated badge rendering across deployment, workflow, trading, oracle, liquidation, and overview components to use normalized tone props.
- Added reusable `MetricGrid` component (`ui/ts/components/MetricGrid.tsx`) and replaced repeated `DataGrid` + metric-class patterns with variant-based usage in question, oracle, liquidation, and security pool summaries.
- Centralized child-universe badge rendering with `ChildUniverseStatusBadge` to remove duplicated status badge JSX.
- Updated workflow panel and section helpers (`RouteWorkflowPanel`, `SectionBlock`) to use shared structure helpers and reusable header/tone behavior.
- Updated component typing (`ui/ts/types/components.ts`) and associated tests (`ui/ts/tests/transactionStatusCard.test.tsx`, `ui/ts/tests/viewTabs.test.tsx`) to align with the refactor and new abstractions.
- Removed obsolete CSS tab-link/subtab-link style blocks from `ui/css/index.css` after adopting shared tab abstractions and reduced duplicated styling concerns.

## Testing
- Not run: `bun run tsc` (not requested in this context).
- Not run: `bun run test` (not requested in this context).
- Not run: `bun run format` (not requested in this context).
- Not run: `bun run check` (not requested in this context).
- Not run: `bun run knip` (not requested in this context).
- Not run: follow-up merge from `main` into branch `t3code/5d3f3b0d` (not requested in this context).