### PR TITLE
Document auction tick-domain bounds and add auction tick fuzz tests

### DIFF
--- a/docs/auction-design.md
+++ b/docs/auction-design.md
@@ -1,0 +1,23 @@
+# Uniform Price Dual Cap Batch Auction
+
+## Gas and Spam Bounds
+
+The auction intentionally does not cap total bids or active price levels. A cap
+would let an attacker spend ETH to fill the available bid slots or tick slots
+early, preventing later valid bidders from participating.
+
+Finalization remains bounded without those caps because it does not iterate over
+raw bids. Bids at the same tick append to per-tick arrays for later paged
+withdrawal, while clearing uses aggregate ETH totals stored in an AVL tree keyed
+by tick. The valid tick range is finite: `[-524288, 524288]`, or `1,048,577`
+possible price levels. An AVL tree containing every possible tick has maximum
+height `28`, so `finalize()` only descends bounded tree paths and pruned
+subtrees.
+
+The gas tests cover both funded and underfunded finalization over a synthetic
+max-depth tree for the full tick domain. They assert each path remains below
+`20,000,000` gas and print the measured gas values in the test output.
+
+Bid-count spam at one tick does not change finalization gas or clearing
+correctness because same-tick bids only increase that tick's aggregate ETH. They
+are settled later through caller-supplied, paged bid indexes.

--- a/knip.json
+++ b/knip.json
@@ -1,5 +1,5 @@
 {
-	"entry": ["solidity/ts/compile.ts", "solidity/ts/gas-costs.ts", "solidity/ts/tests/**/*.ts", "solidity/ts/types/bun-test.d.ts", "solidity/ts/types/index.d.ts", "ui/ts/tests/**/*.ts", "ui/ts/tests/**/*.tsx", "ui/ts/index.ts", "ui/build/vendor.mts", "ui/build/tests.mts"],
+	"entry": ["solidity/ts/compile.ts", "solidity/ts/gas-costs.ts", "solidity/ts/tests/**/*.ts", "solidity/ts/fuzz/**/*.ts", "solidity/ts/types/bun-test.d.ts", "solidity/ts/types/index.d.ts", "ui/ts/tests/**/*.ts", "ui/ts/tests/**/*.tsx", "ui/ts/index.ts", "ui/build/vendor.mts", "ui/build/tests.mts"],
 	"project": ["solidity/ts/**/*.ts", "ui/ts/**/*.ts", "ui/ts/**/*.tsx", "ui/build/**/*.mts"],
 	"ignoreDependencies": ["better-typescript-lib"],
 	"ignoreIssues": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
 		"ui:vendor": "cd ui && bun ./build/vendor.mts",
 		"gas-costs": "cd solidity && bun run gas-costs",
 		"test": "bun run ensure-contract-artifacts && bun run check:shared-dependencies && bun run tsc && bun test --parallel=4 --timeout 300000",
+		"test:auction-fuzz": "bun run ensure-contract-artifacts && bun run check:shared-dependencies && bun run tsc && bun test --timeout 300000 ./solidity/ts/fuzz/auctionTickMath.fuzz.ts",
 		"coverage:ui": "bun run ensure-shared-build && bun run check:shared-dependencies && bun test --isolate --coverage --coverage-reporter=lcov --coverage-reporter=text --coverage-dir=coverage/ui ui/ts/tests",
 		"coverage:contracts:ts": "bun run ensure-contract-artifacts && bun test --coverage --coverage-reporter=lcov --coverage-reporter=text --coverage-dir=coverage/contracts-ts solidity/ts/tests",
 		"coverage:contracts:bytecode": "bun run ensure-contract-artifacts && SOLIDITY_BYTECODE_COVERAGE=1 bun test solidity/ts/tests",

--- a/solidity/contracts/peripherals/UniformPriceDualCapBatchAuction.sol
+++ b/solidity/contracts/peripherals/UniformPriceDualCapBatchAuction.sol
@@ -3,7 +3,11 @@ pragma solidity 0.8.35;
 
 import { IUniformPriceDualCapBatchAuction } from './interfaces/IUniformPriceDualCapBatchAuction.sol';
 
-// TODO: figure out if this can run up issues with gas and figure out how to avoid them
+// Gas bound: finalize() descends AVL aggregate paths and never scans bids. The
+// tick range admits at most 1,048,577 distinct price levels, so an AVL tree over
+// every possible tick has height <= 28. The auction intentionally does not add a
+// bid or tick cap because valid price levels must remain open during bidding; see
+// the synthetic max-depth gas tests.
 contract UniformPriceDualCapBatchAuction {
 	struct Node {
 		int256 tick; // ETH/REP price (tick)
@@ -32,7 +36,7 @@ contract UniformPriceDualCapBatchAuction {
 	int256 constant MAX_TICK = 524288;
 	uint256 constant AUCTION_TIME = 1 weeks;
 	uint256 constant PRICE_PRECISION = 1e18;
-	uint256 constant MAX_NUMBER_BINDING_BIDS = 100_000;
+	uint256 constant MIN_BID_SIZE_DIVISOR = 100_000;
 
 	mapping(uint256 => Node) private nodes;
 	mapping(int256 => Bid[]) private bidsAtTick;
@@ -47,7 +51,7 @@ contract UniformPriceDualCapBatchAuction {
 	bool public finalized;
 	int256 public clearingTick;
 	uint256 public ethFilledAtClearing;
-	uint256 public ethRaised; // TODO, if ethRaised is less than ethRaiseCap (underfunded), we should give all the rep we have to bidders
+	uint256 public ethRaised;
 	uint256 public totalRepPurchased;
 
 	uint256 public auctionStarted;
@@ -97,7 +101,7 @@ contract UniformPriceDualCapBatchAuction {
 		maxRepBeingSold = _maxRepBeingSold;
 		ethRaiseCap = _ethRaiseCap;
 		auctionStarted = block.timestamp;
-		minBidSize = _ethRaiseCap / MAX_NUMBER_BINDING_BIDS;
+		minBidSize = _ethRaiseCap / MIN_BID_SIZE_DIVISOR;
 		if (minBidSize < 1) minBidSize = 1;
 
 		emit AuctionStarted(_ethRaiseCap, _maxRepBeingSold, minBidSize);

--- a/solidity/ts/fuzz/auctionTickMath.fuzz.ts
+++ b/solidity/ts/fuzz/auctionTickMath.fuzz.ts
@@ -1,0 +1,80 @@
+import { beforeAll, describe, setDefaultTimeout, test } from 'bun:test'
+import assert from 'assert'
+import { type Address } from 'viem'
+import { peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction } from '../types/contractArtifact'
+import { AnvilWindowEthereum } from '../testsuite/simulator/AnvilWindowEthereum'
+import { TEST_TIMEOUT_MS, useIsolatedAnvilNode } from '../testsuite/simulator/useIsolatedAnvilNode'
+import { TEST_ADDRESSES } from '../testsuite/simulator/utils/constants'
+import { ensureInfraDeployed } from '../testsuite/simulator/utils/contracts/deployPeripherals'
+import { getUniformPriceDualCapBatchAuctionAddress } from '../testsuite/simulator/utils/contracts/deployments'
+import { deployUniformPriceDualCapBatchAuction } from '../testsuite/simulator/utils/contracts/auction'
+import { ensureZoltarDeployed } from '../testsuite/simulator/utils/contracts/zoltar'
+import { tickToPrice } from '../testsuite/simulator/utils/tickMath'
+import { createWriteClient, WriteClient } from '../testsuite/simulator/utils/viem'
+import { contractExists, setupTestAccounts } from '../testsuite/simulator/utils/utilities'
+
+const MIN_TICK = -524288n
+const MAX_TICK = 524288n
+const FUZZ_CASES = 2_000
+
+setDefaultTimeout(TEST_TIMEOUT_MS)
+
+const nextRandomUint32 = (state: bigint): bigint => (state * 1664525n + 1013904223n) & 0xffffffffn
+
+const buildFuzzTicks = () => {
+	const ticks = new Set<bigint>([MIN_TICK, MIN_TICK + 1n, -1n, 0n, 1n, MAX_TICK - 1n, MAX_TICK])
+	let state = 0xdecafbadn
+	const tickDomainSize = MAX_TICK - MIN_TICK + 1n
+	while (ticks.size < FUZZ_CASES) {
+		state = nextRandomUint32(state)
+		ticks.add(MIN_TICK + (state % tickDomainSize))
+	}
+	return [...ticks]
+}
+
+describe('Auction tick math fuzz', () => {
+	const { getAnvilWindowEthereum, setBaselineSnapshot } = useIsolatedAnvilNode()
+	let mockWindow: AnvilWindowEthereum
+	let client: WriteClient
+	let auctionAddress: Address
+
+	beforeAll(async () => {
+		mockWindow = getAnvilWindowEthereum()
+		await setupTestAccounts(mockWindow)
+		client = createWriteClient(mockWindow, TEST_ADDRESSES[0], 0)
+		await ensureZoltarDeployed(client)
+		await ensureInfraDeployed(client)
+		await deployUniformPriceDualCapBatchAuction(client, client.account.address)
+		auctionAddress = getUniformPriceDualCapBatchAuctionAddress(client.account.address)
+		assert.ok(await contractExists(client, auctionAddress), 'auction exists')
+		await setBaselineSnapshot()
+	})
+
+	test('tickToPrice matches the TypeScript model across deterministic fuzz ticks', async () => {
+		for (const tick of buildFuzzTicks()) {
+			const solidityPrice = await client.readContract({
+				abi: peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.abi,
+				functionName: 'tickToPrice',
+				address: auctionAddress,
+				args: [tick],
+			})
+			const typescriptPrice = tickToPrice(tick)
+			assert.strictEqual(solidityPrice, typescriptPrice, `tickToPrice mismatch at tick ${tick.toString()}`)
+		}
+	})
+
+	test('tickToPrice rejects ticks outside the finite domain', async () => {
+		for (const tick of [MIN_TICK - 1n, MAX_TICK + 1n]) {
+			await assert.rejects(
+				async () =>
+					await client.readContract({
+						abi: peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.abi,
+						functionName: 'tickToPrice',
+						address: auctionAddress,
+						args: [tick],
+					}),
+				/tick out of bounds/,
+			)
+		}
+	})
+})

--- a/solidity/ts/tests/auction.test.ts
+++ b/solidity/ts/tests/auction.test.ts
@@ -58,7 +58,7 @@ const AUCTION_MAX_REP_BEING_SOLD_SLOT = 5n
 const AUCTION_ETH_RAISE_CAP_SLOT = 6n
 const BID_STRUCT_SLOT_COUNT = 4n
 const NODE_STRUCT_SLOT_COUNT = 8n
-const MAX_DISTINCT_TICK_COUNT = 1_048_577n
+const MAX_DISTINCT_TICK_COUNT = MAX_TICK - MIN_TICK + 1n
 const FINALIZE_GAS_LIMIT = 20_000_000n
 
 setDefaultTimeout(TEST_TIMEOUT_MS)
@@ -282,12 +282,12 @@ describe('Auction', () => {
 		return height
 	}
 
-	const buildSyntheticWorstCaseFinalizeStateDiff = (height: bigint, bidAmount: bigint) => {
+	const buildSyntheticWorstCaseFinalizeStateDiff = (height: bigint, bidAmount: bigint, maxRepBeingSold: bigint = 1n, ethRaiseCap: bigint = height * bidAmount + bidAmount) => {
 		const stateDiff: Record<string, bigint> = {
 			[formatStorageSlot(AUCTION_ROOT_SLOT)]: 1n,
 			[formatStorageSlot(AUCTION_NEXT_ID_SLOT)]: height + 1n,
-			[formatStorageSlot(AUCTION_MAX_REP_BEING_SOLD_SLOT)]: 1n,
-			[formatStorageSlot(AUCTION_ETH_RAISE_CAP_SLOT)]: height * bidAmount + bidAmount,
+			[formatStorageSlot(AUCTION_MAX_REP_BEING_SOLD_SLOT)]: maxRepBeingSold,
+			[formatStorageSlot(AUCTION_ETH_RAISE_CAP_SLOT)]: ethRaiseCap,
 		}
 
 		for (let nodeId = 1n; nodeId <= height; nodeId++) {
@@ -317,6 +317,32 @@ describe('Auction', () => {
 			[localAuctionAddress]: {
 				balance: height * bidAmount,
 				stateDiff: buildSyntheticWorstCaseFinalizeStateDiff(height, bidAmount),
+			},
+		})
+
+		return await ownerClient.estimateContractGas({
+			abi: peripherals_UniformPriceDualCapBatchAuction_UniformPriceDualCapBatchAuction.abi,
+			functionName: 'finalize',
+			address: localAuctionAddress,
+			args: [],
+		})
+	}
+
+	const estimateUnderfundedFinalizeGasForSyntheticWorstCaseDepth = async (height: bigint, clientIndex: number) => {
+		const ownerClient = createTestClient(clientIndex)
+		await deployUniformPriceDualCapBatchAuction(client, ownerClient.account.address)
+		const localAuctionAddress = getUniformPriceDualCapBatchAuctionAddress(ownerClient.account.address)
+		const bidAmount = 1n * ATTOETH_PER_ETH
+		const totalEth = height * bidAmount
+		const maxRepBeingSold = totalEth + 1n
+		const ethRaiseCap = totalEth + bidAmount
+		await startAuction(ownerClient, localAuctionAddress, ethRaiseCap, maxRepBeingSold)
+		await mockWindow.advanceTime(AUCTION_TIME + 1n)
+
+		await mockWindow.addStateOverrides({
+			[localAuctionAddress]: {
+				balance: totalEth,
+				stateDiff: buildSyntheticWorstCaseFinalizeStateDiff(height, bidAmount, maxRepBeingSold, ethRaiseCap),
 			},
 		})
 
@@ -653,13 +679,24 @@ describe('Auction', () => {
 			assert.ok(gasWithThirtyTwoDistinctTicks < gasWithThirtyTwoSameTickBids * 2n, `distinct price levels should stay close to same-tick finalize gas after subtree pruning: same tick=${gasWithThirtyTwoSameTickBids.toString()}, distinct ticks=${gasWithThirtyTwoDistinctTicks.toString()}`)
 		})
 
-		test('finalize stays under 20 million gas on a synthetic max-depth clearing path for the full tick cap', async () => {
-			const maxAvlHeightWithinTickCap = getMaxAvlHeightWithinNodeCap(MAX_DISTINCT_TICK_COUNT)
-			strictEqualTypeSafe(maxAvlHeightWithinTickCap, 28n, 'unexpected AVL height bound for the tick cap')
+		test('finalize stays under 20 million gas on a synthetic max-depth clearing path for the full tick domain', async () => {
+			const maxAvlHeightWithinTickDomain = getMaxAvlHeightWithinNodeCap(MAX_DISTINCT_TICK_COUNT)
+			strictEqualTypeSafe(maxAvlHeightWithinTickDomain, 28n, 'unexpected AVL height bound for the tick domain')
 
-			const finalizeGas = await estimateFinalizeGasForSyntheticWorstCaseDepth(maxAvlHeightWithinTickCap, 1)
+			const finalizeGas = await estimateFinalizeGasForSyntheticWorstCaseDepth(maxAvlHeightWithinTickDomain, 1)
+			console.info(`auction max-depth funded finalize gas: ${finalizeGas.toString()} (height=${maxAvlHeightWithinTickDomain.toString()}, limit=${FINALIZE_GAS_LIMIT.toString()})`)
 
-			assert.ok(finalizeGas < FINALIZE_GAS_LIMIT, `finalize gas should stay below ${FINALIZE_GAS_LIMIT.toString()} for the synthetic max-depth clearing path: gas=${finalizeGas.toString()}, height=${maxAvlHeightWithinTickCap.toString()}`)
+			assert.ok(finalizeGas < FINALIZE_GAS_LIMIT, `finalize gas should stay below ${FINALIZE_GAS_LIMIT.toString()} for the synthetic max-depth clearing path: gas=${finalizeGas.toString()}, height=${maxAvlHeightWithinTickDomain.toString()}`)
+		})
+
+		test('underfunded finalize stays under 20 million gas on a synthetic max-depth tick domain', async () => {
+			const maxAvlHeightWithinTickDomain = getMaxAvlHeightWithinNodeCap(MAX_DISTINCT_TICK_COUNT)
+			strictEqualTypeSafe(maxAvlHeightWithinTickDomain, 28n, 'unexpected AVL height bound for the tick domain')
+
+			const finalizeGas = await estimateUnderfundedFinalizeGasForSyntheticWorstCaseDepth(maxAvlHeightWithinTickDomain, 1)
+			console.info(`auction max-depth underfunded finalize gas: ${finalizeGas.toString()} (height=${maxAvlHeightWithinTickDomain.toString()}, limit=${FINALIZE_GAS_LIMIT.toString()})`)
+
+			assert.ok(finalizeGas < FINALIZE_GAS_LIMIT, `underfunded finalize gas should stay below ${FINALIZE_GAS_LIMIT.toString()} for the synthetic max-depth tree: gas=${finalizeGas.toString()}, height=${maxAvlHeightWithinTickDomain.toString()}`)
 		})
 
 		test('winner unaffected after bidder refunds multiple losing bids', async () => {
@@ -809,6 +846,18 @@ describe('Auction', () => {
 			await assert.rejects(async () => await submitBid(client, auctionAddress, 0n, 0n), 'invalid')
 
 			await submitBid(client, auctionAddress, 0n, 1n)
+		})
+
+		test('submitBid accepts both finite tick-domain edges', async () => {
+			const ethRaiseCap = 100n * 10n ** 18n
+			const maxRepBeingSold = 10n * 10n ** 18n
+			await startAuction(client, auctionAddress, ethRaiseCap, maxRepBeingSold)
+
+			await submitBid(client, auctionAddress, MIN_TICK, 1n * 10n ** 18n)
+			await submitBid(client, auctionAddress, MAX_TICK, 1n * 10n ** 18n)
+
+			strictEqualTypeSafe(await getBidCountAtTick(client, auctionAddress, MIN_TICK), 1n, 'minimum tick bid count')
+			strictEqualTypeSafe(await getBidCountAtTick(client, auctionAddress, MAX_TICK), 1n, 'maximum tick bid count')
 		})
 
 		test('submitBid invalid states: before auction start and after finalize', async () => {


### PR DESCRIPTION
## Summary
- Added `docs/auction-design.md` documenting finite tick-domain bounds, gas rationale, and why bid/tick caps are intentionally omitted.
- Updated `knip.json` entry points to include `solidity/ts/fuzz/**/*.ts` so fuzz tests are included in dead-code analysis.
- Added `test:auction-fuzz` script to `package.json` for targeted auction tick math fuzz execution.
- Updated `UniformPriceDualCapBatchAuction.sol` to align min-bid sizing naming with intent (`MIN_BID_SIZE_DIVISOR`) and expanded in-contract gas-bound commentary.
- Added new fuzz test file `solidity/ts/fuzz/auctionTickMath.fuzz.ts` to verify `tickToPrice` against TS model and enforce out-of-bounds tick reverts.
- Extended `solidity/ts/tests/auction.test.ts` with synthetic max-depth funded/underfunded finalize gas checks at full tick-domain height and edge-tick submitBid coverage for `MIN_TICK`/`MAX_TICK`.

## Testing
- Not run: `bun run tsc`
- Not run: `bun run test`
- Not run: `bun run test:auction-fuzz`
- Not run: `bun run format`
- Not run: `bun run check`
- Not run: `bun run knip`
- Not run: `bun run knip:fix`