### PR TITLE
Forward truth-auction proceeds to child security pool on finalize

### DIFF
--- a/solidity/contracts/peripherals/SecurityPoolForker.sol
+++ b/solidity/contracts/peripherals/SecurityPoolForker.sol
@@ -482,7 +482,13 @@ contract SecurityPoolForker is SecurityPoolForkerVaultMigrationBase {
 		SecurityPoolForkerForkData storage data
 	) private returns (uint256 repPurchased) {
 		if (data.truthAuction.auctionStarted() != 0) {
+			uint256 balanceBeforeFinalize = address(this).balance;
 			data.truthAuction.finalize();
+			uint256 ethReceived = address(this).balance - balanceBeforeFinalize;
+			if (ethReceived > 0) {
+				(bool sent, ) = payable(address(securityPool)).call{ value: ethReceived }('');
+				require(sent, 'truth auction ETH transfer failed');
+			}
 			repPurchased = data.truthAuction.totalRepPurchased();
 		}
 		securityPool.setSystemState(SystemState.Operational);

--- a/solidity/ts/tests/peripherals.test.ts
+++ b/solidity/ts/tests/peripherals.test.ts
@@ -3642,8 +3642,13 @@ describe('Peripherals Contract Test Suite', () => {
 		const auctionTick = await participateAuction(auctionParticipant, yesSecurityPool.truthAuction, repToBuy, expectedEthToBuy)
 
 		// Finalize auction
+		const childEthBalanceBeforeFinalize = await getETHBalance(client, yesSecurityPool.securityPool)
+		const forkerEthBalanceBeforeFinalize = await getETHBalance(client, getInfraContractAddresses().securityPoolForker)
 		await mockWindow.advanceTime(7n * DAY + DAY)
 		await finalizeTruthAuction(client, yesSecurityPool.securityPool)
+		strictEqualTypeSafe(await getETHBalance(client, yesSecurityPool.securityPool), childEthBalanceBeforeFinalize + expectedEthToBuy, 'child pool should receive truth-auction ETH on finalization')
+		strictEqualTypeSafe(await getCompleteSetCollateralAmount(client, yesSecurityPool.securityPool), childEthBalanceBeforeFinalize + expectedEthToBuy, 'child pool collateral accounting should include truth-auction ETH')
+		strictEqualTypeSafe(await getETHBalance(client, getInfraContractAddresses().securityPoolForker), forkerEthBalanceBeforeFinalize, 'forker should not retain truth-auction ETH')
 
 		// Verify participant got REP allocation
 


### PR DESCRIPTION
## Summary
- In `solidity/contracts/peripherals/SecurityPoolForker.sol`, updated finalization flow to capture ETH received by the forker during `truthAuction.finalize()` and immediately forward it to the target `securityPool`.
- Added explicit failure handling for ETH forwarding with a `require(sent, 'truth auction ETH transfer failed')` guard to avoid silent fund loss.
- Kept forker contract state transitions unchanged; only the post-finalization settlement path is affected.
- In `solidity/ts/tests/peripherals.test.ts`, added assertions that: child security pool receives the expected ETH on finalization, collateral accounting reflects that amount, and forker balance does not retain transferred ETH.
- Base branch: `main`, head branch: `t3code/c9c1df93`.

## Testing
- Not run (no commands executed in this response).
- Added/updated unit test coverage in `solidity/ts/tests/peripherals.test.ts` for truth-auction finalization ETH flow.
- Recommended checks when available: `bun run tsc`, `bun run test`, `bun run format`, `bun run check`, `bun run knip`.