### PR TITLE
Document forked pool operational lifecycle

### DIFF
--- a/solidity/contracts/peripherals/SecurityPool.sol
+++ b/solidity/contracts/peripherals/SecurityPool.sol
@@ -90,8 +90,8 @@ contract SecurityPool is ISecurityPool {
 	modifier isOperational() {
 		// Once a universe forks, the parent pool freezes operational flows permanently.
 		// Outcome child pools can re-enter `SystemState.Operational` after migration and
-		// truth-auction processing complete. Finalized claim paths intentionally avoid
-		// this modifier so late unrelated forks do not block share or REP redemption.
+		// truth-auction processing complete. Finalized claim paths keep their own state
+		// and finality guards so late unrelated forks do not block share or REP redemption.
 		require(zoltar.getForkTime(universeId) == 0, 'zoltar forked');
 		require(systemState == SystemState.Operational, 'not operational');
 		_;

--- a/solidity/contracts/peripherals/SecurityPool.sol
+++ b/solidity/contracts/peripherals/SecurityPool.sol
@@ -88,12 +88,10 @@ contract SecurityPool is ISecurityPool {
 	event RedeemRep(address caller, address vault, uint256 repAmount);
 
 	modifier isOperational() {
-		// TODO, system can be operational if the fork has happened after this question has finalized
-		// Once a universe forks, the parent pool must freeze all operational flows permanently.
-		// The continuation path lives in the outcome child pools, which can re-enter
-		// `SystemState.Operational` after migration / truth-auction processing completes.
-		// Post-fork claims use the dedicated migration and redemption functions instead of
-		// continuing to mutate the parent pool's accounting.
+		// Once a universe forks, the parent pool freezes operational flows permanently.
+		// Outcome child pools can re-enter `SystemState.Operational` after migration and
+		// truth-auction processing complete. Finalized claim paths intentionally avoid
+		// this modifier so late unrelated forks do not block share or REP redemption.
 		require(zoltar.getForkTime(universeId) == 0, 'zoltar forked');
 		require(systemState == SystemState.Operational, 'not operational');
 		_;


### PR DESCRIPTION
## Summary
- Replace the stale fork operational TODO with the intended parent/child lifecycle behavior
- Clarify that finalized claim paths are separate from operational mutation flows

## QA
- bun run tsc
- bun run test
- bun run format
- bun run check
- bun run knip