### PR TITLE
Reward security pool fork initiators

### DIFF
--- a/solidity/contracts/peripherals/SecurityPoolForker.sol
+++ b/solidity/contracts/peripherals/SecurityPoolForker.sol
@@ -306,12 +306,13 @@ contract SecurityPoolForker is SecurityPoolForkerVaultMigrationBase {
 		if (reward == 0) return;
 		uint256 collateral = securityPool.completeSetCollateralAmount();
 		if (collateral < reward) return;
+		uint256 totalSecurityBondAllowance = securityPool.totalSecurityBondAllowance();
 
-		securityPool.setPoolFinancials(collateral - reward, securityPool.totalSecurityBondAllowance());
+		securityPool.setPoolFinancials(collateral - reward, totalSecurityBondAllowance);
 		try securityPool.transferEth(payable(caller), reward) {
 			emit InitiateSecurityPoolForkCallerReward(securityPool, caller, reward);
 		} catch {
-			securityPool.setPoolFinancials(collateral, securityPool.totalSecurityBondAllowance());
+			securityPool.setPoolFinancials(collateral, totalSecurityBondAllowance);
 		}
 	}
 

--- a/solidity/contracts/peripherals/SecurityPoolForker.sol
+++ b/solidity/contracts/peripherals/SecurityPoolForker.sol
@@ -282,6 +282,7 @@ contract SecurityPoolForker is SecurityPoolForkerVaultMigrationBase {
 	}
 
 	function initiateSecurityPoolFork(ISecurityPool securityPool) public {
+		uint256 forkGasStart = gasleft();
 		EscalationGame escalationGame = securityPool.escalationGame();
 		SecurityPoolForkerForkData storage data = _prepareForkState(securityPool, escalationGame);
 		ReputationToken rep = securityPool.repToken();
@@ -298,11 +299,11 @@ contract SecurityPoolForker is SecurityPoolForkerVaultMigrationBase {
 		data.auctionableRepAtFork = zoltar.getMigrationRepBalance(address(migrationProxy), universe);
 		require(data.auctionableRepAtFork >= previousMigrationBalance, 'migration balance regressed');
 		emit InitiateSecurityPoolFork(data.auctionableRepAtFork);
-		_payForkInitiatorReward(securityPool, msg.sender);
+		_payForkInitiatorReward(securityPool, msg.sender, forkGasStart);
 	}
 
-	function _payForkInitiatorReward(ISecurityPool securityPool, address caller) private {
-		uint256 reward = block.basefee * 2;
+	function _payForkInitiatorReward(ISecurityPool securityPool, address caller, uint256 forkGasStart) private {
+		uint256 reward = (forkGasStart - gasleft()) * block.basefee * 2;
 		if (reward == 0) return;
 		uint256 collateral = securityPool.completeSetCollateralAmount();
 		if (collateral < reward) return;

--- a/solidity/contracts/peripherals/SecurityPoolForker.sol
+++ b/solidity/contracts/peripherals/SecurityPoolForker.sol
@@ -24,6 +24,11 @@ contract SecurityPoolForker is SecurityPoolForkerVaultMigrationBase {
 	address private immutable escalationGameForkerDelegate;
 
 	event InitiateSecurityPoolFork(uint256 auctionableRepAtFork);
+	event InitiateSecurityPoolForkCallerReward(
+		ISecurityPool indexed securityPool,
+		address indexed caller,
+		uint256 reward
+	);
 	event TruthAuctionStarted(uint256 completeSetCollateralAmount, uint256 repMigrated, uint256 auctionableRepAtFork);
 	event TruthAuctionFinalized();
 	event ClaimAuctionProceeds(
@@ -293,7 +298,21 @@ contract SecurityPoolForker is SecurityPoolForkerVaultMigrationBase {
 		data.auctionableRepAtFork = zoltar.getMigrationRepBalance(address(migrationProxy), universe);
 		require(data.auctionableRepAtFork >= previousMigrationBalance, 'migration balance regressed');
 		emit InitiateSecurityPoolFork(data.auctionableRepAtFork);
-		// TODO: we could pay the caller basefee*2 out of Open interest. We have to reward caller
+		_payForkInitiatorReward(securityPool, msg.sender);
+	}
+
+	function _payForkInitiatorReward(ISecurityPool securityPool, address caller) private {
+		uint256 reward = block.basefee * 2;
+		if (reward == 0) return;
+		uint256 collateral = securityPool.completeSetCollateralAmount();
+		if (collateral < reward) return;
+
+		securityPool.setPoolFinancials(collateral - reward, securityPool.totalSecurityBondAllowance());
+		try securityPool.transferEth(payable(caller), reward) {
+			emit InitiateSecurityPoolForkCallerReward(securityPool, caller, reward);
+		} catch {
+			securityPool.setPoolFinancials(collateral, securityPool.totalSecurityBondAllowance());
+		}
 	}
 
 	function migrateRepToZoltar(ISecurityPool securityPool, uint256[] calldata outcomeIndices) external {

--- a/solidity/ts/tests/anvilWindowEthereum.test.ts
+++ b/solidity/ts/tests/anvilWindowEthereum.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test'
-import { getDefaultAnvilRpcUrl, normalizeAnvilTransactionParams } from '../testsuite/simulator/AnvilWindowEthereum'
+import { getDefaultAnvilRpcUrl, normalizeAnvilTransactionParams, preserveAnvilFeeCap } from '../testsuite/simulator/AnvilWindowEthereum'
 
 test('getDefaultAnvilRpcUrl uses localhost on Windows and docker host elsewhere', () => {
 	const expected = process.platform === 'win32' ? 'http://127.0.0.1:8545' : 'http://host.docker.internal:8545'
@@ -31,15 +31,14 @@ test('normalizeAnvilTransactionParams forces legacy zero-gas pricing for send tr
 
 test('normalizeAnvilTransactionParams preserves fee cap when explicitly requested', () => {
 	const params = [
-		{
+		preserveAnvilFeeCap({
 			from: '0x1234',
 			to: '0x5678',
 			maxFeePerGas: '0x10',
 			maxPriorityFeePerGas: '0x1',
 			type: '0x2',
 			value: '0x0',
-			__preserveFeeCap: true,
-		},
+		}),
 	]
 
 	expect(normalizeAnvilTransactionParams(params)).toEqual([

--- a/solidity/ts/tests/anvilWindowEthereum.test.ts
+++ b/solidity/ts/tests/anvilWindowEthereum.test.ts
@@ -29,6 +29,31 @@ test('normalizeAnvilTransactionParams forces legacy zero-gas pricing for send tr
 	])
 })
 
+test('normalizeAnvilTransactionParams preserves fee cap when explicitly requested', () => {
+	const params = [
+		{
+			from: '0x1234',
+			to: '0x5678',
+			maxFeePerGas: '0x10',
+			maxPriorityFeePerGas: '0x1',
+			type: '0x2',
+			value: '0x0',
+			__preserveFeeCap: true,
+		},
+	]
+
+	expect(normalizeAnvilTransactionParams(params)).toEqual([
+		{
+			from: '0x1234',
+			to: '0x5678',
+			maxFeePerGas: '0x10',
+			maxPriorityFeePerGas: '0x1',
+			type: '0x2',
+			value: '0x0',
+		},
+	])
+})
+
 test('normalizeAnvilTransactionParams leaves non-object params unchanged', () => {
 	const params = ['latest']
 

--- a/solidity/ts/tests/peripherals.test.ts
+++ b/solidity/ts/tests/peripherals.test.ts
@@ -2,7 +2,7 @@ import { beforeAll, beforeEach, describe, setDefaultTimeout, test } from 'bun:te
 import assert from 'node:assert/strict'
 import { decodeEventLog, encodeAbiParameters, encodeFunctionData, keccak256 } from 'viem'
 import type { Abi, Address, Hash } from 'viem'
-import { AnvilWindowEthereum } from '../testsuite/simulator/AnvilWindowEthereum'
+import { AnvilWindowEthereum, preserveAnvilFeeCap } from '../testsuite/simulator/AnvilWindowEthereum'
 import { TEST_TIMEOUT_MS, useIsolatedAnvilNode } from '../testsuite/simulator/useIsolatedAnvilNode'
 import { sortBigIntsAscending } from '@zoltar/shared/bigInt'
 import { createWriteClient, WriteClient } from '../testsuite/simulator/utils/viem'
@@ -1903,18 +1903,18 @@ describe('Peripherals Contract Test Suite', () => {
 
 		const forkCaller = createWriteClient(mockWindow, TEST_ADDRESSES[6], 0)
 		const forkBaseFee = 1000n
-		const expectedReward = forkBaseFee * 2n
 		await mockWindow.request({ method: 'anvil_setNextBlockBaseFeePerGas', params: [`0x${forkBaseFee.toString(16)}`] })
 		const callerBalanceBeforeFork = await getETHBalance(client, forkCaller.account.address)
 		const collateralBeforeFork = await getCompleteSetCollateralAmount(client, securityPoolAddresses.securityPool)
 		const feesBeforeFork = await getTotalFeesOwedToVaults(client, securityPoolAddresses.securityPool)
 		let forkGasCost = 0n
+		let forkReward = 0n
 
 		try {
 			const forkHash = (await mockWindow.request({
 				method: 'eth_sendTransaction',
 				params: [
-					{
+					preserveAnvilFeeCap({
 						from: forkCaller.account.address,
 						to: getInfraContractAddresses().securityPoolForker,
 						data: encodeFunctionData({
@@ -1925,8 +1925,7 @@ describe('Peripherals Contract Test Suite', () => {
 						maxFeePerGas: `0x${forkBaseFee.toString(16)}`,
 						maxPriorityFeePerGas: '0x0',
 						type: '0x2',
-						__preserveFeeCap: true,
-					},
+					}),
 				],
 			})) as Hash
 			const forkReceipt = await forkCaller.waitForTransactionReceipt({ hash: forkHash })
@@ -1949,13 +1948,14 @@ describe('Peripherals Contract Test Suite', () => {
 			assert.ok(callerRewardLog, 'fork reward should emit a caller reward event')
 			strictEqualTypeSafe(BigInt(callerRewardLog.args.securityPool), BigInt(securityPoolAddresses.securityPool), 'fork reward event should identify the security pool')
 			strictEqualTypeSafe(BigInt(callerRewardLog.args.caller), BigInt(forkCaller.account.address), 'fork reward event should identify the caller')
-			strictEqualTypeSafe(callerRewardLog.args.reward, expectedReward, 'fork reward event should report the paid amount')
+			forkReward = callerRewardLog.args.reward
+			assert.ok(forkReward > forkBaseFee * 21_000n, 'fork reward should scale by measured gas instead of paying only two base-fee units')
 		} finally {
 			await mockWindow.setNextBlockBaseFeePerGasToZero()
 		}
 
-		strictEqualTypeSafe((await getETHBalance(client, forkCaller.account.address)) - callerBalanceBeforeFork + forkGasCost, expectedReward, 'fork initiator should receive the basefee reward')
-		strictEqualTypeSafe(collateralBeforeFork - (await getCompleteSetCollateralAmount(client, securityPoolAddresses.securityPool)), expectedReward, 'fork reward should be paid from complete-set collateral')
+		strictEqualTypeSafe((await getETHBalance(client, forkCaller.account.address)) - callerBalanceBeforeFork + forkGasCost, forkReward, 'fork initiator should receive the basefee reward')
+		strictEqualTypeSafe(collateralBeforeFork - (await getCompleteSetCollateralAmount(client, securityPoolAddresses.securityPool)), forkReward, 'fork reward should be paid from complete-set collateral')
 		strictEqualTypeSafe(await getTotalFeesOwedToVaults(client, securityPoolAddresses.securityPool), feesBeforeFork, 'fork reward should not spend accrued vault fees')
 	})
 

--- a/solidity/ts/tests/peripherals.test.ts
+++ b/solidity/ts/tests/peripherals.test.ts
@@ -1932,6 +1932,24 @@ describe('Peripherals Contract Test Suite', () => {
 			const forkReceipt = await forkCaller.waitForTransactionReceipt({ hash: forkHash })
 			strictEqualTypeSafe(forkReceipt.status, 'success', 'fork transaction should succeed with the test fee cap')
 			forkGasCost = forkReceipt.gasUsed * forkReceipt.effectiveGasPrice
+			const callerRewardLog = forkReceipt.logs
+				.map(log => {
+					try {
+						return decodeEventLog({
+							abi: peripherals_SecurityPoolForker_SecurityPoolForker.abi,
+							data: log.data,
+							topics: log.topics,
+						})
+					} catch (error) {
+						if (!isIgnorableLogDecodeError(error)) throw error
+						return undefined
+					}
+				})
+				.find(log => log?.eventName === 'InitiateSecurityPoolForkCallerReward')
+			assert.ok(callerRewardLog, 'fork reward should emit a caller reward event')
+			strictEqualTypeSafe(BigInt(callerRewardLog.args.securityPool), BigInt(securityPoolAddresses.securityPool), 'fork reward event should identify the security pool')
+			strictEqualTypeSafe(BigInt(callerRewardLog.args.caller), BigInt(forkCaller.account.address), 'fork reward event should identify the caller')
+			strictEqualTypeSafe(callerRewardLog.args.reward, expectedReward, 'fork reward event should report the paid amount')
 		} finally {
 			await mockWindow.setNextBlockBaseFeePerGasToZero()
 		}

--- a/solidity/ts/tests/peripherals.test.ts
+++ b/solidity/ts/tests/peripherals.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, beforeEach, describe, setDefaultTimeout, test } from 'bun:test'
 import assert from 'node:assert/strict'
-import { decodeEventLog, encodeAbiParameters, keccak256 } from 'viem'
+import { decodeEventLog, encodeAbiParameters, encodeFunctionData, keccak256 } from 'viem'
 import type { Abi, Address, Hash } from 'viem'
 import { AnvilWindowEthereum } from '../testsuite/simulator/AnvilWindowEthereum'
 import { TEST_TIMEOUT_MS, useIsolatedAnvilNode } from '../testsuite/simulator/useIsolatedAnvilNode'
@@ -1880,6 +1880,65 @@ describe('Peripherals Contract Test Suite', () => {
 		const forkData = await getSecurityPoolForkerForkData(client, securityPoolAddresses.securityPool)
 		strictEqualTypeSafe(await getSystemState(client, securityPoolAddresses.securityPool), SystemState.PoolForked, 're-initiating after the own-game fork should leave the parent pool in PoolForked')
 		strictEqualTypeSafe(forkData.auctionableRepAtFork, forkDataBeforeStrayRep.auctionableRepAtFork, 'repAtFork should ignore unrelated REP transferred to the forker after the own-game fork')
+	})
+
+	test('initiateSecurityPoolFork pays the caller reward from complete-set collateral', async () => {
+		const securityPoolAllowance = repDeposit / 4n
+		await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, securityPoolAllowance)
+		const openInterestAmount = 5n * 10n ** 18n
+		await createCompleteSet(client, securityPoolAddresses.securityPool, openInterestAmount)
+
+		const forkSourceClient = createWriteClient(mockWindow, TEST_ADDRESSES[5], 0)
+		const forkSourceQuestionData = {
+			...questionData,
+			title: 'fork caller reward source question',
+			endTime: (await mockWindow.getTime()) + DAY,
+		}
+		const forkSourceQuestionId = getQuestionId(forkSourceQuestionData, outcomes)
+		await createQuestion(forkSourceClient, forkSourceQuestionData, outcomes)
+		await mockWindow.setTime(forkSourceQuestionData.endTime + 1n)
+		await approveToken(forkSourceClient, addressString(GENESIS_REPUTATION_TOKEN), getZoltarAddress())
+		await forkUniverse(forkSourceClient, genesisUniverse, forkSourceQuestionId)
+		await updateVaultFees(client, securityPoolAddresses.securityPool, client.account.address)
+
+		const forkCaller = createWriteClient(mockWindow, TEST_ADDRESSES[6], 0)
+		const forkBaseFee = 1000n
+		const expectedReward = forkBaseFee * 2n
+		await mockWindow.request({ method: 'anvil_setNextBlockBaseFeePerGas', params: [`0x${forkBaseFee.toString(16)}`] })
+		const callerBalanceBeforeFork = await getETHBalance(client, forkCaller.account.address)
+		const collateralBeforeFork = await getCompleteSetCollateralAmount(client, securityPoolAddresses.securityPool)
+		const feesBeforeFork = await getTotalFeesOwedToVaults(client, securityPoolAddresses.securityPool)
+		let forkGasCost = 0n
+
+		try {
+			const forkHash = (await mockWindow.request({
+				method: 'eth_sendTransaction',
+				params: [
+					{
+						from: forkCaller.account.address,
+						to: getInfraContractAddresses().securityPoolForker,
+						data: encodeFunctionData({
+							abi: peripherals_SecurityPoolForker_SecurityPoolForker.abi,
+							functionName: 'initiateSecurityPoolFork',
+							args: [securityPoolAddresses.securityPool],
+						}),
+						maxFeePerGas: `0x${forkBaseFee.toString(16)}`,
+						maxPriorityFeePerGas: '0x0',
+						type: '0x2',
+						__preserveFeeCap: true,
+					},
+				],
+			})) as Hash
+			const forkReceipt = await forkCaller.waitForTransactionReceipt({ hash: forkHash })
+			strictEqualTypeSafe(forkReceipt.status, 'success', 'fork transaction should succeed with the test fee cap')
+			forkGasCost = forkReceipt.gasUsed * forkReceipt.effectiveGasPrice
+		} finally {
+			await mockWindow.setNextBlockBaseFeePerGasToZero()
+		}
+
+		strictEqualTypeSafe((await getETHBalance(client, forkCaller.account.address)) - callerBalanceBeforeFork + forkGasCost, expectedReward, 'fork initiator should receive the basefee reward')
+		strictEqualTypeSafe(collateralBeforeFork - (await getCompleteSetCollateralAmount(client, securityPoolAddresses.securityPool)), expectedReward, 'fork reward should be paid from complete-set collateral')
+		strictEqualTypeSafe(await getTotalFeesOwedToVaults(client, securityPoolAddresses.securityPool), feesBeforeFork, 'fork reward should not spend accrued vault fees')
 	})
 
 	test('Can Liquidate', async () => {

--- a/solidity/ts/testsuite/simulator/AnvilWindowEthereum.ts
+++ b/solidity/ts/testsuite/simulator/AnvilWindowEthereum.ts
@@ -47,6 +47,7 @@ type RpcTransactionRequest = {
 	readonly maxFeePerGas?: string
 	readonly maxPriorityFeePerGas?: string
 	readonly type?: string
+	readonly __preserveFeeCap?: boolean
 }
 
 const isObjectRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
@@ -76,6 +77,14 @@ function isRpcTransactionRequest(value: unknown): value is RpcTransactionRequest
 export function normalizeAnvilTransactionParams(params: unknown[]) {
 	const [firstParam, ...remainingParams] = params
 	if (!isRpcTransactionRequest(firstParam)) return params
+
+	if (firstParam.__preserveFeeCap === true) {
+		const normalizedTransactionRequest: Record<string, unknown> = {
+			...firstParam,
+		}
+		delete normalizedTransactionRequest['__preserveFeeCap']
+		return [normalizedTransactionRequest, ...remainingParams]
+	}
 
 	const normalizedTransactionRequest: Record<string, unknown> = {
 		...firstParam,

--- a/solidity/ts/testsuite/simulator/AnvilWindowEthereum.ts
+++ b/solidity/ts/testsuite/simulator/AnvilWindowEthereum.ts
@@ -39,6 +39,8 @@ type RpcTransaction = {
 	readonly blockNumber?: string
 }
 
+const PRESERVE_ANVIL_FEE_CAP_FIELD = '__preserveFeeCap'
+
 type RpcTransactionRequest = {
 	readonly from?: string
 	readonly to?: string
@@ -47,7 +49,7 @@ type RpcTransactionRequest = {
 	readonly maxFeePerGas?: string
 	readonly maxPriorityFeePerGas?: string
 	readonly type?: string
-	readonly __preserveFeeCap?: boolean
+	readonly [PRESERVE_ANVIL_FEE_CAP_FIELD]?: boolean
 }
 
 const isObjectRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
@@ -74,15 +76,20 @@ function isRpcTransactionRequest(value: unknown): value is RpcTransactionRequest
 	return typeof value === 'object' && value !== null
 }
 
+export const preserveAnvilFeeCap = <T extends Record<string, unknown>>(transaction: T) => ({
+	...transaction,
+	[PRESERVE_ANVIL_FEE_CAP_FIELD]: true,
+})
+
 export function normalizeAnvilTransactionParams(params: unknown[]) {
 	const [firstParam, ...remainingParams] = params
 	if (!isRpcTransactionRequest(firstParam)) return params
 
-	if (firstParam.__preserveFeeCap === true) {
+	if (firstParam[PRESERVE_ANVIL_FEE_CAP_FIELD] === true) {
 		const normalizedTransactionRequest: Record<string, unknown> = {
 			...firstParam,
 		}
-		delete normalizedTransactionRequest['__preserveFeeCap']
+		delete normalizedTransactionRequest[PRESERVE_ANVIL_FEE_CAP_FIELD]
 		return [normalizedTransactionRequest, ...remainingParams]
 	}
 


### PR DESCRIPTION
## Summary
- pay security-pool fork initiators from complete-set collateral using twice the measured fork execution gas at the block base fee when available
- emit a caller reward event and preserve fork progress if the reward transfer cannot be paid
- add nonzero-basefee test coverage with a named simulator fee-cap opt-in helper

## QA
- bun run tsc
- bun run test
- bun run format
- bun run check
- bun run knip