### PR TITLE
Refresh mainnet deployment manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BUN_VERSION: 1.3.11
+  BUN_VERSION: 1.3.13
   FOUNDRY_VERSION: v1.5.1
 
 jobs:

--- a/docs/mainnet-deployment-addresses.json
+++ b/docs/mainnet-deployment-addresses.json
@@ -13,7 +13,7 @@
 		{
 			"id": "deploymentStatusOracle",
 			"label": "Deployment Status Oracle",
-			"address": "0x138aa911c7E0d63DD3C81e4675EC8A08883728b3"
+			"address": "0xD262Bb8bBa927dD08a3fd3d6adcbAB9660B5F2e5"
 		},
 		{
 			"id": "multicall3",
@@ -23,7 +23,7 @@
 		{
 			"id": "uniformPriceDualCapBatchAuctionFactory",
 			"label": "UniformPriceDualCapBatchAuctionFactory",
-			"address": "0x47A117D404C31b5CFF82883D40c0610404D26a60"
+			"address": "0xbA605970da511b08539bcC4F77B54CF1Cd72783c"
 		},
 		{
 			"id": "scalarOutcomes",
@@ -33,7 +33,7 @@
 		{
 			"id": "securityPoolUtils",
 			"label": "SecurityPoolUtils",
-			"address": "0x9E90338b17E1Fea80Cd356607EbB6eC46653fB24"
+			"address": "0x04349f6A0302F32f8c87bb8555648AD77634343C"
 		},
 		{
 			"id": "openOracle",
@@ -53,27 +53,27 @@
 		{
 			"id": "shareTokenFactory",
 			"label": "ShareTokenFactory",
-			"address": "0x253d011F3A0f46096A4756a439543E9Dab36AA23"
+			"address": "0x95fB9708d8e54e057d2bdf027D6C43B586Ca898F"
 		},
 		{
 			"id": "priceOracleManagerAndOperatorQueuerFactory",
 			"label": "Price Oracle Manager Factory",
-			"address": "0x38d22Ec4282621eeeBE4EBFf04E08b893dC020FF"
+			"address": "0xAA71aD70f8bed84f0fd57D711f21fae8D6310354"
 		},
 		{
 			"id": "securityPoolForker",
 			"label": "Security Pool Forker",
-			"address": "0x290BF23Dd1912AdEDBdfd7419b85605C66e3d24B"
+			"address": "0x21547294899fc37CAfa9EA0d1231D3F0b9ABd1F7"
 		},
 		{
 			"id": "escalationGameFactory",
 			"label": "Escalation Game Factory",
-			"address": "0x94A7FB6E5a8EDC6559B748aD4FEAd0Bc68f4fCfD"
+			"address": "0x0f8E07792B60329dD8FFcbAc99577816c74c130F"
 		},
 		{
 			"id": "securityPoolFactory",
 			"label": "Security Pool Factory",
-			"address": "0x0070464ef3Fb90B5D3e128e47D5ffB20e12f24E6"
+			"address": "0x8d36A27ce150F7F7f4077dC84589Bd501fA363B5"
 		}
 	]
 }

--- a/docs/mainnet-deployment-addresses.md
+++ b/docs/mainnet-deployment-addresses.md
@@ -15,18 +15,18 @@ These values are derived from the frozen mainnet protocol config, current contra
 | ID | Label | Expected Address |
 | --- | --- | --- |
 | proxyDeployer | Proxy Deployer | `0x7A0D94F55792C434d74a40883C6ed8545E406D12` |
-| deploymentStatusOracle | Deployment Status Oracle | `0x138aa911c7E0d63DD3C81e4675EC8A08883728b3` |
+| deploymentStatusOracle | Deployment Status Oracle | `0xD262Bb8bBa927dD08a3fd3d6adcbAB9660B5F2e5` |
 | multicall3 | Multicall3 | `0x77609e84c39893D5fB99049FE0F461aEB4F4Ec79` |
-| uniformPriceDualCapBatchAuctionFactory | UniformPriceDualCapBatchAuctionFactory | `0x47A117D404C31b5CFF82883D40c0610404D26a60` |
+| uniformPriceDualCapBatchAuctionFactory | UniformPriceDualCapBatchAuctionFactory | `0xbA605970da511b08539bcC4F77B54CF1Cd72783c` |
 | scalarOutcomes | ScalarOutcomes | `0x5890b011CF7E36d4Fee28Bac8B5be6f61C392a4C` |
-| securityPoolUtils | SecurityPoolUtils | `0x9E90338b17E1Fea80Cd356607EbB6eC46653fB24` |
+| securityPoolUtils | SecurityPoolUtils | `0x04349f6A0302F32f8c87bb8555648AD77634343C` |
 | openOracle | OpenOracle | `0x51DED022c087758c187ce636aa5f6adE6B919abB` |
 | zoltarQuestionData | ZoltarQuestionData | `0xeadF91d12F549786891350B3D535638713651207` |
 | zoltar | Zoltar | `0xd282Ae3cC11423c740afD608e715CD4e22831A29` |
-| shareTokenFactory | ShareTokenFactory | `0x253d011F3A0f46096A4756a439543E9Dab36AA23` |
-| priceOracleManagerAndOperatorQueuerFactory | Price Oracle Manager Factory | `0x38d22Ec4282621eeeBE4EBFf04E08b893dC020FF` |
-| securityPoolForker | Security Pool Forker | `0x290BF23Dd1912AdEDBdfd7419b85605C66e3d24B` |
-| escalationGameFactory | Escalation Game Factory | `0x94A7FB6E5a8EDC6559B748aD4FEAd0Bc68f4fCfD` |
-| securityPoolFactory | Security Pool Factory | `0x0070464ef3Fb90B5D3e128e47D5ffB20e12f24E6` |
+| shareTokenFactory | ShareTokenFactory | `0x95fB9708d8e54e057d2bdf027D6C43B586Ca898F` |
+| priceOracleManagerAndOperatorQueuerFactory | Price Oracle Manager Factory | `0xAA71aD70f8bed84f0fd57D711f21fae8D6310354` |
+| securityPoolForker | Security Pool Forker | `0x21547294899fc37CAfa9EA0d1231D3F0b9ABd1F7` |
+| escalationGameFactory | Escalation Game Factory | `0x0f8E07792B60329dD8FFcbAc99577816c74c130F` |
+| securityPoolFactory | Security Pool Factory | `0x8d36A27ce150F7F7f4077dC84589Bd501fA363B5` |
 
 Security pool deployments are deterministic per pool input rather than globally fixed. Their addresses are derived from the deployed factory set plus parent universe, universe ID, question ID, and security multiplier.


### PR DESCRIPTION
Refresh the checked-in mainnet deployment manifest after the bun bump so `ui:build:prod` passes again.

Changes:
- Update `docs/mainnet-deployment-addresses.json`
- Update `docs/mainnet-deployment-addresses.md`
- Keep CI Bun pinned to `1.3.13`