### PR TITLE
Refresh mainnet deployment manifest

### DIFF
--- a/docs/mainnet-deployment-addresses.json
+++ b/docs/mainnet-deployment-addresses.json
@@ -13,7 +13,7 @@
 		{
 			"id": "deploymentStatusOracle",
 			"label": "Deployment Status Oracle",
-			"address": "0xD262Bb8bBa927dD08a3fd3d6adcbAB9660B5F2e5"
+			"address": "0x725502CbB4877619dC825e7CB4a83FCa1bB809bE"
 		},
 		{
 			"id": "multicall3",
@@ -48,32 +48,32 @@
 		{
 			"id": "zoltar",
 			"label": "Zoltar",
-			"address": "0xd282Ae3cC11423c740afD608e715CD4e22831A29"
+			"address": "0x6b5003e3715D5Bc8C753ca9822A0c550801B1fca"
 		},
 		{
 			"id": "shareTokenFactory",
 			"label": "ShareTokenFactory",
-			"address": "0x95fB9708d8e54e057d2bdf027D6C43B586Ca898F"
+			"address": "0x6a360dD5d6b958ED1690296D0B3D003E290B4e0e"
 		},
 		{
 			"id": "priceOracleManagerAndOperatorQueuerFactory",
 			"label": "Price Oracle Manager Factory",
-			"address": "0xAA71aD70f8bed84f0fd57D711f21fae8D6310354"
+			"address": "0xb1779119842a8692cf0a47Fc743A90744f910092"
 		},
 		{
 			"id": "securityPoolForker",
 			"label": "Security Pool Forker",
-			"address": "0x21547294899fc37CAfa9EA0d1231D3F0b9ABd1F7"
+			"address": "0x19a2ba34c49Cb9aB9289F35fe36b4C28F6e0B582"
 		},
 		{
 			"id": "escalationGameFactory",
 			"label": "Escalation Game Factory",
-			"address": "0x0f8E07792B60329dD8FFcbAc99577816c74c130F"
+			"address": "0xDF85248e59F374DC46B32d83368f0c7DE9878Ae5"
 		},
 		{
 			"id": "securityPoolFactory",
 			"label": "Security Pool Factory",
-			"address": "0x8d36A27ce150F7F7f4077dC84589Bd501fA363B5"
+			"address": "0x78FE3889B0329d36EBC52216EAD96F2048efC9AE"
 		}
 	]
 }

--- a/docs/mainnet-deployment-addresses.md
+++ b/docs/mainnet-deployment-addresses.md
@@ -15,18 +15,18 @@ These values are derived from the frozen mainnet protocol config, current contra
 | ID | Label | Expected Address |
 | --- | --- | --- |
 | proxyDeployer | Proxy Deployer | `0x7A0D94F55792C434d74a40883C6ed8545E406D12` |
-| deploymentStatusOracle | Deployment Status Oracle | `0xD262Bb8bBa927dD08a3fd3d6adcbAB9660B5F2e5` |
+| deploymentStatusOracle | Deployment Status Oracle | `0x725502CbB4877619dC825e7CB4a83FCa1bB809bE` |
 | multicall3 | Multicall3 | `0x77609e84c39893D5fB99049FE0F461aEB4F4Ec79` |
 | uniformPriceDualCapBatchAuctionFactory | UniformPriceDualCapBatchAuctionFactory | `0xbA605970da511b08539bcC4F77B54CF1Cd72783c` |
 | scalarOutcomes | ScalarOutcomes | `0x5890b011CF7E36d4Fee28Bac8B5be6f61C392a4C` |
 | securityPoolUtils | SecurityPoolUtils | `0x04349f6A0302F32f8c87bb8555648AD77634343C` |
 | openOracle | OpenOracle | `0x51DED022c087758c187ce636aa5f6adE6B919abB` |
 | zoltarQuestionData | ZoltarQuestionData | `0xeadF91d12F549786891350B3D535638713651207` |
-| zoltar | Zoltar | `0xd282Ae3cC11423c740afD608e715CD4e22831A29` |
-| shareTokenFactory | ShareTokenFactory | `0x95fB9708d8e54e057d2bdf027D6C43B586Ca898F` |
-| priceOracleManagerAndOperatorQueuerFactory | Price Oracle Manager Factory | `0xAA71aD70f8bed84f0fd57D711f21fae8D6310354` |
-| securityPoolForker | Security Pool Forker | `0x21547294899fc37CAfa9EA0d1231D3F0b9ABd1F7` |
-| escalationGameFactory | Escalation Game Factory | `0x0f8E07792B60329dD8FFcbAc99577816c74c130F` |
-| securityPoolFactory | Security Pool Factory | `0x8d36A27ce150F7F7f4077dC84589Bd501fA363B5` |
+| zoltar | Zoltar | `0x6b5003e3715D5Bc8C753ca9822A0c550801B1fca` |
+| shareTokenFactory | ShareTokenFactory | `0x6a360dD5d6b958ED1690296D0B3D003E290B4e0e` |
+| priceOracleManagerAndOperatorQueuerFactory | Price Oracle Manager Factory | `0xb1779119842a8692cf0a47Fc743A90744f910092` |
+| securityPoolForker | Security Pool Forker | `0x19a2ba34c49Cb9aB9289F35fe36b4C28F6e0B582` |
+| escalationGameFactory | Escalation Game Factory | `0xDF85248e59F374DC46B32d83368f0c7DE9878Ae5` |
+| securityPoolFactory | Security Pool Factory | `0x78FE3889B0329d36EBC52216EAD96F2048efC9AE` |
 
 Security pool deployments are deterministic per pool input rather than globally fixed. Their addresses are derived from the deployed factory set plus parent universe, universe ID, question ID, and security multiplier.


### PR DESCRIPTION
## Summary
- Refresh the mainnet deployment manifest JSON and Markdown docs from the current deterministic deployment calculation.
- Updates the stale deployment addresses produced by the current contract artifacts and deployment helpers.

## Validation
- bun run tsc
- bun run test
- bun run format
- bun run check
- bun run knip
- bun run ui:build:prod
- bun run check:generated-clean
- bun audit
- cd ui && bun audit
- cd solidity && bun audit

## Main Sync
- Fetched and merged latest origin/main after the commit; branch was already up to date.