### PR TITLE
Test mainnet deployment manifest freshness

### DIFF
--- a/scripts/check-mainnet-deployment.mts
+++ b/scripts/check-mainnet-deployment.mts
@@ -73,8 +73,8 @@ function normalizeManifest(manifest: MainnetDeploymentManifest) {
 }
 
 async function loadComputedManifest(): Promise<MainnetDeploymentManifest> {
-	const deploymentModulePath = path.join(repositoryRootPath, 'ui', 'js', 'contracts', 'deployment.js')
-	const protocolConfigModulePath = path.join(repositoryRootPath, 'shared', 'js', 'protocolConfig.js')
+	const deploymentModulePath = path.join(repositoryRootPath, 'ui', 'ts', 'contracts', 'deployment.ts')
+	const protocolConfigModulePath = path.join(repositoryRootPath, 'shared', 'ts', 'protocolConfig.ts')
 
 	try {
 		const deploymentModule = await import(url.pathToFileURL(deploymentModulePath).href)
@@ -142,15 +142,13 @@ async function readManifest(): Promise<MainnetDeploymentManifest> {
 	}
 }
 
-async function main() {
-	const write = process.argv.includes('--write')
-	const computedManifest = await loadComputedManifest()
-	if (write) {
-		await writeManifest(computedManifest)
-		return
-	}
+export async function writeMainnetDeploymentManifest(): Promise<void> {
+	await writeManifest(await loadComputedManifest())
+}
 
+export async function assertMainnetDeploymentManifestFresh(): Promise<void> {
 	const expectedManifest = await readManifest()
+	const computedManifest = await loadComputedManifest()
 	const expected = normalizeManifest(expectedManifest)
 	const computed = normalizeManifest(computedManifest)
 	if (expected !== computed) {
@@ -158,7 +156,22 @@ async function main() {
 	}
 }
 
-main().catch(error => {
-	console.error(error)
-	process.exit(1)
-})
+async function main() {
+	const write = process.argv.includes('--write')
+	if (write) {
+		await writeMainnetDeploymentManifest()
+		return
+	}
+
+	await assertMainnetDeploymentManifestFresh()
+}
+
+const currentScriptPath = url.fileURLToPath(import.meta.url)
+const invokedScriptPath = process.argv[1]
+
+if (invokedScriptPath !== undefined && path.resolve(invokedScriptPath) === currentScriptPath) {
+	main().catch(error => {
+		console.error(error)
+		process.exit(1)
+	})
+}

--- a/scripts/check-mainnet-deployment.test.ts
+++ b/scripts/check-mainnet-deployment.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from 'bun:test'
+import { assertMainnetDeploymentManifestFresh } from './check-mainnet-deployment.mts'
+
+test('mainnet deployment manifest matches the current deterministic deployment calculation', async () => {
+	await expect(assertMainnetDeploymentManifestFresh()).resolves.toBeUndefined()
+})

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -20,5 +20,5 @@
 		"lib": ["ESNext", "DOM"],
 		"types": ["bun-types", "node"]
 	},
-	"include": ["bun-test-setup.ts", "scripts/**/*.mts", "ui/build/**/*.mts", "ui/dev-server.ts"]
+	"include": ["bun-test-setup.ts", "scripts/**/*.mts", "scripts/**/*.ts", "ui/build/**/*.mts", "ui/dev-server.ts"]
 }


### PR DESCRIPTION
## Summary
- Add a Bun test that asserts the committed mainnet deployment manifest matches the current deterministic deployment calculation.
- Make scripts/check-mainnet-deployment.mts importable so the test uses the same freshness assertion as the CLI.
- Compute the check from TypeScript sources/current generated TS artifacts, so bun run test catches stale manifests after contract changes without relying on stale ui/js output.

## Validation
Ran on the merged latest-main tree before creating the clean branch; the clean branch has the same tree hash as that validated state.

- bun run tsc
- bun run test (1333 pass, 0 fail)
- bun run format
- bun run check
- bun run knip
- bun run ui:build:prod
- bun run check:generated-clean
- bun audit
- cd ui && bun audit
- cd solidity && bun audit
- bun test scripts/check-mainnet-deployment.test.ts

## Main Sync
- Fetched and merged latest origin/main before final validation.
- Created this PR branch from current origin/main after PR #357 was already merged.