### PR TITLE
Refactor integration tests to reuse seeded simulation and oracle setup

### DIFF
--- a/ui/ts/tests/activeEnvironment.test.ts
+++ b/ui/ts/tests/activeEnvironment.test.ts
@@ -17,6 +17,7 @@ const DEFAULT_SIMULATION_REP_PER_ETH_PRICE = 3n * 10n ** 18n
 const SIMULATION_REP_MINT_AMOUNT = 1_000_000n * 10n ** 18n
 const SEEDED_REP_DEPOSIT = 10_000n * 10n ** 18n
 const SEEDED_SECURITY_BOND_ALLOWANCE = 100n * 10n ** 18n
+type SimulationBackend = Awaited<ReturnType<typeof createSimulationBackend>>
 afterEach(() => {
 	resetActiveEnvironmentForTesting()
 })
@@ -34,6 +35,12 @@ async function createBootstrappedSimulationBackendWithRetry(scenario: Simulation
 		}
 	}
 	throw lastError instanceof Error ? lastError : new Error(`Failed to bootstrap ${scenario} simulation backend`)
+}
+
+async function resetSelectedAccountAndTransactionDelay(backend: SimulationBackend) {
+	const primaryAccount = backend.accounts[0]
+	if (primaryAccount !== undefined && backend.selectedAccount !== primaryAccount) await backend.selectAccount(primaryAccount)
+	backend.setTransactionDelayMilliseconds(0)
 }
 
 void describe('active environment', () => {
@@ -172,33 +179,47 @@ void describe('active environment', () => {
 })
 
 void describe('simulation backend', () => {
-	let coldBaselineBackend: Awaited<ReturnType<typeof createSimulationBackend>>
-	let warmBaselineBackend: Awaited<ReturnType<typeof createSimulationBackend>>
-	let deployedBackend: Awaited<ReturnType<typeof createSimulationBackend>>
+	let coldBaselineBackend: SimulationBackend
+	let warmBaselineBackend: SimulationBackend
+	let deployedBackend: SimulationBackend
+	let securityPoolBackend: SimulationBackend
+	let securityPoolX2Backend: SimulationBackend
+	let securityPoolX2AuctionBackend: SimulationBackend
 
 	beforeAll(async () => {
 		coldBaselineBackend = await createSimulationBackend({ scenario: 'baseline' })
-		warmBaselineBackend = await createBootstrappedSimulationBackendWithRetry('baseline')
-		deployedBackend = await createBootstrappedSimulationBackendWithRetry('deployed')
+		const [nextWarmBaselineBackend, nextDeployedBackend, nextSecurityPoolBackend, nextSecurityPoolX2Backend, nextSecurityPoolX2AuctionBackend] = await Promise.all([
+			createBootstrappedSimulationBackendWithRetry('baseline'),
+			createBootstrappedSimulationBackendWithRetry('deployed'),
+			createBootstrappedSimulationBackendWithRetry('security-pool', 1),
+			createBootstrappedSimulationBackendWithRetry('securitypoolx2', 1),
+			createBootstrappedSimulationBackendWithRetry('securitypoolx2-auction', 1),
+		])
+		warmBaselineBackend = nextWarmBaselineBackend
+		deployedBackend = nextDeployedBackend
+		securityPoolBackend = nextSecurityPoolBackend
+		securityPoolX2Backend = nextSecurityPoolX2Backend
+		securityPoolX2AuctionBackend = nextSecurityPoolX2AuctionBackend
 		warmBaselineBackend.setTransactionDelayMilliseconds(0)
 		deployedBackend.setTransactionDelayMilliseconds(0)
-	}, 30_000)
+		securityPoolBackend.setTransactionDelayMilliseconds(0)
+		securityPoolX2Backend.setTransactionDelayMilliseconds(0)
+		securityPoolX2AuctionBackend.setTransactionDelayMilliseconds(0)
+	}, 180_000)
 
 	beforeEach(async () => {
-		const coldPrimaryAccount = coldBaselineBackend.accounts[0]
-		if (coldPrimaryAccount !== undefined && coldBaselineBackend.selectedAccount !== coldPrimaryAccount) await coldBaselineBackend.selectAccount(coldPrimaryAccount)
-		const warmPrimaryAccount = warmBaselineBackend.accounts[0]
-		if (warmPrimaryAccount !== undefined && warmBaselineBackend.selectedAccount !== warmPrimaryAccount) await warmBaselineBackend.selectAccount(warmPrimaryAccount)
-		warmBaselineBackend.setTransactionDelayMilliseconds(0)
-		const deployedPrimaryAccount = deployedBackend.accounts[0]
-		if (deployedPrimaryAccount !== undefined && deployedBackend.selectedAccount !== deployedPrimaryAccount) await deployedBackend.selectAccount(deployedPrimaryAccount)
-		deployedBackend.setTransactionDelayMilliseconds(0)
+		await resetSelectedAccountAndTransactionDelay(coldBaselineBackend)
+		await resetSelectedAccountAndTransactionDelay(warmBaselineBackend)
+		await resetSelectedAccountAndTransactionDelay(deployedBackend)
 	}, 30_000)
 
 	afterAll(async () => {
 		if (coldBaselineBackend !== undefined) await coldBaselineBackend.dispose()
 		if (warmBaselineBackend !== undefined) await warmBaselineBackend.dispose()
 		if (deployedBackend !== undefined) await deployedBackend.dispose()
+		if (securityPoolBackend !== undefined) await securityPoolBackend.dispose()
+		if (securityPoolX2Backend !== undefined) await securityPoolX2Backend.dispose()
+		if (securityPoolX2AuctionBackend !== undefined) await securityPoolX2AuctionBackend.dispose()
 	}, 30_000)
 
 	void test('reports wallet presence and returns the selected account', async () => {
@@ -335,32 +356,28 @@ void describe('simulation backend', () => {
 	}, 30_000)
 
 	void test('keeps the deployed-scenario fork threshold in sync after minting REP', async () => {
-		const backend = await createBootstrappedSimulationBackendWithRetry('deployed')
+		const backend = deployedBackend
 
-		try {
-			const readClient = backend.createReadClient()
-			const zoltarStep = getDeploymentSteps().find(step => step.id === 'zoltar')
-			if (zoltarStep === undefined) throw new Error('Expected the Zoltar deployment step')
-			const universeSummaryBefore = await loadZoltarUniverseSummary(readClient, 0n)
-			if (universeSummaryBefore === undefined) {
-				throw new Error('Expected the genesis Zoltar universe to be available in the deployed scenario')
-			}
-			const zoltarBalanceBefore = await readClient.getBalance({ address: zoltarStep.address })
-
-			await backend.mintRep(SIMULATION_REP_MINT_AMOUNT)
-
-			const universeSummaryAfter = await loadZoltarUniverseSummary(readClient, 0n)
-			if (universeSummaryAfter === undefined) {
-				throw new Error('Expected the genesis Zoltar universe after minting REP')
-			}
-			const zoltarBalanceAfter = await readClient.getBalance({ address: zoltarStep.address })
-
-			expect(universeSummaryAfter.totalTheoreticalSupply).toBe(universeSummaryBefore.totalTheoreticalSupply + SIMULATION_REP_MINT_AMOUNT)
-			expect(universeSummaryAfter.forkThreshold).toBe(universeSummaryBefore.forkThreshold + SIMULATION_REP_MINT_AMOUNT / 20n)
-			expect(zoltarBalanceAfter).toBe(zoltarBalanceBefore)
-		} finally {
-			await backend.dispose()
+		const readClient = backend.createReadClient()
+		const zoltarStep = getDeploymentSteps().find(step => step.id === 'zoltar')
+		if (zoltarStep === undefined) throw new Error('Expected the Zoltar deployment step')
+		const universeSummaryBefore = await loadZoltarUniverseSummary(readClient, 0n)
+		if (universeSummaryBefore === undefined) {
+			throw new Error('Expected the genesis Zoltar universe to be available in the deployed scenario')
 		}
+		const zoltarBalanceBefore = await readClient.getBalance({ address: zoltarStep.address })
+
+		await backend.mintRep(SIMULATION_REP_MINT_AMOUNT)
+
+		const universeSummaryAfter = await loadZoltarUniverseSummary(readClient, 0n)
+		if (universeSummaryAfter === undefined) {
+			throw new Error('Expected the genesis Zoltar universe after minting REP')
+		}
+		const zoltarBalanceAfter = await readClient.getBalance({ address: zoltarStep.address })
+
+		expect(universeSummaryAfter.totalTheoreticalSupply).toBe(universeSummaryBefore.totalTheoreticalSupply + SIMULATION_REP_MINT_AMOUNT)
+		expect(universeSummaryAfter.forkThreshold).toBe(universeSummaryBefore.forkThreshold + SIMULATION_REP_MINT_AMOUNT / 20n)
+		expect(zoltarBalanceAfter).toBe(zoltarBalanceBefore)
 	}, 60_000)
 
 	void test('submits simulation writes without deprecated Tevm transaction RPC warnings', async () => {
@@ -517,23 +534,21 @@ void describe('simulation backend', () => {
 	}, 30_000)
 
 	void test('bootstraps seeded security-pool scenarios without reverting', async () => {
-		const seededScenarios: Array<SimulationScenario> = ['security-pool', 'securitypoolx2', 'securitypoolx2-auction']
-		for (const scenario of seededScenarios) {
-			const backend = await createBootstrappedSimulationBackendWithRetry(scenario, 1)
-			try {
-				expect(backend.currentScenario).toBe(scenario)
-				const readClient = backend.createReadClient()
-				const pools = await loadAllSecurityPools(readClient)
-				expect(pools.length).toBeGreaterThan(0)
-			} finally {
-				await backend.dispose()
-			}
+		const seededScenarios = [
+			{ backend: securityPoolBackend, scenario: 'security-pool' },
+			{ backend: securityPoolX2Backend, scenario: 'securitypoolx2' },
+			{ backend: securityPoolX2AuctionBackend, scenario: 'securitypoolx2-auction' },
+		] satisfies Array<{ backend: SimulationBackend; scenario: SimulationScenario }>
+		for (const { backend, scenario } of seededScenarios) {
+			expect(backend.currentScenario).toBe(scenario)
+			const readClient = backend.createReadClient()
+			const pools = await loadAllSecurityPools(readClient)
+			expect(pools.length).toBeGreaterThan(0)
 		}
 	}, 180_000)
 
 	void test('bootstraps the security-pool scenario with one undercollateralized seeded vault', async () => {
-		const backend = await createSimulationBackend({ scenario: 'security-pool' })
-		await backend.bootstrap()
+		const backend = securityPoolBackend
 		const primaryAccount = backend.accounts[0]
 		if (primaryAccount === undefined) throw new Error('Expected seeded simulation QA accounts')
 

--- a/ui/ts/tests/openOracleSection.integration.test.tsx
+++ b/ui/ts/tests/openOracleSection.integration.test.tsx
@@ -5,10 +5,10 @@ import { fireEvent, waitFor, within } from './testUtils/queries'
 import { useState } from 'preact/hooks'
 import { act } from 'preact/test-utils'
 import type { Address, Hash } from 'viem'
-import { zeroAddress } from 'viem'
+import { getAddress, zeroAddress } from 'viem'
 import { OpenOracleSection } from '../components/OpenOracleSection.js'
 import { RouteSubNavigation } from '../components/RouteSubNavigation.js'
-import { getOpenOracleAddress, loadErc20Allowance, loadErc20Balance, loadOpenOracleReportDetails } from '../contracts.js'
+import { approveErc20, createOpenOracleReportInstance, getOpenOracleAddress, loadErc20Allowance, loadErc20Balance, loadOpenOracleReportDetails, submitInitialOracleReport, wrapWeth } from '../contracts.js'
 import { useOpenOracleOperations } from '../hooks/useOpenOracleOperations.js'
 import type { AccountState } from '../types/app.js'
 import type { InjectedEthereum } from '../injectedEthereum.js'
@@ -32,6 +32,20 @@ setDefaultTimeout(TEST_TIMEOUT_MS)
 
 const walletAddress = addressString(TEST_ADDRESSES[0])
 const reportId = 1n
+const initialReportPrice = 4n
+const openOracleCreateParameters = {
+	disputeDelay: 10,
+	escalationHalt: 0n,
+	exactToken1Report: 100n * 10n ** 18n,
+	ethValue: 1100n,
+	feePercentage: 100,
+	multiplier: 100,
+	protocolFee: 100,
+	settlementTime: 60,
+	settlerReward: 1000n,
+	token1Address: addressString(GENESIS_REPUTATION_TOKEN),
+	token2Address: getAddress(WETH_ADDRESS),
+}
 
 function createInjectedWalletShim(mockWindow: AnvilWindowEthereum, accountAddress: Address): InjectedEthereum {
 	const request: InjectedEthereum['request'] = async parameters => {
@@ -47,8 +61,8 @@ function createInjectedWalletShim(mockWindow: AnvilWindowEthereum, accountAddres
 	}
 }
 
-function OpenOracleSectionHarness({ accountAddress }: { accountAddress: Address }) {
-	const [activeView, setActiveView] = useState<OpenOracleView>('create')
+function OpenOracleSectionHarness({ accountAddress, initialActiveView = 'create' }: { accountAddress: Address; initialActiveView?: OpenOracleView }) {
+	const [activeView, setActiveView] = useState<OpenOracleView>(initialActiveView)
 	const openOracle = useOpenOracleOperations({
 		accountAddress,
 		enabled: true,
@@ -156,6 +170,46 @@ async function clickElement(element: HTMLElement) {
 	})
 }
 
+async function fillOpenOracleCreateForm() {
+	await setInputValue('Token1 Address', openOracleCreateParameters.token1Address)
+	await setInputValue('Token2 Address', openOracleCreateParameters.token2Address)
+	await setInputValue('Exact Token1 Report', openOracleCreateParameters.exactToken1Report.toString())
+	await setInputValue('Settler Reward', openOracleCreateParameters.settlerReward.toString())
+	await setInputValue('ETH Value To Send', openOracleCreateParameters.ethValue.toString())
+	await setInputValue('Fee Percentage', openOracleCreateParameters.feePercentage.toString())
+	await setInputValue('Multiplier', openOracleCreateParameters.multiplier.toString())
+	await setInputValue('Settlement Time', openOracleCreateParameters.settlementTime.toString())
+	await setInputValue('Escalation Halt', openOracleCreateParameters.escalationHalt.toString())
+	await setInputValue('Dispute Delay', openOracleCreateParameters.disputeDelay.toString())
+	await setInputValue('Protocol Fee', openOracleCreateParameters.protocolFee.toString())
+}
+
+async function loadSelectedReportInUi() {
+	const reportIdInput = await setInputValue('Report ID', reportId.toString())
+	const reportIdField = reportIdInput.closest('.field')
+	if (!(reportIdField instanceof HTMLElement)) throw new Error('Expected report ID field wrapper')
+	const reportControlButton = reportIdField.querySelector('button')
+	if (!(reportControlButton instanceof HTMLButtonElement)) throw new Error('Expected report ID control button')
+	await clickElement(reportControlButton)
+	await waitFor(() => getSectionByTitle('Selected Report Actions'))
+}
+
+async function createSubmittedOpenOracleReport(writeClient: WriteClient, readClient: ReturnType<typeof createConnectedReadClient>) {
+	const openOracleAddress = getOpenOracleAddress()
+	await createOpenOracleReportInstance(writeClient, openOracleCreateParameters)
+	const reportDetails = await loadOpenOracleReportDetails(readClient, openOracleAddress, reportId)
+	const amount2 = reportDetails.exactToken1Report / initialReportPrice
+
+	await approveErc20(writeClient, reportDetails.token1, openOracleAddress, reportDetails.exactToken1Report, 'approveToken1')
+	await approveErc20(writeClient, reportDetails.token2, openOracleAddress, amount2, 'approveToken2')
+	await wrapWeth(writeClient, amount2)
+	await submitInitialOracleReport(writeClient, openOracleAddress, reportId, reportDetails.exactToken1Report, amount2, reportDetails.stateHash)
+
+	return {
+		openOracleAddress,
+	}
+}
+
 async function waitForLatestAction(actionName: string) {
 	for (let attempt = 0; attempt < 20; attempt += 1) {
 		if (within(document.body).queryAllByText(actionName).length > 0) return
@@ -210,17 +264,7 @@ describe.serial('OpenOracleSection integration', () => {
 		const renderedComponent = await renderIntoDocument(<OpenOracleSectionHarness accountAddress={walletAddress} />)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		await setInputValue('Token1 Address', addressString(GENESIS_REPUTATION_TOKEN))
-		await setInputValue('Token2 Address', WETH_ADDRESS)
-		await setInputValue('Exact Token1 Report', '100000000000000000000')
-		await setInputValue('Settler Reward', '1000')
-		await setInputValue('ETH Value To Send', '1100')
-		await setInputValue('Fee Percentage', '100')
-		await setInputValue('Multiplier', '100')
-		await setInputValue('Settlement Time', '60')
-		await setInputValue('Escalation Halt', '0')
-		await setInputValue('Dispute Delay', '10')
-		await setInputValue('Protocol Fee', '100')
+		await fillOpenOracleCreateForm()
 
 		await clickElement(within(document.body).getByRole('button', { name: 'Create Open Oracle Game' }))
 
@@ -247,11 +291,11 @@ describe.serial('OpenOracleSection integration', () => {
 		expect(within(document.body).queryByRole('heading', { level: 2, name: 'Open Oracle' })).toBeNull()
 		expect(within(document.body).queryByRole('heading', { level: 3, name: 'Report Details' })).toBeNull()
 		expect(within(document.body).queryByRole('heading', { level: 3, name: 'Report Actions' })).toBeNull()
-		await setInputValue(/^Price \(/, '4')
+		await setInputValue(/^Price \(/, initialReportPrice.toString())
 
 		const reportDetails = await loadOpenOracleReportDetails(uiReadClient, getOpenOracleAddress(), reportId)
 		const openOracleAddress = getOpenOracleAddress()
-		const expectedAmount2 = reportDetails.exactToken1Report / 4n
+		const expectedAmount2 = reportDetails.exactToken1Report / initialReportPrice
 
 		await waitFor(() => {
 			const [currentToken1ApprovalSection, currentToken2ApprovalSection] = getApprovalSections()
@@ -323,87 +367,11 @@ describe.serial('OpenOracleSection integration', () => {
 	})
 
 	test('disables dispute and enables settle after the settlement window elapses', async () => {
-		const renderedComponent = await renderIntoDocument(<OpenOracleSectionHarness accountAddress={walletAddress} />)
+		const { openOracleAddress } = await createSubmittedOpenOracleReport(client, uiReadClient)
+		const renderedComponent = await renderIntoDocument(<OpenOracleSectionHarness accountAddress={walletAddress} initialActiveView='selected-report' />)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		await setInputValue('Token1 Address', addressString(GENESIS_REPUTATION_TOKEN))
-		await setInputValue('Token2 Address', WETH_ADDRESS)
-		await setInputValue('Exact Token1 Report', '100000000000000000000')
-		await setInputValue('Settler Reward', '1000')
-		await setInputValue('ETH Value To Send', '1100')
-		await setInputValue('Fee Percentage', '100')
-		await setInputValue('Multiplier', '100')
-		await setInputValue('Settlement Time', '60')
-		await setInputValue('Escalation Halt', '0')
-		await setInputValue('Dispute Delay', '10')
-		await setInputValue('Protocol Fee', '100')
-
-		await clickElement(within(document.body).getByRole('button', { name: 'Create Open Oracle Game' }))
-		await waitForLatestAction('createReportInstance')
-		await waitFor(async () => {
-			const createdReport = await loadOpenOracleReportDetails(uiReadClient, getOpenOracleAddress(), reportId)
-			expect(createdReport.reportId).toBe(reportId)
-		})
-
-		await clickElement(within(document.body).getByRole('tab', { name: 'Browse' }))
-		await waitFor(() => {
-			expect(within(document.body).getByText(`Report #${reportId.toString()}`)).not.toBeNull()
-		})
-		await clickElement(within(document.body).getByRole('button', { name: 'Open report' }))
-
-		await waitFor(() => getSectionByTitle('Selected Report'))
-		await waitFor(() => {
-			expect(within(document.body).getByRole('button', { name: 'Initial Report' })).not.toBeNull()
-		})
-		await clickElement(within(document.body).getByRole('button', { name: 'Initial Report' }))
-		await waitFor(() => {
-			expect(within(document.body).getByRole('heading', { level: 4, name: 'Initial Report' })).not.toBeNull()
-		})
-		expect(within(document.body).queryByRole('heading', { level: 2, name: 'Open Oracle' })).toBeNull()
-		expect(within(document.body).queryByRole('heading', { level: 3, name: 'Report Details' })).toBeNull()
-		expect(within(document.body).queryByRole('heading', { level: 3, name: 'Report Actions' })).toBeNull()
-		await setInputValue(/^Price \(/, '4')
-
-		const reportDetails = await loadOpenOracleReportDetails(uiReadClient, getOpenOracleAddress(), reportId)
-		const openOracleAddress = getOpenOracleAddress()
-		const expectedAmount2 = reportDetails.exactToken1Report / 4n
-
-		const [token1ApprovalSection, token2ApprovalSection] = getApprovalSections()
-		if (token1ApprovalSection === undefined || token2ApprovalSection === undefined) throw new Error('Expected both token approval sections to be rendered')
-
-		await clickElement(getApproveButton(token1ApprovalSection))
-		await waitForLatestAction('approveToken1')
-		await waitFor(async () => {
-			expect(await loadErc20Allowance(uiReadClient, reportDetails.token1, walletAddress, openOracleAddress)).toBe(reportDetails.exactToken1Report)
-		})
-
-		const refreshedApprovalSections = getApprovalSections()
-		const refreshedToken2ApprovalSection = refreshedApprovalSections[1]
-		if (refreshedToken2ApprovalSection === undefined) throw new Error('Expected the second token approval section to remain rendered')
-
-		await clickElement(getApproveButton(refreshedToken2ApprovalSection))
-		await waitForLatestAction('approveToken2')
-		await waitFor(async () => {
-			expect(await loadErc20Allowance(uiReadClient, reportDetails.token2, walletAddress, openOracleAddress)).toBe(expectedAmount2)
-		})
-
-		await clickElement(within(document.body).getByRole('button', { name: 'Wrap needed ETH to WETH' }))
-		await waitFor(async () => {
-			expect(await loadErc20Balance(uiReadClient, reportDetails.token2, walletAddress)).toBe(expectedAmount2)
-		})
-
-		await waitFor(() => {
-			const submitButton = within(document.body).getByRole('button', { name: 'Submit Initial Report' }) as HTMLButtonElement
-			expect(submitButton.disabled).toBe(false)
-		})
-
-		await clickElement(within(document.body).getByRole('button', { name: 'Submit Initial Report' }))
-		await waitForLatestAction('submitInitialReport')
-		await waitFor(async () => {
-			const submittedReport = await loadOpenOracleReportDetails(uiReadClient, openOracleAddress, reportId)
-			expect(submittedReport.currentReporter).not.toBe(zeroAddress)
-			expect(submittedReport.reportTimestamp > 0n).toBe(true)
-		})
+		await loadSelectedReportInUi()
 
 		const submittedReport = await loadOpenOracleReportDetails(uiReadClient, openOracleAddress, reportId)
 		const submittedClock = submittedReport.timeType ? submittedReport.currentTime : submittedReport.currentBlockNumber


### PR DESCRIPTION
## Summary
- Refactored `ui/ts/tests/activeEnvironment.test.ts` to centralize simulation backends with shared bootstrapped instances for baseline/deployed/security-pool variants, eliminating repeated per-test backend creation/disposal.
- Added `SimulationBackend` typing and reset helper to normalize selected account/transaction delay before each simulation test.
- Reworked seeded security-pool coverage to reuse pre-created backends (`security-pool`, `securitypoolx2`, `securitypoolx2-auction`) while preserving scenario assertions.
- Refactored `ui/ts/tests/openOracleSection.integration.test.tsx` by extracting repeated Open Oracle setup into reusable helpers for form filling and report creation/submission flow.
- Added small API helper integration in the Open Oracle test (`getAddress`, `approveErc20`, `createOpenOracleReportInstance`, `submitInitialOracleReport`, `wrapWeth`) to reduce duplicated inline interactions and improve determinism/readability.

## Testing
- `bun run tsc` (not run)
- `bun run test` (not run)
- `bun run format` (not run)
- `bun run check` (not run)
- `bun run knip` (not run)
- Note: no local test/validation commands were executed in this PR write-up pass; only review of provided diff was performed.