### PR TITLE
Use viem ESM vendor aliases and harden production asset copy

### DIFF
--- a/ui/build/production.mts
+++ b/ui/build/production.mts
@@ -26,12 +26,12 @@ globalThis.global ??= globalThis
 function createBrowserVendorAliasPlugin() {
 	const aliasEntries: Array<[RegExp, string]> = [
 		[/^pino$/, path.join(MODULES_ROOT_PATH, 'pino', 'browser.js')],
-		[/^viem$/, path.join(MODULES_ROOT_PATH, 'viem', 'index.ts')],
-		[/^viem\/chains$/, path.join(MODULES_ROOT_PATH, 'viem', 'chains', 'index.ts')],
-		[/^viem\/window$/, path.join(MODULES_ROOT_PATH, 'viem', 'window', 'index.ts')],
-		[/^viem\/actions$/, path.join(MODULES_ROOT_PATH, 'viem', 'actions', 'index.ts')],
-		[/^viem\/accounts$/, path.join(MODULES_ROOT_PATH, 'viem', 'accounts', 'index.ts')],
-		[/^viem\/utils$/, path.join(MODULES_ROOT_PATH, 'viem', 'utils', 'index.ts')],
+		[/^viem$/, path.join(MODULES_ROOT_PATH, 'viem', '_esm', 'index.js')],
+		[/^viem\/chains$/, path.join(MODULES_ROOT_PATH, 'viem', '_esm', 'chains', 'index.js')],
+		[/^viem\/window$/, path.join(MODULES_ROOT_PATH, 'viem', '_esm', 'window', 'index.js')],
+		[/^viem\/actions$/, path.join(MODULES_ROOT_PATH, 'viem', '_esm', 'actions', 'index.js')],
+		[/^viem\/accounts$/, path.join(MODULES_ROOT_PATH, 'viem', '_esm', 'accounts', 'index.js')],
+		[/^viem\/utils$/, path.join(MODULES_ROOT_PATH, 'viem', '_esm', 'utils', 'index.js')],
 		[/^tevm$/, path.join(MODULES_ROOT_PATH, '@tevm', 'memory-client', 'dist', 'index.js')],
 		[/^tevm\/common$/, path.join(MODULES_ROOT_PATH, '@tevm', 'common', 'dist', 'index.js')],
 		[/^@tevm\/memory-client$/, path.join(MODULES_ROOT_PATH, '@tevm', 'memory-client', 'dist', 'index.js')],
@@ -53,7 +53,11 @@ function createBrowserVendorAliasPlugin() {
 
 async function copyStaticAsset(sourcePath: string, destinationPath: string) {
 	await fs.mkdir(path.dirname(destinationPath), { recursive: true })
-	await fs.copyFile(sourcePath, destinationPath)
+	const sourceFile = Bun.file(sourcePath)
+	if (!(await sourceFile.exists())) {
+		throw new Error(`Missing static asset: ${sourcePath}`)
+	}
+	await Bun.write(destinationPath, await sourceFile.arrayBuffer())
 }
 
 async function writeProductionIndexHtml() {

--- a/ui/build/productionBuild.test.ts
+++ b/ui/build/productionBuild.test.ts
@@ -1,8 +1,8 @@
 import { afterAll, beforeAll, expect, test } from 'bun:test'
+import { spawnSync } from 'node:child_process'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import * as url from 'node:url'
-import { buildProductionBundle } from './production.mts'
 
 const directoryOfThisFile = path.dirname(url.fileURLToPath(import.meta.url))
 const repositoryRootPath = path.join(directoryOfThisFile, '..', '..')
@@ -19,7 +19,13 @@ const productionFaviconPaths = [path.join(distRootPath, 'favicon.ico'), path.joi
 let server: Bun.Server | undefined
 
 beforeAll(async () => {
-	await buildProductionBundle()
+	const result = spawnSync('bun', ['run', 'ui:build:prod'], {
+		cwd: repositoryRootPath,
+		encoding: 'utf8',
+	})
+	if (result.status !== 0) {
+		throw new Error(`ui:build:prod failed\n${result.stdout}${result.stderr}`)
+	}
 
 	server = Bun.serve({
 		fetch: async request => {


### PR DESCRIPTION
## Summary
- Switched browser viem aliases in the production bundler to the package ESM entrypoints under `viem/_esm/.../index.js`, avoiding TypeScript source entry selection for runtime builds.
- Updated production static asset copy logic to fail fast when source assets are missing by checking existence before writing.
- Adjusted production build test setup to execute `bun run ui:build:prod` via `spawnSync` in `beforeAll`, surfacing build failures as test errors early.

## Testing
- Not run (not executed in this PR creation step).
- Verified diff includes updated behavior: alias paths changed from `viem/*/index.ts` to `viem/_esm/*/index.js`, and added `sourceFile.exists()` guard in `copyStaticAsset`.