### PR TITLE
Hardening complete-set minting and fork REP migration semantics

### DIFF
--- a/docs/mainnet-deployment-addresses.json
+++ b/docs/mainnet-deployment-addresses.json
@@ -13,7 +13,7 @@
 		{
 			"id": "deploymentStatusOracle",
 			"label": "Deployment Status Oracle",
-			"address": "0x725502CbB4877619dC825e7CB4a83FCa1bB809bE"
+			"address": "0x3fb2564F0Ac182cF8ef669dF9CDAF67a29ac9D51"
 		},
 		{
 			"id": "multicall3",
@@ -53,27 +53,27 @@
 		{
 			"id": "shareTokenFactory",
 			"label": "ShareTokenFactory",
-			"address": "0x6a360dD5d6b958ED1690296D0B3D003E290B4e0e"
+			"address": "0x716a9F6A0798ab8480eDB4458AE00aBaE9E83126"
 		},
 		{
 			"id": "priceOracleManagerAndOperatorQueuerFactory",
 			"label": "Price Oracle Manager Factory",
-			"address": "0xb1779119842a8692cf0a47Fc743A90744f910092"
+			"address": "0xb765212473540a283B2CdA1DFfF81a2F0c546046"
 		},
 		{
 			"id": "securityPoolForker",
 			"label": "Security Pool Forker",
-			"address": "0x19a2ba34c49Cb9aB9289F35fe36b4C28F6e0B582"
+			"address": "0xe9035933Eade1352F17dE51055685C4F8709e01C"
 		},
 		{
 			"id": "escalationGameFactory",
 			"label": "Escalation Game Factory",
-			"address": "0xDF85248e59F374DC46B32d83368f0c7DE9878Ae5"
+			"address": "0x4B66D801B256b57258B7bAE7aa4d02Bd98313e47"
 		},
 		{
 			"id": "securityPoolFactory",
 			"label": "Security Pool Factory",
-			"address": "0x78FE3889B0329d36EBC52216EAD96F2048efC9AE"
+			"address": "0xeb763530ba82be2ecbA64B528EC094F8B9D6AD93"
 		}
 	]
 }

--- a/docs/mainnet-deployment-addresses.md
+++ b/docs/mainnet-deployment-addresses.md
@@ -15,7 +15,7 @@ These values are derived from the frozen mainnet protocol config, current contra
 | ID | Label | Expected Address |
 | --- | --- | --- |
 | proxyDeployer | Proxy Deployer | `0x7A0D94F55792C434d74a40883C6ed8545E406D12` |
-| deploymentStatusOracle | Deployment Status Oracle | `0x725502CbB4877619dC825e7CB4a83FCa1bB809bE` |
+| deploymentStatusOracle | Deployment Status Oracle | `0x3fb2564F0Ac182cF8ef669dF9CDAF67a29ac9D51` |
 | multicall3 | Multicall3 | `0x77609e84c39893D5fB99049FE0F461aEB4F4Ec79` |
 | uniformPriceDualCapBatchAuctionFactory | UniformPriceDualCapBatchAuctionFactory | `0xbA605970da511b08539bcC4F77B54CF1Cd72783c` |
 | scalarOutcomes | ScalarOutcomes | `0x5890b011CF7E36d4Fee28Bac8B5be6f61C392a4C` |
@@ -23,10 +23,10 @@ These values are derived from the frozen mainnet protocol config, current contra
 | openOracle | OpenOracle | `0x51DED022c087758c187ce636aa5f6adE6B919abB` |
 | zoltarQuestionData | ZoltarQuestionData | `0xeadF91d12F549786891350B3D535638713651207` |
 | zoltar | Zoltar | `0x6b5003e3715D5Bc8C753ca9822A0c550801B1fca` |
-| shareTokenFactory | ShareTokenFactory | `0x6a360dD5d6b958ED1690296D0B3D003E290B4e0e` |
-| priceOracleManagerAndOperatorQueuerFactory | Price Oracle Manager Factory | `0xb1779119842a8692cf0a47Fc743A90744f910092` |
-| securityPoolForker | Security Pool Forker | `0x19a2ba34c49Cb9aB9289F35fe36b4C28F6e0B582` |
-| escalationGameFactory | Escalation Game Factory | `0xDF85248e59F374DC46B32d83368f0c7DE9878Ae5` |
-| securityPoolFactory | Security Pool Factory | `0x78FE3889B0329d36EBC52216EAD96F2048efC9AE` |
+| shareTokenFactory | ShareTokenFactory | `0x716a9F6A0798ab8480eDB4458AE00aBaE9E83126` |
+| priceOracleManagerAndOperatorQueuerFactory | Price Oracle Manager Factory | `0xb765212473540a283B2CdA1DFfF81a2F0c546046` |
+| securityPoolForker | Security Pool Forker | `0xe9035933Eade1352F17dE51055685C4F8709e01C` |
+| escalationGameFactory | Escalation Game Factory | `0x4B66D801B256b57258B7bAE7aa4d02Bd98313e47` |
+| securityPoolFactory | Security Pool Factory | `0xeb763530ba82be2ecbA64B528EC094F8B9D6AD93` |
 
 Security pool deployments are deterministic per pool input rather than globally fixed. Their addresses are derived from the deployed factory set plus parent universe, universe ID, question ID, and security multiplier.

--- a/docs/whitepaper_placeholder.html
+++ b/docs/whitepaper_placeholder.html
@@ -860,8 +860,8 @@
 							<path class="svg-line" marker-end="url(#arrow-assets)" d="M 584 94 H 734"></path>
 							<text class="svg-small" x="654" y="79" text-anchor="middle">mint shares</text>
 							<path class="svg-line" marker-end="url(#arrow-assets)" d="M 734 126 C 610 182 350 182 224 126"></path>
-							<text class="svg-small" x="484" y="205" text-anchor="middle">redeem full set before finalization</text>
-							<text class="svg-small" x="484" y="227" text-anchor="middle">or winning shares after finalization</text>
+							<text class="svg-small" x="484" y="205" text-anchor="middle">redeem full sets while operational</text>
+							<text class="svg-small" x="484" y="227" text-anchor="middle">or finalized winning shares</text>
 							<rect class="svg-gold" x="54" y="272" width="170" height="72" rx="10"></rect>
 							<text class="svg-label" x="139" y="304" text-anchor="middle">Vault</text>
 							<text class="svg-small" x="139" y="327" text-anchor="middle">deposits REP</text>
@@ -899,8 +899,8 @@
 						becomes <code>completeSetCollateralAmount</code>.
 					</p>
 					<ul>
-						<li>Before finalization, a full complete set can be burned with <code>redeemCompleteSet</code> to recover its pro rata share of collateral.</li>
-						<li>After finalization, users redeem only the winning outcome through <code>redeemShares</code>.</li>
+						<li>While the pool is operational, a full complete set can be burned with <code>redeemCompleteSet</code> to recover its pro rata share of collateral.</li>
+						<li>After the fork route finalizes an outcome, users can redeem winning outcome shares through <code>redeemShares</code>.</li>
 					</ul>
 					<h3>Fee Extraction and Retention Rate</h3>
 					<p>
@@ -980,7 +980,7 @@
 					<figure class="diagram">
 						<svg viewBox="0 0 860 340" role="img" aria-labelledby="shares-title shares-desc">
 							<title id="shares-title">Complete set lifecycle</title>
-							<desc id="shares-desc">ETH mints Invalid, Yes, and No shares. Before finalization a full set redeems collateral; after finalization only winning shares redeem.</desc>
+							<desc id="shares-desc">ETH mints Invalid, Yes, and No shares. Operational pools redeem full sets, and finalized winning shares redeem through outcome settlement.</desc>
 							<defs>
 								<marker id="arrow-shares" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
 									<path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"></path>
@@ -1825,10 +1825,10 @@
 							<text class="svg-label" x="695" y="74" text-anchor="middle">1 week</text>
 							<text class="svg-small" x="695" y="98" text-anchor="middle">auction</text>
 							<rect class="svg-box" x="780" y="42" width="150" height="76" rx="10"></rect>
-							<text class="svg-label" x="855" y="74" text-anchor="middle">1 hour</text>
+							<text class="svg-label" x="855" y="74" text-anchor="middle">5 minutes</text>
 							<text class="svg-small" x="855" y="98" text-anchor="middle">price validity</text>
 						</svg>
-						<p class="diagram-caption">The operational clock is mostly measured in days and weeks, except REP/ETH solvency prices, which expire after one hour.</p>
+						<p class="diagram-caption">The operational clock is mostly measured in days and weeks, except REP/ETH solvency prices, which expire after five minutes.</p>
 					</figure>
 					<div class="parameter-grid">
 						<div class="parameter-card">
@@ -1865,7 +1865,7 @@
 						</div>
 						<div class="parameter-card">
 							<span>Price Validity</span>
-							<b><code>PRICE_VALID_FOR_SECONDS = 1 hour</code>.</b>
+							<b><code>PRICE_VALID_FOR_SECONDS = 5 minutes</code>.</b>
 						</div>
 					</div>
 					<h3>Escalation Parameters</h3>
@@ -1982,22 +1982,26 @@
 							</tr>
 						</thead>
 						<tbody>
-							<tr><td><code>PRICE_VALID_FOR_SECONDS</code></td><td><code>1 hour</code></td><td>How long a settled REP/ETH price remains valid.</td></tr>
+							<tr><td><code>PRICE_VALID_FOR_SECONDS</code></td><td><code>5 minutes</code></td><td>How long a settled REP/ETH price remains valid.</td></tr>
 							<tr><td><code>gasConsumedOpenOracleReportPrice</code></td><td><code>100000</code></td><td>Coordinator gas estimate for report submission.</td></tr>
 							<tr><td><code>gasConsumedSettlement</code></td><td><code>1000000</code></td><td>Coordinator gas estimate for settlement callback.</td></tr>
-							<tr><td>OpenOracle <code>exactToken1Report</code></td><td><code>26392439800</code></td><td>Hard-coded initial report liquidity parameter.</td></tr>
-							<tr><td>OpenOracle <code>escalationHalt</code></td><td><code>reputationToken.totalSupply() / 100000</code></td><td>Dynamic halt threshold for report escalation.</td></tr>
+							<tr><td>OpenOracle <code>exactToken1Report</code></td><td><code>250 * 10^18</code></td><td>Hard-coded initial report liquidity parameter.</td></tr>
+							<tr><td>OpenOracle <code>escalationHalt</code></td><td><code>exactToken1Report * 10</code></td><td>Dynamic halt threshold for report escalation.</td></tr>
 							<tr><td>OpenOracle <code>settlerReward</code></td><td><code>block.basefee * 2 * gasConsumedOpenOracleReportPrice</code></td><td>Dynamic ETH reward paid to settler.</td></tr>
-							<tr><td>OpenOracle <code>settlementTime</code></td><td><code>180</code></td><td>Settlement delay encoded as <code>15 * 12</code>.</td></tr>
+							<tr><td>OpenOracle <code>settlementTime</code></td><td><code>480</code></td><td>Settlement delay encoded as <code>40 * 12</code>.</td></tr>
 							<tr><td>OpenOracle <code>disputeDelay</code></td><td><code>0</code></td><td>No extra waiting period after each report.</td></tr>
-							<tr><td>OpenOracle <code>protocolFee</code></td><td><code>0</code></td><td>Protocol fee disabled.</td></tr>
+							<tr><td>OpenOracle <code>protocolFee</code></td><td><code>100000</code></td><td>OpenOracle protocol fee parameter.</td></tr>
 							<tr><td>OpenOracle <code>callbackGasLimit</code></td><td><code>1000000</code></td><td>Settlement callback gas limit.</td></tr>
 							<tr><td>OpenOracle <code>feePercentage</code></td><td><code>10000</code></td><td>Fee paid to previous reporter, annotated in code as <code>0.1%</code>.</td></tr>
-							<tr><td>OpenOracle <code>multiplier</code></td><td><code>140</code></td><td>New report amount must be <code>1.4x</code> the prior amount.</td></tr>
+							<tr><td>OpenOracle <code>multiplier</code></td><td><code>115</code></td><td>New report amount must be <code>1.15x</code> the prior amount.</td></tr>
 							<tr><td>OpenOracle <code>timeType</code></td><td><code>true</code></td><td>OpenOracle uses block timestamps rather than block numbers.</td></tr>
-							<tr><td>OpenOracle <code>trackDisputes</code></td><td><code>false</code></td><td>Dispute history is not stored for these reports.</td></tr>
+							<tr><td>OpenOracle <code>trackDisputes</code></td><td><code>true</code></td><td>Dispute history is stored for these reports.</td></tr>
 							<tr><td>OpenOracle <code>keepFee</code></td><td><code>false</code></td><td>Initial reporter reward does not stay with the initial reporter.</td></tr>
 							<tr><td>OpenOracle <code>feeToken</code></td><td><code>true</code></td><td>OpenOracle fees are paid in token-to-swap terms.</td></tr>
+							<tr><td>Coordinator <code>priceRoundBudgetMultiplierBps</code></td><td><code>40000</code></td><td>Shared per-price-round operation budget multiplier.</td></tr>
+							<tr><td>Coordinator <code>escalationHaltMultiplierBps</code></td><td><code>100000</code></td><td>Multiplier used to derive the OpenOracle escalation halt from <code>exactToken1Report</code>.</td></tr>
+							<tr><td>Coordinator <code>maxSettlementBaseFeeMultiplierBps</code></td><td><code>30000</code></td><td>Maximum base-fee multiplier accepted for automated oracle settlement.</td></tr>
+							<tr><td>Coordinator <code>minLiquidationPriceDistanceBps</code></td><td><code>1000</code></td><td>Minimum distance from the liquidation threshold required for oracle-backed liquidation execution.</td></tr>
 							<tr><td>Coordinator <code>WETH</code></td><td><code>0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2</code></td><td>Mainnet WETH address used in REP/ETH price reports.</td></tr>
 						</tbody>
 					</table>

--- a/solidity/contracts/peripherals/EscalationGame.sol
+++ b/solidity/contracts/peripherals/EscalationGame.sol
@@ -537,7 +537,7 @@ contract EscalationGame {
 		require(outcome != BinaryOutcomes.BinaryOutcome.None, 'bad outcome');
 		require(getQuestionResolution() == BinaryOutcomes.BinaryOutcome.None, 'to');
 		require(outcomeState[uint8(outcome)].balance < nonDecisionThreshold, 'af');
-		require(amount >= startBond, 'md');
+		require(amount > 0, 'md');
 		uint256 outcomeIndex = uint256(outcome);
 		OutcomeState storage selectedOutcomeState = outcomeState[outcomeIndex];
 		uint256 currentBalance = selectedOutcomeState.balance;
@@ -1361,9 +1361,9 @@ contract EscalationGame {
 
 		if (newBalance == maxBalance && otherHasMax && maxBalance < nonDecisionThreshold) {
 			acceptedAmount -= 1;
-			require(acceptedAmount >= startBond, 'tie adjustment would break min deposit');
 			newBalance = currentBalance + acceptedAmount;
 		}
+		require(acceptedAmount >= startBond || newBalance == nonDecisionThreshold, 'md');
 	}
 
 	function _getStableLocalParentDepositIndex(uint256 depositIndex) private view returns (uint256) {

--- a/solidity/contracts/peripherals/SecurityPool.sol
+++ b/solidity/contracts/peripherals/SecurityPool.sol
@@ -477,11 +477,12 @@ contract SecurityPool is ISecurityPool {
 		require(!isEscalationResolved(), 'question resolved');
 		require(msg.value > 0, 'need eth');
 		updateCollateralAmount();
-		require(totalSecurityBondAllowance >= msg.value + completeSetCollateralAmount, 'no set capacity');
 		uint256 completeSetsToMint = cashToShares(msg.value);
-		shareToken.mintCompleteSets(universeId, msg.sender, completeSetsToMint);
+		uint256 nextCompleteSetCollateralAmount = completeSetCollateralAmount + msg.value;
+		require(totalSecurityBondAllowance >= nextCompleteSetCollateralAmount, 'no set capacity');
 		shareTokenSupply += completeSetsToMint;
-		completeSetCollateralAmount += msg.value;
+		completeSetCollateralAmount = nextCompleteSetCollateralAmount;
+		shareToken.mintCompleteSets(universeId, msg.sender, completeSetsToMint);
 		emit CreateCompleteSet(shareTokenSupply, completeSetsToMint, completeSetCollateralAmount);
 		updateRetentionRate();
 	}

--- a/solidity/contracts/peripherals/SecurityPoolForker.sol
+++ b/solidity/contracts/peripherals/SecurityPoolForker.sol
@@ -313,9 +313,7 @@ contract SecurityPoolForker is SecurityPoolForkerVaultMigrationBase {
 					block.timestamp <= zoltar.getForkTime(securityPool.universeId()) + SecurityPoolUtils.MIGRATION_TIME,
 					'migration window closed'
 				);
-				_splitMigrationRepToChild(securityPool, outcomeIndex, migrationAmount, data.ownFork, false);
-				pendingChildRepByPoolAndOutcome[securityPool][outcomeIndex] += migrationAmount;
-				_sweepChildRepToPool(securityPool, outcomeIndex);
+				_ensureChildPoolRepSplit(securityPool, outcomeIndex, migrationAmount);
 			}
 		}
 	}

--- a/solidity/contracts/peripherals/SecurityPoolForkerStorage.sol
+++ b/solidity/contracts/peripherals/SecurityPoolForkerStorage.sol
@@ -12,5 +12,6 @@ abstract contract SecurityPoolForkerStorage {
 	mapping(ISecurityPool => mapping(uint256 => ISecurityPool)) internal childrenByPoolAndOutcome;
 	mapping(ISecurityPool => SecurityPoolMigrationProxy) internal migrationProxyByPool;
 	mapping(ISecurityPool => mapping(uint256 => uint256)) internal pendingChildRepByPoolAndOutcome;
+	mapping(ISecurityPool => mapping(uint256 => uint256)) internal childPoolRepSplitByPoolAndOutcome;
 	mapping(address => bool) internal trustedAuctionAddresses;
 }

--- a/solidity/contracts/peripherals/SecurityPoolForkerVaultMigrationBase.sol
+++ b/solidity/contracts/peripherals/SecurityPoolForkerVaultMigrationBase.sol
@@ -186,6 +186,27 @@ abstract contract SecurityPoolForkerVaultMigrationBase is SecurityPoolForkerStor
 		parent.transferEth(payable(address(child)), ethToTransfer);
 	}
 
+	function _ensureMigratedVaultRepBacked(
+		ISecurityPool parent,
+		ISecurityPool child,
+		uint256 requiredMigratedRep
+	) internal {
+		if (requiredMigratedRep == 0) return;
+		uint256 outcomeIndex = forkDataByPool[child].outcomeIndex;
+		_ensureChildPoolRepSplit(parent, outcomeIndex, requiredMigratedRep);
+		require(child.repToken().balanceOf(address(child)) >= requiredMigratedRep, 'child rep shortfall');
+	}
+
+	function _ensureChildPoolRepSplit(ISecurityPool parent, uint256 outcomeIndex, uint256 requiredSplit) internal {
+		uint256 alreadySplit = childPoolRepSplitByPoolAndOutcome[parent][outcomeIndex];
+		if (alreadySplit >= requiredSplit) return;
+		uint256 shortfall = requiredSplit - alreadySplit;
+		_splitMigrationRepToChild(parent, outcomeIndex, shortfall, forkDataByPool[parent].ownFork, false);
+		childPoolRepSplitByPoolAndOutcome[parent][outcomeIndex] = requiredSplit;
+		pendingChildRepByPoolAndOutcome[parent][outcomeIndex] += shortfall;
+		_sweepChildRepToPool(parent, outcomeIndex);
+	}
+
 	function _migrateVaultUnlockedState(
 		ISecurityPool parent,
 		ISecurityPool child,
@@ -214,7 +235,10 @@ abstract contract SecurityPoolForkerVaultMigrationBase is SecurityPoolForkerStor
 		if (parentSecurityBondAllowance > 0) vaultFeeIndex = child.feeIndex();
 		if (parent.poolOwnershipDenominator() > 0 && parentRepAtFork > 0 && parentPoolOwnership > 0) {
 			migratedRep = (parentPoolOwnership * parentRepAtFork) / parent.poolOwnershipDenominator();
-			forkDataByPool[child].migratedRep += migratedRep;
+			SecurityPoolForkerForkData storage childForkData = forkDataByPool[child];
+			uint256 nextMigratedRep = childForkData.migratedRep + migratedRep;
+			_ensureMigratedVaultRepBacked(parent, child, nextMigratedRep);
+			childForkData.migratedRep = nextMigratedRep;
 			if (shouldTransferCollateral) {
 				uint256 collateralToTransfer = (parent.completeSetCollateralAmount() * migratedRep) / parentRepAtFork;
 				parent.transferEth(payable(child), collateralToTransfer);

--- a/solidity/contracts/test/peripherals/CompleteSetReentrantReceiver.sol
+++ b/solidity/contracts/test/peripherals/CompleteSetReentrantReceiver.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.35;
+
+import '../../peripherals/interfaces/IERC1155Receiver.sol';
+import '../../peripherals/interfaces/ISecurityPool.sol';
+
+contract CompleteSetReentrantReceiver is IERC1155Receiver {
+	bytes4 private constant ERC1155_RECEIVED_SELECTOR = 0xf23a6e61;
+	bytes4 private constant ERC1155_BATCH_RECEIVED_SELECTOR = 0xbc197c81;
+	bytes4 private constant ERC1155_RECEIVER_INTERFACE_ID = 0x4e2312e0;
+	bytes4 private constant ERC165_INTERFACE_ID = 0x01ffc9a7;
+
+	ISecurityPool public immutable securityPool;
+	uint256 public reentrantValue;
+	uint256 public reentryCount;
+
+	constructor(ISecurityPool _securityPool) payable {
+		securityPool = _securityPool;
+	}
+
+	function attack(uint256 initialValue, uint256 _reentrantValue) external payable {
+		require(msg.value == initialValue + _reentrantValue, 'funding');
+		reentrantValue = _reentrantValue;
+		securityPool.createCompleteSet{ value: initialValue }();
+	}
+
+	function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+		return interfaceId == ERC165_INTERFACE_ID || interfaceId == ERC1155_RECEIVER_INTERFACE_ID;
+	}
+
+	function onERC1155Received(address, address, uint256, uint256, bytes calldata) external pure returns (bytes4) {
+		return ERC1155_RECEIVED_SELECTOR;
+	}
+
+	function onERC1155BatchReceived(
+		address,
+		address,
+		uint256[] calldata,
+		uint256[] calldata,
+		bytes calldata
+	) external returns (bytes4) {
+		if (reentryCount == 0 && reentrantValue > 0) {
+			reentryCount = 1;
+			securityPool.createCompleteSet{ value: reentrantValue }();
+		}
+		return ERC1155_BATCH_RECEIVED_SELECTOR;
+	}
+
+	receive() external payable {}
+}

--- a/solidity/ts/tests/escalationGame.test.ts
+++ b/solidity/ts/tests/escalationGame.test.ts
@@ -509,7 +509,7 @@ describe('Escalation Game Test Suite', () => {
 	test('depositOnOutcome rejects tie adjustments that would drop the accepted deposit below the minimum bond', async () => {
 		const { escalationGameAddress, testSecurityPoolAddress } = await deployEscalationGameTestSecurityPool()
 		await depositOnOutcomeViaTestSecurityPool(testSecurityPoolAddress, client.account.address, QuestionOutcome.Invalid, reportBond)
-		await assert.rejects(depositOnOutcomeViaTestSecurityPool(testSecurityPoolAddress, client.account.address, QuestionOutcome.Yes, reportBond), /tie adjustment would break min deposit/i)
+		await assert.rejects(depositOnOutcomeViaTestSecurityPool(testSecurityPoolAddress, client.account.address, QuestionOutcome.Yes, reportBond), /md/i)
 		const balances = await getBalances(client, escalationGameAddress)
 		assert.strictEqual(balances.invalid, reportBond, 'original leading balance should stay untouched')
 		assert.strictEqual(balances.yes, 0n, 'tying minimum deposit should not be partially accepted')

--- a/solidity/ts/tests/peripherals.test.ts
+++ b/solidity/ts/tests/peripherals.test.ts
@@ -245,7 +245,7 @@ describe('Peripherals Contract Test Suite', () => {
 
 		await triggerExternalForkForSecurityPool(undefined, 'mixed bids fork source')
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
-		await assert.rejects(migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes]), /cannot migrate more than internal balance/i)
+		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
 		await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
 
 		const yesUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
@@ -2878,7 +2878,7 @@ describe('Peripherals Contract Test Suite', () => {
 		const unlockedVaultRepAtFork = ownForkRepBuckets.vaultRepAtFork
 
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
-		await assert.rejects(migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes]), /vm/i)
+		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
 
 		const childRepToken = getRepTokenAddress(yesUniverse)
 		const forkerBalance = await getERC20Balance(client, childRepToken, getInfraContractAddresses().securityPoolForker)
@@ -4261,8 +4261,8 @@ describe('Peripherals Contract Test Suite', () => {
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.No])
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Invalid])
 
-		// Additional migration should fail (all rep already allocated)
-		await assert.rejects(migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes]), /vm/)
+		// Additional migration is idempotent once all REP for the branch has been split.
+		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
 
 		// Create child security pools to verify outcomes
 		// Create Yes child

--- a/solidity/ts/tests/peripheralsInvariant.test.ts
+++ b/solidity/ts/tests/peripheralsInvariant.test.ts
@@ -132,7 +132,7 @@ describe('Peripherals invariant harness', () => {
 		await createCompleteSet(openInterestHolder, context.securityPool, openInterestAmount)
 		await triggerExternalForkForSecurityPool(undefined, 'mixed bids fork source')
 		await migrateRepToZoltar(client, context.securityPool, [QuestionOutcome.Yes])
-		await assert.rejects(migrateRepToZoltar(client, context.securityPool, [QuestionOutcome.Yes]), /cannot migrate more than internal balance/i)
+		await migrateRepToZoltar(client, context.securityPool, [QuestionOutcome.Yes])
 		await migrateVault(client, context.securityPool, QuestionOutcome.Yes)
 
 		const yesUniverse = getChildUniverseIdForOutcome(QuestionOutcome.Yes)
@@ -235,7 +235,12 @@ describe('Peripherals invariant harness', () => {
 			assert.ok(childMinted <= migrationBalanceBefore, 'child REP minted must not exceed the caller migration balance for the selected branch')
 		}
 
-		await assert.rejects(migrateRepToZoltar(client, context.securityPool, [QuestionOutcome.Yes]))
+		const repeatedYesChildRepToken = getRepTokenAddress(getChildUniverseIdForOutcome(QuestionOutcome.Yes))
+		const repeatedYesSecurityPool = getSecurityPoolAddresses(context.securityPool, getChildUniverseIdForOutcome(QuestionOutcome.Yes), context.questionId, securityMultiplier).securityPool
+		const repeatedYesBalanceBefore = await getERC20Balance(client, repeatedYesChildRepToken, repeatedYesSecurityPool)
+		await migrateRepToZoltar(client, context.securityPool, [QuestionOutcome.Yes])
+		const repeatedYesBalanceAfter = await getERC20Balance(client, repeatedYesChildRepToken, repeatedYesSecurityPool)
+		strictEqualTypeSafe(repeatedYesBalanceAfter, repeatedYesBalanceBefore, 'repeated branch migration should be a no-op once child REP is fully split')
 
 		for (const outcome of branchOrder) {
 			await migrateVault(client, context.securityPool, outcome)
@@ -248,7 +253,9 @@ describe('Peripherals invariant harness', () => {
 		const yesUniverseId = getChildUniverseIdForOutcome(QuestionOutcome.Yes)
 		const yesSecurityPool = getSecurityPoolAddresses(context.securityPool, yesUniverseId, context.questionId, securityMultiplier).securityPool
 		strictEqualTypeSafe(await getSystemState(client, yesSecurityPool), SystemState.ForkMigration, 'yes child should be in fork migration')
-		await assert.rejects(migrateRepToZoltar(client, context.securityPool, [QuestionOutcome.Yes]))
+		const yesBalanceBeforeRepeat = await getERC20Balance(client, getRepTokenAddress(yesUniverseId), yesSecurityPool)
+		await migrateRepToZoltar(client, context.securityPool, [QuestionOutcome.Yes])
+		strictEqualTypeSafe(await getERC20Balance(client, getRepTokenAddress(yesUniverseId), yesSecurityPool), yesBalanceBeforeRepeat, 'repeat migration after vault migration should not mint extra child REP')
 	})
 
 	test('own-fork locks excess parent REP into the migration balance', async () => {

--- a/solidity/ts/tests/securityRegression.test.ts
+++ b/solidity/ts/tests/securityRegression.test.ts
@@ -1,22 +1,23 @@
 import { beforeAll, beforeEach, describe, setDefaultTimeout, test } from 'bun:test'
 import assert from 'node:assert/strict'
-import { decodeEventLog, encodeAbiParameters, keccak256, zeroAddress } from 'viem'
+import { decodeEventLog, encodeAbiParameters, encodeDeployData, keccak256, type Address, zeroAddress } from 'viem'
 import { QuestionOutcome } from '../testsuite/simulator/types/types'
 import { addressString } from '../testsuite/simulator/utils/bigint'
 import { DAY, GENESIS_REPUTATION_TOKEN, TEST_ADDRESSES } from '../testsuite/simulator/utils/constants'
 import { deployUniformPriceDualCapBatchAuction } from '../testsuite/simulator/utils/contracts/auction'
 import { deployOriginSecurityPool, ensureInfraDeployed, getInfraContractAddresses, getSecurityPoolAddresses } from '../testsuite/simulator/utils/contracts/deployPeripherals'
+import { depositOnOutcome, deployEscalationGame, getEscalationGameOutcomeState } from '../testsuite/simulator/utils/contracts/escalationGame'
 import { executeStagedOperation, getEthRaiseCap, getStagedOperation, getStagedOperationCounter, OperationType, requestPriceIfNeededAndStageOperation } from '../testsuite/simulator/utils/contracts/peripherals'
 import { approveAndDepositRep, handleOracleReporting, manipulatePriceOracleAndPerformOperation, triggerOwnGameFork } from '../testsuite/simulator/utils/contracts/peripheralsTestUtils'
-import { depositRep, getRepToken, getSecurityVault, getTotalSecurityBondAllowance } from '../testsuite/simulator/utils/contracts/securityPool'
-import { createChildUniverse, initiateSecurityPoolFork, migrateRepToZoltar } from '../testsuite/simulator/utils/contracts/securityPoolForker'
+import { depositRep, getCompleteSetCollateralAmount, getRepToken, getSecurityVault, getTotalSecurityBondAllowance } from '../testsuite/simulator/utils/contracts/securityPool'
+import { createChildUniverse, getMigratedRep, getOwnForkRepBuckets, initiateSecurityPoolFork, migrateRepToZoltar, migrateVault } from '../testsuite/simulator/utils/contracts/securityPoolForker'
 import { getScalarOutcomeIndex } from '../testsuite/simulator/utils/contracts/scalarOutcome'
-import { ensureZoltarDeployed, forkUniverse, getTotalTheoreticalSupply, getZoltarAddress } from '../testsuite/simulator/utils/contracts/zoltar'
+import { ensureZoltarDeployed, forkUniverse, getRepTokenAddress, getTotalTheoreticalSupply, getZoltarAddress } from '../testsuite/simulator/utils/contracts/zoltar'
 import { createQuestion, getQuestionId } from '../testsuite/simulator/utils/contracts/zoltarQuestionData'
 import { TEST_TIMEOUT_MS, useIsolatedAnvilNode } from '../testsuite/simulator/useIsolatedAnvilNode'
-import { approveToken, contractExists, getChildUniverseId, setupTestAccounts } from '../testsuite/simulator/utils/utilities'
-import { createWriteClient, type WriteClient } from '../testsuite/simulator/utils/viem'
-import { peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator } from '../types/contractArtifact'
+import { approveToken, contractExists, getChildUniverseId, getERC20Balance, setupTestAccounts } from '../testsuite/simulator/utils/utilities'
+import { createWriteClient, type WriteClient, writeContractAndWait } from '../testsuite/simulator/utils/viem'
+import { peripherals_EscalationGame_EscalationGame, peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator, test_peripherals_CompleteSetReentrantReceiver_CompleteSetReentrantReceiver } from '../types/contractArtifact'
 import { isIgnorableLogDecodeError } from './logDecodeErrors'
 
 setDefaultTimeout(TEST_TIMEOUT_MS)
@@ -79,6 +80,89 @@ describe('security regression coverage', () => {
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
 		return getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
 	}
+
+	const deployCompleteSetReentrantReceiver = async (securityPool: Address) => {
+		const hash = await client.sendTransaction({
+			data: encodeDeployData({
+				abi: test_peripherals_CompleteSetReentrantReceiver_CompleteSetReentrantReceiver.abi,
+				bytecode: `0x${test_peripherals_CompleteSetReentrantReceiver_CompleteSetReentrantReceiver.evm.bytecode.object}`,
+				args: [securityPool],
+			}),
+		})
+		const receipt = await client.waitForTransactionReceipt({ hash })
+		const contractAddress = receipt.contractAddress
+		if (contractAddress === undefined || contractAddress === null) throw new Error('reentrant receiver deployment missing address')
+		return contractAddress
+	}
+
+	test('complete-set capacity is enforced across ERC1155 receiver reentrancy', async () => {
+		const mockWindow = getAnvilWindowEthereum()
+		const capacity = 10n * 10n ** 18n
+		await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, capacity)
+		const receiver = await deployCompleteSetReentrantReceiver(securityPoolAddresses.securityPool)
+
+		await assert.rejects(
+			writeContractAndWait(client, () =>
+				client.writeContract({
+					abi: test_peripherals_CompleteSetReentrantReceiver_CompleteSetReentrantReceiver.abi,
+					address: receiver,
+					functionName: 'attack',
+					args: [6n * 10n ** 18n, 6n * 10n ** 18n],
+					value: 12n * 10n ** 18n,
+				}),
+			),
+			/receiver rejected tokens/,
+		)
+		assert.equal(await getCompleteSetCollateralAmount(client, securityPoolAddresses.securityPool), 0n)
+	})
+
+	test('vault migration backs migrated child accounting even without prior branch REP migration', async () => {
+		const mockWindow = getAnvilWindowEthereum()
+		await mockWindow.setTime(questionEndDate + 10n * DAY)
+		const attacker = createWriteClient(mockWindow, TEST_ADDRESSES[1], 0)
+		await approveAndDepositRep(attacker, repDeposit, questionId)
+		const repToken = await getRepToken(client, securityPoolAddresses.securityPool)
+		const forkThreshold = (await getTotalTheoreticalSupply(client, repToken)) / 20n / securityMultiplier
+		await depositRep(client, securityPoolAddresses.securityPool, 2n * forkThreshold)
+		await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
+		const { vaultRepAtFork } = await getOwnForkRepBuckets(client, securityPoolAddresses.securityPool)
+
+		await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
+
+		const yesUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
+		const yesChild = getSecurityPoolAddresses(securityPoolAddresses.securityPool, yesUniverse, questionId, securityMultiplier)
+		const migratedRep = await getMigratedRep(client, yesChild.securityPool)
+		const childPoolRepBalance = await getERC20Balance(client, getRepTokenAddress(yesUniverse), yesChild.securityPool)
+		assert.ok(migratedRep > 0n, 'vault migration should credit migrated REP')
+		assert.ok(childPoolRepBalance >= migratedRep, 'child pool REP must back migrated vault accounting')
+		assert.ok(migratedRep < vaultRepAtFork, 'single-vault migration should leave remaining branch REP unsplit')
+
+		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
+		const toppedUpChildPoolRepBalance = await getERC20Balance(client, getRepTokenAddress(yesUniverse), yesChild.securityPool)
+		assert.ok(toppedUpChildPoolRepBalance >= vaultRepAtFork, 'bulk migration should top up the remaining branch REP')
+
+		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
+		assert.equal(await getERC20Balance(client, getRepTokenAddress(yesUniverse), yesChild.securityPool), toppedUpChildPoolRepBalance)
+	})
+
+	test('escalation deposits can fill final threshold dust below the start bond', async () => {
+		const startBond = 10n * 10n ** 18n
+		const nonDecisionThreshold = 25n * 10n ** 18n
+		const escalationGame = await deployEscalationGame(client, startBond, nonDecisionThreshold)
+
+		await depositOnOutcome(client, escalationGame, client.account.address, QuestionOutcome.Yes, nonDecisionThreshold)
+		await depositOnOutcome(client, escalationGame, client.account.address, QuestionOutcome.No, nonDecisionThreshold - 1n)
+		await depositOnOutcome(client, escalationGame, client.account.address, QuestionOutcome.No, startBond)
+
+		const noState = await getEscalationGameOutcomeState(client, escalationGame, QuestionOutcome.No)
+		const nonDecisionTimestamp = await client.readContract({
+			abi: peripherals_EscalationGame_EscalationGame.abi,
+			address: escalationGame,
+			functionName: 'nonDecisionTimestamp',
+		})
+		assert.equal(noState.balance, nonDecisionThreshold)
+		assert.ok(nonDecisionTimestamp > 0n, 'final dust fill should trigger non-decision')
+	})
 
 	test('external scalar Zoltar forks allow Placeholder REP migration to the scalar child branch', async () => {
 		const mockWindow = getAnvilWindowEthereum()


### PR DESCRIPTION
## Summary
- Updated mainnet deployment pointer docs and whitepaper parameters to reflect the audited mainnet redeploy values and revised Oracle/Fork lifecycle constants.
- Hardened complete-set minting in `SecurityPool` by moving collateral-capacity checks after mintable amount calculation so reentrant `createCompleteSet` calls cannot bypass capacity limits.
- Added reentrancy regression coverage via new test contract `CompleteSetReentrantReceiver` and `securityRegression` test to verify reentrant ERC1155 callbacks cannot exceed complete-set capacity.
- Reworked fork REP migration to be idempotent and safe without prior branch pre-splitting by introducing tracked `childPoolRepSplitByPoolAndOutcome` state and helper-backed replenishment in `SecurityPoolForker`/`SecurityPoolForkerVaultMigrationBase`.
- Relaxed escalation dust behavior in `EscalationGame` so tie-adjusted deposits can complete final threshold transitions even when the final add-on is below `startBond`, while still rejecting zero deposits.
- Adjusted peripheral regression/invariant tests to enforce new idempotent migration behavior (repeated branch vault/reporter calls become no-ops instead of reverting).

## Testing
- Not run (user-provided context only; no commands executed in this message).
- Not run: `bun run tsc` (or UI-only `cd ui && bun x tsc --project tsconfig.json` if applicable).
- Not run: `bun run test`
- Not run: `bun run format`
- Not run: `bun run check`
- Not run: `bun run knip`