### PR TITLE
Refactor Anvil node lifecycle for reusable connection modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,20 @@ Measure Solidity gas costs:
 bun run gas-costs
 ```
 
+By default, `gas-costs` starts an isolated Anvil node. To measure against an existing local node instead, start Anvil in one terminal:
+
+```bash
+anvil --host 127.0.0.1 --port 8545 --chain-id 1 --block-base-fee-per-gas 0 --gas-price 0 --no-priority-fee
+```
+
+Then run `gas-costs` against it from another terminal:
+
+```bash
+ANVIL_RPC=http://127.0.0.1:8545 bun run gas-costs
+```
+
+Use `ANVIL_RPC=http://host.docker.internal:8545 bun run gas-costs` when the command runs from a container that reaches the host through Docker routing.
+
 ## Notes
 
 - `bun run setup` is the quickest way to bootstrap a fresh checkout.

--- a/solidity/ts/gas-costs.ts
+++ b/solidity/ts/gas-costs.ts
@@ -1,7 +1,7 @@
 import { zeroAddress } from 'viem'
 import type { Hash } from 'viem'
 import { Zoltar_Zoltar } from './types/contractArtifact'
-import { getMockedEthSimulateWindowEthereum } from './testsuite/simulator/AnvilWindowEthereum'
+import { createAnvilNodeForConnectionMode, getGasCostsAnvilConnectionMode } from './testsuite/simulator/anvilNode'
 import { submitBid, refundLosingBids } from './testsuite/simulator/utils/contracts/auction'
 import { deployOriginSecurityPool, ensureInfraDeployed, getInfraContractAddresses, getSecurityPoolAddresses } from './testsuite/simulator/utils/contracts/deployPeripherals'
 import { getOpenOracleExtraData, getOpenOracleReportMeta, getPendingReportId, migrateShares, openOracleSettle, openOracleSubmitInitialReport, OperationType, requestPrice, requestPriceIfNeededAndStageOperation, wrapWeth } from './testsuite/simulator/utils/contracts/peripherals'
@@ -65,7 +65,8 @@ if (!Number.isFinite(priorityFeeGwei) || priorityFeeGwei < 0) throw new Error('P
 if (!Number.isFinite(baseFeeGwei) || baseFeeGwei < 0) throw new Error('BASE_FEE_GWEI must be a non-negative number')
 if (totalGasPriceGwei <= 0) throw new Error('BASE_FEE_GWEI + PRIORITY_FEE_GWEI must be greater than zero')
 
-const anvil = await getMockedEthSimulateWindowEthereum()
+const anvilNode = await createAnvilNodeForConnectionMode(getGasCostsAnvilConnectionMode(), { context: 'gas-costs', startTimestamp: 1n })
+const anvil = anvilNode.anvilWindowEthereum
 const alice = createWriteClient(anvil, TEST_ADDRESSES[0], 0)
 const bob = createWriteClient(anvil, TEST_ADDRESSES[1], 0)
 const carol = createWriteClient(anvil, TEST_ADDRESSES[2], 0)
@@ -659,36 +660,40 @@ const scenarios: Scenario[] = [
 	},
 ]
 
-const results: { section: string; label: string; gas: bigint }[] = []
+try {
+	const results: { section: string; label: string; gas: bigint }[] = []
 
-for (const scenario of scenarios) {
-	await initializeChain(scenario.init ?? { deployZoltar: true, deployInfra: true })
-	try {
-		const gas = await scenario.run()
-		results.push({ section: scenario.section, label: scenario.label, gas })
-	} catch (error) {
-		throw new Error(`Scenario failed: ${scenario.section} / ${scenario.label} - ${error instanceof Error ? error.message : String(error)}`)
+	for (const scenario of scenarios) {
+		await initializeChain(scenario.init ?? { deployZoltar: true, deployInfra: true })
+		try {
+			const gas = await scenario.run()
+			results.push({ section: scenario.section, label: scenario.label, gas })
+		} catch (error) {
+			throw new Error(`Scenario failed: ${scenario.section} / ${scenario.label} - ${error instanceof Error ? error.message : String(error)}`)
+		}
 	}
-}
 
-const labelWidth = results.reduce((max, result) => (result.label.length > max ? result.label.length : max), 0)
-const gasCostInEth = (gas: bigint) => (Number(gas) * totalGasPriceGwei) / 1_000_000_000
-const gasCostInUsd = (gas: bigint) => gasCostInEth(gas) * ethPriceUsd
+	const labelWidth = results.reduce((max, result) => (result.label.length > max ? result.label.length : max), 0)
+	const gasCostInEth = (gas: bigint) => (Number(gas) * totalGasPriceGwei) / 1_000_000_000
+	const gasCostInUsd = (gas: bigint) => gasCostInEth(gas) * ethPriceUsd
 
-console.log(`# Pricing Assumptions`)
-console.log(`ETH price: $${usdFormatter.format(ethPriceUsd)}`)
-console.log(`Base fee: ${baseFeeGwei} gwei`)
-console.log(`Priority fee: ${priorityFeeGwei} gwei`)
-console.log(`Total gas price: ${totalGasPriceGwei} gwei`)
-console.log('')
+	console.log(`# Pricing Assumptions`)
+	console.log(`ETH price: $${usdFormatter.format(ethPriceUsd)}`)
+	console.log(`Base fee: ${baseFeeGwei} gwei`)
+	console.log(`Priority fee: ${priorityFeeGwei} gwei`)
+	console.log(`Total gas price: ${totalGasPriceGwei} gwei`)
+	console.log('')
 
-let currentSection = ''
-for (const result of results) {
-	if (result.section !== currentSection) {
-		if (currentSection !== '') console.log('')
-		currentSection = result.section
-		console.log(`# ${currentSection}`)
+	let currentSection = ''
+	for (const result of results) {
+		if (result.section !== currentSection) {
+			if (currentSection !== '') console.log('')
+			currentSection = result.section
+			console.log(`# ${currentSection}`)
+		}
+		const line = `${result.label.padEnd(labelWidth)}  ${numberFormatter.format(result.gas).padStart(10)} gas  ${ethFormatter.format(gasCostInEth(result.gas)).padStart(10)} ETH  $${usdFormatter.format(gasCostInUsd(result.gas)).padStart(8)}`
+		console.log(line)
 	}
-	const line = `${result.label.padEnd(labelWidth)}  ${numberFormatter.format(result.gas).padStart(10)} gas  ${ethFormatter.format(gasCostInEth(result.gas)).padStart(10)} ETH  $${usdFormatter.format(gasCostInUsd(result.gas)).padStart(8)}`
-	console.log(line)
+} finally {
+	await anvilNode.dispose()
 }

--- a/solidity/ts/tests/anvilWindowEthereum.test.ts
+++ b/solidity/ts/tests/anvilWindowEthereum.test.ts
@@ -1,10 +1,21 @@
 import { expect, test } from 'bun:test'
-import { getDefaultAnvilRpcUrl, normalizeAnvilTransactionParams } from '../testsuite/simulator/AnvilWindowEthereum'
+import { getDefaultAnvilRpcUrl, normalizeAnvilTransactionParams, validateLocalAnvilRpcUrl } from '../testsuite/simulator/AnvilWindowEthereum'
 
-test('getDefaultAnvilRpcUrl uses localhost on Windows and docker host elsewhere', () => {
-	const expected = process.platform === 'win32' ? 'http://127.0.0.1:8545' : 'http://host.docker.internal:8545'
+test('getDefaultAnvilRpcUrl uses localhost for host CLI execution', () => {
+	expect(getDefaultAnvilRpcUrl()).toBe('http://127.0.0.1:8545')
+})
 
-	expect(getDefaultAnvilRpcUrl()).toBe(expected)
+test('validateLocalAnvilRpcUrl accepts local HTTP endpoints', () => {
+	expect(() => validateLocalAnvilRpcUrl('http://127.0.0.1:8545')).not.toThrow()
+	expect(() => validateLocalAnvilRpcUrl('http://host.docker.internal:8545')).not.toThrow()
+})
+
+test('validateLocalAnvilRpcUrl rejects non-HTTP endpoints', () => {
+	expect(() => validateLocalAnvilRpcUrl('https://127.0.0.1:8545')).toThrow('Must use http:// for a local Anvil endpoint')
+})
+
+test('validateLocalAnvilRpcUrl rejects non-local endpoints', () => {
+	expect(() => validateLocalAnvilRpcUrl('http://example.com:8545')).toThrow("ANVIL_RPC points to unauthorized host 'example.com'")
 })
 
 test('normalizeAnvilTransactionParams forces legacy zero-gas pricing for send transactions', () => {

--- a/solidity/ts/tests/useIsolatedAnvilNode.test.ts
+++ b/solidity/ts/tests/useIsolatedAnvilNode.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test'
-import { getAnvilConnectionMode } from '../testsuite/simulator/useIsolatedAnvilNode'
+import { connectToExistingAnvilNode, getAnvilConnectionMode, getGasCostsAnvilConnectionMode } from '../testsuite/simulator/anvilNode'
 
 test('getAnvilConnectionMode uses the platform default when ANVIL_RPC is not set', () => {
 	const originalAnvilRpc = process.env['ANVIL_RPC']
@@ -43,4 +43,45 @@ test('getAnvilConnectionMode uses ANVIL_RPC when provided', () => {
 			process.env['ANVIL_RPC'] = originalAnvilRpc
 		}
 	}
+})
+
+test('getGasCostsAnvilConnectionMode spawns an isolated node when ANVIL_RPC is not set', () => {
+	const originalAnvilRpc = process.env['ANVIL_RPC']
+
+	try {
+		delete process.env['ANVIL_RPC']
+		expect(getGasCostsAnvilConnectionMode()).toEqual({
+			type: 'spawn-isolated',
+			rpcUrl: '',
+			port: 0,
+		})
+	} finally {
+		if (originalAnvilRpc === undefined) {
+			delete process.env['ANVIL_RPC']
+		} else {
+			process.env['ANVIL_RPC'] = originalAnvilRpc
+		}
+	}
+})
+
+test('getGasCostsAnvilConnectionMode uses ANVIL_RPC when provided', () => {
+	const originalAnvilRpc = process.env['ANVIL_RPC']
+
+	try {
+		process.env['ANVIL_RPC'] = 'http://127.0.0.1:8545'
+		expect(getGasCostsAnvilConnectionMode()).toEqual({
+			type: 'use-existing',
+			rpcUrl: 'http://127.0.0.1:8545',
+		})
+	} finally {
+		if (originalAnvilRpc === undefined) {
+			delete process.env['ANVIL_RPC']
+		} else {
+			process.env['ANVIL_RPC'] = originalAnvilRpc
+		}
+	}
+})
+
+test('connectToExistingAnvilNode reports an actionable setup message when RPC validation fails', async () => {
+	await expect(connectToExistingAnvilNode('https://127.0.0.1:8545', 'gas-costs')).rejects.toThrow('Unable to connect to Anvil at https://127.0.0.1:8545 for gas-costs. Start Anvil or set ANVIL_RPC to a local endpoint.')
 })

--- a/solidity/ts/testsuite/simulator/AnvilWindowEthereum.ts
+++ b/solidity/ts/testsuite/simulator/AnvilWindowEthereum.ts
@@ -141,25 +141,29 @@ export interface AnvilWindowEthereum {
 	removeListener: () => void
 }
 
-export const getDefaultAnvilRpcUrl = (): string => (process.platform === 'win32' ? 'http://127.0.0.1:8545' : 'http://host.docker.internal:8545')
+export const getDefaultAnvilRpcUrl = (): string => 'http://127.0.0.1:8545'
+
+export const validateLocalAnvilRpcUrl = (url: string): void => {
+	let parsed: URL
+	try {
+		parsed = new URL(url)
+	} catch (error) {
+		const detail = error instanceof Error ? ` ${error.message}` : ''
+		throw new Error(`Invalid ANVIL_RPC URL: ${url}. Must be a valid HTTP URL.${detail}`)
+	}
+
+	if (parsed.protocol !== 'http:') throw new Error(`Invalid ANVIL_RPC URL: ${url}. Must use http:// for a local Anvil endpoint.`)
+
+	const allowedHosts = ['localhost', '127.0.0.1', '::1', '[::1]', 'host.docker.internal']
+	if (!allowedHosts.includes(parsed.hostname)) throw new Error(`ANVIL_RPC points to unauthorized host '${parsed.hostname}'. ` + `Test RPC endpoints must be local (localhost, 127.0.0.1, ::1, host.docker.internal). ` + `Set ANVIL_RPC to a local Anvil instance.`)
+}
 
 export const getMockedEthSimulateWindowEthereum = async (rpcUrl?: string): Promise<AnvilWindowEthereum> => {
 	const ANVIL_RPC = rpcUrl ?? process.env['ANVIL_RPC'] ?? getDefaultAnvilRpcUrl()
 	let currentTimestamp = 0n
 	let snapshotTimestamp = 0n
 
-	// Validate RPC endpoint points to localhost only for test security
-	const validateLocalhostUrl = (url: string): void => {
-		try {
-			const parsed = new URL(url)
-			const allowedHosts = ['localhost', '127.0.0.1', '::1', 'host.docker.internal']
-			if (!allowedHosts.includes(parsed.hostname)) throw new Error(`ANVIL_RPC points to unauthorized host '${parsed.hostname}'. ` + `Test RPC endpoints must be local (localhost, 127.0.0.1, ::1, host.docker.internal). ` + `Set ANVIL_RPC to a local Anvil instance.`)
-		} catch (error) {
-			if (error instanceof Error && error.message.includes('unauthorized')) throw error
-			throw new Error(`Invalid ANVIL_RPC URL: ${url}. Must be a valid HTTP URL.`)
-		}
-	}
-	validateLocalhostUrl(ANVIL_RPC)
+	validateLocalAnvilRpcUrl(ANVIL_RPC)
 
 	// Make JSON-RPC request to Anvil
 	let requestId = 0

--- a/solidity/ts/testsuite/simulator/anvilNode.ts
+++ b/solidity/ts/testsuite/simulator/anvilNode.ts
@@ -1,0 +1,249 @@
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { createServer } from 'node:net'
+import type { AddressInfo } from 'node:net'
+import { setTimeout as sleep } from 'node:timers/promises'
+import type { AnvilWindowEthereum } from './AnvilWindowEthereum'
+import { getDefaultAnvilRpcUrl, getMockedEthSimulateWindowEthereum, validateLocalAnvilRpcUrl } from './AnvilWindowEthereum'
+
+const DEFAULT_ANVIL_HOST = '127.0.0.1'
+const RPC_READY_TIMEOUT_MS = 30_000
+const RPC_PROBE_TIMEOUT_MS = 3_000
+const SHUTDOWN_TIMEOUT_MS = 15_000
+
+type AnvilProcess = ReturnType<typeof spawn>
+
+export type AnvilConnectionMode = { readonly type: 'spawn-isolated'; readonly rpcUrl: string; readonly port: number } | { readonly type: 'use-existing'; readonly rpcUrl: string }
+
+export type AnvilNode = {
+	readonly rpcUrl: string
+	readonly anvilWindowEthereum: AnvilWindowEthereum
+	readonly dispose: () => Promise<void>
+}
+
+const getErrorMessage = (error: unknown): string => (error instanceof Error ? error.message : String(error))
+
+function getAddressPort(address: string | AddressInfo | undefined) {
+	if (address === undefined || typeof address === 'string') throw new Error('Failed to resolve TCP port for Anvil')
+	return address.port
+}
+
+const getFreePort = async (): Promise<number> =>
+	await new Promise((resolve, reject) => {
+		const server = createServer()
+		server.listen(0, DEFAULT_ANVIL_HOST, () => {
+			const address = server.address() ?? undefined
+			if (address === undefined) {
+				server.close(() => reject(new Error('Failed to allocate a free TCP port for Anvil')))
+				return
+			}
+			server.close(error => {
+				if (error !== undefined) {
+					reject(error)
+					return
+				}
+				resolve(getAddressPort(address))
+			})
+		})
+		server.on('error', reject)
+	})
+
+const resolveAnvilBinary = (): string => {
+	const explicitAnvilBin = process.env['ANVIL_BIN']?.trim()
+	if (explicitAnvilBin !== undefined && explicitAnvilBin !== '') return explicitAnvilBin
+
+	const homeDirectory = process.env['USERPROFILE'] ?? process.env['HOME']
+	if (homeDirectory !== undefined) {
+		const candidates = process.platform === 'win32' ? [`${homeDirectory}\\.foundry\\bin\\anvil.exe`, `${homeDirectory}\\.foundry\\bin\\anvil.cmd`, `${homeDirectory}\\.foundry\\bin\\anvil.bat`] : [`${homeDirectory}/.foundry/bin/anvil`]
+
+		for (const candidate of candidates) {
+			if (existsSync(candidate)) return candidate
+		}
+	}
+
+	return 'anvil'
+}
+
+const DEFAULT_ANVIL_BIN = resolveAnvilBinary()
+
+const getConfiguredAnvilRpc = (): string | undefined => {
+	const anvilRpc = process.env['ANVIL_RPC']?.trim()
+	if (anvilRpc === undefined || anvilRpc === '') return undefined
+	return anvilRpc
+}
+
+export const getAnvilConnectionMode = (): AnvilConnectionMode => {
+	const anvilRpc = getConfiguredAnvilRpc()
+	if (anvilRpc !== undefined) return { type: 'use-existing', rpcUrl: anvilRpc }
+
+	if (process.platform === 'win32') return { type: 'use-existing', rpcUrl: getDefaultAnvilRpcUrl() }
+
+	return {
+		type: 'spawn-isolated',
+		rpcUrl: '',
+		port: 0,
+	}
+}
+
+export const getGasCostsAnvilConnectionMode = (): AnvilConnectionMode => {
+	const anvilRpc = getConfiguredAnvilRpc()
+	if (anvilRpc !== undefined) return { type: 'use-existing', rpcUrl: anvilRpc }
+
+	return {
+		type: 'spawn-isolated',
+		rpcUrl: '',
+		port: 0,
+	}
+}
+
+const waitForRpcReady = async (rpcUrl: string): Promise<void> => {
+	validateLocalAnvilRpcUrl(rpcUrl)
+
+	const deadline = Date.now() + RPC_READY_TIMEOUT_MS
+	let lastError: unknown
+
+	while (Date.now() < deadline) {
+		const controller = new AbortController()
+		const remainingMs = deadline - Date.now()
+		const probeTimeoutMs = Math.min(RPC_PROBE_TIMEOUT_MS, remainingMs)
+		const timeoutId = setTimeout(() => controller.abort(), probeTimeoutMs)
+
+		try {
+			const response = await fetch(rpcUrl, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				signal: controller.signal,
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 1,
+					method: 'eth_chainId',
+					params: [],
+				}),
+			})
+			if (response.ok) {
+				clearTimeout(timeoutId)
+				return
+			}
+			lastError = new Error(`HTTP ${response.status}: ${response.statusText}`)
+		} catch (error) {
+			lastError = error
+		} finally {
+			clearTimeout(timeoutId)
+		}
+		await sleep(100)
+	}
+
+	throw new Error(`Timed out waiting for Anvil RPC at ${rpcUrl}: ${getErrorMessage(lastError)}`)
+}
+
+const waitForExit = async (child: AnvilProcess): Promise<void> =>
+	await new Promise((resolve, reject) => {
+		if (child.pid === undefined || child.exitCode !== null || child.signalCode !== null) {
+			resolve()
+			return
+		}
+
+		const timeoutId = setTimeout(() => {
+			child.kill('SIGKILL')
+			resolve()
+		}, SHUTDOWN_TIMEOUT_MS)
+
+		child.once('exit', () => {
+			clearTimeout(timeoutId)
+			resolve()
+		})
+		child.once('error', error => {
+			clearTimeout(timeoutId)
+			reject(error)
+		})
+	})
+
+const getErrorCode = (error: unknown): string | undefined => {
+	if (typeof error !== 'object' || error === null || !('code' in error) || typeof error.code !== 'string') return undefined
+	return error.code
+}
+
+const terminateProcess = (child: AnvilProcess, signal: NodeJS.Signals = 'SIGTERM') => {
+	if (child.pid === undefined || child.exitCode !== null || child.signalCode !== null) return
+	try {
+		child.kill(signal)
+	} catch (error) {
+		const errorCode = getErrorCode(error)
+		if (errorCode !== 'ESRCH' && errorCode !== 'EPERM') throw error
+		// Ignore termination errors while cleaning up a failed spawn/startup path.
+	}
+}
+
+export const connectToExistingAnvilNode = async (rpcUrl: string, context: string): Promise<AnvilNode> => {
+	try {
+		await waitForRpcReady(rpcUrl)
+		const anvilWindowEthereum = await getMockedEthSimulateWindowEthereum(rpcUrl)
+		await anvilWindowEthereum.setNextBlockBaseFeePerGasToZero()
+		return {
+			rpcUrl,
+			anvilWindowEthereum,
+			dispose: async () => {},
+		}
+	} catch (error) {
+		throw new Error(`Unable to connect to Anvil at ${rpcUrl} for ${context}. Start Anvil or set ANVIL_RPC to a local endpoint. ${getErrorMessage(error)}`)
+	}
+}
+
+const createIsolatedAnvilNode = async ({ context, printTraces = false, startTimestamp }: { context: string; printTraces?: boolean; startTimestamp?: bigint }): Promise<AnvilNode> => {
+	const port = await getFreePort()
+	const rpcUrl = `http://${DEFAULT_ANVIL_HOST}:${port}`
+	const anvilArgs = ['--host', DEFAULT_ANVIL_HOST, '--port', `${port}`, '--chain-id', '1', '--timestamp', '1', '--block-base-fee-per-gas', '0', '--gas-price', '0', '--no-priority-fee']
+	if (printTraces) anvilArgs.push('--print-traces')
+
+	const childProcess = spawn(DEFAULT_ANVIL_BIN, anvilArgs, {
+		windowsHide: true,
+		stdio: ['ignore', 'ignore', 'pipe'],
+	})
+	const spawnErrorPromise = new Promise<never>((_, reject) => {
+		childProcess.once('error', error => {
+			if (getErrorCode(error) === 'ENOENT') {
+				reject(new Error(`Failed to start isolated Anvil node: could not find Anvil executable '${DEFAULT_ANVIL_BIN}'. On Windows, Foundry usually installs to %USERPROFILE%\\.foundry\\bin\\anvil.exe. Set ANVIL_BIN to the full path if Anvil is not on PATH.`))
+				return
+			}
+			reject(error)
+		})
+	})
+
+	let stderr = ''
+	if (childProcess.stderr === null) {
+		terminateProcess(childProcess)
+		await waitForExit(childProcess)
+		throw new Error(`Failed to start isolated Anvil node for ${context}: Anvil stderr pipe is unavailable`)
+	}
+	childProcess.stderr.on('data', chunk => {
+		stderr += chunk.toString()
+	})
+
+	try {
+		await Promise.race([waitForRpcReady(rpcUrl), spawnErrorPromise])
+		const anvilWindowEthereum = await getMockedEthSimulateWindowEthereum(rpcUrl)
+		if (startTimestamp !== undefined) await anvilWindowEthereum.setTime(startTimestamp)
+		await anvilWindowEthereum.setNextBlockBaseFeePerGasToZero()
+		let disposed = false
+		return {
+			rpcUrl,
+			anvilWindowEthereum,
+			dispose: async () => {
+				if (disposed) return
+				disposed = true
+				terminateProcess(childProcess)
+				await waitForExit(childProcess)
+			},
+		}
+	} catch (error) {
+		terminateProcess(childProcess)
+		await waitForExit(childProcess)
+		const stderrMessage = stderr.trim() === '' ? '' : `\nAnvil stderr:\n${stderr.trim()}`
+		throw new Error(`Failed to start isolated Anvil node for ${context}: ${getErrorMessage(error)}${stderrMessage}`)
+	}
+}
+
+export const createAnvilNodeForConnectionMode = async (connectionMode: AnvilConnectionMode, options: { context: string; printTraces?: boolean; startTimestamp?: bigint }): Promise<AnvilNode> => {
+	if (connectionMode.type === 'use-existing') return await connectToExistingAnvilNode(connectionMode.rpcUrl, options.context)
+	return await createIsolatedAnvilNode(options)
+}

--- a/solidity/ts/testsuite/simulator/useIsolatedAnvilNode.ts
+++ b/solidity/ts/testsuite/simulator/useIsolatedAnvilNode.ts
@@ -1,211 +1,29 @@
 import { afterAll, beforeAll, beforeEach, setDefaultTimeout } from 'bun:test'
-import { spawn } from 'node:child_process'
-import { existsSync } from 'node:fs'
-import { AddressInfo, createServer } from 'node:net'
-import { setTimeout as sleep } from 'node:timers/promises'
-import { getDefaultAnvilRpcUrl, getMockedEthSimulateWindowEthereum, AnvilWindowEthereum } from './AnvilWindowEthereum'
+import type { AnvilWindowEthereum } from './AnvilWindowEthereum'
+import type { AnvilNode } from './anvilNode'
+import { createAnvilNodeForConnectionMode, getAnvilConnectionMode } from './anvilNode'
 import { ensureDefined } from './utils/testUtils'
 const isSolidityBytecodeCoverageEnabled = (): boolean => process.env['SOLIDITY_BYTECODE_COVERAGE'] === '1'
 
-const DEFAULT_ANVIL_HOST = '127.0.0.1'
-const RPC_READY_TIMEOUT_MS = 30_000
-const RPC_PROBE_TIMEOUT_MS = 3_000
-const SHUTDOWN_TIMEOUT_MS = 15_000
 const TEST_CHAIN_START_TIMESTAMP = 1n
 export const TEST_TIMEOUT_MS = 300_000
 
 setDefaultTimeout(TEST_TIMEOUT_MS)
 
-function getAddressPort(address: string | AddressInfo | undefined) {
-	if (address === undefined || typeof address === 'string') throw new Error('Failed to resolve TCP port for Anvil')
-	return address.port
-}
-
-const getFreePort = async (): Promise<number> =>
-	await new Promise((resolve, reject) => {
-		const server = createServer()
-		server.listen(0, DEFAULT_ANVIL_HOST, () => {
-			const address = server.address() ?? undefined
-			if (address === undefined) {
-				server.close(() => reject(new Error('Failed to allocate a free TCP port for Anvil')))
-				return
-			}
-			server.close(error => {
-				if (error !== undefined) {
-					reject(error)
-					return
-				}
-				resolve(getAddressPort(address))
-			})
-		})
-		server.on('error', reject)
-	})
-
-type AnvilProcess = ReturnType<typeof spawn>
-
-type AnvilConnectionMode = { readonly type: 'spawn-isolated'; readonly rpcUrl: string; readonly port: number } | { readonly type: 'use-existing'; readonly rpcUrl: string }
-
-const resolveAnvilBinary = (): string => {
-	const explicitAnvilBin = process.env['ANVIL_BIN']?.trim()
-	if (explicitAnvilBin !== undefined && explicitAnvilBin !== '') return explicitAnvilBin
-
-	const homeDirectory = process.env['USERPROFILE'] ?? process.env['HOME']
-	if (homeDirectory !== undefined) {
-		const candidates = process.platform === 'win32' ? [`${homeDirectory}\\.foundry\\bin\\anvil.exe`, `${homeDirectory}\\.foundry\\bin\\anvil.cmd`, `${homeDirectory}\\.foundry\\bin\\anvil.bat`] : [`${homeDirectory}/.foundry/bin/anvil`]
-
-		for (const candidate of candidates) {
-			if (existsSync(candidate)) return candidate
-		}
-	}
-
-	return 'anvil'
-}
-
-const DEFAULT_ANVIL_BIN = resolveAnvilBinary()
-
-export const getAnvilConnectionMode = (): AnvilConnectionMode => {
-	const anvilRpc = process.env['ANVIL_RPC']
-	if (anvilRpc !== undefined && anvilRpc.trim() !== '') return { type: 'use-existing', rpcUrl: anvilRpc }
-
-	if (process.platform === 'win32') return { type: 'use-existing', rpcUrl: getDefaultAnvilRpcUrl() }
-
-	return {
-		type: 'spawn-isolated',
-		rpcUrl: '',
-		port: 0,
-	}
-}
-
-const waitForRpcReady = async (rpcUrl: string): Promise<void> => {
-	const deadline = Date.now() + RPC_READY_TIMEOUT_MS
-	let lastError: unknown
-
-	while (Date.now() < deadline) {
-		const controller = new AbortController()
-		const remainingMs = deadline - Date.now()
-		const probeTimeoutMs = Math.min(RPC_PROBE_TIMEOUT_MS, remainingMs)
-		const timeoutId = setTimeout(() => controller.abort(), probeTimeoutMs)
-
-		try {
-			const response = await fetch(rpcUrl, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				signal: controller.signal,
-				body: JSON.stringify({
-					jsonrpc: '2.0',
-					id: 1,
-					method: 'eth_chainId',
-					params: [],
-				}),
-			})
-			if (response.ok) {
-				clearTimeout(timeoutId)
-				return
-			}
-			lastError = new Error(`HTTP ${response.status}: ${response.statusText}`)
-		} catch (error) {
-			lastError = error
-		} finally {
-			clearTimeout(timeoutId)
-		}
-		await sleep(100)
-	}
-
-	const detail = lastError instanceof Error ? lastError.message : String(lastError)
-	throw new Error(`Timed out waiting for Anvil RPC at ${rpcUrl}: ${detail}`)
-}
-
-const waitForExit = async (child: AnvilProcess): Promise<void> =>
-	await new Promise((resolve, reject) => {
-		if (child.exitCode !== null || child.signalCode !== null) {
-			resolve()
-			return
-		}
-
-		const timeoutId = setTimeout(() => {
-			child.kill('SIGKILL')
-			resolve()
-		}, SHUTDOWN_TIMEOUT_MS)
-
-		child.once('exit', () => {
-			clearTimeout(timeoutId)
-			resolve()
-		})
-		child.once('error', error => {
-			clearTimeout(timeoutId)
-			reject(error)
-		})
-	})
-
-const terminateProcess = (child: AnvilProcess, signal: NodeJS.Signals = 'SIGTERM') => {
-	if (child.exitCode !== null || child.signalCode !== null) return
-	try {
-		child.kill(signal)
-	} catch (error) {
-		if (!(error instanceof Error) || !('code' in error) || (error.code !== 'ESRCH' && error.code !== 'EPERM')) throw error
-		// Ignore termination errors while cleaning up a failed spawn/startup path.
-	}
-}
-
 export const useIsolatedAnvilNode = () => {
-	let anvilProcess: AnvilProcess | undefined
+	let anvilNode: AnvilNode | undefined
 	let anvilWindowEthereum: AnvilWindowEthereum | undefined
 	let snapshotId: string | undefined
 
 	beforeAll(async () => {
 		const connectionMode = getAnvilConnectionMode()
-
-		if (connectionMode.type === 'use-existing') {
-			try {
-				await waitForRpcReady(connectionMode.rpcUrl)
-				anvilWindowEthereum = await getMockedEthSimulateWindowEthereum(connectionMode.rpcUrl)
-				await anvilWindowEthereum.setNextBlockBaseFeePerGasToZero()
-				snapshotId = await anvilWindowEthereum.anvilSnapshot()
-			} catch (error) {
-				const errorMessage = error instanceof Error ? error.message : String(error)
-				throw new Error(`Failed to connect to existing Anvil node for test file at ${connectionMode.rpcUrl}: ${errorMessage}`)
-			}
-			return
-		}
-
-		const port = await getFreePort()
-		const rpcUrl = `http://${DEFAULT_ANVIL_HOST}:${port}`
-
-		const anvilArgs = ['--host', DEFAULT_ANVIL_HOST, '--port', `${port}`, '--chain-id', '1', '--timestamp', '1', '--block-base-fee-per-gas', '0', '--gas-price', '0', '--no-priority-fee']
-		if (isSolidityBytecodeCoverageEnabled()) anvilArgs.push('--print-traces')
-
-		const childProcess = spawn(DEFAULT_ANVIL_BIN, anvilArgs, {
-			windowsHide: true,
-			stdio: ['ignore', 'ignore', 'pipe'],
+		anvilNode = await createAnvilNodeForConnectionMode(connectionMode, {
+			context: 'test file',
+			printTraces: isSolidityBytecodeCoverageEnabled(),
+			startTimestamp: TEST_CHAIN_START_TIMESTAMP,
 		})
-		anvilProcess = childProcess
-		const spawnErrorPromise = new Promise<never>((_, reject) => {
-			childProcess.once('error', error => {
-				if (typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT') {
-					reject(new Error(`Failed to start isolated Anvil node: could not find Anvil executable '${DEFAULT_ANVIL_BIN}'. On Windows, Foundry usually installs to %USERPROFILE%\\.foundry\\bin\\anvil.exe. Set ANVIL_BIN to the full path if Anvil is not on PATH.`))
-					return
-				}
-				reject(error)
-			})
-		})
-
-		let stderr = ''
-		ensureDefined(childProcess.stderr, 'Anvil stderr pipe is unavailable').on('data', chunk => {
-			stderr += chunk.toString()
-		})
-
-		try {
-			await Promise.race([waitForRpcReady(rpcUrl), spawnErrorPromise])
-			anvilWindowEthereum = await getMockedEthSimulateWindowEthereum(rpcUrl)
-			await anvilWindowEthereum.setTime(TEST_CHAIN_START_TIMESTAMP)
-			await anvilWindowEthereum.setNextBlockBaseFeePerGasToZero()
-			snapshotId = await anvilWindowEthereum.anvilSnapshot()
-		} catch (error) {
-			terminateProcess(childProcess)
-			const errorMessage = error instanceof Error ? error.message : String(error)
-			const stderrMessage = stderr.trim() === '' ? '' : `\nAnvil stderr:\n${stderr.trim()}`
-			throw new Error(`Failed to start isolated Anvil node for test file: ${errorMessage}${stderrMessage}`)
-		}
+		anvilWindowEthereum = anvilNode.anvilWindowEthereum
+		snapshotId = await anvilWindowEthereum.anvilSnapshot()
 	})
 
 	beforeEach(async () => {
@@ -223,10 +41,8 @@ export const useIsolatedAnvilNode = () => {
 	})
 
 	afterAll(async () => {
-		if (anvilProcess === undefined) return
-		terminateProcess(anvilProcess)
-		await waitForExit(anvilProcess)
-		anvilProcess = undefined
+		await anvilNode?.dispose()
+		anvilNode = undefined
 		anvilWindowEthereum = undefined
 		snapshotId = undefined
 	})


### PR DESCRIPTION
## Summary
- Introduced `solidity/ts/testsuite/simulator/anvilNode.ts` to centralize Anvil process management, connection mode detection, and node lifecycle handling.
- Updated gas-costs flow to use `createAnvilNodeForConnectionMode`/`getGasCostsAnvilConnectionMode`, with explicit cleanup via `anvilNode.dispose()`.
- Expanded Anvil RPC URL handling by adding `validateLocalAnvilRpcUrl`, enforcing local HTTP endpoints and clearer validation errors.
- Refactored `useIsolatedAnvilNode` to delegate startup/shutdown to the shared `anvilNode` module, removing duplicated spawn/health-check logic.
- Added tests for gas-cost connection mode selection and actionable connection failure errors, plus URL validation edge cases.
- Updated README with documented workflow for connecting gas-costs to an externally started Anvil via `ANVIL_RPC`.

## Testing
- `bun test` (Not run)
- `bun run test` (Not run)
- `bun run format` (Not run)
- `bun run check` (Not run)
- `bun run knip` (Not run)
- `bun run tsc` (Not run)