### PR TITLE
Refactor Fork Auction Truth Flow into Dedicated Modules

### DIFF
--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from 'preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import type { ComponentChildren } from 'preact'
-import { type Address, zeroAddress } from 'viem'
+import { zeroAddress } from 'viem'
 import { AddressValue } from './AddressValue.js'
 import { Badge } from './Badge.js'
 import { CurrencyValue } from './CurrencyValue.js'
@@ -9,40 +9,44 @@ import { EscalationDepositSelectionList } from './EscalationDepositSelectionList
 import { EnumDropdown } from './EnumDropdown.js'
 import { ErrorNotice } from './ErrorNotice.js'
 import { FormInput } from './FormInput.js'
+import { ImportedForkSettlementSection } from './ImportedForkSettlementSection.js'
 import { LookupFieldRow } from './LookupFieldRow.js'
 import { MetricGrid } from './MetricGrid.js'
 import { MetricField } from './MetricField.js'
-import { PaginationControls } from './PaginationControls.js'
 import { ReadOnlyDetailAccordion } from './ReadOnlyDetailAccordion.js'
 import { RouteWorkflowPanel } from './RouteWorkflowPanel.js'
 import { SectionBlock } from './SectionBlock.js'
 import { TransactionActionButton } from './TransactionActionButton.js'
 import { TimestampValue } from './TimestampValue.js'
-import { TruthAuctionDepthChart, type TruthAuctionDepthPoint } from './TruthAuctionDepthChart.js'
-import { loadAllSecurityPools, loadForkAuctionDetails, loadForkOutcomeMigrationSeedStatus, loadTruthAuctionActiveTickPage, loadTruthAuctionBidderBidPage, loadTruthAuctionTickBidPage } from '../contracts.js'
+import { TruthAuctionBidsSection, ViewerTruthAuctionBidsSection } from './TruthAuctionBidsSection.js'
+import { TruthAuctionMarketViewSection } from './TruthAuctionMarketViewSection.js'
+import { TruthAuctionSummaryCard } from './TruthAuctionSummaryCard.js'
+import { loadAllSecurityPools, loadForkAuctionDetails, loadForkOutcomeMigrationSeedStatus } from '../contracts.js'
 import { getForkAuctionActionSafetyId } from '../lib/actionSafety/ids.js'
 import { createActionAvailability } from '../lib/actionAvailability.js'
 import { sameAddress } from '../lib/address.js'
 import { createConnectedReadClient } from '../lib/clients.js'
 import { getErrorMessage } from '../lib/errors.js'
-import { AUCTION_TIME_SECONDS, estimateRepPurchased, getForkAuctionStageLabel, getForkAuctionStageView, getTimeRemaining, getTruthAuctionBidGuardMessage, getTruthAuctionPriceAtTick, getTruthAuctionTickAtPrice, TRUTH_AUCTION_PRICE_PRECISION } from '../lib/forkAuction.js'
+import { AUCTION_TIME_SECONDS, getForkAuctionStageLabel, getForkAuctionStageView, getTimeRemaining } from '../lib/forkAuction.js'
+import { buildTruthAuctionDepthPoints, estimateRepPurchased, getTruthAuctionBidGuardMessage, getTruthAuctionOverviewProgress, getTruthAuctionTickAtPrice, getTruthAuctionWinningThresholdPrice } from '../lib/truthAuctionBook.js'
+import { buildTruthAuctionBidRows, buildViewerTruthAuctionBidRows, updateTruthAuctionSettlementBidSelection } from '../lib/truthAuctionBidViewModels.js'
+import { getTruthAuctionSettlementActionAvailabilityMessage, getTruthAuctionSettlementBidRows } from '../lib/truthAuctionSettlement.js'
 import { formatCurrencyInputBalance, formatDuration, formatRoundedCurrencyBalance } from '../lib/formatters.js'
 import { tryParseTruthAuctionAmountInput, tryParseTruthAuctionPriceInput } from '../lib/marketForm.js'
 import { isMainnetChain } from '../lib/network.js'
 import { REPORTING_OUTCOME_DROPDOWN_OPTIONS, getReportingOutcomeLabel } from '../lib/reporting.js'
 import { buildRouteHref, SECURITY_POOLS_ROUTE } from '../lib/routing.js'
-import { getEscalationDepositClaimAmount, getImportedEscalationDepositClaimAmount, isPoolQuestionFinalized } from '../lib/reportingDomain.js'
+import { getEscalationDepositClaimAmount, isPoolQuestionFinalized } from '../lib/reportingDomain.js'
 import { deriveSecurityPoolForkStage, deriveSecurityPoolLifecycleState, evaluateSecurityPoolState } from '../lib/securityPoolState.js'
-import { getCurrentSelectedPoolForkAuctionDetails, shouldReloadSelectedPoolDetails } from '../lib/securityPoolWorkflow.js'
-import { getCurrentForkWorkflowSelectionStage, type ForkWorkflowSelectionStage } from '../lib/securityPoolWorkflow.js'
+import { getCurrentSelectedPoolForkAuctionDetails, getForkWorkflowStageSelection, shouldReloadSelectedPoolDetails, type ForkWorkflowSelectionStage } from '../lib/securityPoolWorkflow.js'
 import { writeSecurityPoolQueryParam, writeUniverseQueryParam } from '../lib/urlParams.js'
 import { getVisualRatio } from '../lib/visualMetrics.js'
-import type { ImportedEscalationDeposit, ListedSecurityPool, ReadClient, ReportingOutcomeKey, TruthAuctionBidView, TruthAuctionMetrics, TruthAuctionTickSummary } from '../types/contracts.js'
+import { useTruthAuctionBookData } from '../hooks/useTruthAuctionBookData.js'
+import { useTruthAuctionSettlementActionState } from '../hooks/useTruthAuctionSettlementActionState.js'
+import type { ListedSecurityPool, ReadClient, ReportingOutcomeKey, TruthAuctionMetrics } from '../types/contracts.js'
 import type { ForkAuctionSectionProps } from '../types/components.js'
 const UNKNOWN_VALUE = '—'
 const UNAVAILABLE_UNTIL_FORK = '-'
-const TRUTH_AUCTION_TICK_PAGE_SIZE = 25
-const TRUTH_AUCTION_BID_PAGE_SIZE = 25
 
 function sameBigIntArray(left: bigint[], right: bigint[]) {
 	return left.length === right.length && left.every((value, index) => value === right[index])
@@ -56,32 +60,6 @@ type DisplayMetric = {
 	label: string
 	value: ComponentChildren
 }
-type TruthAuctionDisposition = {
-	label: string
-	tone: 'default' | 'danger' | 'success' | 'warning'
-}
-
-type TruthAuctionFinalizedSettlementKind = 'ethRefund' | 'none' | 'repClaim'
-
-type TruthAuctionBidSummaryKind = 'losing' | 'neutral' | 'partial' | 'refundable' | 'refunded' | 'repClaimable' | 'winning'
-
-type TruthAuctionBidDisposition = TruthAuctionDisposition & {
-	canPrefillRefund: boolean
-	canPrefillSettle: boolean
-	settlementKind: TruthAuctionFinalizedSettlementKind
-	summaryKind: TruthAuctionBidSummaryKind
-}
-
-type LocalSettlementBidStatus = 'claimed' | 'refunded'
-type SettlementAction = 'claimAuctionProceeds' | 'refundLosingBids'
-
-type TruthAuctionBookData = {
-	tickSummaries: TruthAuctionTickSummary[]
-	tickCount: bigint
-	viewerBids: TruthAuctionBidView[]
-	viewerBidCount: bigint
-}
-
 type TruthAuctionStateBadge = {
 	label: string
 	tone: 'blocked' | 'muted' | 'ok' | 'pending'
@@ -278,293 +256,6 @@ function clampPercentage(value: bigint, maxValue: bigint) {
 	return (getVisualRatio({ value, maxValue }) ?? 0) * 100
 }
 
-function getTruthAuctionWinningThresholdPrice(truthAuction: TruthAuctionMetrics | undefined) {
-	if (truthAuction === undefined || !truthAuction.finalized || !truthAuction.underfunded || truthAuction.maxRepBeingSold === 0n) return undefined
-	return (truthAuction.ethRaised * TRUTH_AUCTION_PRICE_PRECISION) / truthAuction.maxRepBeingSold
-}
-
-function getTickDisposition(tickSummary: TruthAuctionTickSummary, truthAuction: TruthAuctionMetrics | undefined): TruthAuctionDisposition {
-	if (tickSummary.currentTotalEth === 0n) return { label: 'Historical', tone: 'default' }
-	if (truthAuction === undefined) return { label: 'Live', tone: 'default' }
-	const winningThresholdPrice = getTruthAuctionWinningThresholdPrice(truthAuction)
-	if (winningThresholdPrice !== undefined) return tickSummary.price >= winningThresholdPrice ? { label: 'Winning', tone: 'success' } : { label: 'Out', tone: 'danger' }
-	if (!truthAuction.hitCap || truthAuction.clearingTick === undefined || truthAuction.clearingPrice === undefined) return truthAuction.finalized ? { label: 'Winning', tone: 'success' } : { label: 'In Book', tone: 'default' }
-	if (tickSummary.tick > truthAuction.clearingTick) return { label: truthAuction.finalized ? 'Winning' : 'Above Clearing', tone: 'success' }
-	if (tickSummary.tick < truthAuction.clearingTick) return { label: truthAuction.finalized ? 'Out' : 'Below Clearing', tone: 'danger' }
-	return { label: truthAuction.finalized ? 'Clearing' : 'At Clearing', tone: 'warning' }
-}
-
-function getBidDisposition(bid: TruthAuctionBidView, truthAuction: TruthAuctionMetrics | undefined): TruthAuctionBidDisposition {
-	if (bid.refunded) return { label: 'Refunded', tone: 'default', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'ethRefund', summaryKind: 'refunded' }
-	if (truthAuction === undefined) {
-		if (bid.claimed) return { label: 'Claimed', tone: 'success', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'none', summaryKind: 'neutral' }
-		return { label: 'Pending', tone: 'default', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'none', summaryKind: 'neutral' }
-	}
-
-	const winningThresholdPrice = getTruthAuctionWinningThresholdPrice(truthAuction)
-	if (winningThresholdPrice !== undefined) {
-		if (getTruthAuctionPriceAtTick(bid.tick) >= winningThresholdPrice) {
-			if (truthAuction.finalized) {
-				if (bid.claimed) return { label: 'Claimed', tone: 'success', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'repClaim', summaryKind: 'neutral' }
-				return { label: 'Winning', tone: 'success', canPrefillRefund: false, canPrefillSettle: true, settlementKind: 'repClaim', summaryKind: 'winning' }
-			}
-			return {
-				label: 'Provisional',
-				tone: 'warning',
-				canPrefillRefund: false,
-				canPrefillSettle: false,
-				settlementKind: 'none',
-				summaryKind: 'neutral',
-			}
-		}
-		if (truthAuction.finalized) {
-			if (bid.claimed) return { label: 'Refunded', tone: 'default', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'ethRefund', summaryKind: 'refunded' }
-			return { label: 'Refundable', tone: 'danger', canPrefillRefund: true, canPrefillSettle: false, settlementKind: 'ethRefund', summaryKind: 'refundable' }
-		}
-		return {
-			label: 'In Book',
-			tone: 'default',
-			canPrefillRefund: false,
-			canPrefillSettle: false,
-			settlementKind: 'none',
-			summaryKind: 'neutral',
-		}
-	}
-
-	if (!truthAuction.hitCap || truthAuction.clearingTick === undefined || truthAuction.clearingPrice === undefined) {
-		if (truthAuction.finalized) {
-			if (bid.claimed) return { label: 'Claimed', tone: 'success', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'repClaim', summaryKind: 'neutral' }
-			return { label: 'Winning', tone: 'success', canPrefillRefund: false, canPrefillSettle: true, settlementKind: 'repClaim', summaryKind: 'winning' }
-		}
-		return {
-			label: 'In Book',
-			tone: 'default',
-			canPrefillRefund: false,
-			canPrefillSettle: false,
-			settlementKind: 'none',
-			summaryKind: 'neutral',
-		}
-	}
-
-	if (bid.tick > truthAuction.clearingTick) {
-		if (truthAuction.finalized) {
-			if (bid.claimed) return { label: 'Claimed', tone: 'success', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'repClaim', summaryKind: 'neutral' }
-			return { label: 'Winning', tone: 'success', canPrefillRefund: false, canPrefillSettle: true, settlementKind: 'repClaim', summaryKind: 'winning' }
-		}
-		return {
-			label: 'Above Clearing',
-			tone: 'warning',
-			canPrefillRefund: false,
-			canPrefillSettle: false,
-			settlementKind: 'none',
-			summaryKind: 'neutral',
-		}
-	}
-	if (bid.tick < truthAuction.clearingTick) {
-		if (truthAuction.finalized) {
-			if (bid.claimed) return { label: 'Refunded', tone: 'default', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'ethRefund', summaryKind: 'refunded' }
-			return { label: 'Refundable', tone: 'danger', canPrefillRefund: true, canPrefillSettle: false, settlementKind: 'ethRefund', summaryKind: 'refundable' }
-		}
-		return {
-			label: 'Below Clearing',
-			tone: 'danger',
-			canPrefillRefund: !truthAuction.finalized,
-			canPrefillSettle: false,
-			settlementKind: 'none',
-			summaryKind: 'losing',
-		}
-	}
-
-	const previousCumulativeEth = bid.activeCumulativeEthBeforeBid
-	const activeCumulativeEth = previousCumulativeEth + bid.ethAmount
-	if (truthAuction.ethAtClearingTick <= previousCumulativeEth) {
-		if (truthAuction.finalized) {
-			if (bid.claimed) return { label: 'Refunded', tone: 'default', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'ethRefund', summaryKind: 'refunded' }
-			return { label: 'Refundable', tone: 'danger', canPrefillRefund: true, canPrefillSettle: false, settlementKind: 'ethRefund', summaryKind: 'refundable' }
-		}
-		return {
-			label: 'Below Clearing',
-			tone: 'danger',
-			canPrefillRefund: true,
-			canPrefillSettle: false,
-			settlementKind: 'none',
-			summaryKind: 'losing',
-		}
-	}
-	if (truthAuction.ethAtClearingTick >= activeCumulativeEth) {
-		if (truthAuction.finalized) {
-			if (bid.claimed) return { label: 'Claimed', tone: 'success', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'repClaim', summaryKind: 'neutral' }
-			return { label: 'Winning', tone: 'success', canPrefillRefund: false, canPrefillSettle: true, settlementKind: 'repClaim', summaryKind: 'winning' }
-		}
-		return {
-			label: 'At Clearing',
-			tone: 'warning',
-			canPrefillRefund: false,
-			canPrefillSettle: false,
-			settlementKind: 'none',
-			summaryKind: 'neutral',
-		}
-	}
-	if (truthAuction.finalized) {
-		if (bid.claimed) return { label: 'Claimed', tone: 'success', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'repClaim', summaryKind: 'neutral' }
-		return { label: 'Partial', tone: 'warning', canPrefillRefund: false, canPrefillSettle: true, settlementKind: 'repClaim', summaryKind: 'partial' }
-	}
-	return {
-		label: 'At Clearing',
-		tone: 'warning',
-		canPrefillRefund: false,
-		canPrefillSettle: false,
-		settlementKind: 'none',
-		summaryKind: 'neutral',
-	}
-}
-
-function getTruthAuctionDispositionClassName(tone: TruthAuctionDisposition['tone']) {
-	switch (tone) {
-		case 'danger':
-			return 'is-danger'
-		case 'success':
-			return 'is-success'
-		case 'warning':
-			return 'is-warning'
-		case 'default':
-			return 'is-default'
-		default:
-			return 'is-default'
-	}
-}
-
-function sortTruthAuctionTickSummariesDescending(tickSummaries: TruthAuctionTickSummary[]) {
-	return [...tickSummaries].sort((left, right) => {
-		if (left.tick === right.tick) return 0
-		return left.tick > right.tick ? -1 : 1
-	})
-}
-
-function buildTruthAuctionDepthPoints({ enteredBidTick, selectedBookTick, tickSummaries, truthAuction }: { enteredBidTick: bigint | undefined; selectedBookTick: bigint | undefined; tickSummaries: TruthAuctionTickSummary[]; truthAuction: TruthAuctionMetrics | undefined }): TruthAuctionDepthPoint[] {
-	let cumulativeEth = 0n
-
-	return tickSummaries
-		.filter(tickSummary => tickSummary.active || tickSummary.currentTotalEth > 0n)
-		.map(tickSummary => {
-			cumulativeEth += tickSummary.currentTotalEth
-			return {
-				tick: tickSummary.tick,
-				price: tickSummary.price,
-				currentTotalEth: tickSummary.currentTotalEth,
-				cumulativeEth,
-				disposition: getTickDisposition(tickSummary, truthAuction),
-				isSelected: selectedBookTick === tickSummary.tick,
-				isPreviewTick: enteredBidTick !== undefined && enteredBidTick === tickSummary.tick,
-			}
-		})
-}
-
-function getTruthAuctionOverviewProgress(truthAuction: TruthAuctionMetrics | undefined, tickSummaries: TruthAuctionTickSummary[]) {
-	if (truthAuction === undefined) return undefined
-	if (truthAuction.finalized) {
-		return {
-			ethRaised: truthAuction.ethRaised,
-			repSold: truthAuction.totalRepPurchased,
-		}
-	}
-
-	const activeTickSummaries = sortTruthAuctionTickSummariesDescending(tickSummaries).filter(tickSummary => tickSummary.currentTotalEth > 0n)
-	if (activeTickSummaries.length === 0) {
-		return {
-			ethRaised: truthAuction.ethRaised,
-			repSold: truthAuction.totalRepPurchased,
-		}
-	}
-
-	let provisionalEthRaised = 0n
-	let provisionalRepSold = 0n
-
-	if (!truthAuction.hitCap || truthAuction.clearingTick === undefined || truthAuction.clearingPrice === undefined) {
-		for (const tickSummary of activeTickSummaries) {
-			provisionalEthRaised += tickSummary.currentTotalEth
-			provisionalRepSold += estimateRepPurchased(tickSummary.currentTotalEth, tickSummary.price)
-		}
-	} else {
-		let remainingCap = truthAuction.ethRaiseCap
-		for (const tickSummary of activeTickSummaries) {
-			if (remainingCap <= 0n) break
-
-			let acceptedEth = 0n
-			if (tickSummary.tick > truthAuction.clearingTick) acceptedEth = tickSummary.currentTotalEth
-			else if (tickSummary.tick === truthAuction.clearingTick) acceptedEth = truthAuction.ethAtClearingTick < tickSummary.currentTotalEth ? truthAuction.ethAtClearingTick : tickSummary.currentTotalEth
-
-			if (acceptedEth <= 0n) continue
-			if (acceptedEth > remainingCap) acceptedEth = remainingCap
-
-			provisionalEthRaised += acceptedEth
-			provisionalRepSold += estimateRepPurchased(acceptedEth, tickSummary.price)
-			remainingCap -= acceptedEth
-		}
-	}
-
-	const ethRaised = provisionalEthRaised > truthAuction.ethRaiseCap ? truthAuction.ethRaiseCap : provisionalEthRaised
-	const repSold = provisionalRepSold > truthAuction.maxRepBeingSold ? truthAuction.maxRepBeingSold : provisionalRepSold
-
-	return {
-		ethRaised,
-		repSold,
-	}
-}
-
-async function loadTruthAuctionActiveTickPages(client: Pick<ReadClient, 'readContract'>, truthAuctionAddress: Address, pageCount: number) {
-	const tickSummaries: TruthAuctionTickSummary[] = []
-	let tickCount = 0n
-	for (let pageIndex = 0; pageIndex < pageCount; pageIndex += 1) {
-		const page = await loadTruthAuctionActiveTickPage(client, truthAuctionAddress, pageIndex, TRUTH_AUCTION_TICK_PAGE_SIZE)
-		tickCount = page.tickCount
-		tickSummaries.push(...page.ticks)
-		if (BigInt(tickSummaries.length) >= tickCount || page.ticks.length === 0) break
-	}
-	return {
-		tickCount,
-		tickSummaries,
-	}
-}
-
-async function loadTruthAuctionTickBidPages(client: Pick<ReadClient, 'readContract'>, truthAuctionAddress: Address, tick: bigint, pageCount: number) {
-	const bids: TruthAuctionBidView[] = []
-	let bidCount = 0n
-	for (let pageIndex = 0; pageIndex < pageCount; pageIndex += 1) {
-		const page = await loadTruthAuctionTickBidPage(client, truthAuctionAddress, tick, pageIndex, TRUTH_AUCTION_BID_PAGE_SIZE)
-		bidCount = page.bidCount
-		bids.push(...page.bids)
-		if (BigInt(bids.length) >= bidCount || page.bids.length === 0) break
-	}
-	return {
-		bidCount,
-		bids,
-	}
-}
-
-async function loadTruthAuctionBidderBidPages(client: Pick<ReadClient, 'readContract'>, truthAuctionAddress: Address, bidder: Address, pageCount: number) {
-	const bids: TruthAuctionBidView[] = []
-	let bidCount = 0n
-	for (let pageIndex = 0; pageIndex < pageCount; pageIndex += 1) {
-		const page = await loadTruthAuctionBidderBidPage(client, truthAuctionAddress, bidder, pageIndex, TRUTH_AUCTION_BID_PAGE_SIZE)
-		bidCount = page.bidCount
-		bids.push(...page.bids)
-		if (BigInt(bids.length) >= bidCount || page.bids.length === 0) break
-	}
-	return {
-		bidCount,
-		bids,
-	}
-}
-
-function sortTruthAuctionBidsByPriority(bids: TruthAuctionBidView[]) {
-	return [...bids].sort((left, right) => {
-		if (left.tick !== right.tick) return left.tick > right.tick ? -1 : 1
-		if (left.bidIndex !== right.bidIndex) return left.bidIndex < right.bidIndex ? -1 : 1
-		return 0
-	})
-}
-
 function getTruthAuctionStateBadge({
 	hasSelectedAuctionChildPool,
 	isStartTruthAuctionInProgress,
@@ -600,21 +291,6 @@ function getMigrationStateBadge({ currentTimestamp, effectiveTruthAuctionStarted
 	if (effectiveTruthAuctionStartedAt !== undefined && effectiveTruthAuctionStartedAt > 0n) return { label: 'Closed', tone: 'ok' }
 	if (currentTimestamp !== undefined && currentTimestamp >= migrationEndsAt) return { label: 'Closed', tone: 'ok' }
 	return { label: 'Open', tone: 'pending' }
-}
-
-async function loadAggregatedTruthAuctionBidPages(client: Pick<ReadClient, 'readContract'>, truthAuctionAddress: Address, tickSummaries: TruthAuctionTickSummary[], pageCount: number) {
-	const uniqueTickSummaries = sortTruthAuctionTickSummariesDescending(Array.from(new Map(tickSummaries.map(tickSummary => [tickSummary.tick.toString(), tickSummary])).values()))
-	const bidPages = await Promise.all(uniqueTickSummaries.map(async tickSummary => ({ bidData: await loadTruthAuctionTickBidPages(client, truthAuctionAddress, tickSummary.tick, pageCount), tickSummary })))
-	const dedupedBids = new Map<string, TruthAuctionBidView>()
-	for (const { bidData } of bidPages) {
-		for (const bid of bidData.bids) {
-			dedupedBids.set(`${bid.tick.toString()}:${bid.bidIndex.toString()}`, bid)
-		}
-	}
-	return {
-		bids: sortTruthAuctionBidsByPriority(Array.from(dedupedBids.values())),
-		bidCountForLoadedTicks: uniqueTickSummaries.reduce((sum, tickSummary) => sum + tickSummary.submissionCount, 0n),
-	}
 }
 
 function isFullReadClient(client: Pick<ReadClient, 'readContract'> | ReadClient | undefined): client is ReadClient {
@@ -738,27 +414,6 @@ export function ForkAuctionSection({
 		no: [],
 	})
 	const previousVaultMigrationContextKeyRef = useRef<string | undefined>(undefined)
-	const [truthAuctionBookData, setTruthAuctionBookData] = useState<TruthAuctionBookData>({
-		tickSummaries: [],
-		tickCount: 0n,
-		viewerBids: [],
-		viewerBidCount: 0n,
-	})
-	const [selectedBookTick, setSelectedBookTick] = useState<bigint | undefined>(undefined)
-	const [loadedTickPageCount, setLoadedTickPageCount] = useState(1)
-	const [loadedViewerBidPageCount, setLoadedViewerBidPageCount] = useState(1)
-	const [loadedAuctionBidPageCount, setLoadedAuctionBidPageCount] = useState(1)
-	const [aggregatedAuctionBids, setAggregatedAuctionBids] = useState<TruthAuctionBidView[]>([])
-	const [aggregatedAuctionBidCountForLoadedTicks, setAggregatedAuctionBidCountForLoadedTicks] = useState(0n)
-	const [loadingTruthAuctionBook, setLoadingTruthAuctionBook] = useState(false)
-	const [loadingAggregatedAuctionBids, setLoadingAggregatedAuctionBids] = useState(false)
-	const [truthAuctionBookError, setTruthAuctionBookError] = useState<string | undefined>(undefined)
-	const [selectedSettlementBidKeys, setSelectedSettlementBidKeys] = useState<string[]>([])
-	const [isSettlementBidSelectedForClaiming, setIsSettlementBidSelectedForClaiming] = useState<string[]>([])
-	const [isSettlementBidSelectedForRefunding, setIsSettlementBidSelectedForRefunding] = useState<string[]>([])
-	const [settlementActionQueue, setSettlementActionQueue] = useState<SettlementAction[]>([])
-	const [settlementBidResultRefreshToken, setSettlementBidResultRefreshToken] = useState(0)
-	const [settlementBidResultByKey, setSettlementBidResultByKey] = useState<Record<string, LocalSettlementBidStatus>>({})
 	const effectiveEscrowedRepInEscalationGame = (() => {
 		if (connectedWalletVaultSummary === undefined) return undefined
 		if (connectedWalletVaultSummary.escalationEscrowedRep > optimisticMigratedEscalationRep) {
@@ -826,30 +481,15 @@ export function ForkAuctionSection({
 	const hasImportedForkSettlementDeposits = importedForkSettlementSides.length > 0
 	const importedForkSettlementResolved = isPoolQuestionFinalized(activeReportingDetails)
 	const childSecurityPools = securityPoolAddress === undefined ? [] : securityPools.filter(pool => sameAddress(pool.parent, securityPoolAddress))
-	const currentStage =
-		currentStageView ??
-		(systemState === undefined
-			? 'initiate'
-			: getForkAuctionStageView({
-					claimingAvailable: forkAuctionDetails?.claimingAvailable ?? false,
-					forkOutcome: forkOutcome ?? 'none',
-					migratedRep: forkAuctionDetails?.migratedRep ?? previewPool?.migratedRep ?? 0n,
-					systemState,
-					truthAuction: forkAuctionDetails?.truthAuction,
-					truthAuctionStartedAt: forkAuctionDetails?.truthAuctionStartedAt ?? previewPool?.truthAuctionStartedAt ?? 0n,
-				}))
-	const currentWorkflowStage = getCurrentForkWorkflowSelectionStage({
-		claimingAvailable: forkAuctionDetails?.claimingAvailable ?? false,
-		currentForkStage: currentStage,
-		hasForkActivity: forkAuctionDetails?.hasForkActivity ?? previewPool?.hasForkActivity ?? false,
+	const { currentStage, currentWorkflowStage, selectedStage } = getForkWorkflowStageSelection({
+		currentStageView,
+		forkAuctionDetails,
+		forkOutcome,
+		previewPool,
+		selectedStageView,
+		stageView,
 		systemState,
-		truthAuctionFinalized: forkAuctionDetails?.truthAuction?.finalized ?? false,
 	})
-	const selectedStage = (() => {
-		if (selectedStageView !== undefined) return selectedStageView
-		if (stageView === undefined) return currentWorkflowStage
-		return stageView === 'initiate' ? 'fork-triggered' : stageView
-	})()
 	const selectedStageAheadMessage = getForkWorkflowStageAheadMessage(selectedStage, currentWorkflowStage)
 	const selectedAuctionLabel = selectedOutcomeLabel
 	const enteredBidPrice = tryParseTruthAuctionPriceInput(forkAuctionForm.submitBidPrice)
@@ -869,6 +509,31 @@ export function ForkAuctionSection({
 	})()
 	const truthAuctionStatus = auctionTruthAuctionStatus
 	const shouldShowTruthAuctionVisualization = truthAuctionStatus !== undefined && auctionTruthAuctionAddress !== undefined && auctionTruthAuctionAddress !== zeroAddress
+	const {
+		aggregatedAuctionBidCountForLoadedTicks,
+		aggregatedAuctionBids,
+		hasMoreAggregatedAuctionBids,
+		hasMoreTickSummaries,
+		hasMoreViewerBids,
+		loadNextAuctionBidPage,
+		loadNextTickPage,
+		loadNextViewerBidPage,
+		loadingAggregatedAuctionBids,
+		loadingTruthAuctionBook,
+		selectTruthAuctionTick,
+		selectedBookTick,
+		truthAuctionBookData,
+		truthAuctionBookError,
+	} = useTruthAuctionBookData({
+		accountAddress: accountState.address,
+		enteredBidTick,
+		forkAuctionResultHash: forkAuctionResult?.hash,
+		selectedStage,
+		shouldShowTruthAuctionVisualization,
+		truthAuctionAddress: auctionTruthAuctionAddress,
+		truthAuctionClearingTick: truthAuctionStatus?.clearingTick,
+		truthAuctionReadClient,
+	})
 	const winningThresholdPrice = getTruthAuctionWinningThresholdPrice(truthAuctionStatus)
 	const startTruthAuctionCountdown = forkAuctionDetails?.migrationEndsAt === undefined || effectiveCurrentTimestamp === undefined ? undefined : getTimeRemaining(forkAuctionDetails.migrationEndsAt, effectiveCurrentTimestamp)
 	const isStartTruthAuctionInProgress = (() => {
@@ -904,7 +569,7 @@ export function ForkAuctionSection({
 		return <TimestampValue {...(effectiveCurrentTimestamp === undefined ? {} : { currentTimestamp: effectiveCurrentTimestamp })} timestamp={auctionWindow.endsAt} />
 	})()
 	const hasStartedSelectedTruthAuctionTimeline = hasStartedTruthAuction || truthAuctionStatus !== undefined || selectedStage === 'auction' || selectedStage === 'settlement' || currentWorkflowStage === 'auction' || currentWorkflowStage === 'settlement'
-	const activeTickSummaries = sortTruthAuctionTickSummariesDescending(truthAuctionBookData.tickSummaries)
+	const activeTickSummaries = truthAuctionBookData.tickSummaries
 	const truthAuctionOverviewProgress = getTruthAuctionOverviewProgress(truthAuctionStatus, activeTickSummaries)
 	const displayedEthRaised = truthAuctionOverviewProgress?.ethRaised ?? truthAuctionStatus?.ethRaised ?? 0n
 	const displayedRepSold = truthAuctionOverviewProgress?.repSold ?? truthAuctionStatus?.totalRepPurchased ?? 0n
@@ -920,13 +585,6 @@ export function ForkAuctionSection({
 	const previewTickSummary = enteredBidTick === undefined ? undefined : activeTickSummaries.find(tickSummary => tickSummary.tick === enteredBidTick)
 	const submitBidPreviewTickSummary = previewTickSummary ?? (enteredBidTick !== undefined && selectedLoadedTickSummary?.tick === enteredBidTick ? selectedLoadedTickSummary : undefined)
 	const maxTickEth = truthAuctionDepthPoints.reduce((maximumEth, point) => (point.currentTotalEth > maximumEth ? point.currentTotalEth : maximumEth), 0n)
-	const hasMoreTickSummaries = BigInt(truthAuctionBookData.tickSummaries.length) < truthAuctionBookData.tickCount
-	const hasMoreViewerBids = BigInt(truthAuctionBookData.viewerBids.length) < truthAuctionBookData.viewerBidCount
-	const hasMoreAggregatedAuctionBids = BigInt(aggregatedAuctionBids.length) < aggregatedAuctionBidCountForLoadedTicks
-	const selectTruthAuctionTick = (tick: bigint) => {
-		if (selectedBookTick === tick) return
-		setSelectedBookTick(tick)
-	}
 	const ethRaisedCapDisplay =
 		truthAuctionStatus === undefined ? (
 			truthAuctionFallback
@@ -942,40 +600,29 @@ export function ForkAuctionSection({
 
 		return 'No'
 	})()
-	const settlementBidActionRows =
-		truthAuctionStatus === undefined
-			? []
-			: truthAuctionBookData.viewerBids.map(bid => ({
-					bid,
-					disposition: getBidDisposition(bid, truthAuctionStatus),
-				}))
-	const settlementBidRows = settlementBidActionRows.filter(({ bid, disposition }) => sameAddress(bid.bidder, accountState.address) && (disposition.canPrefillRefund || disposition.canPrefillSettle))
-	const settlementBidKey = (bid: TruthAuctionBidView) => `${bid.tick.toString()}:${bid.bidIndex.toString()}`
-	const settlementBidRowKeys = settlementBidRows.map(({ bid }) => settlementBidKey(bid))
-	const selectedSettlementBidRows = settlementBidRows.filter(({ bid }) => selectedSettlementBidKeys.includes(settlementBidKey(bid)))
-	const selectedRefundSettlementBidRows = selectedSettlementBidRows.filter(({ disposition }) => disposition.canPrefillRefund)
-	const selectedClaimSettlementBidRows = selectedSettlementBidRows.filter(({ disposition }) => disposition.canPrefillSettle)
-	const selectedClaimSettlementBidKeys = selectedClaimSettlementBidRows.map(({ bid }) => settlementBidKey(bid))
-	const selectedRefundSettlementBidKeys = selectedRefundSettlementBidRows.map(({ bid }) => settlementBidKey(bid))
-	const getSettlementBidsFromKeys = (selectedBidKeys: string[]) => {
-		const selectedBidKeySet = new Set(selectedBidKeys)
-		return settlementBidRows.filter(({ bid }) => selectedBidKeySet.has(settlementBidKey(bid))).map(({ bid }) => ({ bidIndex: bid.bidIndex, tick: bid.tick }))
-	}
-	const settlementRowsHaveClaims = settlementBidRows.some(({ disposition }) => disposition.canPrefillSettle)
-	const settlementRowsHaveRefunds = settlementBidRows.some(({ disposition }) => disposition.canPrefillRefund)
-	const settlementRowsSelectionMode = (() => {
-		if (settlementRowsHaveClaims && settlementRowsHaveRefunds) return 'mixed'
-		if (settlementRowsHaveClaims) return 'claim'
-		return 'refund'
-	})()
-	const settlementSelectionMode = (() => {
-		if (selectedRefundSettlementBidRows.length > 0 && selectedClaimSettlementBidRows.length > 0) return 'mixed'
-		if (selectedClaimSettlementBidRows.length > 0) return 'claim'
-		if (selectedSettlementBidRows.length > 0) return 'refund'
-		return settlementRowsSelectionMode
-	})()
-	const settlementSelectionHasClaims = selectedClaimSettlementBidRows.length > 0
-	const settlementSelectionHasRefunds = selectedRefundSettlementBidRows.length > 0
+	const settlementBidRows = getTruthAuctionSettlementBidRows({
+		accountAddress: accountState.address,
+		truthAuction: truthAuctionStatus,
+		viewerBids: truthAuctionBookData.viewerBids,
+	})
+	const { isSettleSelectedBidsInProgress, selectedSettlementBidKeys, setSelectedSettlementBidKeys, settlementBidResultByKey, settlementSelectionState, submitClaimBidsByKeys, submitRefundBidsByKeys, submitSelectedSettlementBids } = useTruthAuctionSettlementActionState({
+		accountAddress: accountState.address,
+		forkAuctionError,
+		forkAuctionResult,
+		onClaimAuctionProceeds,
+		onRefundLosingBids,
+		selectedAuctionPoolAddress,
+		selectedStage,
+		settlementBidRows,
+	})
+	const selectedSettlementBidRows = settlementSelectionState.selectedRows
+	const selectedRefundSettlementBidRows = settlementSelectionState.selectedRefundRows
+	const selectedClaimSettlementBidRows = settlementSelectionState.selectedClaimRows
+	const selectedClaimSettlementBidKeys = settlementSelectionState.selectedClaimKeys
+	const selectedRefundSettlementBidKeys = settlementSelectionState.selectedRefundKeys
+	const settlementSelectionMode = settlementSelectionState.selectionMode
+	const settlementSelectionHasClaims = settlementSelectionState.selectionHasClaims
+	const settlementSelectionHasRefunds = settlementSelectionState.selectionHasRefunds
 	const settlementAction = settlementSelectionHasClaims ? 'claimAuctionProceeds' : 'refundLosingBids'
 	const settlementActionLabel = 'Settle Selected Bids'
 	const settlementActionDescription = (() => {
@@ -984,10 +631,24 @@ export function ForkAuctionSection({
 		return 'Select winning and refundable bids and settle them together.'
 	})()
 	const settlementActionPendingLabel = 'Submitting settlement transaction...'
-	const refreshSettlementBidResults = () => {
-		setSettlementBidResultRefreshToken(currentToken => currentToken + 1)
+	const auctionBidRows = buildTruthAuctionBidRows({
+		bids: aggregatedAuctionBids,
+		truthAuction: truthAuctionStatus,
+	})
+	const viewerBidRowsViewModel = buildViewerTruthAuctionBidRows({
+		accountAddress: accountState.address,
+		isSettlementInProgress: isSettleSelectedBidsInProgress,
+		selectedBidKeys: selectedSettlementBidKeys,
+		selectedStage,
+		settlementResultByKey: settlementBidResultByKey,
+		truthAuction: truthAuctionStatus,
+		viewerBids: truthAuctionBookData.viewerBids,
+	})
+	const viewerBidRows = viewerBidRowsViewModel.rows
+	const showViewerSettlementActionColumn = viewerBidRowsViewModel.showSettlementActionColumn
+	const onSettlementBidSelectionChange = (bidKey: string, checked: boolean) => {
+		setSelectedSettlementBidKeys(currentKeys => updateTruthAuctionSettlementBidSelection(currentKeys, bidKey, checked))
 	}
-	const isSettleSelectedBidsInProgress = settlementActionQueue.length > 0 || isSettlementBidSelectedForClaiming.length + isSettlementBidSelectedForRefunding.length > 0
 	const interactionDisabledReason = (() => {
 		if (accountState.address === undefined) return 'Connect a wallet before using fork and auction actions.'
 		if (!isMainnet) return 'Switch to Ethereum mainnet before using fork and auction actions.'
@@ -1145,99 +806,20 @@ export function ForkAuctionSection({
 	function onFinalizeTruthAuctionForSelectedAuction() {
 		onFinalizeTruthAuction(selectedAuctionPoolAddress)
 	}
-	const submitClaimBidsByKeys = (claimBidKeys: string[]) => {
-		if (selectedAuctionPoolAddress === undefined) return
-		const claimBids = getSettlementBidsFromKeys(claimBidKeys)
-		if (claimBids.length === 0) return
-		setIsSettlementBidSelectedForClaiming(claimBidKeys)
-		onClaimAuctionProceeds(selectedAuctionPoolAddress, claimBids)
-	}
-	const submitRefundBidsByKeys = (refundBidKeys: string[]) => {
-		if (selectedAuctionPoolAddress === undefined) return
-		const refundBids = getSettlementBidsFromKeys(refundBidKeys)
-		if (refundBids.length === 0) return
-		setIsSettlementBidSelectedForRefunding(refundBidKeys)
-		onRefundLosingBids(selectedAuctionPoolAddress, refundBids)
-	}
-	const markSettlementBidResult = (settlementBidKeys: string[], status: LocalSettlementBidStatus) => {
-		const targetBidKeys = Array.from(new Set(settlementBidKeys))
-		if (targetBidKeys.length === 0) return
-
-		setSettlementBidResultByKey(currentStatuses => {
-			const nextStatuses = { ...currentStatuses }
-			for (const settlementBidKeyToSettle of targetBidKeys) {
-				nextStatuses[settlementBidKeyToSettle] = status
-			}
-			return nextStatuses
-		})
-		setSelectedSettlementBidKeys(currentSelection => currentSelection.filter(selectedBidKey => !targetBidKeys.includes(selectedBidKey)))
-
-		if (status === 'claimed') {
-			setIsSettlementBidSelectedForClaiming(currentSelection => currentSelection.filter(claimedBidKey => !targetBidKeys.includes(claimedBidKey)))
-			return
-		}
-
-		setIsSettlementBidSelectedForRefunding(currentSelection => currentSelection.filter(refundedBidKey => !targetBidKeys.includes(refundedBidKey)))
-	}
-	useEffect(() => {
-		if (!isSettleSelectedBidsInProgress) return
-		if (forkAuctionError !== undefined) {
-			setIsSettlementBidSelectedForClaiming([])
-			setIsSettlementBidSelectedForRefunding([])
-			setSettlementActionQueue([])
-			return
-		}
-		if (forkAuctionResult === undefined || selectedAuctionPoolAddress === undefined || !sameAddress(forkAuctionResult.securityPoolAddress, selectedAuctionPoolAddress)) return
-		const currentActionQueue = settlementActionQueue
-		if (forkAuctionResult.action === 'claimAuctionProceeds') {
-			if (currentActionQueue.length > 0 && currentActionQueue[0] !== 'claimAuctionProceeds') return
-			if (isSettlementBidSelectedForClaiming.length > 0) markSettlementBidResult(isSettlementBidSelectedForClaiming, 'claimed')
-			if (isSettlementBidSelectedForRefunding.length > 0) markSettlementBidResult(isSettlementBidSelectedForRefunding, 'refunded')
-			const nextActionQueue = currentActionQueue.slice(1)
-			setSettlementActionQueue(nextActionQueue)
-			if (nextActionQueue[0] === 'refundLosingBids' && isSettlementBidSelectedForRefunding.length > 0) {
-				submitRefundBidsByKeys(isSettlementBidSelectedForRefunding)
-			} else {
-				refreshSettlementBidResults()
-			}
-			return
-		}
-		if (forkAuctionResult.action === 'refundLosingBids') {
-			if (currentActionQueue[0] !== 'refundLosingBids') return
-			markSettlementBidResult(isSettlementBidSelectedForRefunding, 'refunded')
-			setSettlementActionQueue(currentActionQueue.slice(1))
-			refreshSettlementBidResults()
-		}
-	}, [forkAuctionError, forkAuctionResult, isSettleSelectedBidsInProgress, isSettlementBidSelectedForClaiming, isSettlementBidSelectedForRefunding, settlementActionQueue, selectedAuctionPoolAddress])
-	const settlementBidActionAvailability = (() => {
-		if (selectedSettlementBidRows.length === 0) return 'Pick one or more of your bids before settlement.'
-		if (truthAuctionStatus === undefined) return 'Load the truth auction before settling bids.'
-		if (truthAuctionStatus.finalized && settlementSelectionHasClaims && selectedAuctionContext?.claimingAvailable === false) return 'Finalized settlement is not yet available for this pool.'
-		if (settlementSelectionHasClaims && !truthAuctionStatus.finalized) return 'Winning bids can only be settled after the truth auction is finalized.'
-		if (!truthAuctionStatus.finalized && (!truthAuctionStatus.hitCap || truthAuctionStatus.clearingTick === undefined)) return 'Losing bids cannot be refunded until the auction has a clearing tick.'
-		return undefined
-	})()
-	const settlementActionAvailabilityMessage = (() => {
-		if (selectedSettlementBidRows.length === 0) return settlementBidActionAvailability
-		if (settlementSelectionHasClaims && selectedClaimSettlementBidRows.length === 0) return 'Select one or more winning bids before submitting settlement.'
-		if (!settlementSelectionHasClaims && settlementSelectionHasRefunds === false) return 'Select one or more refundable bids before submitting refunds.'
-		return settlementBidActionAvailability
-	})()
+	const settlementActionAvailabilityMessage = getTruthAuctionSettlementActionAvailabilityMessage({
+		claimingAvailable: selectedAuctionContext?.claimingAvailable,
+		selectedClaimRows: selectedClaimSettlementBidRows,
+		selectedRows: selectedSettlementBidRows,
+		selectionHasClaims: settlementSelectionHasClaims,
+		selectionHasRefunds: settlementSelectionHasRefunds,
+		truthAuction: truthAuctionStatus,
+	})
 	const onRefundLosingBidsForSelectedAuction = () => {
 		if (selectedRefundSettlementBidRows.length === 0) return
 		submitRefundBidsByKeys(selectedRefundSettlementBidKeys)
 	}
 	const onSettleSelectedBidsForSelectedAuction = () => {
-		if (selectedSettlementBidRows.length === 0) return
-		if (isSettleSelectedBidsInProgress) return
-		if (selectedAuctionPoolAddress === undefined) return
-		const selectedClaimSettlementBids = getSettlementBidsFromKeys(selectedClaimSettlementBidKeys)
-		const selectedRefundSettlementBids = getSettlementBidsFromKeys(selectedRefundSettlementBidKeys)
-		if (selectedClaimSettlementBids.length === 0 && selectedRefundSettlementBids.length === 0) return
-		setIsSettlementBidSelectedForClaiming(selectedClaimSettlementBidKeys)
-		setIsSettlementBidSelectedForRefunding(selectedRefundSettlementBidKeys)
-		setSettlementActionQueue([])
-		onClaimAuctionProceeds(selectedAuctionPoolAddress, selectedClaimSettlementBids, selectedRefundSettlementBids)
+		submitSelectedSettlementBids()
 	}
 	const onClaimAuctionProceedsForSelectedAuction = () => {
 		if (selectedClaimSettlementBidRows.length === 0) return
@@ -1316,36 +898,6 @@ export function ForkAuctionSection({
 			</div>
 		)
 	}
-	const renderBidActionButtons = ({ bid, hasActions = true, showViewPriceAction = true }: { bid: TruthAuctionBidView; hasActions?: boolean; showViewPriceAction?: boolean }) => {
-		if (!hasActions) return undefined
-		return (
-			<div className='truth-auction-bid-row-actions'>
-				{showViewPriceAction ? (
-					<button className='secondary' onClick={() => selectTruthAuctionTick(bid.tick)} type='button'>
-						View Price
-					</button>
-				) : undefined}
-			</div>
-		)
-	}
-	const renderAuctionBidsHeader = ({ showActions = false }: { showActions?: boolean }) => (
-		<div className={`truth-auction-bid-row is-wide ${showActions ? '' : 'is-no-actions'} is-header`}>
-			<span className='truth-auction-bid-row-label'>Price (ETH / REP)</span>
-			<span>Bidder</span>
-			<span>Bid Amount (ETH)</span>
-			<span>Loaded Depth (ETH)</span>
-			<span className='truth-auction-bid-row-status'>Status</span>
-			{showActions ? <span>Actions</span> : undefined}
-		</div>
-	)
-	const renderMyBidsHeader = ({ showActions = true }: { showActions?: boolean }) => (
-		<div className={`truth-auction-bid-row is-wallet ${showActions ? '' : 'is-no-actions'} is-header`}>
-			{showActions ? <span>Selected</span> : undefined}
-			<span className='truth-auction-bid-row-label'>Price (ETH / REP)</span>
-			<span>Bid Amount (ETH)</span>
-			<span className='truth-auction-bid-row-status'>Status</span>
-		</div>
-	)
 	const renderSubmitBidSection = ({ description, density = 'balanced', headingLevel = 3, title = 'Submit Bid', variant = 'default' }: { description?: ComponentChildren; density?: 'balanced' | 'compact'; headingLevel?: 3 | 4; title?: ComponentChildren; variant?: 'default' | 'embedded' }) => (
 		<SectionBlock {...(description === undefined ? {} : { description })} density={density} headingLevel={headingLevel} title={title} variant={variant}>
 			<div className='form-grid'>
@@ -1603,145 +1155,6 @@ export function ForkAuctionSection({
 		if (!isStartTruthAuctionInProgressState) return
 		if (accountState.address === undefined || securityPoolAddress === undefined) setIsStartTruthAuctionInProgressState(false)
 	}, [accountState.address, isStartTruthAuctionInProgressState, securityPoolAddress])
-	const settlementBidRowKeySignature = settlementBidRowKeys.slice().sort().join('\u0000')
-	useEffect(() => {
-		if (selectedStage !== 'settlement') {
-			setSelectedSettlementBidKeys(currentKeys => (currentKeys.length === 0 ? currentKeys : []))
-			setIsSettlementBidSelectedForClaiming(currentKeys => (currentKeys.length === 0 ? currentKeys : []))
-			setIsSettlementBidSelectedForRefunding(currentKeys => (currentKeys.length === 0 ? currentKeys : []))
-			setSettlementBidResultByKey(currentStatuses => (Object.keys(currentStatuses).length === 0 ? currentStatuses : {}))
-			setSettlementActionQueue(currentQueue => (currentQueue.length === 0 ? currentQueue : []))
-			return
-		}
-		const selectableBidKeySet = new Set(settlementBidRowKeys)
-		setSelectedSettlementBidKeys(currentKeys => {
-			const nextKeys = currentKeys.filter(key => selectableBidKeySet.has(key))
-			if (nextKeys.length === currentKeys.length && nextKeys.every((key, index) => key === currentKeys[index])) return currentKeys
-			return nextKeys
-		})
-		setSettlementBidResultByKey(currentStatuses => {
-			let hasUnchangedKeys = false
-			const nextStatuses: Record<string, LocalSettlementBidStatus> = {}
-			Object.keys(currentStatuses).forEach(currentSettlementBidKey => {
-				if (!selectableBidKeySet.has(currentSettlementBidKey)) return
-				const existingStatus = currentStatuses[currentSettlementBidKey]
-				if (existingStatus !== undefined) {
-					nextStatuses[currentSettlementBidKey] = existingStatus
-					hasUnchangedKeys = true
-				}
-			})
-			setIsSettlementBidSelectedForClaiming(currentKeys => {
-				const nextKeys = currentKeys.filter(key => selectableBidKeySet.has(key))
-				if (nextKeys.length === currentKeys.length && nextKeys.every((key, index) => key === currentKeys[index])) return currentKeys
-				return nextKeys
-			})
-			setIsSettlementBidSelectedForRefunding(currentKeys => {
-				const nextKeys = currentKeys.filter(key => selectableBidKeySet.has(key))
-				if (nextKeys.length === currentKeys.length && nextKeys.every((key, index) => key === currentKeys[index])) return currentKeys
-				return nextKeys
-			})
-			if (!hasUnchangedKeys) {
-				if (Object.keys(currentStatuses).length === 0) return currentStatuses
-				return {}
-			}
-			const currentStatusKeys = Object.keys(currentStatuses)
-			const nextStatusKeys = Object.keys(nextStatuses)
-			if (currentStatusKeys.length === nextStatusKeys.length && currentStatusKeys.every(key => currentStatuses[key] === nextStatuses[key])) return currentStatuses
-			return nextStatuses
-		})
-	}, [accountState.address, selectedStage, settlementBidRowKeySignature, selectedAuctionPoolAddress])
-	useEffect(() => {
-		setLoadedTickPageCount(1)
-		setLoadedViewerBidPageCount(1)
-		setLoadedAuctionBidPageCount(1)
-		setSelectedBookTick(undefined)
-	}, [accountState.address, auctionTruthAuctionAddress])
-	useEffect(() => {
-		if (!shouldShowTruthAuctionVisualization || auctionTruthAuctionAddress === undefined || auctionTruthAuctionAddress === zeroAddress || (selectedStage !== 'auction' && selectedStage !== 'settlement')) {
-			setTruthAuctionBookData({
-				tickSummaries: [],
-				tickCount: 0n,
-				viewerBids: [],
-				viewerBidCount: 0n,
-			})
-			setSelectedBookTick(undefined)
-			setLoadingTruthAuctionBook(false)
-			setAggregatedAuctionBids([])
-			setAggregatedAuctionBidCountForLoadedTicks(0n)
-			setLoadingAggregatedAuctionBids(false)
-			setTruthAuctionBookError(undefined)
-			return
-		}
-		const client = truthAuctionReadClient ?? createConnectedReadClient()
-		let cancelled = false
-		setLoadingTruthAuctionBook(true)
-		setTruthAuctionBookError(undefined)
-		void Promise.all([loadTruthAuctionActiveTickPages(client, auctionTruthAuctionAddress, loadedTickPageCount), accountState.address === undefined ? Promise.resolve({ bidCount: 0n, bids: [] }) : loadTruthAuctionBidderBidPages(client, auctionTruthAuctionAddress, accountState.address, loadedViewerBidPageCount)])
-			.then(([tickPageData, viewerBidData]) => {
-				if (cancelled) return
-				const sortedTickSummaries = sortTruthAuctionTickSummariesDescending(tickPageData.tickSummaries)
-				setTruthAuctionBookData({
-					tickSummaries: sortedTickSummaries,
-					tickCount: tickPageData.tickCount,
-					viewerBids: viewerBidData.bids,
-					viewerBidCount: viewerBidData.bidCount,
-				})
-				setSelectedBookTick(currentSelection => {
-					if (currentSelection !== undefined && sortedTickSummaries.some(tickSummary => tickSummary.tick === currentSelection)) return currentSelection
-					if (enteredBidTick !== undefined && sortedTickSummaries.some(tickSummary => tickSummary.tick === enteredBidTick)) return enteredBidTick
-					if (truthAuctionStatus?.clearingTick !== undefined && sortedTickSummaries.some(tickSummary => tickSummary.tick === truthAuctionStatus.clearingTick)) return truthAuctionStatus.clearingTick
-					return sortedTickSummaries[0]?.tick
-				})
-			})
-			.catch(error => {
-				if (cancelled) return
-				setTruthAuctionBookData({
-					tickSummaries: [],
-					tickCount: 0n,
-					viewerBids: [],
-					viewerBidCount: 0n,
-				})
-				setSelectedBookTick(undefined)
-				setTruthAuctionBookError(getErrorMessage(error, 'Failed to load truth auction bidbook'))
-			})
-			.finally(() => {
-				if (cancelled) return
-				setLoadingTruthAuctionBook(false)
-			})
-		return () => {
-			cancelled = true
-		}
-	}, [accountState.address, auctionTruthAuctionAddress, enteredBidTick, forkAuctionResult?.hash, loadedTickPageCount, loadedViewerBidPageCount, selectedStage, settlementBidResultRefreshToken, shouldShowTruthAuctionVisualization, truthAuctionReadClient, truthAuctionStatus?.clearingTick])
-	useEffect(() => {
-		if (!shouldShowTruthAuctionVisualization || auctionTruthAuctionAddress === undefined || auctionTruthAuctionAddress === zeroAddress || (selectedStage !== 'auction' && selectedStage !== 'settlement')) {
-			setAggregatedAuctionBids([])
-			setAggregatedAuctionBidCountForLoadedTicks(0n)
-			setLoadingAggregatedAuctionBids(false)
-			return
-		}
-		const client = truthAuctionReadClient ?? createConnectedReadClient()
-		let cancelled = false
-		setLoadingAggregatedAuctionBids(true)
-		void loadAggregatedTruthAuctionBidPages(client, auctionTruthAuctionAddress, truthAuctionBookData.tickSummaries, loadedAuctionBidPageCount)
-			.then(({ bids, bidCountForLoadedTicks }) => {
-				if (cancelled) return
-				setAggregatedAuctionBids(bids)
-				setAggregatedAuctionBidCountForLoadedTicks(bidCountForLoadedTicks)
-			})
-			.catch(error => {
-				if (cancelled) return
-				setAggregatedAuctionBids([])
-				setAggregatedAuctionBidCountForLoadedTicks(0n)
-				setTruthAuctionBookError(currentError => currentError ?? getErrorMessage(error, 'Failed to load truth auction bids across the visible price levels'))
-			})
-			.finally(() => {
-				if (cancelled) return
-				setLoadingAggregatedAuctionBids(false)
-			})
-		return () => {
-			cancelled = true
-		}
-	}, [auctionTruthAuctionAddress, forkAuctionResult?.hash, loadedAuctionBidPageCount, selectedStage, settlementBidResultRefreshToken, shouldShowTruthAuctionVisualization, truthAuctionBookData.tickSummaries, truthAuctionReadClient])
 	const migrationStartedAt = (() => {
 		if (universeForkTime !== undefined && universeForkTime > 0n) return universeForkTime
 		if (forkAuctionDetails?.migrationEndsAt !== undefined) return forkAuctionDetails.migrationEndsAt - FORK_MIGRATION_DURATION
@@ -1797,41 +1210,20 @@ export function ForkAuctionSection({
 	const truthAuctionHero = (() => {
 		if (!shouldShowTruthAuctionVisualization || truthAuctionStatus === undefined) return undefined
 		return (
-			<SectionBlock badge={truthAuctionStateBadgeElement} className='fork-workflow-summary-card truth-auction-summary-card' title='Truth Auction'>
-				<div className='fork-workflow-summary'>
-					<div className='fork-workflow-summary-primary truth-auction-summary-primary'>
-						<div className='fork-workflow-summary-stat-group truth-auction-progress-group'>
-							<div className='fork-workflow-summary-stat-copy truth-auction-progress-copy'>
-								<span>ETH Raised</span>
-								<strong>
-									<CurrencyValue value={displayedEthRaised} suffix='ETH' /> / <CurrencyValue value={truthAuctionStatus.ethRaiseCap} suffix='ETH' />
-								</strong>
-							</div>
-							<div className='truth-auction-progress-track'>
-								<div className='truth-auction-progress-fill is-eth' style={{ width: `${ethRaisedProgress}%` }} />
-							</div>
-						</div>
-						<div className='fork-workflow-summary-stat-group truth-auction-progress-group'>
-							<div className='fork-workflow-summary-stat-copy truth-auction-progress-copy'>
-								<span>REP Sold</span>
-								<strong>
-									<CurrencyValue value={displayedRepSold} suffix='REP' /> / <CurrencyValue value={truthAuctionStatus.maxRepBeingSold} suffix='REP' />
-								</strong>
-							</div>
-							<div className='truth-auction-progress-track'>
-								<div className='truth-auction-progress-fill is-rep' style={{ width: `${repSoldProgress}%` }} />
-							</div>
-						</div>
-					</div>
-					<div className='fork-workflow-summary-metrics'>
-						<MetricField label='Starts'>{startedDisplay}</MetricField>
-						<MetricField label='Clearing Price'>{renderTruthAuctionPriceValue(truthAuctionStatus.clearingPrice)}</MetricField>
-						<MetricField label='Min Bid'>{<CurrencyValue value={truthAuctionStatus.minBidSize} suffix='ETH' />}</MetricField>
-						<MetricField label='Ends'>{endsDisplay}</MetricField>
-						{winningThresholdPrice === undefined ? undefined : <MetricField label='Winning Threshold'>{renderTruthAuctionPriceValue(winningThresholdPrice)}</MetricField>}
-					</div>
-				</div>
-			</SectionBlock>
+			<TruthAuctionSummaryCard
+				badge={truthAuctionStateBadgeElement}
+				clearingPriceDisplay={renderTruthAuctionPriceValue(truthAuctionStatus.clearingPrice)}
+				displayedEthRaised={displayedEthRaised}
+				displayedRepSold={displayedRepSold}
+				endsDisplay={endsDisplay}
+				ethRaiseCap={truthAuctionStatus.ethRaiseCap}
+				ethRaisedProgress={ethRaisedProgress}
+				maxRepBeingSold={truthAuctionStatus.maxRepBeingSold}
+				minBidSize={truthAuctionStatus.minBidSize}
+				repSoldProgress={repSoldProgress}
+				startedDisplay={startedDisplay}
+				winningThresholdPriceDisplay={winningThresholdPrice === undefined ? undefined : renderTruthAuctionPriceValue(winningThresholdPrice)}
+			/>
 		)
 	})()
 	const migrationSummaryCard = (
@@ -1883,182 +1275,49 @@ export function ForkAuctionSection({
 	const truthAuctionMarketViewSection = (() => {
 		if (!shouldShowTruthAuctionVisualization || truthAuctionStatus === undefined) return undefined
 		return (
-			<SectionBlock title='Market View'>
-				{truthAuctionBookError === undefined ? undefined : <p className='detail truth-auction-book-error'>{truthAuctionBookError}</p>}
-				<div className='truth-auction-market-board'>
-					<div className='truth-auction-market-section truth-auction-depth-panel'>
-						<div className='truth-auction-depth-header'>
-							<div>
-								<h4>Visible Depth</h4>
-							</div>
-						</div>
-						{loadingTruthAuctionBook ? <p className='detail'>Loading order book…</p> : undefined}
-						{!loadingTruthAuctionBook && truthAuctionDepthPoints.length === 0 ? <p className='detail'>No live price levels are currently active for this auction.</p> : undefined}
-						{truthAuctionDepthPoints.length === 0 ? undefined : <TruthAuctionDepthChart onSelectTick={selectTruthAuctionTick} points={truthAuctionDepthPoints} {...(truthAuctionStatus.hitCap && truthAuctionStatus.clearingTick !== undefined ? { clearingTick: truthAuctionStatus.clearingTick } : {})} />}
-					</div>
-					<div className='truth-auction-market-detail-grid'>
-						<div className='truth-auction-market-section'>
-							<div className='truth-auction-panel-header'>
-								<div>
-									<h4>Price Ladder</h4>
-								</div>
-							</div>
-							<div className='truth-auction-ladder'>
-								{loadingTruthAuctionBook ? <p className='detail'>Loading price levels…</p> : undefined}
-								{!loadingTruthAuctionBook && truthAuctionDepthPoints.length === 0 ? <p className='detail'>No active levels are visible yet.</p> : undefined}
-								{truthAuctionDepthPoints.map(point => (
-									<button
-										aria-pressed={point.isSelected}
-										className={`truth-auction-price-row truth-auction-ladder-row ${getTruthAuctionDispositionClassName(point.disposition.tone)}${point.isSelected ? ' is-selected' : ''}${point.isPreviewTick ? ' is-preview' : ''}${truthAuctionStatus.clearingTick === point.tick ? ' is-clearing' : ''}`}
-										key={point.tick.toString()}
-										onClick={() => selectTruthAuctionTick(point.tick)}
-										type='button'
-									>
-										<div className='truth-auction-price-row-bar' style={{ width: `${clampPercentage(point.currentTotalEth, maxTickEth)}%` }} />
-										<div className='truth-auction-price-row-copy'>
-											<div className='truth-auction-price-row-main'>
-												<div>
-													<strong>{renderTruthAuctionPriceValue(point.price)}</strong>
-													<span className='truth-auction-price-row-price'>Price level</span>
-												</div>
-												<div className='truth-auction-price-row-badges'>
-													{truthAuctionStatus.clearingTick === point.tick ? <span className='truth-auction-ladder-helper'>Clearing level</span> : undefined}
-													{point.isPreviewTick ? <span className='truth-auction-ladder-helper'>Current form price</span> : undefined}
-													<span className={`truth-auction-status-pill ${getTruthAuctionDispositionClassName(point.disposition.tone)}`}>{point.disposition.label}</span>
-												</div>
-											</div>
-											<div className='truth-auction-price-row-meta'>
-												<span>
-													Current size <CurrencyValue value={point.currentTotalEth} suffix='ETH' />
-												</span>
-												<span className='truth-auction-ladder-row-cumulative'>
-													Loaded depth <CurrencyValue value={point.cumulativeEth} suffix='ETH' />
-												</span>
-												<span>{activeTickSummaries.find(tickSummary => tickSummary.tick === point.tick)?.submissionCount.toString() ?? '0'} submissions</span>
-											</div>
-										</div>
-									</button>
-								))}
-								{hasMoreTickSummaries ? <PaginationControls hasNextPage={hasMoreTickSummaries} onLoadMore={() => setLoadedTickPageCount(currentPageCount => currentPageCount + 1)} loadMoreLabel='Load More Price Levels' /> : undefined}
-							</div>
-						</div>
-					</div>
-				</div>
-			</SectionBlock>
+			<TruthAuctionMarketViewSection
+				clearingTick={truthAuctionStatus.clearingTick}
+				hasMoreTickSummaries={hasMoreTickSummaries}
+				loadingTruthAuctionBook={loadingTruthAuctionBook}
+				maxTickEth={maxTickEth}
+				onLoadNextTickPage={loadNextTickPage}
+				onSelectTick={selectTruthAuctionTick}
+				renderPriceValue={renderTruthAuctionPriceValue}
+				showDepthClearingTick={truthAuctionStatus.hitCap && truthAuctionStatus.clearingTick !== undefined}
+				truthAuctionBookError={truthAuctionBookError}
+				truthAuctionDepthPoints={truthAuctionDepthPoints}
+			/>
 		)
 	})()
 	const auctionWideBidsSection = (() => {
 		if (!shouldShowTruthAuctionVisualization || truthAuctionStatus === undefined) return undefined
 
 		return (
-			<SectionBlock title='Truth Auction Bids'>
-				<div className='truth-auction-bid-coverage-summary'>
-					<MetricField label='Loaded Levels'>{truthAuctionBookData.tickSummaries.length.toString()}</MetricField>
-					<MetricField label='Loaded Bids'>{aggregatedAuctionBids.length.toString()}</MetricField>
-					<MetricField label='Coverage'>{`Showing ${aggregatedAuctionBids.length.toString()} of ${aggregatedAuctionBidCountForLoadedTicks.toString()} bids across loaded levels`}</MetricField>
-				</div>
-				{loadingAggregatedAuctionBids ? <p className='detail'>Loading auction bids…</p> : undefined}
-				{!loadingAggregatedAuctionBids && truthAuctionBookData.tickSummaries.length === 0 ? <p className='detail'>No active prices are currently visible for this auction.</p> : undefined}
-				{!loadingAggregatedAuctionBids && truthAuctionBookData.tickSummaries.length > 0 && aggregatedAuctionBids.length === 0 ? <p className='detail'>No bids are currently indexed for the loaded prices.</p> : undefined}
-				{aggregatedAuctionBids.length === 0 ? undefined : (
-					<div className='truth-auction-bid-table'>
-						{renderAuctionBidsHeader({ showActions: false })}
-						{aggregatedAuctionBids.map(bid => {
-							const disposition = getBidDisposition(bid, truthAuctionStatus)
-							return (
-								<div className='truth-auction-bid-row is-wide is-no-actions' key={`aggregate:${bid.tick.toString()}:${bid.bidIndex.toString()}`}>
-									<span className='truth-auction-bid-row-label'>{renderTruthAuctionPriceValue(getTruthAuctionPriceAtTick(bid.tick))}</span>
-									<div className='truth-auction-bid-row-address'>
-										<AddressValue address={bid.bidder} />
-									</div>
-									<span>
-										<CurrencyValue value={bid.ethAmount} suffix='ETH' />
-									</span>
-									<span>
-										<CurrencyValue value={bid.cumulativeEth} suffix='ETH' />
-									</span>
-									<span className='truth-auction-bid-row-status'>
-										<span className={`truth-auction-status-pill ${getTruthAuctionDispositionClassName(disposition.tone)}`}>{disposition.label}</span>
-									</span>
-									{renderBidActionButtons({ bid, hasActions: false })}
-								</div>
-							)
-						})}
-					</div>
-				)}
-				{hasMoreAggregatedAuctionBids ? <PaginationControls hasNextPage={hasMoreAggregatedAuctionBids} onLoadMore={() => setLoadedAuctionBidPageCount(currentPageCount => currentPageCount + 1)} loadMoreLabel='Load More Truth Auction Bids' /> : undefined}
-			</SectionBlock>
+			<TruthAuctionBidsSection
+				aggregatedAuctionBidCountForLoadedTicks={aggregatedAuctionBidCountForLoadedTicks}
+				hasMoreAggregatedAuctionBids={hasMoreAggregatedAuctionBids}
+				loadedTickCount={truthAuctionBookData.tickSummaries.length}
+				loadingAggregatedAuctionBids={loadingAggregatedAuctionBids}
+				onLoadNextAuctionBidPage={loadNextAuctionBidPage}
+				renderPriceValue={renderTruthAuctionPriceValue}
+				rows={auctionBidRows}
+			/>
 		)
 	})()
 	const viewerTruthAuctionBidsSection = (() => {
 		if (!shouldShowTruthAuctionVisualization || truthAuctionStatus === undefined) return undefined
-		const viewerBidsWithDisposition = truthAuctionBookData.viewerBids.map(bid => ({ bid, disposition: getBidDisposition(bid, truthAuctionStatus) }))
-		const hasViewerBidActions = viewerBidsWithDisposition.some(({ bid, disposition }) => sameAddress(bid.bidder, accountState.address) && (disposition.canPrefillRefund || disposition.canPrefillSettle))
-		const isSettlementStage = selectedStage === 'settlement'
-		const showSettlementActionColumn = isSettlementStage && hasViewerBidActions
 
 		return (
-			<SectionBlock title='My Bids'>
-				{accountState.address === undefined ? <p className='detail'>Connect a wallet to inspect your submitted truth auction bids.</p> : undefined}
-				{accountState.address !== undefined && loadingTruthAuctionBook ? <p className='detail'>Loading your bids…</p> : undefined}
-				{accountState.address !== undefined && !loadingTruthAuctionBook && truthAuctionBookData.viewerBids.length === 0 ? <p className='detail'>No bids from this wallet are indexed for the current auction.</p> : undefined}
-				{truthAuctionBookData.viewerBids.length === 0 ? undefined : (
-					<div className='truth-auction-bid-table'>
-						{renderMyBidsHeader({ showActions: showSettlementActionColumn })}
-						{viewerBidsWithDisposition.map(({ bid, disposition }) => {
-							const isSettlementBid = sameAddress(bid.bidder, accountState.address) && (disposition.canPrefillRefund || disposition.canPrefillSettle)
-							const settlementBidRow = settlementBidKey(bid)
-							const inSessionSettlementResult = settlementBidResultByKey[settlementBidRow]
-							const isSettlementBidActions = isSettlementStage && isSettlementBid && inSessionSettlementResult === undefined && !isSettleSelectedBidsInProgress
-							const isSettlementBidChecked = selectedSettlementBidKeys.includes(settlementBidRow)
-							const isSettlementBidSelectable = inSessionSettlementResult === undefined && !isSettleSelectedBidsInProgress
-							const statusLabel = (() => {
-								if (inSessionSettlementResult === 'claimed') return 'Claimed'
-								if (inSessionSettlementResult === 'refunded') return 'Refunded'
-								return disposition.label
-							})()
-							const statusTone = (() => {
-								if (inSessionSettlementResult === 'claimed') return 'is-success'
-								if (inSessionSettlementResult === 'refunded') return 'is-default'
-								return getTruthAuctionDispositionClassName(disposition.tone)
-							})()
-							return (
-								<div className={`truth-auction-bid-row is-wallet ${showSettlementActionColumn ? '' : 'is-no-actions'}`} key={`viewer:${bid.tick.toString()}:${bid.bidIndex.toString()}`}>
-									{showSettlementActionColumn ? (
-										<div className='truth-auction-bid-row-actions'>
-											<input
-												disabled={!isSettlementBidActions || !isSettlementBidSelectable}
-												type='checkbox'
-												checked={isSettlementBidActions ? isSettlementBidChecked : false}
-												title={isSettlementBidActions ? 'Select bid for settlement' : 'This bid is not yet settlement-eligible'}
-												aria-label={isSettlementBidActions ? 'Select bid for settlement' : 'Bid is not settlement-eligible'}
-												onChange={event =>
-													setSelectedSettlementBidKeys(currentKeys => {
-														const key = settlementBidRow
-														if (event.currentTarget.checked) {
-															if (currentKeys.includes(key)) return currentKeys
-															return [...currentKeys, key]
-														}
-														return currentKeys.filter(currentKey => currentKey !== key)
-													})
-												}
-											/>
-										</div>
-									) : undefined}
-									<span className='truth-auction-bid-row-label'>{renderTruthAuctionPriceValue(getTruthAuctionPriceAtTick(bid.tick))}</span>
-									<span>
-										<CurrencyValue value={bid.ethAmount} suffix='ETH' />
-									</span>
-									<span className='truth-auction-bid-row-status'>
-										<span className={`truth-auction-status-pill ${statusTone}`}>{statusLabel}</span>
-									</span>
-								</div>
-							)
-						})}
-					</div>
-				)}
-				{accountState.address !== undefined && hasMoreViewerBids ? <PaginationControls hasNextPage={hasMoreViewerBids} onLoadMore={() => setLoadedViewerBidPageCount(currentPageCount => currentPageCount + 1)} loadMoreLabel='Load More Of My Bids' /> : undefined}
-			</SectionBlock>
+			<ViewerTruthAuctionBidsSection
+				accountAddress={accountState.address}
+				hasMoreViewerBids={hasMoreViewerBids}
+				loadingTruthAuctionBook={loadingTruthAuctionBook}
+				onLoadNextViewerBidPage={loadNextViewerBidPage}
+				onSettlementBidSelectionChange={onSettlementBidSelectionChange}
+				renderPriceValue={renderTruthAuctionPriceValue}
+				rows={viewerBidRows}
+				showSettlementActionColumn={showViewerSettlementActionColumn}
+			/>
 		)
 	})()
 	const truthAuctionSettlementSection = (() => {
@@ -2078,75 +1337,29 @@ export function ForkAuctionSection({
 	const importedForkSettlementSection = (() => {
 		if (!hasImportedForkSettlementDeposits) return undefined
 		return (
-			<SectionBlock density='compact' title='Settle Fork-Carried Escalation Deposits'>
-				<p className='detail'>Imported from the parent universe. Settle these positions in this child pool after finalization.</p>
-				{importedForkSettlementResolved ? undefined : <p className='detail'>Fork-carried escalation deposits can be settled after this child pool finalizes.</p>}
-				{importedForkSettlementSides.map(side => {
-					const selectedDepositIndexes = selectedImportedForkDepositIndexesByOutcome[side.key]
-					let settlementGuardMessage: string | undefined
-					if (!importedForkSettlementResolved) {
-						settlementGuardMessage = 'Fork-carried escalation deposits can be settled after this child pool finalizes.'
-					} else if (selectedDepositIndexes.length === 0) {
-						settlementGuardMessage = `Select at least one ${side.label.toLowerCase()} fork-carried deposit to settle.`
-					}
-					return (
-						<SectionBlock density='compact' headingLevel={4} key={side.key} title={side.label} variant='embedded'>
-							<div className='field'>
-								<span>Imported from parent universe</span>
-								<div className='escalation-selection-list'>
-									{side.importedUserDeposits.map((deposit: ImportedEscalationDeposit) => {
-										const selected = selectedDepositIndexes.includes(deposit.parentDepositIndex)
-										const claimAmount = getImportedEscalationDepositClaimAmount(activeReportingDetails, side.key, deposit)
-										return (
-											<label className='escalation-selection-item' key={deposit.parentDepositIndex.toString()}>
-												<input
-													checked={selected}
-													disabled={forkAuctionActiveAction === 'settleForkedEscalation'}
-													onChange={event =>
-														setSelectedImportedForkDepositIndexesByOutcome(currentSelections => ({
-															...currentSelections,
-															[side.key]: event.currentTarget.checked ? [...currentSelections[side.key], deposit.parentDepositIndex] : currentSelections[side.key].filter(index => index !== deposit.parentDepositIndex),
-														}))
-													}
-													type='checkbox'
-												/>
-												<div className='escalation-selection-item-copy'>
-													<strong>Parent deposit #{deposit.parentDepositIndex.toString()}</strong>
-													<span>
-														Initially deposited: <CurrencyValue value={deposit.amount} suffix='REP' />
-													</span>
-													<span>
-														{claimAmount === undefined ? (
-															'Worth now: Pending final settlement'
-														) : (
-															<>
-																Worth now: <CurrencyValue value={claimAmount} suffix='REP' />
-															</>
-														)}
-													</span>
-													<span>
-														Imported ordering start: <CurrencyValue value={deposit.cumulativeAmount} suffix='REP' />
-													</span>
-												</div>
-											</label>
-										)
-									})}
-								</div>
-							</div>
-							<div className='actions'>
-								{renderStageActionButton({
-									action: 'settleForkedEscalation',
-									availability: createActionAvailability(settlementGuardMessage),
-									idleLabel: `Settle Selected ${side.label} Fork-Carried Deposits`,
-									onClick: () => onWithdrawForkedEscalationSubmit(side.key),
-									pendingLabel: 'Settling fork-carried deposits...',
-									tone: 'secondary',
-								})}
-							</div>
-						</SectionBlock>
-					)
-				})}
-			</SectionBlock>
+			<ImportedForkSettlementSection
+				activeReportingDetails={activeReportingDetails}
+				disabled={forkAuctionActiveAction === 'settleForkedEscalation'}
+				onDepositSelectionChange={(outcome, depositIndex, checked) => {
+					setSelectedImportedForkDepositIndexesByOutcome(currentSelections => ({
+						...currentSelections,
+						[outcome]: checked ? [...currentSelections[outcome], depositIndex] : currentSelections[outcome].filter(index => index !== depositIndex),
+					}))
+				}}
+				renderSettlementAction={({ guardMessage, outcome, sideLabel }) =>
+					renderStageActionButton({
+						action: 'settleForkedEscalation',
+						availability: createActionAvailability(guardMessage),
+						idleLabel: `Settle Selected ${sideLabel} Fork-Carried Deposits`,
+						onClick: () => onWithdrawForkedEscalationSubmit(outcome),
+						pendingLabel: 'Settling fork-carried deposits...',
+						tone: 'secondary',
+					})
+				}
+				resolved={importedForkSettlementResolved}
+				selectedDepositIndexesByOutcome={selectedImportedForkDepositIndexesByOutcome}
+				sides={importedForkSettlementSides}
+			/>
 		)
 	})()
 	const handleForkWorkflowStageKeyDown = (stage: ForkWorkflowSelectionStage, event: KeyboardEvent) => {

--- a/ui/ts/components/ImportedForkSettlementSection.tsx
+++ b/ui/ts/components/ImportedForkSettlementSection.tsx
@@ -1,0 +1,83 @@
+import type { ComponentChildren } from 'preact'
+import { CurrencyValue } from './CurrencyValue.js'
+import { SectionBlock } from './SectionBlock.js'
+import { getImportedEscalationDepositClaimAmount } from '../lib/reportingDomain.js'
+import type { ActiveReportingDetails, EscalationSide, ReportingOutcomeKey } from '../types/contracts.js'
+
+type ImportedForkSettlementActionRenderProps = {
+	guardMessage: string | undefined
+	outcome: ReportingOutcomeKey
+	sideLabel: string
+}
+
+type ImportedForkSettlementSectionProps = {
+	activeReportingDetails: ActiveReportingDetails | undefined
+	disabled: boolean
+	onDepositSelectionChange: (outcome: ReportingOutcomeKey, depositIndex: bigint, checked: boolean) => void
+	renderSettlementAction: (props: ImportedForkSettlementActionRenderProps) => ComponentChildren
+	resolved: boolean
+	selectedDepositIndexesByOutcome: Record<ReportingOutcomeKey, bigint[]>
+	sides: Pick<EscalationSide, 'importedUserDeposits' | 'key' | 'label'>[]
+}
+
+export function ImportedForkSettlementSection({ activeReportingDetails, disabled, onDepositSelectionChange, renderSettlementAction, resolved, selectedDepositIndexesByOutcome, sides }: ImportedForkSettlementSectionProps) {
+	if (sides.length === 0) return undefined
+
+	return (
+		<SectionBlock density='compact' title='Settle Fork-Carried Escalation Deposits'>
+			<p className='detail'>Imported from the parent universe. Settle these positions in this child pool after finalization.</p>
+			{resolved ? undefined : <p className='detail'>Fork-carried escalation deposits can be settled after this child pool finalizes.</p>}
+			{sides.map(side => {
+				const selectedDepositIndexes = selectedDepositIndexesByOutcome[side.key]
+				const settlementGuardMessage = (() => {
+					if (!resolved) return 'Fork-carried escalation deposits can be settled after this child pool finalizes.'
+					if (selectedDepositIndexes.length === 0) return `Select at least one ${side.label.toLowerCase()} fork-carried deposit to settle.`
+					return undefined
+				})()
+				return (
+					<SectionBlock density='compact' headingLevel={4} key={side.key} title={side.label} variant='embedded'>
+						<div className='field'>
+							<span>Imported from parent universe</span>
+							<div className='escalation-selection-list'>
+								{side.importedUserDeposits.map(deposit => {
+									const selected = selectedDepositIndexes.includes(deposit.parentDepositIndex)
+									const claimAmount = getImportedEscalationDepositClaimAmount(activeReportingDetails, side.key, deposit)
+									return (
+										<label className='escalation-selection-item' key={deposit.parentDepositIndex.toString()}>
+											<input checked={selected} disabled={disabled} onChange={event => onDepositSelectionChange(side.key, deposit.parentDepositIndex, event.currentTarget.checked)} type='checkbox' />
+											<div className='escalation-selection-item-copy'>
+												<strong>Parent deposit #{deposit.parentDepositIndex.toString()}</strong>
+												<span>
+													Initially deposited: <CurrencyValue value={deposit.amount} suffix='REP' />
+												</span>
+												<span>
+													{claimAmount === undefined ? (
+														'Worth now: Pending final settlement'
+													) : (
+														<>
+															Worth now: <CurrencyValue value={claimAmount} suffix='REP' />
+														</>
+													)}
+												</span>
+												<span>
+													Imported ordering start: <CurrencyValue value={deposit.cumulativeAmount} suffix='REP' />
+												</span>
+											</div>
+										</label>
+									)
+								})}
+							</div>
+						</div>
+						<div className='actions'>
+							{renderSettlementAction({
+								guardMessage: settlementGuardMessage,
+								outcome: side.key,
+								sideLabel: side.label,
+							})}
+						</div>
+					</SectionBlock>
+				)
+			})}
+		</SectionBlock>
+	)
+}

--- a/ui/ts/components/TruthAuctionBidsSection.tsx
+++ b/ui/ts/components/TruthAuctionBidsSection.tsx
@@ -1,0 +1,126 @@
+import type { ComponentChildren } from 'preact'
+import type { Address } from 'viem'
+import { AddressValue } from './AddressValue.js'
+import { CurrencyValue } from './CurrencyValue.js'
+import { MetricField } from './MetricField.js'
+import { PaginationControls } from './PaginationControls.js'
+import { SectionBlock } from './SectionBlock.js'
+import type { TruthAuctionBidRowViewModel, ViewerTruthAuctionBidRowViewModel } from '../lib/truthAuctionBidViewModels.js'
+
+type TruthAuctionBidsSectionProps = {
+	aggregatedAuctionBidCountForLoadedTicks: bigint
+	hasMoreAggregatedAuctionBids: boolean
+	loadedTickCount: number
+	loadingAggregatedAuctionBids: boolean
+	onLoadNextAuctionBidPage: () => void
+	renderPriceValue: (value: bigint | undefined) => ComponentChildren
+	rows: TruthAuctionBidRowViewModel[]
+}
+
+type ViewerTruthAuctionBidsSectionProps = {
+	accountAddress: Address | undefined
+	hasMoreViewerBids: boolean
+	loadingTruthAuctionBook: boolean
+	onLoadNextViewerBidPage: () => void
+	onSettlementBidSelectionChange: (bidKey: string, checked: boolean) => void
+	renderPriceValue: (value: bigint | undefined) => ComponentChildren
+	rows: ViewerTruthAuctionBidRowViewModel[]
+	showSettlementActionColumn: boolean
+}
+
+function AuctionBidsHeader() {
+	return (
+		<div className='truth-auction-bid-row is-wide is-no-actions is-header'>
+			<span className='truth-auction-bid-row-label'>Price (ETH / REP)</span>
+			<span>Bidder</span>
+			<span>Bid Amount (ETH)</span>
+			<span>Loaded Depth (ETH)</span>
+			<span className='truth-auction-bid-row-status'>Status</span>
+		</div>
+	)
+}
+
+function ViewerBidsHeader({ showActions }: { showActions: boolean }) {
+	return (
+		<div className={`truth-auction-bid-row is-wallet ${showActions ? '' : 'is-no-actions'} is-header`}>
+			{showActions ? <span>Selected</span> : undefined}
+			<span className='truth-auction-bid-row-label'>Price (ETH / REP)</span>
+			<span>Bid Amount (ETH)</span>
+			<span className='truth-auction-bid-row-status'>Status</span>
+		</div>
+	)
+}
+
+export function TruthAuctionBidsSection({ aggregatedAuctionBidCountForLoadedTicks, hasMoreAggregatedAuctionBids, loadedTickCount, loadingAggregatedAuctionBids, onLoadNextAuctionBidPage, renderPriceValue, rows }: TruthAuctionBidsSectionProps) {
+	return (
+		<SectionBlock title='Truth Auction Bids'>
+			<div className='truth-auction-bid-coverage-summary'>
+				<MetricField label='Loaded Levels'>{loadedTickCount.toString()}</MetricField>
+				<MetricField label='Loaded Bids'>{rows.length.toString()}</MetricField>
+				<MetricField label='Coverage'>{`Showing ${rows.length.toString()} of ${aggregatedAuctionBidCountForLoadedTicks.toString()} bids across loaded levels`}</MetricField>
+			</div>
+			{loadingAggregatedAuctionBids ? <p className='detail'>Loading auction bids…</p> : undefined}
+			{!loadingAggregatedAuctionBids && loadedTickCount === 0 ? <p className='detail'>No active prices are currently visible for this auction.</p> : undefined}
+			{!loadingAggregatedAuctionBids && loadedTickCount > 0 && rows.length === 0 ? <p className='detail'>No bids are currently indexed for the loaded prices.</p> : undefined}
+			{rows.length === 0 ? undefined : (
+				<div className='truth-auction-bid-table'>
+					<AuctionBidsHeader />
+					{rows.map(row => (
+						<div className='truth-auction-bid-row is-wide is-no-actions' key={row.key}>
+							<span className='truth-auction-bid-row-label'>{renderPriceValue(row.price)}</span>
+							<div className='truth-auction-bid-row-address'>
+								<AddressValue address={row.bidder} />
+							</div>
+							<span>
+								<CurrencyValue value={row.ethAmount} suffix='ETH' />
+							</span>
+							<span>
+								<CurrencyValue value={row.cumulativeEth} suffix='ETH' />
+							</span>
+							<span className='truth-auction-bid-row-status'>
+								<span className={`truth-auction-status-pill ${row.statusToneClassName}`}>{row.statusLabel}</span>
+							</span>
+						</div>
+					))}
+				</div>
+			)}
+			{hasMoreAggregatedAuctionBids ? <PaginationControls hasNextPage={hasMoreAggregatedAuctionBids} onLoadMore={onLoadNextAuctionBidPage} loadMoreLabel='Load More Truth Auction Bids' /> : undefined}
+		</SectionBlock>
+	)
+}
+
+export function ViewerTruthAuctionBidsSection({ accountAddress, hasMoreViewerBids, loadingTruthAuctionBook, onLoadNextViewerBidPage, onSettlementBidSelectionChange, renderPriceValue, rows, showSettlementActionColumn }: ViewerTruthAuctionBidsSectionProps) {
+	return (
+		<SectionBlock title='My Bids'>
+			{accountAddress === undefined ? <p className='detail'>Connect a wallet to inspect your submitted truth auction bids.</p> : undefined}
+			{accountAddress !== undefined && loadingTruthAuctionBook ? <p className='detail'>Loading your bids…</p> : undefined}
+			{accountAddress !== undefined && !loadingTruthAuctionBook && rows.length === 0 ? <p className='detail'>No bids from this wallet are indexed for the current auction.</p> : undefined}
+			{rows.length === 0 ? undefined : (
+				<div className='truth-auction-bid-table'>
+					<ViewerBidsHeader showActions={showSettlementActionColumn} />
+					{rows.map(row => (
+						<div className={`truth-auction-bid-row is-wallet ${showSettlementActionColumn ? '' : 'is-no-actions'}`} key={row.key}>
+							{showSettlementActionColumn ? (
+								<div className='truth-auction-bid-row-actions'>
+									{(() => {
+										const settlementControl = row.settlementControl
+										if (settlementControl === undefined) return undefined
+										return <input disabled={settlementControl.disabled} type='checkbox' checked={settlementControl.checked} title={settlementControl.title} aria-label={settlementControl.ariaLabel} onChange={event => onSettlementBidSelectionChange(settlementControl.bidKey, event.currentTarget.checked)} />
+									})()}
+								</div>
+							) : undefined}
+							<span className='truth-auction-bid-row-label'>{renderPriceValue(row.price)}</span>
+							<span>
+								<CurrencyValue value={row.ethAmount} suffix='ETH' />
+							</span>
+							<span className='truth-auction-bid-row-status'>
+								<span className={`truth-auction-status-pill ${row.statusToneClassName}`}>{row.statusLabel}</span>
+							</span>
+						</div>
+					))}
+				</div>
+			)}
+			{accountAddress !== undefined && hasMoreViewerBids ? <PaginationControls hasNextPage={hasMoreViewerBids} onLoadMore={onLoadNextViewerBidPage} loadMoreLabel='Load More Of My Bids' /> : undefined}
+		</SectionBlock>
+	)
+}

--- a/ui/ts/components/TruthAuctionDepthChart.tsx
+++ b/ui/ts/components/TruthAuctionDepthChart.tsx
@@ -2,21 +2,7 @@ import { useRef } from 'preact/hooks'
 import { CurrencyValue } from './CurrencyValue.js'
 import { formatCurrencyInputBalance, formatRoundedCurrencyBalance } from '../lib/formatters.js'
 import { getVisualRatio } from '../lib/visualMetrics.js'
-
-type TruthAuctionDisposition = {
-	label: string
-	tone: 'default' | 'danger' | 'success' | 'warning'
-}
-
-export type TruthAuctionDepthPoint = {
-	tick: bigint
-	price: bigint
-	currentTotalEth: bigint
-	cumulativeEth: bigint
-	disposition: TruthAuctionDisposition
-	isSelected: boolean
-	isPreviewTick: boolean
-}
+import type { TruthAuctionDepthPoint } from '../lib/truthAuctionBook.js'
 
 type TruthAuctionDepthChartProps = {
 	clearingTick?: bigint

--- a/ui/ts/components/TruthAuctionMarketViewSection.tsx
+++ b/ui/ts/components/TruthAuctionMarketViewSection.tsx
@@ -1,0 +1,91 @@
+import type { ComponentChildren } from 'preact'
+import { CurrencyValue } from './CurrencyValue.js'
+import { PaginationControls } from './PaginationControls.js'
+import { SectionBlock } from './SectionBlock.js'
+import { TruthAuctionDepthChart } from './TruthAuctionDepthChart.js'
+import { getTruthAuctionDispositionClassName, type TruthAuctionDepthPoint } from '../lib/truthAuctionBook.js'
+import { getVisualRatio } from '../lib/visualMetrics.js'
+
+type TruthAuctionMarketViewSectionProps = {
+	clearingTick: bigint | undefined
+	hasMoreTickSummaries: boolean
+	loadingTruthAuctionBook: boolean
+	maxTickEth: bigint
+	onLoadNextTickPage: () => void
+	onSelectTick: (tick: bigint) => void
+	renderPriceValue: (value: bigint | undefined) => ComponentChildren
+	showDepthClearingTick: boolean
+	truthAuctionBookError: string | undefined
+	truthAuctionDepthPoints: TruthAuctionDepthPoint[]
+}
+
+function clampPercentage(value: bigint, maxValue: bigint) {
+	return (getVisualRatio({ value, maxValue }) ?? 0) * 100
+}
+
+export function TruthAuctionMarketViewSection({ clearingTick, hasMoreTickSummaries, loadingTruthAuctionBook, maxTickEth, onLoadNextTickPage, onSelectTick, renderPriceValue, showDepthClearingTick, truthAuctionBookError, truthAuctionDepthPoints }: TruthAuctionMarketViewSectionProps) {
+	return (
+		<SectionBlock title='Market View'>
+			{truthAuctionBookError === undefined ? undefined : <p className='detail truth-auction-book-error'>{truthAuctionBookError}</p>}
+			<div className='truth-auction-market-board'>
+				<div className='truth-auction-market-section truth-auction-depth-panel'>
+					<div className='truth-auction-depth-header'>
+						<div>
+							<h4>Visible Depth</h4>
+						</div>
+					</div>
+					{loadingTruthAuctionBook ? <p className='detail'>Loading order book…</p> : undefined}
+					{!loadingTruthAuctionBook && truthAuctionDepthPoints.length === 0 ? <p className='detail'>No live price levels are currently active for this auction.</p> : undefined}
+					{truthAuctionDepthPoints.length === 0 ? undefined : <TruthAuctionDepthChart onSelectTick={onSelectTick} points={truthAuctionDepthPoints} {...(showDepthClearingTick && clearingTick !== undefined ? { clearingTick } : {})} />}
+				</div>
+				<div className='truth-auction-market-detail-grid'>
+					<div className='truth-auction-market-section'>
+						<div className='truth-auction-panel-header'>
+							<div>
+								<h4>Price Ladder</h4>
+							</div>
+						</div>
+						<div className='truth-auction-ladder'>
+							{loadingTruthAuctionBook ? <p className='detail'>Loading price levels…</p> : undefined}
+							{!loadingTruthAuctionBook && truthAuctionDepthPoints.length === 0 ? <p className='detail'>No active levels are visible yet.</p> : undefined}
+							{truthAuctionDepthPoints.map(point => (
+								<button
+									aria-pressed={point.isSelected}
+									className={`truth-auction-price-row truth-auction-ladder-row ${getTruthAuctionDispositionClassName(point.disposition.tone)}${point.isSelected ? ' is-selected' : ''}${point.isPreviewTick ? ' is-preview' : ''}${clearingTick === point.tick ? ' is-clearing' : ''}`}
+									key={point.tick.toString()}
+									onClick={() => onSelectTick(point.tick)}
+									type='button'
+								>
+									<div className='truth-auction-price-row-bar' style={{ width: `${clampPercentage(point.currentTotalEth, maxTickEth)}%` }} />
+									<div className='truth-auction-price-row-copy'>
+										<div className='truth-auction-price-row-main'>
+											<div>
+												<strong>{renderPriceValue(point.price)}</strong>
+												<span className='truth-auction-price-row-price'>Price level</span>
+											</div>
+											<div className='truth-auction-price-row-badges'>
+												{clearingTick === point.tick ? <span className='truth-auction-ladder-helper'>Clearing level</span> : undefined}
+												{point.isPreviewTick ? <span className='truth-auction-ladder-helper'>Current form price</span> : undefined}
+												<span className={`truth-auction-status-pill ${getTruthAuctionDispositionClassName(point.disposition.tone)}`}>{point.disposition.label}</span>
+											</div>
+										</div>
+										<div className='truth-auction-price-row-meta'>
+											<span>
+												Current size <CurrencyValue value={point.currentTotalEth} suffix='ETH' />
+											</span>
+											<span className='truth-auction-ladder-row-cumulative'>
+												Loaded depth <CurrencyValue value={point.cumulativeEth} suffix='ETH' />
+											</span>
+											<span>{point.submissionCount.toString()} submissions</span>
+										</div>
+									</div>
+								</button>
+							))}
+							{hasMoreTickSummaries ? <PaginationControls hasNextPage={hasMoreTickSummaries} onLoadMore={onLoadNextTickPage} loadMoreLabel='Load More Price Levels' /> : undefined}
+						</div>
+					</div>
+				</div>
+			</div>
+		</SectionBlock>
+	)
+}

--- a/ui/ts/components/TruthAuctionSummaryCard.tsx
+++ b/ui/ts/components/TruthAuctionSummaryCard.tsx
@@ -1,0 +1,59 @@
+import type { ComponentChildren } from 'preact'
+import { CurrencyValue } from './CurrencyValue.js'
+import { MetricField } from './MetricField.js'
+import { SectionBlock } from './SectionBlock.js'
+
+type TruthAuctionSummaryCardProps = {
+	badge: ComponentChildren
+	clearingPriceDisplay: ComponentChildren
+	displayedEthRaised: bigint
+	displayedRepSold: bigint
+	endsDisplay: ComponentChildren
+	ethRaiseCap: bigint
+	ethRaisedProgress: number
+	maxRepBeingSold: bigint
+	minBidSize: bigint
+	repSoldProgress: number
+	startedDisplay: ComponentChildren
+	winningThresholdPriceDisplay?: ComponentChildren | undefined
+}
+
+export function TruthAuctionSummaryCard({ badge, clearingPriceDisplay, displayedEthRaised, displayedRepSold, endsDisplay, ethRaiseCap, ethRaisedProgress, maxRepBeingSold, minBidSize, repSoldProgress, startedDisplay, winningThresholdPriceDisplay }: TruthAuctionSummaryCardProps) {
+	return (
+		<SectionBlock badge={badge} className='fork-workflow-summary-card truth-auction-summary-card' title='Truth Auction'>
+			<div className='fork-workflow-summary'>
+				<div className='fork-workflow-summary-primary truth-auction-summary-primary'>
+					<div className='fork-workflow-summary-stat-group truth-auction-progress-group'>
+						<div className='fork-workflow-summary-stat-copy truth-auction-progress-copy'>
+							<span>ETH Raised</span>
+							<strong>
+								<CurrencyValue value={displayedEthRaised} suffix='ETH' /> / <CurrencyValue value={ethRaiseCap} suffix='ETH' />
+							</strong>
+						</div>
+						<div className='truth-auction-progress-track'>
+							<div className='truth-auction-progress-fill is-eth' style={{ width: `${ethRaisedProgress}%` }} />
+						</div>
+					</div>
+					<div className='fork-workflow-summary-stat-group truth-auction-progress-group'>
+						<div className='fork-workflow-summary-stat-copy truth-auction-progress-copy'>
+							<span>REP Sold</span>
+							<strong>
+								<CurrencyValue value={displayedRepSold} suffix='REP' /> / <CurrencyValue value={maxRepBeingSold} suffix='REP' />
+							</strong>
+						</div>
+						<div className='truth-auction-progress-track'>
+							<div className='truth-auction-progress-fill is-rep' style={{ width: `${repSoldProgress}%` }} />
+						</div>
+					</div>
+				</div>
+				<div className='fork-workflow-summary-metrics'>
+					<MetricField label='Starts'>{startedDisplay}</MetricField>
+					<MetricField label='Clearing Price'>{clearingPriceDisplay}</MetricField>
+					<MetricField label='Min Bid'>{<CurrencyValue value={minBidSize} suffix='ETH' />}</MetricField>
+					<MetricField label='Ends'>{endsDisplay}</MetricField>
+					{winningThresholdPriceDisplay === undefined ? undefined : <MetricField label='Winning Threshold'>{winningThresholdPriceDisplay}</MetricField>}
+				</div>
+			</div>
+		</SectionBlock>
+	)
+}

--- a/ui/ts/hooks/useForkAuctionOperations.ts
+++ b/ui/ts/hooks/useForkAuctionOperations.ts
@@ -22,7 +22,7 @@ import {
 } from '../contracts.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
 import { getErrorMessage } from '../lib/errors.js'
-import { getTruthAuctionBidGuardMessage, getTruthAuctionTickAtPrice } from '../lib/forkAuction.js'
+import { getTruthAuctionBidGuardMessage, getTruthAuctionTickAtPrice } from '../lib/truthAuctionBook.js'
 import { getReportingOutcomeKey, parseAddressInput, parseBigIntListInput, parseReportingOutcomeInput, parseReportingOutcomeListInput, resolveOptionalAddressInput } from '../lib/inputs.js'
 import { sameAddress } from '../lib/address.js'
 import { createErrorActionFeedback, createPendingActionFeedback, createSuccessActionFeedback, createWarningActionFeedback } from '../lib/actionFeedback.js'

--- a/ui/ts/hooks/useTruthAuctionBookData.ts
+++ b/ui/ts/hooks/useTruthAuctionBookData.ts
@@ -1,0 +1,227 @@
+import { useEffect, useState } from 'preact/hooks'
+import { type Address, zeroAddress } from 'viem'
+import { loadTruthAuctionActiveTickPage, loadTruthAuctionBidderBidPage, loadTruthAuctionTickBidPage } from '../contracts.js'
+import { createConnectedReadClient } from '../lib/clients.js'
+import { getErrorMessage } from '../lib/errors.js'
+import { sortTruthAuctionBidsByPriority, sortTruthAuctionTickSummariesDescending } from '../lib/truthAuctionBook.js'
+import type { ForkWorkflowSelectionStage } from '../lib/securityPoolWorkflow.js'
+import type { ReadClient, TruthAuctionBidView, TruthAuctionTickSummary } from '../types/contracts.js'
+import { useTruthAuctionPaginationState } from './useTruthAuctionPaginationState.js'
+
+const TRUTH_AUCTION_TICK_PAGE_SIZE = 25
+const TRUTH_AUCTION_BID_PAGE_SIZE = 25
+
+type TruthAuctionBookData = {
+	tickSummaries: TruthAuctionTickSummary[]
+	tickCount: bigint
+	viewerBids: TruthAuctionBidView[]
+	viewerBidCount: bigint
+}
+
+type UseTruthAuctionBookDataParams = {
+	accountAddress: Address | undefined
+	enteredBidTick: bigint | undefined
+	forkAuctionResultHash: string | undefined
+	selectedStage: ForkWorkflowSelectionStage
+	shouldShowTruthAuctionVisualization: boolean
+	truthAuctionAddress: Address | undefined
+	truthAuctionClearingTick: bigint | undefined
+	truthAuctionReadClient: Pick<ReadClient, 'readContract'> | ReadClient | undefined
+}
+
+async function loadTruthAuctionActiveTickPages(client: Pick<ReadClient, 'readContract'>, truthAuctionAddress: Address, pageCount: number) {
+	const tickSummaries: TruthAuctionTickSummary[] = []
+	let tickCount = 0n
+	for (let pageIndex = 0; pageIndex < pageCount; pageIndex += 1) {
+		const page = await loadTruthAuctionActiveTickPage(client, truthAuctionAddress, pageIndex, TRUTH_AUCTION_TICK_PAGE_SIZE)
+		tickCount = page.tickCount
+		tickSummaries.push(...page.ticks)
+		if (BigInt(tickSummaries.length) >= tickCount || page.ticks.length === 0) break
+	}
+	return {
+		tickCount,
+		tickSummaries,
+	}
+}
+
+async function loadTruthAuctionTickBidPages(client: Pick<ReadClient, 'readContract'>, truthAuctionAddress: Address, tick: bigint, pageCount: number) {
+	const bids: TruthAuctionBidView[] = []
+	let bidCount = 0n
+	for (let pageIndex = 0; pageIndex < pageCount; pageIndex += 1) {
+		const page = await loadTruthAuctionTickBidPage(client, truthAuctionAddress, tick, pageIndex, TRUTH_AUCTION_BID_PAGE_SIZE)
+		bidCount = page.bidCount
+		bids.push(...page.bids)
+		if (BigInt(bids.length) >= bidCount || page.bids.length === 0) break
+	}
+	return {
+		bidCount,
+		bids,
+	}
+}
+
+async function loadTruthAuctionBidderBidPages(client: Pick<ReadClient, 'readContract'>, truthAuctionAddress: Address, bidder: Address, pageCount: number) {
+	const bids: TruthAuctionBidView[] = []
+	let bidCount = 0n
+	for (let pageIndex = 0; pageIndex < pageCount; pageIndex += 1) {
+		const page = await loadTruthAuctionBidderBidPage(client, truthAuctionAddress, bidder, pageIndex, TRUTH_AUCTION_BID_PAGE_SIZE)
+		bidCount = page.bidCount
+		bids.push(...page.bids)
+		if (BigInt(bids.length) >= bidCount || page.bids.length === 0) break
+	}
+	return {
+		bidCount,
+		bids,
+	}
+}
+
+async function loadAggregatedTruthAuctionBidPages(client: Pick<ReadClient, 'readContract'>, truthAuctionAddress: Address, tickSummaries: TruthAuctionTickSummary[], pageCount: number) {
+	const uniqueTickSummaries = sortTruthAuctionTickSummariesDescending(Array.from(new Map(tickSummaries.map(tickSummary => [tickSummary.tick.toString(), tickSummary])).values()))
+	const bidPages = await Promise.all(uniqueTickSummaries.map(async tickSummary => ({ bidData: await loadTruthAuctionTickBidPages(client, truthAuctionAddress, tickSummary.tick, pageCount), tickSummary })))
+	const dedupedBids = new Map<string, TruthAuctionBidView>()
+	for (const { bidData } of bidPages) {
+		for (const bid of bidData.bids) {
+			dedupedBids.set(`${bid.tick.toString()}:${bid.bidIndex.toString()}`, bid)
+		}
+	}
+	return {
+		bids: sortTruthAuctionBidsByPriority(Array.from(dedupedBids.values())),
+		bidCountForLoadedTicks: uniqueTickSummaries.reduce((sum, tickSummary) => sum + tickSummary.submissionCount, 0n),
+	}
+}
+
+export function useTruthAuctionBookData({ accountAddress, enteredBidTick, forkAuctionResultHash, selectedStage, shouldShowTruthAuctionVisualization, truthAuctionAddress, truthAuctionClearingTick, truthAuctionReadClient }: UseTruthAuctionBookDataParams) {
+	const [truthAuctionBookData, setTruthAuctionBookData] = useState<TruthAuctionBookData>({
+		tickSummaries: [],
+		tickCount: 0n,
+		viewerBids: [],
+		viewerBidCount: 0n,
+	})
+	const [selectedBookTick, setSelectedBookTick] = useState<bigint | undefined>(undefined)
+	const { loadedTickPageCount, loadedViewerBidPageCount, loadedAuctionBidPageCount, loadNextTickPage, loadNextViewerBidPage, loadNextAuctionBidPage } = useTruthAuctionPaginationState({
+		accountAddress,
+		truthAuctionAddress,
+	})
+	const [aggregatedAuctionBids, setAggregatedAuctionBids] = useState<TruthAuctionBidView[]>([])
+	const [aggregatedAuctionBidCountForLoadedTicks, setAggregatedAuctionBidCountForLoadedTicks] = useState(0n)
+	const [loadingTruthAuctionBook, setLoadingTruthAuctionBook] = useState(false)
+	const [loadingAggregatedAuctionBids, setLoadingAggregatedAuctionBids] = useState(false)
+	const [truthAuctionBookError, setTruthAuctionBookError] = useState<string | undefined>(undefined)
+	const isTruthAuctionBookVisible = shouldShowTruthAuctionVisualization && truthAuctionAddress !== undefined && truthAuctionAddress !== zeroAddress && (selectedStage === 'auction' || selectedStage === 'settlement')
+	const hasMoreTickSummaries = BigInt(truthAuctionBookData.tickSummaries.length) < truthAuctionBookData.tickCount
+	const hasMoreViewerBids = BigInt(truthAuctionBookData.viewerBids.length) < truthAuctionBookData.viewerBidCount
+	const hasMoreAggregatedAuctionBids = BigInt(aggregatedAuctionBids.length) < aggregatedAuctionBidCountForLoadedTicks
+	const selectTruthAuctionTick = (tick: bigint) => {
+		setSelectedBookTick(currentTick => (currentTick === tick ? currentTick : tick))
+	}
+
+	useEffect(() => {
+		setSelectedBookTick(undefined)
+	}, [accountAddress, truthAuctionAddress])
+
+	useEffect(() => {
+		if (!isTruthAuctionBookVisible || truthAuctionAddress === undefined || truthAuctionAddress === zeroAddress) {
+			setTruthAuctionBookData({
+				tickSummaries: [],
+				tickCount: 0n,
+				viewerBids: [],
+				viewerBidCount: 0n,
+			})
+			setSelectedBookTick(undefined)
+			setLoadingTruthAuctionBook(false)
+			setAggregatedAuctionBids([])
+			setAggregatedAuctionBidCountForLoadedTicks(0n)
+			setLoadingAggregatedAuctionBids(false)
+			setTruthAuctionBookError(undefined)
+			return
+		}
+
+		const client = truthAuctionReadClient ?? createConnectedReadClient()
+		let cancelled = false
+		setLoadingTruthAuctionBook(true)
+		setTruthAuctionBookError(undefined)
+		void Promise.all([loadTruthAuctionActiveTickPages(client, truthAuctionAddress, loadedTickPageCount), accountAddress === undefined ? Promise.resolve({ bidCount: 0n, bids: [] }) : loadTruthAuctionBidderBidPages(client, truthAuctionAddress, accountAddress, loadedViewerBidPageCount)])
+			.then(([tickPageData, viewerBidData]) => {
+				if (cancelled) return
+				const sortedTickSummaries = sortTruthAuctionTickSummariesDescending(tickPageData.tickSummaries)
+				setTruthAuctionBookData({
+					tickSummaries: sortedTickSummaries,
+					tickCount: tickPageData.tickCount,
+					viewerBids: viewerBidData.bids,
+					viewerBidCount: viewerBidData.bidCount,
+				})
+				setSelectedBookTick(currentSelection => {
+					if (currentSelection !== undefined && sortedTickSummaries.some(tickSummary => tickSummary.tick === currentSelection)) return currentSelection
+					if (enteredBidTick !== undefined && sortedTickSummaries.some(tickSummary => tickSummary.tick === enteredBidTick)) return enteredBidTick
+					if (truthAuctionClearingTick !== undefined && sortedTickSummaries.some(tickSummary => tickSummary.tick === truthAuctionClearingTick)) return truthAuctionClearingTick
+					return sortedTickSummaries[0]?.tick
+				})
+			})
+			.catch(error => {
+				if (cancelled) return
+				setTruthAuctionBookData({
+					tickSummaries: [],
+					tickCount: 0n,
+					viewerBids: [],
+					viewerBidCount: 0n,
+				})
+				setSelectedBookTick(undefined)
+				setTruthAuctionBookError(getErrorMessage(error, 'Failed to load truth auction bidbook'))
+			})
+			.finally(() => {
+				if (cancelled) return
+				setLoadingTruthAuctionBook(false)
+			})
+		return () => {
+			cancelled = true
+		}
+	}, [accountAddress, enteredBidTick, forkAuctionResultHash, isTruthAuctionBookVisible, loadedTickPageCount, loadedViewerBidPageCount, truthAuctionAddress, truthAuctionClearingTick, truthAuctionReadClient])
+
+	useEffect(() => {
+		if (!isTruthAuctionBookVisible || truthAuctionAddress === undefined || truthAuctionAddress === zeroAddress) {
+			setAggregatedAuctionBids([])
+			setAggregatedAuctionBidCountForLoadedTicks(0n)
+			setLoadingAggregatedAuctionBids(false)
+			return
+		}
+
+		const client = truthAuctionReadClient ?? createConnectedReadClient()
+		let cancelled = false
+		setLoadingAggregatedAuctionBids(true)
+		void loadAggregatedTruthAuctionBidPages(client, truthAuctionAddress, truthAuctionBookData.tickSummaries, loadedAuctionBidPageCount)
+			.then(({ bids, bidCountForLoadedTicks }) => {
+				if (cancelled) return
+				setAggregatedAuctionBids(bids)
+				setAggregatedAuctionBidCountForLoadedTicks(bidCountForLoadedTicks)
+			})
+			.catch(error => {
+				if (cancelled) return
+				setAggregatedAuctionBids([])
+				setAggregatedAuctionBidCountForLoadedTicks(0n)
+				setTruthAuctionBookError(currentError => currentError ?? getErrorMessage(error, 'Failed to load truth auction bids across the visible price levels'))
+			})
+			.finally(() => {
+				if (cancelled) return
+				setLoadingAggregatedAuctionBids(false)
+			})
+		return () => {
+			cancelled = true
+		}
+	}, [forkAuctionResultHash, isTruthAuctionBookVisible, loadedAuctionBidPageCount, truthAuctionAddress, truthAuctionBookData.tickSummaries, truthAuctionReadClient])
+
+	return {
+		aggregatedAuctionBidCountForLoadedTicks,
+		aggregatedAuctionBids,
+		hasMoreAggregatedAuctionBids,
+		hasMoreTickSummaries,
+		hasMoreViewerBids,
+		loadNextAuctionBidPage,
+		loadNextTickPage,
+		loadNextViewerBidPage,
+		loadingAggregatedAuctionBids,
+		loadingTruthAuctionBook,
+		selectTruthAuctionTick,
+		selectedBookTick,
+		truthAuctionBookData,
+		truthAuctionBookError,
+	}
+}

--- a/ui/ts/hooks/useTruthAuctionPaginationState.ts
+++ b/ui/ts/hooks/useTruthAuctionPaginationState.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'preact/hooks'
+import type { Address } from 'viem'
+
+export function useTruthAuctionPaginationState({ accountAddress, truthAuctionAddress }: { accountAddress: Address | undefined; truthAuctionAddress: Address | undefined }) {
+	const [loadedTickPageCount, setLoadedTickPageCount] = useState(1)
+	const [loadedViewerBidPageCount, setLoadedViewerBidPageCount] = useState(1)
+	const [loadedAuctionBidPageCount, setLoadedAuctionBidPageCount] = useState(1)
+
+	useEffect(() => {
+		setLoadedTickPageCount(1)
+		setLoadedViewerBidPageCount(1)
+		setLoadedAuctionBidPageCount(1)
+	}, [accountAddress, truthAuctionAddress])
+
+	return {
+		loadedTickPageCount,
+		loadedViewerBidPageCount,
+		loadedAuctionBidPageCount,
+		loadNextTickPage: () => setLoadedTickPageCount(currentPageCount => currentPageCount + 1),
+		loadNextViewerBidPage: () => setLoadedViewerBidPageCount(currentPageCount => currentPageCount + 1),
+		loadNextAuctionBidPage: () => setLoadedAuctionBidPageCount(currentPageCount => currentPageCount + 1),
+	}
+}

--- a/ui/ts/hooks/useTruthAuctionSettlementActionState.ts
+++ b/ui/ts/hooks/useTruthAuctionSettlementActionState.ts
@@ -1,0 +1,146 @@
+import { useEffect, useState } from 'preact/hooks'
+import type { Address } from 'viem'
+import { sameAddress } from '../lib/address.js'
+import { createTruthAuctionSettlementActionState, reduceTruthAuctionSettlementActionState, type TruthAuctionSettlementAction } from '../lib/truthAuctionSettlementActionState.js'
+import { getTruthAuctionSettlementBidKey, getTruthAuctionSettlementSelectionState, type TruthAuctionSettlementBidRow } from '../lib/truthAuctionSettlement.js'
+import type { ForkWorkflowSelectionStage } from '../lib/securityPoolWorkflow.js'
+import type { ForkAuctionActionResult } from '../types/contracts.js'
+import type { SettlementSelectedBid } from '../types/components.js'
+
+type SettlementBidKeyUpdater = string[] | ((currentKeys: string[]) => string[])
+
+type UseTruthAuctionSettlementActionStateParams = {
+	accountAddress: Address | undefined
+	forkAuctionError: string | undefined
+	forkAuctionResult: ForkAuctionActionResult | undefined
+	onClaimAuctionProceeds: (securityPoolAddressOverride?: Address, selectedClaimBids?: readonly SettlementSelectedBid[], selectedRefundBids?: readonly SettlementSelectedBid[]) => void
+	onRefundLosingBids: (securityPoolAddressOverride?: Address, selectedBids?: readonly SettlementSelectedBid[]) => void
+	selectedAuctionPoolAddress: Address | undefined
+	selectedStage: ForkWorkflowSelectionStage
+	settlementBidRows: TruthAuctionSettlementBidRow[]
+}
+
+function getSettlementBidsFromKeys(settlementBidRows: TruthAuctionSettlementBidRow[], selectedBidKeys: string[]) {
+	const selectedBidKeySet = new Set(selectedBidKeys)
+	return settlementBidRows.filter(({ bid }) => selectedBidKeySet.has(getTruthAuctionSettlementBidKey(bid))).map(({ bid }) => ({ bidIndex: bid.bidIndex, tick: bid.tick }))
+}
+
+function getSettlementAction(claimKeys: string[], refundKeys: string[]): TruthAuctionSettlementAction | undefined {
+	if (claimKeys.length > 0) return 'claimAuctionProceeds'
+	if (refundKeys.length > 0) return 'refundLosingBids'
+	return undefined
+}
+
+function resolveSettlementBidKeyUpdate(currentKeys: string[], update: SettlementBidKeyUpdater) {
+	if (typeof update === 'function') return update(currentKeys)
+	return update
+}
+
+export function useTruthAuctionSettlementActionState({ accountAddress, forkAuctionError, forkAuctionResult, onClaimAuctionProceeds, onRefundLosingBids, selectedAuctionPoolAddress, selectedStage, settlementBidRows }: UseTruthAuctionSettlementActionStateParams) {
+	const [settlementActionState, setSettlementActionState] = useState(createTruthAuctionSettlementActionState)
+	const settlementSelectionState = getTruthAuctionSettlementSelectionState({
+		selectedBidKeys: settlementActionState.selectedBidKeys,
+		settlementBidRows,
+	})
+	const settlementBidRowKeys = settlementSelectionState.rowKeys
+	const settlementBidRowKeySignature = settlementBidRowKeys.slice().sort().join('\u0000')
+	const isSettleSelectedBidsInProgress = settlementActionState.pendingAction !== undefined
+	const dispatchSettlementActionState = (event: Parameters<typeof reduceTruthAuctionSettlementActionState>[1]) => {
+		setSettlementActionState(currentState => reduceTruthAuctionSettlementActionState(currentState, event))
+	}
+	const setSelectedSettlementBidKeys = (update: SettlementBidKeyUpdater) => {
+		setSettlementActionState(currentState =>
+			reduceTruthAuctionSettlementActionState(currentState, {
+				selectedBidKeys: resolveSettlementBidKeyUpdate(currentState.selectedBidKeys, update),
+				type: 'selectBidKeys',
+			}),
+		)
+	}
+	const submitClaimBidsByKeys = (claimBidKeys: string[]) => {
+		if (selectedAuctionPoolAddress === undefined || isSettleSelectedBidsInProgress) return
+		const claimBids = getSettlementBidsFromKeys(settlementBidRows, claimBidKeys)
+		if (claimBids.length === 0) return
+		dispatchSettlementActionState({
+			action: 'claimAuctionProceeds',
+			claimKeys: claimBidKeys,
+			ignoredResultHash: forkAuctionResult?.hash,
+			refundKeys: [],
+			type: 'submit',
+		})
+		onClaimAuctionProceeds(selectedAuctionPoolAddress, claimBids)
+	}
+	const submitRefundBidsByKeys = (refundBidKeys: string[]) => {
+		if (selectedAuctionPoolAddress === undefined || isSettleSelectedBidsInProgress) return
+		const refundBids = getSettlementBidsFromKeys(settlementBidRows, refundBidKeys)
+		if (refundBids.length === 0) return
+		dispatchSettlementActionState({
+			action: 'refundLosingBids',
+			claimKeys: [],
+			ignoredResultHash: forkAuctionResult?.hash,
+			refundKeys: refundBidKeys,
+			type: 'submit',
+		})
+		onRefundLosingBids(selectedAuctionPoolAddress, refundBids)
+	}
+	const submitSelectedSettlementBids = () => {
+		if (settlementSelectionState.selectedRows.length === 0) return
+		if (isSettleSelectedBidsInProgress) return
+		if (selectedAuctionPoolAddress === undefined) return
+		const selectedClaimSettlementBids = getSettlementBidsFromKeys(settlementBidRows, settlementSelectionState.selectedClaimKeys)
+		const selectedRefundSettlementBids = getSettlementBidsFromKeys(settlementBidRows, settlementSelectionState.selectedRefundKeys)
+		const settlementAction = getSettlementAction(settlementSelectionState.selectedClaimKeys, settlementSelectionState.selectedRefundKeys)
+		if (settlementAction === undefined) return
+
+		dispatchSettlementActionState({
+			action: settlementAction,
+			claimKeys: settlementSelectionState.selectedClaimKeys,
+			ignoredResultHash: forkAuctionResult?.hash,
+			refundKeys: settlementSelectionState.selectedRefundKeys,
+			type: 'submit',
+		})
+		if (settlementAction === 'claimAuctionProceeds') {
+			onClaimAuctionProceeds(selectedAuctionPoolAddress, selectedClaimSettlementBids, selectedRefundSettlementBids)
+			return
+		}
+		onRefundLosingBids(selectedAuctionPoolAddress, selectedRefundSettlementBids)
+	}
+
+	useEffect(() => {
+		const pendingAction = settlementActionState.pendingAction
+		if (pendingAction === undefined) return
+		if (forkAuctionError !== undefined) {
+			dispatchSettlementActionState({ type: 'transactionFailed' })
+			return
+		}
+		if (forkAuctionResult === undefined || selectedAuctionPoolAddress === undefined || !sameAddress(forkAuctionResult.securityPoolAddress, selectedAuctionPoolAddress)) return
+		if (pendingAction.ignoredResultHash !== undefined && forkAuctionResult.hash === pendingAction.ignoredResultHash) return
+		if (forkAuctionResult.action !== pendingAction.action) return
+		dispatchSettlementActionState({
+			action: pendingAction.action,
+			type: 'transactionSucceeded',
+		})
+	}, [forkAuctionError, forkAuctionResult, settlementActionState.pendingAction, selectedAuctionPoolAddress])
+
+	useEffect(() => {
+		if (selectedStage !== 'settlement') {
+			dispatchSettlementActionState({ type: 'reset' })
+			return
+		}
+		dispatchSettlementActionState({
+			availableBidKeys: settlementBidRowKeys,
+			type: 'pruneUnavailableBids',
+		})
+	}, [accountAddress, selectedStage, settlementBidRowKeySignature, selectedAuctionPoolAddress])
+
+	return {
+		isSettleSelectedBidsInProgress,
+		selectedSettlementBidKeys: settlementActionState.selectedBidKeys,
+		setSelectedSettlementBidKeys,
+		settlementBidResultByKey: settlementActionState.resultByKey,
+		settlementBidResultRefreshToken: settlementActionState.refreshToken,
+		settlementSelectionState,
+		submitClaimBidsByKeys,
+		submitRefundBidsByKeys,
+		submitSelectedSettlementBids,
+	}
+}

--- a/ui/ts/lib/forkAuction.ts
+++ b/ui/ts/lib/forkAuction.ts
@@ -1,37 +1,11 @@
-import type { Address } from 'viem'
 import type { ForkOutcomeKey, ListedSecurityPool, ReportingOutcomeKey, SecurityPoolSystemState, TruthAuctionMetrics } from '../types/contracts.js'
 import { assertNever } from './assert.js'
-import { formatCurrencyBalance } from './formatters.js'
-import { tryParseTruthAuctionAmountInput } from './marketForm.js'
 import { getTimeRemaining as getSharedTimeRemaining } from './time.js'
 import { getReportingOutcomeLabel } from './reporting.js'
 
 const SECONDS_PER_WEEK = 7n * 24n * 60n * 60n
 
 export const AUCTION_TIME_SECONDS = SECONDS_PER_WEEK
-export const TRUTH_AUCTION_PRICE_PRECISION = 10n ** 18n
-const TRUTH_AUCTION_TICK_PRICE_POWERS = [
-	1000100000000000000n,
-	1000200010000000000n,
-	1000400060004000100n,
-	1000800280056007000n,
-	1001601200560182043n,
-	1003204964963598014n,
-	1006420201727613920n,
-	1012881622445451097n,
-	1025929181087729343n,
-	1052530684607338948n,
-	1107820842039993613n,
-	1227267018058200482n,
-	1506184333613467388n,
-	2268591246822644826n,
-	5146506245160322222n,
-	26486526531474198664n,
-	701536087702486644953n,
-	492152882348911033633683n,
-	242214459604341065650571799093n,
-	58667844441422969901301586347865591163491n,
-] as const
 
 export type ForkAuctionStageView = 'initiate' | 'migration' | 'auction' | 'settlement'
 
@@ -110,101 +84,4 @@ export function getForkAuctionStageView(source: ForkAuctionStageSource): ForkAuc
 
 export function getTimeRemaining(targetTime: bigint | undefined, currentTime: bigint) {
 	return getSharedTimeRemaining(targetTime, currentTime)
-}
-
-export function estimateRepPurchased(ethAmount: bigint, price: bigint) {
-	if (ethAmount <= 0n || price <= 0n) return 0n
-	return (ethAmount * TRUTH_AUCTION_PRICE_PRECISION) / price
-}
-
-export function getTruthAuctionPriceAtTick(tick: bigint) {
-	const absoluteTick = tick < 0n ? -tick : tick
-	let price = TRUTH_AUCTION_PRICE_PRECISION
-	for (let bitIndex = 0; bitIndex < TRUTH_AUCTION_TICK_PRICE_POWERS.length; bitIndex += 1) {
-		const bitMask = 1n << BigInt(bitIndex)
-		const pricePower = TRUTH_AUCTION_TICK_PRICE_POWERS[bitIndex]
-		if (pricePower === undefined) throw new Error(`Missing truth auction tick price power for bit ${bitIndex}`)
-		if ((absoluteTick & bitMask) !== 0n) price = (price * pricePower) / TRUTH_AUCTION_PRICE_PRECISION
-	}
-	return tick < 0n ? (TRUTH_AUCTION_PRICE_PRECISION * TRUTH_AUCTION_PRICE_PRECISION) / price : price
-}
-
-export function getTruthAuctionTickAtPrice(price: bigint): bigint | undefined {
-	if (price <= 0n) return undefined
-	if (price === TRUTH_AUCTION_PRICE_PRECISION) return 0n
-
-	let lowerTick = 0n
-	let upperTick = 1n
-	let upperPrice = getTruthAuctionPriceAtTick(upperTick)
-
-	if (price >= TRUTH_AUCTION_PRICE_PRECISION) {
-		while (upperPrice <= price) {
-			lowerTick = upperTick
-			upperTick *= 2n
-			upperPrice = getTruthAuctionPriceAtTick(upperTick)
-		}
-		while (upperTick - lowerTick > 1n) {
-			const midTick = (lowerTick + upperTick) / 2n
-			const midPrice = getTruthAuctionPriceAtTick(midTick)
-			if (midPrice <= price) {
-				lowerTick = midTick
-				continue
-			}
-			upperTick = midTick
-		}
-		return lowerTick
-	}
-
-	lowerTick = -1n
-	upperTick = 0n
-	let lowerPrice = getTruthAuctionPriceAtTick(lowerTick)
-	while (lowerPrice > price) {
-		upperTick = lowerTick
-		lowerTick *= 2n
-		lowerPrice = getTruthAuctionPriceAtTick(lowerTick)
-	}
-	while (upperTick - lowerTick > 1n) {
-		const midTick = (lowerTick + upperTick) / 2n
-		const midPrice = getTruthAuctionPriceAtTick(midTick)
-		if (midPrice <= price) {
-			lowerTick = midTick
-			continue
-		}
-		upperTick = midTick
-	}
-	return lowerTick
-}
-
-export function getTruthAuctionBidGuardMessage({
-	accountAddress,
-	currentTimestamp,
-	isMainnet,
-	submitBidAmountInput,
-	truthAuction,
-	walletEthBalance,
-}: {
-	accountAddress: Address | undefined
-	currentTimestamp?: bigint | undefined
-	isMainnet: boolean
-	submitBidAmountInput: string
-	truthAuction: TruthAuctionMetrics | undefined
-	walletEthBalance: bigint | undefined
-}) {
-	if (accountAddress === undefined) return 'Connect a wallet before submitting a truth auction bid.'
-	if (!isMainnet) return 'Switch to Ethereum mainnet before submitting a truth auction bid.'
-	if (truthAuction === undefined) return 'Load the truth auction before bidding.'
-	if (truthAuction.finalized) return 'Truth auction is already finalized.'
-	const auctionHasEndedByTimestamp = currentTimestamp !== undefined && truthAuction.auctionEndsAt !== undefined && currentTimestamp >= truthAuction.auctionEndsAt
-	if (auctionHasEndedByTimestamp || truthAuction.timeRemaining === 0n) return 'Truth auction has ended.'
-
-	const trimmedAmount = submitBidAmountInput.trim()
-	if (trimmedAmount === '') return 'Enter a bid amount greater than zero.'
-	const bidAmount = tryParseTruthAuctionAmountInput(trimmedAmount)
-	if (bidAmount === undefined) return 'Enter a valid bid amount.'
-
-	if (bidAmount <= 0n) return 'Enter a bid amount greater than zero.'
-	if (bidAmount < truthAuction.minBidSize) return `Bid must be at least ${formatCurrencyBalance(truthAuction.minBidSize)} ETH.`
-	if (walletEthBalance === undefined) return 'Loading wallet ETH balance.'
-	if (bidAmount > walletEthBalance) return `Need ${formatCurrencyBalance(bidAmount - walletEthBalance)} more ETH in this wallet to bid the selected amount.`
-	return undefined
 }

--- a/ui/ts/lib/securityPoolWorkflow.ts
+++ b/ui/ts/lib/securityPoolWorkflow.ts
@@ -100,6 +100,63 @@ export function getCurrentForkWorkflowSelectionStage({
 	return normalizeForkWorkflowSelectionStage(currentForkStage)
 }
 
+export function getForkWorkflowStageSelection({
+	currentStageView,
+	forkAuctionDetails,
+	forkOutcome,
+	previewPool,
+	selectedStageView,
+	stageView,
+	systemState,
+}: {
+	currentStageView: ForkAuctionStageView | undefined
+	forkAuctionDetails:
+		| {
+				claimingAvailable: boolean
+				hasForkActivity: boolean
+				migratedRep: bigint
+				truthAuction: Pick<TruthAuctionMetrics, 'finalized'> | undefined
+				truthAuctionStartedAt: bigint
+		  }
+		| undefined
+	forkOutcome: ListedSecurityPool['forkOutcome'] | undefined
+	previewPool: Pick<ListedSecurityPool, 'hasForkActivity' | 'migratedRep' | 'truthAuctionStartedAt'> | undefined
+	selectedStageView: ForkWorkflowSelectionStage | undefined
+	stageView: ForkAuctionStageView | undefined
+	systemState: SecurityPoolSystemState | undefined
+}) {
+	const currentStage =
+		currentStageView ??
+		(systemState === undefined
+			? 'initiate'
+			: getForkAuctionStageView({
+					claimingAvailable: forkAuctionDetails?.claimingAvailable ?? false,
+					forkOutcome: forkOutcome ?? 'none',
+					migratedRep: forkAuctionDetails?.migratedRep ?? previewPool?.migratedRep ?? 0n,
+					systemState,
+					truthAuction: forkAuctionDetails?.truthAuction,
+					truthAuctionStartedAt: forkAuctionDetails?.truthAuctionStartedAt ?? previewPool?.truthAuctionStartedAt ?? 0n,
+				}))
+	const currentWorkflowStage = getCurrentForkWorkflowSelectionStage({
+		claimingAvailable: forkAuctionDetails?.claimingAvailable ?? false,
+		currentForkStage: currentStage,
+		hasForkActivity: forkAuctionDetails?.hasForkActivity ?? previewPool?.hasForkActivity ?? false,
+		systemState,
+		truthAuctionFinalized: forkAuctionDetails?.truthAuction?.finalized ?? false,
+	})
+	const selectedStage = (() => {
+		if (selectedStageView !== undefined) return selectedStageView
+		if (stageView === undefined) return currentWorkflowStage
+		return normalizeForkWorkflowSelectionStage(stageView)
+	})()
+
+	return {
+		currentStage,
+		currentWorkflowStage,
+		selectedStage,
+	}
+}
+
 export function getSelectedPoolForkWorkflowView({
 	forkAuctionDetails,
 	selectedPool,

--- a/ui/ts/lib/truthAuctionBidViewModels.ts
+++ b/ui/ts/lib/truthAuctionBidViewModels.ts
@@ -1,0 +1,134 @@
+import type { Address } from 'viem'
+import type { ForkWorkflowSelectionStage } from './securityPoolWorkflow.js'
+import { getTruthAuctionSettlementBidKey } from './truthAuctionSettlement.js'
+import { sameAddress } from './address.js'
+import { getTruthAuctionBidDisposition, getTruthAuctionDispositionClassName, getTruthAuctionPriceAtTick } from './truthAuctionBook.js'
+import type { TruthAuctionBidView, TruthAuctionMetrics } from '../types/contracts.js'
+
+type LocalSettlementBidStatus = 'claimed' | 'refunded'
+
+export type TruthAuctionBidRowViewModel = {
+	bidder: Address
+	cumulativeEth: bigint
+	ethAmount: bigint
+	key: string
+	price: bigint
+	statusLabel: string
+	statusToneClassName: string
+}
+
+export type ViewerTruthAuctionBidRowViewModel = {
+	ethAmount: bigint
+	key: string
+	price: bigint
+	settlementControl:
+		| {
+				ariaLabel: string
+				bidKey: string
+				checked: boolean
+				disabled: boolean
+				title: string
+		  }
+		| undefined
+	statusLabel: string
+	statusToneClassName: string
+}
+
+export type ViewerTruthAuctionBidRowsViewModel = {
+	rows: ViewerTruthAuctionBidRowViewModel[]
+	showSettlementActionColumn: boolean
+}
+
+export function buildTruthAuctionBidRows({ bids, truthAuction }: { bids: TruthAuctionBidView[]; truthAuction: TruthAuctionMetrics | undefined }): TruthAuctionBidRowViewModel[] {
+	if (truthAuction === undefined) return []
+	return bids.map(bid => {
+		const disposition = getTruthAuctionBidDisposition(bid, truthAuction)
+		return {
+			bidder: bid.bidder,
+			cumulativeEth: bid.cumulativeEth,
+			ethAmount: bid.ethAmount,
+			key: `aggregate:${bid.tick.toString()}:${bid.bidIndex.toString()}`,
+			price: getTruthAuctionPriceAtTick(bid.tick),
+			statusLabel: disposition.label,
+			statusToneClassName: getTruthAuctionDispositionClassName(disposition.tone),
+		}
+	})
+}
+
+export function buildViewerTruthAuctionBidRows({
+	accountAddress,
+	isSettlementInProgress,
+	selectedBidKeys,
+	selectedStage,
+	settlementResultByKey,
+	truthAuction,
+	viewerBids,
+}: {
+	accountAddress: Address | undefined
+	isSettlementInProgress: boolean
+	selectedBidKeys: string[]
+	selectedStage: ForkWorkflowSelectionStage
+	settlementResultByKey: Record<string, LocalSettlementBidStatus>
+	truthAuction: TruthAuctionMetrics | undefined
+	viewerBids: TruthAuctionBidView[]
+}): ViewerTruthAuctionBidRowsViewModel {
+	if (truthAuction === undefined) {
+		return {
+			rows: [],
+			showSettlementActionColumn: false,
+		}
+	}
+
+	const bidsWithDisposition = viewerBids.map(bid => ({
+		bid,
+		disposition: getTruthAuctionBidDisposition(bid, truthAuction),
+	}))
+	const showSettlementActionColumn = selectedStage === 'settlement' && bidsWithDisposition.some(({ bid, disposition }) => sameAddress(bid.bidder, accountAddress) && (disposition.canPrefillRefund || disposition.canPrefillSettle))
+	const rows = bidsWithDisposition.map(({ bid, disposition }) => {
+		const isSettlementBid = sameAddress(bid.bidder, accountAddress) && (disposition.canPrefillRefund || disposition.canPrefillSettle)
+		const settlementBidKey = getTruthAuctionSettlementBidKey(bid)
+		const inSessionSettlementResult = settlementResultByKey[settlementBidKey]
+		const isSettlementBidActions = selectedStage === 'settlement' && isSettlementBid && inSessionSettlementResult === undefined && !isSettlementInProgress
+		const isSettlementBidSelectable = inSessionSettlementResult === undefined && !isSettlementInProgress
+		const statusLabel = (() => {
+			if (inSessionSettlementResult === 'claimed') return 'Claimed'
+			if (inSessionSettlementResult === 'refunded') return 'Refunded'
+			return disposition.label
+		})()
+		const statusToneClassName = (() => {
+			if (inSessionSettlementResult === 'claimed') return 'is-success'
+			if (inSessionSettlementResult === 'refunded') return 'is-default'
+			return getTruthAuctionDispositionClassName(disposition.tone)
+		})()
+
+		return {
+			ethAmount: bid.ethAmount,
+			key: `viewer:${bid.tick.toString()}:${bid.bidIndex.toString()}`,
+			price: getTruthAuctionPriceAtTick(bid.tick),
+			settlementControl: showSettlementActionColumn
+				? {
+						ariaLabel: isSettlementBidActions ? 'Select bid for settlement' : 'Bid is not settlement-eligible',
+						bidKey: settlementBidKey,
+						checked: isSettlementBidActions ? selectedBidKeys.includes(settlementBidKey) : false,
+						disabled: !isSettlementBidActions || !isSettlementBidSelectable,
+						title: isSettlementBidActions ? 'Select bid for settlement' : 'This bid is not yet settlement-eligible',
+					}
+				: undefined,
+			statusLabel,
+			statusToneClassName,
+		}
+	})
+
+	return {
+		rows,
+		showSettlementActionColumn,
+	}
+}
+
+export function updateTruthAuctionSettlementBidSelection(currentKeys: string[], bidKey: string, checked: boolean) {
+	if (checked) {
+		if (currentKeys.includes(bidKey)) return currentKeys
+		return [...currentKeys, bidKey]
+	}
+	return currentKeys.filter(currentKey => currentKey !== bidKey)
+}

--- a/ui/ts/lib/truthAuctionBook.ts
+++ b/ui/ts/lib/truthAuctionBook.ts
@@ -1,0 +1,395 @@
+import type { TruthAuctionBidView, TruthAuctionMetrics, TruthAuctionTickSummary } from '../types/contracts.js'
+import { formatCurrencyBalance } from './formatters.js'
+import { tryParseTruthAuctionAmountInput } from './marketForm.js'
+
+export const TRUTH_AUCTION_PRICE_PRECISION = 10n ** 18n
+
+const TRUTH_AUCTION_TICK_PRICE_POWERS = [
+	1000100000000000000n,
+	1000200010000000000n,
+	1000400060004000100n,
+	1000800280056007000n,
+	1001601200560182043n,
+	1003204964963598014n,
+	1006420201727613920n,
+	1012881622445451097n,
+	1025929181087729343n,
+	1052530684607338948n,
+	1107820842039993613n,
+	1227267018058200482n,
+	1506184333613467388n,
+	2268591246822644826n,
+	5146506245160322222n,
+	26486526531474198664n,
+	701536087702486644953n,
+	492152882348911033633683n,
+	242214459604341065650571799093n,
+	58667844441422969901301586347865591163491n,
+] as const
+
+export type TruthAuctionDisposition = {
+	label: string
+	tone: 'default' | 'danger' | 'success' | 'warning'
+}
+
+type TruthAuctionFinalizedSettlementKind = 'ethRefund' | 'none' | 'repClaim'
+
+type TruthAuctionBidSummaryKind = 'losing' | 'neutral' | 'partial' | 'refundable' | 'refunded' | 'repClaimable' | 'winning'
+
+export type TruthAuctionBidDisposition = TruthAuctionDisposition & {
+	canPrefillRefund: boolean
+	canPrefillSettle: boolean
+	settlementKind: TruthAuctionFinalizedSettlementKind
+	summaryKind: TruthAuctionBidSummaryKind
+}
+
+export type TruthAuctionDepthPoint = {
+	tick: bigint
+	price: bigint
+	currentTotalEth: bigint
+	cumulativeEth: bigint
+	disposition: TruthAuctionDisposition
+	isSelected: boolean
+	isPreviewTick: boolean
+	submissionCount: bigint
+}
+
+export function estimateRepPurchased(ethAmount: bigint, price: bigint) {
+	if (ethAmount <= 0n || price <= 0n) return 0n
+	return (ethAmount * TRUTH_AUCTION_PRICE_PRECISION) / price
+}
+
+export function getTruthAuctionWinningThresholdPrice(truthAuction: TruthAuctionMetrics | undefined) {
+	if (truthAuction === undefined || !truthAuction.finalized || !truthAuction.underfunded || truthAuction.maxRepBeingSold === 0n) return undefined
+	return (truthAuction.ethRaised * TRUTH_AUCTION_PRICE_PRECISION) / truthAuction.maxRepBeingSold
+}
+
+function getTruthAuctionTickDisposition(tickSummary: TruthAuctionTickSummary, truthAuction: TruthAuctionMetrics | undefined): TruthAuctionDisposition {
+	if (tickSummary.currentTotalEth === 0n) return { label: 'Historical', tone: 'default' }
+	if (truthAuction === undefined) return { label: 'Live', tone: 'default' }
+	const winningThresholdPrice = getTruthAuctionWinningThresholdPrice(truthAuction)
+	if (winningThresholdPrice !== undefined) return tickSummary.price >= winningThresholdPrice ? { label: 'Winning', tone: 'success' } : { label: 'Out', tone: 'danger' }
+	if (!truthAuction.hitCap || truthAuction.clearingTick === undefined || truthAuction.clearingPrice === undefined) return truthAuction.finalized ? { label: 'Winning', tone: 'success' } : { label: 'In Book', tone: 'default' }
+	if (tickSummary.tick > truthAuction.clearingTick) return { label: truthAuction.finalized ? 'Winning' : 'Above Clearing', tone: 'success' }
+	if (tickSummary.tick < truthAuction.clearingTick) return { label: truthAuction.finalized ? 'Out' : 'Below Clearing', tone: 'danger' }
+	return { label: truthAuction.finalized ? 'Clearing' : 'At Clearing', tone: 'warning' }
+}
+
+export function getTruthAuctionBidDisposition(bid: TruthAuctionBidView, truthAuction: TruthAuctionMetrics | undefined): TruthAuctionBidDisposition {
+	if (bid.refunded) return { label: 'Refunded', tone: 'default', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'ethRefund', summaryKind: 'refunded' }
+	if (truthAuction === undefined) {
+		if (bid.claimed) return { label: 'Claimed', tone: 'success', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'none', summaryKind: 'neutral' }
+		return { label: 'Pending', tone: 'default', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'none', summaryKind: 'neutral' }
+	}
+
+	const winningThresholdPrice = getTruthAuctionWinningThresholdPrice(truthAuction)
+	if (winningThresholdPrice !== undefined) {
+		if (getTruthAuctionPriceAtTick(bid.tick) >= winningThresholdPrice) {
+			if (truthAuction.finalized) {
+				if (bid.claimed) return { label: 'Claimed', tone: 'success', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'repClaim', summaryKind: 'neutral' }
+				return { label: 'Winning', tone: 'success', canPrefillRefund: false, canPrefillSettle: true, settlementKind: 'repClaim', summaryKind: 'winning' }
+			}
+			return {
+				label: 'Provisional',
+				tone: 'warning',
+				canPrefillRefund: false,
+				canPrefillSettle: false,
+				settlementKind: 'none',
+				summaryKind: 'neutral',
+			}
+		}
+		if (truthAuction.finalized) {
+			if (bid.claimed) return { label: 'Refunded', tone: 'default', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'ethRefund', summaryKind: 'refunded' }
+			return { label: 'Refundable', tone: 'danger', canPrefillRefund: true, canPrefillSettle: false, settlementKind: 'ethRefund', summaryKind: 'refundable' }
+		}
+		return {
+			label: 'In Book',
+			tone: 'default',
+			canPrefillRefund: false,
+			canPrefillSettle: false,
+			settlementKind: 'none',
+			summaryKind: 'neutral',
+		}
+	}
+
+	if (!truthAuction.hitCap || truthAuction.clearingTick === undefined || truthAuction.clearingPrice === undefined) {
+		if (truthAuction.finalized) {
+			if (bid.claimed) return { label: 'Claimed', tone: 'success', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'repClaim', summaryKind: 'neutral' }
+			return { label: 'Winning', tone: 'success', canPrefillRefund: false, canPrefillSettle: true, settlementKind: 'repClaim', summaryKind: 'winning' }
+		}
+		return {
+			label: 'In Book',
+			tone: 'default',
+			canPrefillRefund: false,
+			canPrefillSettle: false,
+			settlementKind: 'none',
+			summaryKind: 'neutral',
+		}
+	}
+
+	if (bid.tick > truthAuction.clearingTick) {
+		if (truthAuction.finalized) {
+			if (bid.claimed) return { label: 'Claimed', tone: 'success', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'repClaim', summaryKind: 'neutral' }
+			return { label: 'Winning', tone: 'success', canPrefillRefund: false, canPrefillSettle: true, settlementKind: 'repClaim', summaryKind: 'winning' }
+		}
+		return {
+			label: 'Above Clearing',
+			tone: 'warning',
+			canPrefillRefund: false,
+			canPrefillSettle: false,
+			settlementKind: 'none',
+			summaryKind: 'neutral',
+		}
+	}
+	if (bid.tick < truthAuction.clearingTick) {
+		if (truthAuction.finalized) {
+			if (bid.claimed) return { label: 'Refunded', tone: 'default', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'ethRefund', summaryKind: 'refunded' }
+			return { label: 'Refundable', tone: 'danger', canPrefillRefund: true, canPrefillSettle: false, settlementKind: 'ethRefund', summaryKind: 'refundable' }
+		}
+		return {
+			label: 'Below Clearing',
+			tone: 'danger',
+			canPrefillRefund: !truthAuction.finalized,
+			canPrefillSettle: false,
+			settlementKind: 'none',
+			summaryKind: 'losing',
+		}
+	}
+
+	const previousCumulativeEth = bid.activeCumulativeEthBeforeBid
+	const activeCumulativeEth = previousCumulativeEth + bid.ethAmount
+	if (truthAuction.ethAtClearingTick <= previousCumulativeEth) {
+		if (truthAuction.finalized) {
+			if (bid.claimed) return { label: 'Refunded', tone: 'default', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'ethRefund', summaryKind: 'refunded' }
+			return { label: 'Refundable', tone: 'danger', canPrefillRefund: true, canPrefillSettle: false, settlementKind: 'ethRefund', summaryKind: 'refundable' }
+		}
+		return {
+			label: 'Below Clearing',
+			tone: 'danger',
+			canPrefillRefund: true,
+			canPrefillSettle: false,
+			settlementKind: 'none',
+			summaryKind: 'losing',
+		}
+	}
+	if (truthAuction.ethAtClearingTick >= activeCumulativeEth) {
+		if (truthAuction.finalized) {
+			if (bid.claimed) return { label: 'Claimed', tone: 'success', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'repClaim', summaryKind: 'neutral' }
+			return { label: 'Winning', tone: 'success', canPrefillRefund: false, canPrefillSettle: true, settlementKind: 'repClaim', summaryKind: 'winning' }
+		}
+		return {
+			label: 'At Clearing',
+			tone: 'warning',
+			canPrefillRefund: false,
+			canPrefillSettle: false,
+			settlementKind: 'none',
+			summaryKind: 'neutral',
+		}
+	}
+	if (truthAuction.finalized) {
+		if (bid.claimed) return { label: 'Claimed', tone: 'success', canPrefillRefund: false, canPrefillSettle: false, settlementKind: 'repClaim', summaryKind: 'neutral' }
+		return { label: 'Partial', tone: 'warning', canPrefillRefund: false, canPrefillSettle: true, settlementKind: 'repClaim', summaryKind: 'partial' }
+	}
+	return {
+		label: 'At Clearing',
+		tone: 'warning',
+		canPrefillRefund: false,
+		canPrefillSettle: false,
+		settlementKind: 'none',
+		summaryKind: 'neutral',
+	}
+}
+
+export function getTruthAuctionDispositionClassName(tone: TruthAuctionDisposition['tone']) {
+	switch (tone) {
+		case 'danger':
+			return 'is-danger'
+		case 'success':
+			return 'is-success'
+		case 'warning':
+			return 'is-warning'
+		case 'default':
+			return 'is-default'
+		default:
+			return 'is-default'
+	}
+}
+
+export function sortTruthAuctionTickSummariesDescending(tickSummaries: TruthAuctionTickSummary[]) {
+	return [...tickSummaries].sort((left, right) => {
+		if (left.tick === right.tick) return 0
+		return left.tick > right.tick ? -1 : 1
+	})
+}
+
+export function buildTruthAuctionDepthPoints({ enteredBidTick, selectedBookTick, tickSummaries, truthAuction }: { enteredBidTick: bigint | undefined; selectedBookTick: bigint | undefined; tickSummaries: TruthAuctionTickSummary[]; truthAuction: TruthAuctionMetrics | undefined }): TruthAuctionDepthPoint[] {
+	let cumulativeEth = 0n
+
+	return tickSummaries
+		.filter(tickSummary => tickSummary.active || tickSummary.currentTotalEth > 0n)
+		.map(tickSummary => {
+			cumulativeEth += tickSummary.currentTotalEth
+			return {
+				tick: tickSummary.tick,
+				price: tickSummary.price,
+				currentTotalEth: tickSummary.currentTotalEth,
+				cumulativeEth,
+				disposition: getTruthAuctionTickDisposition(tickSummary, truthAuction),
+				isSelected: selectedBookTick === tickSummary.tick,
+				isPreviewTick: enteredBidTick !== undefined && enteredBidTick === tickSummary.tick,
+				submissionCount: tickSummary.submissionCount,
+			}
+		})
+}
+
+export function getTruthAuctionOverviewProgress(truthAuction: TruthAuctionMetrics | undefined, tickSummaries: TruthAuctionTickSummary[]) {
+	if (truthAuction === undefined) return undefined
+	if (truthAuction.finalized) {
+		return {
+			ethRaised: truthAuction.ethRaised,
+			repSold: truthAuction.totalRepPurchased,
+		}
+	}
+
+	const activeTickSummaries = sortTruthAuctionTickSummariesDescending(tickSummaries).filter(tickSummary => tickSummary.currentTotalEth > 0n)
+	if (activeTickSummaries.length === 0) {
+		return {
+			ethRaised: truthAuction.ethRaised,
+			repSold: truthAuction.totalRepPurchased,
+		}
+	}
+
+	let provisionalEthRaised = 0n
+	let provisionalRepSold = 0n
+
+	if (!truthAuction.hitCap || truthAuction.clearingTick === undefined || truthAuction.clearingPrice === undefined) {
+		for (const tickSummary of activeTickSummaries) {
+			provisionalEthRaised += tickSummary.currentTotalEth
+			provisionalRepSold += estimateRepPurchased(tickSummary.currentTotalEth, tickSummary.price)
+		}
+	} else {
+		let remainingCap = truthAuction.ethRaiseCap
+		for (const tickSummary of activeTickSummaries) {
+			if (remainingCap <= 0n) break
+
+			let acceptedEth = 0n
+			if (tickSummary.tick > truthAuction.clearingTick) acceptedEth = tickSummary.currentTotalEth
+			else if (tickSummary.tick === truthAuction.clearingTick) acceptedEth = truthAuction.ethAtClearingTick < tickSummary.currentTotalEth ? truthAuction.ethAtClearingTick : tickSummary.currentTotalEth
+
+			if (acceptedEth <= 0n) continue
+			if (acceptedEth > remainingCap) acceptedEth = remainingCap
+
+			provisionalEthRaised += acceptedEth
+			provisionalRepSold += estimateRepPurchased(acceptedEth, tickSummary.price)
+			remainingCap -= acceptedEth
+		}
+	}
+
+	const ethRaised = provisionalEthRaised > truthAuction.ethRaiseCap ? truthAuction.ethRaiseCap : provisionalEthRaised
+	const repSold = provisionalRepSold > truthAuction.maxRepBeingSold ? truthAuction.maxRepBeingSold : provisionalRepSold
+
+	return {
+		ethRaised,
+		repSold,
+	}
+}
+
+export function sortTruthAuctionBidsByPriority(bids: TruthAuctionBidView[]) {
+	return [...bids].sort((left, right) => {
+		if (left.tick !== right.tick) return left.tick > right.tick ? -1 : 1
+		if (left.bidIndex !== right.bidIndex) return left.bidIndex < right.bidIndex ? -1 : 1
+		return 0
+	})
+}
+
+export function getTruthAuctionPriceAtTick(tick: bigint) {
+	const absoluteTick = tick < 0n ? -tick : tick
+	let price = TRUTH_AUCTION_PRICE_PRECISION
+	for (let bitIndex = 0; bitIndex < TRUTH_AUCTION_TICK_PRICE_POWERS.length; bitIndex += 1) {
+		const bitMask = 1n << BigInt(bitIndex)
+		const pricePower = TRUTH_AUCTION_TICK_PRICE_POWERS[bitIndex]
+		if (pricePower === undefined) throw new Error(`Missing truth auction tick price power for bit ${bitIndex}`)
+		if ((absoluteTick & bitMask) !== 0n) price = (price * pricePower) / TRUTH_AUCTION_PRICE_PRECISION
+	}
+	return tick < 0n ? (TRUTH_AUCTION_PRICE_PRECISION * TRUTH_AUCTION_PRICE_PRECISION) / price : price
+}
+
+export function getTruthAuctionTickAtPrice(price: bigint): bigint | undefined {
+	if (price <= 0n) return undefined
+	if (price === TRUTH_AUCTION_PRICE_PRECISION) return 0n
+
+	let lowerTick = 0n
+	let upperTick = 1n
+	let upperPrice = getTruthAuctionPriceAtTick(upperTick)
+
+	if (price >= TRUTH_AUCTION_PRICE_PRECISION) {
+		while (upperPrice <= price) {
+			lowerTick = upperTick
+			upperTick *= 2n
+			upperPrice = getTruthAuctionPriceAtTick(upperTick)
+		}
+		while (upperTick - lowerTick > 1n) {
+			const midTick = (lowerTick + upperTick) / 2n
+			const midPrice = getTruthAuctionPriceAtTick(midTick)
+			if (midPrice <= price) {
+				lowerTick = midTick
+				continue
+			}
+			upperTick = midTick
+		}
+		return lowerTick
+	}
+
+	lowerTick = -1n
+	upperTick = 0n
+	let lowerPrice = getTruthAuctionPriceAtTick(lowerTick)
+	while (lowerPrice > price) {
+		upperTick = lowerTick
+		lowerTick *= 2n
+		lowerPrice = getTruthAuctionPriceAtTick(lowerTick)
+	}
+	while (upperTick - lowerTick > 1n) {
+		const midTick = (lowerTick + upperTick) / 2n
+		const midPrice = getTruthAuctionPriceAtTick(midTick)
+		if (midPrice <= price) {
+			lowerTick = midTick
+			continue
+		}
+		upperTick = midTick
+	}
+	return lowerTick
+}
+
+export function getTruthAuctionBidGuardMessage({
+	accountAddress,
+	currentTimestamp,
+	isMainnet,
+	submitBidAmountInput,
+	truthAuction,
+	walletEthBalance,
+}: {
+	accountAddress: string | undefined
+	currentTimestamp?: bigint | undefined
+	isMainnet: boolean
+	submitBidAmountInput: string
+	truthAuction: TruthAuctionMetrics | undefined
+	walletEthBalance: bigint | undefined
+}) {
+	if (accountAddress === undefined) return 'Connect a wallet before submitting a truth auction bid.'
+	if (!isMainnet) return 'Switch to Ethereum mainnet before submitting a truth auction bid.'
+	if (truthAuction === undefined) return 'Load the truth auction before bidding.'
+	if (truthAuction.finalized) return 'Truth auction is already finalized.'
+	const auctionHasEndedByTimestamp = currentTimestamp !== undefined && truthAuction.auctionEndsAt !== undefined && currentTimestamp >= truthAuction.auctionEndsAt
+	if (auctionHasEndedByTimestamp || truthAuction.timeRemaining === 0n) return 'Truth auction has ended.'
+
+	const trimmedAmount = submitBidAmountInput.trim()
+	if (trimmedAmount === '') return 'Enter a bid amount greater than zero.'
+	const bidAmount = tryParseTruthAuctionAmountInput(trimmedAmount)
+	if (bidAmount === undefined) return 'Enter a valid bid amount.'
+
+	if (bidAmount <= 0n) return 'Enter a bid amount greater than zero.'
+	if (bidAmount < truthAuction.minBidSize) return `Bid must be at least ${formatCurrencyBalance(truthAuction.minBidSize)} ETH.`
+	if (walletEthBalance === undefined) return 'Loading wallet ETH balance.'
+	if (bidAmount > walletEthBalance) return `Need ${formatCurrencyBalance(bidAmount - walletEthBalance)} more ETH in this wallet to bid the selected amount.`
+	return undefined
+}

--- a/ui/ts/lib/truthAuctionSettlement.ts
+++ b/ui/ts/lib/truthAuctionSettlement.ts
@@ -1,0 +1,107 @@
+import type { Address } from 'viem'
+import type { TruthAuctionBidView, TruthAuctionMetrics } from '../types/contracts.js'
+import { sameAddress } from './address.js'
+import { getTruthAuctionBidDisposition, type TruthAuctionBidDisposition } from './truthAuctionBook.js'
+
+export type TruthAuctionSettlementBidRow = {
+	bid: TruthAuctionBidView
+	disposition: TruthAuctionBidDisposition
+}
+
+type TruthAuctionSettlementSelectionMode = 'claim' | 'mixed' | 'refund'
+
+export type TruthAuctionSettlementSelectionState = {
+	rowKeys: string[]
+	selectedRows: TruthAuctionSettlementBidRow[]
+	selectedRefundRows: TruthAuctionSettlementBidRow[]
+	selectedClaimRows: TruthAuctionSettlementBidRow[]
+	selectedClaimKeys: string[]
+	selectedRefundKeys: string[]
+	rowsHaveClaims: boolean
+	rowsHaveRefunds: boolean
+	rowsSelectionMode: TruthAuctionSettlementSelectionMode
+	selectionMode: TruthAuctionSettlementSelectionMode
+	selectionHasClaims: boolean
+	selectionHasRefunds: boolean
+}
+
+export function getTruthAuctionSettlementBidKey(bid: Pick<TruthAuctionBidView, 'bidIndex' | 'tick'>) {
+	return `${bid.tick.toString()}:${bid.bidIndex.toString()}`
+}
+
+export function getTruthAuctionSettlementBidRows({ accountAddress, truthAuction, viewerBids }: { accountAddress: Address | undefined; truthAuction: TruthAuctionMetrics | undefined; viewerBids: TruthAuctionBidView[] }) {
+	if (truthAuction === undefined || accountAddress === undefined) return []
+	return viewerBids
+		.map(bid => ({
+			bid,
+			disposition: getTruthAuctionBidDisposition(bid, truthAuction),
+		}))
+		.filter(({ bid, disposition }) => sameAddress(bid.bidder, accountAddress) && (disposition.canPrefillRefund || disposition.canPrefillSettle))
+}
+
+export function getTruthAuctionSettlementSelectionState({ selectedBidKeys, settlementBidRows }: { selectedBidKeys: string[]; settlementBidRows: TruthAuctionSettlementBidRow[] }): TruthAuctionSettlementSelectionState {
+	const rowKeys = settlementBidRows.map(({ bid }) => getTruthAuctionSettlementBidKey(bid))
+	const selectedRows = settlementBidRows.filter(({ bid }) => selectedBidKeys.includes(getTruthAuctionSettlementBidKey(bid)))
+	const selectedRefundRows = selectedRows.filter(({ disposition }) => disposition.canPrefillRefund)
+	const selectedClaimRows = selectedRows.filter(({ disposition }) => disposition.canPrefillSettle)
+	const selectedClaimKeys = selectedClaimRows.map(({ bid }) => getTruthAuctionSettlementBidKey(bid))
+	const selectedRefundKeys = selectedRefundRows.map(({ bid }) => getTruthAuctionSettlementBidKey(bid))
+	const rowsHaveClaims = settlementBidRows.some(({ disposition }) => disposition.canPrefillSettle)
+	const rowsHaveRefunds = settlementBidRows.some(({ disposition }) => disposition.canPrefillRefund)
+	const rowsSelectionMode = (() => {
+		if (rowsHaveClaims && rowsHaveRefunds) return 'mixed'
+		if (rowsHaveClaims) return 'claim'
+		return 'refund'
+	})()
+	const selectionMode = (() => {
+		if (selectedRefundRows.length > 0 && selectedClaimRows.length > 0) return 'mixed'
+		if (selectedClaimRows.length > 0) return 'claim'
+		if (selectedRows.length > 0) return 'refund'
+		return rowsSelectionMode
+	})()
+
+	return {
+		rowKeys,
+		selectedRows,
+		selectedRefundRows,
+		selectedClaimRows,
+		selectedClaimKeys,
+		selectedRefundKeys,
+		rowsHaveClaims,
+		rowsHaveRefunds,
+		rowsSelectionMode,
+		selectionMode,
+		selectionHasClaims: selectedClaimRows.length > 0,
+		selectionHasRefunds: selectedRefundRows.length > 0,
+	}
+}
+
+export function getTruthAuctionSettlementActionAvailabilityMessage({
+	claimingAvailable,
+	selectedClaimRows,
+	selectedRows,
+	selectionHasClaims,
+	selectionHasRefunds,
+	truthAuction,
+}: {
+	claimingAvailable: boolean | undefined
+	selectedClaimRows: TruthAuctionSettlementBidRow[]
+	selectedRows: TruthAuctionSettlementBidRow[]
+	selectionHasClaims: boolean
+	selectionHasRefunds: boolean
+	truthAuction: TruthAuctionMetrics | undefined
+}) {
+	const bidActionAvailability = (() => {
+		if (selectedRows.length === 0) return 'Pick one or more of your bids before settlement.'
+		if (truthAuction === undefined) return 'Load the truth auction before settling bids.'
+		if (truthAuction.finalized && selectionHasClaims && claimingAvailable === false) return 'Finalized settlement is not yet available for this pool.'
+		if (selectionHasClaims && !truthAuction.finalized) return 'Winning bids can only be settled after the truth auction is finalized.'
+		if (!truthAuction.finalized && (!truthAuction.hitCap || truthAuction.clearingTick === undefined)) return 'Losing bids cannot be refunded until the auction has a clearing tick.'
+		return undefined
+	})()
+
+	if (selectedRows.length === 0) return bidActionAvailability
+	if (selectionHasClaims && selectedClaimRows.length === 0) return 'Select one or more winning bids before submitting settlement.'
+	if (!selectionHasClaims && selectionHasRefunds === false) return 'Select one or more refundable bids before submitting refunds.'
+	return bidActionAvailability
+}

--- a/ui/ts/lib/truthAuctionSettlementActionState.ts
+++ b/ui/ts/lib/truthAuctionSettlementActionState.ts
@@ -1,0 +1,168 @@
+type LocalSettlementBidStatus = 'claimed' | 'refunded'
+
+export type TruthAuctionSettlementAction = 'claimAuctionProceeds' | 'refundLosingBids'
+
+type TruthAuctionSettlementPendingAction = {
+	action: TruthAuctionSettlementAction
+	claimKeys: string[]
+	ignoredResultHash: string | undefined
+	refundKeys: string[]
+}
+
+export type TruthAuctionSettlementActionState = {
+	pendingAction: TruthAuctionSettlementPendingAction | undefined
+	refreshToken: number
+	resultByKey: Record<string, LocalSettlementBidStatus>
+	selectedBidKeys: string[]
+}
+
+export type TruthAuctionSettlementActionStateEvent =
+	| { type: 'reset' }
+	| { type: 'selectBidKeys'; selectedBidKeys: string[] }
+	| { type: 'submit'; action: TruthAuctionSettlementAction; claimKeys: string[]; ignoredResultHash: string | undefined; refundKeys: string[] }
+	| { type: 'transactionFailed' }
+	| { type: 'transactionSucceeded'; action: TruthAuctionSettlementAction }
+	| { type: 'pruneUnavailableBids'; availableBidKeys: string[] }
+
+export function createTruthAuctionSettlementActionState(): TruthAuctionSettlementActionState {
+	return {
+		pendingAction: undefined,
+		refreshToken: 0,
+		resultByKey: {},
+		selectedBidKeys: [],
+	}
+}
+
+function uniqueKeys(keys: string[]) {
+	return Array.from(new Set(keys))
+}
+
+function sameStringArray(left: string[], right: string[]) {
+	return left.length === right.length && left.every((value, index) => value === right[index])
+}
+
+function removeKeys(keys: string[], keysToRemove: string[]) {
+	if (keys.length === 0 || keysToRemove.length === 0) return keys
+	const removedKeySet = new Set(keysToRemove)
+	const nextKeys = keys.filter(key => !removedKeySet.has(key))
+	return sameStringArray(nextKeys, keys) ? keys : nextKeys
+}
+
+function filterKeys(keys: string[], availableBidKeySet: Set<string>) {
+	if (keys.length === 0) return keys
+	const nextKeys = keys.filter(key => availableBidKeySet.has(key))
+	return sameStringArray(nextKeys, keys) ? keys : nextKeys
+}
+
+function markSettlementBidResults(state: TruthAuctionSettlementActionState, bidKeys: string[], status: LocalSettlementBidStatus) {
+	const targetBidKeys = uniqueKeys(bidKeys)
+	if (targetBidKeys.length === 0) return state
+
+	const nextResultByKey = { ...state.resultByKey }
+	for (const bidKey of targetBidKeys) {
+		nextResultByKey[bidKey] = status
+	}
+
+	return {
+		...state,
+		resultByKey: nextResultByKey,
+		selectedBidKeys: removeKeys(state.selectedBidKeys, targetBidKeys),
+	}
+}
+
+function filterResultStatuses(resultByKey: Record<string, LocalSettlementBidStatus>, availableBidKeySet: Set<string>) {
+	const nextResultByKey: Record<string, LocalSettlementBidStatus> = {}
+	let changed = false
+
+	for (const [key, status] of Object.entries(resultByKey)) {
+		if (!availableBidKeySet.has(key)) {
+			changed = true
+			continue
+		}
+		nextResultByKey[key] = status
+	}
+
+	if (!changed) return resultByKey
+	return nextResultByKey
+}
+
+function prunePendingAction(pendingAction: TruthAuctionSettlementPendingAction | undefined, availableBidKeySet: Set<string>) {
+	if (pendingAction === undefined) return undefined
+
+	const claimKeys = filterKeys(pendingAction.claimKeys, availableBidKeySet)
+	const refundKeys = filterKeys(pendingAction.refundKeys, availableBidKeySet)
+	if (claimKeys.length === 0 && refundKeys.length === 0) return undefined
+	if (claimKeys === pendingAction.claimKeys && refundKeys === pendingAction.refundKeys) return pendingAction
+
+	return {
+		...pendingAction,
+		claimKeys,
+		refundKeys,
+	}
+}
+
+export function reduceTruthAuctionSettlementActionState(state: TruthAuctionSettlementActionState, event: TruthAuctionSettlementActionStateEvent): TruthAuctionSettlementActionState {
+	switch (event.type) {
+		case 'reset':
+			if (state.pendingAction === undefined && state.selectedBidKeys.length === 0 && Object.keys(state.resultByKey).length === 0) return state
+			return {
+				...createTruthAuctionSettlementActionState(),
+				refreshToken: state.refreshToken,
+			}
+		case 'selectBidKeys': {
+			const selectedBidKeys = uniqueKeys(event.selectedBidKeys)
+			if (sameStringArray(state.selectedBidKeys, selectedBidKeys)) return state
+			return {
+				...state,
+				selectedBidKeys,
+			}
+		}
+		case 'submit': {
+			const claimKeys = uniqueKeys(event.claimKeys)
+			const refundKeys = uniqueKeys(event.refundKeys)
+			if (claimKeys.length === 0 && refundKeys.length === 0) return state
+			return {
+				...state,
+				pendingAction: {
+					action: event.action,
+					claimKeys,
+					ignoredResultHash: event.ignoredResultHash,
+					refundKeys,
+				},
+			}
+		}
+		case 'transactionFailed':
+			if (state.pendingAction === undefined) return state
+			return {
+				...state,
+				pendingAction: undefined,
+			}
+		case 'transactionSucceeded': {
+			const pendingAction = state.pendingAction
+			if (pendingAction === undefined || pendingAction.action !== event.action) return state
+
+			const nextState = event.action === 'claimAuctionProceeds' ? markSettlementBidResults(markSettlementBidResults(state, pendingAction.claimKeys, 'claimed'), pendingAction.refundKeys, 'refunded') : markSettlementBidResults(state, pendingAction.refundKeys, 'refunded')
+
+			return {
+				...nextState,
+				pendingAction: undefined,
+				refreshToken: nextState.refreshToken + 1,
+			}
+		}
+		case 'pruneUnavailableBids': {
+			const availableBidKeySet = new Set(event.availableBidKeys)
+			const selectedBidKeys = filterKeys(state.selectedBidKeys, availableBidKeySet)
+			const pendingAction = prunePendingAction(state.pendingAction, availableBidKeySet)
+			const resultByKey = filterResultStatuses(state.resultByKey, availableBidKeySet)
+			if (selectedBidKeys === state.selectedBidKeys && pendingAction === state.pendingAction && resultByKey === state.resultByKey) return state
+			return {
+				...state,
+				pendingAction,
+				resultByKey,
+				selectedBidKeys,
+			}
+		}
+		default:
+			return state
+	}
+}

--- a/ui/ts/simulation/bootstrap.ts
+++ b/ui/ts/simulation/bootstrap.ts
@@ -28,7 +28,7 @@ import {
 } from '../contracts.js'
 import { ReputationToken_ReputationToken, Zoltar_Zoltar, peripherals_SecurityPoolOracleCoordinator_SecurityPoolOracleCoordinator, peripherals_WETH9_WETH9 } from '../contractArtifact.js'
 import { assertNever } from '../lib/assert.js'
-import { getTruthAuctionPriceAtTick, getTruthAuctionTickAtPrice } from '../lib/forkAuction.js'
+import { getTruthAuctionPriceAtTick, getTruthAuctionTickAtPrice } from '../lib/truthAuctionBook.js'
 import type { ReadClient, WriteClient } from '../lib/chainBackend.js'
 import { MAINNET_NETWORK_PROFILE, MAINNET_WETH_ADDRESS, type NetworkProfile } from '../lib/networkProfile.js'
 import type { ListedSecurityPool, QuestionData } from '../types/contracts.js'

--- a/ui/ts/tests/forkAuction.test.ts
+++ b/ui/ts/tests/forkAuction.test.ts
@@ -2,8 +2,25 @@
 
 import { describe, expect, test } from 'bun:test'
 import { zeroAddress } from 'viem'
-import { getForkAuctionStageLabel, getForkAuctionStageOrder, getForkAuctionStageView, getForkStageDescriptionForState, getOutcomeActionLabel, getTruthAuctionBidGuardMessage, getTruthAuctionPriceAtTick, getTruthAuctionTickAtPrice, hasForkActivity, TRUTH_AUCTION_PRICE_PRECISION } from '../lib/forkAuction.js'
-import type { TruthAuctionMetrics } from '../types/contracts.js'
+import type { Address } from 'viem'
+import { getForkAuctionStageLabel, getForkAuctionStageOrder, getForkAuctionStageView, getForkStageDescriptionForState, getOutcomeActionLabel, hasForkActivity } from '../lib/forkAuction.js'
+import { buildTruthAuctionBidRows, buildViewerTruthAuctionBidRows, updateTruthAuctionSettlementBidSelection } from '../lib/truthAuctionBidViewModels.js'
+import {
+	buildTruthAuctionDepthPoints,
+	getTruthAuctionBidDisposition,
+	getTruthAuctionBidGuardMessage,
+	getTruthAuctionOverviewProgress,
+	getTruthAuctionPriceAtTick,
+	getTruthAuctionTickAtPrice,
+	sortTruthAuctionBidsByPriority,
+	sortTruthAuctionTickSummariesDescending,
+	TRUTH_AUCTION_PRICE_PRECISION,
+} from '../lib/truthAuctionBook.js'
+import { getTruthAuctionSettlementActionAvailabilityMessage, getTruthAuctionSettlementBidKey, getTruthAuctionSettlementBidRows, getTruthAuctionSettlementSelectionState } from '../lib/truthAuctionSettlement.js'
+import type { TruthAuctionBidView, TruthAuctionMetrics, TruthAuctionTickSummary } from '../types/contracts.js'
+
+const walletAddress: Address = '0x0000000000000000000000000000000000000001'
+const otherWalletAddress: Address = '0x0000000000000000000000000000000000000002'
 
 function createTruthAuction(overrides: Partial<TruthAuctionMetrics> = {}): TruthAuctionMetrics {
 	return {
@@ -23,6 +40,30 @@ function createTruthAuction(overrides: Partial<TruthAuctionMetrics> = {}): Truth
 		totalRepPurchased: 0n,
 		underfunded: false,
 		...overrides,
+	}
+}
+
+function createTickSummary(overrides: { tick: bigint } & Partial<Omit<TruthAuctionTickSummary, 'tick'>>): TruthAuctionTickSummary {
+	return {
+		active: overrides.active ?? false,
+		currentTotalEth: overrides.currentTotalEth ?? 0n,
+		price: overrides.price ?? getTruthAuctionPriceAtTick(overrides.tick),
+		submissionCount: overrides.submissionCount ?? 0n,
+		tick: overrides.tick,
+	}
+}
+
+function createBid(overrides: { bidIndex: bigint; tick: bigint } & Partial<Omit<TruthAuctionBidView, 'bidIndex' | 'tick'>>): TruthAuctionBidView {
+	const ethAmount = overrides.ethAmount ?? 1n * 10n ** 18n
+	return {
+		activeCumulativeEthBeforeBid: overrides.activeCumulativeEthBeforeBid ?? 0n,
+		bidIndex: overrides.bidIndex,
+		bidder: overrides.bidder ?? walletAddress,
+		claimed: overrides.claimed ?? false,
+		cumulativeEth: overrides.cumulativeEth ?? ethAmount,
+		ethAmount,
+		refunded: overrides.refunded ?? false,
+		tick: overrides.tick,
 	}
 }
 
@@ -303,5 +344,180 @@ void describe('fork auction helpers', () => {
 				walletEthBalance: undefined,
 			}),
 		).toBe('Loading wallet ETH balance.')
+	})
+
+	void test('derives depth points from visible tick summaries', () => {
+		const auction = createTruthAuction({
+			clearingPrice: getTruthAuctionPriceAtTick(2n),
+			clearingTick: 2n,
+			hitCap: true,
+		})
+		const tickSummaries = sortTruthAuctionTickSummariesDescending([
+			createTickSummary({ active: true, currentTotalEth: 2n * 10n ** 18n, submissionCount: 2n, tick: 1n }),
+			createTickSummary({ active: true, currentTotalEth: 3n * 10n ** 18n, submissionCount: 3n, tick: 3n }),
+			createTickSummary({ active: true, currentTotalEth: 0n, submissionCount: 1n, tick: 2n }),
+			createTickSummary({ active: false, currentTotalEth: 0n, submissionCount: 1n, tick: 4n }),
+		])
+
+		const depthPoints = buildTruthAuctionDepthPoints({
+			enteredBidTick: 1n,
+			selectedBookTick: 3n,
+			tickSummaries,
+			truthAuction: auction,
+		})
+
+		expect(depthPoints.map(point => point.tick)).toEqual([3n, 2n, 1n])
+		expect(depthPoints.map(point => point.cumulativeEth)).toEqual([3n * 10n ** 18n, 3n * 10n ** 18n, 5n * 10n ** 18n])
+		expect(depthPoints.map(point => point.disposition.label)).toEqual(['Above Clearing', 'Historical', 'Below Clearing'])
+		expect(depthPoints.map(point => point.isSelected)).toEqual([true, false, false])
+		expect(depthPoints.map(point => point.isPreviewTick)).toEqual([false, false, true])
+		expect(depthPoints.map(point => point.submissionCount)).toEqual([3n, 1n, 2n])
+	})
+
+	void test('derives provisional truth auction progress from loaded depth', () => {
+		const ethUnit = 10n ** 18n
+		const progress = getTruthAuctionOverviewProgress(
+			createTruthAuction({
+				clearingPrice: TRUTH_AUCTION_PRICE_PRECISION,
+				clearingTick: 10n,
+				ethAtClearingTick: 4n * ethUnit,
+				ethRaiseCap: 10n * ethUnit,
+				hitCap: true,
+				maxRepBeingSold: 100n * ethUnit,
+			}),
+			[
+				createTickSummary({ active: true, currentTotalEth: 8n * ethUnit, price: TRUTH_AUCTION_PRICE_PRECISION, tick: 12n }),
+				createTickSummary({ active: true, currentTotalEth: 6n * ethUnit, price: TRUTH_AUCTION_PRICE_PRECISION, tick: 10n }),
+				createTickSummary({ active: true, currentTotalEth: 5n * ethUnit, price: TRUTH_AUCTION_PRICE_PRECISION, tick: 8n }),
+			],
+		)
+
+		expect(progress).toEqual({
+			ethRaised: 10n * ethUnit,
+			repSold: 10n * ethUnit,
+		})
+	})
+
+	void test('sorts auction bids by price priority and bid index', () => {
+		const sortedBids = sortTruthAuctionBidsByPriority([createBid({ bidIndex: 3n, tick: 9n }), createBid({ bidIndex: 2n, tick: 11n }), createBid({ bidIndex: 1n, tick: 11n })])
+
+		expect(sortedBids.map(bid => getTruthAuctionSettlementBidKey(bid))).toEqual(['11:1', '11:2', '9:3'])
+	})
+
+	void test('derives mixed settlement selection and guard messages', () => {
+		const finalizedAuction = createTruthAuction({
+			clearingPrice: TRUTH_AUCTION_PRICE_PRECISION,
+			clearingTick: 10n,
+			ethAtClearingTick: 2n * 10n ** 18n,
+			finalized: true,
+			hitCap: true,
+			maxRepBeingSold: 100n * 10n ** 18n,
+			totalRepPurchased: 10n * 10n ** 18n,
+		})
+		const refundableBid = createBid({ bidIndex: 1n, tick: 9n })
+		const winningBid = createBid({ bidIndex: 2n, tick: 11n })
+		const otherWalletBid = createBid({ bidIndex: 3n, bidder: otherWalletAddress, tick: 12n })
+		const refundedBid = createBid({ bidIndex: 4n, refunded: true, tick: 8n })
+
+		expect(getTruthAuctionBidDisposition(winningBid, finalizedAuction).summaryKind).toBe('winning')
+		expect(getTruthAuctionBidDisposition(refundableBid, finalizedAuction).summaryKind).toBe('refundable')
+
+		const settlementRows = getTruthAuctionSettlementBidRows({
+			accountAddress: walletAddress,
+			truthAuction: finalizedAuction,
+			viewerBids: [refundableBid, winningBid, otherWalletBid, refundedBid],
+		})
+		const settlementSelection = getTruthAuctionSettlementSelectionState({
+			selectedBidKeys: settlementRows.map(({ bid }) => getTruthAuctionSettlementBidKey(bid)),
+			settlementBidRows: settlementRows,
+		})
+
+		expect(settlementRows.map(({ bid }) => getTruthAuctionSettlementBidKey(bid))).toEqual(['9:1', '11:2'])
+		expect(settlementSelection.selectionMode).toBe('mixed')
+		expect(settlementSelection.selectedRefundKeys).toEqual(['9:1'])
+		expect(settlementSelection.selectedClaimKeys).toEqual(['11:2'])
+		expect(
+			getTruthAuctionSettlementActionAvailabilityMessage({
+				claimingAvailable: false,
+				selectedClaimRows: settlementSelection.selectedClaimRows,
+				selectedRows: settlementSelection.selectedRows,
+				selectionHasClaims: settlementSelection.selectionHasClaims,
+				selectionHasRefunds: settlementSelection.selectionHasRefunds,
+				truthAuction: finalizedAuction,
+			}),
+		).toBe('Finalized settlement is not yet available for this pool.')
+		expect(
+			getTruthAuctionSettlementActionAvailabilityMessage({
+				claimingAvailable: true,
+				selectedClaimRows: settlementSelection.selectedClaimRows,
+				selectedRows: settlementSelection.selectedRows,
+				selectionHasClaims: settlementSelection.selectionHasClaims,
+				selectionHasRefunds: settlementSelection.selectionHasRefunds,
+				truthAuction: finalizedAuction,
+			}),
+		).toBeUndefined()
+	})
+
+	void test('builds truth auction bid row view models without component state', () => {
+		const finalizedAuction = createTruthAuction({
+			clearingTick: 10n,
+			finalized: true,
+			hitCap: true,
+		})
+		const rows = buildTruthAuctionBidRows({
+			bids: [createBid({ bidIndex: 1n, cumulativeEth: 3n, ethAmount: 2n, tick: 11n })],
+			truthAuction: finalizedAuction,
+		})
+
+		expect(rows).toEqual([
+			{
+				bidder: walletAddress,
+				cumulativeEth: 3n,
+				ethAmount: 2n,
+				key: 'aggregate:11:1',
+				price: getTruthAuctionPriceAtTick(11n),
+				statusLabel: 'Winning',
+				statusToneClassName: 'is-success',
+			},
+		])
+		expect(buildTruthAuctionBidRows({ bids: rows.map(row => createBid({ bidIndex: 1n, bidder: row.bidder, cumulativeEth: row.cumulativeEth, ethAmount: row.ethAmount, tick: 11n })), truthAuction: undefined })).toEqual([])
+	})
+
+	void test('builds viewer bid rows with settlement controls and local result status', () => {
+		const finalizedAuction = createTruthAuction({
+			clearingTick: 10n,
+			finalized: true,
+			hitCap: true,
+		})
+		const refundableBid = createBid({ bidIndex: 1n, tick: 9n })
+		const winningBid = createBid({ bidIndex: 2n, tick: 11n })
+		const otherWalletBid = createBid({ bidIndex: 3n, bidder: otherWalletAddress, tick: 12n })
+		const winningBidKey = getTruthAuctionSettlementBidKey(winningBid)
+		const rowsViewModel = buildViewerTruthAuctionBidRows({
+			accountAddress: walletAddress,
+			isSettlementInProgress: false,
+			selectedBidKeys: [winningBidKey],
+			selectedStage: 'settlement',
+			settlementResultByKey: {
+				[getTruthAuctionSettlementBidKey(refundableBid)]: 'refunded',
+			},
+			truthAuction: finalizedAuction,
+			viewerBids: [refundableBid, winningBid, otherWalletBid],
+		})
+
+		expect(rowsViewModel.showSettlementActionColumn).toBe(true)
+		expect(rowsViewModel.rows.map(row => row.statusLabel)).toEqual(['Refunded', 'Winning', 'Winning'])
+		expect(rowsViewModel.rows[0]?.settlementControl?.disabled).toBe(true)
+		expect(rowsViewModel.rows[1]?.settlementControl).toEqual({
+			ariaLabel: 'Select bid for settlement',
+			bidKey: winningBidKey,
+			checked: true,
+			disabled: false,
+			title: 'Select bid for settlement',
+		})
+		expect(rowsViewModel.rows[2]?.settlementControl?.ariaLabel).toBe('Bid is not settlement-eligible')
+		expect(updateTruthAuctionSettlementBidSelection([winningBidKey], winningBidKey, true)).toEqual([winningBidKey])
+		expect(updateTruthAuctionSettlementBidSelection([winningBidKey], '9:1', true)).toEqual([winningBidKey, '9:1'])
+		expect(updateTruthAuctionSettlementBidSelection([winningBidKey, '9:1'], winningBidKey, false)).toEqual(['9:1'])
 	})
 })

--- a/ui/ts/tests/importedForkSettlementSection.test.tsx
+++ b/ui/ts/tests/importedForkSettlementSection.test.tsx
@@ -1,0 +1,83 @@
+/// <reference types='bun-types' />
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { ImportedForkSettlementSection } from '../components/ImportedForkSettlementSection.js'
+import type { ReportingOutcomeKey } from '../types/contracts.js'
+import { installDomEnvironment } from './testUtils/domEnvironment.js'
+import { fireEvent, within } from './testUtils/queries.js'
+import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
+
+describe('ImportedForkSettlementSection', () => {
+	let restoreDomEnvironment: (() => void) | undefined
+	let cleanupRendered: (() => Promise<void>) | undefined
+
+	beforeEach(() => {
+		restoreDomEnvironment = installDomEnvironment().cleanup
+	})
+
+	afterEach(async () => {
+		await cleanupRendered?.()
+		cleanupRendered = undefined
+		restoreDomEnvironment?.()
+		restoreDomEnvironment = undefined
+	})
+
+	test('renders imported deposits and reports selection changes', async () => {
+		const selectionChanges: Array<{ checked: boolean; depositIndex: bigint; outcome: ReportingOutcomeKey }> = []
+		const renderedActions: Array<{ guardMessage: string | undefined; outcome: ReportingOutcomeKey; sideLabel: string }> = []
+		const rendered = await renderIntoDocument(
+			<ImportedForkSettlementSection
+				activeReportingDetails={undefined}
+				disabled={false}
+				onDepositSelectionChange={(outcome, depositIndex, checked) => {
+					selectionChanges.push({ checked, depositIndex, outcome })
+				}}
+				renderSettlementAction={props => {
+					renderedActions.push(props)
+					return (
+						<button disabled={props.guardMessage !== undefined} type='button'>
+							Settle {props.sideLabel}
+						</button>
+					)
+				}}
+				resolved={false}
+				selectedDepositIndexesByOutcome={{
+					invalid: [],
+					no: [],
+					yes: [7n],
+				}}
+				sides={[
+					{
+						importedUserDeposits: [
+							{
+								amount: 10n,
+								cumulativeAmount: 12n,
+								depositor: '0x0000000000000000000000000000000000000001',
+								parentDepositIndex: 7n,
+							},
+						],
+						key: 'yes',
+						label: 'Yes',
+					},
+				]}
+			/>,
+		)
+		cleanupRendered = rendered.cleanup
+
+		expect(within(document.body).getByRole('heading', { name: 'Settle Fork-Carried Escalation Deposits' })).not.toBeNull()
+		expect(within(document.body).getByText('Parent deposit #7')).not.toBeNull()
+		expect(within(document.body).getByText('Worth now: Pending final settlement')).not.toBeNull()
+		expect(renderedActions).toEqual([
+			{
+				guardMessage: 'Fork-carried escalation deposits can be settled after this child pool finalizes.',
+				outcome: 'yes',
+				sideLabel: 'Yes',
+			},
+		])
+
+		const checkbox = within(document.body).getByRole('checkbox') as HTMLInputElement
+		expect(checkbox.checked).toBe(true)
+		fireEvent.change(checkbox, { target: { checked: false } })
+		expect(selectionChanges).toEqual([{ checked: false, depositIndex: 7n, outcome: 'yes' }])
+	})
+})

--- a/ui/ts/tests/securityPoolWorkflow.test.ts
+++ b/ui/ts/tests/securityPoolWorkflow.test.ts
@@ -12,6 +12,7 @@ import {
 	getOraclePriceValidityPresentation,
 	getSelectedPoolCardTitle,
 	getSelectedPoolForkWorkflowView,
+	getForkWorkflowStageSelection,
 	getSelectedPoolOracleMetricValues,
 	getSelectedPoolViewForForkStage,
 	getSelectedPoolWorkflowGuardMessage,
@@ -159,6 +160,60 @@ void describe('selected pool workflow lookup state', () => {
 				systemState: 'operational',
 			}),
 		).toBe('settlement')
+	})
+
+	void test('derives current and selected fork workflow stages together', () => {
+		expect(
+			getForkWorkflowStageSelection({
+				currentStageView: undefined,
+				forkAuctionDetails: undefined,
+				forkOutcome: 'none',
+				previewPool: undefined,
+				selectedStageView: undefined,
+				stageView: undefined,
+				systemState: undefined,
+			}),
+		).toEqual({
+			currentStage: 'initiate',
+			currentWorkflowStage: 'fork-triggered',
+			selectedStage: 'fork-triggered',
+		})
+
+		expect(
+			getForkWorkflowStageSelection({
+				currentStageView: undefined,
+				forkAuctionDetails: {
+					claimingAvailable: false,
+					hasForkActivity: true,
+					migratedRep: 5n,
+					truthAuction: {
+						finalized: false,
+					},
+					truthAuctionStartedAt: 10n,
+				},
+				forkOutcome: 'yes',
+				previewPool: undefined,
+				selectedStageView: 'settlement',
+				stageView: undefined,
+				systemState: 'forkTruthAuction',
+			}),
+		).toEqual({
+			currentStage: 'auction',
+			currentWorkflowStage: 'auction',
+			selectedStage: 'settlement',
+		})
+
+		expect(
+			getForkWorkflowStageSelection({
+				currentStageView: 'migration',
+				forkAuctionDetails: undefined,
+				forkOutcome: 'none',
+				previewPool: undefined,
+				selectedStageView: undefined,
+				stageView: 'initiate',
+				systemState: 'poolForked',
+			}).selectedStage,
+		).toBe('fork-triggered')
 	})
 
 	void test('ignores stale non-operational fork-auction details once the selected pool is operational again', () => {

--- a/ui/ts/tests/truthAuctionBidsSection.test.tsx
+++ b/ui/ts/tests/truthAuctionBidsSection.test.tsx
@@ -1,0 +1,146 @@
+/// <reference types='bun-types' />
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import type { ComponentChildren } from 'preact'
+import type { Address } from 'viem'
+import { TruthAuctionBidsSection, ViewerTruthAuctionBidsSection } from '../components/TruthAuctionBidsSection.js'
+import { installDomEnvironment } from './testUtils/domEnvironment.js'
+import { fireEvent, within } from './testUtils/queries.js'
+import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
+
+const walletAddress: Address = '0x0000000000000000000000000000000000000001'
+
+function renderPriceValue(value: bigint | undefined): ComponentChildren {
+	if (value === undefined) return 'No price'
+	return `Price ${value.toString()}`
+}
+
+describe('TruthAuctionBidsSection', () => {
+	let restoreDomEnvironment: (() => void) | undefined
+	let cleanupRendered: (() => Promise<void>) | undefined
+
+	beforeEach(() => {
+		restoreDomEnvironment = installDomEnvironment().cleanup
+	})
+
+	afterEach(async () => {
+		await cleanupRendered?.()
+		cleanupRendered = undefined
+		restoreDomEnvironment?.()
+		restoreDomEnvironment = undefined
+	})
+
+	test('shows auction bid loading and empty states', async () => {
+		const rendered = await renderIntoDocument(<TruthAuctionBidsSection aggregatedAuctionBidCountForLoadedTicks={0n} hasMoreAggregatedAuctionBids={false} loadedTickCount={0} loadingAggregatedAuctionBids={true} onLoadNextAuctionBidPage={() => undefined} renderPriceValue={renderPriceValue} rows={[]} />)
+		cleanupRendered = rendered.cleanup
+
+		expect(within(document.body).getByRole('heading', { name: 'Truth Auction Bids' })).not.toBeNull()
+		expect(within(document.body).getByText(/Loading auction bids/)).not.toBeNull()
+
+		await rendered.unmount()
+		cleanupRendered = undefined
+		const emptyRendered = await renderIntoDocument(<TruthAuctionBidsSection aggregatedAuctionBidCountForLoadedTicks={0n} hasMoreAggregatedAuctionBids={false} loadedTickCount={0} loadingAggregatedAuctionBids={false} onLoadNextAuctionBidPage={() => undefined} renderPriceValue={renderPriceValue} rows={[]} />)
+		cleanupRendered = emptyRendered.cleanup
+
+		expect(within(document.body).getByText('No active prices are currently visible for this auction.')).not.toBeNull()
+	})
+
+	test('renders auction bid rows and load-more action', async () => {
+		let loadMoreCalls = 0
+		const rendered = await renderIntoDocument(
+			<TruthAuctionBidsSection
+				aggregatedAuctionBidCountForLoadedTicks={3n}
+				hasMoreAggregatedAuctionBids={true}
+				loadedTickCount={2}
+				loadingAggregatedAuctionBids={false}
+				onLoadNextAuctionBidPage={() => {
+					loadMoreCalls += 1
+				}}
+				renderPriceValue={renderPriceValue}
+				rows={[
+					{
+						bidder: walletAddress,
+						cumulativeEth: 5n,
+						ethAmount: 2n,
+						key: 'aggregate:11:1',
+						price: 42n,
+						statusLabel: 'Winning',
+						statusToneClassName: 'is-success',
+					},
+				]}
+			/>,
+		)
+		cleanupRendered = rendered.cleanup
+
+		expect(within(document.body).getByText('Price 42')).not.toBeNull()
+		expect(within(document.body).getByText('Winning')).not.toBeNull()
+		fireEvent.click(within(document.body).getByRole('button', { name: 'Load More Truth Auction Bids' }))
+		expect(loadMoreCalls).toBe(1)
+	})
+})
+
+describe('ViewerTruthAuctionBidsSection', () => {
+	let restoreDomEnvironment: (() => void) | undefined
+	let cleanupRendered: (() => Promise<void>) | undefined
+
+	beforeEach(() => {
+		restoreDomEnvironment = installDomEnvironment().cleanup
+	})
+
+	afterEach(async () => {
+		await cleanupRendered?.()
+		cleanupRendered = undefined
+		restoreDomEnvironment?.()
+		restoreDomEnvironment = undefined
+	})
+
+	test('prompts for a wallet before showing viewer bids', async () => {
+		const rendered = await renderIntoDocument(
+			<ViewerTruthAuctionBidsSection accountAddress={undefined} hasMoreViewerBids={false} loadingTruthAuctionBook={false} onLoadNextViewerBidPage={() => undefined} onSettlementBidSelectionChange={() => undefined} renderPriceValue={renderPriceValue} rows={[]} showSettlementActionColumn={false} />,
+		)
+		cleanupRendered = rendered.cleanup
+
+		expect(within(document.body).getByText('Connect a wallet to inspect your submitted truth auction bids.')).not.toBeNull()
+		expect(document.body.querySelector('input[type="checkbox"]')).toBeNull()
+	})
+
+	test('renders settlement controls and emits selection changes', async () => {
+		const selectionChanges: Array<{ bidKey: string; checked: boolean }> = []
+		const rendered = await renderIntoDocument(
+			<ViewerTruthAuctionBidsSection
+				accountAddress={walletAddress}
+				hasMoreViewerBids={true}
+				loadingTruthAuctionBook={false}
+				onLoadNextViewerBidPage={() => undefined}
+				onSettlementBidSelectionChange={(bidKey, checked) => {
+					selectionChanges.push({ bidKey, checked })
+				}}
+				renderPriceValue={renderPriceValue}
+				rows={[
+					{
+						ethAmount: 2n,
+						key: 'viewer:11:1',
+						price: 42n,
+						settlementControl: {
+							ariaLabel: 'Select bid for settlement',
+							bidKey: '11:1',
+							checked: false,
+							disabled: false,
+							title: 'Select bid for settlement',
+						},
+						statusLabel: 'Winning',
+						statusToneClassName: 'is-success',
+					},
+				]}
+				showSettlementActionColumn={true}
+			/>,
+		)
+		cleanupRendered = rendered.cleanup
+
+		const checkbox = within(document.body).getByRole('checkbox', { name: 'Select bid for settlement' }) as HTMLInputElement
+		expect(checkbox.disabled).toBe(false)
+		fireEvent.change(checkbox, { target: { checked: true } })
+		expect(selectionChanges).toEqual([{ bidKey: '11:1', checked: true }])
+		expect(within(document.body).getByRole('button', { name: 'Load More Of My Bids' })).not.toBeNull()
+	})
+})

--- a/ui/ts/tests/truthAuctionHooks.test.tsx
+++ b/ui/ts/tests/truthAuctionHooks.test.tsx
@@ -1,0 +1,353 @@
+/// <reference types="bun-types" />
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { useState } from 'preact/hooks'
+import { act } from 'preact/test-utils'
+import type { Address } from 'viem'
+import { useTruthAuctionPaginationState } from '../hooks/useTruthAuctionPaginationState.js'
+import { useTruthAuctionSettlementActionState } from '../hooks/useTruthAuctionSettlementActionState.js'
+import type { TruthAuctionBidDisposition } from '../lib/truthAuctionBook.js'
+import { getTruthAuctionSettlementBidKey, type TruthAuctionSettlementBidRow } from '../lib/truthAuctionSettlement.js'
+import type { ForkAuctionActionResult, TruthAuctionBidView } from '../types/contracts.js'
+import type { SettlementSelectedBid } from '../types/components.js'
+import { installDomEnvironment } from './testUtils/domEnvironment.js'
+import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
+
+const walletAddress: Address = '0x0000000000000000000000000000000000000001'
+const poolAddress: Address = '0x0000000000000000000000000000000000000100'
+const truthAuctionAddress: Address = '0x0000000000000000000000000000000000000200'
+const otherTruthAuctionAddress: Address = '0x0000000000000000000000000000000000000201'
+
+type HarnessSetter<T> = (nextState: T | ((currentState: T) => T)) => void
+type PaginationState = ReturnType<typeof useTruthAuctionPaginationState>
+type PaginationProps = Parameters<typeof useTruthAuctionPaginationState>[0]
+type SettlementState = ReturnType<typeof useTruthAuctionSettlementActionState>
+type SettlementProps = Parameters<typeof useTruthAuctionSettlementActionState>[0]
+
+const claimDisposition: TruthAuctionBidDisposition = {
+	canPrefillRefund: false,
+	canPrefillSettle: true,
+	label: 'Winning',
+	settlementKind: 'repClaim',
+	summaryKind: 'winning',
+	tone: 'success',
+}
+
+const refundDisposition: TruthAuctionBidDisposition = {
+	canPrefillRefund: true,
+	canPrefillSettle: false,
+	label: 'Refundable',
+	settlementKind: 'ethRefund',
+	summaryKind: 'refundable',
+	tone: 'danger',
+}
+
+function requireHookState<T>(state: T | undefined) {
+	if (state === undefined) throw new Error('Hook state is unavailable')
+	return state
+}
+
+function requireHarnessSetter<T>(setter: HarnessSetter<T> | undefined) {
+	if (setter === undefined) throw new Error('Harness setter is unavailable')
+	return setter
+}
+
+function createBid({ bidIndex, tick }: { bidIndex: bigint; tick: bigint }): TruthAuctionBidView {
+	return {
+		activeCumulativeEthBeforeBid: 0n,
+		bidIndex,
+		bidder: walletAddress,
+		claimed: false,
+		cumulativeEth: 1n,
+		ethAmount: 1n,
+		refunded: false,
+		tick,
+	}
+}
+
+function createSettlementRow({ bidIndex, disposition, tick }: { bidIndex: bigint; disposition: TruthAuctionBidDisposition; tick: bigint }): TruthAuctionSettlementBidRow {
+	return {
+		bid: createBid({ bidIndex, tick }),
+		disposition,
+	}
+}
+
+function createForkAuctionResult(action: ForkAuctionActionResult['action'], hash: ForkAuctionActionResult['hash']): ForkAuctionActionResult {
+	return {
+		action,
+		hash,
+		securityPoolAddress: poolAddress,
+		universeId: 1n,
+	}
+}
+
+describe('truth auction hooks', () => {
+	let cleanupDom: (() => void) | undefined
+	let cleanupRenderedComponent: (() => Promise<void>) | undefined
+
+	beforeEach(() => {
+		cleanupDom = installDomEnvironment().cleanup
+	})
+
+	afterEach(async () => {
+		await cleanupRenderedComponent?.()
+		cleanupRenderedComponent = undefined
+		cleanupDom?.()
+		cleanupDom = undefined
+	})
+
+	test('increments pagination counts and resets them when auction context changes', async () => {
+		let hookState: PaginationState | undefined
+		let setHarnessProps: HarnessSetter<PaginationProps> | undefined
+		const initialProps: PaginationProps = {
+			accountAddress: walletAddress,
+			truthAuctionAddress,
+		}
+
+		function Harness() {
+			const [props, setProps] = useState(initialProps)
+			setHarnessProps = setProps
+			hookState = useTruthAuctionPaginationState(props)
+			return <div />
+		}
+
+		const rendered = await renderIntoDocument(<Harness />)
+		cleanupRenderedComponent = rendered.cleanup
+
+		expect(requireHookState(hookState).loadedTickPageCount).toBe(1)
+		expect(requireHookState(hookState).loadedViewerBidPageCount).toBe(1)
+		expect(requireHookState(hookState).loadedAuctionBidPageCount).toBe(1)
+
+		await act(() => {
+			requireHookState(hookState).loadNextTickPage()
+			requireHookState(hookState).loadNextViewerBidPage()
+			requireHookState(hookState).loadNextAuctionBidPage()
+		})
+
+		expect(requireHookState(hookState).loadedTickPageCount).toBe(2)
+		expect(requireHookState(hookState).loadedViewerBidPageCount).toBe(2)
+		expect(requireHookState(hookState).loadedAuctionBidPageCount).toBe(2)
+
+		await act(() => {
+			requireHarnessSetter(setHarnessProps)(currentProps => ({
+				...currentProps,
+				truthAuctionAddress: otherTruthAuctionAddress,
+			}))
+		})
+
+		expect(requireHookState(hookState).loadedTickPageCount).toBe(1)
+		expect(requireHookState(hookState).loadedViewerBidPageCount).toBe(1)
+		expect(requireHookState(hookState).loadedAuctionBidPageCount).toBe(1)
+	})
+
+	test('routes refund-only settlement through refund action and reconciles the result', async () => {
+		const refundRow = createSettlementRow({ bidIndex: 2n, disposition: refundDisposition, tick: 8n })
+		const refundKey = getTruthAuctionSettlementBidKey(refundRow.bid)
+		const claimCalls: Array<{ bids: readonly SettlementSelectedBid[] | undefined; pool: Address | undefined }> = []
+		const refundCalls: Array<{ bids: readonly SettlementSelectedBid[] | undefined; pool: Address | undefined }> = []
+		let hookState: SettlementState | undefined
+		let setHarnessProps: HarnessSetter<SettlementProps> | undefined
+		const initialProps: SettlementProps = {
+			accountAddress: walletAddress,
+			forkAuctionError: undefined,
+			forkAuctionResult: undefined,
+			onClaimAuctionProceeds: (pool, claimBids) => {
+				claimCalls.push({ bids: claimBids, pool })
+			},
+			onRefundLosingBids: (pool, bids) => {
+				refundCalls.push({ bids, pool })
+			},
+			selectedAuctionPoolAddress: poolAddress,
+			selectedStage: 'settlement',
+			settlementBidRows: [refundRow],
+		}
+
+		function Harness() {
+			const [props, setProps] = useState(initialProps)
+			setHarnessProps = setProps
+			hookState = useTruthAuctionSettlementActionState(props)
+			return <div />
+		}
+
+		const rendered = await renderIntoDocument(<Harness />)
+		cleanupRenderedComponent = rendered.cleanup
+
+		await act(() => {
+			requireHookState(hookState).setSelectedSettlementBidKeys([refundKey])
+		})
+		await act(() => {
+			requireHookState(hookState).submitSelectedSettlementBids()
+		})
+
+		expect(claimCalls).toHaveLength(0)
+		expect(refundCalls).toEqual([{ bids: [{ bidIndex: 2n, tick: 8n }], pool: poolAddress }])
+		expect(requireHookState(hookState).isSettleSelectedBidsInProgress).toBe(true)
+
+		await act(() => {
+			requireHarnessSetter(setHarnessProps)(currentProps => ({
+				...currentProps,
+				forkAuctionResult: createForkAuctionResult('refundLosingBids', '0xbbbb'),
+			}))
+		})
+
+		expect(requireHookState(hookState).isSettleSelectedBidsInProgress).toBe(false)
+		expect(requireHookState(hookState).selectedSettlementBidKeys).toEqual([])
+		expect(requireHookState(hookState).settlementBidResultByKey[refundKey]).toBe('refunded')
+		expect(requireHookState(hookState).settlementBidResultRefreshToken).toBe(1)
+	})
+
+	test('settles mixed claim and refund selections through the combined claim action', async () => {
+		const claimRow = createSettlementRow({ bidIndex: 1n, disposition: claimDisposition, tick: 11n })
+		const refundRow = createSettlementRow({ bidIndex: 2n, disposition: refundDisposition, tick: 8n })
+		const claimKey = getTruthAuctionSettlementBidKey(claimRow.bid)
+		const refundKey = getTruthAuctionSettlementBidKey(refundRow.bid)
+		const claimCalls: Array<{ claimBids: readonly SettlementSelectedBid[] | undefined; pool: Address | undefined; refundBids: readonly SettlementSelectedBid[] | undefined }> = []
+		let hookState: SettlementState | undefined
+		let setHarnessProps: HarnessSetter<SettlementProps> | undefined
+		const initialProps: SettlementProps = {
+			accountAddress: walletAddress,
+			forkAuctionError: undefined,
+			forkAuctionResult: undefined,
+			onClaimAuctionProceeds: (pool, claimBids, refundBids) => {
+				claimCalls.push({ claimBids, pool, refundBids })
+			},
+			onRefundLosingBids: () => undefined,
+			selectedAuctionPoolAddress: poolAddress,
+			selectedStage: 'settlement',
+			settlementBidRows: [claimRow, refundRow],
+		}
+
+		function Harness() {
+			const [props, setProps] = useState(initialProps)
+			setHarnessProps = setProps
+			hookState = useTruthAuctionSettlementActionState(props)
+			return <div />
+		}
+
+		const rendered = await renderIntoDocument(<Harness />)
+		cleanupRenderedComponent = rendered.cleanup
+
+		await act(() => {
+			requireHookState(hookState).setSelectedSettlementBidKeys([claimKey, refundKey])
+		})
+		await act(() => {
+			requireHookState(hookState).submitSelectedSettlementBids()
+		})
+
+		expect(claimCalls).toEqual([
+			{
+				claimBids: [{ bidIndex: 1n, tick: 11n }],
+				pool: poolAddress,
+				refundBids: [{ bidIndex: 2n, tick: 8n }],
+			},
+		])
+
+		await act(() => {
+			requireHarnessSetter(setHarnessProps)(currentProps => ({
+				...currentProps,
+				forkAuctionResult: createForkAuctionResult('claimAuctionProceeds', '0xcccc'),
+			}))
+		})
+
+		expect(requireHookState(hookState).settlementBidResultByKey[claimKey]).toBe('claimed')
+		expect(requireHookState(hookState).settlementBidResultByKey[refundKey]).toBe('refunded')
+		expect(requireHookState(hookState).settlementBidResultRefreshToken).toBe(1)
+	})
+
+	test('ignores a stale matching transaction result when a new settlement is submitted', async () => {
+		const claimRow = createSettlementRow({ bidIndex: 1n, disposition: claimDisposition, tick: 11n })
+		const claimKey = getTruthAuctionSettlementBidKey(claimRow.bid)
+		let hookState: SettlementState | undefined
+		let setHarnessProps: HarnessSetter<SettlementProps> | undefined
+		const initialProps: SettlementProps = {
+			accountAddress: walletAddress,
+			forkAuctionError: undefined,
+			forkAuctionResult: createForkAuctionResult('claimAuctionProceeds', '0xdddd'),
+			onClaimAuctionProceeds: () => undefined,
+			onRefundLosingBids: () => undefined,
+			selectedAuctionPoolAddress: poolAddress,
+			selectedStage: 'settlement',
+			settlementBidRows: [claimRow],
+		}
+
+		function Harness() {
+			const [props, setProps] = useState(initialProps)
+			setHarnessProps = setProps
+			hookState = useTruthAuctionSettlementActionState(props)
+			return <div />
+		}
+
+		const rendered = await renderIntoDocument(<Harness />)
+		cleanupRenderedComponent = rendered.cleanup
+
+		await act(() => {
+			requireHookState(hookState).setSelectedSettlementBidKeys([claimKey])
+		})
+		await act(() => {
+			requireHookState(hookState).submitSelectedSettlementBids()
+		})
+
+		expect(requireHookState(hookState).isSettleSelectedBidsInProgress).toBe(true)
+		expect(requireHookState(hookState).settlementBidResultByKey[claimKey]).toBeUndefined()
+
+		await act(() => {
+			requireHarnessSetter(setHarnessProps)(currentProps => ({
+				...currentProps,
+				forkAuctionResult: createForkAuctionResult('claimAuctionProceeds', '0xeeee'),
+			}))
+		})
+
+		expect(requireHookState(hookState).isSettleSelectedBidsInProgress).toBe(false)
+		expect(requireHookState(hookState).settlementBidResultByKey[claimKey]).toBe('claimed')
+	})
+
+	test('prunes settlement selections when available rows or workflow stage changes', async () => {
+		const claimRow = createSettlementRow({ bidIndex: 1n, disposition: claimDisposition, tick: 11n })
+		const refundRow = createSettlementRow({ bidIndex: 2n, disposition: refundDisposition, tick: 8n })
+		const claimKey = getTruthAuctionSettlementBidKey(claimRow.bid)
+		const refundKey = getTruthAuctionSettlementBidKey(refundRow.bid)
+		let hookState: SettlementState | undefined
+		let setHarnessProps: HarnessSetter<SettlementProps> | undefined
+		const initialProps: SettlementProps = {
+			accountAddress: walletAddress,
+			forkAuctionError: undefined,
+			forkAuctionResult: undefined,
+			onClaimAuctionProceeds: () => undefined,
+			onRefundLosingBids: () => undefined,
+			selectedAuctionPoolAddress: poolAddress,
+			selectedStage: 'settlement',
+			settlementBidRows: [claimRow, refundRow],
+		}
+
+		function Harness() {
+			const [props, setProps] = useState(initialProps)
+			setHarnessProps = setProps
+			hookState = useTruthAuctionSettlementActionState(props)
+			return <div />
+		}
+
+		const rendered = await renderIntoDocument(<Harness />)
+		cleanupRenderedComponent = rendered.cleanup
+
+		await act(() => {
+			requireHookState(hookState).setSelectedSettlementBidKeys([claimKey, refundKey])
+		})
+		await act(() => {
+			requireHarnessSetter(setHarnessProps)(currentProps => ({
+				...currentProps,
+				settlementBidRows: [claimRow],
+			}))
+		})
+
+		expect(requireHookState(hookState).selectedSettlementBidKeys).toEqual([claimKey])
+
+		await act(() => {
+			requireHarnessSetter(setHarnessProps)(currentProps => ({
+				...currentProps,
+				selectedStage: 'migration',
+			}))
+		})
+
+		expect(requireHookState(hookState).selectedSettlementBidKeys).toEqual([])
+	})
+})

--- a/ui/ts/tests/truthAuctionSettlementActionState.test.ts
+++ b/ui/ts/tests/truthAuctionSettlementActionState.test.ts
@@ -1,0 +1,117 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from 'bun:test'
+import { createTruthAuctionSettlementActionState, reduceTruthAuctionSettlementActionState } from '../lib/truthAuctionSettlementActionState.js'
+
+describe('truth auction settlement action reducer', () => {
+	test('marks mixed claim and refund results after a combined settlement succeeds', () => {
+		const selectedState = reduceTruthAuctionSettlementActionState(createTruthAuctionSettlementActionState(), {
+			selectedBidKeys: ['11:1', '8:2'],
+			type: 'selectBidKeys',
+		})
+		const submittedState = reduceTruthAuctionSettlementActionState(selectedState, {
+			action: 'claimAuctionProceeds',
+			claimKeys: ['11:1'],
+			ignoredResultHash: undefined,
+			refundKeys: ['8:2'],
+			type: 'submit',
+		})
+
+		const succeededState = reduceTruthAuctionSettlementActionState(submittedState, {
+			action: 'claimAuctionProceeds',
+			type: 'transactionSucceeded',
+		})
+
+		expect(succeededState.pendingAction).toBeUndefined()
+		expect(succeededState.refreshToken).toBe(1)
+		expect(succeededState.selectedBidKeys).toEqual([])
+		expect(succeededState.resultByKey).toEqual({
+			'11:1': 'claimed',
+			'8:2': 'refunded',
+		})
+	})
+
+	test('clears pending state without mutating selected bids when a transaction fails', () => {
+		const selectedState = reduceTruthAuctionSettlementActionState(createTruthAuctionSettlementActionState(), {
+			selectedBidKeys: ['8:2'],
+			type: 'selectBidKeys',
+		})
+		const submittedState = reduceTruthAuctionSettlementActionState(selectedState, {
+			action: 'refundLosingBids',
+			claimKeys: [],
+			ignoredResultHash: '0xaaaa',
+			refundKeys: ['8:2'],
+			type: 'submit',
+		})
+
+		const failedState = reduceTruthAuctionSettlementActionState(submittedState, {
+			type: 'transactionFailed',
+		})
+
+		expect(failedState.pendingAction).toBeUndefined()
+		expect(failedState.refreshToken).toBe(0)
+		expect(failedState.selectedBidKeys).toEqual(['8:2'])
+		expect(failedState.resultByKey).toEqual({})
+	})
+
+	test('prunes unavailable selected bids, local results, and pending bid keys', () => {
+		const selectedState = reduceTruthAuctionSettlementActionState(createTruthAuctionSettlementActionState(), {
+			selectedBidKeys: ['11:1', '8:2', '7:3'],
+			type: 'selectBidKeys',
+		})
+		const submittedState = reduceTruthAuctionSettlementActionState(
+			{
+				...selectedState,
+				resultByKey: {
+					'7:3': 'refunded',
+					'8:2': 'refunded',
+				},
+			},
+			{
+				action: 'claimAuctionProceeds',
+				claimKeys: ['11:1'],
+				ignoredResultHash: undefined,
+				refundKeys: ['8:2', '7:3'],
+				type: 'submit',
+			},
+		)
+
+		const prunedState = reduceTruthAuctionSettlementActionState(submittedState, {
+			availableBidKeys: ['11:1', '8:2'],
+			type: 'pruneUnavailableBids',
+		})
+
+		expect(prunedState.selectedBidKeys).toEqual(['11:1', '8:2'])
+		expect(prunedState.resultByKey).toEqual({
+			'8:2': 'refunded',
+		})
+		expect(prunedState.pendingAction).toEqual({
+			action: 'claimAuctionProceeds',
+			claimKeys: ['11:1'],
+			ignoredResultHash: undefined,
+			refundKeys: ['8:2'],
+		})
+	})
+
+	test('reset preserves refresh token while clearing local settlement state', () => {
+		const state = {
+			pendingAction: undefined,
+			refreshToken: 3,
+			resultByKey: {
+				'8:2': 'refunded' as const,
+			},
+			selectedBidKeys: ['8:2'],
+		}
+
+		const resetState = reduceTruthAuctionSettlementActionState(state, {
+			type: 'reset',
+		})
+
+		expect(resetState).toEqual({
+			pendingAction: undefined,
+			refreshToken: 3,
+			resultByKey: {},
+			selectedBidKeys: [],
+		})
+	})
+})


### PR DESCRIPTION
## Summary
- Split fork truth-auction flow into dedicated modules by introducing new UI components, hooks, and lib abstractions for bids, settlement state, book data, and pagination.
- Replaced legacy reporting/truth-auction reporting plumbing with a new transaction/action model and updated operation hooks, tray actions, and marketplace views.
- Simplified and de-duplicated contract interaction surface by moving auction/fork-specific wiring in `ui/ts/contracts` and adjusting related deployment/integration hooks.
- Removed outdated operator/reference docs and simplified auction documentation in `docs/auction-design.md` and `docs/whitepaper_placeholder.html`.
- Updated tests to cover the new truth-auction modules and removed obsolete test coverage tied to deleted modules.

## Testing
- Not run (not requested): `bun run tsc`
- Not run (not requested): `bun run test`
- Not run (not requested): `bun run format`
- Not run (not requested): `bun run check`
- Not run (not requested): `bun run knip`