### PR TITLE
Introduce manifest-based coverage source-map gap exclusions

### DIFF
--- a/solidity/ts/coverage/sourceMapCoverageGaps.ts
+++ b/solidity/ts/coverage/sourceMapCoverageGaps.ts
@@ -1,0 +1,61 @@
+interface KnownSourceMapCoverageGapContext {
+	readonly maxPreviousLines: number
+	readonly linePattern: RegExp
+}
+
+export interface KnownSourceMapCoverageGapLineRule {
+	readonly currentSourceMatches: number
+	readonly linePattern: RegExp
+	readonly precededBy?: KnownSourceMapCoverageGapContext
+}
+
+interface KnownSourceMapCoverageGapFileRule {
+	readonly sourcePath: string
+	readonly lineRules: readonly KnownSourceMapCoverageGapLineRule[]
+}
+
+// Source-map ranges with adjacent executed PCs but no traceable PC for the line itself.
+export const knownSourceMapCoverageGaps = [
+	{
+		sourcePath: 'solidity/contracts/peripherals/SecurityPoolForkerVaultMigrationBase.sol',
+		lineRules: [{ currentSourceMatches: 1, linePattern: /^[A-Za-z_][A-Za-z0-9_]*\s*=\s*_[A-Za-z_][A-Za-z0-9_]*;$/ }],
+	},
+	{
+		sourcePath: 'solidity/contracts/peripherals/tokens/ERC1155.sol',
+		lineRules: [
+			{ currentSourceMatches: 1, linePattern: /^return\s+[A-Za-z_][A-Za-z0-9_]*;$/ },
+			{ currentSourceMatches: 2, linePattern: /^_transferFrom\s*\(\s*[^,]+,\s*[^,]+,\s*[^,]+,\s*[^,]+,\s*''\s*\);$/ },
+		],
+	},
+	{
+		sourcePath: 'solidity/contracts/peripherals/EscalationGameSettlement.sol',
+		lineRules: [
+			{
+				currentSourceMatches: 3,
+				linePattern: /^require\s*\(\s*[A-Za-z_][A-Za-z0-9_]*\s*!=\s*BinaryOutcomes\.BinaryOutcome\.None,\s*'No outcome'\s*\);$/,
+				precededBy: {
+					maxPreviousLines: 8,
+					linePattern: /^uint256\s+[A-Za-z_][A-Za-z0-9_]*Index,?$/,
+				},
+			},
+		],
+	},
+	{
+		sourcePath: 'solidity/contracts/peripherals/EscalationGameEscrow.sol',
+		lineRules: [
+			{ currentSourceMatches: 1, linePattern: /^uint256\s+[A-Za-z_][A-Za-z0-9_]*\s*=\s*state\.sourcePrincipalClaimed\s*\+\s*[A-Za-z_][A-Za-z0-9_]*;$/ },
+			{ currentSourceMatches: 1, linePattern: /^state\.sourcePrincipalClaimed\s*=\s*next[A-Za-z_][A-Za-z0-9_]*;$/ },
+			{ currentSourceMatches: 1, linePattern: /^state\.childRepClaimed\s*=\s*next[A-Za-z_][A-Za-z0-9_]*;$/ },
+		],
+	},
+	{
+		sourcePath: 'solidity/contracts/peripherals/EscalationGameCarry.sol',
+		lineRules: [
+			{ currentSourceMatches: 1, linePattern: /^if\s*\([A-Za-z_][A-Za-z0-9_]*\s*!=\s*bytes32\(0\)\)\s*return\s+[A-Za-z_][A-Za-z0-9_]*;$/ },
+			{ currentSourceMatches: 1, linePattern: /^require\s*\(\s*[A-Za-z_][A-Za-z0-9_]*\.length\s*==\s*NULLIFIER_DEPTH,\s*'Bad nullifier length'\s*\);$/ },
+			{ currentSourceMatches: 1, linePattern: /^bytes32\s+[A-Za-z_][A-Za-z0-9_]*\s*=\s*_getCurrentNullifierRoot\s*\(\s*[A-Za-z_][A-Za-z0-9_]*\s*\);$/ },
+			{ currentSourceMatches: 1, linePattern: /^require\s*\(\s*[A-Za-z_][A-Za-z0-9_]*\s*==\s*[A-Za-z_][A-Za-z0-9_]*,\s*'Bad nullifier proof'\s*\);$/ },
+			{ currentSourceMatches: 1, linePattern: /^if\s*\(\s*[A-Za-z_][A-Za-z0-9_]*\s*>\s*inheritedAmountToConsume\s*\)\s*\{$/ },
+		],
+	},
+] satisfies readonly KnownSourceMapCoverageGapFileRule[]

--- a/solidity/ts/coverage/traceToSource.ts
+++ b/solidity/ts/coverage/traceToSource.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'node:fs'
 import { buildPcToSourceMap, normalizeBytecode, type ParsedSourceMapSegment } from './sourceMapParser'
 import { getSolidityBytecodeCoverageConfig, isSolidityBytecodeCoverageEnabled } from './coverageConfig'
 import { writeCoverageArtifacts } from './reporter'
+import { knownSourceMapCoverageGaps, type KnownSourceMapCoverageGapLineRule } from './sourceMapCoverageGaps'
 
 type RpcRequest = (args: { method: string; params?: unknown[] | undefined }) => Promise<unknown>
 
@@ -356,32 +357,35 @@ const isSolidityCallStatementLine = (line: string): boolean => {
 	return line.endsWith(';') || line.endsWith('(') || line.includes(');')
 }
 
-// These source-map ranges have adjacent executed PCs but no traceable PC for the line itself.
-const isKnownSourceMapCoverageGapLine = (absoluteSourcePath: string, lines: readonly string[], lineIndex: number): boolean => {
+const sourcePathMatchesKnownGap = (absoluteSourcePath: string, sourcePath: string): boolean => {
+	const normalizedAbsoluteSourcePath = absoluteSourcePath.replaceAll('\\', '/')
+	return normalizedAbsoluteSourcePath === sourcePath || normalizedAbsoluteSourcePath.endsWith(`/${sourcePath}`)
+}
+
+const isKnownSourceMapCoverageGapRuleMatch = (rule: KnownSourceMapCoverageGapLineRule, lines: readonly string[], lineIndex: number): boolean => {
 	const line = lines[lineIndex]
-	if (absoluteSourcePath.endsWith('/solidity/contracts/peripherals/SecurityPoolForkerVaultMigrationBase.sol')) {
-		return line === 'zoltar = _zoltar;'
-	}
-	if (absoluteSourcePath.endsWith('/solidity/contracts/peripherals/tokens/ERC1155.sol')) {
-		return line === 'return batchBalances;' || line === "_transferFrom(from, to, id, value, '');"
-	}
-	if (absoluteSourcePath.endsWith('/solidity/contracts/peripherals/EscalationGameSettlement.sol')) {
-		const localExportContext = lines.slice(Math.max(0, lineIndex - 8), lineIndex).some(previousLine => previousLine.includes('uint256 depositIndex'))
-		return localExportContext && line === "require(outcome != BinaryOutcomes.BinaryOutcome.None, 'No outcome');"
-	}
-	if (absoluteSourcePath.endsWith('/solidity/contracts/peripherals/EscalationGameEscrow.sol')) {
-		return line === 'uint256 nextSourcePrincipalClaimed = state.sourcePrincipalClaimed + sourcePrincipalToClaim;' || line === 'state.sourcePrincipalClaimed = nextSourcePrincipalClaimed;' || line === 'state.childRepClaimed = nextChildRepClaimed;'
-	}
-	if (absoluteSourcePath.endsWith('/solidity/contracts/peripherals/EscalationGameCarry.sol')) {
-		return (
-			line === 'if (root != bytes32(0)) return root;' ||
-			line === "require(siblings.length == NULLIFIER_DEPTH, 'Bad nullifier length');" ||
-			line === 'bytes32 currentRoot = _getCurrentNullifierRoot(outcomeIndex);' ||
-			line === "require(emptyRoot == currentRoot, 'Bad nullifier proof');" ||
-			line === 'if (amount > inheritedAmountToConsume) {'
-		)
+	if (line === undefined || !rule.linePattern.test(line)) return false
+	const precedingRule = rule.precededBy
+	if (precedingRule === undefined) return true
+	const startIndex = Math.max(0, lineIndex - precedingRule.maxPreviousLines)
+	for (let previousLineIndex = startIndex; previousLineIndex < lineIndex; previousLineIndex++) {
+		const previousLine = lines[previousLineIndex]
+		if (previousLine !== undefined && precedingRule.linePattern.test(previousLine)) return true
 	}
 	return false
+}
+
+const isKnownSourceMapCoverageGapLine = (absoluteSourcePath: string, lines: readonly string[], lineIndex: number): boolean => {
+	const fileGap = knownSourceMapCoverageGaps.find(gap => sourcePathMatchesKnownGap(absoluteSourcePath, gap.sourcePath))
+	if (fileGap === undefined) return false
+	return fileGap.lineRules.some(rule => isKnownSourceMapCoverageGapRuleMatch(rule, lines, lineIndex))
+}
+
+export const getKnownSourceMapCoverageGapRuleMatchCountsForTest = (absoluteSourcePath: string, source: string): readonly number[] => {
+	const fileGap = knownSourceMapCoverageGaps.find(gap => sourcePathMatchesKnownGap(absoluteSourcePath, gap.sourcePath))
+	if (fileGap === undefined) return []
+	const lines = stripSolidityComments(source)
+	return fileGap.lineRules.map(rule => lines.filter((_, lineIndex) => isKnownSourceMapCoverageGapRuleMatch(rule, lines, lineIndex)).length)
 }
 
 // Bytecode coverage reports production executable lines, not every source-map-spanned declaration or harness line.

--- a/solidity/ts/tests/coverageHelpers.test.ts
+++ b/solidity/ts/tests/coverageHelpers.test.ts
@@ -3,7 +3,8 @@ import { beforeEach, describe, setDefaultTimeout, test } from 'bun:test'
 import assert from '../testsuite/simulator/utils/assert'
 import { encodeDeployData, encodeFunctionData, type Address, type Hash, type Hex, zeroAddress } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { collectBytecodeCoverageForTransaction, flushSolidityBytecodeCoverageForTest, getSolidityCoverableLineNumbersForTest, resetSolidityBytecodeCoverageAddressCache } from '../coverage/traceToSource'
+import { knownSourceMapCoverageGaps } from '../coverage/sourceMapCoverageGaps'
+import { collectBytecodeCoverageForTransaction, flushSolidityBytecodeCoverageForTest, getKnownSourceMapCoverageGapRuleMatchCountsForTest, getSolidityCoverableLineNumbersForTest, resetSolidityBytecodeCoverageAddressCache } from '../coverage/traceToSource'
 import { AnvilWindowEthereum } from '../testsuite/simulator/AnvilWindowEthereum'
 import { TEST_TIMEOUT_MS, useIsolatedAnvilNode } from '../testsuite/simulator/useIsolatedAnvilNode'
 import { TEST_ADDRESSES } from '../testsuite/simulator/utils/constants'
@@ -103,15 +104,97 @@ test('coverage classifier keeps side-effect-only call statements coverable', () 
 	assert.deepStrictEqual(getSolidityCoverableLineNumbersForTest('/tmp/CoverageClassifierCalls.sol', source), [3, 4, 5, 6])
 })
 
-test('coverage classifier keeps known untraceable source-map lines out of production totals', () => {
-	assert.deepStrictEqual(
-		getSolidityCoverableLineNumbersForTest(
-			'/tmp/solidity/contracts/peripherals/tokens/ERC1155.sol',
-			['contract ERC1155 {', '    function balanceOfBatch() external returns (uint256[] memory) {', '        return batchBalances;', '    }', '    function legacyTransfer(address from, address to, uint256 id, uint256 value) internal {', "        _transferFrom(from, to, id, value, '');", '    }', '}'].join('\n'),
-		),
-		[],
-	)
-	assert.deepStrictEqual(getSolidityCoverableLineNumbersForTest('/tmp/solidity/contracts/peripherals/SecurityPoolForkerVaultMigrationBase.sol', ['contract SecurityPoolForkerVaultMigrationBase {', '    constructor() {', '        zoltar = _zoltar;', '    }', '}'].join('\n')), [])
+test('coverage classifier keeps known untraceable source-map lines from manifest out of production totals', () => {
+	const cases = [
+		{
+			sourcePath: '/tmp/solidity/contracts/peripherals/SecurityPoolForkerVaultMigrationBase.sol',
+			source: ['contract SecurityPoolForkerVaultMigrationBase {', '    constructor() {', '        pool = _pool;', '    }', '}'],
+		},
+		{
+			sourcePath: '/tmp/solidity/contracts/peripherals/tokens/ERC1155.sol',
+			source: [
+				'contract ERC1155 {',
+				'    function balanceOfBatch() external returns (uint256[] memory) {',
+				'        return balances;',
+				'    }',
+				'    function legacyTransfer(address sender, address recipient, uint256 tokenId, uint256 amount) internal {',
+				"        _transferFrom(sender, recipient, tokenId, amount, '');",
+				'    }',
+				'}',
+			],
+		},
+		{
+			sourcePath: '/tmp/solidity/contracts/peripherals/EscalationGameSettlement.sol',
+			source: ['contract EscalationGameSettlement {', '    function withdrawDeposit(', '        uint256 claimIndex,', '        BinaryOutcomes.BinaryOutcome selectedOutcome', '    ) public {', "        require(selectedOutcome != BinaryOutcomes.BinaryOutcome.None, 'No outcome');", '    }', '}'],
+		},
+		{
+			sourcePath: '/tmp/solidity/contracts/peripherals/EscalationGameEscrow.sol',
+			source: [
+				'contract EscalationGameEscrow {',
+				'    function claim(ForkedEscrowState storage state, uint256 principalToClaim) internal {',
+				'        uint256 nextPrincipalClaimed = state.sourcePrincipalClaimed + principalToClaim;',
+				'        state.sourcePrincipalClaimed = nextPrincipalClaimed;',
+				'        state.childRepClaimed = nextRepClaimed;',
+				'    }',
+				'}',
+			],
+		},
+		{
+			sourcePath: '/tmp/solidity/contracts/peripherals/EscalationGameCarry.sol',
+			source: [
+				'contract EscalationGameCarry {',
+				'    function verify(bytes32[] calldata proofSiblings, uint8 selectedOutcome, uint256 parentDepositIndex, uint256 amount) internal {',
+				'        if (currentRoot != bytes32(0)) return currentRoot;',
+				"        require(proofSiblings.length == NULLIFIER_DEPTH, 'Bad nullifier length');",
+				'        bytes32 observedRoot = _getCurrentNullifierRoot(selectedOutcome);',
+				"        require(emptyRoot == observedRoot, 'Bad nullifier proof');",
+				'        if (amount > inheritedAmountToConsume) {',
+				'        }',
+				'    }',
+				'}',
+			],
+		},
+	]
+
+	for (const { sourcePath, source } of cases) {
+		assert.deepStrictEqual(getSolidityCoverableLineNumbersForTest(sourcePath, source.join('\n')), [], `${sourcePath} should exclude manifest-covered source-map gaps`)
+	}
+})
+
+test('coverage source-map gap manifest stays aligned with current Solidity sources', async () => {
+	for (const fileGap of knownSourceMapCoverageGaps) {
+		const source = await readFile(fileGap.sourcePath, 'utf8')
+		const expectedRuleMatchCounts = fileGap.lineRules.map(rule => rule.currentSourceMatches)
+		assert.deepStrictEqual(getKnownSourceMapCoverageGapRuleMatchCountsForTest(fileGap.sourcePath, source), expectedRuleMatchCounts, `${fileGap.sourcePath} source-map gap manifest should match current source`)
+	}
+})
+
+test('coverage classifier keeps similar lines coverable when source-map gap context does not match', () => {
+	const settlementProofOverload = [
+		'contract EscalationGameSettlement {',
+		'    function exportUnresolvedDeposit(',
+		'        CarriedDepositProof calldata proof,',
+		'        BinaryOutcomes.BinaryOutcome selectedOutcome',
+		'    ) public {',
+		"        require(selectedOutcome != BinaryOutcomes.BinaryOutcome.None, 'No outcome');",
+		'    }',
+		'}',
+	].join('\n')
+	const settlementUnrelatedUintOverload = [
+		'contract EscalationGameSettlement {',
+		'    function validateAmount(',
+		'        uint256 amount,',
+		'        BinaryOutcomes.BinaryOutcome selectedOutcome',
+		'    ) public {',
+		"        require(selectedOutcome != BinaryOutcomes.BinaryOutcome.None, 'No outcome');",
+		'    }',
+		'}',
+	].join('\n')
+	const erc1155Return = ['contract ERC1155 {', '    function balanceOf(address account, uint256 id) public view returns (uint256) {', '        return _balances[id][account];', '    }', '}'].join('\n')
+
+	assert.deepStrictEqual(getSolidityCoverableLineNumbersForTest('/tmp/solidity/contracts/peripherals/EscalationGameSettlement.sol', settlementProofOverload), [6])
+	assert.deepStrictEqual(getSolidityCoverableLineNumbersForTest('/tmp/solidity/contracts/peripherals/EscalationGameSettlement.sol', settlementUnrelatedUintOverload), [6])
+	assert.deepStrictEqual(getSolidityCoverableLineNumbersForTest('/tmp/solidity/contracts/peripherals/tokens/ERC1155.sol', erc1155Return), [3])
 })
 
 describe('Solidity bytecode coverage helpers', () => {


### PR DESCRIPTION
## Summary
- Added a new `solidity/ts/coverage/sourceMapCoverageGaps.ts` manifest defining known source-map coverage gaps by source file and regex-based line rules.
- Refactored `solidity/ts/coverage/traceToSource.ts` to evaluate coverage gaps via manifest lookup (`sourcePath` matching, rule patterns, optional preceding-line context) instead of hardcoded file string checks.
- Exposed a test helper to count manifest rule matches against source text and used it to validate manifest/contract alignment.
- Expanded `solidity/ts/tests/coverageHelpers.test.ts` with coverage scenarios for all manifest entries, including a regression test for context-sensitive matching and a guard against false positives on similar lines.

## Testing
- Not run (no command output provided in this context).
- New/updated test coverage added in `solidity/ts/tests/coverageHelpers.test.ts` covering:
  - manifest-backed exclusions for known untraceable source-map lines
  - manifest alignment checks against live Solidity sources
  - context/false-positive protection for similar statements