### PR TITLE
Add repository governance and security process documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing
+
+This repository contains immutable protocol contracts, TypeScript tooling, and the Preact UI. Keep changes scoped, review generated-output side effects explicitly, and prefer the existing contract, UI, and test patterns over new abstractions.
+
+## Local Setup
+
+Use Bun 1.3+ and Foundry Anvil. From a fresh checkout:
+
+```bash
+bun install --frozen-lockfile
+bun run setup
+```
+
+Install Anvil when it is not already available:
+
+```bash
+bun run install:anvil
+```
+
+## Development Workflow
+
+For contract, shared, or UI changes, start from the TypeScript source and Solidity source. Do not edit generated `js/` trees or generated contract artifacts directly.
+
+Common entrypoints:
+
+- `bun run app:serve` refreshes Solidity artifacts/types, UI contract artifact and ABI copies, shared JavaScript, UI vendor assets, emitted UI JavaScript, and generated UI test JavaScript before serving locally.
+- `bun run app:watch` performs the same refresh/build side effects as `app:build`, then starts the watcher.
+- `bun run app:build` refreshes Solidity artifacts/types, UI contract artifact and ABI copies, shared JavaScript, UI vendor assets, emitted UI JavaScript, and generated UI test JavaScript.
+- `bun run generate` refreshes Solidity artifacts/types, UI contract artifact and ABI copies, shared JavaScript, and UI vendor assets.
+- `bun run compile-contracts` refreshes shared JavaScript, Solidity artifacts/types, and the UI contract artifact and ABI copies derived from those artifacts.
+- `bun run tsc` type-checks after ensuring generated shared JavaScript is present and current. It can refresh `shared/js` when those outputs are missing or stale, but it does not regenerate contract artifacts, UI vendor assets, emitted UI JavaScript, or generated UI test JavaScript.
+
+## Validation
+
+Pick validation based on the files touched by the change. For broad code changes, a common local sequence is:
+
+```bash
+bun run tsc
+bun run test
+bun run format
+bun run check
+bun run knip
+```
+
+For docs-only changes, TypeScript, tests, and knip are normally out of scope. Run formatting and checks for the changed Markdown/docs paths, plus `git diff --check`.
+
+For release readiness or CI parity, use [docs/release-operator-runbook.md](./docs/release-operator-runbook.md), which includes generated-artifact freshness, production UI build validation, dependency audits, and worktree cleanliness gates.
+
+## Generated Output Policy
+
+Generated build outputs and protocol artifacts are intentionally untracked. Keep these paths out of source review unless the artifact policy is intentionally changed in the same pull request:
+
+- `ui/js`
+- `shared/js`
+- `ui/vendor`
+- `solidity/artifacts`
+- `ui/ts/contractArtifact.ts`
+- `solidity/ts/types/contractArtifact.ts`
+
+Local generation also refreshes ignored helper copies such as `ui/ts/abis.ts` and `solidity/types/contractArtifact.ts`. They are generated outputs too; do not commit them unless the artifact policy is intentionally expanded.
+
+If a local command refreshes these files, review the tracked diff before committing. Regenerate only when a workflow explicitly needs current generated output or a required check reports a missing generated artifact.
+
+## Pull Request Checklist
+
+- Link the issue, design note, or operator need that motivated the change.
+- Summarize behavior changes and any generated-output side effects.
+- Note validation commands and skipped checks with scope-based reasons.
+- Update [SECURITY.md](./SECURITY.md), [docs/audit-status.md](./docs/audit-status.md), or [docs/release-operator-runbook.md](./docs/release-operator-runbook.md) when the change affects launch posture, disclosure policy, deployment, or release operations.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ Protocol documentation lives in `docs/`:
 
 - [Zoltar visual whitepaper](./docs/whitepaper_zoltar.html)
 - [Augur Placeholder visual whitepaper](./docs/whitepaper_placeholder.html)
+- [Operator reference](./docs/operator-reference.md)
+- [Auction design](./docs/auction-design.md)
+- [Escalation game architecture](./docs/escalation-game-architecture.md)
+- [Release and operator runbook](./docs/release-operator-runbook.md)
+- [Audit status](./docs/audit-status.md)
+
+Repository process documentation:
+
+- [Contributing guide](./CONTRIBUTING.md)
+- [Security policy and disclosure process](./SECURITY.md)
+- [Ownership map](./ownership/CODEOWNERS)
 
 ## Prerequisites
 
@@ -93,61 +104,61 @@ Simulation mode details:
 
 ## Common Commands
 
-Run the full app in development mode. This includes contract generation and the frontend build pipeline:
+Run the full app in development mode. This refreshes Solidity artifacts/types, UI contract artifact and ABI copies, shared JavaScript, UI vendor assets, emitted UI JavaScript, and generated UI test JavaScript before serving the frontend:
 
 ```bash
 bun run app:serve
 ```
 
-Watch and rebuild the full app pipeline:
+Watch and rebuild the full app pipeline. This performs the same generated-output refresh as `app:build` before starting the watcher:
 
 ```bash
 bun run app:watch
 ```
 
-Build the full app:
+Build the full app. This refreshes Solidity artifacts/types, UI contract artifact and ABI copies, shared JavaScript, UI vendor assets, emitted UI JavaScript, and generated UI test JavaScript:
 
 ```bash
 bun run app:build
 ```
 
-Regenerate contract bindings and UI vendor assets:
+Regenerate generated protocol and UI inputs. This refreshes Solidity artifacts/types, UI contract artifact and ABI copies, shared JavaScript, and UI vendor assets:
 
 ```bash
 bun run generate
 ```
 
-Compile the Solidity contracts:
+Compile the Solidity contracts. This refreshes shared JavaScript, Solidity artifacts/types, and the UI contract artifact and ABI copies derived from those artifacts:
 
 ```bash
 bun run compile-contracts
 ```
 
-Run the full test suite:
+Run the full test suite. This may refresh shared JavaScript, Solidity artifacts/types, and UI contract artifact and ABI copies before type-checking and executing tests:
 
 ```bash
 bun run test
 ```
 
-Run the launch-focused fork, auction, and exit invariant gate:
+Run the launch-focused fork, auction, and exit invariant gate. This may refresh shared JavaScript, Solidity artifacts/types, and UI contract artifact and ABI copies before the Solidity type-check and targeted tests:
 
 ```bash
 bun run test:launch-invariants
 ```
 
-Run fast coverage checks:
+Run fast coverage checks. The UI phase may refresh shared JavaScript; the contract phase may refresh shared JavaScript, Solidity artifacts/types, and UI contract artifact and ABI copies:
 
 ```bash
 bun run coverage
 ```
 
-Run full coverage, including the slow Solidity bytecode trace phase:
+Run full coverage, including the slow Solidity bytecode trace phase. This includes the same generated-output preflights as fast coverage:
 
 ```bash
 bun run coverage:full
 ```
 
-Type-check the TypeScript code:
+Type-check the TypeScript code. This may refresh shared JavaScript when it is missing or stale, but it does not emit UI JavaScript, generated UI test JavaScript, UI vendor assets, or contract artifacts:
 
 ```bash
 bun run tsc
@@ -205,10 +216,11 @@ Use `ANVIL_RPC=http://host.docker.internal:8545 bun run gas-costs` when the comm
 
 ## Notes
 
-- `bun run setup` is the quickest way to bootstrap a fresh checkout.
+- `bun run setup` is the quickest way to bootstrap a fresh checkout. It installs root, UI, and Solidity dependencies, then refreshes Solidity artifacts/types, UI contract artifact and ABI copies, shared JavaScript, UI vendor assets, emitted UI JavaScript, and generated UI test JavaScript.
 - `bun install --frozen-lockfile` must be run before standalone commands like `bun run tsc` on a fresh checkout.
-- `bun run tsc` is a pure typecheck for the app TypeScript, the Solidity-side TypeScript utilities, and the Bun build/dev scripts. It does not regenerate shared assets or vendor output.
+- `bun run tsc` type-checks the app TypeScript, the Solidity-side TypeScript utilities, and the Bun build/dev scripts after ensuring generated shared JavaScript is present and current. It can refresh `shared/js` when those outputs are missing or stale, but it does not regenerate contract artifacts, UI vendor assets, emitted UI JavaScript, or generated UI test JavaScript.
 - `bun run test` runs the TypeScript check first, then executes the test suite.
+- Generated build outputs and protocol artifacts are intentionally untracked. See [Contributing](./CONTRIBUTING.md#generated-output-policy) before committing files under generated-output paths.
 - `bun run test:launch-invariants` is the targeted pre-release gate for adversarial fork, truth-auction, unresolved escalation carry, and auction edge-case invariants.
 - `bun run coverage` runs the fast UI and contract TypeScript coverage phases. Use `bun run coverage:full` when you also need the slower Solidity bytecode trace coverage phase.
 - The legacy `ui:*` commands still exist as compatibility aliases, but `app:*` names are the clearer entrypoints because they run more than frontend-only work.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Scope
+
+The active security scope is the current `main` branch and any tagged release intended for production use. Security-sensitive areas include Solidity contracts, deterministic deployment tooling, generated artifact policy, release workflows, UI transaction construction, RPC/read behavior, simulation boundaries, and documentation that operators rely on during launch or incident response.
+
+## Reporting a Vulnerability
+
+Do not open a public issue with vulnerability details. Report privately through GitHub Security Advisories for this repository when available, or contact the repository maintainers privately through the AugurProject GitHub organization. If neither private channel is available, open a public issue titled `Security contact request` that contains no vulnerability details and asks maintainers to establish a private reporting channel.
+
+Include:
+
+- affected commit, tag, contract address, or UI release hash when known
+- impact and attacker capability
+- reproduction steps or proof-of-concept details
+- suggested fix or mitigation when available
+- whether the report has been shared with anyone else
+
+Maintainers should acknowledge credible reports promptly, keep the reporter informed while triage is active, and publish public details only after a fix or operational mitigation is available.
+
+## Disclosure Policy
+
+Coordinated disclosure is expected. Public disclosure should wait until maintainers have had a reasonable opportunity to validate impact, prepare a fix or mitigation, and notify users or operators. For immutable contract deployments, the response may be documentation, UI routing, user warnings, or a migration/redeployment plan rather than an on-chain pause or upgrade.
+
+## Bug Bounty Status
+
+No standing paid bug bounty is documented in this repository. Maintainers may still accept responsible reports under the disclosure process above. Add bounty scope, reward ranges, eligibility rules, and safe-harbor language here before advertising any paid bounty.
+
+## Audit Status
+
+Current audit status is tracked in [docs/audit-status.md](./docs/audit-status.md). Do not describe the protocol as audited unless that file links to the completed report and identifies the reviewed commit, scope, and unresolved findings.

--- a/docs/audit-status.md
+++ b/docs/audit-status.md
@@ -1,0 +1,27 @@
+# Audit Status
+
+No completed third-party audit report is tracked in this repository. Treat the protocol as unaudited until this page links to a completed report and records the reviewed commit, scope, and unresolved findings.
+
+## Current Assurance Sources
+
+- CI runs formatting, generated-artifact freshness checks, TypeScript type checking, production UI build validation, tests, Biome/custom lint checks, dead-code analysis, and dependency audits.
+- The launch invariant test target is `bun run test:launch-invariants`.
+- Mainnet deployment address expectations are tracked in [mainnet-deployment-addresses.md](./mainnet-deployment-addresses.md) and [mainnet-deployment-addresses.json](./mainnet-deployment-addresses.json).
+- Operator guardrails are tracked in [operator-reference.md](./operator-reference.md).
+- Release steps are tracked in [release-operator-runbook.md](./release-operator-runbook.md).
+
+## Required Audit Record
+
+Before any release note, README, website, or operator communication describes the protocol as audited, update this page with:
+
+- auditor name and report link
+- reviewed commit and tag
+- reviewed contract and UI scope
+- final report date
+- finding summary by severity
+- unresolved findings and accepted risks
+- any code, configuration, or documentation changes made after the reviewed commit
+
+## Disclosure and Bug Bounty
+
+Security disclosure policy and bug bounty status are tracked in [../SECURITY.md](../SECURITY.md).

--- a/docs/escalation-game-architecture.md
+++ b/docs/escalation-game-architecture.md
@@ -66,7 +66,7 @@ The proof verifier split keeps `EscalationGame` as the state-owning contract and
 - project deployed-bytecode budget headroom: `142` bytes below `24,000`
 - EIP-170 deployed-bytecode headroom: `718` bytes below `24,576`
 
-This PR intentionally adds revert strings and event payloads across the system, so `EscalationGame` is not expected to be smaller than the pre-audit `origin/main` artifact. The size target is to keep the enriched contract below the project budget while moving proof verification out to the verifier contract.
+The current size posture reserves room for revert strings and event payloads across the system, so `EscalationGame` is not expected to be smaller than older pre-extraction artifacts. The size target is to keep the enriched contract below the project budget while moving proof verification out to the verifier contract.
 
 Any Solidity change can alter deterministic deployment addresses because address derivation uses init code. After contract changes, regenerate and review deployment outputs with the normal artifact workflow and keep `docs/mainnet-deployment-addresses.json` plus `docs/mainnet-deployment-addresses.md` in sync when expected addresses change.
 

--- a/docs/release-operator-runbook.md
+++ b/docs/release-operator-runbook.md
@@ -1,0 +1,79 @@
+# Release and Operator Runbook
+
+This runbook covers release preparation and operator-facing checks for Zoltar and Placeholder. It does not assume contracts can be paused, upgraded, rolled back, or disabled after deployment; publish verifiable provenance instead.
+
+## Release Inputs
+
+Collect these inputs before tagging a release:
+
+- final commit SHA and planned `v*` tag
+- deterministic deployment address diff, if contracts or deployment config changed
+- validation command results
+- production UI artifact hash after the IPFS workflow completes
+- audit status from [audit-status.md](./audit-status.md)
+- known limitations and operator notes
+
+## Pre-Release Validation
+
+From a fresh dependency install, run:
+
+```bash
+bun install --frozen-lockfile
+(cd ui && bun install --frozen-lockfile)
+(cd solidity && bun install --frozen-lockfile)
+bun run check:generated-clean
+bun run format
+git diff --exit-code -- .
+git diff --check
+bun run tsc
+bun run ui:build:prod:optimized
+bun run test:run -- --bail=1
+bun run check
+bun run knip
+bun audit && (cd ui && bun audit) && (cd solidity && bun audit)
+```
+
+Run `bun run test:launch-invariants` for launch-candidate protocol releases and record the result in the release notes.
+
+## Generated Artifact Review
+
+Generated build outputs and protocol artifacts are intentionally untracked. `bun run check:generated-clean` is the release freshness check; do not commit regenerated outputs unless the generated artifact policy is changed in the same release.
+
+Expected generated-output side effects:
+
+- `bun run setup` installs dependencies and refreshes Solidity artifacts/types, UI contract artifact and ABI copies, shared JavaScript, UI vendor assets, emitted UI JavaScript, and generated UI test JavaScript.
+- `bun run generate` refreshes Solidity artifacts/types, UI contract artifact and ABI copies, shared JavaScript, and UI vendor assets.
+- `bun run compile-contracts` refreshes shared JavaScript, Solidity artifacts/types, and the UI contract artifact and ABI copies derived from those artifacts.
+- `bun run tsc` may refresh shared JavaScript through its shared-build preflight, then type-checks. It does not refresh contract artifacts, UI vendor assets, emitted UI JavaScript, or generated UI test JavaScript.
+
+## Deployment Address Review
+
+When Solidity contracts, deployment config, or deterministic address derivation changes:
+
+1. Run `bun run check:mainnet-deployment`.
+2. Review [mainnet-deployment-addresses.json](./mainnet-deployment-addresses.json) and [mainnet-deployment-addresses.md](./mainnet-deployment-addresses.md).
+3. Explain expected address changes in the release notes.
+4. If an address changes unexpectedly, stop the release until the derivation, artifact, or config change is understood.
+
+## Tagging and Publishing
+
+1. Confirm CI Gate is green on the final commit.
+2. Push the `v*` tag from that final commit.
+3. Wait for the `Build and Push to IPFS` workflow.
+4. Record the IPFS hash from the GitHub release created by the workflow.
+5. Confirm the published release body links to the expected IPFS gateways.
+6. Publish release notes with the final commit, tag, validation summary, deterministic address status, IPFS hash, audit status, and known limitations.
+
+## Operator Checks
+
+Before directing users to a production UI:
+
+- Verify the UI release hash matches the GitHub release.
+- Verify the UI points at expected mainnet deployment addresses.
+- Confirm `?simulate=1` is described as a browser-local sandbox only.
+- Confirm quote-dependent flows block or degrade when live RPC data or Uniswap liquidity is unavailable.
+- Review [operator-reference.md](./operator-reference.md), [auction-design.md](./auction-design.md), and [escalation-game-architecture.md](./escalation-game-architecture.md) for any changed operational assumptions.
+
+## Incident Response Notes
+
+For immutable deployments, do not document UI changes as contract-level emergency controls. Use public advisories, release notes, verified UI updates, warnings, or migration/redeployment plans as appropriate. Follow [../SECURITY.md](../SECURITY.md) for private intake and coordinated disclosure.

--- a/ownership/CODEOWNERS
+++ b/ownership/CODEOWNERS
@@ -1,0 +1,16 @@
+# Advisory ownership map for review routing.
+# GitHub only enforces CODEOWNERS from the repository root, .github/, or docs/.
+# Keep this file in sync with branch-protection CODEOWNERS if enforcement is enabled later.
+
+* @KillariDev
+
+/solidity/ @KillariDev
+/shared/ @KillariDev
+/ui/ @KillariDev
+/scripts/ @KillariDev
+/docs/ @KillariDev
+/.github/ @KillariDev
+/AGENTS.md @KillariDev
+/CONTRIBUTING.md @KillariDev
+/SECURITY.md @KillariDev
+/README.md @KillariDev


### PR DESCRIPTION
## Summary
- Add new contribution and security policy documentation to define setup, validation, disclosure, and audit posture:
  - `CONTRIBUTING.md`
  - `SECURITY.md`
  - `docs/audit-status.md`
  - `docs/release-operator-runbook.md`
- Expand repository guidance in `README.md` to reference process, operator, architecture, and security docs.
- Add advisory ownership map via `ownership/CODEOWNERS` for review routing and key paths.
- Clarify deterministic-contract sizing context in `docs/escalation-game-architecture.md`.

## Testing
- Not run (docs-only changes: no code paths touched).
- No validation commands executed in this PR content-only update.