### PR TITLE
Add shared scalar outcome parity fixtures with cross-layer tests

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -22,6 +22,10 @@
 		"./protocolConfig": {
 			"types": "./ts/protocolConfig.ts",
 			"default": "./js/protocolConfig.js"
+		},
+		"./testing/scalarOutcomeParityFixtures": {
+			"types": "./ts/testing/scalarOutcomeParityFixtures.ts",
+			"default": "./js/testing/scalarOutcomeParityFixtures.js"
 		}
 	},
 	"files": [

--- a/shared/ts/testing/scalarOutcomeParityFixtures.ts
+++ b/shared/ts/testing/scalarOutcomeParityFixtures.ts
@@ -1,0 +1,254 @@
+export type ScalarParityQuestion = {
+	name: string
+	answerUnit: string
+	displayValueMax: bigint
+	displayValueMin: bigint
+	numTicks: bigint
+}
+
+export type ScalarParityLabelFixture = {
+	name: string
+	expectedLabel: string
+	questionName: string
+	tickIndex: bigint
+}
+
+export type ScalarParityOutcomeIndexDescriptor =
+	| {
+			kind: 'invalid'
+	  }
+	| {
+			kind: 'malformed'
+	  }
+	| {
+			kind: 'tick'
+			tickIndex: bigint
+	  }
+
+export type ScalarParityEncodingFixture = {
+	name: string
+	expectedDescriptor: ScalarParityOutcomeIndexDescriptor
+	expectedLabel: string
+	firstPart: bigint
+	invalid: boolean
+	questionName: string
+	secondPart: bigint
+}
+
+export const SCALAR_PARITY_DECIMALS = 18n
+export const SCALAR_PARITY_DECIMAL_BASE = 10n ** SCALAR_PARITY_DECIMALS
+export const SCALAR_PARITY_PART_BIT_LENGTH = 120n
+export const SCALAR_PARITY_TOTAL_BITS = 256n
+export const SCALAR_PARITY_PART_MASK = (1n << SCALAR_PARITY_PART_BIT_LENGTH) - 1n
+export const SCALAR_PARITY_UINT120_MAX = SCALAR_PARITY_PART_MASK
+export const SCALAR_PARITY_INT256_MIN = -(1n << 255n)
+export const SCALAR_PARITY_INT256_MAX = (1n << 255n) - 1n
+
+const ONE = SCALAR_PARITY_DECIMAL_BASE
+
+export const SCALAR_PARITY_QUESTIONS: ScalarParityQuestion[] = [
+	{
+		name: 'tenths-positive',
+		answerUnit: 'km',
+		displayValueMax: 10n * ONE,
+		displayValueMin: ONE,
+		numTicks: 90n,
+	},
+	{
+		name: 'signed-eighths',
+		answerUnit: 'units',
+		displayValueMax: 5n * ONE,
+		displayValueMin: -5n * ONE,
+		numTicks: 8n,
+	},
+	{
+		name: 'repeating-sevenths',
+		answerUnit: '',
+		displayValueMax: 2n * ONE,
+		displayValueMin: -ONE,
+		numTicks: 7n,
+	},
+	{
+		name: 'uint120-boundary',
+		answerUnit: '',
+		displayValueMax: 1n,
+		displayValueMin: 0n,
+		numTicks: SCALAR_PARITY_UINT120_MAX,
+	},
+	{
+		name: 'int256-extreme',
+		answerUnit: '',
+		displayValueMax: SCALAR_PARITY_INT256_MAX,
+		displayValueMin: SCALAR_PARITY_INT256_MIN,
+		numTicks: 17n,
+	},
+]
+
+export const SCALAR_PARITY_LABEL_FIXTURES: ScalarParityLabelFixture[] = [
+	{ name: 'positive lower endpoint', questionName: 'tenths-positive', tickIndex: 0n, expectedLabel: '1 km' },
+	{ name: 'positive first tenth', questionName: 'tenths-positive', tickIndex: 1n, expectedLabel: '1.1 km' },
+	{ name: 'positive middle tenth', questionName: 'tenths-positive', tickIndex: 44n, expectedLabel: '5.4 km' },
+	{ name: 'positive penultimate tenth', questionName: 'tenths-positive', tickIndex: 89n, expectedLabel: '9.9 km' },
+	{ name: 'positive upper endpoint', questionName: 'tenths-positive', tickIndex: 90n, expectedLabel: '10 km' },
+	{ name: 'signed lower endpoint', questionName: 'signed-eighths', tickIndex: 0n, expectedLabel: '-5 units' },
+	{ name: 'signed fractional tick', questionName: 'signed-eighths', tickIndex: 1n, expectedLabel: '-3.75 units' },
+	{ name: 'signed zero crossing', questionName: 'signed-eighths', tickIndex: 4n, expectedLabel: '0 units' },
+	{ name: 'signed upper endpoint', questionName: 'signed-eighths', tickIndex: 8n, expectedLabel: '5 units' },
+	{ name: 'repeating lower endpoint', questionName: 'repeating-sevenths', tickIndex: 0n, expectedLabel: '-1' },
+	{ name: 'repeating negative truncation', questionName: 'repeating-sevenths', tickIndex: 1n, expectedLabel: '-0.571428571428571429' },
+	{ name: 'repeating positive truncation', questionName: 'repeating-sevenths', tickIndex: 6n, expectedLabel: '1.571428571428571428' },
+	{ name: 'repeating upper endpoint', questionName: 'repeating-sevenths', tickIndex: 7n, expectedLabel: '2' },
+	{ name: 'uint120 lower endpoint', questionName: 'uint120-boundary', tickIndex: 0n, expectedLabel: '0' },
+	{ name: 'uint120 upper endpoint', questionName: 'uint120-boundary', tickIndex: SCALAR_PARITY_UINT120_MAX, expectedLabel: '0.000000000000000001' },
+	{
+		name: 'int256 lower endpoint',
+		questionName: 'int256-extreme',
+		tickIndex: 0n,
+		expectedLabel: '-57896044618658097711785492504343953926634992332820282019728.792003956564819968',
+	},
+	{
+		name: 'int256 interior tick',
+		questionName: 'int256-extreme',
+		tickIndex: 8n,
+		expectedLabel: '-3405649683450476335987381912020232583919705431342369530572.281882585680283528',
+	},
+	{
+		name: 'int256 upper endpoint',
+		questionName: 'int256-extreme',
+		tickIndex: 17n,
+		expectedLabel: '57896044618658097711785492504343953926634992332820282019728.792003956564819967',
+	},
+]
+
+export const SCALAR_PARITY_ENCODING_FIXTURES: ScalarParityEncodingFixture[] = [
+	{
+		name: 'canonical invalid answer',
+		questionName: 'tenths-positive',
+		invalid: true,
+		firstPart: 0n,
+		secondPart: 0n,
+		expectedDescriptor: { kind: 'invalid' },
+		expectedLabel: 'Invalid',
+	},
+	{
+		name: 'invalid flag with payload is malformed',
+		questionName: 'tenths-positive',
+		invalid: true,
+		firstPart: 1n,
+		secondPart: 0n,
+		expectedDescriptor: { kind: 'malformed' },
+		expectedLabel: 'Malformed',
+	},
+	{
+		name: 'high-bit payload with wrong sum is malformed',
+		questionName: 'tenths-positive',
+		invalid: false,
+		firstPart: 89n,
+		secondPart: 0n,
+		expectedDescriptor: { kind: 'malformed' },
+		expectedLabel: 'Malformed',
+	},
+	{
+		name: 'high-bit lower endpoint',
+		questionName: 'signed-eighths',
+		invalid: false,
+		firstPart: 8n,
+		secondPart: 0n,
+		expectedDescriptor: { kind: 'tick', tickIndex: 0n },
+		expectedLabel: '-5 units',
+	},
+	{
+		name: 'high-bit fractional tick',
+		questionName: 'signed-eighths',
+		invalid: false,
+		firstPart: 7n,
+		secondPart: 1n,
+		expectedDescriptor: { kind: 'tick', tickIndex: 1n },
+		expectedLabel: '-3.75 units',
+	},
+	{
+		name: 'high-bit uint120 upper endpoint',
+		questionName: 'uint120-boundary',
+		invalid: false,
+		firstPart: 0n,
+		secondPart: SCALAR_PARITY_UINT120_MAX,
+		expectedDescriptor: { kind: 'tick', tickIndex: SCALAR_PARITY_UINT120_MAX },
+		expectedLabel: '0.000000000000000001',
+	},
+	{
+		name: 'masked overflow payload remains malformed',
+		questionName: 'tenths-positive',
+		invalid: false,
+		firstPart: SCALAR_PARITY_UINT120_MAX + 10n,
+		secondPart: 80n,
+		expectedDescriptor: { kind: 'malformed' },
+		expectedLabel: 'Malformed',
+	},
+]
+
+export function getScalarParityQuestion(questionName: string) {
+	const question = SCALAR_PARITY_QUESTIONS.find(candidate => candidate.name === questionName)
+	if (question === undefined) throw new Error(`Unknown scalar parity question: ${questionName}`)
+	return question
+}
+
+export function combineScalarParityOutcomeIndex(invalid: boolean, firstPart: bigint, secondPart: bigint) {
+	const normalizedFirstPart = firstPart & SCALAR_PARITY_PART_MASK
+	const normalizedSecondPart = secondPart & SCALAR_PARITY_PART_MASK
+	const highestBit = invalid ? 0n : 1n
+	return (highestBit << (SCALAR_PARITY_TOTAL_BITS - 1n)) | (normalizedFirstPart << SCALAR_PARITY_PART_BIT_LENGTH) | normalizedSecondPart
+}
+
+export function getScalarParityOutcomeIndex(question: ScalarParityQuestion, tickIndex: bigint) {
+	validateScalarParityTickIndex(question, tickIndex)
+	return combineScalarParityOutcomeIndex(false, question.numTicks - tickIndex, tickIndex)
+}
+
+export function formatScalarParityLabel(question: ScalarParityQuestion, tickIndex: bigint) {
+	validateScalarParityTickIndex(question, tickIndex)
+	const scalarRange = question.displayValueMax - question.displayValueMin
+	const scalarValue = question.displayValueMin + (tickIndex * scalarRange) / question.numTicks
+	const formattedValue = formatSignedDecimal(scalarValue)
+	return question.answerUnit === '' ? formattedValue : `${formattedValue} ${question.answerUnit}`
+}
+
+export function describeScalarParityOutcomeIndex(question: ScalarParityQuestion, outcomeIndex: bigint): ScalarParityOutcomeIndexDescriptor {
+	if (question.numTicks <= 0n) return { kind: 'malformed' }
+	const { invalid, firstPart, secondPart } = splitScalarParityOutcomeIndex(outcomeIndex)
+	if (invalid) return firstPart === 0n && secondPart === 0n ? { kind: 'invalid' } : { kind: 'malformed' }
+	if (firstPart + secondPart !== question.numTicks) return { kind: 'malformed' }
+	return { kind: 'tick', tickIndex: secondPart }
+}
+
+export function isScalarParityMalformedOutcomeIndex(question: ScalarParityQuestion, outcomeIndex: bigint) {
+	return describeScalarParityOutcomeIndex(question, outcomeIndex).kind === 'malformed'
+}
+
+export function formatScalarParityOutcomeName(question: ScalarParityQuestion, outcomeIndex: bigint) {
+	const descriptor = describeScalarParityOutcomeIndex(question, outcomeIndex)
+	if (descriptor.kind === 'invalid') return 'Invalid'
+	if (descriptor.kind === 'malformed') return 'Malformed'
+	return formatScalarParityLabel(question, descriptor.tickIndex)
+}
+
+function validateScalarParityTickIndex(question: ScalarParityQuestion, tickIndex: bigint) {
+	if (question.numTicks <= 0n) throw new Error('Scalar question numTicks must be positive')
+	if (tickIndex < 0n || tickIndex > question.numTicks) throw new Error('Tick index is out of range')
+}
+
+function splitScalarParityOutcomeIndex(outcomeIndex: bigint) {
+	const invalid = outcomeIndex >> (SCALAR_PARITY_TOTAL_BITS - 1n) === 0n
+	const firstPart = (outcomeIndex >> SCALAR_PARITY_PART_BIT_LENGTH) & SCALAR_PARITY_PART_MASK
+	const secondPart = outcomeIndex & SCALAR_PARITY_PART_MASK
+	return { invalid, firstPart, secondPart }
+}
+
+function formatSignedDecimal(value: bigint) {
+	const isNegative = value < 0n
+	const absoluteValue = isNegative ? -value : value
+	const integerPart = absoluteValue / SCALAR_PARITY_DECIMAL_BASE
+	const fractionalPart = absoluteValue % SCALAR_PARITY_DECIMAL_BASE
+	if (fractionalPart === 0n) return `${isNegative ? '-' : ''}${integerPart.toString()}`
+	const fractionalString = fractionalPart.toString().padStart(Number(SCALAR_PARITY_DECIMALS), '0').replace(/0+$/, '')
+	return `${isNegative ? '-' : ''}${integerPart.toString()}.${fractionalString}`
+}

--- a/solidity/ts/tests/questionData.test.ts
+++ b/solidity/ts/tests/questionData.test.ts
@@ -12,8 +12,56 @@ import { combineUint256FromTwoWithInvalid, createQuestion, getAnswerOptionName, 
 import { areEqualArrays } from '../testsuite/simulator/utils/array-utils'
 import { ZoltarQuestionData_ZoltarQuestionData } from '../types/contractArtifact'
 import { decodeEventLog } from 'viem'
+import {
+	SCALAR_PARITY_ENCODING_FIXTURES,
+	SCALAR_PARITY_LABEL_FIXTURES,
+	SCALAR_PARITY_QUESTIONS,
+	SCALAR_PARITY_UINT120_MAX,
+	combineScalarParityOutcomeIndex,
+	describeScalarParityOutcomeIndex,
+	formatScalarParityLabel,
+	formatScalarParityOutcomeName,
+	getScalarParityOutcomeIndex,
+	getScalarParityQuestion,
+	isScalarParityMalformedOutcomeIndex,
+} from '@zoltar/shared/testing/scalarOutcomeParityFixtures'
+import type { ScalarParityQuestion } from '@zoltar/shared/testing/scalarOutcomeParityFixtures'
 
 const MAX_UINT256 = 2n ** 256n - 1n
+const SCALAR_ENCODING_FUZZ_SAMPLE_COUNT = 12
+const SCALAR_ENCODING_FUZZ_STATE_MASK = (1n << 128n) - 1n
+
+type ScalarEncodingFuzzSample = {
+	firstPart: bigint
+	invalid: boolean
+	secondPart: bigint
+}
+
+function advanceScalarEncodingFuzzState(state: bigint) {
+	return (state * 6364136223846793005n + 1442695040888963407n) & SCALAR_ENCODING_FUZZ_STATE_MASK
+}
+
+function getScalarEncodingFuzzSamples(question: ScalarParityQuestion, seed: bigint) {
+	const samples: ScalarEncodingFuzzSample[] = [
+		{ invalid: true, firstPart: 0n, secondPart: 0n },
+		{ invalid: false, firstPart: question.numTicks, secondPart: 0n },
+		{ invalid: false, firstPart: 0n, secondPart: question.numTicks },
+	]
+	let state = seed
+	for (let index = 0; index < SCALAR_ENCODING_FUZZ_SAMPLE_COUNT; index++) {
+		state = advanceScalarEncodingFuzzState(state)
+		const invalid = (state & 1n) === 0n
+		state = advanceScalarEncodingFuzzState(state)
+		const firstPart = state & SCALAR_PARITY_UINT120_MAX
+		state = advanceScalarEncodingFuzzState(state)
+		const secondPart = state & SCALAR_PARITY_UINT120_MAX
+		const tickIndex = state % (question.numTicks + 1n)
+		samples.push({ invalid, firstPart, secondPart })
+		samples.push({ invalid: false, firstPart: question.numTicks - tickIndex, secondPart: tickIndex })
+		if (index % 3 === 0) samples.push({ invalid: true, firstPart: (firstPart % 19n) + 1n, secondPart: secondPart % 23n })
+	}
+	return samples
+}
 
 setDefaultTimeout(TEST_TIMEOUT_MS)
 
@@ -35,6 +83,42 @@ describe('Question Data', () => {
 		mockWindow = getAnvilWindowEthereum()
 		client = createWriteClient(mockWindow, TEST_ADDRESSES[0], 0)
 	})
+
+	const createScalarParityQuestion = async (question: ScalarParityQuestion) => {
+		const questionData = {
+			title: `scalar parity ${question.name}`,
+			description: 'scalar parity fixture',
+			startTime: (await mockWindow.getTime()) + 100000n,
+			endTime: (await mockWindow.getTime()) + 200000n,
+			numTicks: question.numTicks,
+			displayValueMin: question.displayValueMin,
+			displayValueMax: question.displayValueMax,
+			answerUnit: question.answerUnit,
+		}
+		await createQuestion(client, questionData, [])
+		return getQuestionId(questionData, [])
+	}
+
+	const createScalarParityQuestionIds = async () => {
+		const questionIdsByName = new Map<string, bigint>()
+		for (const question of SCALAR_PARITY_QUESTIONS) {
+			questionIdsByName.set(question.name, await createScalarParityQuestion(question))
+		}
+		return questionIdsByName
+	}
+
+	const getScalarParityQuestionId = (questionIdsByName: Map<string, bigint>, questionName: string) => {
+		const questionId = questionIdsByName.get(questionName)
+		if (questionId === undefined) throw new Error(`Missing scalar parity question id: ${questionName}`)
+		return questionId
+	}
+
+	const assertScalarContractMatchesParityModel = async (questionId: bigint, question: ScalarParityQuestion, answer: bigint, context: string) => {
+		const expectedMalformed = isScalarParityMalformedOutcomeIndex(question, answer)
+		const expectedName = formatScalarParityOutcomeName(question, answer)
+		assert.strictEqual(await isMalformedAnswerOption(client, questionId, answer), expectedMalformed, `${context} malformed flag mismatch`)
+		assert.strictEqual(await getAnswerOptionName(client, questionId, answer), expectedName, `${context} outcome name mismatch`)
+	}
 
 	test('can make categorical question', async () => {
 		const outcomeLabels = ['Yes', 'No']
@@ -138,6 +222,42 @@ describe('Question Data', () => {
 		assert.strictEqual(await getAnswerOptionName(client, questionId, combineUint256FromTwoWithInvalid(false, testScalarQuestion.numTicks / 2n, testScalarQuestion.numTicks / 2n)), '0 km', 'Middle is valid')
 		assert.strictEqual(await getAnswerOptionName(client, questionId, combineUint256FromTwoWithInvalid(false, testScalarQuestion.numTicks + 1n, 0n)), 'Malformed', 'Overflow')
 		assert.strictEqual(await getAnswerOptionName(client, questionId, combineUint256FromTwoWithInvalid(false, 0n, testScalarQuestion.numTicks + 1n)), 'Malformed', 'Overflow')
+	})
+
+	test('scalar outcome labels match shared TypeScript renderer fixtures', async () => {
+		const questionIdsByName = await createScalarParityQuestionIds()
+		for (const fixture of SCALAR_PARITY_LABEL_FIXTURES) {
+			const question = getScalarParityQuestion(fixture.questionName)
+			const questionId = getScalarParityQuestionId(questionIdsByName, fixture.questionName)
+			const answer = getScalarParityOutcomeIndex(question, fixture.tickIndex)
+			assert.strictEqual(formatScalarParityLabel(question, fixture.tickIndex), fixture.expectedLabel, `${fixture.name} fixture label should be internally consistent`)
+			assert.strictEqual(await getAnswerOptionName(client, questionId, answer), fixture.expectedLabel, `${fixture.name} contract label mismatch`)
+		}
+	})
+
+	test('scalar answer encoding fixtures match shared TypeScript renderer model', async () => {
+		const questionIdsByName = await createScalarParityQuestionIds()
+		for (const fixture of SCALAR_PARITY_ENCODING_FIXTURES) {
+			const question = getScalarParityQuestion(fixture.questionName)
+			const questionId = getScalarParityQuestionId(questionIdsByName, fixture.questionName)
+			const answer = combineScalarParityOutcomeIndex(fixture.invalid, fixture.firstPart, fixture.secondPart)
+			assert.deepStrictEqual(describeScalarParityOutcomeIndex(question, answer), fixture.expectedDescriptor, `${fixture.name} descriptor fixture mismatch`)
+			assert.strictEqual(formatScalarParityOutcomeName(question, answer), fixture.expectedLabel, `${fixture.name} expected name fixture mismatch`)
+			await assertScalarContractMatchesParityModel(questionId, question, answer, fixture.name)
+		}
+	})
+
+	test('fuzzes scalar answer encoding against the shared TypeScript renderer model', async () => {
+		const questionIdsByName = await createScalarParityQuestionIds()
+		let seed = 0x5ca1ab1ef00dn
+		for (const question of SCALAR_PARITY_QUESTIONS) {
+			const questionId = getScalarParityQuestionId(questionIdsByName, question.name)
+			for (const sample of getScalarEncodingFuzzSamples(question, seed)) {
+				const answer = combineScalarParityOutcomeIndex(sample.invalid, sample.firstPart, sample.secondPart)
+				await assertScalarContractMatchesParityModel(questionId, question, answer, `${question.name} fuzz sample ${seed.toString(16)}`)
+				seed = advanceScalarEncodingFuzzState(seed)
+			}
+		}
 	})
 
 	test('isMalformedAnswerOption: scalar answers with high bit set follow the scalar validity rules', async () => {

--- a/ui/ts/tests/scalarOutcome.test.ts
+++ b/ui/ts/tests/scalarOutcome.test.ts
@@ -1,6 +1,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from 'bun:test'
+import { SCALAR_PARITY_ENCODING_FIXTURES, SCALAR_PARITY_LABEL_FIXTURES, combineScalarParityOutcomeIndex, describeScalarParityOutcomeIndex, formatScalarParityOutcomeName, getScalarParityQuestion } from '@zoltar/shared/testing/scalarOutcomeParityFixtures'
 import { formatScalarOutcomeIndexLabel, formatScalarOutcomeLabel, getScalarOutcomeIndex, getScalarOutcomeIndexDescriptor, getScalarSliderProgress, isValidScalarOutcomeIndex, parseScalarFormInputs } from '../lib/scalarOutcome.js'
 
 const scalarQuestion = {
@@ -55,4 +56,30 @@ void describe('scalar outcome helpers', () => {
 	void test('rejects scalar inputs that do not divide into whole ticks', () => {
 		expect(() => parseScalarFormInputs({ scalarMin: '1', scalarMax: '10', scalarIncrement: '0.4' })).toThrow('Scalar min, max, and increment do not produce a whole number of ticks')
 	})
+
+	for (const fixture of SCALAR_PARITY_LABEL_FIXTURES) {
+		void test(`formats scalar parity fixture: ${fixture.name}`, () => {
+			const question = getScalarParityQuestion(fixture.questionName)
+			const outcomeIndex = getScalarOutcomeIndex(question, fixture.tickIndex)
+			expect(formatScalarOutcomeLabel(question, fixture.tickIndex)).toBe(fixture.expectedLabel)
+			expect(formatScalarOutcomeIndexLabel(question, outcomeIndex)).toBe(fixture.expectedLabel)
+		})
+	}
+
+	for (const fixture of SCALAR_PARITY_ENCODING_FIXTURES) {
+		void test(`describes scalar encoding fixture: ${fixture.name}`, () => {
+			const question = getScalarParityQuestion(fixture.questionName)
+			const outcomeIndex = combineScalarParityOutcomeIndex(fixture.invalid, fixture.firstPart, fixture.secondPart)
+			const descriptor = getScalarOutcomeIndexDescriptor(question, outcomeIndex)
+			expect(descriptor).toEqual(fixture.expectedDescriptor)
+			expect(descriptor).toEqual(describeScalarParityOutcomeIndex(question, outcomeIndex))
+			expect(isValidScalarOutcomeIndex(question, outcomeIndex)).toBe(fixture.expectedDescriptor.kind !== 'malformed')
+			expect(formatScalarParityOutcomeName(question, outcomeIndex)).toBe(fixture.expectedLabel)
+			if (fixture.expectedDescriptor.kind === 'malformed') {
+				expect(() => formatScalarOutcomeIndexLabel(question, outcomeIndex)).toThrow('Scalar outcome index is malformed')
+			} else {
+				expect(formatScalarOutcomeIndexLabel(question, outcomeIndex)).toBe(fixture.expectedLabel)
+			}
+		})
+	}
 })


### PR DESCRIPTION
## Summary
- Add shared scalar parity fixture module under `shared/ts/testing/scalarOutcomeParityFixtures.ts` with canonical question definitions, deterministic encoding/decoding helpers, and label/descriptor helpers for scalar outcome parity.
- Export the new fixture module via `shared/package.json` exports so Solidity and UI tests can consume it from `@zoltar/shared/testing/...`.
- Extend `solidity/ts/tests/questionData.test.ts` with deterministic fixture assertions and pseudo-fuzz checks to verify contract scalar label/malformed behavior matches the shared TypeScript model.
- Extend `ui/ts/tests/scalarOutcome.test.ts` to reuse shared fixtures for expected labels and descriptor behavior parity with UI scalar helpers.

## Testing
- Not run (no test commands executed in this request).
- Suggested checks:
  - `cd ui && bun x tsc --project tsconfig.json`
  - `bun run test:run -- --bail=1`
  - `bun run check`