### PR TITLE
Reject zero REP vault operations with explicit UI and contract guards

### DIFF
--- a/docs/escalation-game-architecture.md
+++ b/docs/escalation-game-architecture.md
@@ -66,7 +66,7 @@ The proof verifier split keeps `EscalationGame` as the state-owning contract and
 - project deployed-bytecode budget headroom: `142` bytes below `24,000`
 - EIP-170 deployed-bytecode headroom: `718` bytes below `24,576`
 
-This PR intentionally adds revert strings and event payloads across the system, so `EscalationGame` is not expected to be smaller than the pre-audit `origin/main` artifact. The size target is to keep the enriched contract below the project budget while moving proof verification out to the verifier contract.
+The enriched contract includes revert strings and event payloads across the system, so the size target is to stay below the project budget while moving proof verification out to the verifier contract.
 
 Any Solidity change can alter deterministic deployment addresses because address derivation uses init code. After contract changes, regenerate and review deployment outputs with the normal artifact workflow and keep `docs/mainnet-deployment-addresses.json` plus `docs/mainnet-deployment-addresses.md` in sync when expected addresses change.
 

--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -307,7 +307,6 @@ export function SecurityVaultSection({
 	})
 		? securityVaultDetails
 		: undefined
-	const hasWithdrawAmount = normalizedSecurityVaultForm.repWithdrawAmount.trim() !== '' && normalizedSecurityVaultForm.repWithdrawAmount.trim() !== '0'
 	const selectedVaultIsOwnedByAccount = isSelectedVaultOwnedByAccountHelper(selectedVaultAddress, accountState.address)
 	const depositAmount = tryParseRepAmountInput(normalizedSecurityVaultForm.depositAmount)
 	const securityBondAllowanceAmount = tryParseRepAmountInput(normalizedSecurityVaultForm.securityBondAllowanceAmount)
@@ -368,6 +367,7 @@ export function SecurityVaultSection({
 	const depositGuardMessage = getVaultDepositGuardMessage({
 		accountAddress: accountState.address,
 		approvalSatisfied: hasSufficientDepositAllowance,
+		depositAmount,
 		isDepositBelowMinimum,
 		isMainnet,
 		repBalanceGap: hasInsufficientRepBalance ? repBalanceGap : undefined,
@@ -381,7 +381,7 @@ export function SecurityVaultSection({
 		requestPriceEthCost: oracleManagerDetails?.requestPriceEthCost,
 		selectedVaultIsOwnedByAccount,
 		stagedOperationTimeoutMinutes,
-		withdrawAmount: hasWithdrawAmount ? withdrawAmount : undefined,
+		withdrawAmount,
 		withdrawableRepAmount,
 		walletEthBalance: accountState.ethBalance,
 	})

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -305,6 +305,7 @@ export async function approveErc20<Action extends SecurityVaultActionResult['act
 	return { action, hash }
 }
 export async function depositRepToSecurityPool(client: WriteClient, securityPoolAddress: Address, amount: bigint) {
+	if (amount <= 0n) throw new Error('REP deposit amount must be greater than zero')
 	const hash = await writeContractAndWait(client, () => ({
 		address: securityPoolAddress,
 		abi: peripherals_SecurityPool_SecurityPool.abi,

--- a/ui/ts/hooks/useSecurityVaultOperations.ts
+++ b/ui/ts/hooks/useSecurityVaultOperations.ts
@@ -293,6 +293,7 @@ export function useSecurityVaultOperations({ accountAddress, enabled, onTransact
 			'depositRep',
 			async (vaultAddress, securityPoolAddress) => {
 				const depositAmount = parseRepAmountInput(securityVaultForm.value.depositAmount, 'REP collateral amount')
+				if (depositAmount <= 0n) throw new Error('REP deposit amount must be greater than zero')
 				const details = await loadExistingSecurityVaultDetails(securityPoolAddress, vaultAddress, 'Security pool does not exist')
 				if (details === undefined) return undefined
 				const currentRepBalance = await loadErc20Balance(createConnectedReadClient(), details.repToken, vaultAddress)

--- a/ui/ts/lib/securityVaultGuards.ts
+++ b/ui/ts/lib/securityVaultGuards.ts
@@ -14,6 +14,7 @@ export function getVaultApprovalGuardMessage({ accountAddress, isMainnet, select
 export function getVaultDepositGuardMessage({
 	accountAddress,
 	approvalSatisfied,
+	depositAmount,
 	isDepositBelowMinimum,
 	isMainnet,
 	repBalanceGap,
@@ -22,6 +23,7 @@ export function getVaultDepositGuardMessage({
 }: {
 	accountAddress: Address | undefined
 	approvalSatisfied: boolean
+	depositAmount: bigint | undefined
 	isDepositBelowMinimum: boolean
 	isMainnet: boolean
 	repBalanceGap: bigint | undefined
@@ -32,6 +34,8 @@ export function getVaultDepositGuardMessage({
 	if (accountAddress === undefined) return 'Connect a wallet before depositing REP.'
 	if (!isMainnet) return 'Switch to Ethereum mainnet before depositing REP.'
 	if (!selectedVaultDetailsLoaded) return 'Refresh the vault before depositing REP.'
+	if (depositAmount === undefined) return 'Enter a valid REP deposit amount.'
+	if (depositAmount <= 0n) return 'Enter a REP deposit amount greater than zero.'
 	if (!approvalSatisfied) return 'Approve enough REP before depositing.'
 	if (repBalanceGap !== undefined && repBalanceGap > 0n) return `Need ${formatCurrencyBalance(repBalanceGap)} more REP in this wallet.`
 	if (isDepositBelowMinimum) return `New vaults require at least ${formatCurrencyBalance(MIN_SECURITY_VAULT_REP_DEPOSIT)} REP in the first deposit.`
@@ -63,7 +67,8 @@ export function getVaultWithdrawGuardMessage({
 	if (accountAddress === undefined) return 'Connect a wallet before withdrawing REP.'
 	if (!isMainnet) return 'Switch to Ethereum mainnet before withdrawing REP.'
 	if (!hasValidOraclePrice) return 'A valid oracle price is required before withdrawing REP.'
-	if (withdrawAmount === undefined || withdrawAmount <= 0n) return 'Enter a valid REP withdraw amount.'
+	if (withdrawAmount === undefined) return 'Enter a valid REP withdraw amount.'
+	if (withdrawAmount <= 0n) return 'Enter a REP withdraw amount greater than zero.'
 	if (withdrawableRepAmount === undefined || withdrawableRepAmount <= 0n) return 'No REP is currently withdrawable from this vault.'
 	if (withdrawAmount > withdrawableRepAmount) return `Reduce the withdrawal to ${formatCurrencyBalance(withdrawableRepAmount)} REP or less.`
 	if (stagedOperationTimeoutMinutes === undefined || stagedOperationTimeoutMinutes < MIN_STAGED_OPERATION_TIMEOUT_MINUTES) return 'Enter a staged operation timeout of at least 1 minute.'

--- a/ui/ts/tests/contracts.test.ts
+++ b/ui/ts/tests/contracts.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from 'bun:test'
 import { decodeFunctionData, getAddress, zeroAddress, type Address, type Hash, type Hex, type TransactionReceipt } from 'viem'
 import {
 	buildForkCarriedEscalationProofs,
+	depositRepToSecurityPool,
 	getOpenOracleAddress,
 	loadAllSecurityPools,
 	loadEscalationDeposits,
@@ -138,6 +139,16 @@ describe('contracts helpers', () => {
 		expect(getForkOutcomeKey(0n, getAddress('0x0000000000000000000000000000000000000000'))).toBe('none')
 		expect(getForkOutcomeKey(0n, securityPoolAddress)).toBe('invalid')
 		expect(getForkOutcomeKey(1n, securityPoolAddress)).toBe('yes')
+	})
+
+	test('depositRepToSecurityPool rejects zero amounts before encoding a transaction', async () => {
+		let sendTransactionCount = 0
+		const client = createMockWriteClient(() => {
+			sendTransactionCount += 1
+		})
+
+		await expect(depositRepToSecurityPool(asWriteClient(client), securityPoolAddress, 0n)).rejects.toThrow('REP deposit amount must be greater than zero')
+		expect(sendTransactionCount).toBe(0)
 	})
 
 	test('loadForkAuctionDetails keeps the default root-pool fork outcome unset and inactive', async () => {

--- a/ui/ts/tests/securityVaultGuards.test.ts
+++ b/ui/ts/tests/securityVaultGuards.test.ts
@@ -12,6 +12,7 @@ describe('security vault guards', () => {
 			getVaultDepositGuardMessage({
 				accountAddress: zeroAddress,
 				approvalSatisfied: true,
+				depositAmount: 1n,
 				isDepositBelowMinimum: false,
 				isMainnet: true,
 				repBalanceGap: undefined,
@@ -24,6 +25,20 @@ describe('security vault guards', () => {
 			getVaultDepositGuardMessage({
 				accountAddress: zeroAddress,
 				approvalSatisfied: false,
+				depositAmount: 0n,
+				isDepositBelowMinimum: false,
+				isMainnet: true,
+				repBalanceGap: undefined,
+				selectedVaultDetailsLoaded: true,
+				selectedVaultIsOwnedByAccount: true,
+			}),
+		).toBe('Enter a REP deposit amount greater than zero.')
+
+		expect(
+			getVaultDepositGuardMessage({
+				accountAddress: zeroAddress,
+				approvalSatisfied: false,
+				depositAmount: 1n,
 				isDepositBelowMinimum: false,
 				isMainnet: true,
 				repBalanceGap: undefined,
@@ -36,6 +51,7 @@ describe('security vault guards', () => {
 			getVaultDepositGuardMessage({
 				accountAddress: zeroAddress,
 				approvalSatisfied: true,
+				depositAmount: 3n * 10n ** 18n,
 				isDepositBelowMinimum: false,
 				isMainnet: true,
 				repBalanceGap: 2n * 10n ** 18n,
@@ -48,6 +64,7 @@ describe('security vault guards', () => {
 			getVaultDepositGuardMessage({
 				accountAddress: zeroAddress,
 				approvalSatisfied: true,
+				depositAmount: 3n * 10n ** 18n,
 				isDepositBelowMinimum: false,
 				isMainnet: true,
 				repBalanceGap: undefined,
@@ -71,6 +88,20 @@ describe('security vault guards', () => {
 				walletEthBalance: 1n,
 			}),
 		).toBe('A valid oracle price is required before withdrawing REP.')
+
+		expect(
+			getVaultWithdrawGuardMessage({
+				accountAddress: zeroAddress,
+				hasValidOraclePrice: true,
+				isMainnet: true,
+				requestPriceEthCost: undefined,
+				selectedVaultIsOwnedByAccount: true,
+				stagedOperationTimeoutMinutes: 5n,
+				withdrawAmount: 0n,
+				withdrawableRepAmount: 2_500n * 10n ** 18n,
+				walletEthBalance: 1n,
+			}),
+		).toBe('Enter a REP withdraw amount greater than zero.')
 
 		expect(
 			getVaultWithdrawGuardMessage({


### PR DESCRIPTION
## Summary
- Adds explicit non-zero guards for security vault REP deposits in both UI validation and contract call path.
- Prevents zero/empty deposit submission early in `SecurityVaultSection` and `useSecurityVaultOperations`.
- Adds runtime validation in `depositRepToSecurityPool` so zero-value deposits are rejected before encoding/sending a transaction.
- Tightens vault guard messages for clearer validation: separate messages for missing vs zero deposit/withdraw amounts.
- Removes shared scalar parity fixture module from `@zoltar/shared/testing` exports and drops its fixture-based usages in UI tests.
- Updates tests to cover the new zero-amount behavior (`contracts.test.ts`, `securityVaultGuards.test.ts`).

## Testing
- Not run (no command output provided with request).
- Added/updated unit tests in:
  - `ui/ts/tests/contracts.test.ts` (zero-amount deposit rejection)
  - `ui/ts/tests/securityVaultGuards.test.ts` (zero deposit/withdraw guard messages)
- Removed tests in `ui/ts/tests/scalarOutcome.test.ts` that depended on deleted shared parity fixtures.
- Suggested verification commands:
  - `bun run tsc`
  - `bun run test`
  - `bun run check`