### PR TITLE
Propagate recursive carry read failures

### DIFF
--- a/ui/ts/contracts/reporting.ts
+++ b/ui/ts/contracts/reporting.ts
@@ -1,7 +1,6 @@
 import { concatHex, encodeAbiParameters, keccak256, parseAbiItem, parseAbiParameters, zeroAddress, type Address, type ContractFunctionParameters, type Hex } from 'viem'
 import { Zoltar_Zoltar, peripherals_EscalationGame_EscalationGame, peripherals_SecurityPool_SecurityPool } from '../contractArtifact.js'
 import { sameAddress } from '../lib/address.js'
-import { isIgnorableLogDecodeError } from '../lib/errors.js'
 import type { CarriedDepositProof, EscalationDeposit, EscalationSide, ImportedEscalationDeposit, ReadClient, ReportingActionResult, ReportingDetails, ReportingOutcomeKey, ReportingSettlementState, WriteClient } from '../types/contracts.js'
 import { readRequiredMulticall, writeContractAndWait } from './core.js'
 import { requireAddressValue, requireArrayValue, requireBigintValue, requireIntegerLikeValue, requireObjectValue, requireTupleValue } from './decoders.js'
@@ -174,9 +173,40 @@ async function readForkContinuation(client: Pick<ReadClient, 'readContract'>, es
 			args: [],
 		})
 	} catch (error) {
-		if (isIgnorableLogDecodeError(error)) return undefined
-		return undefined
+		if (isForkContinuationCompatibilityError(error)) return undefined
+		throw error
 	}
+}
+
+function collectErrorMessages(error: unknown, seen = new Set<object>()): string[] {
+	if (typeof error === 'string') return [error]
+	if (typeof error !== 'object' || error === null) return []
+	if (seen.has(error)) return []
+	seen.add(error)
+
+	const messages: string[] = []
+	for (const key of ['message', 'shortMessage', 'details']) {
+		const value = Reflect.get(error, key)
+		if (typeof value === 'string') messages.push(value)
+	}
+
+	const metaMessages = Reflect.get(error, 'metaMessages')
+	if (Array.isArray(metaMessages)) {
+		for (const message of metaMessages) {
+			if (typeof message === 'string') messages.push(message)
+		}
+	}
+
+	messages.push(...collectErrorMessages(Reflect.get(error, 'cause'), seen))
+	return messages
+}
+
+function isForkContinuationCompatibilityError(error: unknown) {
+	return collectErrorMessages(error).some(message => {
+		const normalizedMessage = message.toLowerCase()
+		if (!normalizedMessage.includes('forkcontinuation')) return false
+		return normalizedMessage.includes('returned no data') || normalizedMessage.includes('does not have the function') || normalizedMessage.includes('function not found') || normalizedMessage.includes('function selector') || normalizedMessage.includes('unknown function')
+	})
 }
 
 async function readEscalationOutcomeState(client: Pick<ReadClient, 'readContract'>, escalationGameAddress: Address, outcome: ReportingOutcomeKey) {

--- a/ui/ts/tests/contracts.test.ts
+++ b/ui/ts/tests/contracts.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from 'bun:test'
-import { decodeFunctionData, getAddress, zeroAddress, type Address, type Hash, type Hex, type TransactionReceipt } from 'viem'
+import { concatHex, decodeFunctionData, getAddress, keccak256, zeroAddress, type Address, type Hash, type Hex, type TransactionReceipt } from 'viem'
 import {
 	buildForkCarriedEscalationProofs,
 	getOpenOracleAddress,
@@ -38,6 +38,7 @@ const zoltarAddress = getAddress('0x00000000000000000000000000000000000000e7')
 const token1Address = getAddress('0x00000000000000000000000000000000000000d1')
 const token2Address = getAddress('0x00000000000000000000000000000000000000d2')
 const transactionHash = '0x00000000000000000000000000000000000000000000000000000000000000c3' satisfies Hash
+const zeroBytes32 = '0x0000000000000000000000000000000000000000000000000000000000000000' satisfies Hex
 const defaultForkData = [0n, zeroAddress, 0n, 0n, 0n, 0n, 0n, 0n, false, false, 0n] as const
 
 type MockReadClient = Parameters<typeof loadEscalationDeposits>[0]
@@ -102,6 +103,38 @@ function createMockReadClient(readContract: MockReadContractHandler): MockReadCl
 	return {
 		readContract: createReadContractStub(readContract),
 	}
+}
+
+function buildEmptyNullifierRoot() {
+	let currentHash: Hex = zeroBytes32
+	for (let depth = 1; depth < 64; depth += 1) currentHash = keccak256(concatHex([currentHash, currentHash]))
+	return currentHash
+}
+
+function createForkCarriedProofReadClient(readForkContinuation: () => Promise<unknown>) {
+	const parentEscalationGameAddress = getAddress('0x00000000000000000000000000000000000000f1')
+	const emptyNullifierRoot = buildEmptyNullifierRoot()
+	return {
+		multicall: createMulticallStub(async request => {
+			const firstContract = request.contracts[0]
+			const functionName = getContractFunctionName(firstContract)
+			if (functionName === 'parent') return [alternateSecurityPoolAddress, escalationGameAddress]
+			throw new Error(`Unexpected multicall contract: ${functionName}`)
+		}),
+		readContract: createReadContractStub(async request => {
+			if (request.functionName === 'escalationGame') return parentEscalationGameAddress
+			if (request.functionName === 'getOutcomeState')
+				return {
+					currentCarryRoot: zeroBytes32,
+					currentLeafCount: 0n,
+					currentNullifierRoot: emptyNullifierRoot,
+				}
+			if (request.functionName === 'forkContinuation') return await readForkContinuation()
+			if (request.functionName === 'getCarryLeafPageByOutcome') return [[], 0n]
+			if (request.functionName === 'getProofConsumedCarriedDepositIndexesByOutcome') return []
+			throw new Error(`Unexpected readContract function: ${request.functionName}`)
+		}),
+	} as unknown as Parameters<typeof buildForkCarriedEscalationProofs>[0]
 }
 
 function createMockLoaderClient({ getBlock, multicall, readContract }: { getBlock: () => Promise<{ timestamp: bigint }>; multicall: MockLoaderMulticallHandler; readContract: MockReadContractHandler }): MockLoaderClient {
@@ -755,6 +788,7 @@ describe('contracts helpers', () => {
 				if (request.functionName === 'getQuestionOutcome') return 3
 				if (request.functionName === 'getForkTime') return 0n
 				if (request.functionName === 'hasReachedNonDecision') return false
+				if (request.functionName === 'forkContinuation') return false
 				if (request.functionName === 'getForkThreshold') return 100n
 				if (request.functionName === 'escalationGame') return escalationGameAddress
 				if (request.functionName === 'escrowedRepByVault') return escrowedRep
@@ -806,6 +840,7 @@ describe('contracts helpers', () => {
 				if (request.functionName === 'getQuestionOutcome') return 3
 				if (request.functionName === 'getForkTime') return 123n
 				if (request.functionName === 'hasReachedNonDecision') return false
+				if (request.functionName === 'forkContinuation') return false
 				if (request.functionName === 'getForkThreshold') return 100n
 				if (request.functionName === 'escalationGame') return escalationGameAddress
 				if (request.functionName === 'escrowedRepByVault') return 9n
@@ -867,6 +902,7 @@ describe('contracts helpers', () => {
 				if (request.functionName === 'getQuestionOutcome') return 3
 				if (request.functionName === 'getForkTime') return 120n
 				if (request.functionName === 'hasReachedNonDecision') return false
+				if (request.functionName === 'forkContinuation') return false
 				if (request.functionName === 'getForkThreshold') return 100n
 				if (request.functionName === 'escalationGame') return escalationGameAddress
 				if (request.functionName === 'escrowedRepByVault') return 9n
@@ -1023,6 +1059,22 @@ describe('contracts helpers', () => {
 		} as unknown as Parameters<typeof buildForkCarriedEscalationProofs>[0]
 
 		await expect(buildForkCarriedEscalationProofs(client, securityPoolAddress, 'yes', [1n])).rejects.toThrow('Unexpected carry leaf page response')
+	})
+
+	test('buildForkCarriedEscalationProofs treats a missing recursive forkContinuation getter as backward-compatible', async () => {
+		const client = createForkCarriedProofReadClient(async () => {
+			throw new Error('The contract function "forkContinuation" returned no data ("0x"). The contract does not have the function "forkContinuation".')
+		})
+
+		await expect(buildForkCarriedEscalationProofs(client, securityPoolAddress, 'yes', [])).resolves.toEqual([])
+	})
+
+	test('buildForkCarriedEscalationProofs rejects recursive forkContinuation RPC failures', async () => {
+		const client = createForkCarriedProofReadClient(async () => {
+			throw new Error('RPC request failed while reading forkContinuation')
+		})
+
+		await expect(buildForkCarriedEscalationProofs(client, securityPoolAddress, 'yes', [])).rejects.toThrow('RPC request failed while reading forkContinuation')
 	})
 
 	test('migrateVaultWithUnresolvedEscalation helper encodes the selected child outcome correctly', async () => {


### PR DESCRIPTION
## Summary
- Narrowed `readForkContinuation` fallback handling so only known backward-compatibility errors for a missing/unsupported `forkContinuation` getter return `undefined`.
- Re-throws RPC/read failures during recursive carry snapshot loading so the UI can surface recoverable load errors instead of displaying incomplete carry/proof state.
- Added UI contract-loader coverage for missing `forkContinuation` versus RPC failure, and made existing reporting fixtures return `forkContinuation: false` explicitly.

## Testing
- `bun test --preload ./bun-test-setup-ui.ts --timeout 300000 ui/ts/tests/contracts.test.ts`
- `bun run tsc`
- `bun run ensure-contract-artifacts && bun run check:shared-dependencies && bun run test:run -- --bail=1` (`1504 pass`, `11 skip`, `0 fail` after merging latest `origin/main`)
- `bun run format`
- `bun run check`
- `bun run knip`
- `git diff --check`
