### PR TITLE
Clarify UI copy and improve accessibility workflows

### DIFF
--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -507,6 +507,7 @@ export function App() {
 			onLoadPoolOracleManager: (managerAddress: Address) => void loadPoolOracleManager(managerAddress),
 			onLoadSecurityPools: () => void loadSecurityPools(),
 			onCreateSecurityPool: () => setSecurityPoolsView('create'),
+			onOpenLiquidationModal: (managerAddress: Address, selectedSecurityPoolAddress: Address, vaultAddress: Address, maxAmount: bigint | undefined) => openLiquidationModal(managerAddress, selectedSecurityPoolAddress, vaultAddress, maxAmount),
 			onQueueLiquidation: (managerAddress: Address, selectedSecurityPoolAddress: Address) => void queueLiquidation(managerAddress, selectedSecurityPoolAddress),
 			poolOracleManagerDetails,
 			securityPoolBrowseCount,
@@ -716,7 +717,7 @@ export function App() {
 				options={[
 					{ href: buildRouteHref(SECURITY_POOLS_ROUTE, writeSecurityPoolsViewQueryParam(getRouteHashSearch(), 'browse')), label: 'Browse Pools', value: 'browse' },
 					{ href: buildRouteHref(SECURITY_POOLS_ROUTE, writeSecurityPoolsViewQueryParam(getRouteHashSearch(), 'create')), label: 'Create Pool', value: 'create' },
-					{ href: buildRouteHref(SECURITY_POOLS_ROUTE, writeSecurityPoolsViewQueryParam(getRouteHashSearch(), 'operate')), label: 'Pool Workflows', value: 'operate' },
+					{ href: buildRouteHref(SECURITY_POOLS_ROUTE, writeSecurityPoolsViewQueryParam(getRouteHashSearch(), 'operate')), label: 'Manage Pool', value: 'operate' },
 				]}
 			/>
 		)

--- a/ui/ts/components/NotFoundSection.tsx
+++ b/ui/ts/components/NotFoundSection.tsx
@@ -9,7 +9,7 @@ export function NotFoundSection() {
 	return (
 		<>
 			<RouteHeader eyebrow='Augur PLACEHOLDER' title='404' description='That page is not here.' />
-			<SectionBlock className='not-found-shell' title='Hash route not found' description='Use the main routes below to return to a supported workflow.'>
+			<SectionBlock className='not-found-shell' title='Hash route not found' description='Use the main routes below to return to a supported page.'>
 				<div className='not-found-copy'>
 					<StateHint presentation={presentation} />
 					<div className='hero-status'>

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -57,8 +57,8 @@ const NO_SELECTED_SIDE_CAPACITY_REASON = 'No remaining contribution capacity is 
 const BELOW_MINIMUM_SELECTED_SIDE_CAPACITY_REASON = 'Remaining selected-side capacity is below the minimum report bond.'
 const FORK_TRIGGERED_REPORT_REASON = 'Escalation reached non-decision. Trigger Zoltar Fork here if this pool should fork the universe.'
 const FORK_TRIGGERED_SETTLEMENT_REASON = 'Escalation deposits remain locked after non-decision. Trigger Zoltar Fork here if this pool should fork the universe.'
-const FORK_ALREADY_TRIGGERED_REPORT_REASON = 'Escalation reached non-decision and Zoltar fork has already been triggered for this pool. Continue in the Fork workflow.'
-const FORK_ALREADY_TRIGGERED_SETTLEMENT_REASON = 'Escalation deposits remain locked after non-decision. Zoltar fork has already been triggered for this pool, so continue in the Fork workflow.'
+const FORK_ALREADY_TRIGGERED_REPORT_REASON = 'Escalation reached non-decision and Zoltar fork has already been triggered for this pool. Continue in Fork & Migration.'
+const FORK_ALREADY_TRIGGERED_SETTLEMENT_REASON = 'Escalation deposits remain locked after non-decision. Zoltar fork has already been triggered for this pool, so continue in Fork & Migration.'
 function getOutcomeSides(reportingDetails: ReportingDetails | undefined) {
 	if (reportingDetails?.status === 'active')
 		return reportingDetails.sides.map<EscalationSideDisplay>(side => ({
@@ -280,7 +280,7 @@ export function ReportingSection({
 	if (reportingStageKey === 'forkTriggered') {
 		settlementLifecycleReason = forkAlreadyTriggered ? FORK_ALREADY_TRIGGERED_SETTLEMENT_REASON : FORK_TRIGGERED_SETTLEMENT_REASON
 	} else if (activeReportingDetails?.settlementState === 'migration-required') {
-		settlementLifecycleReason = forkAlreadyTriggered ? 'Continue in the Fork Workflow to migrate unresolved escalation deposits into a child universe.' : 'These escalation deposits must migrate in the Fork Workflow.'
+		settlementLifecycleReason = forkAlreadyTriggered ? 'Continue in Fork & Migration to migrate unresolved escalation deposits into a child universe.' : 'These escalation deposits must migrate in Fork & Migration.'
 	} else if (activeReportingDetails?.settlementState === 'migration-expired') {
 		settlementLifecycleReason = 'The migration window for these unresolved escalation deposits has closed.'
 	} else if (reportingStageKey === 'activeLocked') {
@@ -448,7 +448,7 @@ export function ReportingSection({
 				) : undefined}
 				{showForkWorkflowAction ? (
 					<button className='secondary' type='button' onClick={onOpenForkWorkflow}>
-						Open Fork Workflow
+						Open Fork & Migration
 					</button>
 				) : undefined}
 			</div>
@@ -642,9 +642,9 @@ export function ReportingSection({
 			{showSettlementSection ? (
 				<SectionBlock title='Settle Escalation Deposits'>
 					{reportingStageKey === 'forkTriggered' ? <p className='detail'>{forkAlreadyTriggered ? FORK_ALREADY_TRIGGERED_SETTLEMENT_REASON : FORK_TRIGGERED_SETTLEMENT_REASON}</p> : undefined}
-					{activeReportingDetails?.settlementState === 'migration-required' ? <p className='detail'>{forkAlreadyTriggered ? 'Continue in the Fork Workflow to migrate unresolved escalation deposits into a child universe.' : 'These escalation deposits must migrate in the Fork Workflow.'}</p> : undefined}
+					{activeReportingDetails?.settlementState === 'migration-required' ? <p className='detail'>{forkAlreadyTriggered ? 'Continue in Fork & Migration to migrate unresolved escalation deposits into a child universe.' : 'These escalation deposits must migrate in Fork & Migration.'}</p> : undefined}
 					{activeReportingDetails?.settlementState === 'migration-expired' ? <p className='detail'>The migration window for these unresolved escalation deposits has closed.</p> : undefined}
-					{hasImportedForkedDeposits ? <p className='detail'>This pool also has fork-carried escalation positions. Settle those in the Fork Workflow.</p> : undefined}
+					{hasImportedForkedDeposits ? <p className='detail'>This pool also has fork-carried escalation positions. Settle those in Fork & Migration.</p> : undefined}
 					{loadingReportingDetails ? (
 						<p className='detail'>
 							<LoadingText>Loading escalation deposits...</LoadingText>

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -227,10 +227,10 @@ export function SecurityPoolWorkflowSection({
 	})
 	const triggerZoltarForkReason = (() => {
 		if (selectedPoolReportingStage === 'forkTriggered' && selectedPoolHasActualForkActivity) {
-			return 'Zoltar fork has already been triggered for this pool. Continue in the Fork workflow.'
+			return 'Zoltar fork has already been triggered for this pool. Continue in Fork & Migration.'
 		}
 		if (selectedPoolReportingStage === 'forkTriggered' && selectedPoolState !== 'operational') {
-			return 'This pool has already entered its fork workflow. Continue in the Fork workflow.'
+			return 'This pool has already entered Fork & Migration.'
 		}
 		return 'Triggering a Zoltar fork is not available in the current pool state.'
 	})()
@@ -244,7 +244,7 @@ export function SecurityPoolWorkflowSection({
 	})()
 	const selectedPoolForkWorkflowSystemState = selectedPoolLifecycleState === undefined || selectedPoolLifecycleState === 'ended' ? selectedPoolState : selectedPoolLifecycleState
 	const reportingLockedReason = (() => {
-		if (selectedPoolState === 'poolForked') return 'This parent pool is forked. Continue in the Fork Workflow for migration and settlement.'
+		if (selectedPoolState === 'poolForked') return 'This parent pool is forked. Continue in Fork & Migration for migration and settlement.'
 		if (selectedPoolState === 'forkMigration') return 'This pool is in fork migration. Reporting actions unlock once the pool becomes operational.'
 		if (selectedPoolState === 'forkTruthAuction') return 'This pool is in truth auction. Reporting actions unlock once the pool becomes operational.'
 		if (reportingReady) return undefined
@@ -766,8 +766,8 @@ export function SecurityPoolWorkflowSection({
 							ariaLabel='Selected pool views'
 							className='selected-pool-workflow-nav'
 							groups={[
-								{ ariaLabel: 'Primary pool workflows', className: 'selected-pool-workflow-group', values: SELECTED_POOL_PRIMARY_VIEWS },
-								{ ariaLabel: 'Additional pool workflows', className: 'selected-pool-workflow-group selected-pool-workflow-group-secondary', values: SELECTED_POOL_SECONDARY_VIEWS },
+								{ ariaLabel: 'Primary pool actions', className: 'selected-pool-workflow-group', values: SELECTED_POOL_PRIMARY_VIEWS },
+								{ ariaLabel: 'Additional pool actions', className: 'selected-pool-workflow-group selected-pool-workflow-group-secondary', values: SELECTED_POOL_SECONDARY_VIEWS },
 							]}
 							orientation='vertical'
 							size='compact'
@@ -779,7 +779,7 @@ export function SecurityPoolWorkflowSection({
 
 					<div className='selected-pool-workflow-content'>
 						{!showSelectedPoolWorkflowDetails ? (
-							<SectionBlock title={selectedPoolLookupState === 'missing' ? 'Pool not found' : 'Pool Workflows'}>{selectedPoolWorkflowLockedPresentation === undefined ? undefined : <StateHint presentation={selectedPoolWorkflowLockedPresentation} />}</SectionBlock>
+							<SectionBlock title={selectedPoolLookupState === 'missing' ? 'Pool not found' : 'Manage Pool'}>{selectedPoolWorkflowLockedPresentation === undefined ? undefined : <StateHint presentation={selectedPoolWorkflowLockedPresentation} />}</SectionBlock>
 						) : (
 							<>
 								{view === 'vaults' ? (

--- a/ui/ts/components/SecurityPoolsOverviewSection.tsx
+++ b/ui/ts/components/SecurityPoolsOverviewSection.tsx
@@ -48,6 +48,7 @@ export function SecurityPoolsOverviewSection({
 	onLiquidationTimeoutMinutesChange,
 	onLoadPoolOracleManager,
 	onLoadSecurityPoolPage,
+	onOpenLiquidationModal,
 	onQueueLiquidation,
 	onSelectSecurityPool,
 	poolOracleManagerDetails,
@@ -138,7 +139,7 @@ export function SecurityPoolsOverviewSection({
 			<SectionBlock
 				density='compact'
 				title='Security Pools'
-				description='Browse deployed pools, inspect their vaults, and open a selected pool workflow.'
+				description='Browse deployed pools, inspect their vaults, and open a selected pool to manage it.'
 				actions={
 					<PaginationControls
 						hasNextPage={hasNextPage}
@@ -222,6 +223,7 @@ export function SecurityPoolsOverviewSection({
 						<div className='entity-card-list'>
 							{filteredSecurityPools.map(({ hasKnownForkActivity, pool, poolState }) => {
 								const displayState = poolState.lifecycleState
+								const liquidationEnabled = poolState.actions.queueLiquidation.enabled
 								const collateralizationPercent = getPoolCollateralizationPercent(pool.totalRepDeposit, pool.totalSecurityBondAllowance, repPerEthPrice)
 								const targetCollateralizationPercent = pool.securityMultiplier * 100n * 10n ** 18n
 								const badgeTone = (() => {
@@ -375,8 +377,13 @@ export function SecurityPoolsOverviewSection({
 																						<CurrencyValue value={vault.repDepositShare} suffix='REP' />
 																					</strong>
 																				</div>
-																				<button className='secondary security-pool-browse-vault-row-liquidate' onClick={() => onSelectSecurityPool?.(pool.securityPoolAddress)} disabled={onSelectSecurityPool === undefined} title='Open the selected pool workflow before reviewing liquidation actions.'>
-																					Open Pool to Liquidate
+																				<button
+																					className='secondary security-pool-browse-vault-row-liquidate'
+																					onClick={() => onOpenLiquidationModal(pool.managerAddress, pool.securityPoolAddress, vault.vaultAddress, vault.securityBondAllowance)}
+																					disabled={accountState.address === undefined || !isMainnet || !liquidationEnabled}
+																					title='Review liquidation details for this vault before queueing the action.'
+																				>
+																					Review Liquidation
 																				</button>
 																			</div>
 																		</div>

--- a/ui/ts/components/TradingSection.tsx
+++ b/ui/ts/components/TradingSection.tsx
@@ -288,17 +288,17 @@ export function TradingSection({
 			)}
 
 			{selectedPool === undefined ? undefined : (
-				<SectionBlock title='Your Shares' description='Current wallet holdings in the selected pool.'>
+				<SectionBlock title='Your Holdings' description='Balances are shown as complete-set amounts for the selected pool.'>
 					<div className='trading-holdings-stage'>
 						<div className='trading-holdings-hero'>
-							<span>Total Complete Sets</span>
+							<span>Redeemable Complete Sets</span>
 							<strong>{renderShareMetricValue(displayMaxRedeemableCompleteSets)}</strong>
-							<p className='detail'>Wallet composition by outcome.</p>
+							<p className='detail'>Limited by your smallest Yes, No, or Invalid balance.</p>
 						</div>
 						<div className='trading-holdings-layout'>
 							<RankedBarList
 								className='trading-share-distribution'
-								emptyMessage='Wallet share balances are not loaded yet.'
+								emptyMessage='Wallet balances are not loaded yet.'
 								items={[
 									{
 										key: 'yes',
@@ -334,7 +334,7 @@ export function TradingSection({
 									<strong>{renderShareMetricValue(displayShareBalances?.invalid)}</strong>
 								</div>
 								<div className='trading-share-callouts-total'>
-									<span>Total Collateral Equivalent</span>
+									<span>Total Across Outcomes</span>
 									<strong>{renderShareMetricValue(totalShareCount)}</strong>
 								</div>
 							</div>
@@ -381,7 +381,7 @@ export function TradingSection({
 				</div>
 			</OperationModal>
 
-			<OperationModal description='Redeeming complete sets requires matching yes, no, and invalid shares. Use the total complete sets metric as the ceiling.' isOpen={activeModal === 'redeem-complete-sets'} onClose={() => setActiveModal(undefined)} title='Redeem Complete Sets'>
+			<OperationModal description='Redeeming complete sets requires matching yes, no, and invalid shares. Use the redeemable complete sets amount as the ceiling.' isOpen={activeModal === 'redeem-complete-sets'} onClose={() => setActiveModal(undefined)} title='Redeem Complete Sets'>
 				<label className='field'>
 					<span>Redeem Complete Sets Amount</span>
 					<div className='field-inline'>

--- a/ui/ts/hooks/useReportingOperations.ts
+++ b/ui/ts/hooks/useReportingOperations.ts
@@ -176,7 +176,7 @@ export function useReportingOperations({ accountAddress, onTransactionFailed, on
 				}
 				const availableDepositIndexes = selectedSide?.userDeposits.map(deposit => deposit.depositIndex) ?? []
 
-				if (latestDetails.settlementState === 'migration-required') throw new Error('Unresolved escalation deposits must migrate in the Fork Workflow.')
+				if (latestDetails.settlementState === 'migration-required') throw new Error('Unresolved escalation deposits must migrate in Fork & Migration.')
 				if (latestDetails.settlementState === 'migration-expired') throw new Error('The migration window for these unresolved escalation deposits has closed.')
 				if (!latestDetails.parentWithdrawalEnabled) throw new Error('Escalation deposits cannot be settled until the question is finalized.')
 

--- a/ui/ts/lib/appPageTitle.ts
+++ b/ui/ts/lib/appPageTitle.ts
@@ -20,7 +20,7 @@ export function getAppPageTitle({ activeOpenOracleView, activeSecurityPoolsView,
 	}
 	if (route === 'security-pools') {
 		if (activeSecurityPoolsView === 'create') return 'Create Security Pool'
-		if (activeSecurityPoolsView === 'operate') return 'Pool Workflows'
+		if (activeSecurityPoolsView === 'operate') return 'Manage Security Pool'
 		return 'Security Pools'
 	}
 	if (route === 'open-oracle') {

--- a/ui/ts/lib/securityPoolWorkflow.ts
+++ b/ui/ts/lib/securityPoolWorkflow.ts
@@ -301,7 +301,7 @@ export function shouldShowSelectedPoolWorkflowDetails({ hasSelectedPoolAddress, 
 	return hasSelectedPoolAddress && selectedPoolExists && !selectedPoolUniverseMismatch
 }
 export function getSelectedPoolCardTitle() {
-	return 'Pool Workflows'
+	return 'Manage Pool'
 }
 export function applySelectedPoolWorkflowState(
 	pool: ListedSecurityPool | undefined,
@@ -322,10 +322,10 @@ export function applySelectedPoolWorkflowState(
 	}
 }
 export function getSelectedPoolWorkflowGuardMessage({ hasSelectedPoolAddress, selectedPoolLookupState, selectedPoolUniverseMismatch }: { hasSelectedPoolAddress: boolean; selectedPoolLookupState: LoadableValueState; selectedPoolUniverseMismatch: boolean }) {
-	if (selectedPoolUniverseMismatch) return 'Switch to the same universe before using this pool workflow.'
+	if (selectedPoolUniverseMismatch) return 'Switch to the same universe before managing this pool.'
 	if (selectedPoolLookupState === 'loading') return 'Wait for this pool to finish loading.'
-	if (selectedPoolLookupState === 'missing') return 'Load a valid pool to open this workflow.'
-	if (!hasSelectedPoolAddress || selectedPoolLookupState === 'unknown') return 'Load a pool to open this workflow.'
+	if (selectedPoolLookupState === 'missing') return 'Load a valid pool before using pool actions.'
+	if (!hasSelectedPoolAddress || selectedPoolLookupState === 'unknown') return 'Load a pool before using pool actions.'
 	return undefined
 }
 export function getSelectedPoolWorkflowLockedPresentation({ hasSelectedPoolAddress, selectedPoolLookupState, selectedPoolUniverseMismatch }: { hasSelectedPoolAddress: boolean; selectedPoolLookupState: LoadableValueState; selectedPoolUniverseMismatch: boolean }): UserMessagePresentation {
@@ -334,7 +334,7 @@ export function getSelectedPoolWorkflowLockedPresentation({ hasSelectedPoolAddre
 			actionHint: 'Switch to the matching universe first.',
 			badgeLabel: 'Unavailable',
 			badgeTone: 'blocked',
-			detail: 'Switch to the same universe before using vault, trading, reporting, and fork workflows.',
+			detail: 'Switch to the same universe before using vault, trading, reporting, and fork actions.',
 			key: 'unavailable',
 		}
 	if (selectedPoolLookupState === 'loading')

--- a/ui/ts/lib/trading.ts
+++ b/ui/ts/lib/trading.ts
@@ -67,6 +67,11 @@ export function getMaxRedeemableCompleteSets(shareBalances: TradingShareBalances
 	return shareBalances.no
 }
 
+function formatCompleteSetAmount(value: bigint) {
+	const formattedValue = formatCurrencyBalance(value)
+	return `${formattedValue} complete ${formattedValue === '1' ? 'set' : 'sets'}`
+}
+
 function divideRoundedUp(numerator: bigint, denominator: bigint) {
 	if (denominator <= 0n) throw new RangeError('Denominator must be greater than zero')
 	return (numerator + denominator - 1n) / denominator
@@ -225,7 +230,7 @@ export function getTradingRedeemCompleteSetGuardMessage({
 	if (redeemShareAmount === undefined) return 'Redeeming is unavailable because this pool has complete-set shares but no collateral.'
 	if (redeemShareAmount > maxRedeemableCompleteSets) {
 		const maxRedeemableCollateralAmount = convertShareAmountToCollateralAmount(maxRedeemableCompleteSets, completeSetCollateralAmount, shareTokenSupply)
-		return `Max redeemable amount is ${formatCurrencyBalance(maxRedeemableCollateralAmount)} complete sets.`
+		return `Max redeemable amount is ${formatCompleteSetAmount(maxRedeemableCollateralAmount)}.`
 	}
 	return undefined
 }

--- a/ui/ts/lib/userCopy.ts
+++ b/ui/ts/lib/userCopy.ts
@@ -64,7 +64,7 @@ export function getPoolRegistryPresentation(
 				detail: 'Load security pools to check what is available in this universe.',
 			})
 		return createPresentation('empty', {
-			actionHint: 'Create a pool from a binary question to enable trading, reporting, and vault collateral workflows.',
+			actionHint: 'Create a pool from a binary question to enable trading, reporting, and vault collateral actions.',
 			badgeLabel: 'None yet',
 			badgeTone: 'muted',
 			detail: 'No security pools are available in this universe yet.',

--- a/ui/ts/simulation/scenarios.ts
+++ b/ui/ts/simulation/scenarios.ts
@@ -36,11 +36,11 @@ export function getSimulationScenarioDescription(scenario: SimulationScenario) {
 		case 'deployed':
 			return 'App contracts are deployed, but no security pools or seeded markets are created. Use it to test setup flows from an empty deployment.'
 		case 'security-pool':
-			return 'One seeded market, one security pool, and one funded vault with an active security bond allowance. Use it to test pool workflows and liquidation paths.'
+			return 'One seeded market, one security pool, and one funded vault with an active security bond allowance. Use it to test pool actions and liquidation paths.'
 		case 'securitypoolx2':
-			return 'Two seeded markets with two security pools and two funded vaults in each pool. Use it to test multi-pool selection and repeated pool workflows.'
+			return 'Two seeded markets with two security pools and two funded vaults in each pool. Use it to test multi-pool selection and repeated pool actions.'
 		case 'securitypoolx2-auction':
-			return 'Two seeded markets with one own-escalation fork already triggered and one child truth auction seeded with ten bids. Use it to test fork-auction bidbook and settlement workflows.'
+			return 'Two seeded markets with one own-escalation fork already triggered and one child truth auction seeded with ten bids. Use it to test the fork-auction bidbook and settlement actions.'
 		default:
 			return assertNever(scenario)
 	}

--- a/ui/ts/tests/appPageTitle.test.tsx
+++ b/ui/ts/tests/appPageTitle.test.tsx
@@ -39,7 +39,7 @@ describe('app page titles', () => {
 			{ input: { ...baseInput, route: 'zoltar', activeZoltarView: 'migrate' }, title: 'Migrate REP' },
 			{ input: { ...baseInput, route: 'security-pools', activeSecurityPoolsView: 'browse' }, title: 'Security Pools' },
 			{ input: { ...baseInput, route: 'security-pools', activeSecurityPoolsView: 'create' }, title: 'Create Security Pool' },
-			{ input: { ...baseInput, route: 'security-pools', activeSecurityPoolsView: 'operate' }, title: 'Pool Workflows' },
+			{ input: { ...baseInput, route: 'security-pools', activeSecurityPoolsView: 'operate' }, title: 'Manage Security Pool' },
 			{ input: { ...baseInput, route: 'open-oracle', activeOpenOracleView: 'browse' }, title: 'Oracle Reports' },
 			{ input: { ...baseInput, route: 'open-oracle', activeOpenOracleView: 'create' }, title: 'Create Oracle Report' },
 			{ input: { ...baseInput, route: 'open-oracle', activeOpenOracleView: 'selected-report' }, title: 'Oracle Report Details' },

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -1304,7 +1304,7 @@ describe('ReportingSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		expect(document.body.textContent?.includes('The migration window for these unresolved escalation deposits has closed.')).toBe(true)
-		expect(document.body.textContent?.includes('must migrate in the Fork Workflow')).toBe(false)
+		expect(document.body.textContent?.includes('must migrate in Fork & Migration')).toBe(false)
 		expect(document.body.textContent?.includes('Connected wallet has no unsettled escalation deposits.')).toBe(false)
 	})
 
@@ -1334,7 +1334,7 @@ describe('ReportingSection', () => {
 		expect(triggerZoltarForkCalls).toBe(1)
 	})
 
-	test('keeps only Open Fork Workflow visible after a fork-triggered pool has already entered its fork workflow', async () => {
+	test('keeps only Open Fork & Migration visible after a fork-triggered pool has already entered its fork workflow', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(
 				ReportingSection,
@@ -1353,8 +1353,8 @@ describe('ReportingSection', () => {
 
 		const documentQueries = within(document.body)
 		expect(documentQueries.queryByRole('button', { name: 'Trigger Zoltar Fork' })).toBeNull()
-		expect(documentQueries.getByRole('button', { name: 'Open Fork Workflow' })).not.toBeNull()
-		expect(document.body.textContent?.includes('Escalation deposits remain locked after non-decision. Zoltar fork has already been triggered for this pool, so continue in the Fork workflow.')).toBe(true)
+		expect(documentQueries.getByRole('button', { name: 'Open Fork & Migration' })).not.toBeNull()
+		expect(document.body.textContent?.includes('Escalation deposits remain locked after non-decision. Zoltar fork has already been triggered for this pool, so continue in Fork & Migration.')).toBe(true)
 	})
 
 	test('shows a Trigger Zoltar Fork action when non-decision blocks reporting', async () => {

--- a/ui/ts/tests/securityPoolWorkflow.test.ts
+++ b/ui/ts/tests/securityPoolWorkflow.test.ts
@@ -28,11 +28,11 @@ import { ORACLE_MANAGER_PRICE_VALID_FOR_SECONDS } from '../lib/securityVault.js'
 
 void describe('selected pool workflow lookup state', () => {
 	void test('uses a single stable operate header title', () => {
-		expect(getSelectedPoolCardTitle()).toBe('Pool Workflows')
+		expect(getSelectedPoolCardTitle()).toBe('Manage Pool')
 
-		expect(getSelectedPoolCardTitle()).toBe('Pool Workflows')
+		expect(getSelectedPoolCardTitle()).toBe('Manage Pool')
 
-		expect(getSelectedPoolCardTitle()).toBe('Pool Workflows')
+		expect(getSelectedPoolCardTitle()).toBe('Manage Pool')
 	})
 
 	void test('maps the legacy resolution view alias to the reporting tab', () => {
@@ -416,14 +416,14 @@ void describe('selected pool workflow visibility', () => {
 		expect(isForkWorkflowDisabled('forkTruthAuction')).toBe(false)
 	})
 
-	void test('uses state-specific reasons before unlocking pool workflows', () => {
+	void test('uses state-specific reasons before unlocking pool actions', () => {
 		expect(
 			getSelectedPoolWorkflowGuardMessage({
 				hasSelectedPoolAddress: false,
 				selectedPoolLookupState: 'unknown',
 				selectedPoolUniverseMismatch: false,
 			}),
-		).toBe('Load a pool to open this workflow.')
+		).toBe('Load a pool before using pool actions.')
 
 		expect(
 			getSelectedPoolWorkflowGuardMessage({
@@ -439,7 +439,7 @@ void describe('selected pool workflow visibility', () => {
 				selectedPoolLookupState: 'missing',
 				selectedPoolUniverseMismatch: false,
 			}),
-		).toBe('Load a valid pool to open this workflow.')
+		).toBe('Load a valid pool before using pool actions.')
 
 		expect(
 			getSelectedPoolWorkflowGuardMessage({
@@ -447,7 +447,7 @@ void describe('selected pool workflow visibility', () => {
 				selectedPoolLookupState: 'ready',
 				selectedPoolUniverseMismatch: true,
 			}),
-		).toBe('Switch to the same universe before using this pool workflow.')
+		).toBe('Switch to the same universe before managing this pool.')
 	})
 
 	void test('keeps a stable locked-workflow presentation before a pool resolves', () => {
@@ -499,7 +499,7 @@ void describe('selected pool workflow visibility', () => {
 			actionHint: 'Switch to the matching universe first.',
 			badgeLabel: 'Unavailable',
 			badgeTone: 'blocked',
-			detail: 'Switch to the same universe before using vault, trading, reporting, and fork workflows.',
+			detail: 'Switch to the same universe before using vault, trading, reporting, and fork actions.',
 			key: 'unavailable',
 		})
 	})

--- a/ui/ts/tests/securityPoolWorkflowSection/forkWorkflowState.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection/forkWorkflowState.test.tsx
@@ -29,7 +29,7 @@ describe('SecurityPoolWorkflowSection: fork workflow state', () => {
 	} = fixture
 
 	describe('stage navigation', () => {
-		test('does not offer Open Fork Workflow before the pool has entered its fork workflow', async () => {
+		test('does not offer Open Fork & Migration before the pool has entered its fork workflow', async () => {
 			const selectedPoolAddress = zeroAddress
 			const renderedComponent = await renderIntoDocument(
 				<SecurityPoolWorkflowSection
@@ -92,7 +92,7 @@ describe('SecurityPoolWorkflowSection: fork workflow state', () => {
 			setCleanup(renderedComponent.cleanup)
 
 			const documentQueries = within(document.body)
-			expect(documentQueries.queryByRole('button', { name: 'Open Fork Workflow' })).toBeNull()
+			expect(documentQueries.queryByRole('button', { name: 'Open Fork & Migration' })).toBeNull()
 		})
 
 		test('opens the concrete migration stage when the pool is already inside its fork workflow', async () => {
@@ -365,7 +365,7 @@ describe('SecurityPoolWorkflowSection: fork workflow state', () => {
 			expect(triggerZoltarForkCalls).toBe(1)
 		})
 
-		test('hides Trigger Zoltar Fork after the pool has already entered its fork workflow and keeps Open Fork Workflow available', async () => {
+		test('hides Trigger Zoltar Fork after the pool has already entered its fork workflow and keeps Open Fork & Migration available', async () => {
 			const selectedPoolAddress = zeroAddress
 			const renderedComponent = await renderIntoDocument(
 				<SecurityPoolWorkflowSection

--- a/ui/ts/tests/securityPoolWorkflowSection/selectedPoolState.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection/selectedPoolState.test.tsx
@@ -32,20 +32,20 @@ describe('SecurityPoolWorkflowSection: selected pool state', () => {
 
 		const documentQueries = within(document.body)
 		expect(documentQueries.getByRole('tablist', { name: 'Selected pool views' })).not.toBeNull()
-		const secondaryGroup = documentQueries.getByRole('group', { name: 'Additional pool workflows' })
+		const secondaryGroup = documentQueries.getByRole('group', { name: 'Additional pool actions' })
 		expect(within(secondaryGroup).getByRole('tab', { name: 'Staged Operations' })).not.toBeNull()
 		expect(within(secondaryGroup).getByRole('tab', { name: 'Open Oracle' })).not.toBeNull()
 
 		for (const label of ['Vaults', 'Trading', 'Reporting', 'Fork & Migration', 'Staged Operations', 'Open Oracle']) {
 			const button = documentQueries.getByRole('tab', { name: label }) as HTMLButtonElement
 			expect(button.disabled).toBe(true)
-			expect(button.title).toBe('Load a pool to open this workflow.')
+			expect(button.title).toBe('Load a pool before using pool actions.')
 		}
 		expect(documentQueries.queryByRole('tab', { name: 'Migration' })).toBeNull()
 		expect(documentQueries.queryByRole('tab', { name: 'Truth Auction' })).toBeNull()
 		expect(documentQueries.queryByRole('tab', { name: 'Settlement' })).toBeNull()
 
-		expect(documentQueries.getByRole('heading', { name: 'Pool Workflows' })).not.toBeNull()
+		expect(documentQueries.getByRole('heading', { name: 'Manage Pool' })).not.toBeNull()
 		expect(documentQueries.getByText('No pool selected.')).not.toBeNull()
 		expect(documentQueries.queryByText('Paste a security pool address or browse pools.')).toBeNull()
 		expect(documentQueries.queryByText('Locked')).toBeNull()
@@ -60,7 +60,7 @@ describe('SecurityPoolWorkflowSection: selected pool state', () => {
 		)
 
 		const documentQueries = within(document.body)
-		expect(documentQueries.getByRole('heading', { name: 'Pool Workflows' })).not.toBeNull()
+		expect(documentQueries.getByRole('heading', { name: 'Manage Pool' })).not.toBeNull()
 		expect(documentQueries.getByText('Pool not found.')).not.toBeNull()
 		expect(documentQueries.queryByText('Refresh this address after the pool is deployed.')).toBeNull()
 	})

--- a/ui/ts/tests/securityPoolsOverviewSection.test.tsx
+++ b/ui/ts/tests/securityPoolsOverviewSection.test.tsx
@@ -118,6 +118,7 @@ function createProps(overrides: Partial<SecurityPoolsOverviewSectionProps> = {})
 		onLoadPoolOracleManager: () => undefined,
 		onLoadSecurityPoolPage: () => undefined,
 		onLoadSecurityPools: () => undefined,
+		onOpenLiquidationModal: () => undefined,
 		onQueueLiquidation: () => undefined,
 		onSelectSecurityPool: () => undefined,
 		poolOracleManagerDetails: undefined,
@@ -621,17 +622,23 @@ describe('SecurityPoolsOverviewSection', () => {
 		expect(poolCardQueries.queryByText('No vaults in this pool yet.')).toBeNull()
 	})
 
-	test('renders browse-mode vault previews and routes liquidation review into the selected pool workflow', async () => {
+	test('renders browse-mode vault previews and opens liquidation review for a vault', async () => {
 		const previewPoolTitle = 'Pool with preview vaults'
-		let selectedSecurityPoolAddress: string | undefined
+		let liquidationRequest: { managerAddress: string; securityPoolAddress: string; vaultAddress: string; maxAmount: bigint | undefined } | undefined
 		const renderedComponent = await renderIntoDocument(
 			<SecurityPoolsOverviewSection
 				{...createProps({
-					onSelectSecurityPool: securityPoolAddress => {
-						selectedSecurityPoolAddress = securityPoolAddress
+					onOpenLiquidationModal: (managerAddress, securityPoolAddress, vaultAddress, maxAmount) => {
+						liquidationRequest = {
+							managerAddress,
+							securityPoolAddress,
+							vaultAddress,
+							maxAmount,
+						}
 					},
 					securityPools: [
 						createSecurityPool({
+							managerAddress: '0x0000000000000000000000000000000000000502',
 							marketDetails: createMarketDetails({ title: 'Pool with preview vaults' }),
 							securityPoolAddress: '0x0000000000000000000000000000000000000500',
 							vaultCount: 5n,
@@ -655,12 +662,17 @@ describe('SecurityPoolsOverviewSection', () => {
 		const poolCardQueries = within(poolCard)
 		expect(poolCardQueries.queryByText('Open this pool to load 1 vault.')).toBeNull()
 		expect(poolCardQueries.getAllByRole('button', { name: 'Copy address 0x0000000000000000000000000000000000000501' }).length).toBeGreaterThan(0)
-		const liquidationReviewButton = poolCardQueries.getByRole('button', { name: 'Open Pool to Liquidate' })
+		const liquidationReviewButton = poolCardQueries.getByRole('button', { name: 'Review Liquidation' })
 		expect(liquidationReviewButton).not.toBeNull()
 		await act(() => {
 			fireEvent.click(liquidationReviewButton)
 		})
-		expect(selectedSecurityPoolAddress).toBe('0x0000000000000000000000000000000000000500')
+		expect(liquidationRequest).toEqual({
+			managerAddress: '0x0000000000000000000000000000000000000502',
+			securityPoolAddress: '0x0000000000000000000000000000000000000500',
+			vaultAddress: '0x0000000000000000000000000000000000000501',
+			maxAmount: 5n,
+		})
 		expect(poolCardQueries.getByText('Showing 1 of 5 active vaults in this preview, newest activity first.')).not.toBeNull()
 		expect(poolCardQueries.getByText('+4 more vaults')).not.toBeNull()
 	})

--- a/ui/ts/tests/securityPoolsSection.test.ts
+++ b/ui/ts/tests/securityPoolsSection.test.ts
@@ -322,6 +322,7 @@ function createOverviewProps(overrides: Partial<SecurityPoolsOverviewRouteConten
 		onLoadPoolOracleManager: () => undefined,
 		onLoadSecurityPoolPage: () => undefined,
 		onLoadSecurityPools: () => undefined,
+		onOpenLiquidationModal: () => undefined,
 		onQueueLiquidation: () => undefined,
 		poolOracleManagerDetails: undefined,
 		repPerEthPrice: undefined,
@@ -508,7 +509,7 @@ void describe('SecurityPoolsSection', () => {
 		const documentQueries = within(document.body)
 		expect(documentQueries.queryByRole('tab', { name: 'Browse' })).toBeNull()
 		expect(documentQueries.queryByRole('tab', { name: 'Create Pool' })).toBeNull()
-		expect(documentQueries.queryByRole('tab', { name: 'Pool Workflows' })).toBeNull()
+		expect(documentQueries.queryByRole('tab', { name: 'Manage Pool' })).toBeNull()
 		expect(documentQueries.queryByText('Mode')).toBeNull()
 		expect(document.body.querySelector('.route-summary-strip')).toBeNull()
 		expect(documentQueries.queryByText('Loaded pools')).toBeNull()
@@ -655,7 +656,7 @@ void describe('SecurityPoolsSection', () => {
 		const contextQueries = within(selectedPoolContext)
 		expect(contextQueries.queryByRole('tab', { name: 'Browse' })).toBeNull()
 		expect(contextQueries.queryByRole('tab', { name: 'Create Pool' })).toBeNull()
-		expect(contextQueries.queryByRole('tab', { name: 'Pool Workflows' })).toBeNull()
+		expect(contextQueries.queryByRole('tab', { name: 'Manage Pool' })).toBeNull()
 		expect(documentQueries.queryByRole('heading', { name: 'Security pools' })).toBeNull()
 		expect(contextQueries.queryByText('Total Security Bond Allowance')).toBeNull()
 		const lookupLabel = contextQueries.getByText('Security Pool Address')

--- a/ui/ts/tests/simulationBanner.test.tsx
+++ b/ui/ts/tests/simulationBanner.test.tsx
@@ -92,7 +92,7 @@ describe('SimulationBanner', () => {
 
 		try {
 			const documentQueries = within(renderedComponent.container)
-			expect(documentQueries.getByText('One seeded market, one security pool, and one funded vault with an active security bond allowance. Use it to test pool workflows and liquidation paths.')).not.toBeNull()
+			expect(documentQueries.getByText('One seeded market, one security pool, and one funded vault with an active security bond allowance. Use it to test pool actions and liquidation paths.')).not.toBeNull()
 		} finally {
 			await renderedComponent.cleanup()
 			domEnvironment.cleanup()
@@ -133,7 +133,7 @@ describe('SimulationBanner', () => {
 
 		try {
 			const documentQueries = within(renderedComponent.container)
-			expect(documentQueries.getByText('One seeded market, one security pool, and one funded vault with an active security bond allowance. Use it to test pool workflows and liquidation paths.')).not.toBeNull()
+			expect(documentQueries.getByText('One seeded market, one security pool, and one funded vault with an active security bond allowance. Use it to test pool actions and liquidation paths.')).not.toBeNull()
 			expect(documentQueries.getByText('Deploying seeded security pool')).not.toBeNull()
 		} finally {
 			await renderedComponent.cleanup()

--- a/ui/ts/tests/simulationScenarios.test.ts
+++ b/ui/ts/tests/simulationScenarios.test.ts
@@ -17,8 +17,8 @@ void describe('simulation scenarios', () => {
 	void test('returns descriptions for each scenario', () => {
 		expect(getSimulationScenarioDescription('baseline')).toBe('Fresh walletless simulation with funded QA accounts and no app contracts deployed. Use it to test the Deploy flow from scratch.')
 		expect(getSimulationScenarioDescription('deployed')).toBe('App contracts are deployed, but no security pools or seeded markets are created. Use it to test setup flows from an empty deployment.')
-		expect(getSimulationScenarioDescription('security-pool')).toBe('One seeded market, one security pool, and one funded vault with an active security bond allowance. Use it to test pool workflows and liquidation paths.')
-		expect(getSimulationScenarioDescription('securitypoolx2')).toBe('Two seeded markets with two security pools and two funded vaults in each pool. Use it to test multi-pool selection and repeated pool workflows.')
-		expect(getSimulationScenarioDescription('securitypoolx2-auction')).toBe('Two seeded markets with one own-escalation fork already triggered and one child truth auction seeded with ten bids. Use it to test fork-auction bidbook and settlement workflows.')
+		expect(getSimulationScenarioDescription('security-pool')).toBe('One seeded market, one security pool, and one funded vault with an active security bond allowance. Use it to test pool actions and liquidation paths.')
+		expect(getSimulationScenarioDescription('securitypoolx2')).toBe('Two seeded markets with two security pools and two funded vaults in each pool. Use it to test multi-pool selection and repeated pool actions.')
+		expect(getSimulationScenarioDescription('securitypoolx2-auction')).toBe('Two seeded markets with one own-escalation fork already triggered and one child truth auction seeded with ten bids. Use it to test the fork-auction bidbook and settlement actions.')
 	})
 })

--- a/ui/ts/tests/trading.test.ts
+++ b/ui/ts/tests/trading.test.ts
@@ -474,7 +474,7 @@ void describe('trading helpers', () => {
 				},
 				shareTokenSupply: firstMintShareAmount,
 			}),
-		).toBe('Max redeemable amount is 1 complete sets.')
+		).toBe('Max redeemable amount is 1 complete set.')
 	})
 
 	void test('validates share migration targets and positive balances once migration is available', () => {

--- a/ui/ts/tests/tradingSection.test.tsx
+++ b/ui/ts/tests/tradingSection.test.tsx
@@ -252,12 +252,12 @@ void describe('TradingSection', () => {
 		restoreDomEnvironment = undefined
 	})
 
-	void test('renames the max complete sets metric to total complete sets', async () => {
+	void test('labels the max complete sets metric as redeemable complete sets', async () => {
 		const renderedComponent = await renderIntoDocument(<TradingSection {...createTradingSectionProps()} />)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		expect(documentQueries.getByText('Total Complete Sets')).not.toBeNull()
+		expect(documentQueries.getByText('Redeemable Complete Sets')).not.toBeNull()
 		expect(documentQueries.queryByText('Max Complete Sets')).toBeNull()
 	})
 
@@ -267,7 +267,7 @@ void describe('TradingSection', () => {
 
 		const documentQueries = within(document.body)
 		expect(documentQueries.queryByText('Trading Workflow')).toBeNull()
-		expect(documentQueries.getByRole('heading', { name: 'Your Shares' })).not.toBeNull()
+		expect(documentQueries.getByRole('heading', { name: 'Your Holdings' })).not.toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Trade' })).not.toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Mint Complete Sets' })).not.toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Redeem Complete Sets' })).not.toBeNull()
@@ -392,7 +392,8 @@ void describe('TradingSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		expect(documentQueries.getByText('Total Collateral Equivalent')).not.toBeNull()
+		expect(documentQueries.getByText('Total Across Outcomes')).not.toBeNull()
+		expect(documentQueries.queryByText('Total Collateral Equivalent')).toBeNull()
 		expect(documentQueries.queryByText('Total Shares')).toBeNull()
 		expect(documentQueries.getAllByText('≈ 1.00').length).toBeGreaterThanOrEqual(4)
 		expect(documentQueries.getAllByRole('button', { name: 'Copy exact value 1' }).length).toBeGreaterThanOrEqual(4)

--- a/ui/ts/tests/userCopy.test.ts
+++ b/ui/ts/tests/userCopy.test.ts
@@ -20,7 +20,7 @@ void describe('user copy helpers', () => {
 		expect(getPoolRegistryPresentation({ hasLoaded: false, isLoading: false, mode: 'collection', poolCount: 0 })?.actionHint).toBeUndefined()
 		expect(getPoolRegistryPresentation({ hasLoaded: true, isLoading: false, mode: 'collection', poolCount: 0 })?.key).toBe('empty')
 		expect(getPoolRegistryPresentation({ hasLoaded: true, isLoading: false, mode: 'collection', poolCount: 0 })?.detail).toBe('No security pools are available in this universe yet.')
-		expect(getPoolRegistryPresentation({ hasLoaded: true, isLoading: false, mode: 'collection', poolCount: 0 })?.actionHint).toBe('Create a pool from a binary question to enable trading, reporting, and vault collateral workflows.')
+		expect(getPoolRegistryPresentation({ hasLoaded: true, isLoading: false, mode: 'collection', poolCount: 0 })?.actionHint).toBe('Create a pool from a binary question to enable trading, reporting, and vault collateral actions.')
 	})
 
 	void test('maps universe and report lookup states semantically', () => {

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -476,6 +476,7 @@ export type SecurityPoolsOverviewRouteContentProps = {
 	loadingSecurityPools: boolean
 	onCreateSecurityPool?: () => void
 	onLoadSecurityPoolPage: (pageIndex: number, pageSize: number) => void
+	onOpenLiquidationModal: (managerAddress: Address, securityPoolAddress: Address, vaultAddress: Address, maxAmount: bigint | undefined) => void
 	onSelectSecurityPool?: (securityPoolAddress: string) => void
 	onLoadSecurityPools: () => void
 	securityPoolOverviewError: string | undefined


### PR DESCRIPTION
## Summary
- Clarify user-facing terminology across Zoltar, Open Oracle, security pool, fork/migration, and trading views so labels describe the action or page directly.
- Replace the unclear trading holdings copy around collateral-equivalent values with complete-set language (`Redeemable Complete Sets`, `Total Across Outcomes`) and add regression coverage for the old wording.
- Improve accessibility and keyboard behavior for modals, market form validation, and report outcome selection, including reusable focus isolation and ARIA/radiogroup semantics.
- Preserve browse-mode vault liquidation behavior while using clearer copy (`Review Liquidation`) and keep the original liquidation modal callback/guards covered by tests.
- Improve simulation transaction status copy and complete-set conversion handling, with expanded tests around trading, transactions, security pools, reporting, and modal behavior.

## Testing
- `bun run tsc`
- `bun run test:run -- ui/ts/tests/securityPoolsOverviewSection.test.tsx ui/ts/tests/tradingSection.test.tsx --bail=1`
- `bun run test:run -- solidity/ts/tests/auction.test.ts --bail=1`
- `bun run ensure-contract-artifacts && bun run check:shared-dependencies && bun run test:run -- --bail=1`
- `bun run format`
- `bun run check`
- `bun run knip`
- `git diff --check`

Note: `bun run check:generated-clean` was not run because no generation scripts, contracts, tracked generated outputs, shared build output, UI contract artifacts, or artifact policy changed. Generated artifacts were regenerated locally only because validation required missing ignored files.