### PR TITLE
Guard injected write operations on disconnect/network changes and add escrow export coverage

### DIFF
--- a/solidity/ts/tests/escalationGame.test.ts
+++ b/solidity/ts/tests/escalationGame.test.ts
@@ -299,6 +299,17 @@ describe('Escalation Game Test Suite', () => {
 			}),
 		)
 
+	// Solidity bytecode coverage records transaction traces, so view getters need this paired trace after their read assertions.
+	const traceForkedEscrowByVaultAndOutcome = async (escalationGameAddress: Address, vault: Address, outcome: QuestionOutcome) =>
+		await transactWithEscalationGame(
+			escalationGameAddress,
+			encodeFunctionData({
+				abi: peripherals_EscalationGame_EscalationGame.abi,
+				functionName: 'getForkedEscrowByVaultAndOutcome',
+				args: [vault, outcome],
+			}),
+		)
+
 	const assertEscrowAccounting = async (escalationGameAddress: Address, expectedTotalEscrowedRep: bigint) => {
 		assert.strictEqual(await readTotalEscrowedRep(escalationGameAddress), expectedTotalEscrowedRep, 'total escrowed REP should match scenario accounting')
 	}
@@ -1208,6 +1219,49 @@ describe('Escalation Game Test Suite', () => {
 		assert.strictEqual(hasUnexportedAfterSecondExport, false, 'second export should exhaust the cursor')
 	})
 
+	test('local unresolved export by deposit index consumes only the selected local deposit', async () => {
+		const { escalationGameAddress, testSecurityPoolAddress } = await deployEscalationGameWithProofPool()
+		await startEscalation(escalationGameAddress, reportBond, nonDecisionThreshold)
+		await depositOnOutcomeViaProofTestSecurityPool(testSecurityPoolAddress, client.account.address, QuestionOutcome.Yes, reportBond)
+		await depositOnOutcomeViaProofTestSecurityPool(testSecurityPoolAddress, client.account.address, QuestionOutcome.Yes, 2n * reportBond)
+		await assertEscrowAccounting(escalationGameAddress, 3n * reportBond)
+
+		const preview = await client.simulateContract({
+			abi: escalationGameProofTestPoolArtifact.abi,
+			address: testSecurityPoolAddress,
+			functionName: 'exportLocalUnresolvedDeposit',
+			args: [0n, QuestionOutcome.Yes],
+		})
+		assert.deepStrictEqual(preview.result, [client.account.address, reportBond, 0n], 'local export should return the selected depositor, amount, and stable parent index')
+
+		await writeContractAndWait(client, async () =>
+			client.writeContract({
+				abi: escalationGameProofTestPoolArtifact.abi,
+				address: testSecurityPoolAddress,
+				functionName: 'exportLocalUnresolvedDeposit',
+				args: [0n, QuestionOutcome.Yes],
+			}),
+		)
+		await assertEscrowAccounting(escalationGameAddress, 2n * reportBond)
+		await assertOutcomeCarryTotalsMatchComponents(escalationGameAddress)
+		const [carryPage] = await readCarryLeafPage(escalationGameAddress, QuestionOutcome.Yes, 0n, 2n)
+		assert.deepStrictEqual(
+			carryPage.map(leaf => ({
+				depositor: leaf.depositor,
+				amount: leaf.amount,
+				parentDepositIndex: leaf.parentDepositIndex,
+			})),
+			[
+				{
+					depositor: client.account.address,
+					amount: 2n * reportBond,
+					parentDepositIndex: 1n,
+				},
+			],
+			'exporting one local deposit should leave only the unresolved sibling deposit in newest-first paging',
+		)
+	})
+
 	test('stateful local accounting model stays balanced across randomized deposits, exports, and claims', async () => {
 		const { escalationGameAddress, testSecurityPoolAddress } = await deployEscalationGameWithProofPool()
 		await startEscalation(escalationGameAddress, reportBond, nonDecisionThreshold)
@@ -1692,6 +1746,7 @@ describe('Escalation Game Test Suite', () => {
 		const receiverBalanceAfter = await getERC20Balance(client, repToken, receiver)
 		const yesEscrow = await readForkedEscrowByVaultAndOutcome(child.escalationGameAddress, client.account.address, QuestionOutcome.Yes)
 		const noEscrow = await readForkedEscrowByVaultAndOutcome(child.escalationGameAddress, client.account.address, QuestionOutcome.No)
+		await traceForkedEscrowByVaultAndOutcome(child.escalationGameAddress, client.account.address, QuestionOutcome.Yes)
 		assert.strictEqual(receiverBalanceAfter - receiverBalanceBefore, yesChildRep + noChildRep, 'export should transfer only child REP backing')
 		assert.deepStrictEqual(yesEscrow, [yesSourcePrincipal, yesSourcePrincipal, yesChildRep, yesChildRep], 'yes forked escrow should be marked fully exported without affecting no')
 		assert.deepStrictEqual(noEscrow, [noSourcePrincipal, noSourcePrincipal, noChildRep, noChildRep], 'no forked escrow should be marked fully exported without affecting yes')

--- a/ui/ts/lib/chainBackend.ts
+++ b/ui/ts/lib/chainBackend.ts
@@ -69,7 +69,7 @@ export type ChainBackend = {
 function createReadClientForProfile(profile: NetworkProfile, transportMode: ReadTransportMode, rpcUrl: string, ethereum?: InjectedEthereum): ReadClient {
 	return createPublicClient({
 		chain: profile.chain,
-		transport: transportMode === 'provider' && ethereum !== undefined ? custom(ethereum) : http(rpcUrl, { batch: { wait: 100 } }),
+		transport: transportMode === 'provider' && ethereum !== undefined ? custom(ethereum, { retryCount: 0 }) : http(rpcUrl, { batch: { wait: 100 } }),
 	})
 }
 

--- a/ui/ts/tests/chainBackend.test.ts
+++ b/ui/ts/tests/chainBackend.test.ts
@@ -36,6 +36,43 @@ type MockRequestParameters = {
 	params?: unknown
 }
 
+type InjectedWriteClient = ReturnType<ReturnType<typeof createInjectedBackend>['createWriteClient']>
+
+type GuardedWriteOperationCase = {
+	execute: (writeClient: InjectedWriteClient) => Promise<unknown>
+	name: string
+}
+
+const TEST_WRITE_ABI = [
+	{
+		type: 'function',
+		name: 'foo',
+		inputs: [],
+		outputs: [],
+		stateMutability: 'nonpayable',
+	},
+] as const
+
+const guardedWriteOperationCases: GuardedWriteOperationCase[] = [
+	{
+		name: 'sendTransaction',
+		execute: async writeClient => await writeClient.sendTransaction({ to: zeroAddress }),
+	},
+	{
+		name: 'sendRawTransaction',
+		execute: async writeClient => await writeClient.sendRawTransaction({ serializedTransaction: '0x' }),
+	},
+	{
+		name: 'writeContract',
+		execute: async writeClient =>
+			await writeClient.writeContract({
+				address: zeroAddress,
+				abi: TEST_WRITE_ABI,
+				functionName: 'foo',
+			}),
+	},
+]
+
 function createMockInjectedEthereum(requestHandler: (parameters: MockRequestParameters) => Promise<unknown>): InjectedEthereum {
 	return {
 		on: () => undefined,
@@ -225,15 +262,7 @@ describe('injected backend read transport', () => {
 		await writeClient.sendRawTransaction({ serializedTransaction: '0x' })
 		await writeClient.writeContract({
 			address: zeroAddress,
-			abi: [
-				{
-					type: 'function',
-					name: 'foo',
-					inputs: [],
-					outputs: [],
-					stateMutability: 'nonpayable',
-				},
-			] as const,
+			abi: TEST_WRITE_ABI,
 			functionName: 'foo',
 		})
 
@@ -245,7 +274,9 @@ describe('injected backend read transport', () => {
 	})
 
 	test('handles provider call failures in read paths without throwing', async () => {
-		ensureWindowObject().ethereum = createMockInjectedEthereum(async () => {
+		const requestCalls: string[] = []
+		ensureWindowObject().ethereum = createMockInjectedEthereum(async ({ method }) => {
+			requestCalls.push(method)
 			throw new Error('provider unavailable')
 		})
 
@@ -254,6 +285,7 @@ describe('injected backend read transport', () => {
 		expect(await backend.getAccounts()).toEqual([])
 		expect(await backend.requestAccounts()).toEqual([])
 		await expect(backend.createReadClient().getCode({ address: zeroAddress })).rejects.toThrow('provider unavailable')
+		expect(requestCalls).toEqual(['eth_accounts', 'eth_requestAccounts', 'eth_getCode'])
 	})
 
 	test('rejects chain RPC failures instead of defaulting to mainnet', async () => {
@@ -265,6 +297,49 @@ describe('injected backend read transport', () => {
 		const backend = createInjectedBackend()
 		await expect(backend.getChainId()).rejects.toThrow('Unable to verify wallet network.')
 	})
+
+	for (const operation of guardedWriteOperationCases) {
+		test(`blocks ${operation.name} when the wallet disconnects before send`, async () => {
+			const requestCalls: string[] = []
+			ensureWindowObject().ethereum = createMockInjectedEthereum(async ({ method }) => {
+				requestCalls.push(method)
+				if (method === 'eth_accounts') return []
+				if (method === 'eth_getTransactionCount') return '0x1'
+				if (method === 'eth_estimateGas') return '0x5208'
+				if (method === 'eth_gasPrice') return '0x1'
+				if (method === 'eth_maxPriorityFeePerGas') return '0x1'
+				if (method === 'eth_sendTransaction' || method === 'eth_sendRawTransaction') return `0x${'1'.padStart(64, '0')}`
+				return '0x'
+			})
+
+			const backend = createInjectedBackend()
+			const writeClient = backend.createWriteClient(zeroAddress)
+
+			await expect(operation.execute(writeClient)).rejects.toThrow('Wallet account is no longer connected.')
+			expect(requestCalls).toEqual(['eth_accounts'])
+		})
+
+		test(`blocks ${operation.name} when the wallet switches networks before send`, async () => {
+			const requestCalls: string[] = []
+			ensureWindowObject().ethereum = createMockInjectedEthereum(async ({ method }) => {
+				requestCalls.push(method)
+				if (method === 'eth_accounts') return [zeroAddress]
+				if (method === 'eth_chainId') return '0x539'
+				if (method === 'eth_getTransactionCount') return '0x1'
+				if (method === 'eth_estimateGas') return '0x5208'
+				if (method === 'eth_gasPrice') return '0x1'
+				if (method === 'eth_maxPriorityFeePerGas') return '0x1'
+				if (method === 'eth_sendTransaction' || method === 'eth_sendRawTransaction') return `0x${'1'.padStart(64, '0')}`
+				return '0x'
+			})
+
+			const backend = createInjectedBackend()
+			const writeClient = backend.createWriteClient(zeroAddress)
+
+			await expect(operation.execute(writeClient)).rejects.toThrow('Wallet network changed. Switch to Ethereum mainnet and try again.')
+			expect(requestCalls).toEqual(['eth_accounts', 'eth_chainId'])
+		})
+	}
 
 	test('subscribes and unsubscribes event listeners cleanly', async () => {
 		const { calls, ethereum } = createMockInjectedEthereumWithListeners()


### PR DESCRIPTION
## Summary
- Added test coverage for a Solidity escalation-game scenario ensuring `exportLocalUnresolvedDeposit` consumes only the selected local deposit index and leaves expected carry-leaf accounting state.
- Added a regression trace call in the same test suite to keep Solidity bytecode-coverage tracking aligned with view-call coverage expectations.
- Updated `ui/ts/lib/chainBackend.ts` to create injected read clients with `custom(ethereum, { retryCount: 0 })` for deterministic behavior after wallet/network transitions.
- Expanded `ui/ts/tests/chainBackend.test.ts` with parameterized coverage for injected write guards, asserting write operations are blocked when wallet is disconnected or network changes before send.
- Refactored repeated ABI usage in tests into a shared `TEST_WRITE_ABI` constant and reused request-call tracking in failure-path assertions.

## Testing
- Not run (no validation commands executed in this request).