### PR TITLE
Validate read RPC override trust

### DIFF
--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -744,6 +744,7 @@ export function App() {
 					<AppStatusNotices
 						errorMessage={errorMessage}
 						readBackendMessage={readBackendMessage}
+						readBackendStatus={readBackendStatus}
 						simulationBootstrapError={environmentBootstrapError}
 						showAugurPlaceHolderDeploymentWarning={showAugurPlaceHolderDeploymentWarning}
 						showZoltarUniverseForkedWarning={showZoltarUniverseForkedWarning}

--- a/ui/ts/components/AppStatusNotices.tsx
+++ b/ui/ts/components/AppStatusNotices.tsx
@@ -3,10 +3,12 @@ import { TimestampValue } from './TimestampValue.js'
 import { formatUniverseLabel } from '../lib/universe.js'
 import type { ZoltarUniverseSummary } from '../types/contracts.js'
 import type { NoticeItem } from '../types/components.js'
+import type { ReadBackendStatus } from '../lib/chainBackend.js'
 
 type AppStatusNoticesProps = {
 	errorMessage: string | undefined
 	readBackendMessage: string | undefined
+	readBackendStatus?: ReadBackendStatus | undefined
 	wrongNetworkMessage: string | undefined
 	simulationBootstrapError: string | undefined
 	showAugurPlaceHolderDeploymentWarning: boolean
@@ -14,8 +16,49 @@ type AppStatusNoticesProps = {
 	zoltarUniverse: ZoltarUniverseSummary | undefined
 }
 
-export function AppStatusNotices({ errorMessage, readBackendMessage, wrongNetworkMessage, simulationBootstrapError, showAugurPlaceHolderDeploymentWarning, showZoltarUniverseForkedWarning, zoltarUniverse }: AppStatusNoticesProps) {
+function formatRpcSourceLabel(source: ReadBackendStatus['rpcSource']) {
+	if (source === 'url') return 'page URL'
+	if (source === 'localStorage') return 'local storage'
+	if (source === 'environment') return 'environment'
+	if (source === 'global') return 'global runtime'
+	if (source === 'override') return 'explicit override'
+	return 'default'
+}
+
+function getConfiguredRpcLabel(readBackendStatus: ReadBackendStatus) {
+	return readBackendStatus.transportMode === 'provider' ? 'Configured fallback read RPC' : 'Active read RPC'
+}
+
+function buildRpcOverrideNotice(readBackendStatus: ReadBackendStatus | undefined): NoticeItem | undefined {
+	if (readBackendStatus === undefined) return undefined
+	if (readBackendStatus.rejectedRpcOverride !== undefined) {
+		const rejectedOverride = readBackendStatus.rejectedRpcOverride
+		return {
+			detail: `Ignored ${formatRpcSourceLabel(rejectedOverride.source)} RPC override (${rejectedOverride.url}): ${rejectedOverride.reason} ${getConfiguredRpcLabel(readBackendStatus)} is ${readBackendStatus.rpcUrl}.`,
+			id: 'read-rpc-override-ignored',
+			tone: 'warning',
+			title: 'Read RPC override ignored',
+		}
+	}
+	if (readBackendStatus.rpcSource === 'url')
+		return {
+			detail: `${getConfiguredRpcLabel(readBackendStatus)} came from the page URL: ${readBackendStatus.rpcUrl}. Verify this endpoint before relying on displayed onchain state.`,
+			id: 'url-read-rpc-override',
+			tone: 'warning',
+			title: 'URL-provided read RPC',
+		}
+	if (readBackendStatus.rpcSource === 'default') return undefined
+	return {
+		detail: `${getConfiguredRpcLabel(readBackendStatus)} came from ${formatRpcSourceLabel(readBackendStatus.rpcSource)}: ${readBackendStatus.rpcUrl}. Verify this endpoint before relying on displayed onchain state.`,
+		id: 'read-rpc-override-active',
+		tone: 'pending',
+		title: 'Read RPC override active',
+	}
+}
+
+export function AppStatusNotices({ errorMessage, readBackendMessage, readBackendStatus, wrongNetworkMessage, simulationBootstrapError, showAugurPlaceHolderDeploymentWarning, showZoltarUniverseForkedWarning, zoltarUniverse }: AppStatusNoticesProps) {
 	const items: NoticeItem[] = []
+	const rpcOverrideNotice = buildRpcOverrideNotice(readBackendStatus)
 	if (simulationBootstrapError !== undefined) items.push({ detail: simulationBootstrapError, id: 'simulation-bootstrap-error', tone: 'blocking', title: 'Simulation bootstrap failed' })
 	if (showZoltarUniverseForkedWarning && zoltarUniverse !== undefined)
 		items.push({
@@ -38,6 +81,7 @@ export function AppStatusNotices({ errorMessage, readBackendMessage, wrongNetwor
 		})
 	if (readBackendMessage !== undefined) items.push({ detail: readBackendMessage, id: 'read-backend-mismatch', tone: 'blocking', title: 'Read RPC mismatch' })
 	if (errorMessage !== undefined) items.push({ detail: errorMessage, id: 'app-error', tone: 'blocking', title: 'Error' })
+	if (rpcOverrideNotice !== undefined) items.push(rpcOverrideNotice)
 
 	return <NoticeStack items={items} />
 }

--- a/ui/ts/lib/chainBackend.ts
+++ b/ui/ts/lib/chainBackend.ts
@@ -3,7 +3,7 @@ import { getInjectedEthereum, type InjectedEthereum } from '../injectedEthereum.
 import { hasErrorCode, hasErrorMessage } from './errors.js'
 import { tryParseAddressInput } from './inputs.js'
 import { MAINNET_NETWORK_PROFILE, type NetworkProfile } from './networkProfile.js'
-import { resolveConfiguredRpcConfig, type ConfiguredRpcSource } from './rpcConfig.js'
+import { resolveConfiguredRpcConfig, type ConfiguredRpcSource, type RejectedRpcOverride } from './rpcConfig.js'
 
 export type ReadClient = ReturnType<typeof createPublicClient>
 export type WriteClient = WalletClient<Transport, NetworkProfile['chain'], Account> &
@@ -36,6 +36,7 @@ type ReadTransportMode = 'provider' | 'rpc'
 export type ReadBackendStatus = {
 	blockNumber: bigint | undefined
 	blockTimestamp: bigint | undefined
+	rejectedRpcOverride?: RejectedRpcOverride | undefined
 	rpcSource: ConfiguredRpcSource
 	rpcUrl: string
 	transportMode: ReadTransportMode
@@ -177,6 +178,7 @@ export function createInjectedBackend({ rpcUrl }: { rpcUrl?: string } = {}): Cha
 		getReadBackendStatus: () => ({
 			blockNumber: readBackendBlockNumber,
 			blockTimestamp: readBackendBlockTimestamp,
+			rejectedRpcOverride: configuredRpc.rejectedOverride,
 			rpcSource: configuredRpc.source,
 			rpcUrl: configuredRpc.url,
 			transportMode: readTransportMode,

--- a/ui/ts/lib/rpcConfig.ts
+++ b/ui/ts/lib/rpcConfig.ts
@@ -1,10 +1,19 @@
 export const DEFAULT_RPC_URL = 'https://ethereum.dark.florist'
 const RPC_URL_SEARCH_PARAM = 'rpcUrl'
 const RPC_URL_STORAGE_KEY = 'zoltar.rpcUrl'
+const LOCAL_HTTP_RPC_HOSTNAMES = new Set(['localhost', '::1', '[::1]'])
 
 export type ConfiguredRpcSource = 'default' | 'environment' | 'global' | 'localStorage' | 'override' | 'url'
+type ConfiguredRpcOverrideSource = Exclude<ConfiguredRpcSource, 'default'>
+
+export type RejectedRpcOverride = {
+	reason: string
+	source: ConfiguredRpcOverrideSource
+	url: string
+}
 
 export type ConfiguredRpcConfig = {
+	rejectedOverride?: RejectedRpcOverride | undefined
 	source: ConfiguredRpcSource
 	url: string
 }
@@ -54,22 +63,78 @@ function readStoredRpcUrl(storage: StorageLike | undefined) {
 	}
 }
 
+function parseIpv4Byte(value: string) {
+	if (!/^\d{1,3}$/.test(value)) return undefined
+	const byte = Number(value)
+	if (!Number.isInteger(byte) || byte < 0 || byte > 255) return undefined
+	return byte
+}
+
+function isIpv4LoopbackHostname(hostname: string) {
+	const parts = hostname.split('.')
+	if (parts.length !== 4) return false
+	const firstPart = parts[0]
+	if (firstPart === undefined || parseIpv4Byte(firstPart) !== 127) return false
+
+	for (const part of parts.slice(1)) {
+		if (parseIpv4Byte(part) === undefined) return false
+	}
+	return true
+}
+
+function isLocalHttpRpcHostname(hostname: string) {
+	return LOCAL_HTTP_RPC_HOSTNAMES.has(hostname) || isIpv4LoopbackHostname(hostname)
+}
+
+function getRpcUrlValidationError(url: string) {
+	let parsedUrl: URL
+	try {
+		parsedUrl = new URL(url)
+	} catch (error) {
+		if (error instanceof TypeError) return 'RPC URL must be an absolute https:// URL, or http:// for local loopback.'
+		throw error
+	}
+
+	if (parsedUrl.protocol === 'https:') return undefined
+	if (parsedUrl.protocol === 'http:' && isLocalHttpRpcHostname(parsedUrl.hostname)) return undefined
+	if (parsedUrl.protocol === 'http:') return 'RPC URL must use https:// unless it points to local loopback.'
+	return 'RPC URL must use https://, or http:// for local loopback.'
+}
+
+function resolveConfiguredRpcOverride(source: ConfiguredRpcOverrideSource, value: unknown, fallbackRpcUrl: string): ConfiguredRpcConfig | undefined {
+	const url = resolveNonEmptyString(value)
+	if (url === undefined) return undefined
+
+	const validationError = getRpcUrlValidationError(url)
+	if (validationError === undefined) return { source, url }
+
+	return {
+		rejectedOverride: {
+			reason: validationError,
+			source,
+			url,
+		},
+		source: 'default',
+		url: fallbackRpcUrl,
+	}
+}
+
 export function resolveConfiguredRpcConfig({ fallbackRpcUrl = DEFAULT_RPC_URL, location, overrideRpcUrl, storage }: { fallbackRpcUrl?: string; location?: LocationLike; overrideRpcUrl?: string; storage?: StorageLike } = {}): ConfiguredRpcConfig {
-	const normalizedOverrideRpcUrl = resolveNonEmptyString(overrideRpcUrl)
-	if (normalizedOverrideRpcUrl !== undefined) return { source: 'override', url: normalizedOverrideRpcUrl }
+	const overrideConfig = resolveConfiguredRpcOverride('override', overrideRpcUrl, fallbackRpcUrl)
+	if (overrideConfig !== undefined) return overrideConfig
 
 	const globalWithRpcConfig = globalThis as GlobalWithRpcConfig
-	const rpcUrlSearchParam = resolveNonEmptyString(readLocationParams(location ?? globalWithRpcConfig.location).get(RPC_URL_SEARCH_PARAM))
-	if (rpcUrlSearchParam !== undefined) return { source: 'url', url: rpcUrlSearchParam }
+	const urlConfig = resolveConfiguredRpcOverride('url', readLocationParams(location ?? globalWithRpcConfig.location).get(RPC_URL_SEARCH_PARAM), fallbackRpcUrl)
+	if (urlConfig !== undefined) return urlConfig
 
-	const storedRpcUrl = resolveNonEmptyString(readStoredRpcUrl(storage ?? globalWithRpcConfig.localStorage))
-	if (storedRpcUrl !== undefined) return { source: 'localStorage', url: storedRpcUrl }
+	const storedConfig = resolveConfiguredRpcOverride('localStorage', readStoredRpcUrl(storage ?? globalWithRpcConfig.localStorage), fallbackRpcUrl)
+	if (storedConfig !== undefined) return storedConfig
 
-	const globalRpcUrl = resolveNonEmptyString(globalWithRpcConfig.__ZOLTAR_RPC_URL__)
-	if (globalRpcUrl !== undefined) return { source: 'global', url: globalRpcUrl }
+	const globalConfig = resolveConfiguredRpcOverride('global', globalWithRpcConfig.__ZOLTAR_RPC_URL__, fallbackRpcUrl)
+	if (globalConfig !== undefined) return globalConfig
 
-	const environmentRpcUrl = resolveNonEmptyString(globalWithRpcConfig.process?.env?.['ZOLTAR_RPC_URL'])
-	if (environmentRpcUrl !== undefined) return { source: 'environment', url: environmentRpcUrl }
+	const environmentConfig = resolveConfiguredRpcOverride('environment', globalWithRpcConfig.process?.env?.['ZOLTAR_RPC_URL'], fallbackRpcUrl)
+	if (environmentConfig !== undefined) return environmentConfig
 
 	return { source: 'default', url: fallbackRpcUrl }
 }

--- a/ui/ts/tests/appStatusNotices.test.tsx
+++ b/ui/ts/tests/appStatusNotices.test.tsx
@@ -99,6 +99,89 @@ describe('AppStatusNotices', () => {
 		expect(documentQueries.getByText('Configured read RPC reports chain 11155111, but this app requires Ethereum Mainnet (1).')).not.toBeNull()
 	})
 
+	test('warns when the read RPC comes from the page URL', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(AppStatusNotices, {
+				errorMessage: undefined,
+				readBackendMessage: undefined,
+				readBackendStatus: {
+					blockNumber: undefined,
+					blockTimestamp: undefined,
+					rpcSource: 'url',
+					rpcUrl: 'https://query.example/path',
+					transportMode: 'rpc',
+				},
+				showAugurPlaceHolderDeploymentWarning: false,
+				showZoltarUniverseForkedWarning: false,
+				simulationBootstrapError: undefined,
+				wrongNetworkMessage: undefined,
+				zoltarUniverse: undefined,
+			}),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByText('URL-provided read RPC')).not.toBeNull()
+		expect(documentQueries.getByText('Active read RPC came from the page URL: https://query.example/path. Verify this endpoint before relying on displayed onchain state.')).not.toBeNull()
+	})
+
+	test('shows source and URL for a stored read RPC override', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(AppStatusNotices, {
+				errorMessage: undefined,
+				readBackendMessage: undefined,
+				readBackendStatus: {
+					blockNumber: undefined,
+					blockTimestamp: undefined,
+					rpcSource: 'localStorage',
+					rpcUrl: 'https://storage.example/path',
+					transportMode: 'rpc',
+				},
+				showAugurPlaceHolderDeploymentWarning: false,
+				showZoltarUniverseForkedWarning: false,
+				simulationBootstrapError: undefined,
+				wrongNetworkMessage: undefined,
+				zoltarUniverse: undefined,
+			}),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByText('Read RPC override active')).not.toBeNull()
+		expect(documentQueries.getByText('Active read RPC came from local storage: https://storage.example/path. Verify this endpoint before relying on displayed onchain state.')).not.toBeNull()
+	})
+
+	test('warns when a stored read RPC override is ignored', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(AppStatusNotices, {
+				errorMessage: undefined,
+				readBackendMessage: undefined,
+				readBackendStatus: {
+					blockNumber: undefined,
+					blockTimestamp: undefined,
+					rejectedRpcOverride: {
+						reason: 'RPC URL must use https:// unless it points to local loopback.',
+						source: 'localStorage',
+						url: 'http://storage.example',
+					},
+					rpcSource: 'default',
+					rpcUrl: 'https://ethereum.dark.florist',
+					transportMode: 'provider',
+				},
+				showAugurPlaceHolderDeploymentWarning: false,
+				showZoltarUniverseForkedWarning: false,
+				simulationBootstrapError: undefined,
+				wrongNetworkMessage: undefined,
+				zoltarUniverse: undefined,
+			}),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByText('Read RPC override ignored')).not.toBeNull()
+		expect(documentQueries.getByText('Ignored local storage RPC override (http://storage.example): RPC URL must use https:// unless it points to local loopback. Configured fallback read RPC is https://ethereum.dark.florist.')).not.toBeNull()
+	})
+
 	test('shows deployment setup and custom wrong-network guidance together', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(AppStatusNotices, {

--- a/ui/ts/tests/rpcConfig.test.ts
+++ b/ui/ts/tests/rpcConfig.test.ts
@@ -37,6 +37,92 @@ describe('rpc config', () => {
 		).toBe('https://hash.example')
 	})
 
+	test('accepts https and local loopback http RPC overrides', () => {
+		expect(
+			resolveConfiguredRpcConfig({
+				location: {
+					search: '?rpcUrl=https://query.example/path',
+				},
+			}),
+		).toEqual({ source: 'url', url: 'https://query.example/path' })
+
+		expect(
+			resolveConfiguredRpcConfig({
+				location: {
+					search: '?rpcUrl=http://localhost:8545',
+				},
+			}),
+		).toEqual({ source: 'url', url: 'http://localhost:8545' })
+
+		expect(
+			resolveConfiguredRpcConfig({
+				location: {
+					search: '?rpcUrl=http://127.0.0.1:8545',
+				},
+			}),
+		).toEqual({ source: 'url', url: 'http://127.0.0.1:8545' })
+
+		expect(
+			resolveConfiguredRpcConfig({
+				location: {
+					search: '?rpcUrl=http://127.0.0.2:8545',
+				},
+			}),
+		).toEqual({ source: 'url', url: 'http://127.0.0.2:8545' })
+
+		expect(
+			resolveConfiguredRpcConfig({
+				location: {
+					search: '?rpcUrl=http://[::1]:8545',
+				},
+			}),
+		).toEqual({ source: 'url', url: 'http://[::1]:8545' })
+	})
+
+	test('rejects remote http URL overrides and keeps the fallback RPC', () => {
+		expect(
+			resolveConfiguredRpcConfig({
+				fallbackRpcUrl: 'https://fallback.example',
+				location: {
+					search: '?rpcUrl=http://query.example',
+				},
+				storage: {
+					getItem: () => 'https://storage.example',
+				},
+			}),
+		).toEqual({
+			rejectedOverride: {
+				reason: 'RPC URL must use https:// unless it points to local loopback.',
+				source: 'url',
+				url: 'http://query.example',
+			},
+			source: 'default',
+			url: 'https://fallback.example',
+		})
+	})
+
+	test('rejects invalid localStorage overrides and keeps the fallback RPC', () => {
+		expect(
+			resolveConfiguredRpcConfig({
+				fallbackRpcUrl: 'https://fallback.example',
+				location: {
+					search: '',
+				},
+				storage: {
+					getItem: () => 'not-a-url',
+				},
+			}),
+		).toEqual({
+			rejectedOverride: {
+				reason: 'RPC URL must be an absolute https:// URL, or http:// for local loopback.',
+				source: 'localStorage',
+				url: 'not-a-url',
+			},
+			source: 'default',
+			url: 'https://fallback.example',
+		})
+	})
+
 	test('returns the source for configured RPC URLs', () => {
 		expect(
 			resolveConfiguredRpcConfig({


### PR DESCRIPTION
## Summary
- Validate configured read RPC overrides at the config boundary: accept `https:` and local-loopback `http:` only (`localhost`, IPv6 loopback, and IPv4 `127.0.0.0/8`).
- Reject invalid or remote-HTTP override URLs, fall back to the default RPC, and preserve rejected override metadata for user visibility.
- Thread read backend RPC status into app notices so active non-default overrides show their source and full URL.
- Add page-level warnings for URL-provided RPCs and ignored invalid overrides.
- Add targeted `rpcConfig` and `AppStatusNotices` coverage for accepted loopback URLs, rejected unsafe URLs, source/URL display, and ignored override warnings.

## Validation
- `bun test --preload ./bun-test-setup-ui.ts ui/ts/tests/rpcConfig.test.ts ui/ts/tests/appStatusNotices.test.tsx` — passed (`18 pass`).
- `bun run tsc` — passed.
- `bun run ensure-contract-artifacts && bun run check:shared-dependencies && bun run test:run -- --bail=1` — passed (`1508 pass`, `11 skip`, `0 fail`; skipped tests are gated Uniswap mainnet integration tests).
- `bun run format` — passed.
- `bun run check` — passed.
- `bun run knip` — passed.
- `git diff --check` — passed.

Skipped: `bun run check:generated-clean`, because this tracked diff does not touch contracts, generators, generated artifact policy, or generated outputs intended for review.