### PR TITLE
Fix escalation deposit pagination and uint256 index handling

### DIFF
--- a/ui/ts/components/EscalationDepositSelectionList.tsx
+++ b/ui/ts/components/EscalationDepositSelectionList.tsx
@@ -1,5 +1,10 @@
 import type { ComponentChildren } from 'preact'
+import { useEffect, useMemo, useState } from 'preact/hooks'
+import { formatPaginationSummary, getHasNextPaginationPage, getPaginationPageCount, resolvePaginationPageIndex } from '../lib/pagination.js'
 import type { EscalationDeposit } from '../types/contracts.js'
+import { PaginationControls } from './PaginationControls.js'
+
+const ESCALATION_DEPOSIT_SELECTION_PAGE_SIZE = 25
 
 type EscalationDepositSelectionItem = {
 	deposit: EscalationDeposit
@@ -14,32 +19,59 @@ type EscalationDepositSelectionListProps = {
 }
 
 export function EscalationDepositSelectionList({ disabled = false, items, onSelectionChange, selectedDepositIndexes }: EscalationDepositSelectionListProps) {
-	return (
-		<div className='withdraw-deposit-list'>
-			{items.map(item => {
-				const { deposit, details } = item
-				const isChecked = selectedDepositIndexes.includes(deposit.depositIndex)
+	const [pageIndex, setPageIndex] = useState(0)
+	const pageCount = getPaginationPageCount(BigInt(items.length), ESCALATION_DEPOSIT_SELECTION_PAGE_SIZE)
+	const resolvedPageIndex = resolvePaginationPageIndex(pageIndex, pageCount)
+	const hasNextPage = getHasNextPaginationPage(resolvedPageIndex, pageCount)
+	const hasPreviousPage = resolvedPageIndex > 0
+	const pageStartIndex = resolvedPageIndex * ESCALATION_DEPOSIT_SELECTION_PAGE_SIZE
+	const pageEndIndex = Math.min(items.length, pageStartIndex + ESCALATION_DEPOSIT_SELECTION_PAGE_SIZE)
+	const visibleItems = useMemo(() => items.slice(pageStartIndex, pageEndIndex), [items, pageEndIndex, pageStartIndex])
+	const paginationSummary = items.length > ESCALATION_DEPOSIT_SELECTION_PAGE_SIZE ? `Showing deposits ${(pageStartIndex + 1).toString()}-${pageEndIndex.toString()} of ${items.length.toString()}. ${formatPaginationSummary(resolvedPageIndex, pageCount) ?? ''}` : undefined
 
-				return (
-					<label key={deposit.depositIndex.toString()} className='withdraw-deposit-option'>
-						<input
-							type='checkbox'
-							checked={isChecked}
-							disabled={disabled}
-							onChange={event => {
-								const nextSelectedDepositIndexes = event.currentTarget.checked ? [...selectedDepositIndexes, deposit.depositIndex] : selectedDepositIndexes.filter(index => index !== deposit.depositIndex)
-								onSelectionChange(nextSelectedDepositIndexes)
-							}}
-						/>
-						<span className='withdraw-deposit-copy'>
-							<strong>Deposit #{deposit.depositIndex.toString()}</strong>
-							{details.map((detail, detailIndex) => (
-								<span key={`${deposit.depositIndex.toString()}:${detailIndex.toString()}`}>{detail}</span>
-							))}
-						</span>
-					</label>
-				)
-			})}
-		</div>
+	useEffect(() => {
+		if (resolvedPageIndex !== pageIndex) setPageIndex(resolvedPageIndex)
+	}, [pageIndex, resolvedPageIndex])
+
+	return (
+		<>
+			<div className='withdraw-deposit-list'>
+				{visibleItems.map(item => {
+					const { deposit, details } = item
+					const isChecked = selectedDepositIndexes.includes(deposit.depositIndex)
+
+					return (
+						<label key={deposit.depositIndex.toString()} className='withdraw-deposit-option'>
+							<input
+								type='checkbox'
+								checked={isChecked}
+								disabled={disabled}
+								onChange={event => {
+									const nextSelectedDepositIndexes = event.currentTarget.checked ? [...selectedDepositIndexes, deposit.depositIndex] : selectedDepositIndexes.filter(index => index !== deposit.depositIndex)
+									onSelectionChange(nextSelectedDepositIndexes)
+								}}
+							/>
+							<span className='withdraw-deposit-copy'>
+								<strong>Deposit #{deposit.depositIndex.toString()}</strong>
+								{details.map((detail, detailIndex) => (
+									<span key={`${deposit.depositIndex.toString()}:${detailIndex.toString()}`}>{detail}</span>
+								))}
+							</span>
+						</label>
+					)
+				})}
+			</div>
+			{paginationSummary === undefined ? undefined : (
+				<PaginationControls
+					hasNextPage={hasNextPage}
+					hasPreviousPage={hasPreviousPage}
+					nextLabel='Next Deposits'
+					onNextPage={() => setPageIndex(currentPageIndex => currentPageIndex + 1)}
+					onPreviousPage={() => setPageIndex(currentPageIndex => Math.max(0, currentPageIndex - 1))}
+					previousLabel='Previous Deposits'
+					summary={paginationSummary}
+				/>
+			)}
+		</>
 	)
 }

--- a/ui/ts/components/ImportedForkSettlementSection.tsx
+++ b/ui/ts/components/ImportedForkSettlementSection.tsx
@@ -1,8 +1,13 @@
 import type { ComponentChildren } from 'preact'
+import { useEffect, useMemo, useState } from 'preact/hooks'
 import { CurrencyValue } from './CurrencyValue.js'
+import { PaginationControls } from './PaginationControls.js'
 import { SectionBlock } from './SectionBlock.js'
+import { formatPaginationSummary, getHasNextPaginationPage, getPaginationPageCount, resolvePaginationPageIndex } from '../lib/pagination.js'
 import { getImportedEscalationDepositClaimAmount } from '../lib/reportingDomain.js'
 import type { ActiveReportingDetails, EscalationSide, ReportingOutcomeKey } from '../types/contracts.js'
+
+const IMPORTED_FORK_SETTLEMENT_PAGE_SIZE = 25
 
 type ImportedForkSettlementActionRenderProps = {
 	guardMessage: string | undefined
@@ -20,6 +25,92 @@ type ImportedForkSettlementSectionProps = {
 	sides: Pick<EscalationSide, 'importedUserDeposits' | 'key' | 'label'>[]
 }
 
+type ImportedForkSettlementSideProps = {
+	activeReportingDetails: ActiveReportingDetails | undefined
+	disabled: boolean
+	onDepositSelectionChange: (outcome: ReportingOutcomeKey, depositIndex: bigint, checked: boolean) => void
+	renderSettlementAction: (props: ImportedForkSettlementActionRenderProps) => ComponentChildren
+	resolved: boolean
+	selectedDepositIndexes: bigint[]
+	side: Pick<EscalationSide, 'importedUserDeposits' | 'key' | 'label'>
+}
+
+function ImportedForkSettlementSide({ activeReportingDetails, disabled, onDepositSelectionChange, renderSettlementAction, resolved, selectedDepositIndexes, side }: ImportedForkSettlementSideProps) {
+	const [pageIndex, setPageIndex] = useState(0)
+	const pageCount = getPaginationPageCount(BigInt(side.importedUserDeposits.length), IMPORTED_FORK_SETTLEMENT_PAGE_SIZE)
+	const resolvedPageIndex = resolvePaginationPageIndex(pageIndex, pageCount)
+	const hasNextPage = getHasNextPaginationPage(resolvedPageIndex, pageCount)
+	const hasPreviousPage = resolvedPageIndex > 0
+	const pageStartIndex = resolvedPageIndex * IMPORTED_FORK_SETTLEMENT_PAGE_SIZE
+	const pageEndIndex = Math.min(side.importedUserDeposits.length, pageStartIndex + IMPORTED_FORK_SETTLEMENT_PAGE_SIZE)
+	const visibleDeposits = useMemo(() => side.importedUserDeposits.slice(pageStartIndex, pageEndIndex), [pageEndIndex, pageStartIndex, side.importedUserDeposits])
+	const paginationSummary = side.importedUserDeposits.length > IMPORTED_FORK_SETTLEMENT_PAGE_SIZE ? `Showing parent deposits ${(pageStartIndex + 1).toString()}-${pageEndIndex.toString()} of ${side.importedUserDeposits.length.toString()}. ${formatPaginationSummary(resolvedPageIndex, pageCount) ?? ''}` : undefined
+	const settlementGuardMessage = (() => {
+		if (!resolved) return 'Fork-carried escalation deposits can be settled after this child pool finalizes.'
+		if (selectedDepositIndexes.length === 0) return `Select at least one ${side.label.toLowerCase()} fork-carried deposit to settle.`
+		return undefined
+	})()
+
+	useEffect(() => {
+		if (resolvedPageIndex !== pageIndex) setPageIndex(resolvedPageIndex)
+	}, [pageIndex, resolvedPageIndex])
+
+	return (
+		<SectionBlock density='compact' headingLevel={4} key={side.key} title={side.label} variant='embedded'>
+			<div className='field'>
+				<span>Imported from parent universe</span>
+				<div className='escalation-selection-list'>
+					{visibleDeposits.map(deposit => {
+						const selected = selectedDepositIndexes.includes(deposit.parentDepositIndex)
+						const claimAmount = getImportedEscalationDepositClaimAmount(activeReportingDetails, side.key, deposit)
+						return (
+							<label className='escalation-selection-item' key={deposit.parentDepositIndex.toString()}>
+								<input checked={selected} disabled={disabled} onChange={event => onDepositSelectionChange(side.key, deposit.parentDepositIndex, event.currentTarget.checked)} type='checkbox' />
+								<div className='escalation-selection-item-copy'>
+									<strong>Parent deposit #{deposit.parentDepositIndex.toString()}</strong>
+									<span>
+										Initially deposited: <CurrencyValue value={deposit.amount} suffix='REP' />
+									</span>
+									<span>
+										{claimAmount === undefined ? (
+											'Worth now: Pending final settlement'
+										) : (
+											<>
+												Worth now: <CurrencyValue value={claimAmount} suffix='REP' />
+											</>
+										)}
+									</span>
+									<span>
+										Imported ordering start: <CurrencyValue value={deposit.cumulativeAmount} suffix='REP' />
+									</span>
+								</div>
+							</label>
+						)
+					})}
+				</div>
+				{paginationSummary === undefined ? undefined : (
+					<PaginationControls
+						hasNextPage={hasNextPage}
+						hasPreviousPage={hasPreviousPage}
+						nextLabel='Next Parent Deposits'
+						onNextPage={() => setPageIndex(currentPageIndex => currentPageIndex + 1)}
+						onPreviousPage={() => setPageIndex(currentPageIndex => Math.max(0, currentPageIndex - 1))}
+						previousLabel='Previous Parent Deposits'
+						summary={paginationSummary}
+					/>
+				)}
+			</div>
+			<div className='actions'>
+				{renderSettlementAction({
+					guardMessage: settlementGuardMessage,
+					outcome: side.key,
+					sideLabel: side.label,
+				})}
+			</div>
+		</SectionBlock>
+	)
+}
+
 export function ImportedForkSettlementSection({ activeReportingDetails, disabled, onDepositSelectionChange, renderSettlementAction, resolved, selectedDepositIndexesByOutcome, sides }: ImportedForkSettlementSectionProps) {
 	if (sides.length === 0) return undefined
 
@@ -27,57 +118,9 @@ export function ImportedForkSettlementSection({ activeReportingDetails, disabled
 		<SectionBlock density='compact' title='Settle Fork-Carried Escalation Deposits'>
 			<p className='detail'>Imported from the parent universe. Settle these positions in this child pool after finalization.</p>
 			{resolved ? undefined : <p className='detail'>Fork-carried escalation deposits can be settled after this child pool finalizes.</p>}
-			{sides.map(side => {
-				const selectedDepositIndexes = selectedDepositIndexesByOutcome[side.key]
-				const settlementGuardMessage = (() => {
-					if (!resolved) return 'Fork-carried escalation deposits can be settled after this child pool finalizes.'
-					if (selectedDepositIndexes.length === 0) return `Select at least one ${side.label.toLowerCase()} fork-carried deposit to settle.`
-					return undefined
-				})()
-				return (
-					<SectionBlock density='compact' headingLevel={4} key={side.key} title={side.label} variant='embedded'>
-						<div className='field'>
-							<span>Imported from parent universe</span>
-							<div className='escalation-selection-list'>
-								{side.importedUserDeposits.map(deposit => {
-									const selected = selectedDepositIndexes.includes(deposit.parentDepositIndex)
-									const claimAmount = getImportedEscalationDepositClaimAmount(activeReportingDetails, side.key, deposit)
-									return (
-										<label className='escalation-selection-item' key={deposit.parentDepositIndex.toString()}>
-											<input checked={selected} disabled={disabled} onChange={event => onDepositSelectionChange(side.key, deposit.parentDepositIndex, event.currentTarget.checked)} type='checkbox' />
-											<div className='escalation-selection-item-copy'>
-												<strong>Parent deposit #{deposit.parentDepositIndex.toString()}</strong>
-												<span>
-													Initially deposited: <CurrencyValue value={deposit.amount} suffix='REP' />
-												</span>
-												<span>
-													{claimAmount === undefined ? (
-														'Worth now: Pending final settlement'
-													) : (
-														<>
-															Worth now: <CurrencyValue value={claimAmount} suffix='REP' />
-														</>
-													)}
-												</span>
-												<span>
-													Imported ordering start: <CurrencyValue value={deposit.cumulativeAmount} suffix='REP' />
-												</span>
-											</div>
-										</label>
-									)
-								})}
-							</div>
-						</div>
-						<div className='actions'>
-							{renderSettlementAction({
-								guardMessage: settlementGuardMessage,
-								outcome: side.key,
-								sideLabel: side.label,
-							})}
-						</div>
-					</SectionBlock>
-				)
-			})}
+			{sides.map(side => (
+				<ImportedForkSettlementSide activeReportingDetails={activeReportingDetails} disabled={disabled} key={side.key} onDepositSelectionChange={onDepositSelectionChange} renderSettlementAction={renderSettlementAction} resolved={resolved} selectedDepositIndexes={selectedDepositIndexesByOutcome[side.key]} side={side} />
+			))}
 		</SectionBlock>
 	)
 }

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -61,7 +61,6 @@ import {
 	requireOpenOracleReportStatusTuple,
 	requireOpenOracleReportStatusTupleArray,
 	requireSecurityVaultTupleArray,
-	toUint8Array,
 } from './contracts/helpers.js'
 import { type ContractRevertReasonParams, type WriteContractClient, readRequiredMulticall, writeContractAndWait, writeContractAndWaitForReceipt } from './contracts/core.js'
 import { getInfraContractAddresses, getOpenOracleAddress, getZoltarAddress } from './contracts/deploymentHelpers.js'
@@ -1314,7 +1313,7 @@ export async function migrateEscalationDeposits(client: WriteClient, securityPoo
 			address: getInfraContractAddresses().securityPoolForker,
 			abi: peripherals_SecurityPoolForker_SecurityPoolForker.abi,
 			functionName: 'claimForkedEscalationDeposits',
-			args: [securityPoolAddress, vaultAddress, outcomeIndex, toUint8Array(depositIndexes)],
+			args: [securityPoolAddress, vaultAddress, outcomeIndex, depositIndexes],
 		}))
 	})
 }

--- a/ui/ts/contracts/helpers.ts
+++ b/ui/ts/contracts/helpers.ts
@@ -248,16 +248,3 @@ export function getMarketType(questionData: QuestionData, outcomeLabels: string[
 	if (outcomeLabels.length === 2 && outcomeLabels[0] === 'Yes' && outcomeLabels[1] === 'No') return 'binary'
 	return 'categorical'
 }
-
-function toUint8(value: bigint) {
-	if (value < 0n || value > 255n) throw new Error(`Deposit index out of range: ${value.toString()}`)
-
-	const numberValue = Number(value)
-	if (!Number.isInteger(numberValue) || numberValue < 0 || numberValue > 255) throw new Error(`Deposit index out of range: ${value.toString()}`)
-
-	return numberValue
-}
-
-export function toUint8Array(values: bigint[]) {
-	return values.map(value => toUint8(value))
-}

--- a/ui/ts/tests/contracts.test.ts
+++ b/ui/ts/tests/contracts.test.ts
@@ -19,6 +19,7 @@ import {
 	loadTruthAuctionTickBidPage,
 	loadTruthAuctionTickPage,
 	loadTruthAuctionTickSummary,
+	migrateEscalationDeposits,
 	migrateVaultWithUnresolvedEscalation,
 	migrateSharesFromUniverse,
 	settleOracleReport,
@@ -1059,6 +1060,36 @@ describe('contracts helpers', () => {
 		expect(decodedArgs[2]).toBe(2n)
 		expect(result).toEqual({
 			action: 'migrateUnresolvedEscalation',
+			hash: transactionHash,
+			securityPoolAddress,
+			universeId: 9n,
+		})
+	})
+
+	test('migrateEscalationDeposits helper keeps deposit indexes as uint256 values', async () => {
+		let capturedData: Hex | undefined
+		let capturedTo: Address | null | undefined
+		const client = createMockWriteClient(request => {
+			capturedData = request.data
+			capturedTo = request.to
+		})
+
+		const result = await migrateEscalationDeposits(asWriteClient(client), securityPoolAddress, 9n, vaultAddress, 'yes', [0n, 255n, 256n])
+
+		expect(capturedTo).toBeDefined()
+		expect(capturedData).toBeDefined()
+		const decodedCall = decodeFunctionData({
+			abi: peripherals_SecurityPoolForker_SecurityPoolForker.abi,
+			data: capturedData ?? ('0x' satisfies Hex),
+		})
+		const decodedArgs = decodedCall.args as readonly [Address, Address, number, bigint[]]
+		expect(decodedCall.functionName).toBe('claimForkedEscalationDeposits')
+		expect(decodedArgs[0]).toBe(securityPoolAddress)
+		expect(decodedArgs[1]).toBe(vaultAddress)
+		expect(decodedArgs[2]).toBe(1)
+		expect(decodedArgs[3]).toEqual([0n, 255n, 256n])
+		expect(result).toEqual({
+			action: 'migrateEscalationDeposits',
 			hash: transactionHash,
 			securityPoolAddress,
 			universeId: 9n,

--- a/ui/ts/tests/contractsHelpers.test.ts
+++ b/ui/ts/tests/contractsHelpers.test.ts
@@ -26,7 +26,6 @@ import {
 	requireOpenOracleReportStatusTupleArray,
 	requireUniverseTupleArray,
 	requireSecurityVaultTupleArray,
-	toUint8Array,
 } from '../contracts/helpers.js'
 
 const questionData = {
@@ -124,13 +123,10 @@ describe('contracts helpers', () => {
 		expect(() => getSecurityPoolSystemState(4)).toThrow('Unhandled security pool system state')
 	})
 
-	test('market and deposit utilities cover binary and boundary paths', () => {
+	test('market utilities cover binary and categorical paths', () => {
 		expect(getMarketType({ ...questionData, numTicks: 100n }, [])).toBe('scalar')
 		expect(getMarketType(questionData, ['Yes', 'No'])).toBe('binary')
 		expect(getMarketType(questionData, ['A', 'B', 'C'])).toBe('categorical')
-		expect(toUint8Array([0n, 1n, 255n])).toEqual([0, 1, 255])
-		expect(() => toUint8Array([-1n])).toThrow('Deposit index out of range')
-		expect(() => toUint8Array([256n])).toThrow('Deposit index out of range')
 	})
 
 	test('getGenesisReputationTokenAddress is wired through helper defaults', () => {

--- a/ui/ts/tests/escalationDepositSelectionList.test.tsx
+++ b/ui/ts/tests/escalationDepositSelectionList.test.tsx
@@ -109,4 +109,65 @@ describe('EscalationDepositSelectionList', () => {
 			fireEvent.click(checkbox)
 		})
 	})
+
+	test('paginates deposits and keeps selections across pages', async () => {
+		const deposits = Array.from({ length: 27 }, (_, index) => {
+			const depositIndex = 250n + BigInt(index)
+			return {
+				deposit: {
+					amount: depositIndex,
+					cumulativeAmount: depositIndex,
+					depositIndex,
+					depositor: zeroAddress,
+				},
+				details: [`Deposit ${depositIndex.toString()}`],
+			}
+		})
+
+		function SelectionHarness() {
+			const [selectedIndexes, setSelectedIndexes] = useState<bigint[]>([])
+			return <EscalationDepositSelectionList disabled={false} items={deposits} onSelectionChange={setSelectedIndexes} selectedDepositIndexes={selectedIndexes} />
+		}
+
+		const rendered = await renderIntoDocument(<SelectionHarness />)
+		cleanupRendered = rendered.cleanup
+
+		expect(document.body.textContent).toMatch('Deposit #256')
+		expect(document.body.textContent).toMatch('Showing deposits 1-25 of 27. Page 1 of 2')
+		expect(document.body.textContent).not.toMatch('Deposit #276')
+
+		const firstPageCheckboxes = document.querySelectorAll('input[type="checkbox"]')
+		const deposit256Checkbox = firstPageCheckboxes.item(6) as HTMLInputElement
+		await act(() => {
+			fireEvent.click(deposit256Checkbox)
+		})
+		expect(deposit256Checkbox.checked).toBe(true)
+
+		const nextButton = Array.from(document.querySelectorAll('button')).find(button => button.textContent === 'Next Deposits')
+		if (nextButton === undefined) throw new Error('Next Deposits button missing')
+		await act(() => {
+			fireEvent.click(nextButton)
+		})
+
+		expect(document.body.textContent).toMatch('Deposit #276')
+		expect(document.body.textContent).toMatch('Showing deposits 26-27 of 27. Page 2 of 2')
+		expect(document.body.textContent).not.toMatch('Deposit #256')
+
+		const secondPageCheckboxes = document.querySelectorAll('input[type="checkbox"]')
+		const deposit276Checkbox = secondPageCheckboxes.item(1) as HTMLInputElement
+		await act(() => {
+			fireEvent.click(deposit276Checkbox)
+		})
+		expect(deposit276Checkbox.checked).toBe(true)
+
+		const previousButton = Array.from(document.querySelectorAll('button')).find(button => button.textContent === 'Previous Deposits')
+		if (previousButton === undefined) throw new Error('Previous Deposits button missing')
+		await act(() => {
+			fireEvent.click(previousButton)
+		})
+
+		const refreshedFirstPageCheckboxes = document.querySelectorAll('input[type="checkbox"]')
+		const refreshedDeposit256Checkbox = refreshedFirstPageCheckboxes.item(6) as HTMLInputElement
+		expect(refreshedDeposit256Checkbox.checked).toBe(true)
+	})
 })

--- a/ui/ts/tests/importedForkSettlementSection.test.tsx
+++ b/ui/ts/tests/importedForkSettlementSection.test.tsx
@@ -1,6 +1,7 @@
 /// <reference types='bun-types' />
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { useState } from 'preact/hooks'
 import { ImportedForkSettlementSection } from '../components/ImportedForkSettlementSection.js'
 import type { ReportingOutcomeKey } from '../types/contracts.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
@@ -79,5 +80,87 @@ describe('ImportedForkSettlementSection', () => {
 		expect(checkbox.checked).toBe(true)
 		fireEvent.change(checkbox, { target: { checked: false } })
 		expect(selectionChanges).toEqual([{ checked: false, depositIndex: 7n, outcome: 'yes' }])
+	})
+
+	test('paginates imported deposits and keeps selections across pages', async () => {
+		const importedUserDeposits = Array.from({ length: 27 }, (_, index) => {
+			const parentDepositIndex = 250n + BigInt(index)
+			return {
+				amount: parentDepositIndex,
+				cumulativeAmount: parentDepositIndex + 1n,
+				depositor: '0x0000000000000000000000000000000000000001' as const,
+				parentDepositIndex,
+			}
+		})
+
+		function SettlementHarness() {
+			const [selectedDepositIndexesByOutcome, setSelectedDepositIndexesByOutcome] = useState<Record<ReportingOutcomeKey, bigint[]>>({
+				invalid: [],
+				no: [],
+				yes: [256n],
+			})
+			return (
+				<ImportedForkSettlementSection
+					activeReportingDetails={undefined}
+					disabled={false}
+					onDepositSelectionChange={(outcome, depositIndex, checked) => {
+						setSelectedDepositIndexesByOutcome(current => ({
+							...current,
+							[outcome]: checked ? [...current[outcome], depositIndex] : current[outcome].filter(index => index !== depositIndex),
+						}))
+					}}
+					renderSettlementAction={props => (
+						<button disabled={props.guardMessage !== undefined} type='button'>
+							Settle {props.sideLabel}
+						</button>
+					)}
+					resolved={true}
+					selectedDepositIndexesByOutcome={selectedDepositIndexesByOutcome}
+					sides={[
+						{
+							importedUserDeposits,
+							key: 'yes',
+							label: 'Yes',
+						},
+					]}
+				/>
+			)
+		}
+
+		const rendered = await renderIntoDocument(<SettlementHarness />)
+		cleanupRendered = rendered.cleanup
+
+		expect(document.body.textContent).toMatch('Parent deposit #256')
+		expect(document.body.textContent).toMatch('Showing parent deposits 1-25 of 27. Page 1 of 2')
+		expect(document.body.textContent).not.toMatch('Parent deposit #276')
+
+		const firstPageCheckboxes = document.querySelectorAll('input[type="checkbox"]')
+		const deposit256Checkbox = firstPageCheckboxes.item(6) as HTMLInputElement
+		expect(deposit256Checkbox.checked).toBe(true)
+
+		const nextButton = within(document.body).getByRole('button', { name: 'Next Parent Deposits' })
+		fireEvent.click(nextButton)
+
+		expect(document.body.textContent).toMatch('Parent deposit #276')
+		expect(document.body.textContent).toMatch('Showing parent deposits 26-27 of 27. Page 2 of 2')
+		expect(document.body.textContent).not.toMatch('Parent deposit #256')
+
+		const secondPageCheckboxes = document.querySelectorAll('input[type="checkbox"]')
+		const deposit276Checkbox = secondPageCheckboxes.item(1) as HTMLInputElement
+		fireEvent.change(deposit276Checkbox, { target: { checked: true } })
+		expect(deposit276Checkbox.checked).toBe(true)
+
+		const previousButton = within(document.body).getByRole('button', { name: 'Previous Parent Deposits' })
+		fireEvent.click(previousButton)
+
+		const refreshedFirstPageCheckboxes = document.querySelectorAll('input[type="checkbox"]')
+		const refreshedDeposit256Checkbox = refreshedFirstPageCheckboxes.item(6) as HTMLInputElement
+		expect(refreshedDeposit256Checkbox.checked).toBe(true)
+
+		fireEvent.click(nextButton)
+
+		const refreshedSecondPageCheckboxes = document.querySelectorAll('input[type="checkbox"]')
+		const refreshedDeposit276Checkbox = refreshedSecondPageCheckboxes.item(1) as HTMLInputElement
+		expect(refreshedDeposit276Checkbox.checked).toBe(true)
 	})
 })


### PR DESCRIPTION
## Summary
- Removed the UI-side `uint8` narrowing for escalation deposit indexes so own-fork escalation migration can submit `uint256[]` indexes such as `256n`.
- Added local pagination to local escalation deposit selection and imported fork-carried escalation settlement selection, preserving selections across pages.
- Added focused tests for paginated deposit selection and `migrateEscalationDeposits([0n, 255n, 256n])` ABI encoding.

## Notes
- This PR does not redesign the escalation reward-window mechanism or add commit/reveal. That remains a protocol-level follow-up.

## Validation
- `bun test --preload ./bun-test-setup-ui.ts --timeout 300000 ui/ts/tests/importedForkSettlementSection.test.tsx ui/ts/tests/escalationDepositSelectionList.test.tsx ui/ts/tests/contracts.test.ts ui/ts/tests/contractsHelpers.test.ts --bail=1` (51 pass)
- `bun run tsc`
- `bun run ensure-contract-artifacts && bun run check:shared-dependencies && bun run test:run -- --bail=1` (1526 pass, 11 skip, 0 fail)
- `bun run format`
- `bun run check`
- `bun run knip`
- `git diff --check`

## Skipped
- `bun run check:generated-clean` was skipped because this change does not touch generation scripts, contracts, generated artifacts, shared build output, UI contract artifacts, or artifact policy.
