### PR TITLE
Improve accessibility labeling, modal focus handling, and liquidation/trading UI flows

### DIFF
--- a/ui/ts/contracts/reporting.ts
+++ b/ui/ts/contracts/reporting.ts
@@ -165,47 +165,11 @@ async function loadProofConsumedCarriedDepositIndexes(client: Pick<ReadClient, '
 }
 
 async function readForkContinuation(client: Pick<ReadClient, 'readContract'>, escalationGameAddress: Address) {
-	try {
-		return await client.readContract({
-			abi: peripherals_EscalationGame_EscalationGame.abi,
-			address: escalationGameAddress,
-			functionName: 'forkContinuation',
-			args: [],
-		})
-	} catch (error) {
-		if (isForkContinuationCompatibilityError(error)) return undefined
-		throw error
-	}
-}
-
-function collectErrorMessages(error: unknown, seen = new Set<object>()): string[] {
-	if (typeof error === 'string') return [error]
-	if (typeof error !== 'object' || error === null) return []
-	if (seen.has(error)) return []
-	seen.add(error)
-
-	const messages: string[] = []
-	for (const key of ['message', 'shortMessage', 'details']) {
-		const value = Reflect.get(error, key)
-		if (typeof value === 'string') messages.push(value)
-	}
-
-	const metaMessages = Reflect.get(error, 'metaMessages')
-	if (Array.isArray(metaMessages)) {
-		for (const message of metaMessages) {
-			if (typeof message === 'string') messages.push(message)
-		}
-	}
-
-	messages.push(...collectErrorMessages(Reflect.get(error, 'cause'), seen))
-	return messages
-}
-
-function isForkContinuationCompatibilityError(error: unknown) {
-	return collectErrorMessages(error).some(message => {
-		const normalizedMessage = message.toLowerCase()
-		if (!normalizedMessage.includes('forkcontinuation')) return false
-		return normalizedMessage.includes('returned no data') || normalizedMessage.includes('does not have the function') || normalizedMessage.includes('function not found') || normalizedMessage.includes('function selector') || normalizedMessage.includes('unknown function')
+	return await client.readContract({
+		abi: peripherals_EscalationGame_EscalationGame.abi,
+		address: escalationGameAddress,
+		functionName: 'forkContinuation',
+		args: [],
 	})
 }
 
@@ -576,7 +540,7 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 	const { questionId, escalationGameAddress, completeSetCollateralAmount, universeId, zoltarAddress, initialEscalationGameDeposit, systemStateValue, questionOutcomeValue, parentSecurityPoolAddress } = requireReportingBootstrapReadResult(await readRequiredMulticall(client, reportingPoolReads))
 	const systemState = getSecurityPoolSystemState(systemStateValue)
 	const normalizedQuestionOutcome = getReportingOutcomeKey(questionOutcomeValue)
-	const [marketDetails, block, escalationGameCode, viewerVaultState, forkThreshold, forkContinuationSnapshot] = await Promise.all([
+	const [marketDetails, block, escalationGameCode, viewerVaultState, forkThreshold] = await Promise.all([
 		loadMarketDetails(client, questionId),
 		client.getBlock(),
 		escalationGameAddress === zeroAddress ? Promise.resolve('0x' as const) : client.getCode({ address: escalationGameAddress }),
@@ -587,7 +551,6 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 			functionName: 'getForkThreshold',
 			args: [universeId],
 		}),
-		escalationGameAddress === zeroAddress ? Promise.resolve(undefined) : readForkContinuation(client, escalationGameAddress),
 	])
 	if (!hasTimestamp(block)) throw new Error('Unexpected block response')
 	if (escalationGameAddress === zeroAddress || escalationGameCode === undefined || escalationGameCode === '0x')
@@ -608,6 +571,7 @@ export async function loadReportingDetails(client: ReadClient, securityPoolAddre
 			parentWithdrawalEnabled: false,
 			...viewerVaultState,
 		}
+	const forkContinuationSnapshot = await readForkContinuation(client, escalationGameAddress)
 	const [startBond, nonDecisionThreshold, activationTime, totalCost, bindingCapital, invalidOutcomeState, yesOutcomeState, noOutcomeState, escalationEndTime, _questionOutcome, universeForkTime, hasReachedNonDecision] = await Promise.all([
 		client.readContract({
 			abi: peripherals_EscalationGame_EscalationGame.abi,

--- a/ui/ts/contracts/reporting.ts
+++ b/ui/ts/contracts/reporting.ts
@@ -1,7 +1,6 @@
 import { concatHex, encodeAbiParameters, keccak256, parseAbiItem, parseAbiParameters, zeroAddress, type Address, type ContractFunctionParameters, type Hex } from 'viem'
 import { Zoltar_Zoltar, peripherals_EscalationGame_EscalationGame, peripherals_SecurityPool_SecurityPool } from '../contractArtifact.js'
 import { sameAddress } from '../lib/address.js'
-import { isIgnorableLogDecodeError } from '../lib/errors.js'
 import type { CarriedDepositProof, EscalationDeposit, EscalationSide, ImportedEscalationDeposit, ReadClient, ReportingActionResult, ReportingDetails, ReportingOutcomeKey, ReportingSettlementState, WriteClient } from '../types/contracts.js'
 import { readRequiredMulticall, writeContractAndWait } from './core.js'
 import { requireAddressValue, requireArrayValue, requireBigintValue, requireIntegerLikeValue, requireObjectValue, requireTupleValue } from './decoders.js'
@@ -174,9 +173,40 @@ async function readForkContinuation(client: Pick<ReadClient, 'readContract'>, es
 			args: [],
 		})
 	} catch (error) {
-		if (isIgnorableLogDecodeError(error)) return undefined
-		return undefined
+		if (isForkContinuationCompatibilityError(error)) return undefined
+		throw error
 	}
+}
+
+function collectErrorMessages(error: unknown, seen = new Set<object>()): string[] {
+	if (typeof error === 'string') return [error]
+	if (typeof error !== 'object' || error === null) return []
+	if (seen.has(error)) return []
+	seen.add(error)
+
+	const messages: string[] = []
+	for (const key of ['message', 'shortMessage', 'details']) {
+		const value = Reflect.get(error, key)
+		if (typeof value === 'string') messages.push(value)
+	}
+
+	const metaMessages = Reflect.get(error, 'metaMessages')
+	if (Array.isArray(metaMessages)) {
+		for (const message of metaMessages) {
+			if (typeof message === 'string') messages.push(message)
+		}
+	}
+
+	messages.push(...collectErrorMessages(Reflect.get(error, 'cause'), seen))
+	return messages
+}
+
+function isForkContinuationCompatibilityError(error: unknown) {
+	return collectErrorMessages(error).some(message => {
+		const normalizedMessage = message.toLowerCase()
+		if (!normalizedMessage.includes('forkcontinuation')) return false
+		return normalizedMessage.includes('returned no data') || normalizedMessage.includes('does not have the function') || normalizedMessage.includes('function not found') || normalizedMessage.includes('function selector') || normalizedMessage.includes('unknown function')
+	})
 }
 
 async function readEscalationOutcomeState(client: Pick<ReadClient, 'readContract'>, escalationGameAddress: Address, outcome: ReportingOutcomeKey) {

--- a/ui/ts/tests/contracts.test.ts
+++ b/ui/ts/tests/contracts.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from 'bun:test'
-import { decodeFunctionData, getAddress, zeroAddress, type Address, type Hash, type Hex, type TransactionReceipt } from 'viem'
+import { concatHex, decodeFunctionData, getAddress, keccak256, zeroAddress, type Address, type Hash, type Hex, type TransactionReceipt } from 'viem'
 import {
 	buildForkCarriedEscalationProofs,
 	getOpenOracleAddress,
@@ -38,6 +38,7 @@ const zoltarAddress = getAddress('0x00000000000000000000000000000000000000e7')
 const token1Address = getAddress('0x00000000000000000000000000000000000000d1')
 const token2Address = getAddress('0x00000000000000000000000000000000000000d2')
 const transactionHash = '0x00000000000000000000000000000000000000000000000000000000000000c3' satisfies Hash
+const zeroBytes32 = '0x0000000000000000000000000000000000000000000000000000000000000000' satisfies Hex
 const defaultForkData = [0n, zeroAddress, 0n, 0n, 0n, 0n, 0n, 0n, false, false, 0n] as const
 
 type MockReadClient = Parameters<typeof loadEscalationDeposits>[0]
@@ -102,6 +103,38 @@ function createMockReadClient(readContract: MockReadContractHandler): MockReadCl
 	return {
 		readContract: createReadContractStub(readContract),
 	}
+}
+
+function buildEmptyNullifierRoot() {
+	let currentHash: Hex = zeroBytes32
+	for (let depth = 1; depth < 64; depth += 1) currentHash = keccak256(concatHex([currentHash, currentHash]))
+	return currentHash
+}
+
+function createForkCarriedProofReadClient(readForkContinuation: () => Promise<unknown>) {
+	const parentEscalationGameAddress = getAddress('0x00000000000000000000000000000000000000f1')
+	const emptyNullifierRoot = buildEmptyNullifierRoot()
+	return {
+		multicall: createMulticallStub(async request => {
+			const firstContract = request.contracts[0]
+			const functionName = getContractFunctionName(firstContract)
+			if (functionName === 'parent') return [alternateSecurityPoolAddress, escalationGameAddress]
+			throw new Error(`Unexpected multicall contract: ${functionName}`)
+		}),
+		readContract: createReadContractStub(async request => {
+			if (request.functionName === 'escalationGame') return parentEscalationGameAddress
+			if (request.functionName === 'getOutcomeState')
+				return {
+					currentCarryRoot: zeroBytes32,
+					currentLeafCount: 0n,
+					currentNullifierRoot: emptyNullifierRoot,
+				}
+			if (request.functionName === 'forkContinuation') return await readForkContinuation()
+			if (request.functionName === 'getCarryLeafPageByOutcome') return [[], 0n]
+			if (request.functionName === 'getProofConsumedCarriedDepositIndexesByOutcome') return []
+			throw new Error(`Unexpected readContract function: ${request.functionName}`)
+		}),
+	} as unknown as Parameters<typeof buildForkCarriedEscalationProofs>[0]
 }
 
 function createMockLoaderClient({ getBlock, multicall, readContract }: { getBlock: () => Promise<{ timestamp: bigint }>; multicall: MockLoaderMulticallHandler; readContract: MockReadContractHandler }): MockLoaderClient {
@@ -755,6 +788,7 @@ describe('contracts helpers', () => {
 				if (request.functionName === 'getQuestionOutcome') return 3
 				if (request.functionName === 'getForkTime') return 0n
 				if (request.functionName === 'hasReachedNonDecision') return false
+				if (request.functionName === 'forkContinuation') return false
 				if (request.functionName === 'getForkThreshold') return 100n
 				if (request.functionName === 'escalationGame') return escalationGameAddress
 				if (request.functionName === 'escrowedRepByVault') return escrowedRep
@@ -806,6 +840,7 @@ describe('contracts helpers', () => {
 				if (request.functionName === 'getQuestionOutcome') return 3
 				if (request.functionName === 'getForkTime') return 123n
 				if (request.functionName === 'hasReachedNonDecision') return false
+				if (request.functionName === 'forkContinuation') return false
 				if (request.functionName === 'getForkThreshold') return 100n
 				if (request.functionName === 'escalationGame') return escalationGameAddress
 				if (request.functionName === 'escrowedRepByVault') return 9n
@@ -867,6 +902,7 @@ describe('contracts helpers', () => {
 				if (request.functionName === 'getQuestionOutcome') return 3
 				if (request.functionName === 'getForkTime') return 120n
 				if (request.functionName === 'hasReachedNonDecision') return false
+				if (request.functionName === 'forkContinuation') return false
 				if (request.functionName === 'getForkThreshold') return 100n
 				if (request.functionName === 'escalationGame') return escalationGameAddress
 				if (request.functionName === 'escrowedRepByVault') return 9n
@@ -1023,6 +1059,22 @@ describe('contracts helpers', () => {
 		} as unknown as Parameters<typeof buildForkCarriedEscalationProofs>[0]
 
 		await expect(buildForkCarriedEscalationProofs(client, securityPoolAddress, 'yes', [1n])).rejects.toThrow('Unexpected carry leaf page response')
+	})
+
+	test('buildForkCarriedEscalationProofs treats a missing recursive forkContinuation getter as backward-compatible', async () => {
+		const client = createForkCarriedProofReadClient(async () => {
+			throw new Error('The contract function "forkContinuation" returned no data ("0x"). The contract does not have the function "forkContinuation".')
+		})
+
+		await expect(buildForkCarriedEscalationProofs(client, securityPoolAddress, 'yes', [])).resolves.toEqual([])
+	})
+
+	test('buildForkCarriedEscalationProofs rejects recursive forkContinuation RPC failures', async () => {
+		const client = createForkCarriedProofReadClient(async () => {
+			throw new Error('RPC request failed while reading forkContinuation')
+		})
+
+		await expect(buildForkCarriedEscalationProofs(client, securityPoolAddress, 'yes', [])).rejects.toThrow('RPC request failed while reading forkContinuation')
 	})
 
 	test('migrateVaultWithUnresolvedEscalation helper encodes the selected child outcome correctly', async () => {

--- a/ui/ts/tests/contracts.test.ts
+++ b/ui/ts/tests/contracts.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from 'bun:test'
-import { concatHex, decodeFunctionData, getAddress, keccak256, zeroAddress, type Address, type Hash, type Hex, type TransactionReceipt } from 'viem'
+import { decodeFunctionData, getAddress, zeroAddress, type Address, type Hash, type Hex, type TransactionReceipt } from 'viem'
 import {
 	buildForkCarriedEscalationProofs,
 	depositRepToSecurityPool,
@@ -39,7 +39,7 @@ const zoltarAddress = getAddress('0x00000000000000000000000000000000000000e7')
 const token1Address = getAddress('0x00000000000000000000000000000000000000d1')
 const token2Address = getAddress('0x00000000000000000000000000000000000000d2')
 const transactionHash = '0x00000000000000000000000000000000000000000000000000000000000000c3' satisfies Hash
-const zeroBytes32 = '0x0000000000000000000000000000000000000000000000000000000000000000' satisfies Hex
+const missingForkContinuationGetterMessage = 'The contract function "forkContinuation" returned no data ("0x"). The contract does not have the function "forkContinuation".'
 const defaultForkData = [0n, zeroAddress, 0n, 0n, 0n, 0n, 0n, 0n, false, false, 0n] as const
 
 type MockReadClient = Parameters<typeof loadEscalationDeposits>[0]
@@ -104,38 +104,6 @@ function createMockReadClient(readContract: MockReadContractHandler): MockReadCl
 	return {
 		readContract: createReadContractStub(readContract),
 	}
-}
-
-function buildEmptyNullifierRoot() {
-	let currentHash: Hex = zeroBytes32
-	for (let depth = 1; depth < 64; depth += 1) currentHash = keccak256(concatHex([currentHash, currentHash]))
-	return currentHash
-}
-
-function createForkCarriedProofReadClient(readForkContinuation: () => Promise<unknown>) {
-	const parentEscalationGameAddress = getAddress('0x00000000000000000000000000000000000000f1')
-	const emptyNullifierRoot = buildEmptyNullifierRoot()
-	return {
-		multicall: createMulticallStub(async request => {
-			const firstContract = request.contracts[0]
-			const functionName = getContractFunctionName(firstContract)
-			if (functionName === 'parent') return [alternateSecurityPoolAddress, escalationGameAddress]
-			throw new Error(`Unexpected multicall contract: ${functionName}`)
-		}),
-		readContract: createReadContractStub(async request => {
-			if (request.functionName === 'escalationGame') return parentEscalationGameAddress
-			if (request.functionName === 'getOutcomeState')
-				return {
-					currentCarryRoot: zeroBytes32,
-					currentLeafCount: 0n,
-					currentNullifierRoot: emptyNullifierRoot,
-				}
-			if (request.functionName === 'forkContinuation') return await readForkContinuation()
-			if (request.functionName === 'getCarryLeafPageByOutcome') return [[], 0n]
-			if (request.functionName === 'getProofConsumedCarriedDepositIndexesByOutcome') return []
-			throw new Error(`Unexpected readContract function: ${request.functionName}`)
-		}),
-	} as unknown as Parameters<typeof buildForkCarriedEscalationProofs>[0]
 }
 
 function createMockLoaderClient({ getBlock, multicall, readContract }: { getBlock: () => Promise<{ timestamp: bigint }>; multicall: MockLoaderMulticallHandler; readContract: MockReadContractHandler }): MockLoaderClient {
@@ -966,6 +934,59 @@ describe('contracts helpers', () => {
 		expect(details.parentWithdrawalEnabled).toBe(false)
 	})
 
+	test('loadReportingDetails skips forkContinuation when escalation game code is missing', async () => {
+		const questionTuple = ['Question', 'Description', 1n, 2n, 2n, 0n, 100n, ''] as const
+		let forkContinuationRead = false
+		const client = {
+			getBlock: async () => createBlockWithTimestamp(88n),
+			getCode: async () => '0x' as Hex,
+			multicall: createMulticallStub(async request => {
+				const firstContract = request.contracts[0]
+				const functionName = getContractFunctionName(firstContract)
+				if (functionName === 'questionId') return [1n, escalationGameAddress, 20n, 3n, zoltarAddress, 5n, 0n, 3n, zeroAddress]
+				if (functionName === 'questions') return [questionTuple, 10n]
+				throw new Error(`Unexpected multicall contract: ${functionName}`)
+			}),
+			readContract: createReadContractStub(async request => {
+				if (request.functionName === 'getForkThreshold') return 100n
+				if (request.functionName === 'getOutcomeLabels') return ['Yes', 'No']
+				if (request.functionName === 'forkContinuation') {
+					forkContinuationRead = true
+					throw new Error(missingForkContinuationGetterMessage)
+				}
+				throw new Error(`Unexpected readContract function: ${request.functionName}`)
+			}),
+		} as unknown as Parameters<typeof loadReportingDetails>[0]
+
+		const details = await loadReportingDetails(client, securityPoolAddress, undefined)
+
+		expect(details.status).toBe('not-started')
+		expect(forkContinuationRead).toBe(false)
+	})
+
+	test('loadReportingDetails requires the forkContinuation getter for deployed escalation games', async () => {
+		const questionTuple = ['Question', 'Description', 1n, 2n, 2n, 0n, 100n, ''] as const
+		const client = {
+			getBlock: async () => createBlockWithTimestamp(88n),
+			getCode: async () => '0x1234' as Hex,
+			multicall: createMulticallStub(async request => {
+				const firstContract = request.contracts[0]
+				const functionName = getContractFunctionName(firstContract)
+				if (functionName === 'questionId') return [1n, escalationGameAddress, 20n, 3n, zoltarAddress, 5n, 0n, 3n, zeroAddress]
+				if (functionName === 'questions') return [questionTuple, 10n]
+				throw new Error(`Unexpected multicall contract: ${functionName}`)
+			}),
+			readContract: createReadContractStub(async request => {
+				if (request.functionName === 'getForkThreshold') return 100n
+				if (request.functionName === 'getOutcomeLabels') return ['Yes', 'No']
+				if (request.functionName === 'forkContinuation') throw new Error(missingForkContinuationGetterMessage)
+				throw new Error(`Unexpected readContract function: ${request.functionName}`)
+			}),
+		} as unknown as Parameters<typeof loadReportingDetails>[0]
+
+		await expect(loadReportingDetails(client, securityPoolAddress, undefined)).rejects.toThrow(missingForkContinuationGetterMessage)
+	})
+
 	test('loadReportingDetails keeps a known child outcome locked until the pool becomes operational', async () => {
 		const questionTuple = ['Question', 'Description', 1n, 2n, 2n, 0n, 100n, ''] as const
 		const client = {
@@ -1072,20 +1093,32 @@ describe('contracts helpers', () => {
 		await expect(buildForkCarriedEscalationProofs(client, securityPoolAddress, 'yes', [1n])).rejects.toThrow('Unexpected carry leaf page response')
 	})
 
-	test('buildForkCarriedEscalationProofs treats a missing recursive forkContinuation getter as backward-compatible', async () => {
-		const client = createForkCarriedProofReadClient(async () => {
-			throw new Error('The contract function "forkContinuation" returned no data ("0x"). The contract does not have the function "forkContinuation".')
-		})
+	test('buildForkCarriedEscalationProofs requires the forkContinuation getter', async () => {
+		const parentEscalationGameAddress = getAddress('0x00000000000000000000000000000000000000f1')
+		const zeroHash = '0x0000000000000000000000000000000000000000000000000000000000000000' satisfies Hex
+		const client = {
+			multicall: createMulticallStub(async request => {
+				const firstContract = request.contracts[0]
+				const functionName = getContractFunctionName(firstContract)
+				if (functionName === 'parent') return [alternateSecurityPoolAddress, escalationGameAddress]
+				throw new Error(`Unexpected multicall contract: ${functionName}`)
+			}),
+			readContract: createReadContractStub(async request => {
+				if (request.functionName === 'escalationGame') return parentEscalationGameAddress
+				if (request.functionName === 'getOutcomeState')
+					return {
+						currentCarryRoot: zeroHash,
+						currentLeafCount: 0n,
+						currentNullifierRoot: zeroHash,
+					}
+				if (request.functionName === 'forkContinuation') throw new Error(missingForkContinuationGetterMessage)
+				if (request.functionName === 'getCarryLeafPageByOutcome') return [[], 0n]
+				if (request.functionName === 'getProofConsumedCarriedDepositIndexesByOutcome') return []
+				throw new Error(`Unexpected readContract function: ${request.functionName}`)
+			}),
+		} as unknown as Parameters<typeof buildForkCarriedEscalationProofs>[0]
 
-		await expect(buildForkCarriedEscalationProofs(client, securityPoolAddress, 'yes', [])).resolves.toEqual([])
-	})
-
-	test('buildForkCarriedEscalationProofs rejects recursive forkContinuation RPC failures', async () => {
-		const client = createForkCarriedProofReadClient(async () => {
-			throw new Error('RPC request failed while reading forkContinuation')
-		})
-
-		await expect(buildForkCarriedEscalationProofs(client, securityPoolAddress, 'yes', [])).rejects.toThrow('RPC request failed while reading forkContinuation')
+		await expect(buildForkCarriedEscalationProofs(client, securityPoolAddress, 'yes', [])).rejects.toThrow(missingForkContinuationGetterMessage)
 	})
 
 	test('migrateVaultWithUnresolvedEscalation helper encodes the selected child outcome correctly', async () => {


### PR DESCRIPTION
## Summary
- Improve form and action accessibility by adding labeled field error text, stronger ARIA attributes, and clearer section/button copy across market, security pool, and open-oracle flows.
- Introduce shared modal focus isolation via a new `useModalFocusIsolation` hook and migrate operation/liquidation modals to it, including improved keyboard behavior and title wiring.
- Update escalation outcome selection to support arrow-key navigation in the radio-group pattern and better focus management.
- Refine security pool liquidation UX from direct vault liquidate actions to opening the selected pool workflow context first, and clarify navigation labels.
- Update trading display logic to use collateral-adjusted complete-set values and close operation modals when a matching trading result is emitted.
- Extend test coverage for these behavior changes, including modal, liquidation, trading, reporting, open-oracle, and trading-operation flows.

## Testing
- `bun run format` (not run)
- `bun run check` (not run)
- `bun run tsc` (not run)
- `bun run test:run -- --bail=1` (not run)
- `bun run ensure-contract-artifacts && bun run check:shared-dependencies && bun run test:run -- --bail=1` (not run)
- Focus and accessibility validations were implemented via unit/integration tests (updated in `ui/ts/tests/*`) but were not executed in this PR draft context.