### PR TITLE
Document FIFO handling for same-tick fills in dual-cap batch auction

### DIFF
--- a/docs/mainnet-deployment-addresses.json
+++ b/docs/mainnet-deployment-addresses.json
@@ -13,7 +13,7 @@
 		{
 			"id": "deploymentStatusOracle",
 			"label": "Deployment Status Oracle",
-			"address": "0x47ea2ba57835b4675E30caF91f790dA6657D8DD1"
+			"address": "0x3E2D809A09A627D199486325ff90d93c4073dAe9"
 		},
 		{
 			"id": "multicall3",
@@ -23,7 +23,7 @@
 		{
 			"id": "uniformPriceDualCapBatchAuctionFactory",
 			"label": "UniformPriceDualCapBatchAuctionFactory",
-			"address": "0x75D2FA67694b18b68DeE15583D65cbf32820Ab1F"
+			"address": "0x71761Fa073a1b5FA49154637Cf61b85172E8cA15"
 		},
 		{
 			"id": "scalarOutcomes",
@@ -53,34 +53,34 @@
 		{
 			"id": "shareTokenFactory",
 			"label": "ShareTokenFactory",
-			"address": "0x0F0beE207Fb2f7d0405fBE5835e95E4C5FEbB066"
+			"address": "0x8e38088707002EebdE043ab424d3b6e3986Fb444"
 		},
 		{
 			"id": "priceOracleManagerAndOperatorQueuerFactory",
 			"label": "Price Oracle Manager Factory",
-			"address": "0xcfe4FBf16d694F87923dDE7c6b2468fBF7AFa7A3"
+			"address": "0x9914b438a094c14722929a6a25D10Cfb242Da5ec"
 		},
 		{
 			"id": "securityPoolForker",
 			"label": "Security Pool Forker",
-			"address": "0xa791c448f4A194F461A17eC35f185d977909865B"
+			"address": "0xF86eedE62FEb3978a8698a1de820bBd953Dbd853"
 		},
 		{
 			"id": "escalationGameFactory",
 			"label": "Escalation Game Factory",
-			"address": "0x1f1F4Ea3996E42175f81AcD54776102a39aD2cbe"
+			"address": "0x6C9a748bFAefc9cFF26ba8ad05a83A9B40F15584"
 		},
 		{
 			"id": "securityPoolFactory",
 			"label": "Security Pool Factory",
-			"address": "0xB5A0cD79c840Ffd1131dE95066801971343E96D1"
+			"address": "0xb455AB4c407eefddfaa325beE4833741E9Cc7899"
 		}
 	],
 	"derivedContracts": [
 		{
 			"id": "escalationGameProofVerifier",
 			"label": "Escalation Game Proof Verifier",
-			"address": "0x2dB7Dc12866Cd17d968471d4d30E64EAEA32FC87"
+			"address": "0x060056235FbDE975613FD83cf2a3d89c1cCD187b"
 		}
 	]
 }

--- a/docs/mainnet-deployment-addresses.md
+++ b/docs/mainnet-deployment-addresses.md
@@ -15,19 +15,19 @@ These values are derived from the frozen mainnet protocol config, current contra
 | ID | Label | Expected Address |
 | --- | --- | --- |
 | proxyDeployer | Proxy Deployer | `0x7A0D94F55792C434d74a40883C6ed8545E406D12` |
-| deploymentStatusOracle | Deployment Status Oracle | `0x47ea2ba57835b4675E30caF91f790dA6657D8DD1` |
+| deploymentStatusOracle | Deployment Status Oracle | `0x3E2D809A09A627D199486325ff90d93c4073dAe9` |
 | multicall3 | Multicall3 | `0x77609e84c39893D5fB99049FE0F461aEB4F4Ec79` |
-| uniformPriceDualCapBatchAuctionFactory | UniformPriceDualCapBatchAuctionFactory | `0x75D2FA67694b18b68DeE15583D65cbf32820Ab1F` |
+| uniformPriceDualCapBatchAuctionFactory | UniformPriceDualCapBatchAuctionFactory | `0x71761Fa073a1b5FA49154637Cf61b85172E8cA15` |
 | scalarOutcomes | ScalarOutcomes | `0x375993210Bd295D329CaB7EeD4CEE17C73493af5` |
 | securityPoolUtils | SecurityPoolUtils | `0x04349f6A0302F32f8c87bb8555648AD77634343C` |
 | openOracle | OpenOracle | `0x51DED022c087758c187ce636aa5f6adE6B919abB` |
 | zoltarQuestionData | ZoltarQuestionData | `0x3fDE26F6C206DDc4991087FCeB5f13EC9f6F3E94` |
 | zoltar | Zoltar | `0x5FaE7E52e81250Fad0fCF05db42eCCCB3B0Bed95` |
-| shareTokenFactory | ShareTokenFactory | `0x0F0beE207Fb2f7d0405fBE5835e95E4C5FEbB066` |
-| priceOracleManagerAndOperatorQueuerFactory | Price Oracle Manager Factory | `0xcfe4FBf16d694F87923dDE7c6b2468fBF7AFa7A3` |
-| securityPoolForker | Security Pool Forker | `0xa791c448f4A194F461A17eC35f185d977909865B` |
-| escalationGameFactory | Escalation Game Factory | `0x1f1F4Ea3996E42175f81AcD54776102a39aD2cbe` |
-| securityPoolFactory | Security Pool Factory | `0xB5A0cD79c840Ffd1131dE95066801971343E96D1` |
+| shareTokenFactory | ShareTokenFactory | `0x8e38088707002EebdE043ab424d3b6e3986Fb444` |
+| priceOracleManagerAndOperatorQueuerFactory | Price Oracle Manager Factory | `0x9914b438a094c14722929a6a25D10Cfb242Da5ec` |
+| securityPoolForker | Security Pool Forker | `0xF86eedE62FEb3978a8698a1de820bBd953Dbd853` |
+| escalationGameFactory | Escalation Game Factory | `0x6C9a748bFAefc9cFF26ba8ad05a83A9B40F15584` |
+| securityPoolFactory | Security Pool Factory | `0xb455AB4c407eefddfaa325beE4833741E9Cc7899` |
 
 ## Derived Side-Effect Contracts
 
@@ -35,6 +35,6 @@ These contracts are deployed by one of the deterministic deployment steps and ar
 
 | ID | Label | Expected Address |
 | --- | --- | --- |
-| escalationGameProofVerifier | Escalation Game Proof Verifier | `0x2dB7Dc12866Cd17d968471d4d30E64EAEA32FC87` |
+| escalationGameProofVerifier | Escalation Game Proof Verifier | `0x060056235FbDE975613FD83cf2a3d89c1cCD187b` |
 
 Security pool deployments are deterministic per pool input rather than globally fixed. Their addresses are derived from the deployed factory set plus parent universe, universe ID, question ID, and security multiplier.

--- a/solidity/contracts/peripherals/UniformPriceDualCapBatchAuction.sol
+++ b/solidity/contracts/peripherals/UniformPriceDualCapBatchAuction.sol
@@ -116,6 +116,9 @@ contract UniformPriceDualCapBatchAuction {
 		require(msg.value >= minBidSize, 'Auction bid is smaller than the minimum bid size');
 		require(tick >= MIN_TICK && tick <= MAX_TICK, 'Auction tick is outside the supported price range');
 		require(tickToPrice(tick) > 0, 'Auction tick price rounds down to zero');
+		// Same-price rationing is intentionally time-priority, not pro-rata. Bids at
+		// one tick append in submission order, and any marginal clearing-tick fill
+		// consumes earlier same-tick ETH before later same-tick ETH.
 		root = _insert(root, tick, msg.sender, msg.value);
 		emit SubmitBid(msg.sender, tick, msg.value);
 	}
@@ -209,7 +212,7 @@ contract UniformPriceDualCapBatchAuction {
 					// Fully winning: convert all ETH to REP
 					totalFilledRep += _allocateRepAtClearingPrice(bid.ethAmount, clearingPriceLocal);
 				} else {
-					// Tick == clearingTick: partial fill
+					// Tick == clearingTick: partial fill using FIFO within this price level.
 					uint256 previousCumulativeEth =
 						bid.cumulativeEth - bid.ethAmount - _getRefundedCumulativeEthBeforeIndex(tick, index);
 					uint256 ethUsed;


### PR DESCRIPTION
## Summary
- Added inline contract documentation in `UniformPriceDualCapBatchAuction` to clarify same-tick auction matching semantics.
- Documented that same-price rationing uses submission-order priority (FIFO), not pro-rata allocation.
- Clarified bid processing at the clearing tick: marginal fills consume earlier same-tick bids before later ones.

## Testing
- Not run (documentation/comment-only change in Solidity source; no logic changes applied).