### PR TITLE
Harden OpenOracle validation, add FIFO auction semantics, and update mainnet deployment addresses

### DIFF
--- a/ui/ts/components/ForkAuctionSection.tsx
+++ b/ui/ts/components/ForkAuctionSection.tsx
@@ -28,11 +28,11 @@ import { sameAddress } from '../lib/address.js'
 import { createConnectedReadClient } from '../lib/clients.js'
 import { getErrorMessage } from '../lib/errors.js'
 import { AUCTION_TIME_SECONDS, getForkAuctionStageLabel, getForkAuctionStageView, getTimeRemaining } from '../lib/forkAuction.js'
-import { buildTruthAuctionDepthPoints, estimateRepPurchased, getTruthAuctionBidGuardMessage, getTruthAuctionOverviewProgress, getTruthAuctionTickAtPrice, getTruthAuctionWinningThresholdPrice } from '../lib/truthAuctionBook.js'
+import { buildTruthAuctionDepthPoints, estimateRepPurchased, getTruthAuctionBidGuardMessage, getTruthAuctionBidPreview, getTruthAuctionBidPriceValidationMessage, getTruthAuctionOverviewProgress, getTruthAuctionWinningThresholdPrice } from '../lib/truthAuctionBook.js'
 import { buildTruthAuctionBidRows, buildViewerTruthAuctionBidRows, updateTruthAuctionSettlementBidSelection } from '../lib/truthAuctionBidViewModels.js'
 import { getTruthAuctionSettlementActionAvailabilityMessage, getTruthAuctionSettlementBidRows } from '../lib/truthAuctionSettlement.js'
 import { formatCurrencyInputBalance, formatDuration, formatRoundedCurrencyBalance } from '../lib/formatters.js'
-import { tryParseTruthAuctionAmountInput, tryParseTruthAuctionPriceInput } from '../lib/marketForm.js'
+import { tryParseTruthAuctionAmountInput } from '../lib/marketForm.js'
 import { isMainnetChain } from '../lib/network.js'
 import { REPORTING_OUTCOME_DROPDOWN_OPTIONS, getReportingOutcomeLabel } from '../lib/reporting.js'
 import { buildRouteHref, SECURITY_POOLS_ROUTE } from '../lib/routing.js'
@@ -492,8 +492,9 @@ export function ForkAuctionSection({
 	})
 	const selectedStageAheadMessage = getForkWorkflowStageAheadMessage(selectedStage, currentWorkflowStage)
 	const selectedAuctionLabel = selectedOutcomeLabel
-	const enteredBidPrice = tryParseTruthAuctionPriceInput(forkAuctionForm.submitBidPrice)
-	const enteredBidTick = enteredBidPrice === undefined ? undefined : getTruthAuctionTickAtPrice(enteredBidPrice)
+	const enteredBidPreview = getTruthAuctionBidPreview(forkAuctionForm.submitBidPrice)
+	const enteredBidPrice = enteredBidPreview?.price
+	const enteredBidTick = enteredBidPreview?.tick
 	const estimatedRep = estimateBidRep(forkAuctionForm.submitBidAmount, enteredBidPrice)
 	const optimisticTruthAuctionStartedAt =
 		forkAuctionResult?.action === 'startTruthAuction' && auctionSecurityPoolAddress !== undefined && sameAddress(forkAuctionResult.securityPoolAddress, auctionSecurityPoolAddress) ? (effectiveCurrentTimestamp ?? forkAuctionDetails?.migrationEndsAt ?? selectedAuctionContext?.currentTime ?? 1n) : undefined
@@ -728,12 +729,7 @@ export function ForkAuctionSection({
 		parentCollateralAmount: forkAuctionDetails?.completeSetCollateralAmount ?? previewPool?.completeSetCollateralAmount,
 		auctionableRepAtFork: forkAuctionDetails?.auctionableRepAtFork,
 	})
-	const bidPriceValidationMessage = (() => {
-		if (forkAuctionForm.submitBidPrice.trim() === '') return 'Enter a bid price greater than zero.'
-		if (enteredBidPrice === undefined || enteredBidTick === undefined) return 'Enter a valid bid price.'
-		if (enteredBidPrice <= 0n) return 'Enter a bid price greater than zero.'
-		return undefined
-	})()
+	const bidPriceValidationMessage = getTruthAuctionBidPriceValidationMessage(forkAuctionForm.submitBidPrice)
 	const startTruthAuctionAvailabilityMessage = (() => {
 		if (hasStartedTruthAuction) return 'Truth auction already started.'
 		if (isStartTruthAuctionInProgress) return 'Starting truth auction...'

--- a/ui/ts/components/OpenOracleSection.tsx
+++ b/ui/ts/components/OpenOracleSection.tsx
@@ -30,6 +30,7 @@ import { createConnectedReadClient } from '../lib/clients.js'
 import { useChainBlockNumber, useChainTimestamp } from '../lib/chainTimestamp.js'
 import {
 	getOpenOracleCreateGuardMessage,
+	getOpenOracleCreateValidationMessage,
 	formatOpenOracleFeePercentage,
 	formatOpenOracleMultiplier,
 	getOpenOracleDisputeAvailability,
@@ -833,6 +834,8 @@ export function OpenOracleSection({
 		walletConnected: isConnected,
 		walletEthBalance: accountState.ethBalance,
 	})
+	const createValidationMessage = getOpenOracleCreateValidationMessage({ form: openOracleCreateForm })
+	const createAvailabilityMessage = createGuardMessage ?? createValidationMessage
 	const effectiveOpenOracleReportDetails = getEffectiveOpenOracleReportDetails(openOracleReportDetails, chainCurrentTimestamp, chainCurrentBlockNumber)
 	useEffect(() => {
 		let cancelled = false
@@ -1058,7 +1061,7 @@ export function OpenOracleSection({
 									pendingLabel='Creating...'
 									onClick={onCreateOpenOracleGame}
 									pending={loadingOpenOracleCreate}
-									availability={{ disabled: createGuardMessage !== undefined, reason: createGuardMessage }}
+									availability={{ disabled: createAvailabilityMessage !== undefined, reason: createAvailabilityMessage }}
 								/>
 							</div>
 						</div>

--- a/ui/ts/components/TabNavigation.tsx
+++ b/ui/ts/components/TabNavigation.tsx
@@ -1,28 +1,30 @@
 import { ViewTabs } from './ViewTabs.js'
+import { buildRouteHref, getRouteHashSearch } from '../lib/routing.js'
 import type { TabNavigationProps } from '../types/components.js'
 
 export function TabNavigation({ route, showDeployTab = true, augurPlaceHolderDeployed, deployRoute, marketRoute, openOracleRoute, securityPoolsRoute, onRouteChange }: TabNavigationProps) {
 	const disabledTabReason = 'Deploy the application contracts before using this section.'
 	const options: Array<{ disabled?: boolean; href: string; label: string; reason?: string; value: Exclude<TabNavigationProps['route'], 'not-found'> }> = []
-	if (showDeployTab) options.push({ value: 'deploy', label: 'Deploy', href: deployRoute })
+	const currentRouteSearch = getRouteHashSearch()
+	if (showDeployTab) options.push({ value: 'deploy', label: 'Deploy', href: buildRouteHref(deployRoute, currentRouteSearch) })
 	options.push({
 		value: 'zoltar',
 		label: 'Markets',
-		href: marketRoute,
+		href: buildRouteHref(marketRoute, currentRouteSearch),
 		disabled: !augurPlaceHolderDeployed,
 		...(!augurPlaceHolderDeployed ? { reason: disabledTabReason } : {}),
 	})
 	options.push({
 		value: 'security-pools',
 		label: 'Security Pools',
-		href: securityPoolsRoute,
+		href: buildRouteHref(securityPoolsRoute, currentRouteSearch),
 		disabled: !augurPlaceHolderDeployed,
 		...(!augurPlaceHolderDeployed ? { reason: disabledTabReason } : {}),
 	})
 	options.push({
 		value: 'open-oracle',
 		label: 'Oracle Reports',
-		href: openOracleRoute,
+		href: buildRouteHref(openOracleRoute, currentRouteSearch),
 		disabled: !augurPlaceHolderDeployed,
 		...(!augurPlaceHolderDeployed ? { reason: disabledTabReason } : {}),
 	})

--- a/ui/ts/contracts.ts
+++ b/ui/ts/contracts.ts
@@ -6,7 +6,7 @@ import { sameAddress } from './lib/address.js'
 import { isIgnorableLogDecodeError } from './lib/errors.js'
 import { deriveHasForkActivity } from './lib/forkAuction.js'
 import { getOracleManagerPriceValidUntilTimestamp } from './lib/securityVault.js'
-import { addOpenOracleBountyBuffer } from './lib/openOracle.js'
+import { addOpenOracleBountyBuffer, getOpenOracleCreateParameterValidationMessage } from './lib/openOracle.js'
 import { getWethAddress } from './lib/uniswapQuoter.js'
 import {
 	Zoltar_Zoltar,
@@ -818,6 +818,20 @@ export async function createOpenOracleReportInstance(
 	assertSafeInteger(parameters.multiplier, 'Multiplier')
 	assertSafeInteger(parameters.protocolFee, 'Protocol fee')
 	assertSafeInteger(parameters.settlementTime, 'Settlement time')
+	const validationMessage = getOpenOracleCreateParameterValidationMessage({
+		disputeDelay: BigInt(parameters.disputeDelay),
+		escalationHalt: parameters.escalationHalt,
+		exactToken1Report: parameters.exactToken1Report,
+		ethValue: parameters.ethValue,
+		feePercentage: BigInt(parameters.feePercentage),
+		multiplier: BigInt(parameters.multiplier),
+		protocolFee: BigInt(parameters.protocolFee),
+		settlementTime: BigInt(parameters.settlementTime),
+		settlerReward: parameters.settlerReward,
+		token1Address: parameters.token1Address,
+		token2Address: parameters.token2Address,
+	})
+	if (validationMessage !== undefined) throw new Error(validationMessage)
 	const callParams = {
 		address: getOpenOracleAddress(),
 		abi: peripherals_openOracle_OpenOracle_OpenOracle.abi,

--- a/ui/ts/hooks/useForkAuctionOperations.ts
+++ b/ui/ts/hooks/useForkAuctionOperations.ts
@@ -22,7 +22,7 @@ import {
 } from '../contracts.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../lib/clients.js'
 import { getErrorMessage } from '../lib/errors.js'
-import { getTruthAuctionBidGuardMessage, getTruthAuctionTickAtPrice } from '../lib/truthAuctionBook.js'
+import { getTruthAuctionBidGuardMessage, getTruthAuctionBidPriceValidationMessage, getTruthAuctionTickAtPrice } from '../lib/truthAuctionBook.js'
 import { getReportingOutcomeKey, parseAddressInput, parseBigIntListInput, parseReportingOutcomeInput, parseReportingOutcomeListInput, resolveOptionalAddressInput } from '../lib/inputs.js'
 import { sameAddress } from '../lib/address.js'
 import { createErrorActionFeedback, createPendingActionFeedback, createSuccessActionFeedback, createWarningActionFeedback } from '../lib/actionFeedback.js'
@@ -186,10 +186,12 @@ export function useForkAuctionOperations({ accountAddress, onTransactionFailed, 
 					walletEthBalance,
 				})
 				if (bidGuardMessage !== undefined) throw new Error(bidGuardMessage)
+				const bidPriceValidationMessage = getTruthAuctionBidPriceValidationMessage(forkAuctionForm.value.submitBidPrice)
+				if (bidPriceValidationMessage !== undefined) throw new Error(bidPriceValidationMessage)
 				const truthAuctionAddress = requireDefined(details.truthAuctionAddress, 'Truth auction not available')
 				const bidPrice = parseTruthAuctionPriceInput(forkAuctionForm.value.submitBidPrice, 'Bid price')
 				const bidTick = getTruthAuctionTickAtPrice(bidPrice)
-				if (bidTick === undefined) throw new Error('Enter a valid bid price.')
+				if (bidTick === undefined) throw new Error('Bid price is outside the supported auction range.')
 				return await submitTruthAuctionBid(createWalletWriteClient(walletAddress, { onTransactionPrepared, onTransactionSubmitted }), details.securityPoolAddress, details.universeId, truthAuctionAddress, bidTick, parseTruthAuctionAmountInput(forkAuctionForm.value.submitBidAmount, 'Bid amount'))
 			},
 			'Failed to submit truth auction bid',

--- a/ui/ts/hooks/useHashRoute.ts
+++ b/ui/ts/hooks/useHashRoute.ts
@@ -1,13 +1,13 @@
 import { useSignal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
-import { ensureRouteHash, getCurrentRoute, getRouteHash } from '../lib/routing.js'
+import { buildRouteHref, ensureRouteHash, getCurrentRoute, getRouteHash, getRouteHashSearch } from '../lib/routing.js'
 import type { Route } from '../types/app.js'
 
 export function useHashRoute() {
 	const route = useSignal<Route>(getCurrentRoute())
 
 	const navigate = (nextRoute: Exclude<Route, 'not-found'>) => {
-		window.location.hash = getRouteHash(nextRoute)
+		window.location.hash = buildRouteHref(getRouteHash(nextRoute), getRouteHashSearch())
 	}
 
 	useEffect(() => {

--- a/ui/ts/hooks/useOpenOracleOperations.ts
+++ b/ui/ts/hooks/useOpenOracleOperations.ts
@@ -16,6 +16,7 @@ import {
 	formatOpenOraclePriceInput,
 	formatOpenOracleSettleWriteErrorMessage,
 	getOpenOracleCreateGuardMessage,
+	getOpenOracleCreateValidationMessage,
 	getOpenOracleDisputeAvailability,
 	getOpenOracleSelectedReportActionMode,
 	getOpenOracleSettleAvailability,
@@ -659,6 +660,8 @@ export function useOpenOracleOperations({ accountAddress, enabled, onTransaction
 						walletEthBalance,
 					})
 					if (createGuardMessage !== undefined) throw new Error(createGuardMessage)
+					const createValidationMessage = getOpenOracleCreateValidationMessage({ form: openOracleCreateForm.value })
+					if (createValidationMessage !== undefined) throw new Error(createValidationMessage)
 					const token1Address = parseAddressInput(openOracleCreateForm.value.token1Address, 'Token1 address')
 					const token1Decimals = requireTokenDecimals(
 						await readClient.readContract({
@@ -669,6 +672,8 @@ export function useOpenOracleOperations({ accountAddress, enabled, onTransaction
 						}),
 						'token1',
 					)
+					const preciseCreateValidationMessage = getOpenOracleCreateValidationMessage({ form: openOracleCreateForm.value, token1Decimals })
+					if (preciseCreateValidationMessage !== undefined) throw new Error(preciseCreateValidationMessage)
 
 					return await createOpenOracleReportInstance(createWalletWriteClient(walletAddress, { onTransactionPrepared, onTransactionSubmitted }), parseOpenOracleCreateFormSubmission({ form: openOracleCreateForm.value, token1Decimals }))
 				},

--- a/ui/ts/lib/chainBackend.ts
+++ b/ui/ts/lib/chainBackend.ts
@@ -190,13 +190,7 @@ export function createInjectedBackend({ rpcUrl }: { rpcUrl?: string } = {}): Cha
 		requestAccounts: async () => {
 			const ethereum = getProvider()
 			if (ethereum === undefined) return []
-			let result: unknown
-			try {
-				result = await ethereum.request({ method: 'eth_requestAccounts' })
-			} catch (error) {
-				if (!isProviderRequestError(error)) throw error
-				return []
-			}
+			const result = await ethereum.request({ method: 'eth_requestAccounts' })
 			if (!Array.isArray(result)) return []
 			return result.map(normalizeAccount).filter((address): address is Address => address !== undefined)
 		},

--- a/ui/ts/lib/openOracle.ts
+++ b/ui/ts/lib/openOracle.ts
@@ -1,11 +1,12 @@
 import { zeroAddress, type Address } from 'viem'
 import type { OpenOracleCreateFormState } from '../types/app.js'
 import type { OpenOracleReportDetails, OpenOracleReportSummary } from '../types/contracts.js'
+import { sameAddress } from './address.js'
 import { assertNever } from './assert.js'
 import { parseDecimalInput, tryParseDecimalInput } from './decimal.js'
 import { formatWriteErrorMessage, getErrorDetail, sanitizeErrorDetail } from './errors.js'
 import { formatCurrencyBalance, formatCurrencyInputBalance, formatDuration } from './formatters.js'
-import { parseAddressInput } from './inputs.js'
+import { parseAddressInput, tryParseAddressInput } from './inputs.js'
 import { parseBigIntInput, tryParseBigIntInput } from './marketForm.js'
 import { deriveTokenApprovalRequirement, formatTokenApprovalUnavailableMessage, type TokenApprovalRequirement } from './tokenApproval.js'
 import { getWethAddress, isRepPricingEnabled, quoteBestExactInputWithSource, quoteBestV3ExactInputWithSource, quoteExactInput } from './uniswapQuoter.js'
@@ -14,6 +15,25 @@ const OPEN_ORACLE_BOUNTY_BUFFER_NUMERATOR = 12n
 const OPEN_ORACLE_BOUNTY_BUFFER_DENOMINATOR = 10n
 const OPEN_ORACLE_PERCENTAGE_PRECISION = 10n ** 7n
 const OPEN_ORACLE_MULTIPLIER_PRECISION = 100n
+const OPEN_ORACLE_UINT16_MAX = (1n << 16n) - 1n
+const OPEN_ORACLE_UINT24_MAX = (1n << 24n) - 1n
+const OPEN_ORACLE_UINT48_MAX = (1n << 48n) - 1n
+const OPEN_ORACLE_UINT96_MAX = (1n << 96n) - 1n
+const OPEN_ORACLE_UINT128_MAX = (1n << 128n) - 1n
+const OPEN_ORACLE_DECIMAL_INPUT_PATTERN = /^-?(?:\d+\.?\d*|\.\d+)$/
+type OpenOracleCreateValidationParameters = {
+	disputeDelay: bigint
+	escalationHalt: bigint
+	exactToken1Report: bigint
+	ethValue: bigint
+	feePercentage: bigint
+	multiplier: bigint
+	protocolFee: bigint
+	settlementTime: bigint
+	settlerReward: bigint
+	token1Address: Address
+	token2Address: Address
+}
 type OpenOracleReportStatus = 'Awaiting Initial Report' | 'Pending' | 'Disputed' | 'Settled'
 export type OpenOracleSelectedReportActionMode = 'initial-report' | 'dispute' | 'settle' | 'read-only'
 export type OpenOracleInitialReportPriceSource = 'Uniswap V4' | 'Uniswap V3' | 'MOCK' | 'Manual override' | 'Unavailable'
@@ -145,6 +165,132 @@ export function getOpenOracleCreateGuardMessage({ ethValueInput, isMainnet, sett
 	if (walletEthBalance === undefined) return 'Loading wallet ETH balance.'
 	if (ethValue > walletEthBalance) return `Need ${formatCurrencyBalance(ethValue - walletEthBalance)} more ETH in this wallet to create the selected standalone Open Oracle game.`
 	return undefined
+}
+
+export function getOpenOracleCreateParameterValidationMessage(
+	{ disputeDelay, escalationHalt, exactToken1Report, ethValue, feePercentage, multiplier, protocolFee, settlementTime, settlerReward, token1Address, token2Address }: OpenOracleCreateValidationParameters,
+	{ skipToken1MagnitudeValidation = false }: { skipToken1MagnitudeValidation?: boolean } = {},
+) {
+	if (sameAddress(token1Address, token2Address)) return 'Token1 and token2 must be different addresses.'
+	if (exactToken1Report <= 0n) return 'Exact token1 report must be greater than zero.'
+	if (!skipToken1MagnitudeValidation && exactToken1Report > OPEN_ORACLE_UINT128_MAX) return 'Exact token1 report exceeds the contract maximum.'
+	if (escalationHalt < 0n) return 'Escalation halt must be non-negative.'
+	if (!skipToken1MagnitudeValidation && escalationHalt > OPEN_ORACLE_UINT128_MAX) return 'Escalation halt exceeds the contract maximum.'
+	if (ethValue < 0n) return 'ETH value to send must be non-negative.'
+	if (ethValue > OPEN_ORACLE_UINT96_MAX) return 'ETH value to send exceeds the contract maximum.'
+	if (settlerReward < 0n) return 'Settler reward must be non-negative.'
+	if (settlerReward > OPEN_ORACLE_UINT96_MAX) return 'Settler reward exceeds the contract maximum.'
+	if (ethValue < settlerReward) return 'ETH value to send must be at least the settler reward.'
+	if (settlementTime < 0n) return 'Enter a valid settlement time.'
+	if (settlementTime > OPEN_ORACLE_UINT48_MAX) return 'Settlement time exceeds the contract maximum.'
+	if (disputeDelay < 0n) return 'Enter a valid dispute delay.'
+	if (disputeDelay > OPEN_ORACLE_UINT24_MAX) return 'Dispute delay exceeds the contract maximum.'
+	if (settlementTime < disputeDelay) return 'Settlement time must be greater than or equal to dispute delay.'
+	if (multiplier < OPEN_ORACLE_MULTIPLIER_PRECISION) return 'Multiplier must be at least 1.00x.'
+	if (multiplier > OPEN_ORACLE_UINT16_MAX) return 'Multiplier exceeds the contract maximum.'
+	if (feePercentage < 0n) return 'Fee percentage must be non-negative.'
+	if (feePercentage > OPEN_ORACLE_UINT24_MAX) return 'Fee percentage exceeds the contract maximum.'
+	if (protocolFee < 0n) return 'Protocol fee must be non-negative.'
+	if (protocolFee > OPEN_ORACLE_UINT24_MAX) return 'Protocol fee exceeds the contract maximum.'
+	if (feePercentage + protocolFee > OPEN_ORACLE_PERCENTAGE_PRECISION) return 'Fee percentage plus protocol fee must not exceed 100%.'
+	return undefined
+}
+
+function normalizeOpenOracleUnknownScaleDecimalInput(value: string) {
+	const trimmed = value.trim()
+	if (trimmed === '') return trimmed
+	if (trimmed.startsWith('.')) return `0${trimmed}`
+	if (trimmed.endsWith('.')) return `${trimmed}0`
+	return trimmed
+}
+
+function isZeroOpenOracleDecimalInput(value: string) {
+	return value
+		.replace('-', '')
+		.replace('.', '')
+		.split('')
+		.every(digit => digit === '0')
+}
+
+function getOpenOracleUnknownScaleDecimalValidationMessage({ allowZero = true, input, invalidMessage, negativeMessage, zeroMessage }: { allowZero?: boolean; input: string; invalidMessage: string; negativeMessage: string; zeroMessage?: string }) {
+	const normalized = normalizeOpenOracleUnknownScaleDecimalInput(input)
+	if (normalized === '' || !OPEN_ORACLE_DECIMAL_INPUT_PATTERN.test(normalized)) return invalidMessage
+	if (normalized.startsWith('-')) return negativeMessage
+	if (!allowZero && isZeroOpenOracleDecimalInput(normalized)) return zeroMessage ?? negativeMessage
+	return undefined
+}
+
+export function getOpenOracleCreateValidationMessage({ form, token1Decimals }: { form: OpenOracleCreateFormState; token1Decimals?: number }) {
+	const token1Address = tryParseAddressInput(form.token1Address)
+	if (token1Address === undefined) return 'Enter a valid token1 address.'
+	const token2Address = tryParseAddressInput(form.token2Address)
+	if (token2Address === undefined) return 'Enter a valid token2 address.'
+	const exactToken1Report =
+		token1Decimals === undefined
+			? (() => {
+					const validationMessage = getOpenOracleUnknownScaleDecimalValidationMessage({
+						allowZero: false,
+						input: form.exactToken1Report,
+						invalidMessage: 'Enter a valid exact token1 report.',
+						negativeMessage: 'Exact token1 report must be greater than zero.',
+						zeroMessage: 'Exact token1 report must be greater than zero.',
+					})
+					if (validationMessage !== undefined) return validationMessage
+					return 1n
+				})()
+			: tryParseDecimalInput(form.exactToken1Report, token1Decimals)
+	if (typeof exactToken1Report === 'string') return exactToken1Report
+	if (exactToken1Report === undefined) return 'Enter a valid exact token1 report.'
+
+	const escalationHalt =
+		token1Decimals === undefined
+			? (() => {
+					const validationMessage = getOpenOracleUnknownScaleDecimalValidationMessage({
+						input: form.escalationHalt,
+						invalidMessage: 'Enter a valid escalation halt.',
+						negativeMessage: 'Escalation halt must be non-negative.',
+					})
+					if (validationMessage !== undefined) return validationMessage
+					return 0n
+				})()
+			: tryParseDecimalInput(form.escalationHalt, token1Decimals)
+	if (typeof escalationHalt === 'string') return escalationHalt
+	if (escalationHalt === undefined) return 'Enter a valid escalation halt.'
+
+	const ethValue = tryParseDecimalInput(form.ethValue)
+	if (ethValue === undefined) return 'Enter a valid ETH value to send.'
+	const settlerReward = tryParseDecimalInput(form.settlerReward)
+	if (settlerReward === undefined) return 'Enter a valid settler reward.'
+
+	const settlementTime = tryParseBigIntInput(form.settlementTime)
+	if (settlementTime === undefined) return 'Enter a valid settlement time.'
+	const disputeDelay = tryParseBigIntInput(form.disputeDelay)
+	if (disputeDelay === undefined) return 'Enter a valid dispute delay.'
+
+	const multiplier = tryParseBigIntInput(form.multiplier)
+	if (multiplier === undefined || multiplier < 0n) return 'Enter a valid multiplier.'
+
+	const feePercentage = tryParseDecimalInput(form.feePercentage, 5)
+	if (feePercentage === undefined) return 'Enter a valid fee percentage.'
+	const protocolFee = tryParseDecimalInput(form.protocolFee, 5)
+	if (protocolFee === undefined) return 'Enter a valid protocol fee.'
+
+	return getOpenOracleCreateParameterValidationMessage(
+		{
+			disputeDelay,
+			escalationHalt,
+			exactToken1Report,
+			ethValue,
+			feePercentage,
+			multiplier,
+			protocolFee,
+			settlementTime,
+			settlerReward,
+			token1Address,
+			token2Address,
+		},
+		{ skipToken1MagnitudeValidation: token1Decimals === undefined },
+	)
 }
 function createHiddenLoadingGateMessage(message: string): OpenOracleGateMessage {
 	return { kind: 'hidden-loading', message }
@@ -301,6 +447,8 @@ export function parseOpenOracleFeePercentageInput(value: string, label: string) 
 	return Number(parsed)
 }
 export function parseOpenOracleCreateFormSubmission({ form, token1Decimals }: { form: OpenOracleCreateFormState; token1Decimals: number }) {
+	const validationMessage = getOpenOracleCreateValidationMessage({ form, token1Decimals })
+	if (validationMessage !== undefined) throw new Error(validationMessage)
 	return {
 		disputeDelay: Number(parseBigIntInput(form.disputeDelay, 'Dispute delay')),
 		escalationHalt: parseDecimalInput(form.escalationHalt, 'Escalation halt', token1Decimals),

--- a/ui/ts/lib/truthAuctionBook.ts
+++ b/ui/ts/lib/truthAuctionBook.ts
@@ -1,8 +1,10 @@
 import type { TruthAuctionBidView, TruthAuctionMetrics, TruthAuctionTickSummary } from '../types/contracts.js'
 import { formatCurrencyBalance } from './formatters.js'
-import { tryParseTruthAuctionAmountInput } from './marketForm.js'
+import { tryParseTruthAuctionAmountInput, tryParseTruthAuctionPriceInput } from './marketForm.js'
 
 export const TRUTH_AUCTION_PRICE_PRECISION = 10n ** 18n
+export const TRUTH_AUCTION_MIN_TICK = -524288n
+export const TRUTH_AUCTION_MAX_TICK = 524288n
 
 const TRUTH_AUCTION_TICK_PRICE_POWERS = [
 	1000100000000000000n,
@@ -302,7 +304,18 @@ export function sortTruthAuctionBidsByPriority(bids: TruthAuctionBidView[]) {
 	})
 }
 
-export function getTruthAuctionPriceAtTick(tick: bigint) {
+function assertTruthAuctionTickInContractDomain(tick: bigint) {
+	if (tick < TRUTH_AUCTION_MIN_TICK || tick > TRUTH_AUCTION_MAX_TICK) throw new Error('Truth auction tick is outside the supported range.')
+}
+
+function normalizeTruthAuctionPriceInput(value: string) {
+	if (value.startsWith('.')) return `0${value}`
+	if (value.endsWith('.')) return `${value}0`
+	return value
+}
+
+function computeTruthAuctionPriceAtTick(tick: bigint) {
+	assertTruthAuctionTickInContractDomain(tick)
 	const absoluteTick = tick < 0n ? -tick : tick
 	let price = TRUTH_AUCTION_PRICE_PRECISION
 	for (let bitIndex = 0; bitIndex < TRUTH_AUCTION_TICK_PRICE_POWERS.length; bitIndex += 1) {
@@ -314,20 +327,69 @@ export function getTruthAuctionPriceAtTick(tick: bigint) {
 	return tick < 0n ? (TRUTH_AUCTION_PRICE_PRECISION * TRUTH_AUCTION_PRICE_PRECISION) / price : price
 }
 
+function findTruthAuctionMinSupportedTick() {
+	let lowerTick = TRUTH_AUCTION_MIN_TICK
+	let upperTick = 0n
+	while (upperTick - lowerTick > 1n) {
+		const midTick = (lowerTick + upperTick) / 2n
+		if (computeTruthAuctionPriceAtTick(midTick) > 0n) {
+			upperTick = midTick
+			continue
+		}
+		lowerTick = midTick
+	}
+	return computeTruthAuctionPriceAtTick(lowerTick) > 0n ? lowerTick : upperTick
+}
+
+export const TRUTH_AUCTION_MIN_SUPPORTED_TICK = findTruthAuctionMinSupportedTick()
+
+function assertTruthAuctionTickInRange(tick: bigint) {
+	if (tick < TRUTH_AUCTION_MIN_SUPPORTED_TICK || tick > TRUTH_AUCTION_MAX_TICK) throw new Error('Truth auction tick is outside the supported range.')
+}
+
+export function getTruthAuctionPriceAtTick(tick: bigint) {
+	assertTruthAuctionTickInRange(tick)
+	return computeTruthAuctionPriceAtTick(tick)
+}
+
+const TRUTH_AUCTION_MAX_PRICE = getTruthAuctionPriceAtTick(TRUTH_AUCTION_MAX_TICK)
+const TRUTH_AUCTION_MIN_PRICE = getTruthAuctionPriceAtTick(TRUTH_AUCTION_MIN_SUPPORTED_TICK)
+
+function formatTruthAuctionValidationPrice(price: bigint) {
+	const wholePart = (price / TRUTH_AUCTION_PRICE_PRECISION).toString()
+	const fractionalDigits = (price % TRUTH_AUCTION_PRICE_PRECISION).toString().padStart(18, '0').replace(/0+$/, '')
+	return fractionalDigits === '' ? wholePart : `${wholePart}.${fractionalDigits}`
+}
+
+const TRUTH_AUCTION_MAX_PRICE_INPUT = formatTruthAuctionValidationPrice(TRUTH_AUCTION_MAX_PRICE)
+const truthAuctionMaxPriceParts = TRUTH_AUCTION_MAX_PRICE_INPUT.split('.')
+const TRUTH_AUCTION_MAX_PRICE_WHOLE = truthAuctionMaxPriceParts[0] ?? '0'
+const rawTruthAuctionMaxPriceFraction = truthAuctionMaxPriceParts[1] ?? ''
+const TRUTH_AUCTION_MAX_PRICE_FRACTION = rawTruthAuctionMaxPriceFraction.padEnd(18, '0')
+
+function isTruthAuctionPriceInputDefinitelyOutOfRange(input: string) {
+	const normalized = normalizeTruthAuctionPriceInput(input.trim())
+	if (normalized === '' || normalized.startsWith('-')) return false
+	const match = normalized.match(/^(\d+)(?:\.(\d+))?$/)
+	if (match === null) return false
+	const wholePart = match[1]?.replace(/^0+/, '') || '0'
+	const fractionalPart = match[2] ?? ''
+	if (fractionalPart.length > 18) return false
+	if (wholePart.length !== TRUTH_AUCTION_MAX_PRICE_WHOLE.length) return wholePart.length > TRUTH_AUCTION_MAX_PRICE_WHOLE.length
+	if (wholePart !== TRUTH_AUCTION_MAX_PRICE_WHOLE) return wholePart > TRUTH_AUCTION_MAX_PRICE_WHOLE
+	return fractionalPart.padEnd(18, '0') > TRUTH_AUCTION_MAX_PRICE_FRACTION
+}
+
 export function getTruthAuctionTickAtPrice(price: bigint): bigint | undefined {
 	if (price <= 0n) return undefined
+	if (price < TRUTH_AUCTION_MIN_PRICE) return undefined
 	if (price === TRUTH_AUCTION_PRICE_PRECISION) return 0n
-
-	let lowerTick = 0n
-	let upperTick = 1n
-	let upperPrice = getTruthAuctionPriceAtTick(upperTick)
+	if (price > TRUTH_AUCTION_MAX_PRICE) return undefined
+	if (price === TRUTH_AUCTION_MAX_PRICE) return TRUTH_AUCTION_MAX_TICK
 
 	if (price >= TRUTH_AUCTION_PRICE_PRECISION) {
-		while (upperPrice <= price) {
-			lowerTick = upperTick
-			upperTick *= 2n
-			upperPrice = getTruthAuctionPriceAtTick(upperTick)
-		}
+		let lowerTick = 0n
+		let upperTick = TRUTH_AUCTION_MAX_TICK
 		while (upperTick - lowerTick > 1n) {
 			const midTick = (lowerTick + upperTick) / 2n
 			const midPrice = getTruthAuctionPriceAtTick(midTick)
@@ -340,14 +402,8 @@ export function getTruthAuctionTickAtPrice(price: bigint): bigint | undefined {
 		return lowerTick
 	}
 
-	lowerTick = -1n
-	upperTick = 0n
-	let lowerPrice = getTruthAuctionPriceAtTick(lowerTick)
-	while (lowerPrice > price) {
-		upperTick = lowerTick
-		lowerTick *= 2n
-		lowerPrice = getTruthAuctionPriceAtTick(lowerTick)
-	}
+	let lowerTick = TRUTH_AUCTION_MIN_SUPPORTED_TICK
+	let upperTick = 0n
 	while (upperTick - lowerTick > 1n) {
 		const midTick = (lowerTick + upperTick) / 2n
 		const midPrice = getTruthAuctionPriceAtTick(midTick)
@@ -358,6 +414,29 @@ export function getTruthAuctionTickAtPrice(price: bigint): bigint | undefined {
 		upperTick = midTick
 	}
 	return lowerTick
+}
+
+export function getTruthAuctionBidPreview(submitBidPriceInput: string) {
+	if (submitBidPriceInput.trim() === '') return undefined
+	if (isTruthAuctionPriceInputDefinitelyOutOfRange(submitBidPriceInput)) return undefined
+	const enteredBidPrice = tryParseTruthAuctionPriceInput(submitBidPriceInput)
+	if (enteredBidPrice === undefined || enteredBidPrice <= 0n) return undefined
+	const enteredBidTick = getTruthAuctionTickAtPrice(enteredBidPrice)
+	if (enteredBidTick === undefined) return undefined
+	return {
+		price: enteredBidPrice,
+		tick: enteredBidTick,
+	}
+}
+
+export function getTruthAuctionBidPriceValidationMessage(submitBidPriceInput: string) {
+	if (submitBidPriceInput.trim() === '') return 'Enter a bid price greater than zero.'
+	if (isTruthAuctionPriceInputDefinitelyOutOfRange(submitBidPriceInput)) return 'Bid price is outside the supported auction range.'
+	const enteredBidPrice = tryParseTruthAuctionPriceInput(submitBidPriceInput)
+	if (enteredBidPrice === undefined) return 'Enter a valid bid price.'
+	if (enteredBidPrice <= 0n) return 'Enter a bid price greater than zero.'
+	if (getTruthAuctionTickAtPrice(enteredBidPrice) === undefined) return 'Bid price is outside the supported auction range.'
+	return undefined
 }
 
 export function getTruthAuctionBidGuardMessage({

--- a/ui/ts/tests/chainBackend.test.ts
+++ b/ui/ts/tests/chainBackend.test.ts
@@ -283,9 +283,20 @@ describe('injected backend read transport', () => {
 		const backend = createInjectedBackend()
 
 		expect(await backend.getAccounts()).toEqual([])
-		expect(await backend.requestAccounts()).toEqual([])
+		await expect(backend.requestAccounts()).rejects.toThrow('provider unavailable')
 		await expect(backend.createReadClient().getCode({ address: zeroAddress })).rejects.toThrow('provider unavailable')
 		expect(requestCalls).toEqual(['eth_accounts', 'eth_requestAccounts', 'eth_getCode'])
+	})
+
+	test('surfaces wallet-request rejections from the injected provider', async () => {
+		const providerRejection = Object.assign(new Error('wallet rejected'), { code: 4001 })
+		ensureWindowObject().ethereum = createMockInjectedEthereum(async ({ method }) => {
+			if (method === 'eth_requestAccounts') throw providerRejection
+			return []
+		})
+
+		const backend = createInjectedBackend()
+		await expect(backend.requestAccounts()).rejects.toBe(providerRejection)
 	})
 
 	test('rejects chain RPC failures instead of defaulting to mainnet', async () => {

--- a/ui/ts/tests/forkAuction.test.ts
+++ b/ui/ts/tests/forkAuction.test.ts
@@ -9,11 +9,16 @@ import {
 	buildTruthAuctionDepthPoints,
 	getTruthAuctionBidDisposition,
 	getTruthAuctionBidGuardMessage,
+	getTruthAuctionBidPreview,
+	getTruthAuctionBidPriceValidationMessage,
+	TRUTH_AUCTION_MIN_SUPPORTED_TICK,
+	TRUTH_AUCTION_MIN_TICK,
 	getTruthAuctionOverviewProgress,
 	getTruthAuctionPriceAtTick,
 	getTruthAuctionTickAtPrice,
 	sortTruthAuctionBidsByPriority,
 	sortTruthAuctionTickSummariesDescending,
+	TRUTH_AUCTION_MAX_TICK,
 	TRUTH_AUCTION_PRICE_PRECISION,
 } from '../lib/truthAuctionBook.js'
 import { getTruthAuctionSettlementActionAvailabilityMessage, getTruthAuctionSettlementBidKey, getTruthAuctionSettlementBidRows, getTruthAuctionSettlementSelectionState } from '../lib/truthAuctionSettlement.js'
@@ -181,6 +186,27 @@ void describe('fork auction helpers', () => {
 
 		expect(getTruthAuctionTickAtPrice(betweenPositiveTicksPrice)).toBe(12n)
 		expect(getTruthAuctionTickAtPrice(0n)).toBeUndefined()
+	})
+
+	void test('rejects prices outside the contract-supported truth auction range', () => {
+		const maxSupportedPrice = getTruthAuctionPriceAtTick(TRUTH_AUCTION_MAX_TICK)
+		const smallestSupportedPositiveTick = getTruthAuctionTickAtPrice(1n)
+
+		expect(smallestSupportedPositiveTick).not.toBeUndefined()
+		expect(getTruthAuctionTickAtPrice(maxSupportedPrice)).toBe(TRUTH_AUCTION_MAX_TICK)
+		expect(getTruthAuctionTickAtPrice(maxSupportedPrice + 1n)).toBeUndefined()
+		expect(getTruthAuctionBidPriceValidationMessage((maxSupportedPrice + 1n).toString())).toBe('Bid price is outside the supported auction range.')
+		expect(getTruthAuctionBidPriceValidationMessage('9'.repeat(2_048))).toBe('Bid price is outside the supported auction range.')
+		expect(getTruthAuctionBidPreview('9'.repeat(2_048))).toBeUndefined()
+	})
+
+	void test('rejects ticks outside the contract-supported truth auction range', () => {
+		expect(TRUTH_AUCTION_MIN_SUPPORTED_TICK).toBeGreaterThan(TRUTH_AUCTION_MIN_TICK)
+		expect(getTruthAuctionPriceAtTick(TRUTH_AUCTION_MIN_SUPPORTED_TICK)).toBeGreaterThan(0n)
+		expect(() => getTruthAuctionPriceAtTick(TRUTH_AUCTION_MAX_TICK + 1n)).toThrow('Truth auction tick is outside the supported range.')
+		expect(() => getTruthAuctionPriceAtTick(TRUTH_AUCTION_MIN_SUPPORTED_TICK - 1n)).toThrow('Truth auction tick is outside the supported range.')
+		expect(() => getTruthAuctionPriceAtTick(TRUTH_AUCTION_MIN_TICK)).toThrow('Truth auction tick is outside the supported range.')
+		expect(() => getTruthAuctionPriceAtTick(1_048_576n)).toThrow('Truth auction tick is outside the supported range.')
 	})
 
 	void test('uses settlement after finalized auction and after active fork flags in settled-like states', () => {

--- a/ui/ts/tests/forkAuctionSection.test.tsx
+++ b/ui/ts/tests/forkAuctionSection.test.tsx
@@ -835,6 +835,69 @@ describe('ForkAuctionSection', () => {
 		expect(truthAuctionCard.querySelector('.fork-workflow-summary')).not.toBeNull()
 	})
 
+	test('disables bid submission when the entered bid price is an oversized out-of-range value', async () => {
+		const currentChildPool = createChildPool({
+			securityPoolAddress: '0x00000000000000000000000000000000000000f7',
+			systemState: 'forkTruthAuction',
+			truthAuctionAddress: getAddress('0x00000000000000000000000000000000000000f8'),
+			truthAuctionStartedAt: 1n,
+		})
+		const renderedComponent = await renderIntoDocument(
+			h(
+				ForkAuctionSection,
+				createProps({
+					accountState: createAccountState({
+						address: getAddress('0x00000000000000000000000000000000000000aa'),
+						ethBalance: 10n ** 18n,
+					}),
+					currentStageView: 'auction',
+					currentTimestamp: 5n,
+					forkAuctionDetails: createForkAuctionDetails({
+						currentTime: 5n,
+						parentSecurityPoolAddress: PARENT_POOL_ADDRESS,
+						questionOutcome: 'yes',
+						securityPoolAddress: currentChildPool.securityPoolAddress,
+						systemState: 'forkTruthAuction',
+						truthAuction: {
+							accumulatedEth: 0n,
+							auctionEndsAt: 604_801n,
+							clearingPrice: 1n,
+							clearingTick: 0n,
+							ethAtClearingTick: 0n,
+							ethRaiseCap: 1n,
+							ethRaised: 0n,
+							finalized: false,
+							hitCap: false,
+							maxRepBeingSold: 1n,
+							minBidSize: 1n,
+							repPurchasableAtBid: undefined,
+							timeRemaining: 604_796n,
+							totalRepPurchased: 0n,
+							underfunded: false,
+						},
+						truthAuctionAddress: currentChildPool.truthAuctionAddress,
+						truthAuctionStartedAt: 1n,
+						universeId: currentChildPool.universeId,
+					}),
+					forkAuctionForm: createForkAuctionForm({
+						submitBidAmount: '1',
+						submitBidPrice: '9'.repeat(2_048),
+					}),
+					previewPool: currentChildPool,
+					securityPools: [currentChildPool],
+					selectedStageView: 'auction',
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		const submitBidButton = documentQueries.getByRole('button', { name: 'Submit Bid' })
+		if (!(submitBidButton instanceof HTMLButtonElement)) throw new Error('Expected Submit Bid button to be a button element')
+		expect(submitBidButton.getAttribute('title')).toBe('Bid price is outside the supported auction range.')
+		expect(submitBidButton.disabled).toBe(true)
+	})
+
 	test('shows a missing-universe notice without a creation button', async () => {
 		const onCreateChildUniverse = mock(() => undefined)
 		const renderedComponent = await renderIntoDocument(

--- a/ui/ts/tests/openOracle.test.ts
+++ b/ui/ts/tests/openOracle.test.ts
@@ -16,6 +16,7 @@ import {
 	formatOpenOracleInitialReportWriteErrorMessage,
 	formatOpenOracleMultiplier,
 	formatOpenOracleSettleWriteErrorMessage,
+	getOpenOracleCreateValidationMessage,
 	getOpenOracleDisputeAvailability,
 	getOpenOracleReportStatus,
 	getOpenOracleSelectedReportActionMode,
@@ -291,6 +292,32 @@ describe('Open Oracle helpers', () => {
 				token2Address: WETH_ADDRESS,
 			}),
 		).rejects.toThrow('Dispute delay exceeds the maximum safe integer range')
+	})
+
+	test('createOpenOracleReportInstance rejects invalid direct configs before preparing a wallet write', async () => {
+		let preparedCount = 0
+		const writeClientWithPrepareSpy = createWalletWriteClient(addressString(TEST_ADDRESSES[0]), {
+			onTransactionPrepared: () => {
+				preparedCount += 1
+			},
+		})
+
+		await expect(
+			createOpenOracleReportInstance(writeClientWithPrepareSpy, {
+				disputeDelay: 10,
+				escalationHalt: 0n,
+				exactToken1Report: 1n,
+				ethValue: 1_100n,
+				feePercentage: 100,
+				multiplier: 65_536,
+				protocolFee: 100,
+				settlementTime: 60,
+				settlerReward: 1_000n,
+				token1Address: addressString(GENESIS_REPUTATION_TOKEN),
+				token2Address: WETH_ADDRESS,
+			}),
+		).rejects.toThrow('Multiplier exceeds the contract maximum.')
+		expect(preparedCount).toBe(0)
 	})
 
 	test('initial report price helpers derive a Uniswap default price and preserve quote failure metadata', async () => {
@@ -881,6 +908,103 @@ describe('Open Oracle helpers', () => {
 			token1Address: getAddress(token1Address),
 			token2Address: getAddress(WETH_ADDRESS),
 		})
+	})
+
+	test('open oracle create validation blocks contract-reverting configurations before submission', () => {
+		const token1Address = addressString(GENESIS_REPUTATION_TOKEN)
+		const highPrecisionToken1Amount = '0.000000000000000000000000000000000001'
+		const baseForm = {
+			...getDefaultOpenOracleCreateFormState(),
+			disputeDelay: '10',
+			exactToken1Report: '1',
+			ethValue: '1',
+			feePercentage: '1',
+			multiplier: '100',
+			protocolFee: '1',
+			settlementTime: '60',
+			settlerReward: '0.1',
+			token1Address,
+			token2Address: WETH_ADDRESS,
+		}
+
+		expect(getOpenOracleCreateValidationMessage({ form: { ...baseForm, exactToken1Report: '0' } })).toBe('Exact token1 report must be greater than zero.')
+		expect(getOpenOracleCreateValidationMessage({ form: { ...baseForm, token2Address: token1Address } })).toBe('Token1 and token2 must be different addresses.')
+		expect(getOpenOracleCreateValidationMessage({ form: { ...baseForm, settlementTime: '9' } })).toBe('Settlement time must be greater than or equal to dispute delay.')
+		expect(getOpenOracleCreateValidationMessage({ form: { ...baseForm, feePercentage: '60', protocolFee: '50.00001' } })).toBe('Fee percentage plus protocol fee must not exceed 100%.')
+		expect(getOpenOracleCreateValidationMessage({ form: { ...baseForm, multiplier: '99' } })).toBe('Multiplier must be at least 1.00x.')
+		expect(getOpenOracleCreateValidationMessage({ form: { ...baseForm, exactToken1Report: '1000000000' } })).toBeUndefined()
+		expect(getOpenOracleCreateValidationMessage({ form: { ...baseForm, exactToken1Report: '1000000000' }, token1Decimals: 18 })).toBeUndefined()
+		expect(getOpenOracleCreateValidationMessage({ form: { ...baseForm, exactToken1Report: highPrecisionToken1Amount, escalationHalt: highPrecisionToken1Amount } })).toBeUndefined()
+		expect(getOpenOracleCreateValidationMessage({ form: { ...baseForm, exactToken1Report: highPrecisionToken1Amount, escalationHalt: highPrecisionToken1Amount }, token1Decimals: 36 })).toBeUndefined()
+		expect(getOpenOracleCreateValidationMessage({ form: { ...baseForm, multiplier: (1n << 16n).toString() } })).toBe('Multiplier exceeds the contract maximum.')
+		expect(getOpenOracleCreateValidationMessage({ form: { ...baseForm, disputeDelay: (1n << 24n).toString() } })).toBe('Dispute delay exceeds the contract maximum.')
+		expect(getOpenOracleCreateValidationMessage({ form: { ...baseForm, settlementTime: (1n << 48n).toString() } })).toBe('Settlement time exceeds the contract maximum.')
+		expect(getOpenOracleCreateValidationMessage({ form: { ...baseForm, exactToken1Report: (1n << 128n).toString() }, token1Decimals: 18 })).toBe('Exact token1 report exceeds the contract maximum.')
+		expect(getOpenOracleCreateValidationMessage({ form: { ...baseForm, escalationHalt: (1n << 128n).toString() }, token1Decimals: 18 })).toBe('Escalation halt exceeds the contract maximum.')
+		expect(getOpenOracleCreateValidationMessage({ form: { ...baseForm, settlerReward: (1n << 96n).toString() } })).toBe('Settler reward exceeds the contract maximum.')
+		expect(getOpenOracleCreateValidationMessage({ form: { ...baseForm, ethValue: (1n << 96n).toString() } })).toBe('ETH value to send exceeds the contract maximum.')
+	})
+
+	test('open oracle create parser accepts high-decimal token1 amounts once token decimals are known', () => {
+		const parsed = parseOpenOracleCreateFormSubmission({
+			form: {
+				...getDefaultOpenOracleCreateFormState(),
+				disputeDelay: '10',
+				escalationHalt: '0.000000000000000000000000000000000001',
+				exactToken1Report: '0.000000000000000000000000000000000001',
+				ethValue: '1',
+				feePercentage: '1',
+				multiplier: '100',
+				protocolFee: '1',
+				settlementTime: '60',
+				settlerReward: '0.1',
+				token1Address: addressString(GENESIS_REPUTATION_TOKEN),
+				token2Address: WETH_ADDRESS,
+			},
+			token1Decimals: 36,
+		})
+
+		expect(parsed.exactToken1Report).toBe(1n)
+		expect(parsed.escalationHalt).toBe(1n)
+	})
+
+	test('open oracle create parser throws invariant validation messages before preparing a write', () => {
+		expect(() =>
+			parseOpenOracleCreateFormSubmission({
+				form: {
+					...getDefaultOpenOracleCreateFormState(),
+					disputeDelay: '10',
+					exactToken1Report: '1',
+					ethValue: '1',
+					feePercentage: '60',
+					multiplier: '100',
+					protocolFee: '50.00001',
+					settlementTime: '60',
+					settlerReward: '0.1',
+					token1Address: addressString(GENESIS_REPUTATION_TOKEN),
+					token2Address: WETH_ADDRESS,
+				},
+				token1Decimals: 18,
+			}),
+		).toThrow('Fee percentage plus protocol fee must not exceed 100%.')
+		expect(() =>
+			parseOpenOracleCreateFormSubmission({
+				form: {
+					...getDefaultOpenOracleCreateFormState(),
+					disputeDelay: '10',
+					exactToken1Report: '1',
+					ethValue: '1',
+					feePercentage: '1',
+					multiplier: (1n << 16n).toString(),
+					protocolFee: '1',
+					settlementTime: '60',
+					settlerReward: '0.1',
+					token1Address: addressString(GENESIS_REPUTATION_TOKEN),
+					token2Address: WETH_ADDRESS,
+				},
+				token1Decimals: 18,
+			}),
+		).toThrow('Multiplier exceeds the contract maximum.')
 	})
 
 	test('oracle bounty buffer adds a 20% headroom and rounds up', () => {

--- a/ui/ts/tests/openOracleRouteSection.test.tsx
+++ b/ui/ts/tests/openOracleRouteSection.test.tsx
@@ -13,7 +13,7 @@ import type { OpenOracleSectionProps } from '../types/components.js'
 import type { OpenOracleReportDetails } from '../types/contracts.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
-import { expectTransactionButtonDisabled } from './testUtils/transactionActionButton.js'
+import { expectTransactionButtonDisabled, expectTransactionButtonEnabled } from './testUtils/transactionActionButton.js'
 
 const ETH = 10n ** 18n
 
@@ -252,6 +252,61 @@ describe('OpenOracleSection route create view', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		expectTransactionButtonDisabled(document.body, 'Create Standalone Oracle Game', 'Need 100 more ETH in this wallet to create the selected standalone Open Oracle game.')
+	})
+
+	test('does not disable create before token decimals are loaded for large but valid token1 amounts', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				OpenOracleSection,
+				createOpenOracleSectionProps({
+					accountState: createAccountState({ ethBalance: 2_000n * ETH }),
+					openOracleCreateForm: {
+						...getDefaultOpenOracleCreateFormState(),
+						disputeDelay: '10',
+						exactToken1Report: '1000000000',
+						ethValue: '1',
+						feePercentage: '1',
+						multiplier: '100',
+						protocolFee: '1',
+						settlementTime: '60',
+						settlerReward: '0.1',
+						token1Address: '0x2000000000000000000000000000000000000000',
+						token2Address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+					},
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expectTransactionButtonEnabled(document.body, 'Create Standalone Oracle Game')
+	})
+
+	test('does not disable create before token decimals are loaded for high-decimal token1 amounts', async () => {
+		const renderedComponent = await renderIntoDocument(
+			h(
+				OpenOracleSection,
+				createOpenOracleSectionProps({
+					accountState: createAccountState({ ethBalance: 2_000n * ETH }),
+					openOracleCreateForm: {
+						...getDefaultOpenOracleCreateFormState(),
+						disputeDelay: '10',
+						escalationHalt: '0.000000000000000000000000000000000001',
+						exactToken1Report: '0.000000000000000000000000000000000001',
+						ethValue: '1',
+						feePercentage: '1',
+						multiplier: '100',
+						protocolFee: '1',
+						settlementTime: '60',
+						settlerReward: '0.1',
+						token1Address: '0x2000000000000000000000000000000000000000',
+						token2Address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+					},
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expectTransactionButtonEnabled(document.body, 'Create Standalone Oracle Game')
 	})
 
 	test('describes advanced create fields with user-facing units and input modes', async () => {

--- a/ui/ts/tests/tabNavigation.test.tsx
+++ b/ui/ts/tests/tabNavigation.test.tsx
@@ -1,69 +1,70 @@
-/// <reference types="bun-types" />
+/// <reference types='bun-types' />
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { fireEvent, within } from './testUtils/queries'
+import { h } from 'preact'
 import { TabNavigation } from '../components/TabNavigation.js'
-import type { TabNavigationProps } from '../types/components.js'
+import { DEPLOY_ROUTE, OPEN_ORACLE_ROUTE, SECURITY_POOLS_ROUTE, ZOLTAR_ROUTE } from '../lib/routing.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
+import { fireEvent, within } from './testUtils/queries'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
 
-function createProps(overrides: Partial<TabNavigationProps> = {}): TabNavigationProps {
+function createProps(overrides: Partial<Parameters<typeof TabNavigation>[0]> = {}): Parameters<typeof TabNavigation>[0] {
 	return {
 		augurPlaceHolderDeployed: true,
-		deployRoute: '#/deploy',
-		marketRoute: '#/zoltar',
+		deployRoute: DEPLOY_ROUTE,
+		marketRoute: ZOLTAR_ROUTE,
 		onRouteChange: () => undefined,
-		openOracleRoute: '#/open-oracle',
+		openOracleRoute: OPEN_ORACLE_ROUTE,
 		route: 'zoltar',
-		securityPoolsRoute: '#/security-pools',
+		securityPoolsRoute: SECURITY_POOLS_ROUTE,
 		showDeployTab: true,
 		...overrides,
 	}
 }
 
 describe('TabNavigation', () => {
-	let restoreDomEnvironment: (() => void) | undefined
+	let cleanupDom: (() => void) | undefined
 	let cleanupRenderedComponent: (() => Promise<void>) | undefined
 
 	beforeEach(() => {
-		const domEnvironment = installDomEnvironment()
-		restoreDomEnvironment = domEnvironment.cleanup
+		cleanupDom = installDomEnvironment('http://localhost/#/zoltar?universe=7&simulate=1').cleanup
 	})
 
 	afterEach(async () => {
 		await cleanupRenderedComponent?.()
 		cleanupRenderedComponent = undefined
-		restoreDomEnvironment?.()
-		restoreDomEnvironment = undefined
+		cleanupDom?.()
+		cleanupDom = undefined
 	})
 
 	test('renders the user-facing application section labels', async () => {
-		const renderedComponent = await renderIntoDocument(<TabNavigation {...createProps()} />)
-		cleanupRenderedComponent = renderedComponent.cleanup
+		const rendered = await renderIntoDocument(h(TabNavigation, createProps()))
+		cleanupRenderedComponent = rendered.cleanup
 
 		const documentQueries = within(document.body)
 		expect(documentQueries.getByRole('tablist', { name: 'Application sections' })).not.toBeNull()
-		expect(documentQueries.getByRole('tab', { name: 'Deploy' }).getAttribute('href')).toBe('#/deploy')
-		expect(documentQueries.getByRole('tab', { name: 'Markets' }).getAttribute('href')).toBe('#/zoltar')
-		expect(documentQueries.getByRole('tab', { name: 'Security Pools' }).getAttribute('href')).toBe('#/security-pools')
-		expect(documentQueries.getByRole('tab', { name: 'Oracle Reports' }).getAttribute('href')).toBe('#/open-oracle')
+		expect(documentQueries.getByRole('tab', { name: 'Deploy' }).getAttribute('href')).toBe('#/deploy?universe=7&simulate=1')
+		expect(documentQueries.getByRole('tab', { name: 'Markets' }).getAttribute('href')).toBe('#/zoltar?universe=7&simulate=1')
+		expect(documentQueries.getByRole('tab', { name: 'Security Pools' }).getAttribute('href')).toBe('#/security-pools?universe=7&simulate=1')
+		expect(documentQueries.getByRole('tab', { name: 'Oracle Reports' }).getAttribute('href')).toBe('#/open-oracle?universe=7&simulate=1')
 		expect(documentQueries.queryByRole('tab', { name: 'Zoltar' })).toBeNull()
 		expect(documentQueries.queryByRole('tab', { name: 'Open Oracle' })).toBeNull()
 	})
 
 	test('uses the deployment prerequisite copy for disabled application sections', async () => {
 		const routeChanges: string[] = []
-		const renderedComponent = await renderIntoDocument(
-			<TabNavigation
-				{...createProps({
+		const rendered = await renderIntoDocument(
+			h(
+				TabNavigation,
+				createProps({
 					augurPlaceHolderDeployed: false,
 					onRouteChange: route => {
 						routeChanges.push(route)
 					},
-				})}
-			/>,
+				}),
+			),
 		)
-		cleanupRenderedComponent = renderedComponent.cleanup
+		cleanupRenderedComponent = rendered.cleanup
 
 		const marketsTab = within(document.body).getByRole('tab', { name: 'Markets' }) as HTMLButtonElement
 		expect(marketsTab.disabled).toBe(true)
@@ -72,5 +73,16 @@ describe('TabNavigation', () => {
 
 		fireEvent.click(marketsTab)
 		expect(routeChanges).toEqual([])
+	})
+
+	test('preserves the current hash query state in top-level tab hrefs', async () => {
+		const rendered = await renderIntoDocument(h(TabNavigation, createProps()))
+		cleanupRenderedComponent = rendered.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByRole('tab', { name: 'Deploy' }).getAttribute('href')).toBe('#/deploy?universe=7&simulate=1')
+		expect(documentQueries.getByRole('tab', { name: 'Markets' }).getAttribute('href')).toBe('#/zoltar?universe=7&simulate=1')
+		expect(documentQueries.getByRole('tab', { name: 'Security Pools' }).getAttribute('href')).toBe('#/security-pools?universe=7&simulate=1')
+		expect(documentQueries.getByRole('tab', { name: 'Oracle Reports' }).getAttribute('href')).toBe('#/open-oracle?universe=7&simulate=1')
 	})
 })

--- a/ui/ts/tests/useHashRoute.test.tsx
+++ b/ui/ts/tests/useHashRoute.test.tsx
@@ -1,0 +1,58 @@
+/// <reference types='bun-types' />
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { act } from 'preact/test-utils'
+import { useHashRoute } from '../hooks/useHashRoute.js'
+import { installDomEnvironment } from './testUtils/domEnvironment.js'
+import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
+
+type UseHashRoute = typeof import('../hooks/useHashRoute.js')['useHashRoute']
+type UseHashRouteState = ReturnType<UseHashRoute>
+
+function createHarness(onRender: (state: UseHashRouteState) => void) {
+	return function HashRouteHarness() {
+		const state = useHashRoute()
+		onRender(state)
+		return <div />
+	}
+}
+
+function requireState(state: UseHashRouteState | undefined) {
+	if (state === undefined) throw new Error('Hook state unavailable')
+	return state
+}
+
+describe('useHashRoute', () => {
+	let cleanupDom: (() => void) | undefined
+	let cleanupRenderedComponent: (() => Promise<void>) | undefined
+
+	beforeEach(() => {
+		cleanupDom = installDomEnvironment('http://localhost/#/zoltar?universe=7&zoltarView=create&simulate=1').cleanup
+	})
+
+	afterEach(async () => {
+		await cleanupRenderedComponent?.()
+		cleanupRenderedComponent = undefined
+		cleanupDom?.()
+		cleanupDom = undefined
+	})
+
+	test('preserves the current hash query state when navigating between top-level routes', async () => {
+		let hookState: UseHashRouteState | undefined
+		const Harness = createHarness(state => {
+			hookState = state
+		})
+
+		const rendered = await renderIntoDocument(<Harness />)
+		cleanupRenderedComponent = rendered.cleanup
+
+		await act(async () => {
+			requireState(hookState).navigate('security-pools')
+			window.dispatchEvent(new Event('hashchange'))
+			await Promise.resolve()
+		})
+
+		expect(window.location.hash).toBe('#/security-pools?universe=7&zoltarView=create&simulate=1')
+		expect(requireState(hookState).route).toBe('security-pools')
+	})
+})


### PR DESCRIPTION
## Summary
- Added OpenOracle creation validation across UI and transaction path, including per-field checks for token/address parsing, numeric bounds, settlement/dispute timing, and value constraints.
- Updated truth auction bidding flow to use centralized bid preview/validation, with clearer range errors and explicit rejection when bid price is out of supported auction bounds.
- Enforced FIFO-based same-tick fill semantics in the uniform price dual-cap batch auction contract and clarified on-chain matching behavior comments.
- Preserved and strengthened unresolved own-fork escalation handling via new Solidity/TS tests covering mixed own-fork claims + unresolved migration and parent vault lock preservation after fork.
- Refined route handling to preserve query/search state across tab navigation and hash navigation.
- Refreshed mainnet deployment address docs and JSON for deterministic/updated deployments.

## Testing
- `ui/ts/tests/chainBackend.test.ts` updated.
- `ui/ts/tests/forkAuction.test.ts` updated.
- `ui/ts/tests/forkAuctionSection.test.tsx` added.
- `ui/ts/tests/openOracle.test.ts` added.
- `ui/ts/tests/openOracleRouteSection.test.tsx` expanded.
- `ui/ts/tests/tabNavigation.test.tsx` updated.
- `ui/ts/tests/useHashRoute.test.tsx` added.
- `ui/ts/tests/useTradingOperations.test.tsx` updated.
- `solidity/ts/tests/peripherals/deploymentAndOwnForkEscalation.test.ts` added own-fork claim + unresolved migration partitioning case.
- `solidity/ts/tests/peripherals/forkMigration.test.ts` added own-fork closes parent withdrawal protection case.
- Not run: typecheck/tests/format/lint commands not executed in this pass (not requested).