### PR TITLE
Use Bun executable path in UI watch spawns

### DIFF
--- a/scripts/ensure-contract-artifacts.test.ts
+++ b/scripts/ensure-contract-artifacts.test.ts
@@ -4,6 +4,10 @@ import { getRequiredSharedOutputRelativePaths } from './ensure-contract-artifact
 test('ensure-contract-artifacts requires shared package testing helper outputs', async () => {
 	const requiredSharedOutputs = await getRequiredSharedOutputRelativePaths()
 
+	expect(requiredSharedOutputs).toContain('shared/js/protocolConfig.js')
+	expect(requiredSharedOutputs).toContain('shared/js/protocolConfig.d.ts')
 	expect(requiredSharedOutputs).toContain('shared/js/testing/pickFixtureProperties.js')
 	expect(requiredSharedOutputs).toContain('shared/js/testing/pickFixtureProperties.d.ts')
+	expect(requiredSharedOutputs).toContain('shared/js/testing/scalarOutcomeParityFixtures.js')
+	expect(requiredSharedOutputs).toContain('shared/js/testing/scalarOutcomeParityFixtures.d.ts')
 })

--- a/ui/build/sharedAssets.test.ts
+++ b/ui/build/sharedAssets.test.ts
@@ -219,6 +219,27 @@ function collectRuntimeModuleSpecifiers(sourceFile: ts.SourceFile) {
 	return specifiers
 }
 
+function isBunStringLiteral(node: ts.Node) {
+	return (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) && node.text === 'bun'
+}
+
+function getSourceLocation(sourceFile: ts.SourceFile, node: ts.Node) {
+	const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile))
+	return `${path.relative(repositoryRootPath, sourceFile.fileName)}:${line + 1}:${character + 1}`
+}
+
+function collectBareBunStringLiterals(sourceFile: ts.SourceFile) {
+	const locations: string[] = []
+	const visit = (node: ts.Node) => {
+		if (isBunStringLiteral(node)) {
+			locations.push(getSourceLocation(sourceFile, node))
+		}
+		ts.forEachChild(node, visit)
+	}
+	visit(sourceFile)
+	return locations
+}
+
 function getExportedNames(filePath: string, imports: Record<string, string>, exportCache: Map<string, Set<string>>) {
 	const cachedExports = exportCache.get(filePath)
 	if (cachedExports !== undefined) return cachedExports
@@ -308,10 +329,17 @@ test('shared helper package imports resolve to browser-served shared outputs', (
 	}
 })
 
+test('watch build regression scanner catches indirect bare Bun commands', () => {
+	const fixtureSourceFile = parseModule(path.join(repositoryRootPath, 'ui', 'build', 'bare-bun-fixture.mts'), ["const BUN_COMMAND = 'bun'", "spawn(BUN_COMMAND, ['x', 'tsc'])", "runSharedBuildStep([BUN_COMMAND, 'run', 'shared:build'])"].join('\n'))
+
+	expect(collectBareBunStringLiterals(fixtureSourceFile)).toEqual(['ui/build/bare-bun-fixture.mts:1:21'])
+})
+
 test('development import map maps browser dependency subpaths', () => {
 	const imports = readDevelopmentImportMap()
 	const vendorBuildSource = fs.readFileSync(uiVendorBuildPath, 'utf8')
 	const watchBuildSource = fs.readFileSync(uiWatchBuildPath, 'utf8')
+	const watchBuildSourceFile = parseModule(uiWatchBuildPath, watchBuildSource)
 
 	for (const [specifier, mappedPath] of Object.entries(developmentImportMapRegressionEntries)) {
 		expect(imports[specifier]).toBe(mappedPath)
@@ -319,6 +347,8 @@ test('development import map maps browser dependency subpaths', () => {
 	expect(vendorBuildSource).toContain("{ packageName: 'isows', subfolderToVendor: '_esm', mainEntrypointFile: 'native.js'")
 	expect(watchBuildSource).toContain('const VENDOR_INPUT_PATHS = [VENDOR_BUILD_PATH, BUNDLER_PATHS_BUILD_PATH')
 	expect(watchBuildSource).toContain('const WORKER_INPUT_PATHS = [WORKER_BUILD_PATH, BUNDLER_PATHS_BUILD_PATH]')
+	expect(watchBuildSource).toContain('const BUN_EXECUTABLE_PATH = process.execPath')
+	expect(collectBareBunStringLiterals(watchBuildSourceFile)).toEqual([])
 })
 
 test('development import map resolves all static imports reachable from the dev entrypoint', () => {

--- a/ui/build/watch.mts
+++ b/ui/build/watch.mts
@@ -24,6 +24,7 @@ const VENDOR_INPUT_PATHS = [VENDOR_BUILD_PATH, BUNDLER_PATHS_BUILD_PATH, path.jo
 const WORKER_BUILD_PATH = path.join(UI_ROOT_PATH, 'build', 'workers.mts')
 const WORKER_INPUT_PATHS = [WORKER_BUILD_PATH, BUNDLER_PATHS_BUILD_PATH]
 const LIVE_RELOAD_ENDPOINT = 'http://127.0.0.1:12345/__live-reload'
+const BUN_EXECUTABLE_PATH = process.execPath
 
 type ManagedProcess = ReturnType<typeof spawn>
 
@@ -169,7 +170,7 @@ const sendLiveReload = async (reason: string) => {
 const spawnServer = () => {
 	console.log('[ui:watch] Starting ui:serve')
 	try {
-		serverProcess = spawn('bun', [DEV_SERVER_PATH], {
+		serverProcess = spawn(BUN_EXECUTABLE_PATH, [DEV_SERVER_PATH], {
 			cwd: REPOSITORY_ROOT_PATH,
 			stdio: 'inherit',
 		})
@@ -456,7 +457,7 @@ const runVendorBuild = async (reason: string) => {
 	vendorBuildRunning = true
 	console.log(`[ui:watch] Rebuilding UI vendor assets because ${reason} changed`)
 	try {
-		vendorBuildProcess = spawn('bun', [VENDOR_BUILD_PATH], {
+		vendorBuildProcess = spawn(BUN_EXECUTABLE_PATH, [VENDOR_BUILD_PATH], {
 			cwd: UI_ROOT_PATH,
 			stdio: 'inherit',
 		})
@@ -505,7 +506,7 @@ const runWorkerBuild = async (reason: string) => {
 	workerBuildRunning = true
 	console.log(`[ui:watch] Rebuilding simulation worker because ${reason} changed`)
 	try {
-		workerBuildProcess = spawn('bun', [WORKER_BUILD_PATH], {
+		workerBuildProcess = spawn(BUN_EXECUTABLE_PATH, [WORKER_BUILD_PATH], {
 			cwd: UI_ROOT_PATH,
 			stdio: 'inherit',
 		})
@@ -552,7 +553,7 @@ const runSharedBuild = async (reason: string) => {
 	}
 	sharedBuildRunning = true
 	console.log(`[ui:watch] Rebuilding shared package outputs because ${reason} changed`)
-	const builtSharedOutputs = await runSharedBuildStep(['bun', 'run', 'shared:build'], REPOSITORY_ROOT_PATH, 'Shared TypeScript build')
+	const builtSharedOutputs = await runSharedBuildStep([BUN_EXECUTABLE_PATH, 'run', 'shared:build'], REPOSITORY_ROOT_PATH, 'Shared TypeScript build')
 	if (!builtSharedOutputs) return
 	sharedBuildRunning = false
 	if (sharedBuildQueued) {
@@ -572,7 +573,7 @@ const runProjectArtifactBuild = async (reason: string) => {
 	projectArtifactBuildRunning = true
 	console.log(`[ui:watch] Rebuilding UI contract artifacts because ${reason} changed`)
 	try {
-		projectArtifactBuildProcess = spawn('bun', ['run', 'generate:ui-contract-artifact'], {
+		projectArtifactBuildProcess = spawn(BUN_EXECUTABLE_PATH, ['run', 'generate:ui-contract-artifact'], {
 			cwd: REPOSITORY_ROOT_PATH,
 			stdio: 'inherit',
 		})
@@ -622,7 +623,7 @@ const runContractBuild = async (reason: string) => {
 	contractBuildRunning = true
 	console.log(`[ui:watch] Rebuilding Solidity contracts and UI artifacts because ${reason} changed`)
 	try {
-		contractBuildProcess = spawn('bun', ['run', 'generate:contracts'], {
+		contractBuildProcess = spawn(BUN_EXECUTABLE_PATH, ['run', 'generate:contracts'], {
 			cwd: REPOSITORY_ROOT_PATH,
 			stdio: 'inherit',
 		})
@@ -692,7 +693,7 @@ const shutdown = async (exitCode: number) => {
 const main = () => {
 	console.log('[ui:watch] Watching UI TypeScript output and serving static assets')
 	try {
-		typeScriptWatchProcess = spawn('bun', ['x', 'tsc', '--project', 'tsconfig.json', '--watch', '--preserveWatchOutput'], {
+		typeScriptWatchProcess = spawn(BUN_EXECUTABLE_PATH, ['x', 'tsc', '--project', 'tsconfig.json', '--watch', '--preserveWatchOutput'], {
 			cwd: UI_ROOT_PATH,
 			stdio: ['inherit', 'pipe', 'pipe'],
 		})


### PR DESCRIPTION
## Summary
- use `process.execPath` for Bun subprocesses managed by `ui/build/watch.mts` so Windows `ui:watch` does not depend on resolving bare `bun` from PATH
- add regression coverage that rejects exact bare `'bun'` literals in the watcher, including indirect constants
- expand shared generated-output freshness test coverage for exported shared outputs

## Validation
- `bun run tsc`
- `bun run ensure-contract-artifacts && bun run check:shared-dependencies && bun run test:run -- --bail=1` (`1617 pass`, `11 skip`, `0 fail`)
- `bun run format`
- `bun run check`
- `bun run knip`
- `bun run check:generated-clean`
- `git diff --check`
- `git fetch origin main:refs/remotes/origin/main && git rev-list --count HEAD..origin/main` (`0`)

## Review
- project-scoped reviewer completed with no High, Medium, or Low findings
- reviewer score: `94/100`

## Notes
- No direct Windows execution was available in this workspace; the Windows-specific behavior is covered by code review and regression tests.
