### PR TITLE
Use Bun executable path in ui watch and improve simulation banner responsive layout

### DIFF
--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -1169,9 +1169,9 @@ button.currency-value.copyable:hover:not(:disabled) {
 
 .simulation-banner-controls {
 	display: grid;
-	grid-template-columns: minmax(0, 1fr) auto;
+	grid-template-columns: minmax(0, 1fr) minmax(16rem, 22rem);
 	gap: 1rem;
-	align-items: center;
+	align-items: start;
 	padding: 1rem;
 	border: 1px dashed rgba(255, 227, 145, 0.42);
 	border-radius: 1rem;
@@ -1186,8 +1186,7 @@ button.currency-value.copyable:hover:not(:disabled) {
 }
 
 .simulation-banner-controls .button-row {
-	flex-wrap: wrap;
-	justify-content: flex-end;
+	justify-content: stretch;
 }
 
 .simulation-control-groups {
@@ -1214,7 +1213,23 @@ button.currency-value.copyable:hover:not(:disabled) {
 }
 
 .simulation-button-row {
-	justify-content: flex-end;
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 0.5rem;
+	width: 100%;
+	justify-content: stretch;
+}
+
+.simulation-time-travel-row {
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.simulation-button-row > button {
+	width: 100%;
+	min-height: 2.45rem;
+	padding: 0.52rem 0.62rem;
+	font-size: var(--font-caption);
+	line-height: 1.15;
 }
 
 .simulation-delay-field {
@@ -6607,6 +6622,10 @@ button:focus-visible {
 
 	.simulation-button-row > button {
 		width: 100%;
+	}
+
+	.simulation-time-travel-row {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
 	}
 
 	.simulation-advanced-controls > summary {

--- a/ui/ts/components/SimulationBanner.tsx
+++ b/ui/ts/components/SimulationBanner.tsx
@@ -475,7 +475,7 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 							</div>
 							<div className='simulation-control-group'>
 								<span className='simulation-control-group-label'>Time travel</span>
-								<div className='button-row simulation-button-row'>
+								<div className='button-row simulation-button-row simulation-time-travel-row'>
 									{SIMULATION_TIME_PRESETS.map(preset => (
 										<button key={preset.label} className='secondary' onClick={() => void runControl(async () => await controller.advanceTime(preset.seconds))} disabled={busy.value || !isBootstrapped.value}>
 											{preset.label}


### PR DESCRIPTION
## Summary
- Use Bun executable path from `process.execPath` in `ui/build/watch.mts` for all spawned Bun processes (`spawn` and watch/typecheck pipeline), preventing failures when `bun` is not on PATH (notably Windows CI/local environments).
- Extend build-regression coverage in `ui/build/sharedAssets.test.ts` to detect indirect bare `bun` string usage and verify `watch.mts` emits `BUN_EXECUTABLE_PATH` without bare `bun` literals.
- Update artifact test expectations in `scripts/ensure-contract-artifacts.test.ts` for new shared outputs (`shared/js/protocolConfig`, `shared/js/testing/scalarOutcomeParityFixtures`).
- Improve simulation banner control layout responsiveness via `ui/css/index.css` and add `simulation-time-travel-row` behavior for larger/smaller viewports.
- Adjust `SimulationBanner` markup to target the dedicated time-travel row class for responsive button grid behavior.

## Testing
- Not run (not requested): no commands executed in this environment.
- Suggested: `bun run test` (full), or at minimum:
  - `bun run ensure-contract-artifacts`
  - `bun run test -- ui/build/sharedAssets.test.ts`
  - Manual check of simulation banner at desktop + narrow widths