### PR TITLE
Auto-load security-pool market details on question ID input and update Bun invocation paths

### DIFF
--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -147,13 +147,12 @@ export function App() {
 		zoltarUniverseMissing,
 	} = useMarketCreation({ ...baseHookConfig, activeUniverseId, activeZoltarView, autoLoadInitialData: walletBootstrapComplete && canReadOnchainData, deploymentStatuses })
 	const zoltarUniverseHasForked = zoltarUniverse?.hasForked === true
-	const { checkingDuplicateOriginPool, createPool, duplicateOriginPoolExists, loadMarket, loadMarketById, loadingMarketDetails, marketDetails, poolCreationMarketDetails, resetSecurityPoolCreation, securityPoolCreating, securityPoolError, securityPoolForm, securityPoolResult, setSecurityPoolForm } =
-		useSecurityPoolCreation({
-			...baseHookConfig,
-			deploymentStatuses,
-			enabled: route === 'security-pools' && canReadOnchainData,
-			zoltarUniverseHasForked,
-		})
+	const { checkingDuplicateOriginPool, createPool, duplicateOriginPoolExists, loadingMarketDetails, marketDetails, poolCreationMarketDetails, resetSecurityPoolCreation, securityPoolCreating, securityPoolError, securityPoolForm, securityPoolResult, setSecurityPoolForm } = useSecurityPoolCreation({
+		...baseHookConfig,
+		deploymentStatuses,
+		enabled: route === 'security-pools' && canReadOnchainData,
+		zoltarUniverseHasForked,
+	})
 	const {
 		approveRep,
 		depositRep,
@@ -470,8 +469,6 @@ export function App() {
 			duplicateOriginPoolExists,
 			poolCreationMarketDetails,
 			onCreateSecurityPool: () => void createPool(),
-			onLoadMarket: () => void loadMarket(),
-			onLoadMarketById: loadMarketById,
 			loadingMarketDetails,
 			marketDetails,
 			onResetSecurityPoolCreation: resetSecurityPoolCreation,

--- a/ui/ts/components/MarketCreateQuestionSection.tsx
+++ b/ui/ts/components/MarketCreateQuestionSection.tsx
@@ -53,8 +53,8 @@ function getScalarCreatePreviewDetails(marketForm: MarketFormState, scalarInputs
 
 function getPoolEligibilityMessage(marketType: MarketFormState['marketType']) {
 	if (marketType === 'binary') return 'Placeholder origin security pools support this exact Yes / No question shape.'
-	if (marketType === 'categorical') return 'This question is valid in Zoltar, but Placeholder origin security pools currently require an exact binary Yes / No question.'
-	return 'This scalar question is valid in Zoltar, but Placeholder origin security pools currently require an exact binary Yes / No question.'
+	if (marketType === 'categorical') return 'Categorical questions are valid in Zoltar, but Placeholder origin security pools currently require an exact binary Yes / No question.'
+	return 'Scalar questions are valid in Zoltar, but Placeholder origin security pools currently require an exact binary Yes / No question.'
 }
 
 function getFieldErrorId(field: MarketFormFieldName) {
@@ -223,7 +223,7 @@ export function MarketCreateQuestionSection({
 				<SectionBlock title='Create Question' description='Define the market type, timing, and outcomes for a new Zoltar question.'>
 					<div className='workflow-summary-strip workflow-guide'>
 						<div className='workflow-guide-intro'>
-							<strong>Write this the way a resolver will read it.</strong>
+							<strong>Write the question the way a resolver will read it.</strong>
 							<p className='detail'>{marketTypeGuidance.description}</p>
 						</div>
 						<div className='workflow-summary-strip-steps'>
@@ -390,7 +390,7 @@ export function MarketCreateQuestionSection({
 							return undefined
 						})()}
 
-						<SectionBlock headingLevel={4} title='Draft Preview' variant='embedded' description='This preview shows the level of clarity traders and reporters will see before trusting the question.'>
+						<SectionBlock headingLevel={4} title='Draft Preview' variant='embedded' description='Draft Preview shows the level of clarity traders and reporters will see before trusting the question.'>
 							<div className='question-draft-preview'>
 								<div className='question-draft-preview-header'>
 									<div className='question-summary-heading'>

--- a/ui/ts/components/MarketQuestionsSection.tsx
+++ b/ui/ts/components/MarketQuestionsSection.tsx
@@ -137,8 +137,8 @@ export function MarketQuestionsSection({ hasForked, loadingZoltarQuestionCount, 
 								</div>
 							}
 						>
-							<Question question={question} showTitle={false} />
-							{question.marketType !== 'binary' ? <p className='detail'>This question is valid in Zoltar, but Placeholder origin pools currently require an exact binary Yes / No question.</p> : undefined}
+							<Question question={question} showMissingContextNote={false} showTitle={false} />
+							{question.marketType !== 'binary' ? <p className='detail'>Non-binary questions are valid in Zoltar, but Placeholder origin pools currently require an exact binary Yes / No question.</p> : undefined}
 						</EntityCard>
 					))}
 				</div>

--- a/ui/ts/components/Question.tsx
+++ b/ui/ts/components/Question.tsx
@@ -11,6 +11,7 @@ type QuestionProps = {
 	className?: string
 	loading?: boolean
 	question: MarketDetails | undefined
+	showMissingContextNote?: boolean
 	showTitle?: boolean
 	variant?: 'full' | 'preview'
 }
@@ -97,7 +98,7 @@ function renderQuestionSummaryField(field: QuestionSummaryField) {
 	)
 }
 
-export function Question({ className = '', loading = false, question, showTitle = true, variant = 'full' }: QuestionProps) {
+export function Question({ className = '', loading = false, question, showMissingContextNote = true, showTitle = true, variant = 'full' }: QuestionProps) {
 	if (loading || question === undefined)
 		return (
 			<div className={`question-summary ${className}`}>
@@ -109,7 +110,7 @@ export function Question({ className = '', loading = false, question, showTitle 
 
 	const title = getQuestionTitle(question)
 	const description = getQuestionDescription(question)
-	const missingContext = !hasQuestionContext(question)
+	const missingContext = showMissingContextNote && !hasQuestionContext(question)
 	const summaryFields = getQuestionSummaryFields(question)
 	const outcomeItems = getDisplayedOutcomes(question).map(outcome => ({
 		key: outcome,

--- a/ui/ts/components/SecurityPoolSection.tsx
+++ b/ui/ts/components/SecurityPoolSection.tsx
@@ -23,7 +23,6 @@ export function SecurityPoolSection({
 	loadingMarketDetails,
 	marketDetails,
 	onCreateSecurityPool,
-	onLoadMarket,
 	onOpenCreatedPool,
 	onReturnToBrowse,
 	onSecurityPoolFormChange,
@@ -127,10 +126,10 @@ export function SecurityPoolSection({
 						<div className='workflow-summary-strip workflow-guide'>
 							<div className='workflow-guide-intro'>
 								<strong>Pool creation turns a binary question into a collateralized trading surface.</strong>
-								<p className='detail'>Load the question, choose how much REP coverage the pool should require, then deploy the pool for vaults, reporting, and trading.</p>
+								<p className='detail'>Enter the question, choose how much REP coverage the pool should require, then deploy the pool for vaults, reporting, and trading.</p>
 							</div>
 							<div className='workflow-summary-strip-steps'>
-								<span className='current'>1. Load a binary question</span>
+								<span className='current'>1. Enter a binary question</span>
 								<span>2. Choose collateral strength</span>
 								<span>3. Deploy the pool</span>
 							</div>
@@ -145,18 +144,8 @@ export function SecurityPoolSection({
 						</SectionBlock>
 						<div className='form-grid'>
 							<div className='field'>
-								<LookupFieldRow
-									label='Question ID'
-									value={securityPoolForm.marketId}
-									onInput={marketId => onSecurityPoolFormChange({ marketId })}
-									placeholder='0x...'
-									action={
-										<button className='secondary' type='button' onClick={onLoadMarket} disabled={loadingMarketDetails || securityPoolForm.marketId.trim() === ''}>
-											{loadingMarketDetails ? <LoadingText>Loading...</LoadingText> : 'Load Question'}
-										</button>
-									}
-								/>
-								<p className='field-help'>Paste an exact binary Yes / No Zoltar question ID, or use "Create Pool From Question" after creating a question. Load the preview before deploying so you can verify the question wording.</p>
+								<LookupFieldRow label='Question ID' value={securityPoolForm.marketId} onInput={marketId => onSecurityPoolFormChange({ marketId })} placeholder='0x...' />
+								<p className='field-help'>Paste an exact binary Yes / No Zoltar question ID.</p>
 							</div>
 							{loadingMarketDetails ? (
 								<p className='detail'>
@@ -175,14 +164,14 @@ export function SecurityPoolSection({
 								</label>
 								<FormInput id='security-pool-security-multiplier' aria-describedby='security-pool-security-multiplier-help' value={securityPoolForm.securityMultiplier} onInput={event => onSecurityPoolFormChange({ securityMultiplier: event.currentTarget.value })} />
 								<p className='field-help' id='security-pool-security-multiplier-help'>
-									This sets the REP collateral target relative to open interest. Higher values are safer but require more REP backing.
+									Security Multiplier sets the REP collateral target relative to open interest. Higher values require more REP backing and create a thicker safety buffer.
 								</p>
 							</div>
 
 							<div className='field'>
 								<span>Initial Open Interest Fee / Year</span>
 								<strong>{formatOpenInterestFeePerYearPercent(ORIGIN_POOL_INITIAL_RETENTION_RATE)}</strong>
-								<p className='field-help'>This fee applies to open interest in the new pool and is fixed at deployment.</p>
+								<p className='field-help'>Initial Open Interest Fee / Year is the starting annualized fee charged against open interest. The rate follows pool utilization after deployment.</p>
 							</div>
 
 							<div className='actions'>
@@ -190,7 +179,7 @@ export function SecurityPoolSection({
 							</div>
 						</div>
 						{!duplicateOriginPoolExists ? undefined : <p className='detail'>A pool for this question and security multiplier already exists. Origin pool deployment is deterministic for that pair, so change the security multiplier to create a different pool.</p>}
-						{marketDetails !== undefined && marketDetails.marketType !== 'binary' ? <p className='notice error'>Security pools can only be created for exact binary Yes / No questions. Load an eligible market to proceed.</p> : undefined}
+						{marketDetails !== undefined && marketDetails.marketType !== 'binary' ? <p className='notice error'>Security pools can only be created for exact binary Yes / No questions. Enter an eligible question to proceed.</p> : undefined}
 						{zoltarUniverseHasForked ? <p className='notice error'>Security pools cannot be created after Zoltar has forked.</p> : undefined}
 					</SectionBlock>
 

--- a/ui/ts/hooks/useSecurityPoolCreation.ts
+++ b/ui/ts/hooks/useSecurityPoolCreation.ts
@@ -117,8 +117,6 @@ export function useSecurityPoolCreation({ accountAddress, deploymentStatuses, en
 		})
 	}
 
-	const loadMarket = async () => await loadMarketById(securityPoolForm.value.marketId)
-
 	const createPool = async () => {
 		if (securityPoolCreating.value) {
 			securityPoolError.value = 'Security pool creation already in progress'
@@ -217,7 +215,6 @@ export function useSecurityPoolCreation({ accountAddress, deploymentStatuses, en
 		checkingDuplicateOriginPool: duplicateOriginPoolCheckLoad.isLoading.value,
 		duplicateOriginPoolExists: duplicateOriginPoolExists.value,
 		loadMarketById,
-		loadMarket,
 		loadingMarketDetails: marketDetailsLoad.isLoading.value,
 		marketDetails: marketDetails.value,
 		securityPoolCreationFeedback: securityPoolCreationFeedback.value,

--- a/ui/ts/lib/securityPoolCreationGuards.ts
+++ b/ui/ts/lib/securityPoolCreationGuards.ts
@@ -23,7 +23,7 @@ export function getSecurityPoolCreateDisabledReason({
 	if (checkingDuplicateOriginPool) return 'Checking whether a pool already exists for this question and security multiplier.'
 	if (securityPoolCreating) return 'Security pool creation is already in progress.'
 	if (duplicateOriginPoolExists) return 'A pool for this question and security multiplier already exists.'
-	if (marketDetails === undefined) return 'Load an exact binary Yes / No question before creating a pool.'
+	if (marketDetails === undefined) return 'Enter an exact binary Yes / No question before creating a pool.'
 	if (marketDetails.marketType !== 'binary') return 'Security pools can only be created for exact binary Yes / No questions.'
 	if (zoltarUniverseHasForked) return 'Security pools cannot be created after Zoltar has forked.'
 	return undefined

--- a/ui/ts/tests/marketCreateQuestionSection.test.tsx
+++ b/ui/ts/tests/marketCreateQuestionSection.test.tsx
@@ -94,6 +94,7 @@ describe('MarketCreateQuestionSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
+		expect(documentQueries.getByText('Write the question the way a resolver will read it.')).not.toBeNull()
 		const questionTypeButton = documentQueries.getByRole('button', { name: 'Question Type: Binary' })
 		await act(() => {
 			fireEvent.click(questionTypeButton)

--- a/ui/ts/tests/marketSection.test.tsx
+++ b/ui/ts/tests/marketSection.test.tsx
@@ -609,6 +609,30 @@ describe('MarketSection', () => {
 		expect(selectedViews).toEqual(['fork'])
 	})
 
+	test('shows immutable questions without an edit-style missing context notice', async () => {
+		const question = createBinaryForkQuestion()
+		question.description = ''
+		const renderedComponent = await renderIntoDocument(
+			h(
+				MarketSection,
+				createMarketSectionProps({
+					zoltarQuestionCount: 1n,
+					zoltarQuestionPage: {
+						pageIndex: 0,
+						pageSize: 10,
+						questionCount: 1n,
+						questions: [question],
+					},
+				}),
+			),
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByText('No resolution notes or supporting context provided.')).not.toBeNull()
+		expect(documentQueries.queryByText('Add resolution notes, evidence sources, and edge-case handling before users rely on this question.')).toBeNull()
+	})
+
 	test('does not render redundant universe summary cards for questions view', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(

--- a/ui/ts/tests/securityPoolCreationGuards.test.ts
+++ b/ui/ts/tests/securityPoolCreationGuards.test.ts
@@ -56,6 +56,18 @@ describe('security pool creation guards', () => {
 				checkingDuplicateOriginPool: false,
 				duplicateOriginPoolExists: false,
 				isMainnet: true,
+				marketDetails: undefined,
+				securityPoolCreating: false,
+				zoltarUniverseHasForked: false,
+			}),
+		).toBe('Enter an exact binary Yes / No question before creating a pool.')
+
+		expect(
+			getSecurityPoolCreateDisabledReason({
+				accountAddress: zeroAddress,
+				checkingDuplicateOriginPool: false,
+				duplicateOriginPoolExists: false,
+				isMainnet: true,
 				marketDetails: createMarketDetails({ marketType: 'categorical' }),
 				securityPoolCreating: false,
 				zoltarUniverseHasForked: false,

--- a/ui/ts/tests/securityPoolSection.test.tsx
+++ b/ui/ts/tests/securityPoolSection.test.tsx
@@ -50,8 +50,6 @@ function createProps(overrides: Partial<SecurityPoolSectionProps> = {}): Securit
 		loadingMarketDetails: false,
 		marketDetails: createMarketDetails(),
 		onCreateSecurityPool: () => undefined,
-		onLoadMarket: () => undefined,
-		onLoadMarketById: async () => undefined,
 		onOpenCreatedPool: () => undefined,
 		onResetSecurityPoolCreation: () => undefined,
 		onReturnToBrowse: () => undefined,
@@ -147,11 +145,10 @@ describe('SecurityPoolSection', () => {
 		const documentQueries = within(document.body)
 		const securityMultiplierInput = documentQueries.getByRole('textbox', { name: 'Security Multiplier' })
 		expect(securityMultiplierInput.getAttribute('aria-describedby')).toBe('security-pool-security-multiplier-help')
-		expect(documentQueries.getByText('This sets the REP collateral target relative to open interest. Higher values are safer but require more REP backing.')).not.toBeNull()
+		expect(documentQueries.getByText('Security Multiplier sets the REP collateral target relative to open interest. Higher values require more REP backing and create a thicker safety buffer.')).not.toBeNull()
 	})
 
-	test('loads and previews the pasted question before pool creation', async () => {
-		let loadMarketCount = 0
+	test('previews the pasted question before pool creation without a manual load action', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(
 				SecurityPoolSection,
@@ -160,22 +157,16 @@ describe('SecurityPoolSection', () => {
 						description: 'Previewed binary question',
 						title: 'Question ready for a pool',
 					}),
-					onLoadMarket: () => {
-						loadMarketCount += 1
-					},
 				}),
 			),
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		expect(documentQueries.getByText('Paste an exact binary Yes / No Zoltar question ID, or use "Create Pool From Question" after creating a question. Load the preview before deploying so you can verify the question wording.')).not.toBeNull()
+		expect(documentQueries.getByText('Paste an exact binary Yes / No Zoltar question ID.')).not.toBeNull()
 		expect(documentQueries.getByText('Question ready for a pool')).not.toBeNull()
 		expect(documentQueries.getByText('Previewed binary question')).not.toBeNull()
-
-		fireEvent.click(documentQueries.getByRole('button', { name: 'Load Question' }))
-
-		expect(loadMarketCount).toBe(1)
+		expect(documentQueries.queryByRole('button', { name: 'Load Question' })).toBeNull()
 	})
 
 	test('shows only the shared missing-context warning when a loaded question lacks description details', async () => {

--- a/ui/ts/tests/securityPoolsSection.test.ts
+++ b/ui/ts/tests/securityPoolsSection.test.ts
@@ -347,8 +347,6 @@ function createCreatePoolProps(overrides: Partial<SecurityPoolRouteContentProps>
 		loadingMarketDetails: false,
 		marketDetails: undefined,
 		onCreateSecurityPool: () => undefined,
-		onLoadMarket: () => undefined,
-		onLoadMarketById: async () => undefined,
 		onResetSecurityPoolCreation: () => undefined,
 		onSecurityPoolFormChange: () => undefined,
 		poolCreationMarketDetails: undefined,

--- a/ui/ts/tests/useSecurityPoolCreation.test.tsx
+++ b/ui/ts/tests/useSecurityPoolCreation.test.tsx
@@ -265,6 +265,51 @@ describe('useSecurityPoolCreation', () => {
 		expect(requireState(state).duplicateOriginPoolExists).toBe(true)
 	})
 
+	test('auto-loads market details when a valid question ID is entered', async () => {
+		const loadedDetails = createMarketDetails({ questionId: '0x0b', title: 'Auto loaded question' })
+		const loadedQuestionIds: bigint[] = []
+		const loadMarketDetails = mock(async (_client: unknown, questionId: bigint) => {
+			loadedQuestionIds.push(questionId)
+			return loadedDetails
+		})
+		setupContractMocks({
+			loadMarketDetails,
+			originSecurityPoolExists: mock(async () => false),
+		})
+
+		const { useSecurityPoolCreation } = await import(`../hooks/useSecurityPoolCreation.js?case=${crypto.randomUUID()}`)
+		let state: UseSecurityPoolCreationState | undefined
+		const Harness = createHarness(
+			useSecurityPoolCreation,
+			{
+				accountAddress: zeroAddress,
+				deploymentStatuses: [createStatus('proxyDeployer', true), createStatus('zoltarQuestionData', true)],
+				enabled: true,
+				onTransactionFinished: () => undefined,
+				onTransactionPresented: () => undefined,
+				onTransactionRequested: () => undefined,
+				onTransactionSubmitted: () => undefined,
+				refreshState: async () => undefined,
+				zoltarUniverseHasForked: false,
+			},
+			newState => {
+				state = newState
+			},
+		)
+		const renderedComponent = await renderIntoDocument(<Harness />)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await act(() => {
+			requireState(state).setSecurityPoolForm(current => ({ ...current, marketId: '0x0b' }))
+		})
+
+		await waitFor(() => {
+			expect(loadMarketDetails).toHaveBeenCalledTimes(1)
+			expect(loadedQuestionIds).toEqual([11n])
+			expect(requireState(state).marketDetails?.title).toBe('Auto loaded question')
+		})
+	})
+
 	test('createPool blocks when required deployment step is missing', async () => {
 		setupContractMocks({
 			loadMarketDetails: mock(async () => createMarketDetails()),

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -425,8 +425,6 @@ export type SecurityPoolRouteContentProps = {
 	checkingDuplicateOriginPool: boolean
 	duplicateOriginPoolExists: boolean
 	onCreateSecurityPool: () => void
-	onLoadMarket: () => void
-	onLoadMarketById: (marketId: string) => Promise<void>
 	onOpenCreatedPool?: (securityPoolAddress: Address) => void
 	loadingMarketDetails: boolean
 	marketDetails: MarketDetails | undefined


### PR DESCRIPTION
## Summary
- Automatically loads security pool market details when a valid question ID is entered in the form, removing the manual "Load Question" action.
- Switched UI watch/build process to execute Bun via `process.execPath` instead of hardcoded `'bun'` command to avoid shell/runtime resolution issues.
- Updated security pool creation guard messaging and removed obsolete manual-load callback plumbing from `SecurityPoolSection` and related types.
- Ensured security pool question preview always shows for pasted/entered IDs and aligned missing-context notices behavior for immutable market views.
- Updated copy/validation messaging around placeholder/eligible question constraints and security pool workflow wording.
- Expanded tests for: script artifact expectations, watch-build Bun literal regression, security pool auto-load behavior, updated security pool and question section copy, and disabled-creation reasons.

## Testing
- Not run in this PR generation context.
- Relevant checks from the provided patch to run:
  - `bun run tsc`
  - `bun run check`
  - `bun run format`
  - `bun run test:run -- --bail=1` (or targeted tests for modified suites)
  - `bun run knip`
- Added/updated unit tests in:
  - `scripts/ensure-contract-artifacts.test.ts`
  - `ui/build/sharedAssets.test.ts`
  - `ui/ts/tests/marketCreateQuestionSection.test.tsx`
  - `ui/ts/tests/marketSection.test.tsx`
  - `ui/ts/tests/securityPoolCreationGuards.test.ts`
  - `ui/ts/tests/securityPoolSection.test.tsx`
  - `ui/ts/tests/useSecurityPoolCreation.test.tsx`