### PR TITLE
Refresh simulation context state on environment changes

### DIFF
--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -24,7 +24,7 @@ import { useRepPrices } from './hooks/useRepPrices.js'
 import { useSecurityVaultOperations } from './hooks/useSecurityVaultOperations.js'
 import { useTradingOperations } from './hooks/useTradingOperations.js'
 import { useUrlState } from './hooks/useUrlState.js'
-import { getActiveSimulationController } from './lib/activeEnvironment.js'
+import { getActiveSimulationController, initializeActiveEnvironment } from './lib/activeEnvironment.js'
 import { getAppPageTitle } from './lib/appPageTitle.js'
 import { ChainBlockNumberContext, ChainTimestampContext } from './lib/chainTimestamp.js'
 import { getDeploymentSections } from './lib/deployment.js'
@@ -47,6 +47,7 @@ import type { DeploymentRouteContentProps, GlobalTransactionPresentation, Market
 export function App() {
 	const transactionState = useSignal<TransactionTrayState>(createInitialTransactionTrayState())
 	const deployNextMissingPending = useSignal(false)
+	const [activeEnvironmentNonce, setActiveEnvironmentNonce] = useState(0)
 	const [selectedPoolRefreshNonce, setSelectedPoolRefreshNonce] = useState(0)
 	const { activeUniverseId, openOracleReportId: urlOpenOracleReportId, openOracleView, securityPoolsView, securityPoolAddress, selectedPoolView, setActiveUniverseId, setOpenOracleReport, setOpenOracleView, setSecurityPoolsView, setSecurityPoolAddress, setSelectedPoolView, setZoltarView, zoltarView } = useUrlState()
 	const activeZoltarView = resolveEnumValue<ZoltarView>(zoltarView, 'questions', ['questions', 'create', 'fork', 'migrate'])
@@ -88,7 +89,7 @@ export function App() {
 		refreshState,
 		setDeploymentStatuses,
 		walletBootstrapComplete,
-	} = useOnchainState()
+	} = useOnchainState({ activeEnvironmentNonce })
 	const readBackendReady = readBackendMessage === undefined
 	const canReadOnchainData = environmentReady && readBackendReady
 	const baseHookConfig = {
@@ -145,7 +146,7 @@ export function App() {
 		zoltarQuestions,
 		zoltarUniverse,
 		zoltarUniverseMissing,
-	} = useMarketCreation({ ...baseHookConfig, activeUniverseId, activeZoltarView, autoLoadInitialData: walletBootstrapComplete && canReadOnchainData, deploymentStatuses })
+	} = useMarketCreation({ ...baseHookConfig, activeUniverseId, activeZoltarView, autoLoadInitialData: walletBootstrapComplete && canReadOnchainData, deploymentStatuses, environmentRefreshKey: activeEnvironmentNonce })
 	const zoltarUniverseHasForked = zoltarUniverse?.hasForked === true
 	const { checkingDuplicateOriginPool, createPool, duplicateOriginPoolExists, loadMarket, loadMarketById, loadingMarketDetails, marketDetails, poolCreationMarketDetails, resetSecurityPoolCreation, securityPoolCreating, securityPoolError, securityPoolForm, securityPoolResult, setSecurityPoolForm } =
 		useSecurityPoolCreation({
@@ -266,6 +267,12 @@ export function App() {
 		await refreshState()
 		refreshRepPrices()
 	}
+	const refreshActiveEnvironment = async () => {
+		await initializeActiveEnvironment()
+		setActiveEnvironmentNonce(currentNonce => currentNonce + 1)
+		setSelectedPoolRefreshNonce(currentNonce => currentNonce + 1)
+		await refreshSimulationView()
+	}
 	const lastSecurityVaultRepRefreshHash = useRef<string | undefined>(undefined)
 	const lastStagedVaultRepRefreshHash = useRef<string | undefined>(undefined)
 	const deploymentSections = getDeploymentSections(deploymentStatuses)
@@ -383,6 +390,7 @@ export function App() {
 		accountAddress: accountState.address,
 		augurPlaceHolderDeploymentMissing,
 		environmentReady: canReadOnchainData,
+		activeEnvironmentNonce,
 		loadOracleReport: async reportId => await loadOracleReport(reportId),
 		loadSecurityPools: async requestedSecurityPoolAddress => await loadSecurityPools(requestedSecurityPoolAddress),
 		navigate,
@@ -417,6 +425,7 @@ export function App() {
 		accountState,
 		activeUniverseId,
 		activeView: activeZoltarView,
+		environmentRefreshKey: activeEnvironmentNonce,
 		hasLoadedZoltarQuestions,
 		loadingZoltarForkAccess,
 		zoltarForkActiveAction,
@@ -491,6 +500,7 @@ export function App() {
 			accountState,
 			checkedSecurityPoolAddress,
 			closeLiquidationModal: () => closeLiquidationModal(),
+			environmentRefreshKey: activeEnvironmentNonce,
 			hasLoadedSecurityPools,
 			hasLoadedSecurityPoolPage,
 			liquidationAmount,
@@ -754,7 +764,7 @@ export function App() {
 							wrongNetworkMessage={wrongNetworkMessage}
 							zoltarUniverse={zoltarUniverse}
 						/>
-						<AppHeaderShell overview={overviewProps} simulationController={simulationController} subNavigation={routeSubNavigation} tabNavigation={tabNavigationProps} onRefresh={refreshSimulationView} />
+						<AppHeaderShell overview={overviewProps} simulationController={simulationController} subNavigation={routeSubNavigation} tabNavigation={tabNavigationProps} onEnvironmentChanged={refreshActiveEnvironment} onRefresh={refreshSimulationView} />
 						<GlobalTransactionTray transaction={transactionState.value.active} />
 
 						<div id='app-content' tabIndex={-1}>

--- a/ui/ts/components/AppHeaderShell.tsx
+++ b/ui/ts/components/AppHeaderShell.tsx
@@ -10,10 +10,11 @@ type AppHeaderShellProps = {
 	simulationController: SimulationController | undefined
 	subNavigation?: ComponentChildren
 	tabNavigation: TabNavigationProps
+	onEnvironmentChanged?: () => Promise<void>
 	onRefresh: () => Promise<void>
 }
 
-export function AppHeaderShell({ overview, simulationController, subNavigation, tabNavigation, onRefresh }: AppHeaderShellProps) {
+export function AppHeaderShell({ overview, simulationController, subNavigation, tabNavigation, onEnvironmentChanged = async () => undefined, onRefresh }: AppHeaderShellProps) {
 	const focusAppContent = () => {
 		const appContent = document.getElementById('app-content')
 		if (appContent instanceof HTMLElement) appContent.focus()
@@ -26,7 +27,7 @@ export function AppHeaderShell({ overview, simulationController, subNavigation, 
 					Skip simulation controls
 				</button>
 			)}
-			{simulationController === undefined ? undefined : <SimulationBanner controller={simulationController} onRefresh={onRefresh} />}
+			{simulationController === undefined ? undefined : <SimulationBanner controller={simulationController} onEnvironmentChanged={onEnvironmentChanged} onRefresh={onRefresh} />}
 			<div className='top-shell'>
 				<div className='top-shell-content'>
 					<OverviewPanels {...overview} />

--- a/ui/ts/components/MarketQuestionsSection.tsx
+++ b/ui/ts/components/MarketQuestionsSection.tsx
@@ -13,6 +13,7 @@ function isCurrentQuestionPage(page: MarketDetailsPage | undefined, pageIndex: n
 }
 
 type MarketQuestionsSectionProps = {
+	environmentRefreshKey: number
 	hasForked: boolean
 	loadingZoltarQuestionCount: boolean
 	loadingZoltarQuestions: boolean
@@ -24,13 +25,14 @@ type MarketQuestionsSectionProps = {
 	zoltarQuestionCount: bigint | undefined
 	zoltarQuestionPage: MarketDetailsPage | undefined
 }
-export function MarketQuestionsSection({ hasForked, loadingZoltarQuestionCount, loadingZoltarQuestions, onCreateQuestion, onLoadZoltarQuestionPage, onOpenForkTab, onUseQuestionForFork, onUseQuestionForPool, zoltarQuestionCount, zoltarQuestionPage }: MarketQuestionsSectionProps) {
+export function MarketQuestionsSection({ environmentRefreshKey, hasForked, loadingZoltarQuestionCount, loadingZoltarQuestions, onCreateQuestion, onLoadZoltarQuestionPage, onOpenForkTab, onUseQuestionForFork, onUseQuestionForPool, zoltarQuestionCount, zoltarQuestionPage }: MarketQuestionsSectionProps) {
 	const noQuestionsAvailable = zoltarQuestionCount === 0n
 	const [pageIndex, setPageIndex] = useState(0)
 	const [activePageRequestKey, setActivePageRequestKey] = useState<string | undefined>(undefined)
 	const [lastFailedPageRequestKey, setLastFailedPageRequestKey] = useState<string | undefined>(undefined)
+	const lastSeenEnvironmentRefreshKeyRef = useRef(environmentRefreshKey)
 	const lastRequestedPageKeyRef = useRef<string | undefined>(undefined)
-	const currentPageRequestKey = `${pageIndex}:${QUESTION_PAGE_SIZE}:${zoltarQuestionCount?.toString() ?? 'unknown'}`
+	const currentPageRequestKey = `${environmentRefreshKey}:${pageIndex}:${QUESTION_PAGE_SIZE}:${zoltarQuestionCount?.toString() ?? 'unknown'}`
 	const hasCurrentPageData = isCurrentQuestionPage(zoltarQuestionPage, pageIndex, zoltarQuestionCount)
 	const effectiveQuestionCount = zoltarQuestionPage?.questionCount ?? zoltarQuestionCount
 	const questionPageCount = getPaginationPageCount(effectiveQuestionCount, QUESTION_PAGE_SIZE)
@@ -46,9 +48,10 @@ export function MarketQuestionsSection({ hasForked, loadingZoltarQuestionCount, 
 	useEffect(() => {
 		if (loadingZoltarQuestionCount) return
 		if (zoltarQuestionCount === undefined || zoltarQuestionCount === 0n) return
-		const pageRequestKey = `${pageIndex}:${QUESTION_PAGE_SIZE}:${zoltarQuestionCount.toString()}`
+		const pageRequestKey = `${environmentRefreshKey}:${pageIndex}:${QUESTION_PAGE_SIZE}:${zoltarQuestionCount.toString()}`
+		const environmentChanged = lastSeenEnvironmentRefreshKeyRef.current !== environmentRefreshKey
 		const hasCurrentPageData = isCurrentQuestionPage(zoltarQuestionPage, pageIndex, zoltarQuestionCount)
-		if (hasCurrentPageData) {
+		if (hasCurrentPageData && !environmentChanged) {
 			if (lastFailedPageRequestKey === pageRequestKey) setLastFailedPageRequestKey(undefined)
 			if (activePageRequestKey === pageRequestKey) setActivePageRequestKey(undefined)
 			return
@@ -57,6 +60,7 @@ export function MarketQuestionsSection({ hasForked, loadingZoltarQuestionCount, 
 		if (activePageRequestKey === pageRequestKey) return
 		if (lastRequestedPageKeyRef.current === pageRequestKey) return
 		lastRequestedPageKeyRef.current = pageRequestKey
+		lastSeenEnvironmentRefreshKeyRef.current = environmentRefreshKey
 		setActivePageRequestKey(pageRequestKey)
 		void Promise.resolve(onLoadZoltarQuestionPage(pageIndex, QUESTION_PAGE_SIZE))
 			.catch(() => {
@@ -65,7 +69,7 @@ export function MarketQuestionsSection({ hasForked, loadingZoltarQuestionCount, 
 			.finally(() => {
 				setActivePageRequestKey(current => (current === pageRequestKey ? undefined : current))
 			})
-	}, [activePageRequestKey, lastFailedPageRequestKey, loadingZoltarQuestionCount, onLoadZoltarQuestionPage, pageIndex, zoltarQuestionCount, zoltarQuestionPage])
+	}, [activePageRequestKey, environmentRefreshKey, lastFailedPageRequestKey, loadingZoltarQuestionCount, onLoadZoltarQuestionPage, pageIndex, zoltarQuestionCount, zoltarQuestionPage])
 	const hasPreviousPage = pageIndex > 0
 	const hasNextPage = getHasNextPaginationPage(pageIndex, questionPageCount)
 	return (

--- a/ui/ts/components/MarketSection.tsx
+++ b/ui/ts/components/MarketSection.tsx
@@ -13,6 +13,7 @@ import type { MarketSectionProps } from '../types/components.js'
 export function MarketSection({
 	accountState,
 	activeView,
+	environmentRefreshKey,
 	hasLoadedZoltarQuestions,
 	loadingZoltarForkAccess,
 	zoltarForkActiveAction,
@@ -114,6 +115,7 @@ export function MarketSection({
 							</SectionBlock>
 						) : undefined}
 						<MarketQuestionsSection
+							environmentRefreshKey={environmentRefreshKey}
 							hasForked={hasForked}
 							onCreateQuestion={() => onActiveViewChange('create')}
 							onLoadZoltarQuestionPage={onLoadZoltarQuestionPage}

--- a/ui/ts/components/SecurityPoolsOverviewSection.tsx
+++ b/ui/ts/components/SecurityPoolsOverviewSection.tsx
@@ -67,6 +67,7 @@ function getSecurityPoolGuidance({ hasKnownForkActivity, lifecycleState, questio
 export function SecurityPoolsOverviewSection({
 	accountState,
 	closeLiquidationModal,
+	environmentRefreshKey,
 	hasLoadedSecurityPoolPage,
 	liquidationAmount,
 	liquidationMaxAmount,
@@ -107,7 +108,7 @@ export function SecurityPoolsOverviewSection({
 	const effectivePoolCount = securityPoolPage?.poolCount ?? securityPoolBrowseCount
 	const poolPageCount = getPaginationPageCount(effectivePoolCount, SECURITY_POOL_PAGE_SIZE)
 	const resolvedPageIndex = resolvePaginationPageIndex(pageIndex, poolPageCount)
-	const currentPageRequestKey = `${resolvedPageIndex}:${SECURITY_POOL_PAGE_SIZE}`
+	const currentPageRequestKey = `${environmentRefreshKey}:${resolvedPageIndex}:${SECURITY_POOL_PAGE_SIZE}`
 	const hasCurrentPageData = securityPoolPage?.pageIndex === resolvedPageIndex && securityPoolPage.pageSize === SECURITY_POOL_PAGE_SIZE
 	const pagedSecurityPools = hasCurrentPageData ? securityPoolPage.pools : []
 	const isWaitingForPageData = activePageRequestKey === currentPageRequestKey
@@ -159,7 +160,7 @@ export function SecurityPoolsOverviewSection({
 		return () => {
 			cancelled = true
 		}
-	}, [currentPageRequestKey, resolvedPageIndex])
+	}, [currentPageRequestKey, environmentRefreshKey, resolvedPageIndex])
 	const filteredSecurityPools = securityPoolsWithState.filter(({ pool, poolState }) => {
 		const displayState = poolState.lifecycleState
 		if (systemStateFilter !== 'all' && displayState !== systemStateFilter) return false

--- a/ui/ts/components/SimulationBanner.tsx
+++ b/ui/ts/components/SimulationBanner.tsx
@@ -24,6 +24,7 @@ const SIMULATION_TIME_PRESETS = [
 const SIMULATION_REP_MINT_AMOUNT = 1_000_000n * 10n ** 18n
 type SimulationBannerProps = {
 	controller: SimulationController
+	onEnvironmentChanged?: () => Promise<void>
 	onRefresh: () => Promise<void>
 }
 
@@ -39,7 +40,7 @@ function buildSimulationSearch(update: (params: URLSearchParams) => void) {
 
 function navigateToSimulationSearch(nextSearch: string) {
 	window.history.pushState({}, '', buildRouteHref(getCurrentRouteHash(), nextSearch))
-	window.dispatchEvent(new PopStateEvent('popstate'))
+	window.dispatchEvent(new window.PopStateEvent('popstate'))
 }
 
 function navigateToBuiltInScenario(scenario: string) {
@@ -87,7 +88,7 @@ function getScenarioStatus(parameters: { bootstrapError: string | undefined; isB
 	}
 }
 
-export function SimulationBanner({ controller, onRefresh }: SimulationBannerProps) {
+export function SimulationBanner({ controller, onEnvironmentChanged = async () => undefined, onRefresh }: SimulationBannerProps) {
 	const { copied, copyText } = useCopyToClipboard()
 	const busy = useSignal(false)
 	const blockCountSinceReset = useSignal(controller.blockCountSinceReset)
@@ -185,10 +186,18 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 		}
 	}
 
+	const navigateAndRefreshEnvironment = async (navigate: () => void) => {
+		await runNavigationControl(async () => {
+			navigate()
+			await onEnvironmentChanged()
+		})
+	}
+
 	const persistAndNavigateToSavedState = async (serialized: string) => {
 		const record = persistSavedSimulationState(serialized, savedStateStorage)
 		reloadSavedStateRecords()
 		navigateToSavedSimulationState(record.id)
+		await onEnvironmentChanged()
 	}
 
 	const showExportModal = async () => {
@@ -250,10 +259,14 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 						onChange={event => {
 							const nextSelection = event.currentTarget.value
 							if (nextSelection.startsWith('saved:')) {
-								navigateToSavedSimulationState(nextSelection.slice('saved:'.length))
+								void navigateAndRefreshEnvironment(() => {
+									navigateToSavedSimulationState(nextSelection.slice('saved:'.length))
+								})
 								return
 							}
-							navigateToBuiltInScenario(nextSelection.slice('scenario:'.length))
+							void navigateAndRefreshEnvironment(() => {
+								navigateToBuiltInScenario(nextSelection.slice('scenario:'.length))
+							})
 						}}
 					>
 						<optgroup label='Built-in scenarios'>
@@ -564,8 +577,10 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 							void runNavigationControl(async () => {
 								if (currentSource.value.kind !== 'saved-state') return
 								if (!deleteSavedSimulationState(currentSource.value.stateId, savedStateStorage)) throw new Error(`Saved simulation state "${currentSource.value.name}" no longer exists`)
+								const baseScenario = currentSource.value.baseScenario
 								reloadSavedStateRecords()
-								navigateToBuiltInScenario(currentSource.value.baseScenario)
+								navigateToBuiltInScenario(baseScenario)
+								await onEnvironmentChanged()
 							})
 						}
 					>
@@ -590,6 +605,7 @@ export function SimulationBanner({ controller, onRefresh }: SimulationBannerProp
 								clearSavedStateStorageWarning()
 								if (hasSavedSimulationStateRoute()) {
 									navigateToBuiltInScenario(currentScenario.value)
+									await onEnvironmentChanged()
 									return
 								}
 							})

--- a/ui/ts/hooks/useAppRouteEffects.ts
+++ b/ui/ts/hooks/useAppRouteEffects.ts
@@ -7,6 +7,7 @@ type AppRoute = 'deploy' | 'not-found' | 'open-oracle' | 'security-pools' | 'zol
 type Props = {
 	accountAddress: Address | undefined
 	augurPlaceHolderDeploymentMissing: boolean
+	activeEnvironmentNonce: number
 	environmentReady: boolean
 	loadOracleReport: (reportId: string) => Promise<void>
 	loadSecurityPools: (securityPoolAddress?: string) => Promise<void>
@@ -64,6 +65,7 @@ export function getSelectedVaultAddressForRoutePoolChange({ accountAddress, last
 export function useAppRouteEffects({
 	accountAddress,
 	augurPlaceHolderDeploymentMissing,
+	activeEnvironmentNonce,
 	environmentReady,
 	loadOracleReport,
 	loadSecurityPools,
@@ -89,6 +91,7 @@ export function useAppRouteEffects({
 	const navigateRef = useRef(navigate)
 	const lastRequestedOpenOracleReportId = useRef<string | undefined>(undefined)
 	const lastRequestedSecurityPoolAddress = useRef<string | undefined>(undefined)
+	const lastSelectedPoolEnvironmentNonce = useRef<number | undefined>(undefined)
 	const lastSelectedSecurityPoolAddress = useRef<string | undefined>(undefined)
 
 	loadOracleReportRef.current = loadOracleReport
@@ -101,10 +104,11 @@ export function useAppRouteEffects({
 			lastRequestedOpenOracleReportId.current = undefined
 			return
 		}
-		if (lastRequestedOpenOracleReportId.current === urlOpenOracleReportId) return
-		lastRequestedOpenOracleReportId.current = urlOpenOracleReportId
+		const requestKey = `${activeEnvironmentNonce}:${urlOpenOracleReportId}`
+		if (lastRequestedOpenOracleReportId.current === requestKey) return
+		lastRequestedOpenOracleReportId.current = requestKey
 		void loadOracleReportRef.current(urlOpenOracleReportId)
-	}, [environmentReady, route, urlOpenOracleReportId])
+	}, [activeEnvironmentNonce, environmentReady, route, urlOpenOracleReportId])
 
 	useEffect(() => {
 		if (openOracleReportDetailsReportId !== undefined) {
@@ -142,7 +146,11 @@ export function useAppRouteEffects({
 	}, [accountAddress, route, securityPoolAddress, setSecurityVaultFormSelectedVaultAddress])
 
 	useEffect(() => {
+		const previousEnvironmentNonce = lastSelectedPoolEnvironmentNonce.current
+		if (previousEnvironmentNonce === undefined) lastSelectedPoolEnvironmentNonce.current = activeEnvironmentNonce
+		const selectedPoolEnvironmentChanged = previousEnvironmentNonce !== undefined && previousEnvironmentNonce !== activeEnvironmentNonce
 		if (
+			!selectedPoolEnvironmentChanged &&
 			!shouldRefreshSelectedPoolForRoute({
 				environmentReady,
 				route,
@@ -154,10 +162,13 @@ export function useAppRouteEffects({
 			if (route !== 'security-pools' || securityPoolAddress === '' || selectedPoolSecurityPoolAddress !== undefined || !environmentReady || !walletBootstrapComplete) lastRequestedSecurityPoolAddress.current = undefined
 			return
 		}
-		if (lastRequestedSecurityPoolAddress.current === securityPoolAddress) return
-		lastRequestedSecurityPoolAddress.current = securityPoolAddress
+		if (!environmentReady || route !== 'security-pools' || securityPoolAddress === '' || !walletBootstrapComplete) return
+		const requestKey = `${activeEnvironmentNonce}:${securityPoolAddress}`
+		if (lastRequestedSecurityPoolAddress.current === requestKey) return
+		lastRequestedSecurityPoolAddress.current = requestKey
+		lastSelectedPoolEnvironmentNonce.current = activeEnvironmentNonce
 		void loadSecurityPoolsRef.current(securityPoolAddress)
-	}, [environmentReady, route, securityPoolAddress, selectedPoolSecurityPoolAddress, walletBootstrapComplete])
+	}, [activeEnvironmentNonce, environmentReady, route, securityPoolAddress, selectedPoolSecurityPoolAddress, walletBootstrapComplete])
 
 	useEffect(() => {
 		if (!environmentReady) return

--- a/ui/ts/hooks/useMarketCreation.ts
+++ b/ui/ts/hooks/useMarketCreation.ts
@@ -19,6 +19,7 @@ type UseMarketCreationParameters = {
 	activeZoltarView: 'create' | 'fork' | 'migrate' | 'questions'
 	autoLoadInitialData: boolean
 	deploymentStatuses: DeploymentStatus[]
+	environmentRefreshKey: number
 	onTransactionFailed?: WriteOperationsParameters['onTransactionFailed']
 	onTransactionFinished: () => void
 	onTransactionPresented: WriteOperationsParameters['onTransactionPresented']
@@ -28,8 +29,22 @@ type UseMarketCreationParameters = {
 	refreshState: () => Promise<void>
 }
 
-export function useMarketCreation({ accountAddress, activeUniverseId, activeZoltarView, autoLoadInitialData, deploymentStatuses, onTransactionFailed, onTransactionFinished, onTransactionPresented, onTransactionPrepared, onTransactionRequested, onTransactionSubmitted, refreshState }: UseMarketCreationParameters) {
-	const zoltar = useZoltarOperations({ accountAddress, activeUniverseId, activeZoltarView, autoLoadInitialData, deploymentStatuses, onTransactionFailed, onTransactionFinished, onTransactionPresented, onTransactionPrepared, onTransactionRequested, onTransactionSubmitted, refreshState })
+export function useMarketCreation({
+	accountAddress,
+	activeUniverseId,
+	activeZoltarView,
+	autoLoadInitialData,
+	deploymentStatuses,
+	environmentRefreshKey,
+	onTransactionFailed,
+	onTransactionFinished,
+	onTransactionPresented,
+	onTransactionPrepared,
+	onTransactionRequested,
+	onTransactionSubmitted,
+	refreshState,
+}: UseMarketCreationParameters) {
+	const zoltar = useZoltarOperations({ accountAddress, activeUniverseId, activeZoltarView, autoLoadInitialData, deploymentStatuses, environmentRefreshKey, onTransactionFailed, onTransactionFinished, onTransactionPresented, onTransactionPrepared, onTransactionRequested, onTransactionSubmitted, refreshState })
 	const { state: marketForm, setState: setMarketForm } = useFormState<MarketFormState>(getDefaultMarketFormState())
 	const marketCreating = useSignal(false)
 	const marketResult = useSignal<MarketCreationResult | undefined>(undefined)

--- a/ui/ts/hooks/useOnchainState.ts
+++ b/ui/ts/hooks/useOnchainState.ts
@@ -16,6 +16,10 @@ type RefreshStateOptions = {
 	loadWalletState?: boolean
 }
 
+type UseOnchainStateOptions = {
+	activeEnvironmentNonce?: number
+}
+
 type ChainClock = {
 	currentBlockNumber: bigint | undefined
 	currentTimestamp: bigint | undefined
@@ -156,7 +160,7 @@ async function loadBackendChainClock(backend: ChainBackend): Promise<ChainClock>
 	}
 }
 
-export function useOnchainState() {
+export function useOnchainState({ activeEnvironmentNonce = 0 }: UseOnchainStateOptions = {}) {
 	const accountState = useSignal<AccountState>({
 		address: undefined,
 		chainId: undefined,
@@ -359,7 +363,7 @@ export function useOnchainState() {
 
 	useEffect(() => {
 		void refreshState()
-	}, [])
+	}, [activeEnvironmentNonce])
 
 	useEffect(() => {
 		const backend = getActiveBackend()
@@ -394,7 +398,7 @@ export function useOnchainState() {
 		return () => {
 			cancelled = true
 		}
-	}, [])
+	}, [activeEnvironmentNonce])
 
 	useEffect(() => {
 		const backend = getActiveBackend()
@@ -416,7 +420,7 @@ export function useOnchainState() {
 			unsubscribeAccounts()
 			unsubscribeState?.()
 		}
-	}, [])
+	}, [activeEnvironmentNonce])
 
 	useEffect(() => {
 		const backend = getActiveBackend()
@@ -432,7 +436,7 @@ export function useOnchainState() {
 		return () => {
 			window.clearInterval(intervalId)
 		}
-	}, [environmentReady.value, readBackendMessage.value, readBackendValidated.value])
+	}, [activeEnvironmentNonce, environmentReady.value, readBackendMessage.value, readBackendValidated.value])
 
 	return {
 		accountState: accountState.value,

--- a/ui/ts/hooks/useZoltarOperations.ts
+++ b/ui/ts/hooks/useZoltarOperations.ts
@@ -12,6 +12,7 @@ type UseZoltarOperationsParameters = {
 	activeZoltarView: 'create' | 'fork' | 'migrate' | 'questions'
 	autoLoadInitialData: boolean
 	deploymentStatuses: DeploymentStatus[]
+	environmentRefreshKey: number
 	onTransactionFailed?: WriteOperationsParameters['onTransactionFailed']
 	onTransactionFinished: () => void
 	onTransactionPresented: WriteOperationsParameters['onTransactionPresented']
@@ -21,8 +22,34 @@ type UseZoltarOperationsParameters = {
 	refreshState: () => Promise<void>
 }
 
-export function useZoltarOperations({ accountAddress, activeUniverseId, activeZoltarView, autoLoadInitialData, deploymentStatuses, onTransactionFailed, onTransactionFinished, onTransactionPresented, onTransactionPrepared, onTransactionRequested, onTransactionSubmitted, refreshState }: UseZoltarOperationsParameters) {
-	const { createChildUniverse: createUniverseChildUniverse, ...universe } = useZoltarUniverse({ accountAddress, activeUniverseId, autoLoadInitialData, deploymentStatuses, onTransactionFailed, onTransactionFinished, onTransactionPresented, onTransactionPrepared, onTransactionRequested, onTransactionSubmitted })
+export function useZoltarOperations({
+	accountAddress,
+	activeUniverseId,
+	activeZoltarView,
+	autoLoadInitialData,
+	deploymentStatuses,
+	environmentRefreshKey,
+	onTransactionFailed,
+	onTransactionFinished,
+	onTransactionPresented,
+	onTransactionPrepared,
+	onTransactionRequested,
+	onTransactionSubmitted,
+	refreshState,
+}: UseZoltarOperationsParameters) {
+	const { createChildUniverse: createUniverseChildUniverse, ...universe } = useZoltarUniverse({
+		accountAddress,
+		activeUniverseId,
+		autoLoadInitialData,
+		deploymentStatuses,
+		environmentRefreshKey,
+		onTransactionFailed,
+		onTransactionFinished,
+		onTransactionPresented,
+		onTransactionPrepared,
+		onTransactionRequested,
+		onTransactionSubmitted,
+	})
 	const refreshZoltarUniverse = useCallback(async () => {
 		await universe.refreshZoltarUniverse()
 	}, [universe.refreshZoltarUniverse])

--- a/ui/ts/hooks/useZoltarUniverse.ts
+++ b/ui/ts/hooks/useZoltarUniverse.ts
@@ -37,6 +37,7 @@ type UseZoltarUniverseParameters = {
 	activeUniverseId: bigint
 	autoLoadInitialData: boolean
 	deploymentStatuses: DeploymentStatus[]
+	environmentRefreshKey: number
 	onTransactionFailed?: WriteOperationsParameters['onTransactionFailed']
 	onTransactionFinished: () => void
 	onTransactionPresented: WriteOperationsParameters['onTransactionPresented']
@@ -45,7 +46,7 @@ type UseZoltarUniverseParameters = {
 	onTransactionSubmitted: (hash: Hash) => void
 }
 
-export function useZoltarUniverse({ accountAddress, activeUniverseId, autoLoadInitialData, deploymentStatuses, onTransactionFailed, onTransactionFinished, onTransactionPresented, onTransactionPrepared, onTransactionRequested, onTransactionSubmitted }: UseZoltarUniverseParameters) {
+export function useZoltarUniverse({ accountAddress, activeUniverseId, autoLoadInitialData, deploymentStatuses, environmentRefreshKey, onTransactionFailed, onTransactionFinished, onTransactionPresented, onTransactionPrepared, onTransactionRequested, onTransactionSubmitted }: UseZoltarUniverseParameters) {
 	const universeLoad = useLoadController()
 	const questionCountLoad = useLoadController()
 	const questionsLoad = useLoadController()
@@ -61,11 +62,15 @@ export function useZoltarUniverse({ accountAddress, activeUniverseId, autoLoadIn
 	const zoltarChildUniverseFeedback = useSignal<ActionFeedback<'createChildUniverse'> | undefined>(undefined)
 	const zoltarChildUniversePendingOutcomeIndex = useSignal<bigint | undefined>(undefined)
 	const isMounted = useRef(true)
+	const currentEnvironmentRefreshKeyRef = useRef(environmentRefreshKey)
+	const questionLoadGenerationRef = useRef(0)
 	const nextUniverseLoad = useRequestGuard()
 	const nextQuestionCountLoad = useRequestGuard()
 	const nextQuestionsLoad = useRequestGuard()
+	currentEnvironmentRefreshKeyRef.current = environmentRefreshKey
 
 	const resetZoltarUniverseState = () => {
+		questionLoadGenerationRef.current += 1
 		zoltarUniverseMissing.value = false
 		zoltarUniverse.value = undefined
 		zoltarUniverseLoadedId.value = undefined
@@ -77,6 +82,7 @@ export function useZoltarUniverse({ accountAddress, activeUniverseId, autoLoadIn
 		zoltarQuestionPage.value = undefined
 		zoltarQuestions.value = []
 	}
+	const isCurrentQuestionLoad = (generation: number, refreshKey: number) => questionLoadGenerationRef.current === generation && currentEnvironmentRefreshKeyRef.current === refreshKey
 
 	const ensureZoltarUniverse = async (): Promise<ZoltarUniverseSummary> => {
 		if (zoltarUniverse.value !== undefined && zoltarUniverseLoadedId.value === activeUniverseId) return zoltarUniverse.value
@@ -128,12 +134,15 @@ export function useZoltarUniverse({ accountAddress, activeUniverseId, autoLoadIn
 
 	const loadZoltarQuestionCountData = async () => {
 		if (!isMounted.current) return
+		const questionLoadGeneration = questionLoadGenerationRef.current
+		const questionLoadRefreshKey = environmentRefreshKey
 		const isCurrent = nextQuestionCountLoad()
 		await questionCountLoad.run({
 			isCurrent,
 			load: async () => await loadZoltarQuestionCount(createConnectedReadClient()),
 			onSuccess: questionCount => {
 				if (!isMounted.current) return
+				if (!isCurrentQuestionLoad(questionLoadGeneration, questionLoadRefreshKey)) return
 				zoltarQuestionCount.value = questionCount
 			},
 			onError: () => undefined,
@@ -144,6 +153,8 @@ export function useZoltarUniverse({ accountAddress, activeUniverseId, autoLoadIn
 		if (!isMounted.current) return
 		const isCountCurrent = nextQuestionCountLoad()
 		const isQuestionsCurrent = nextQuestionsLoad()
+		const questionLoadGeneration = questionLoadGenerationRef.current
+		const questionLoadRefreshKey = environmentRefreshKey
 		const readClient = createConnectedReadClient()
 		let loadError: unknown
 
@@ -152,6 +163,7 @@ export function useZoltarUniverse({ accountAddress, activeUniverseId, autoLoadIn
 			load: async () => await loadZoltarQuestionCount(readClient),
 			onSuccess: questionCount => {
 				if (!isMounted.current) return
+				if (!isCurrentQuestionLoad(questionLoadGeneration, questionLoadRefreshKey)) return
 				zoltarQuestionCount.value = questionCount
 			},
 			onError: error => {
@@ -164,6 +176,7 @@ export function useZoltarUniverse({ accountAddress, activeUniverseId, autoLoadIn
 			load: async () => await loadAllZoltarQuestions(readClient),
 			onSuccess: questions => {
 				if (!isMounted.current) return
+				if (!isCurrentQuestionLoad(questionLoadGeneration, questionLoadRefreshKey)) return
 				zoltarQuestions.value = questions
 				hasLoadedZoltarQuestions.value = true
 				const currentQuestionPage = zoltarQuestionPage.value
@@ -184,6 +197,8 @@ export function useZoltarUniverse({ accountAddress, activeUniverseId, autoLoadIn
 		if (!isMounted.current) return
 		const isCountCurrent = nextQuestionCountLoad()
 		const isQuestionsCurrent = nextQuestionsLoad()
+		const questionLoadGeneration = questionLoadGenerationRef.current
+		const questionLoadRefreshKey = environmentRefreshKey
 		const readClient = createConnectedReadClient()
 		let loadError: unknown
 
@@ -192,6 +207,7 @@ export function useZoltarUniverse({ accountAddress, activeUniverseId, autoLoadIn
 			load: async () => await loadZoltarQuestionCount(readClient),
 			onSuccess: questionCount => {
 				if (!isMounted.current) return
+				if (!isCurrentQuestionLoad(questionLoadGeneration, questionLoadRefreshKey)) return
 				zoltarQuestionCount.value = questionCount
 			},
 			onError: error => {
@@ -204,6 +220,7 @@ export function useZoltarUniverse({ accountAddress, activeUniverseId, autoLoadIn
 			load: async () => await loadZoltarQuestionPage(readClient, pageIndex, pageSize),
 			onSuccess: page => {
 				if (!isMounted.current) return
+				if (!isCurrentQuestionLoad(questionLoadGeneration, questionLoadRefreshKey)) return
 				zoltarQuestionPage.value = page
 				zoltarQuestions.value = mergeQuestionLists(zoltarQuestions.value, page.questions)
 			},
@@ -275,7 +292,7 @@ export function useZoltarUniverse({ accountAddress, activeUniverseId, autoLoadIn
 	useLayoutEffect(() => {
 		if (!autoLoadInitialData) return
 		void Promise.allSettled([loadZoltarUniverse(), loadZoltarQuestionCountData()])
-	}, [activeUniverseId, autoLoadInitialData, zoltarDeployed])
+	}, [activeUniverseId, autoLoadInitialData, environmentRefreshKey, zoltarDeployed])
 
 	useLayoutEffect(() => {
 		return () => {

--- a/ui/ts/tests/appRouteEffects.integration.test.tsx
+++ b/ui/ts/tests/appRouteEffects.integration.test.tsx
@@ -14,6 +14,7 @@ type RouteEffectsProps = Parameters<typeof useAppRouteEffects>[0]
 function createDefaultProps(overrides: Partial<RouteEffectsProps> = {}): RouteEffectsProps {
 	return {
 		accountAddress: undefined,
+		activeEnvironmentNonce: 0,
 		augurPlaceHolderDeploymentMissing: false,
 		environmentReady: true,
 		loadOracleReport: async () => undefined,
@@ -99,6 +100,69 @@ describe('app route effects integration', () => {
 		expect(calls).toEqual(['1'])
 		await cleanup()
 		dom.cleanup()
+	})
+
+	test('reloads route data after the active environment nonce changes', async () => {
+		const dom = installDomEnvironment()
+		const securityPoolCalls: string[] = []
+		const initialProps = createDefaultProps({
+			environmentReady: true,
+			loadSecurityPools: async securityPoolAddress => {
+				securityPoolCalls.push(securityPoolAddress ?? '')
+			},
+			route: 'security-pools',
+			securityPoolAddress: '0x84834d4Dccea071b363e53952BD300F7bf56a009',
+			selectedPoolSecurityPoolAddress: undefined,
+			walletBootstrapComplete: true,
+		})
+
+		try {
+			const rendered = await renderIntoDocument(<RouteEffectsHarness {...initialProps} />)
+			await act(() => Promise.resolve())
+			expect(securityPoolCalls).toEqual(['0x84834d4Dccea071b363e53952BD300F7bf56a009'])
+
+			await act(() => {
+				render(<RouteEffectsHarness {...initialProps} activeEnvironmentNonce={1} />, rendered.container)
+			})
+			await act(() => Promise.resolve())
+			expect(securityPoolCalls).toEqual(['0x84834d4Dccea071b363e53952BD300F7bf56a009', '0x84834d4Dccea071b363e53952BD300F7bf56a009'])
+
+			await rendered.cleanup()
+		} finally {
+			dom.cleanup()
+		}
+	})
+
+	test('reloads a selected security pool after the active environment nonce changes', async () => {
+		const dom = installDomEnvironment()
+		const securityPoolCalls: string[] = []
+		const securityPoolAddress = '0x84834d4Dccea071b363e53952BD300F7bf56a009'
+		const initialProps = createDefaultProps({
+			environmentReady: true,
+			loadSecurityPools: async nextSecurityPoolAddress => {
+				securityPoolCalls.push(nextSecurityPoolAddress ?? '')
+			},
+			route: 'security-pools',
+			securityPoolAddress,
+			selectedPoolSecurityPoolAddress: securityPoolAddress,
+			walletBootstrapComplete: true,
+		})
+
+		try {
+			const rendered = await renderIntoDocument(<RouteEffectsHarness {...initialProps} />)
+			await act(() => Promise.resolve())
+			expect(securityPoolCalls).toEqual([])
+
+			await act(() => {
+				render(<RouteEffectsHarness {...initialProps} activeEnvironmentNonce={1} />, rendered.container)
+			})
+			await act(() => Promise.resolve())
+			expect(securityPoolCalls).toEqual([securityPoolAddress])
+
+			await rendered.cleanup()
+		} finally {
+			dom.cleanup()
+		}
 	})
 
 	test('does not repeatedly reload the same unresolved security pool across rerenders', async () => {

--- a/ui/ts/tests/marketSection.test.tsx
+++ b/ui/ts/tests/marketSection.test.tsx
@@ -1,6 +1,6 @@
 /// <reference types="bun-types" />
 
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import { fireEvent, waitFor, within } from './testUtils/queries'
 import { h } from 'preact'
 import { render } from 'preact'
@@ -74,6 +74,7 @@ function createMarketSectionProps(overrides: Partial<MarketSectionProps> = {}): 
 		accountState: createAccountState(),
 		activeUniverseId: 1n,
 		activeView: 'questions',
+		environmentRefreshKey: 0,
 		hasLoadedZoltarQuestions: false,
 		loadingZoltarForkAccess: false,
 		zoltarForkActiveAction: undefined,
@@ -280,6 +281,33 @@ describe('MarketSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		expect(calls).toEqual([])
+	})
+
+	test('reloads loaded questions when the environment refresh key changes', async () => {
+		const onLoadZoltarQuestionPage = mock(async () => undefined)
+		const initialProps = createMarketSectionProps({
+			onLoadZoltarQuestionPage,
+			zoltarQuestionCount: 1n,
+			zoltarQuestionPage: {
+				pageIndex: 0,
+				pageSize: 10,
+				questionCount: 1n,
+				questions: [createBinaryForkQuestion()],
+			},
+		})
+		const renderedComponent = await renderIntoDocument(h(MarketSection, initialProps))
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(onLoadZoltarQuestionPage).not.toHaveBeenCalled()
+
+		await act(() => {
+			render(h(MarketSection, { ...initialProps, environmentRefreshKey: 1 }), renderedComponent.container)
+		})
+
+		await waitFor(() => {
+			expect(onLoadZoltarQuestionPage).toHaveBeenCalledTimes(1)
+			expect(onLoadZoltarQuestionPage).toHaveBeenCalledWith(0, 10)
+		})
 	})
 
 	test('auto-loads questions once after the count resolves above zero even when the universe is unresolved', async () => {

--- a/ui/ts/tests/securityPoolsOverviewSection.test.tsx
+++ b/ui/ts/tests/securityPoolsOverviewSection.test.tsx
@@ -1,6 +1,6 @@
 /// <reference types="bun-types" />
 
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import { fireEvent, waitFor, within } from './testUtils/queries'
 import { render } from 'preact'
 import { SecurityPoolsOverviewSection } from '../components/SecurityPoolsOverviewSection.js'
@@ -100,6 +100,7 @@ function createProps(overrides: Partial<SecurityPoolsOverviewSectionProps> = {})
 	return {
 		accountState: createAccountState(),
 		checkedSecurityPoolAddress: undefined,
+		environmentRefreshKey: 0,
 		closeLiquidationModal: () => undefined,
 		hasLoadedSecurityPools: true,
 		hasLoadedSecurityPoolPage: true,
@@ -188,6 +189,40 @@ describe('SecurityPoolsOverviewSection', () => {
 		expect(documentQueries.queryByRole('heading', { name: 'Liquidation Submitted' })).toBeNull()
 		expect(documentQueries.queryByText('Check State')).toBeNull()
 		expect(documentQueries.queryByText('0x1234000000000000000000000000000000000000000000000000000000000000')).toBeNull()
+	})
+
+	test('reloads the current browse page when the environment refresh key changes', async () => {
+		const onLoadSecurityPoolPage = mock(() => undefined)
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolsOverviewSection
+				{...createProps({
+					environmentRefreshKey: 0,
+					onLoadSecurityPoolPage,
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await waitFor(() => {
+			expect(onLoadSecurityPoolPage).toHaveBeenCalledTimes(1)
+		})
+
+		await act(() => {
+			render(
+				<SecurityPoolsOverviewSection
+					{...createProps({
+						environmentRefreshKey: 1,
+						onLoadSecurityPoolPage,
+					})}
+				/>,
+				renderedComponent.container,
+			)
+		})
+
+		await waitFor(() => {
+			expect(onLoadSecurityPoolPage).toHaveBeenCalledTimes(2)
+			expect(onLoadSecurityPoolPage).toHaveBeenLastCalledWith(0, 6)
+		})
 	})
 
 	test('keeps pool-list load errors inline instead of opening liquidation', async () => {

--- a/ui/ts/tests/securityPoolsSection.test.ts
+++ b/ui/ts/tests/securityPoolsSection.test.ts
@@ -305,6 +305,7 @@ function createOverviewProps(overrides: Partial<SecurityPoolsOverviewRouteConten
 		accountState: createAccountState(),
 		checkedSecurityPoolAddress: undefined,
 		closeLiquidationModal: () => undefined,
+		environmentRefreshKey: 0,
 		hasLoadedSecurityPools: false,
 		hasLoadedSecurityPoolPage: securityPoolPage !== undefined,
 		liquidationAmount: '',

--- a/ui/ts/tests/simulationBanner.test.tsx
+++ b/ui/ts/tests/simulationBanner.test.tsx
@@ -83,6 +83,12 @@ function openAdvancedControls(container: Element): HTMLElement {
 	return details
 }
 
+function getElementValue(element: Element) {
+	if (!('value' in element)) return undefined
+	const value = element.value
+	return typeof value === 'string' ? value : undefined
+}
+
 describe('SimulationBanner', () => {
 	test('shows the selected scenario description', async () => {
 		const domEnvironment = installDomEnvironment()
@@ -372,8 +378,9 @@ describe('SimulationBanner', () => {
 			]),
 		)
 		const onRefresh = mock(async () => undefined)
+		const onEnvironmentChanged = mock(async () => undefined)
 		const controller = createSimulationController()
-		const renderedComponent = await renderIntoDocument(<SimulationBanner controller={controller} onRefresh={onRefresh} />)
+		const renderedComponent = await renderIntoDocument(<SimulationBanner controller={controller} onEnvironmentChanged={onEnvironmentChanged} onRefresh={onRefresh} />)
 
 		try {
 			const documentQueries = within(renderedComponent.container)
@@ -386,6 +393,7 @@ describe('SimulationBanner', () => {
 				expect(domEnvironment.window.localStorage.getItem('zoltar.simulation.savedStates')).not.toContain('{bad json')
 				expect(domEnvironment.window.location.hash).toContain('simScenario=baseline')
 				expect(domEnvironment.window.location.hash).not.toContain('simState=')
+				expect(onEnvironmentChanged).toHaveBeenCalledTimes(1)
 			})
 		} finally {
 			await renderedComponent.cleanup()
@@ -396,8 +404,9 @@ describe('SimulationBanner', () => {
 	test('imports a saved state and navigates to its saved-state URL', async () => {
 		const domEnvironment = installDomEnvironment()
 		const onRefresh = mock(async () => undefined)
+		const onEnvironmentChanged = mock(async () => undefined)
 		const controller = createSimulationController()
-		const renderedComponent = await renderIntoDocument(<SimulationBanner controller={controller} onRefresh={onRefresh} />)
+		const renderedComponent = await renderIntoDocument(<SimulationBanner controller={controller} onEnvironmentChanged={onEnvironmentChanged} onRefresh={onRefresh} />)
 		const importedState = serializeSavedSimulationStateEnvelope({
 			baseScenario: 'baseline',
 			name: 'Imported state',
@@ -431,6 +440,37 @@ describe('SimulationBanner', () => {
 
 			await waitFor(() => {
 				expect(domEnvironment.window.location.hash).toContain('simState=imported-state-20260602123456')
+				expect(onEnvironmentChanged).toHaveBeenCalledTimes(1)
+			})
+		} finally {
+			await renderedComponent.cleanup()
+			domEnvironment.cleanup()
+		}
+	})
+
+	test('saves a simulation state and refreshes the loaded saved-state environment', async () => {
+		const domEnvironment = installDomEnvironment()
+		const onRefresh = mock(async () => undefined)
+		const onEnvironmentChanged = mock(async () => undefined)
+		const controller = createSimulationController()
+		const renderedComponent = await renderIntoDocument(<SimulationBanner controller={controller} onEnvironmentChanged={onEnvironmentChanged} onRefresh={onRefresh} />)
+
+		try {
+			const documentQueries = within(renderedComponent.container)
+			const advancedControls = openAdvancedControls(renderedComponent.container)
+			fireEvent.click(within(advancedControls).getByRole('button', { name: 'Save state' }))
+			const saveDialog = await waitFor(() => documentQueries.getByRole('dialog'))
+			const dialogQueries = within(saveDialog)
+			const nameInput = dialogQueries.getByLabelText('State name') as HTMLInputElement
+			fireEvent.input(nameInput, {
+				currentTarget: { value: 'Saved via test' },
+				target: { value: 'Saved via test' },
+			})
+			fireEvent.click(dialogQueries.getByRole('button', { name: 'Save' }))
+
+			await waitFor(() => {
+				expect(domEnvironment.window.location.hash).toContain('simState=saved-via-test-20260602123456')
+				expect(onEnvironmentChanged).toHaveBeenCalledTimes(1)
 			})
 		} finally {
 			await renderedComponent.cleanup()
@@ -441,23 +481,41 @@ describe('SimulationBanner', () => {
 	test('switches scenarios through route-state navigation without a full-page reload', async () => {
 		const domEnvironment = installDomEnvironment('http://localhost/#/zoltar?simulate=1&simScenario=baseline')
 		const onRefresh = mock(async () => undefined)
-		const controller = createSimulationController()
+		const subscribers = new Set<() => void>()
+		const controller = createSimulationController({
+			subscribe: handler => {
+				subscribers.add(handler)
+				return () => {
+					subscribers.delete(handler)
+				}
+			},
+		})
+		const onEnvironmentChanged = mock(async () => {
+			controller.currentScenario = 'securitypoolx2'
+			controller.simulationSource = {
+				kind: 'scenario',
+				scenario: 'securitypoolx2',
+			}
+			for (const subscriber of subscribers) subscriber()
+		})
 		const pushState = mock(domEnvironment.window.history.pushState.bind(domEnvironment.window.history))
 		domEnvironment.window.history.pushState = pushState as typeof domEnvironment.window.history.pushState
-		const renderedComponent = await renderIntoDocument(<SimulationBanner controller={controller} onRefresh={onRefresh} />)
+		const renderedComponent = await renderIntoDocument(<SimulationBanner controller={controller} onEnvironmentChanged={onEnvironmentChanged} onRefresh={onRefresh} />)
 
 		try {
 			const documentQueries = within(renderedComponent.container)
 			const picker = documentQueries.getAllByRole('combobox')[0]
 			if (picker === undefined || picker.tagName !== 'SELECT') throw new Error('Expected the scenario picker')
 			fireEvent.change(picker, {
-				currentTarget: { value: 'scenario:deployed' },
-				target: { value: 'scenario:deployed' },
+				currentTarget: { value: 'scenario:securitypoolx2' },
+				target: { value: 'scenario:securitypoolx2' },
 			})
 
 			await waitFor(() => {
 				expect(pushState).toHaveBeenCalledTimes(1)
-				expect(domEnvironment.window.location.hash).toContain('simScenario=deployed')
+				expect(domEnvironment.window.location.hash).toContain('simScenario=securitypoolx2')
+				expect(onEnvironmentChanged).toHaveBeenCalledTimes(1)
+				expect(getElementValue(picker)).toBe('scenario:securitypoolx2')
 			})
 		} finally {
 			await renderedComponent.cleanup()
@@ -517,6 +575,68 @@ describe('SimulationBanner', () => {
 		} finally {
 			await builtInRendered.cleanup()
 			await customRendered.cleanup()
+			domEnvironment.cleanup()
+		}
+	})
+
+	test('deletes a saved simulation state and refreshes the fallback scenario environment', async () => {
+		const domEnvironment = installDomEnvironment('http://localhost/#/zoltar?simulate=1&simState=saved-baseline-20260602123456')
+		domEnvironment.window.localStorage.setItem(
+			'zoltar.simulation.savedStates',
+			JSON.stringify([
+				{
+					baseScenario: 'baseline',
+					id: 'saved-baseline-20260602123456',
+					name: 'Saved baseline',
+					savedAt: '2026-06-02T12:34:56.000Z',
+					serialized: serializeSavedSimulationStateEnvelope({
+						baseScenario: 'baseline',
+						name: 'Saved baseline',
+						savedAt: '2026-06-02T12:34:56.000Z',
+						state: {
+							blockCountSinceReset: 0n,
+							currentTimestamp: 1n,
+							queryDelayMilliseconds: 0,
+							repPerEthPrice: 10n ** 18n,
+							repPerUsdcPrice: 10n ** 6n,
+							selectedAccount: '0x00000000000000000000000000000000000000a1',
+							snapshot: {},
+							transactionCountSinceReset: 0n,
+							transactionDelayMilliseconds: 0,
+						},
+						version: 1,
+					}),
+				},
+			]),
+		)
+		const onRefresh = mock(async () => undefined)
+		const onEnvironmentChanged = mock(async () => undefined)
+		const controller = createSimulationController({
+			simulationSource: {
+				baseScenario: 'baseline',
+				kind: 'saved-state',
+				name: 'Saved baseline',
+				savedAt: '2026-06-02T12:34:56.000Z',
+				stateId: 'saved-baseline-20260602123456',
+			},
+		})
+		const renderedComponent = await renderIntoDocument(<SimulationBanner controller={controller} onEnvironmentChanged={onEnvironmentChanged} onRefresh={onRefresh} />)
+
+		try {
+			const documentQueries = within(renderedComponent.container)
+			const advancedControls = openAdvancedControls(renderedComponent.container)
+			fireEvent.click(within(advancedControls).getByRole('button', { name: 'Delete save' }))
+			const deleteDialog = await waitFor(() => documentQueries.getByRole('dialog'))
+			fireEvent.click(within(deleteDialog).getByRole('button', { name: 'Delete save' }))
+
+			await waitFor(() => {
+				expect(domEnvironment.window.localStorage.getItem('zoltar.simulation.savedStates')).not.toContain('saved-baseline-20260602123456')
+				expect(domEnvironment.window.location.hash).toContain('simScenario=baseline')
+				expect(domEnvironment.window.location.hash).not.toContain('simState=')
+				expect(onEnvironmentChanged).toHaveBeenCalledTimes(1)
+			})
+		} finally {
+			await renderedComponent.cleanup()
 			domEnvironment.cleanup()
 		}
 	})

--- a/ui/ts/tests/useOnchainState.integration.test.tsx
+++ b/ui/ts/tests/useOnchainState.integration.test.tsx
@@ -3,6 +3,7 @@
 import { fireEvent, waitFor, within } from './testUtils/queries'
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import { h } from 'preact'
+import { useState } from 'preact/hooks'
 import { act } from 'preact/test-utils'
 import type { Address } from 'viem'
 import { getAddress } from 'viem'
@@ -249,6 +250,153 @@ describe('useOnchainState (integration)', () => {
 		expect(loadErc20Balance).toHaveBeenCalledTimes(1)
 
 		resetEnvironment()
+	})
+
+	test('resubscribes and refreshes against a replacement active environment when the nonce changes', async () => {
+		const accountA = getAddress('0x00000000000000000000000000000000000000a1')
+		const accountB = getAddress('0x00000000000000000000000000000000000000b2')
+		const { backend: backendA, subscriptionState: subscriptionsA } = createBackend({
+			accountAddress: accountA,
+			readClient: createReadClient({ blockNumber: 100n, blockTimestamp: 200n }),
+		})
+		const { backend: backendB, subscriptionState: subscriptionsB } = createBackend({
+			accountAddress: accountB,
+			readClient: createReadClient({ blockNumber: 300n, blockTimestamp: 400n }),
+		})
+		const loadDeploymentStatusOracleSnapshot = mock(async () => ({
+			augurPlaceHolderDeployed: false,
+			deploymentStatuses,
+		}))
+		const loadErc20Balance = mock(async () => 0n)
+
+		mock.module('../contracts.js', () => ({
+			getDeploymentSteps,
+			loadDeploymentStatusOracleSnapshot,
+			loadErc20Balance,
+		}))
+
+		const { useOnchainState } = await import(`../hooks/useOnchainState.js?case=${crypto.randomUUID()}`)
+		let resetEnvironment = installActiveEnvironmentForTesting(backendA)
+		let hookState: UseOnchainStateState | undefined
+		function Harness() {
+			const [activeEnvironmentNonce, setActiveEnvironmentNonce] = useState(0)
+			const state = useOnchainState({ activeEnvironmentNonce })
+			hookState = state
+			return h(
+				'button',
+				{
+					onClick: () => {
+						setActiveEnvironmentNonce(currentNonce => currentNonce + 1)
+					},
+					type: 'button',
+				},
+				'Refresh environment',
+			)
+		}
+		const renderedComponent = await renderIntoDocument(h(Harness, {}))
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await waitFor(() => expect(requireHookState(hookState).accountState.address).toBe(accountA))
+		expect(requireHookState(hookState).currentBlockNumber).toBe(100n)
+		expect(subscriptionsA.stateHandler).not.toBeUndefined()
+		expect(subscriptionsA.accountHandler).not.toBeUndefined()
+		expect(subscriptionsA.chainHandler).not.toBeUndefined()
+
+		resetEnvironment = installActiveEnvironmentForTesting(backendB)
+		fireEvent.click(within(renderedComponent.container).getByRole('button', { name: 'Refresh environment' }))
+
+		await waitFor(() => expect(requireHookState(hookState).accountState.address).toBe(accountB))
+		expect(requireHookState(hookState).currentBlockNumber).toBe(300n)
+		expect(subscriptionsA.unsub).toEqual({ accounts: 1, chain: 1, subscribe: 1 })
+		expect(subscriptionsB.stateHandler).not.toBeUndefined()
+		expect(subscriptionsB.accountHandler).not.toBeUndefined()
+		expect(subscriptionsB.chainHandler).not.toBeUndefined()
+		expect(loadDeploymentStatusOracleSnapshot).toHaveBeenCalledTimes(2)
+		resetEnvironment()
+	})
+
+	test('replaces chain-clock polling when the active environment nonce changes', async () => {
+		const intervalHandlers: TimerHandler[] = []
+		const clearedIntervals: number[] = []
+		const originalSetInterval = window.setInterval
+		const originalClearInterval = window.clearInterval
+		Object.defineProperty(window, 'setInterval', {
+			configurable: true,
+			value: (handler: TimerHandler) => {
+				intervalHandlers.push(handler)
+				return intervalHandlers.length
+			},
+		})
+		Object.defineProperty(window, 'clearInterval', {
+			configurable: true,
+			value: (handle: number | undefined) => {
+				if (handle !== undefined) clearedIntervals.push(handle)
+			},
+		})
+		const accountA = getAddress('0x00000000000000000000000000000000000000a1')
+		const accountB = getAddress('0x00000000000000000000000000000000000000b2')
+		const { backend: backendA } = createBackend({
+			accountAddress: accountA,
+			readClient: createReadClient({ blockNumber: 100n, blockTimestamp: 200n }),
+		})
+		const { backend: backendB } = createBackend({
+			accountAddress: accountB,
+			readClient: createReadClient({ blockNumber: 300n, blockTimestamp: 400n }),
+		})
+		mock.module('../contracts.js', () => ({
+			getDeploymentSteps,
+			loadDeploymentStatusOracleSnapshot: mock(async () => ({
+				augurPlaceHolderDeployed: false,
+				deploymentStatuses,
+			})),
+			loadErc20Balance: mock(async () => 0n),
+		}))
+
+		try {
+			const { useOnchainState } = await import(`../hooks/useOnchainState.js?case=${crypto.randomUUID()}`)
+			let resetEnvironment = installActiveEnvironmentForTesting(backendA)
+			let hookState: UseOnchainStateState | undefined
+			function Harness() {
+				const [activeEnvironmentNonce, setActiveEnvironmentNonce] = useState(0)
+				const state = useOnchainState({ activeEnvironmentNonce })
+				hookState = state
+				return h(
+					'button',
+					{
+						onClick: () => {
+							setActiveEnvironmentNonce(currentNonce => currentNonce + 1)
+						},
+						type: 'button',
+					},
+					'Refresh environment',
+				)
+			}
+
+			const renderedComponent = await renderIntoDocument(h(Harness, {}))
+			cleanupRenderedComponent = renderedComponent.cleanup
+			await waitFor(() => {
+				requireHookState(hookState)
+				expect(intervalHandlers.length).toBe(1)
+			})
+			expect(intervalHandlers.length).toBe(1)
+
+			resetEnvironment = installActiveEnvironmentForTesting(backendB)
+			fireEvent.click(within(renderedComponent.container).getByRole('button', { name: 'Refresh environment' }))
+
+			await waitFor(() => expect(intervalHandlers.length).toBe(2))
+			expect(clearedIntervals).toEqual([1])
+			expect(intervalHandlers.length).toBe(2)
+			resetEnvironment()
+		} finally {
+			Object.defineProperty(window, 'setInterval', {
+				configurable: true,
+				value: originalSetInterval,
+			})
+			Object.defineProperty(window, 'clearInterval', {
+				configurable: true,
+				value: originalClearInterval,
+			})
+		}
 	})
 
 	test('surfaces a blocking error when the configured read RPC is on the wrong chain', async () => {

--- a/ui/ts/tests/useZoltarUniverse.test.tsx
+++ b/ui/ts/tests/useZoltarUniverse.test.tsx
@@ -1,11 +1,12 @@
 /// <reference types='bun-types' />
 
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
-import { h } from 'preact'
+import { h, render } from 'preact'
 import { act } from 'preact/test-utils'
-import { getAddress } from 'viem'
+import { getAddress, zeroAddress, type Hash } from 'viem'
 import { installActiveEnvironmentForTesting, resetActiveEnvironmentForTesting } from '../lib/activeEnvironment.js'
 import { useZoltarUniverse } from '../hooks/useZoltarUniverse.js'
+import type { DeploymentStatus, MarketDetails } from '../types/contracts.js'
 import { createFakeBackend } from './testUtils/fakeBackend.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
@@ -14,11 +15,51 @@ type UseZoltarUniverseState = ReturnType<typeof useZoltarUniverse>
 
 const WALLET_ADDRESS = getAddress('0x00000000000000000000000000000000000000a1')
 const NEXT_WALLET_ADDRESS = getAddress('0x00000000000000000000000000000000000000b2')
+const TEST_HASH: Hash = '0x0000000000000000000000000000000000000000000000000000000000000001'
 
 function requireHookState(state: UseZoltarUniverseState | undefined) {
 	if (state === undefined) throw new Error('Hook state unavailable')
 
 	return state
+}
+
+function createDeferred<T>() {
+	let resolve: (value: T) => void = () => undefined
+	let reject: (reason?: unknown) => void = () => undefined
+	const promise = new Promise<T>((promiseResolve, promiseReject) => {
+		resolve = promiseResolve
+		reject = promiseReject
+	})
+	return { promise, reject, resolve }
+}
+
+function createZoltarDeploymentStatus(): DeploymentStatus {
+	return {
+		address: zeroAddress,
+		dependencies: [],
+		deploy: async () => TEST_HASH,
+		deployed: true,
+		id: 'zoltar',
+		label: 'Zoltar',
+	}
+}
+
+function createQuestion(questionId: string): MarketDetails {
+	return {
+		answerUnit: '',
+		createdAt: 1n,
+		description: 'Question description',
+		displayValueMax: 2n,
+		displayValueMin: 0n,
+		endTime: 2n,
+		exists: true,
+		marketType: 'binary',
+		numTicks: 2n,
+		outcomeLabels: ['Yes', 'No'],
+		questionId,
+		startTime: 1n,
+		title: `Question ${questionId}`,
+	}
 }
 
 describe('useZoltarUniverse', () => {
@@ -53,6 +94,7 @@ describe('useZoltarUniverse', () => {
 				activeUniverseId: 1n,
 				autoLoadInitialData: false,
 				deploymentStatuses: [],
+				environmentRefreshKey: 0,
 				onTransactionFailed,
 				onTransactionFinished: () => undefined,
 				onTransactionPresented: () => undefined,
@@ -71,5 +113,73 @@ describe('useZoltarUniverse', () => {
 
 		expect(onTransactionRequested).not.toHaveBeenCalled()
 		expect(onTransactionFailed).toHaveBeenCalledWith('Wallet account changed. Review the action with the connected account and try again')
+	})
+
+	test('ignores stale question page results after the environment refresh key changes', async () => {
+		const oldPage = createDeferred<{
+			pageIndex: number
+			pageSize: number
+			questionCount: bigint
+			questions: MarketDetails[]
+		}>()
+		mock.module('../lib/clients.js', () => ({
+			createConnectedReadClient: mock(() => ({})),
+			createWalletWriteClient: mock(() => ({})),
+		}))
+		mock.module('../contracts.js', () => ({
+			createZoltarChildUniverse: mock(async () => ({ hash: TEST_HASH })),
+			loadAllZoltarQuestions: mock(async () => []),
+			loadZoltarQuestionCount: mock(async () => 1n),
+			loadZoltarQuestionPage: mock(async () => await oldPage.promise),
+			loadZoltarUniverseSummary: mock(async () => ({
+				childUniverses: [],
+				forkQuestionDetails: undefined,
+				forkThreshold: 100n,
+				forkTime: 0n,
+				forkingOutcomeIndex: 0n,
+				hasForked: false,
+				parentUniverseId: 0n,
+				reputationToken: zeroAddress,
+				totalTheoreticalSupply: 1000n,
+				universeId: 1n,
+			})),
+		}))
+		const { useZoltarUniverse: useTestZoltarUniverse } = await import(`../hooks/useZoltarUniverse.js?case=${crypto.randomUUID()}`)
+		let hookState: UseZoltarUniverseState | undefined
+		function Harness({ environmentRefreshKey }: { environmentRefreshKey: number }) {
+			hookState = useTestZoltarUniverse({
+				accountAddress: WALLET_ADDRESS,
+				activeUniverseId: 1n,
+				autoLoadInitialData: true,
+				deploymentStatuses: [createZoltarDeploymentStatus()],
+				environmentRefreshKey,
+				onTransactionFinished: () => undefined,
+				onTransactionPresented: () => undefined,
+				onTransactionRequested: () => undefined,
+				onTransactionSubmitted: () => undefined,
+			})
+			return <div />
+		}
+		const renderedComponent = await renderIntoDocument(h(Harness, { environmentRefreshKey: 0 }))
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await act(async () => {
+			void requireHookState(hookState).loadZoltarQuestionPage(0, 10)
+		})
+		await act(() => {
+			render(h(Harness, { environmentRefreshKey: 1 }), renderedComponent.container)
+		})
+		await act(async () => {
+			oldPage.resolve({
+				pageIndex: 0,
+				pageSize: 10,
+				questionCount: 1n,
+				questions: [createQuestion('0x01')],
+			})
+			await oldPage.promise
+		})
+
+		expect(requireHookState(hookState).zoltarQuestionPage).toBeUndefined()
+		expect(requireHookState(hookState).zoltarQuestions).toEqual([])
 	})
 })

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -374,6 +374,7 @@ export type MarketRouteContentProps = {
 	accountState: AccountState
 	activeUniverseId: bigint
 	activeView: ZoltarView
+	environmentRefreshKey: number
 	onApproveZoltarForkRep: (amount?: bigint) => void
 	onCreateChildUniverseForOutcomeIndex: (outcomeIndex: bigint) => void
 	onCreateMarket: () => void
@@ -470,6 +471,7 @@ type LiquidationModalStateProps = {
 export type SecurityPoolsOverviewRouteContentProps = {
 	accountState: AccountState
 	checkedSecurityPoolAddress: string | undefined
+	environmentRefreshKey: number
 	hasLoadedSecurityPools: boolean
 	hasLoadedSecurityPoolPage: boolean
 	loadingSecurityPoolPage: boolean


### PR DESCRIPTION
## Summary
- Added `activeEnvironmentNonce` tracking in `App` and wired a new `refreshActiveEnvironment` flow to reinitialize active simulation state.
- Propagated refresh key through route effects, market creation, and onchain/universe hooks so data reloads are forced when simulation context changes.
- Updated question and security pool pagination/request keys to include environment refresh, preventing stale page reuse across environment swaps.
- Extended `SimulationBanner` actions to trigger environment refresh when switching/deleting/resetting simulation scenarios.
- Added/updated tests covering app route effects, market section paging reload behavior, security pool overview paging reload behavior, simulation banner interactions, and onchain/universe refresh semantics.

## Testing
- `Not run` (not executed in this response): `bun run tsc`
- `Not run` (not executed in this response): `bun run check:generated-clean`
- `Not run` (not executed in this response): `bun run check`
- `Not run` (not executed in this response): `bun run format`
- `Not run` (not executed in this response): `bun run knip`
- `Not run` (not executed in this response): `bun run ensure-contract-artifacts && bun run check:shared-dependencies && bun run test:run -- --bail=1`
- Added/updated tests in:
  - `ui/ts/tests/appRouteEffects.integration.test.tsx`
  - `ui/ts/tests/marketSection.test.tsx`
  - `ui/ts/tests/securityPoolsOverviewSection.test.tsx`
  - `ui/ts/tests/securityPoolsSection.test.ts`
  - `ui/ts/tests/simulationBanner.test.tsx`
  - `ui/ts/tests/useOnchainState.integration.test.tsx`
  - `ui/ts/tests/useZoltarUniverse.test.tsx`