### PR TITLE
Show full address labels and hide stale security-pool pages

### DIFF
--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -527,13 +527,19 @@ button.destructive-subtle:hover:not(:disabled) {
 .security-pool-link {
 	display: inline-flex;
 	align-items: baseline;
+	max-width: 100%;
+	min-width: 0;
+	overflow: hidden;
 	color: inherit;
 	text-decoration: none;
 	text-decoration-thickness: 0.08em;
 	text-underline-offset: 0.16em;
+	text-overflow: ellipsis;
 	transition:
 		color 140ms ease,
 		text-decoration-color 140ms ease;
+	vertical-align: bottom;
+	white-space: nowrap;
 }
 
 .universe-link:hover,

--- a/ui/ts/components/SecurityPoolLink.tsx
+++ b/ui/ts/components/SecurityPoolLink.tsx
@@ -1,6 +1,5 @@
 import type { ComponentChildren } from 'preact'
 import type { Address } from 'viem'
-import { formatAddress } from '../lib/addresses.js'
 import { getSecurityPoolLinkHref, navigateToSecurityPool } from '../lib/securityPoolNavigation.js'
 
 type SecurityPoolLinkProps = {
@@ -13,7 +12,7 @@ type SecurityPoolLinkProps = {
 
 export function SecurityPoolLink({ children, className = '', securityPoolAddress, selectedPoolView, universeId }: SecurityPoolLinkProps) {
 	const href = getSecurityPoolLinkHref(securityPoolAddress, selectedPoolView, universeId)
-	const label = children ?? formatAddress(securityPoolAddress)
+	const label = children ?? securityPoolAddress
 
 	return (
 		<a

--- a/ui/ts/components/SecurityPoolsOverviewSection.tsx
+++ b/ui/ts/components/SecurityPoolsOverviewSection.tsx
@@ -105,17 +105,24 @@ export function SecurityPoolsOverviewSection({
 	const [vaultFilter, setVaultFilter] = useState<'all' | 'has-vaults' | 'empty'>('all')
 	const loadSecurityPoolPageRef = useRef(onLoadSecurityPoolPage)
 	loadSecurityPoolPageRef.current = onLoadSecurityPoolPage
-	const effectivePoolCount = securityPoolPage?.poolCount ?? securityPoolBrowseCount
-	const poolPageCount = getPaginationPageCount(effectivePoolCount, SECURITY_POOL_PAGE_SIZE)
-	const resolvedPageIndex = resolvePaginationPageIndex(pageIndex, poolPageCount)
+	const requestedPoolCount = securityPoolPage?.poolCount ?? securityPoolBrowseCount
+	const requestedPoolPageCount = getPaginationPageCount(requestedPoolCount, SECURITY_POOL_PAGE_SIZE)
+	const resolvedPageIndex = resolvePaginationPageIndex(pageIndex, requestedPoolPageCount)
 	const currentPageRequestKey = `${environmentRefreshKey}:${resolvedPageIndex}:${SECURITY_POOL_PAGE_SIZE}`
-	const hasCurrentPageData = securityPoolPage?.pageIndex === resolvedPageIndex && securityPoolPage.pageSize === SECURITY_POOL_PAGE_SIZE
+	const acceptedPageRequestRef = useRef<{ page: typeof securityPoolPage; requestKey: string } | undefined>(undefined)
+	if (acceptedPageRequestRef.current === undefined || acceptedPageRequestRef.current.page !== securityPoolPage) {
+		acceptedPageRequestRef.current = { page: securityPoolPage, requestKey: currentPageRequestKey }
+	}
+	const hasCurrentPageData = acceptedPageRequestRef.current.requestKey === currentPageRequestKey && securityPoolPage?.pageIndex === resolvedPageIndex && securityPoolPage.pageSize === SECURITY_POOL_PAGE_SIZE
+	const currentPoolCount = hasCurrentPageData ? securityPoolPage.poolCount : undefined
+	const poolPageCount = getPaginationPageCount(currentPoolCount, SECURITY_POOL_PAGE_SIZE)
 	const pagedSecurityPools = hasCurrentPageData ? securityPoolPage.pools : []
 	const isWaitingForPageData = activePageRequestKey === currentPageRequestKey
+	const loadingCurrentPage = loadingSecurityPoolPage || isWaitingForPageData
 	const hasLoadedCurrentPage = hasLoadedSecurityPoolPage && hasCurrentPageData
 	const registryPresentation = getPoolRegistryPresentation({
 		hasLoaded: hasLoadedCurrentPage,
-		isLoading: (loadingSecurityPoolPage || isWaitingForPageData) && !hasLoadedCurrentPage,
+		isLoading: loadingCurrentPage && !hasLoadedCurrentPage,
 		mode: 'collection',
 		poolCount: pagedSecurityPools.length,
 	})
@@ -140,7 +147,7 @@ export function SecurityPoolsOverviewSection({
 	const callerVaultSummary = accountState.address === undefined ? undefined : selectedPool?.vaults.find(vault => sameAddress(vault.vaultAddress, accountState.address))
 	const normalizedSearchText = searchText.trim().toLowerCase()
 	const hasPreviousPage = resolvedPageIndex > 0
-	const hasNextPage = getHasNextPaginationPage(resolvedPageIndex, poolPageCount)
+	const hasNextPage = hasCurrentPageData && getHasNextPaginationPage(resolvedPageIndex, poolPageCount)
 	const retryPoolRegistryLoad = () => {
 		onLoadSecurityPoolPage(resolvedPageIndex, SECURITY_POOL_PAGE_SIZE)
 	}
@@ -179,14 +186,14 @@ export function SecurityPoolsOverviewSection({
 					<PaginationControls
 						hasNextPage={hasNextPage}
 						hasPreviousPage={hasPreviousPage}
-						loading={loadingSecurityPoolPage}
+						loading={loadingCurrentPage}
 						onNextPage={() => {
 							setPageIndex(current => current + 1)
 						}}
 						onPreviousPage={() => {
 							setPageIndex(current => Math.max(0, current - 1))
 						}}
-						summary={securityPoolPage === undefined ? undefined : formatPaginationSummary(resolvedPageIndex, poolPageCount)}
+						summary={hasCurrentPageData ? formatPaginationSummary(resolvedPageIndex, poolPageCount) : undefined}
 					/>
 				}
 			>

--- a/ui/ts/components/SimulationBanner.tsx
+++ b/ui/ts/components/SimulationBanner.tsx
@@ -1,7 +1,6 @@
 import { useSignal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { getErrorMessage } from '../lib/errors.js'
-import { formatAddress } from '../lib/addresses.js'
 import { buildRouteHref, getCurrentRouteHash, getRouteHashSearch } from '../lib/routing.js'
 import type { SimulationController } from '../simulation/controller.js'
 import { tryParseDecimalInput } from '../lib/decimal.js'
@@ -66,7 +65,7 @@ function hasSavedSimulationStateRoute() {
 }
 
 function getSimulationAccountOptionLabel(account: string) {
-	return `QA ${formatAddress(account)}`
+	return `QA ${account}`
 }
 
 function getScenarioStatus(parameters: { bootstrapError: string | undefined; isBootstrapped: boolean }): { badgeTone: BadgeTone; label: string } {

--- a/ui/ts/tests/securityPoolLink.test.tsx
+++ b/ui/ts/tests/securityPoolLink.test.tsx
@@ -31,13 +31,13 @@ describe('SecurityPoolLink', () => {
 		mock.restore()
 	})
 
-	test('renders the shortened pool address and follows normal left-click navigation', async () => {
+	test('renders the full pool address and follows normal left-click navigation', async () => {
 		const securityPoolAddress = getAddress('0x00000000000000000000000000000000000000f1')
 		const renderedComponent = await renderIntoDocument(<SecurityPoolLink securityPoolAddress={securityPoolAddress} selectedPoolView='fork-workflow' universeId={11n} />)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		const link = documentQueries.getByRole('link', { name: '0x0000…00f1' }) as HTMLAnchorElement
+		const link = documentQueries.getByRole('link', { name: securityPoolAddress }) as HTMLAnchorElement
 		expect(link.getAttribute('href')).toBe(`/security-pools/${securityPoolAddress}/fork-workflow/11`)
 
 		await act(() => {

--- a/ui/ts/tests/securityPoolWorkflowSection/selectedPoolState.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection/selectedPoolState.test.tsx
@@ -191,7 +191,7 @@ describe('SecurityPoolWorkflowSection: selected pool state', () => {
 		setCleanup(renderedComponent.cleanup)
 
 		const documentQueries = within(document.body)
-		const parentPoolLink = documentQueries.getByRole('link', { name: '0x0000…0200' })
+		const parentPoolLink = documentQueries.getByRole('link', { name: parentPoolAddress })
 		expect(parentPoolLink).not.toBeNull()
 		expect(document.body.textContent?.includes('Parent Pool')).toBe(true)
 		expect(parentPoolLink.getAttribute('title')).toBe(parentPoolAddress)

--- a/ui/ts/tests/securityPoolsOverviewSection.test.tsx
+++ b/ui/ts/tests/securityPoolsOverviewSection.test.tsx
@@ -225,6 +225,57 @@ describe('SecurityPoolsOverviewSection', () => {
 		})
 	})
 
+	test('hides stale pool page data while an environment refresh reload is pending', async () => {
+		const deferredPageLoad = createDeferred<void>()
+		let pageLoadCount = 0
+		const onLoadSecurityPoolPage = mock(() => {
+			pageLoadCount += 1
+			return pageLoadCount === 2 ? deferredPageLoad.promise : undefined
+		})
+		const securityPoolPage: SecurityPoolPage = {
+			pageIndex: 0,
+			pageSize: 6,
+			poolCount: 12n,
+			pools: [
+				createSecurityPool({
+					marketDetails: createMarketDetails({ title: 'Previous environment pool' }),
+					securityPoolAddress: '0x0000000000000000000000000000000000000100',
+				}),
+			],
+		}
+		const initialProps = createProps({
+			environmentRefreshKey: 0,
+			onLoadSecurityPoolPage,
+			securityPoolPage,
+		})
+		const renderedComponent = await renderIntoDocument(<SecurityPoolsOverviewSection {...initialProps} />)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await waitFor(() => {
+			expect(onLoadSecurityPoolPage).toHaveBeenCalledTimes(1)
+		})
+		expect(within(document.body).getByText('Previous environment pool')).not.toBeNull()
+		expect(within(document.body).getByText('Page 1 of 2')).not.toBeNull()
+
+		await act(() => {
+			render(<SecurityPoolsOverviewSection {...initialProps} environmentRefreshKey={1} />, renderedComponent.container)
+		})
+
+		await waitFor(() => {
+			expect(onLoadSecurityPoolPage).toHaveBeenCalledTimes(2)
+		})
+		const documentQueries = within(document.body)
+		expect(documentQueries.queryByText('Previous environment pool')).toBeNull()
+		expect(documentQueries.queryByText('Page 1 of 2')).toBeNull()
+		expect(documentQueries.getByRole('button', { name: 'Next Page' }).hasAttribute('disabled')).toBe(true)
+		expect(documentQueries.getByText('Refreshing pools.')).not.toBeNull()
+
+		deferredPageLoad.resolve()
+		await act(async () => {
+			await deferredPageLoad.promise
+		})
+	})
+
 	test('keeps pool-list load errors inline instead of opening liquidation', async () => {
 		const renderedComponent = await renderIntoDocument(
 			<SecurityPoolsOverviewSection
@@ -597,11 +648,15 @@ describe('SecurityPoolsOverviewSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
+		await waitFor(() => {
+			expect(loadPageCalls.some(call => call.pageIndex === 0)).toBe(true)
+		})
 		const nextPageButton = documentQueries.getByRole('button', { name: 'Next Page' })
 		await act(() => {
 			nextPageButton.dispatchEvent(new window.MouseEvent('click', { bubbles: true }))
 		})
-		expect(documentQueries.getByText('Page 2 of 2')).not.toBeNull()
+		expect(documentQueries.queryByText('Page 2 of 2')).toBeNull()
+		expect(loadPageCalls.some(call => call.pageIndex === 1)).toBe(true)
 
 		const shrunkProps = createProps({
 			onLoadSecurityPoolPage: initialProps.onLoadSecurityPoolPage,
@@ -627,10 +682,12 @@ describe('SecurityPoolsOverviewSection', () => {
 
 	test('stops showing a loading state when a requested pool page fails to load', async () => {
 		const failedPageLoad = createDeferred<void>()
+		const loadPageCalls: number[] = []
 		const renderedComponent = await renderIntoDocument(
 			<SecurityPoolsOverviewSection
 				{...createProps({
 					onLoadSecurityPoolPage: async pageIndex => {
+						loadPageCalls.push(pageIndex)
 						if (pageIndex === 1) return await failedPageLoad.promise
 					},
 					securityPoolPage: {
@@ -650,6 +707,9 @@ describe('SecurityPoolsOverviewSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
+		await waitFor(() => {
+			expect(loadPageCalls.includes(0)).toBe(true)
+		})
 		const nextPageButton = documentQueries.getByRole('button', { name: 'Next Page' })
 		await act(() => {
 			nextPageButton.dispatchEvent(new window.MouseEvent('click', { bubbles: true }))

--- a/ui/ts/tests/simulationBanner.test.tsx
+++ b/ui/ts/tests/simulationBanner.test.tsx
@@ -119,7 +119,7 @@ describe('SimulationBanner', () => {
 			const accountOption = accountSelect.querySelector('option')
 			if (accountOption === null) throw new Error('Expected QA account option')
 			expect(accountOption.getAttribute('value')).toBe(controller.selectedAccount)
-			expect(accountOption.textContent).toBe('QA 0x0000…00a1')
+			expect(accountOption.textContent).toBe(`QA ${controller.selectedAccount}`)
 		} finally {
 			await renderedComponent.cleanup()
 			domEnvironment.cleanup()


### PR DESCRIPTION
## Summary
- Show full security-pool and simulation QA account addresses by default instead of forcing middle-shortened labels.
- Let address links visually ellipsize only when the layout is constrained, while preserving the full DOM text and link titles.
- Hide stale security-pool overview page data while an environment/page refresh is pending so old pools are not shown as current.
- Update UI tests for full address labels and stale security-pool pagination/loading behavior.

## Validation
- `bun test ui/ts/tests/securityPoolLink.test.tsx --bail=1`
- `bun test ui/ts/tests/simulationBanner.test.tsx --bail=1`
- `bun test ui/ts/tests/securityPoolWorkflowSection/selectedPoolState.test.tsx --bail=1`
- `bun test ui/ts/tests/addressValue.test.tsx --bail=1`
- Headless Chromium layout check against `ui/css/index.css` for wide and constrained `.security-pool-link` rendering
- `bun run tsc`
- `bun run ensure-contract-artifacts && bun run check:shared-dependencies && bun run test:run -- --bail=1` (`1638 pass / 11 skip / 0 fail`)
- `bun run format`
- `bun run check`
- `bun run knip`
- `git diff --check`
- `git rev-list --count HEAD..origin/main` (`0`)

Skipped `bun run check:generated-clean` because this PR does not touch contracts, generation scripts, generated artifacts, shared build output, UI contract artifacts, or artifact policy.