### PR TITLE
Fix stale security pool pagination via request-keyed loading state

### DIFF
--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -511,7 +511,7 @@ export function App() {
 			loadingPoolOracleManager,
 			loadingSecurityPoolPage,
 			loadingSecurityPools,
-			onLoadSecurityPoolPage: (pageIndex: number, pageSize: number) => void loadBrowseSecurityPoolPage(pageIndex, pageSize),
+			onLoadSecurityPoolPage: (pageIndex: number, pageSize: number, requestKey?: string) => void loadBrowseSecurityPoolPage(pageIndex, pageSize, requestKey),
 			onLiquidationAmountChange: setLiquidationAmount,
 			onLiquidationTimeoutMinutesChange: setLiquidationTimeoutMinutes,
 			onLoadPoolOracleManager: (managerAddress: Address) => void loadPoolOracleManager(managerAddress),

--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -511,7 +511,7 @@ export function App() {
 			loadingPoolOracleManager,
 			loadingSecurityPoolPage,
 			loadingSecurityPools,
-			onLoadSecurityPoolPage: (pageIndex: number, pageSize: number, requestKey?: string) => void loadBrowseSecurityPoolPage(pageIndex, pageSize, requestKey),
+			onLoadSecurityPoolPage: (pageIndex: number, pageSize: number, requestKey: string) => void loadBrowseSecurityPoolPage(pageIndex, pageSize, requestKey),
 			onLiquidationAmountChange: setLiquidationAmount,
 			onLiquidationTimeoutMinutesChange: setLiquidationTimeoutMinutes,
 			onLoadPoolOracleManager: (managerAddress: Address) => void loadPoolOracleManager(managerAddress),

--- a/ui/ts/components/SecurityPoolsOverviewSection.tsx
+++ b/ui/ts/components/SecurityPoolsOverviewSection.tsx
@@ -108,12 +108,9 @@ export function SecurityPoolsOverviewSection({
 	const requestedPoolCount = securityPoolPage?.poolCount ?? securityPoolBrowseCount
 	const requestedPoolPageCount = getPaginationPageCount(requestedPoolCount, SECURITY_POOL_PAGE_SIZE)
 	const resolvedPageIndex = resolvePaginationPageIndex(pageIndex, requestedPoolPageCount)
-	const currentPageRequestKey = `${environmentRefreshKey}:${resolvedPageIndex}:${SECURITY_POOL_PAGE_SIZE}`
-	const acceptedPageRequestRef = useRef<{ page: typeof securityPoolPage; requestKey: string } | undefined>(undefined)
-	if (acceptedPageRequestRef.current === undefined || acceptedPageRequestRef.current.page !== securityPoolPage) {
-		acceptedPageRequestRef.current = { page: securityPoolPage, requestKey: currentPageRequestKey }
-	}
-	const hasCurrentPageData = acceptedPageRequestRef.current.requestKey === currentPageRequestKey && securityPoolPage?.pageIndex === resolvedPageIndex && securityPoolPage.pageSize === SECURITY_POOL_PAGE_SIZE
+	const accountRequestKey = accountState.address?.toLowerCase() ?? 'no-account'
+	const currentPageRequestKey = `${environmentRefreshKey}:${resolvedPageIndex}:${SECURITY_POOL_PAGE_SIZE}:${accountRequestKey}`
+	const hasCurrentPageData = securityPoolPage?.requestKey === currentPageRequestKey && securityPoolPage.pageIndex === resolvedPageIndex && securityPoolPage.pageSize === SECURITY_POOL_PAGE_SIZE
 	const currentPoolCount = hasCurrentPageData ? securityPoolPage.poolCount : undefined
 	const poolPageCount = getPaginationPageCount(currentPoolCount, SECURITY_POOL_PAGE_SIZE)
 	const pagedSecurityPools = hasCurrentPageData ? securityPoolPage.pools : []
@@ -149,7 +146,7 @@ export function SecurityPoolsOverviewSection({
 	const hasPreviousPage = resolvedPageIndex > 0
 	const hasNextPage = hasCurrentPageData && getHasNextPaginationPage(resolvedPageIndex, poolPageCount)
 	const retryPoolRegistryLoad = () => {
-		onLoadSecurityPoolPage(resolvedPageIndex, SECURITY_POOL_PAGE_SIZE)
+		onLoadSecurityPoolPage(resolvedPageIndex, SECURITY_POOL_PAGE_SIZE, currentPageRequestKey)
 	}
 	useEffect(() => {
 		if (resolvedPageIndex === pageIndex) return
@@ -158,7 +155,7 @@ export function SecurityPoolsOverviewSection({
 	useEffect(() => {
 		let cancelled = false
 		setActivePageRequestKey(currentPageRequestKey)
-		void Promise.resolve(loadSecurityPoolPageRef.current(resolvedPageIndex, SECURITY_POOL_PAGE_SIZE))
+		void Promise.resolve(loadSecurityPoolPageRef.current(resolvedPageIndex, SECURITY_POOL_PAGE_SIZE, currentPageRequestKey))
 			.catch(() => undefined)
 			.finally(() => {
 				if (cancelled) return

--- a/ui/ts/hooks/useSecurityPoolsOverview.ts
+++ b/ui/ts/hooks/useSecurityPoolsOverview.ts
@@ -39,13 +39,14 @@ export function shouldFallbackToAllSecurityPoolsPage(error: unknown) {
 	return SECURITY_POOL_PAGE_FALLBACK_DETAILS.some(fallbackDetail => normalizedDetail.includes(fallbackDetail))
 }
 
-export function createSecurityPoolPageFromLoadedPools(pools: ListedSecurityPool[], pageIndex: number, pageSize: number): SecurityPoolPage {
+export function createSecurityPoolPageFromLoadedPools(pools: ListedSecurityPool[], pageIndex: number, pageSize: number, requestKey?: string): SecurityPoolPage {
 	const startIndex = pageIndex * pageSize
 	return {
 		pageIndex,
 		pageSize,
 		poolCount: BigInt(pools.length),
 		pools: pools.slice(startIndex, startIndex + pageSize),
+		...(requestKey === undefined ? {} : { requestKey }),
 	}
 }
 
@@ -113,7 +114,7 @@ export function useSecurityPoolsOverview({ accountAddress, onTransactionFailed, 
 		})
 	}
 
-	const loadBrowseSecurityPoolPage = async (pageIndex: number, pageSize: number) => {
+	const loadBrowseSecurityPoolPage = async (pageIndex: number, pageSize: number, requestKey?: string) => {
 		const isCurrent = nextSecurityPoolPageLoad()
 		await securityPoolPageLoad.run({
 			isCurrent,
@@ -128,18 +129,17 @@ export function useSecurityPoolsOverview({ accountAddress, onTransactionFailed, 
 					return await loadSecurityPoolPage(readClient, pageIndex, pageSize, accountAddress)
 				} catch (error) {
 					if (!shouldFallbackToAllSecurityPoolsPage(error)) throw error
-					if (hasLoadedSecurityPools.value) return createSecurityPoolPageFromLoadedPools(securityPools.value, pageIndex, pageSize)
 					const pools = await loadAllSecurityPools(readClient, {
 						...(accountAddress === undefined ? {} : { accountAddress }),
 						vaultDetailMode: 'selected',
 					})
-					return createSecurityPoolPageFromLoadedPools(pools, pageIndex, pageSize)
+					return createSecurityPoolPageFromLoadedPools(pools, pageIndex, pageSize, requestKey)
 				}
 			},
 			onSuccess: page => {
 				hasLoadedSecurityPoolPage.value = true
 				securityPoolBrowseCount.value = page.poolCount
-				securityPoolPage.value = page
+				securityPoolPage.value = requestKey === undefined ? page : { ...page, requestKey }
 			},
 			onError: error => {
 				securityPoolOverviewError.value = getErrorMessage(error, 'Failed to load security pools')

--- a/ui/ts/hooks/useSecurityPoolsOverview.ts
+++ b/ui/ts/hooks/useSecurityPoolsOverview.ts
@@ -17,7 +17,7 @@ import { getOracleRequestEthGuardMessage } from '../lib/oracleRequestEth.js'
 import { useRequestGuard } from '../lib/requestGuard.js'
 import { DEFAULT_STAGED_OPERATION_TIMEOUT_MINUTES, getStagedOperationTimeoutSeconds, MAX_STAGED_OPERATION_TIMEOUT_MINUTES, MIN_STAGED_OPERATION_TIMEOUT_MINUTES } from '../lib/securityVault.js'
 import type { WriteOperationsParameters } from '../types/app.js'
-import type { ListedSecurityPool, SecurityPoolOverviewActionResult, SecurityPoolPage } from '../types/contracts.js'
+import type { ListedSecurityPool, SecurityPoolBrowsePage, SecurityPoolOverviewActionResult, SecurityPoolPage } from '../types/contracts.js'
 
 type UseSecurityPoolsOverviewParameters = {
 	accountAddress: Address | undefined
@@ -39,14 +39,13 @@ export function shouldFallbackToAllSecurityPoolsPage(error: unknown) {
 	return SECURITY_POOL_PAGE_FALLBACK_DETAILS.some(fallbackDetail => normalizedDetail.includes(fallbackDetail))
 }
 
-export function createSecurityPoolPageFromLoadedPools(pools: ListedSecurityPool[], pageIndex: number, pageSize: number, requestKey?: string): SecurityPoolPage {
+export function createSecurityPoolPageFromLoadedPools(pools: ListedSecurityPool[], pageIndex: number, pageSize: number): SecurityPoolPage {
 	const startIndex = pageIndex * pageSize
 	return {
 		pageIndex,
 		pageSize,
 		poolCount: BigInt(pools.length),
 		pools: pools.slice(startIndex, startIndex + pageSize),
-		...(requestKey === undefined ? {} : { requestKey }),
 	}
 }
 
@@ -63,7 +62,7 @@ export function useSecurityPoolsOverview({ accountAddress, onTransactionFailed, 
 	const liquidationSecurityPoolAddress = useSignal<Address | undefined>(undefined)
 	const liquidationModalOpen = useSignal(false)
 	const securityPoolBrowseCount = useSignal<bigint | undefined>(undefined)
-	const securityPoolPage = useSignal<SecurityPoolPage | undefined>(undefined)
+	const securityPoolPage = useSignal<SecurityPoolBrowsePage | undefined>(undefined)
 	const securityPoolsLoad = useLoadController()
 	const securityPoolPageLoad = useLoadController()
 	const hasLoadedSecurityPools = useSignal(false)
@@ -114,7 +113,7 @@ export function useSecurityPoolsOverview({ accountAddress, onTransactionFailed, 
 		})
 	}
 
-	const loadBrowseSecurityPoolPage = async (pageIndex: number, pageSize: number, requestKey?: string) => {
+	const loadBrowseSecurityPoolPage = async (pageIndex: number, pageSize: number, requestKey: string) => {
 		const isCurrent = nextSecurityPoolPageLoad()
 		await securityPoolPageLoad.run({
 			isCurrent,
@@ -133,13 +132,13 @@ export function useSecurityPoolsOverview({ accountAddress, onTransactionFailed, 
 						...(accountAddress === undefined ? {} : { accountAddress }),
 						vaultDetailMode: 'selected',
 					})
-					return createSecurityPoolPageFromLoadedPools(pools, pageIndex, pageSize, requestKey)
+					return createSecurityPoolPageFromLoadedPools(pools, pageIndex, pageSize)
 				}
 			},
 			onSuccess: page => {
 				hasLoadedSecurityPoolPage.value = true
 				securityPoolBrowseCount.value = page.poolCount
-				securityPoolPage.value = requestKey === undefined ? page : { ...page, requestKey }
+				securityPoolPage.value = { ...page, requestKey }
 			},
 			onError: error => {
 				securityPoolOverviewError.value = getErrorMessage(error, 'Failed to load security pools')

--- a/ui/ts/tests/securityPoolsOverviewSection.test.tsx
+++ b/ui/ts/tests/securityPoolsOverviewSection.test.tsx
@@ -89,18 +89,30 @@ function createSecurityPool(overrides: Partial<ListedSecurityPool> = {}): Listed
 }
 
 function createProps(overrides: Partial<SecurityPoolsOverviewSectionProps> = {}): SecurityPoolsOverviewSectionProps {
+	const accountState = overrides.accountState ?? createAccountState()
 	const defaultPools = [createSecurityPool()]
 	const securityPools = overrides.securityPools ?? defaultPools
+	const environmentRefreshKey = overrides.environmentRefreshKey ?? 0
+	const accountRequestKey = accountState.address?.toLowerCase() ?? 'no-account'
 	const defaultPage: SecurityPoolPage = {
 		pageIndex: 0,
 		pageSize: 6,
 		poolCount: BigInt(securityPools.length),
 		pools: securityPools,
+		requestKey: `${environmentRefreshKey}:0:6:${accountRequestKey}`,
 	}
+	const hasSecurityPoolPageOverride = Object.hasOwn(overrides, 'securityPoolPage')
+	const overrideSecurityPoolPage = hasSecurityPoolPageOverride ? overrides.securityPoolPage : defaultPage
+	const securityPoolPage =
+		overrideSecurityPoolPage === undefined
+			? undefined
+			: {
+					...overrideSecurityPoolPage,
+					requestKey: overrideSecurityPoolPage.requestKey ?? `${environmentRefreshKey}:${overrideSecurityPoolPage.pageIndex.toString()}:${overrideSecurityPoolPage.pageSize.toString()}:${accountRequestKey}`,
+				}
 	return {
-		accountState: createAccountState(),
+		accountState,
 		checkedSecurityPoolAddress: undefined,
-		environmentRefreshKey: 0,
 		closeLiquidationModal: () => undefined,
 		hasLoadedSecurityPools: true,
 		hasLoadedSecurityPoolPage: true,
@@ -126,14 +138,15 @@ function createProps(overrides: Partial<SecurityPoolsOverviewSectionProps> = {})
 		repPerEthPrice: undefined,
 		repPerEthSource: undefined,
 		repPerEthSourceUrl: undefined,
-		securityPoolBrowseCount: overrides.securityPoolPage?.poolCount ?? BigInt(securityPools.length),
-		securityPoolPage: overrides.securityPoolPage ?? defaultPage,
 		securityPoolOverviewActiveAction: undefined,
 		securityPoolOverviewError: undefined,
 		securityPoolLiquidationError: undefined,
 		securityPoolOverviewResult: undefined,
-		securityPools,
 		...overrides,
+		environmentRefreshKey,
+		securityPoolBrowseCount: securityPoolPage?.poolCount,
+		securityPoolPage,
+		securityPools,
 	}
 }
 
@@ -221,7 +234,7 @@ describe('SecurityPoolsOverviewSection', () => {
 
 		await waitFor(() => {
 			expect(onLoadSecurityPoolPage).toHaveBeenCalledTimes(2)
-			expect(onLoadSecurityPoolPage).toHaveBeenLastCalledWith(0, 6)
+			expect(onLoadSecurityPoolPage).toHaveBeenLastCalledWith(0, 6, `1:0:6:${zeroAddress}`)
 		})
 	})
 
@@ -270,10 +283,81 @@ describe('SecurityPoolsOverviewSection', () => {
 		expect(documentQueries.getByRole('button', { name: 'Next Page' }).hasAttribute('disabled')).toBe(true)
 		expect(documentQueries.getByText('Refreshing pools.')).not.toBeNull()
 
+		const staleResolvedPage: SecurityPoolPage = {
+			...securityPoolPage,
+			pools: [
+				createSecurityPool({
+					marketDetails: createMarketDetails({ title: 'Stale resolved environment pool' }),
+					securityPoolAddress: '0x0000000000000000000000000000000000000101',
+				}),
+			],
+			requestKey: `0:0:6:${zeroAddress}`,
+		}
+		await act(() => {
+			render(
+				<SecurityPoolsOverviewSection
+					{...createProps({
+						environmentRefreshKey: 1,
+						onLoadSecurityPoolPage,
+						securityPoolPage: staleResolvedPage,
+					})}
+				/>,
+				renderedComponent.container,
+			)
+		})
+
+		expect(documentQueries.queryByText('Stale resolved environment pool')).toBeNull()
+		expect(documentQueries.queryByText('Page 1 of 2')).toBeNull()
+		expect(documentQueries.getByRole('button', { name: 'Next Page' }).hasAttribute('disabled')).toBe(true)
+
 		deferredPageLoad.resolve()
 		await act(async () => {
 			await deferredPageLoad.promise
 		})
+	})
+
+	test('hides stale pool page data while an account-specific reload is pending', async () => {
+		const accountA = '0x00000000000000000000000000000000000000a1'
+		const accountB = '0x00000000000000000000000000000000000000b2'
+		const onLoadSecurityPoolPage = mock(() => undefined)
+		const securityPoolPage: SecurityPoolPage = {
+			pageIndex: 0,
+			pageSize: 6,
+			poolCount: 12n,
+			pools: [
+				createSecurityPool({
+					marketDetails: createMarketDetails({ title: 'Account A pool' }),
+					securityPoolAddress: '0x0000000000000000000000000000000000000102',
+				}),
+			],
+			requestKey: `0:0:6:${accountA}`,
+		}
+		const initialProps = createProps({
+			accountState: createAccountState({ address: accountA }),
+			onLoadSecurityPoolPage,
+			securityPoolPage,
+		})
+		const renderedComponent = await renderIntoDocument(<SecurityPoolsOverviewSection {...initialProps} />)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await waitFor(() => {
+			expect(onLoadSecurityPoolPage).toHaveBeenCalledTimes(1)
+		})
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByText('Account A pool')).not.toBeNull()
+		expect(documentQueries.getByText('Page 1 of 2')).not.toBeNull()
+
+		await act(() => {
+			render(<SecurityPoolsOverviewSection {...initialProps} accountState={createAccountState({ address: accountB })} />, renderedComponent.container)
+		})
+
+		await waitFor(() => {
+			expect(onLoadSecurityPoolPage).toHaveBeenCalledTimes(2)
+			expect(onLoadSecurityPoolPage).toHaveBeenLastCalledWith(0, 6, `0:0:6:${accountB}`)
+		})
+		expect(documentQueries.queryByText('Account A pool')).toBeNull()
+		expect(documentQueries.queryByText('Page 1 of 2')).toBeNull()
+		expect(documentQueries.getByRole('button', { name: 'Next Page' }).hasAttribute('disabled')).toBe(true)
 	})
 
 	test('keeps pool-list load errors inline instead of opening liquidation', async () => {

--- a/ui/ts/tests/securityPoolsOverviewSection.test.tsx
+++ b/ui/ts/tests/securityPoolsOverviewSection.test.tsx
@@ -6,7 +6,7 @@ import { render } from 'preact'
 import { SecurityPoolsOverviewSection } from '../components/SecurityPoolsOverviewSection.js'
 import { deriveHasForkActivity } from '../lib/forkAuction.js'
 import type { AccountState } from '../types/app.js'
-import type { ListedSecurityPool, MarketDetails, SecurityPoolPage } from '../types/contracts.js'
+import type { ListedSecurityPool, MarketDetails, SecurityPoolBrowsePage, SecurityPoolPage } from '../types/contracts.js'
 import type { SecurityPoolsOverviewSectionProps } from '../types/components.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
@@ -88,13 +88,21 @@ function createSecurityPool(overrides: Partial<ListedSecurityPool> = {}): Listed
 	}
 }
 
-function createProps(overrides: Partial<SecurityPoolsOverviewSectionProps> = {}): SecurityPoolsOverviewSectionProps {
+type SecurityPoolsOverviewSectionTestOverrides = Omit<Partial<SecurityPoolsOverviewSectionProps>, 'securityPoolPage'> & {
+	securityPoolPage?: SecurityPoolPage | SecurityPoolBrowsePage | undefined
+}
+
+function getSecurityPoolPageRequestKey(page: SecurityPoolPage | SecurityPoolBrowsePage): string | undefined {
+	return 'requestKey' in page ? page.requestKey : undefined
+}
+
+function createProps(overrides: SecurityPoolsOverviewSectionTestOverrides = {}): SecurityPoolsOverviewSectionProps {
 	const accountState = overrides.accountState ?? createAccountState()
 	const defaultPools = [createSecurityPool()]
 	const securityPools = overrides.securityPools ?? defaultPools
 	const environmentRefreshKey = overrides.environmentRefreshKey ?? 0
 	const accountRequestKey = accountState.address?.toLowerCase() ?? 'no-account'
-	const defaultPage: SecurityPoolPage = {
+	const defaultPage: SecurityPoolBrowsePage = {
 		pageIndex: 0,
 		pageSize: 6,
 		poolCount: BigInt(securityPools.length),
@@ -108,7 +116,7 @@ function createProps(overrides: Partial<SecurityPoolsOverviewSectionProps> = {})
 			? undefined
 			: {
 					...overrideSecurityPoolPage,
-					requestKey: overrideSecurityPoolPage.requestKey ?? `${environmentRefreshKey}:${overrideSecurityPoolPage.pageIndex.toString()}:${overrideSecurityPoolPage.pageSize.toString()}:${accountRequestKey}`,
+					requestKey: getSecurityPoolPageRequestKey(overrideSecurityPoolPage) ?? `${environmentRefreshKey}:${overrideSecurityPoolPage.pageIndex.toString()}:${overrideSecurityPoolPage.pageSize.toString()}:${accountRequestKey}`,
 				}
 	return {
 		accountState,
@@ -283,7 +291,7 @@ describe('SecurityPoolsOverviewSection', () => {
 		expect(documentQueries.getByRole('button', { name: 'Next Page' }).hasAttribute('disabled')).toBe(true)
 		expect(documentQueries.getByText('Refreshing pools.')).not.toBeNull()
 
-		const staleResolvedPage: SecurityPoolPage = {
+		const staleResolvedPage: SecurityPoolBrowsePage = {
 			...securityPoolPage,
 			pools: [
 				createSecurityPool({
@@ -320,7 +328,7 @@ describe('SecurityPoolsOverviewSection', () => {
 		const accountA = '0x00000000000000000000000000000000000000a1'
 		const accountB = '0x00000000000000000000000000000000000000b2'
 		const onLoadSecurityPoolPage = mock(() => undefined)
-		const securityPoolPage: SecurityPoolPage = {
+		const securityPoolPage: SecurityPoolBrowsePage = {
 			pageIndex: 0,
 			pageSize: 6,
 			poolCount: 12n,

--- a/ui/ts/tests/securityPoolsSection.test.ts
+++ b/ui/ts/tests/securityPoolsSection.test.ts
@@ -290,22 +290,33 @@ function createWorkflowProps(overrides: Partial<SecurityPoolWorkflowRouteContent
 }
 
 function createOverviewProps(overrides: Partial<SecurityPoolsOverviewRouteContentProps> = {}): SecurityPoolsOverviewRouteContentProps {
+	const accountState = overrides.accountState ?? createAccountState()
 	const securityPools = overrides.securityPools ?? []
-	const securityPoolPage: SecurityPoolPage | undefined =
-		overrides.securityPoolPage ??
-		(securityPools.length === 0
+	const environmentRefreshKey = overrides.environmentRefreshKey ?? 0
+	const accountRequestKey = accountState.address?.toLowerCase() ?? 'no-account'
+	const hasSecurityPoolPageOverride = Object.hasOwn(overrides, 'securityPoolPage')
+	const defaultSecurityPoolPage: SecurityPoolPage | undefined =
+		securityPools.length === 0
 			? undefined
 			: {
 					pageIndex: 0,
 					pageSize: 6,
 					poolCount: BigInt(securityPools.length),
 					pools: securityPools,
-				})
+					requestKey: `${environmentRefreshKey}:0:6:${accountRequestKey}`,
+				}
+	const overrideSecurityPoolPage = hasSecurityPoolPageOverride ? overrides.securityPoolPage : defaultSecurityPoolPage
+	const securityPoolPage =
+		overrideSecurityPoolPage === undefined
+			? undefined
+			: {
+					...overrideSecurityPoolPage,
+					requestKey: overrideSecurityPoolPage.requestKey ?? `${environmentRefreshKey}:${overrideSecurityPoolPage.pageIndex.toString()}:${overrideSecurityPoolPage.pageSize.toString()}:${accountRequestKey}`,
+				}
 	return {
-		accountState: createAccountState(),
+		accountState,
 		checkedSecurityPoolAddress: undefined,
 		closeLiquidationModal: () => undefined,
-		environmentRefreshKey: 0,
 		hasLoadedSecurityPools: false,
 		hasLoadedSecurityPoolPage: securityPoolPage !== undefined,
 		liquidationAmount: '',
@@ -329,14 +340,15 @@ function createOverviewProps(overrides: Partial<SecurityPoolsOverviewRouteConten
 		repPerEthPrice: undefined,
 		repPerEthSource: undefined,
 		repPerEthSourceUrl: undefined,
-		securityPoolBrowseCount: securityPoolPage?.poolCount,
-		securityPoolPage,
 		securityPoolOverviewActiveAction: undefined,
 		securityPoolOverviewError: undefined,
 		securityPoolLiquidationError: undefined,
 		securityPoolOverviewResult: undefined,
-		securityPools,
 		...overrides,
+		environmentRefreshKey,
+		securityPoolBrowseCount: securityPoolPage?.poolCount,
+		securityPoolPage,
+		securityPools,
 	}
 }
 

--- a/ui/ts/tests/securityPoolsSection.test.ts
+++ b/ui/ts/tests/securityPoolsSection.test.ts
@@ -9,7 +9,7 @@ import { getAddress, zeroAddress, zeroHash, type Address } from 'viem'
 import { SecurityPoolsSection, shouldRefreshSelectedPoolDataOnViewOpen } from '../components/SecurityPoolsSection.js'
 import { deriveHasForkActivity } from '../lib/forkAuction.js'
 import type { AccountState } from '../types/app.js'
-import type { ListedSecurityPool, MarketDetails, OracleManagerDetails, SecurityPoolPage } from '../types/contracts.js'
+import type { ListedSecurityPool, MarketDetails, OracleManagerDetails, SecurityPoolBrowsePage, SecurityPoolPage } from '../types/contracts.js'
 import type { ForkAuctionRouteContentProps, ReportingRouteContentProps, SecurityPoolRouteContentProps, SecurityPoolsOverviewRouteContentProps, SecurityPoolsSectionProps, SecurityPoolWorkflowRouteContentProps, SecurityVaultRouteContentProps, TradingRouteContentProps } from '../types/components.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
@@ -289,13 +289,21 @@ function createWorkflowProps(overrides: Partial<SecurityPoolWorkflowRouteContent
 	}
 }
 
-function createOverviewProps(overrides: Partial<SecurityPoolsOverviewRouteContentProps> = {}): SecurityPoolsOverviewRouteContentProps {
+type SecurityPoolsOverviewRouteTestOverrides = Omit<Partial<SecurityPoolsOverviewRouteContentProps>, 'securityPoolPage'> & {
+	securityPoolPage?: SecurityPoolPage | SecurityPoolBrowsePage | undefined
+}
+
+function getSecurityPoolPageRequestKey(page: SecurityPoolPage | SecurityPoolBrowsePage): string | undefined {
+	return 'requestKey' in page ? page.requestKey : undefined
+}
+
+function createOverviewProps(overrides: SecurityPoolsOverviewRouteTestOverrides = {}): SecurityPoolsOverviewRouteContentProps {
 	const accountState = overrides.accountState ?? createAccountState()
 	const securityPools = overrides.securityPools ?? []
 	const environmentRefreshKey = overrides.environmentRefreshKey ?? 0
 	const accountRequestKey = accountState.address?.toLowerCase() ?? 'no-account'
 	const hasSecurityPoolPageOverride = Object.hasOwn(overrides, 'securityPoolPage')
-	const defaultSecurityPoolPage: SecurityPoolPage | undefined =
+	const defaultSecurityPoolPage: SecurityPoolBrowsePage | undefined =
 		securityPools.length === 0
 			? undefined
 			: {
@@ -311,7 +319,7 @@ function createOverviewProps(overrides: Partial<SecurityPoolsOverviewRouteConten
 			? undefined
 			: {
 					...overrideSecurityPoolPage,
-					requestKey: overrideSecurityPoolPage.requestKey ?? `${environmentRefreshKey}:${overrideSecurityPoolPage.pageIndex.toString()}:${overrideSecurityPoolPage.pageSize.toString()}:${accountRequestKey}`,
+					requestKey: getSecurityPoolPageRequestKey(overrideSecurityPoolPage) ?? `${environmentRefreshKey}:${overrideSecurityPoolPage.pageIndex.toString()}:${overrideSecurityPoolPage.pageSize.toString()}:${accountRequestKey}`,
 				}
 	return {
 		accountState,

--- a/ui/ts/tests/useSecurityPoolsOverview.test.ts
+++ b/ui/ts/tests/useSecurityPoolsOverview.test.ts
@@ -217,7 +217,7 @@ void describe('useSecurityPoolsOverview helpers', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		await act(async () => {
-			await requireHookState(hookState).loadBrowseSecurityPoolPage(0, 2)
+			await requireHookState(hookState).loadBrowseSecurityPoolPage(0, 2, 'ready-request')
 		})
 
 		expect(loadSecurityPoolPage).toHaveBeenCalledTimes(1)

--- a/ui/ts/tests/useSecurityPoolsOverview.test.ts
+++ b/ui/ts/tests/useSecurityPoolsOverview.test.ts
@@ -113,13 +113,13 @@ void describe('useSecurityPoolsOverview helpers', () => {
 		expect(page.pools.map(pool => pool.questionId)).toEqual(['0x03'])
 	})
 
-	void test('recovers registry page no-data reads from already loaded pools without rereading the registry', async () => {
-		const loadedPools = [createListedSecurityPool('0x01', '0x0000000000000000000000000000000000000001'), createListedSecurityPool('0x02', '0x0000000000000000000000000000000000000002'), createListedSecurityPool('0x03', '0x0000000000000000000000000000000000000003')]
+	void test('recovers registry page no-data reads by rereading current registry context', async () => {
+		const initialPools = [createListedSecurityPool('0x01', '0x0000000000000000000000000000000000000001')]
+		const currentPools = [createListedSecurityPool('0x02', '0x0000000000000000000000000000000000000002'), createListedSecurityPool('0x03', '0x0000000000000000000000000000000000000003'), createListedSecurityPool('0x04', '0x0000000000000000000000000000000000000004')]
 		let allPoolsLoadCount = 0
 		const loadAllSecurityPools = mock(async () => {
 			allPoolsLoadCount += 1
-			if (allPoolsLoadCount > 1) throw new Error('loadAllSecurityPools should not be called for cached registry page fallback')
-			return loadedPools
+			return allPoolsLoadCount === 1 ? initialPools : currentPools
 		})
 		const loadSecurityPoolPage = mock(async () => {
 			throw new Error('Contract function returned no data for registry page')
@@ -156,15 +156,19 @@ void describe('useSecurityPoolsOverview helpers', () => {
 			await requireHookState(hookState).loadSecurityPools()
 		})
 
+		expect(allPoolsLoadCount).toBe(1)
+		expect(requireHookState(hookState).securityPools.map(pool => pool.questionId)).toEqual(['0x01'])
+
 		await act(async () => {
-			await requireHookState(hookState).loadBrowseSecurityPoolPage(1, 2)
+			await requireHookState(hookState).loadBrowseSecurityPoolPage(1, 2, 'current-request')
 		})
 
-		expect(allPoolsLoadCount).toBe(1)
+		expect(allPoolsLoadCount).toBe(2)
 		expect(loadSecurityPoolPage).toHaveBeenCalledTimes(1)
 		expect(requireHookState(hookState).securityPoolOverviewError).toBeUndefined()
 		expect(requireHookState(hookState).securityPoolBrowseCount).toBe(3n)
-		expect(requireHookState(hookState).securityPoolPage?.pools.map(pool => pool.questionId)).toEqual(['0x03'])
+		expect(requireHookState(hookState).securityPoolPage?.requestKey).toBe('current-request')
+		expect(requireHookState(hookState).securityPoolPage?.pools.map(pool => pool.questionId)).toEqual(['0x04'])
 	})
 
 	void test('waits for active backend readiness before loading the registry page', async () => {

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -17,8 +17,8 @@ import type {
 	ReportingActionResult,
 	ReportingDetails,
 	ReportingOutcomeKey,
+	SecurityPoolBrowsePage,
 	SecurityPoolCreationResult,
-	SecurityPoolPage,
 	SecurityPoolOverviewActionResult,
 	SecurityPoolVaultSummary,
 	SecurityVaultActionResult,
@@ -476,14 +476,14 @@ export type SecurityPoolsOverviewRouteContentProps = {
 	loadingSecurityPoolPage: boolean
 	loadingSecurityPools: boolean
 	onCreateSecurityPool?: () => void
-	onLoadSecurityPoolPage: (pageIndex: number, pageSize: number, requestKey?: string) => void
+	onLoadSecurityPoolPage: (pageIndex: number, pageSize: number, requestKey: string) => void
 	onOpenLiquidationModal: (managerAddress: Address, securityPoolAddress: Address, vaultAddress: Address, maxAmount: bigint | undefined) => void
 	onSelectSecurityPool?: (securityPoolAddress: string) => void
 	onLoadSecurityPools: () => void
 	securityPoolOverviewError: string | undefined
 	securityPoolOverviewResult: SecurityPoolOverviewActionResult | undefined
 	securityPoolBrowseCount: bigint | undefined
-	securityPoolPage: SecurityPoolPage | undefined
+	securityPoolPage: SecurityPoolBrowsePage | undefined
 	securityPools: ListedSecurityPool[]
 } & LiquidationModalStateProps &
 	RepPerEthPriceProps

--- a/ui/ts/types/components.ts
+++ b/ui/ts/types/components.ts
@@ -476,7 +476,7 @@ export type SecurityPoolsOverviewRouteContentProps = {
 	loadingSecurityPoolPage: boolean
 	loadingSecurityPools: boolean
 	onCreateSecurityPool?: () => void
-	onLoadSecurityPoolPage: (pageIndex: number, pageSize: number) => void
+	onLoadSecurityPoolPage: (pageIndex: number, pageSize: number, requestKey?: string) => void
 	onOpenLiquidationModal: (managerAddress: Address, securityPoolAddress: Address, vaultAddress: Address, maxAmount: bigint | undefined) => void
 	onSelectSecurityPool?: (securityPoolAddress: string) => void
 	onLoadSecurityPools: () => void

--- a/ui/ts/types/contracts.ts
+++ b/ui/ts/types/contracts.ts
@@ -311,7 +311,10 @@ export type SecurityPoolPage = {
 	pageSize: number
 	poolCount: bigint
 	pools: ListedSecurityPool[]
-	requestKey?: string
+}
+
+export type SecurityPoolBrowsePage = SecurityPoolPage & {
+	requestKey: string
 }
 
 export type SecurityPoolVaultSummary = {

--- a/ui/ts/types/contracts.ts
+++ b/ui/ts/types/contracts.ts
@@ -311,6 +311,7 @@ export type SecurityPoolPage = {
 	pageSize: number
 	poolCount: bigint
 	pools: ListedSecurityPool[]
+	requestKey?: string
 }
 
 export type SecurityPoolVaultSummary = {


### PR DESCRIPTION
## Summary
- Added request-key based security pool page tracking so `environmentRefreshKey` and selected account are part of page identity, preventing stale page data from rendering during reloads.
- Updated page loading flow to pass and persist a `requestKey` through `onLoadSecurityPoolPage`, hook, and `SecurityPoolPage` type.
- Updated pagination rendering to hide stale data while pending refreshes and to show loading state only for the active request.
- Kept pagination retry/loading behavior aligned with resolved request keys so Next/Previous and summaries reflect current data only.
- Switched security pool and simulation QA account link labels from shortened addresses to full addresses for link text and tests.
- Added/updated tests for:
  - `SecurityPoolsOverviewSection` stale-data behavior on environment/account changes
  - page reload keying and loading state
  - link label changes for full addresses
  - fallback behavior in `useSecurityPoolsOverview` to refresh from current registry context

## Testing
- Not run (no command execution requested in this PR content task).