### PR TITLE
Add interactive contract-mechanics examples to docs

### DIFF
--- a/docs/openOracleIntegration.html
+++ b/docs/openOracleIntegration.html
@@ -304,7 +304,7 @@
 				<figure class="diagram" id="fig-openoracle-budget-consumption">
 					<svg viewBox="0 0 980 310" role="img" aria-labelledby="budget-consumption-title budget-consumption-desc">
 						<title id="budget-consumption-title">Price-round budget consumption</title>
-						<desc id="budget-consumption-desc">One settled OpenOracle report creates a maximum price-round budget. Successful operations consume that budget until the remaining room is too small and a new report is required.</desc>
+						<desc id="budget-consumption-desc">One settled OpenOracle report creates a maximum price-round budget. Successful operations consume that budget; new requests that do not fit are staged for another report, while pending callback operations that do not fit are consumed as failed.</desc>
 						<defs>
 							<marker id="arrow-budget-consumption" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
 								<path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"></path>
@@ -327,10 +327,10 @@
 						<rect class="svg-red" x="610" y="214" width="378" height="72" rx="8"></rect>
 						<text class="svg-label" x="799" y="239" text-anchor="middle">Remaining Room</text>
 						<text class="svg-label" x="799" y="258" text-anchor="middle">Too Small</text>
-						<text class="svg-small" x="799" y="277" text-anchor="middle">stage for a later OpenOracle report</text>
+						<text class="svg-small" x="799" y="277" text-anchor="middle">new requests stage; pending ones fail</text>
 						<path class="svg-line" marker-end="url(#arrow-budget-consumption)" d="M 610 250 H 468 V 158"></path>
 					</svg>
-					<p class="diagram-caption"><span class="figure-label">Budget Consumption</span>The coordinator treats the settled price as a bounded resource: successful operations subtract from the price-round budget, and operations that no longer fit must wait for another settled report.</p>
+					<p class="diagram-caption"><span class="figure-label">Budget Consumption</span>The coordinator treats the settled price as a bounded resource: successful operations subtract from the price-round budget. A new request that does not fit the cached price round stages for another report; an already staged operation that does not fit during execution is consumed as a failed operation.</p>
 				</figure>
 				<p>
 					Each operation consumes budget according to the exposure it adds or moves.
@@ -439,30 +439,36 @@
 					<p class="equation-caption"><span class="equation-label">Execution Error Threshold</span>The manipulated price only creates liquidation payoff when its fractional error crosses the guarded liquidation threshold.</p>
 				</div>
 				<p>
-					Next ask what the attacker earns and what delay costs. The payoff is binary:
-					crossing the threshold unlocks <code>externalPayoffNotional</code>, while missing
-					the threshold unlocks nothing. The censorship cost grows with duration, the
-					dispute barrier, and the report liquidity honest reporters can use.
-				</p>
-				<div class="equation" id="eq-openoracle-binary-payoff-cost">
-					<math display="block" aria-label="binary attacker payoff and censorship cost" data-source="attackerProfit = { externalPayoffNotional, manipulatedPriceError >= executionErrorThreshold; 0, manipulatedPriceError < executionErrorThreshold }; censorshipRate = max(0, manipulatedPriceError - honestDisputeBarrierFraction); censorshipCost = censorshipDuration \cdot censorshipRate \cdot oracleReportLiquidity">
-						<mtable>
-							<mtr>
-								<mtd><mi>attackerProfit</mi></mtd>
-								<mtd><mo>=</mo></mtd>
+						Next ask what the attacker earns and what delay costs. The payoff is binary:
+						only a price strictly beyond the liquidation threshold and far enough past the
+						guarded distance unlocks <code>externalPayoffNotional</code>; everything else
+						unlocks nothing. The censorship cost grows with duration, the
+						dispute barrier, and the report liquidity honest reporters can use.
+					</p>
+					<div class="equation" id="eq-openoracle-binary-payoff-cost">
+						<math display="block" aria-label="binary attacker payoff and censorship cost" data-source="liquidationExecutable = manipulatedPrice > liquidationThresholdPrice and manipulatedPriceError >= executionErrorThreshold; attackerProfit = { externalPayoffNotional, liquidationExecutable; 0, otherwise }; censorshipRate = max(0, manipulatedPriceError - honestDisputeBarrierFraction); censorshipCost = censorshipDuration \cdot censorshipRate \cdot oracleReportLiquidity">
+							<mtable>
+								<mtr>
+									<mtd><mi>liquidationExecutable</mi></mtd>
+									<mtd><mo>=</mo></mtd>
+									<mtd><mi>manipulatedPrice</mi><mo>&gt;</mo><mi>liquidationThresholdPrice</mi><mo>&#x22C0;</mo><mi>manipulatedPriceError</mi><mo>&ge;</mo><mi>executionErrorThreshold</mi></mtd>
+								</mtr>
+								<mtr>
+									<mtd><mi>attackerProfit</mi></mtd>
+									<mtd><mo>=</mo></mtd>
 								<mtd>
 									<mo>{</mo>
 									<mtable>
-										<mtr>
-											<mtd><mi>externalPayoffNotional</mi></mtd>
-											<mtd><mo>,</mo></mtd>
-											<mtd><mi>manipulatedPriceError</mi><mo>&ge;</mo><mi>executionErrorThreshold</mi></mtd>
-										</mtr>
-										<mtr>
-											<mtd><mn>0</mn></mtd>
-											<mtd><mo>,</mo></mtd>
-											<mtd><mi>manipulatedPriceError</mi><mo>&lt;</mo><mi>executionErrorThreshold</mi></mtd>
-										</mtr>
+											<mtr>
+												<mtd><mi>externalPayoffNotional</mi></mtd>
+												<mtd><mo>,</mo></mtd>
+												<mtd><mi>liquidationExecutable</mi></mtd>
+											</mtr>
+											<mtr>
+												<mtd><mn>0</mn></mtd>
+												<mtd><mo>,</mo></mtd>
+												<mtd><mtext>otherwise</mtext></mtd>
+											</mtr>
 									</mtable>
 								</mtd>
 							</mtr>
@@ -511,47 +517,71 @@
 						<div class="example-grid">
 							<label>
 								Honest price
-								<input type="number" min="0.0001" step="0.01" value="100" data-example-input="honestPrice">
+								<input type="range" min="50" max="200" step="1" value="100" data-example-input="honestPrice">
+								<span class="example-value" data-example-value="honestPrice">100</span>
 							</label>
 							<label>
 								Manipulated price
-								<input type="number" min="0.0001" step="0.01" value="113" data-example-input="manipulatedPrice">
+								<input type="range" min="50" max="250" step="1" value="113" data-example-input="manipulatedPrice">
+								<span class="example-value" data-example-value="manipulatedPrice">113</span>
 							</label>
 							<label>
 								Liquidation threshold
-								<input type="number" min="0.0001" step="0.01" value="101" data-example-input="liquidationThresholdPrice">
+								<input type="range" min="50" max="200" step="1" value="101" data-example-input="liquidationThresholdPrice">
+								<span class="example-value" data-example-value="liquidationThresholdPrice">101</span>
 							</label>
 								<label>
 									Liquidation distance bps
-									<input type="number" min="0" max="10000" step="1" value="1000" data-example-input="minLiquidationPriceDistanceBps">
+									<input type="range" min="0" max="3000" step="100" value="1000" data-example-input="minLiquidationPriceDistanceBps">
+									<span class="example-value" data-example-value="minLiquidationPriceDistanceBps">1000 bps</span>
 								</label>
 							<label>
 								Payoff notional ETH
-								<input type="number" min="0.0001" step="1" value="1000" data-example-input="externalPayoffNotional">
+								<input type="range" min="100" max="10000" step="100" value="1000" data-example-input="externalPayoffNotional">
+								<span class="example-value" data-example-value="externalPayoffNotional">1000 ETH</span>
 							</label>
 							<label>
 								Report liquidity ETH-notional
-								<input type="number" min="0.0001" step="1" value="4000" data-example-input="oracleReportLiquidity">
+								<input type="range" min="100" max="20000" step="100" value="4000" data-example-input="oracleReportLiquidity">
+								<span class="example-value" data-example-value="oracleReportLiquidity">4000 ETH</span>
 							</label>
 							<label>
 								Honest dispute barrier
-								<input type="number" min="0" max="1" step="0.001" value="0.01" data-example-input="honestDisputeBarrierFraction">
+								<input type="range" min="0" max="0.1" step="0.005" value="0.01" data-example-input="honestDisputeBarrierFraction">
+								<span class="example-value" data-example-value="honestDisputeBarrierFraction">1.00%</span>
 							</label>
 							<label>
 									Censorship duration (steps)
-								<input type="number" min="0" step="1" value="24" data-example-input="censorshipDuration">
+								<input type="range" min="0" max="168" step="1" value="24" data-example-input="censorshipDuration">
+								<span class="example-value" data-example-value="censorshipDuration">24 steps</span>
 							</label>
 							<label>
 								Target grief ratio
-								<input type="number" min="0" step="0.1" value="1" data-example-input="targetGriefRatio">
+								<input type="range" min="0" max="5" step="0.1" value="1" data-example-input="targetGriefRatio">
+								<span class="example-value" data-example-value="targetGriefRatio">1.0</span>
 							</label>
-						</div>
-						<ul class="example-output" aria-live="polite">
-							<li>Execution error threshold: <output data-example-output="executionErrorThreshold">0%</output></li>
-							<li>Manipulated price error: <output data-example-output="manipulatedPriceError">0%</output></li>
-							<li>Attacker payoff: <output data-example-output="attackerProfit">0 ETH</output></li>
-							<li>Censorship cost: <output data-example-output="censorshipCost">0 ETH</output></li>
-							<li>Oracle liquidity ratio: <output data-example-output="oracleLiquidityRatio">0</output></li>
+							</div>
+							<div class="example-visual">
+								<svg viewBox="0 0 760 210" role="img" aria-label="Binary censorship threshold and cost comparison">
+									<rect class="example-bar-base" x="120" y="42" width="520" height="28" rx="6"></rect>
+									<rect class="example-bar-blue" x="120" y="42" width="120" height="28" rx="6" data-example-rect="executionErrorThreshold"></rect>
+									<rect class="example-bar-red" x="120" y="86" width="130" height="28" rx="6" data-example-rect="manipulatedPriceError"></rect>
+									<text class="svg-label" x="120" y="30">Price error needed vs. supplied</text>
+									<text class="svg-small" x="650" y="63" text-anchor="end" data-example-text="thresholdText">threshold 0%</text>
+									<text class="svg-small" x="650" y="107" text-anchor="end" data-example-text="errorText">error 0%</text>
+									<rect class="example-bar-base" x="120" y="150" width="520" height="24" rx="6"></rect>
+									<rect class="example-bar-gold" x="120" y="150" width="180" height="24" rx="6" data-example-rect="censorshipCost"></rect>
+									<line class="svg-line" x1="640" y1="136" x2="640" y2="188"></line>
+									<text class="svg-small" x="650" y="190" text-anchor="end" data-example-text="payoffText">payoff 0 ETH</text>
+								</svg>
+							</div>
+								<ul class="example-output" aria-live="polite">
+									<li>Execution error threshold: <output data-example-output="executionErrorThreshold">0%</output></li>
+									<li>Manipulated price error: <output data-example-output="manipulatedPriceError">0%</output></li>
+									<li>Liquidation executable: <output data-example-output="liquidationExecutable">no</output></li>
+								<li>Attacker payoff: <output data-example-output="attackerProfit">0 ETH</output></li>
+								<li>Censorship cost: <output data-example-output="censorshipCost">0 ETH</output></li>
+								<li>Oracle liquidity ratio: <output data-example-output="oracleLiquidityRatio">0</output></li>
 							<li>Safe censorship duration (steps): <output data-example-output="safeCensorshipDuration">0</output></li>
 						</ul>
 					</details>
@@ -579,9 +609,66 @@
 								<mtd><mfrac><mi>oracleReportLiquidity</mi><mi>externalPayoffNotional</mi></mfrac><mo>&ge;</mo><mfrac><mi>ORACLE_BUDGET_BPS</mi><mi>priceRoundBudgetMultiplierBps</mi></mfrac></mtd>
 							</mtr>
 						</mtable>
-					</math>
+				</math>
 					<p class="equation-caption"><span class="equation-label">Budgeted Liquidity Ratio</span>The <span class="term" tabindex="0">ETH-notional</span> budget keeps parasitic or repeated operation volume from attaching unlimited payoff to a single OpenOracle report.</p>
 				</div>
+				<details class="interactive-example" id="price-round-budget-example">
+					<summary>Adjust price-round budget consumption</summary>
+					<p>
+						One settled REP/ETH report can authorize only a bounded ETH-notional volume.
+						Withdrawals, liquidations, and allowance increases all spend the same round
+						budget, so repeated operations cannot attach unlimited payoff to one price.
+							This ordered sequence is specifically pending callback replay: an operation that
+							does not fit during replay fails and is removed. A new request that does not fit
+							the cached price round stages for a later report instead.
+					</p>
+					<div class="example-grid">
+						<label>
+							Report liquidity ETH-notional
+							<input type="range" min="100" max="20000" step="100" value="4000" data-example-input="reportLiquidity">
+							<span class="example-value" data-example-value="reportLiquidity">4000 ETH</span>
+						</label>
+						<label>
+							Price-round multiplier
+							<input type="range" min="10000" max="80000" step="5000" value="40000" data-example-input="budgetMultiplierBps">
+							<span class="example-value" data-example-value="budgetMultiplierBps">4.0x</span>
+						</label>
+						<label>
+							Withdrawal notional
+							<input type="range" min="0" max="20000" step="100" value="3000" data-example-input="withdrawalNotional">
+							<span class="example-value" data-example-value="withdrawalNotional">3000 ETH</span>
+						</label>
+						<label>
+							Liquidation notional
+							<input type="range" min="0" max="20000" step="100" value="7000" data-example-input="liquidationNotional">
+							<span class="example-value" data-example-value="liquidationNotional">7000 ETH</span>
+						</label>
+						<label>
+							Allowance increase notional
+							<input type="range" min="0" max="20000" step="100" value="5000" data-example-input="allowanceNotional">
+							<span class="example-value" data-example-value="allowanceNotional">5000 ETH</span>
+						</label>
+						</div>
+						<div class="example-visual">
+							<svg viewBox="0 0 760 180" role="img" aria-label="Price-round budget consumed and remaining">
+								<rect class="example-bar-base" x="110" y="54" width="540" height="34" rx="6"></rect>
+								<rect class="example-bar-green" x="110" y="54" width="101" height="34" rx="6" data-example-rect="withdrawalBudget"></rect>
+								<rect class="example-bar-blue" x="211" y="54" width="236" height="34" rx="0" data-example-rect="liquidationBudget"></rect>
+								<rect class="example-bar-gold" x="447" y="54" width="169" height="34" rx="0" data-example-rect="allowanceBudget"></rect>
+								<line class="svg-line" x1="650" y1="36" x2="650" y2="108"></line>
+								<text class="svg-label" x="110" y="36">Sequential round-budget consumption</text>
+								<text class="svg-small" x="650" y="126" text-anchor="end" data-example-text="budgetCapText">budget 16000 ETH</text>
+								<text class="svg-small" x="110" y="150" data-example-text="budgetStatusText">1000 ETH remains</text>
+							</svg>
+						</div>
+						<ul class="example-output" aria-live="polite">
+							<li>Round budget: <output data-example-output="roundBudget">16000 ETH</output></li>
+							<li>Withdrawal: <output data-example-output="withdrawalResult">executes; 13000 ETH remains</output></li>
+						<li>Liquidation: <output data-example-output="liquidationResult">executes; 6000 ETH remains</output></li>
+						<li>Allowance increase: <output data-example-output="allowanceResult">executes; 1000 ETH remains</output></li>
+						<li>Consumed by successful operations: <output data-example-output="consumedNotional">15000 ETH</output></li>
+					</ul>
+				</details>
 				<ul>
 					<li><strong>Censorship and delay:</strong> <code>settlementTime</code> gives reporters time to dispute, while the price-round budget keeps <code>oracleLiquidityRatio</code> from collapsing as more operations use the same price.</li>
 					<li><strong>Binary threshold attacks:</strong> staged liquidations must satisfy <code>minLiquidationPriceDistanceBps = 1000</code>, so <math aria-label="current price minus threshold price divided by current price" data-source="(currentPrice - thresholdPrice) / currentPrice"><mfrac><mrow><mi>currentPrice</mi><mo>-</mo><mi>thresholdPrice</mi></mrow><mi>currentPrice</mi></mfrac></math> must be at least <code>10%</code> rather than barely crossing the threshold.</li>
@@ -593,40 +680,46 @@
 					The <a href="https://docs.openoracle.org/openoracle/attack-vectors-inclusion#dynamic-programming-analysis">dynamic-programming
 					section</a> of OpenOracle's inclusion analysis is a template for the inclusion
 					tradeoff, not a drop-in Placeholder proof. For a simplified binary censorship
-					bound, replace the linear price-error payoff with a thresholded payoff that only
-					pays after the manipulated report crosses the liquidation threshold. A full
-					binary-delay model also needs state for distance to threshold, price evolution,
-					and continuation value. Locally, OpenOracle escalation is also capped: once
+						bound, replace the linear price-error payoff with a thresholded payoff that only
+						pays after the manipulated report is strictly beyond the liquidation threshold
+						and far enough past the guarded distance. A full binary-delay model also needs
+						state for distance to threshold, price evolution,
+						and continuation value. Locally, OpenOracle escalation is also capped: once
 					<code>escalationHalt</code> is reached, disputes can continue, but the required
-					token1 amount advances by <code>1</code> instead of multiplying by
-					<code>reportEscalationMultiplier</code>.
+					token1 amount advances by <code>1</code> atomic token1 unit instead of multiplying
+					by <code>reportEscalationMultiplier</code>.
 				</p>
-				<div class="equation" id="eq-openoracle-binary-dp-terminal">
-					<math display="block" aria-label="binary dynamic programming terminal payoff equals external payoff notional when manipulated price error is at least execution error threshold and zero when it is below the threshold, per block bribe equals max zero manipulated price error minus honest dispute barrier fraction times report size, and report size is capped by escalation halt before advancing by one" data-source="binarySettlePayoff(manipulatedPriceError) = { externalPayoffNotional, manipulatedPriceError >= executionErrorThreshold; 0, manipulatedPriceError < executionErrorThreshold }; censorshipBribeAtStep(manipulatedPriceError) = max(0, manipulatedPriceError - honestDisputeBarrierFraction) \cdot reportSizeAtStep; nextReportSize = min(escalationHalt, reportEscalationMultiplier \cdot reportSizeAtStep) before halt; nextReportSize = reportSizeAtStep + 1 after halt">
-						<mtable>
-							<mtr>
-								<mtd><mi>binarySettlePayoff</mi><mo>(</mo><mi>manipulatedPriceError</mi><mo>)</mo></mtd>
-								<mtd><mo>=</mo></mtd>
+					<div class="equation" id="eq-openoracle-binary-dp-terminal">
+						<math display="block" aria-label="binary dynamic programming terminal payoff equals external payoff notional when liquidation executable is true and zero otherwise, per block bribe equals max zero manipulated price error minus honest dispute barrier fraction times report size divided by REP per ETH price, and report size is capped by escalation halt before advancing by one atomic token one unit" data-source="liquidationExecutable = manipulatedPrice > liquidationThresholdPrice and manipulatedPriceError >= executionErrorThreshold; binarySettlePayoff(manipulatedPriceError) = { externalPayoffNotional, liquidationExecutable; 0, otherwise }; censorshipBribeAtStep(manipulatedPriceError) = max(0, manipulatedPriceError - honestDisputeBarrierFraction) \cdot reportSizeAtStep / repPerEthPrice; nextReportSize = min(escalationHalt, reportEscalationMultiplier \cdot reportSizeAtStep) before halt; nextReportSize = reportSizeAtStep + 1 atomic token1 unit after halt">
+							<mtable>
+								<mtr>
+									<mtd><mi>liquidationExecutable</mi></mtd>
+									<mtd><mo>=</mo></mtd>
+									<mtd><mi>manipulatedPrice</mi><mo>&gt;</mo><mi>liquidationThresholdPrice</mi><mo>&#x22C0;</mo><mi>manipulatedPriceError</mi><mo>&ge;</mo><mi>executionErrorThreshold</mi></mtd>
+								</mtr>
+								<mtr>
+									<mtd><mi>binarySettlePayoff</mi><mo>(</mo><mi>manipulatedPriceError</mi><mo>)</mo></mtd>
+									<mtd><mo>=</mo></mtd>
 								<mtd>
 									<mo>{</mo>
 									<mtable>
-										<mtr>
-											<mtd><mi>externalPayoffNotional</mi></mtd>
-											<mtd><mo>,</mo></mtd>
-											<mtd><mi>manipulatedPriceError</mi><mo>&ge;</mo><mi>executionErrorThreshold</mi></mtd>
-										</mtr>
-										<mtr>
-											<mtd><mn>0</mn></mtd>
-											<mtd><mo>,</mo></mtd>
-											<mtd><mi>manipulatedPriceError</mi><mo>&lt;</mo><mi>executionErrorThreshold</mi></mtd>
-										</mtr>
+											<mtr>
+												<mtd><mi>externalPayoffNotional</mi></mtd>
+												<mtd><mo>,</mo></mtd>
+												<mtd><mi>liquidationExecutable</mi></mtd>
+											</mtr>
+											<mtr>
+												<mtd><mn>0</mn></mtd>
+												<mtd><mo>,</mo></mtd>
+													<mtd><mtext>otherwise</mtext></mtd>
+											</mtr>
 									</mtable>
 								</mtd>
 							</mtr>
 							<mtr>
 								<mtd><mi>censorshipBribeAtStep</mi><mo>(</mo><mi>manipulatedPriceError</mi><mo>)</mo></mtd>
 								<mtd><mo>=</mo></mtd>
-								<mtd><mi>max</mi><mo>(</mo><mn>0</mn><mo>,</mo><mi>manipulatedPriceError</mi><mo>-</mo><mi>honestDisputeBarrierFraction</mi><mo>)</mo><mo>&#x22C5;</mo><mi>reportSizeAtStep</mi></mtd>
+									<mtd><mfrac><mrow><mi>max</mi><mo>(</mo><mn>0</mn><mo>,</mo><mi>manipulatedPriceError</mi><mo>-</mo><mi>honestDisputeBarrierFraction</mi><mo>)</mo><mo>&#x22C5;</mo><mi>reportSizeAtStep</mi></mrow><mi>repPerEthPrice</mi></mfrac></mtd>
 							</mtr>
 							<mtr>
 								<mtd><mi>nextReportSize</mi></mtd>
@@ -636,13 +729,79 @@
 							<mtr>
 								<mtd><mi>nextReportSize</mi></mtd>
 								<mtd><mo>=</mo></mtd>
-								<mtd><mi>reportSizeAtStep</mi><mo>+</mo><mn>1</mn><mtext> after halt</mtext></mtd>
+								<mtd><mi>reportSizeAtStep</mi><mo>+</mo><mn>1</mn><mtext> atomic token1 unit after halt</mtext></mtd>
 							</mtr>
 						</mtable>
-					</math>
-					<p class="equation-caption"><span class="equation-label">Binary Dynamic Programming Terminal</span>The simplified terminal payoff pays only after the reported error crosses the threshold distance. The censorship bribe still scales with report size, but local report-size growth is capped by <code>escalationHalt</code> before continuing linearly.</p>
-				</div>
-			</section>
+						</math>
+						<p class="equation-caption"><span class="equation-label">Binary Dynamic Programming Terminal</span>The simplified terminal payoff pays only after the reported error crosses the threshold distance. The censorship bribe still scales with report size, but local report-size growth is capped by <code>escalationHalt</code> before continuing by one atomic unit per step.</p>
+					</div>
+					<details class="interactive-example" id="report-escalation-example">
+						<summary>Adjust report escalation and censorship bribe growth</summary>
+						<p>
+							OpenOracle disputes multiply the required report size until the halt is reached.
+							After that, the next required amount advances by <code>+1</code> atomic token1
+							unit, which is <code>0.000000000000000001 REP</code> for REP. The REP-scale
+							visual therefore remains effectively pinned at the halt while the exact amount
+							and per-step bribe continue to advance by one wei of REP. The bribe output
+							converts REP-side report size to ETH notional through the selected REP/ETH price.
+						</p>
+						<div class="example-grid">
+							<label>
+								Initial report size
+								<input type="range" min="10" max="1000" step="10" value="250" data-example-input="initialReportSize">
+								<span class="example-value" data-example-value="initialReportSize">250 REP</span>
+							</label>
+							<label>
+								Escalation multiplier
+								<input type="range" min="1" max="5" step="0.05" value="1.15" data-example-input="reportMultiplier">
+								<span class="example-value" data-example-value="reportMultiplier">1.15x</span>
+							</label>
+							<label>
+								Escalation halt
+								<input type="range" min="250" max="10000" step="250" value="2500" data-example-input="escalationHalt">
+								<span class="example-value" data-example-value="escalationHalt">2500 REP</span>
+							</label>
+							<label>
+								Steps
+								<input type="range" min="1" max="24" step="1" value="20" data-example-input="reportSteps">
+								<span class="example-value" data-example-value="reportSteps">20 steps</span>
+							</label>
+							<label>
+								Manipulated price error
+								<input type="range" min="0" max="0.5" step="0.01" value="0.12" data-example-input="reportError">
+								<span class="example-value" data-example-value="reportError">12.00%</span>
+							</label>
+								<label>
+									Honest dispute barrier
+									<input type="range" min="0" max="0.2" step="0.005" value="0.02" data-example-input="reportBarrier">
+									<span class="example-value" data-example-value="reportBarrier">2.00%</span>
+								</label>
+								<label>
+									REP per ETH price
+									<input type="range" min="10" max="500" step="10" value="100" data-example-input="repPerEthPrice">
+									<span class="example-value" data-example-value="repPerEthPrice">100 REP/ETH</span>
+								</label>
+							</div>
+						<div class="example-visual">
+							<svg viewBox="0 0 760 230" role="img" aria-label="Report escalation sizes and bribe cost">
+								<text class="svg-label" x="80" y="32">Report size by step</text>
+								<rect class="example-bar-base" x="90" y="52" width="560" height="28" rx="6"></rect>
+								<rect class="example-bar-blue" x="90" y="52" width="56" height="28" rx="6" data-example-rect="reportStepOne"></rect>
+								<rect class="example-bar-green" x="90" y="92" width="112" height="28" rx="6" data-example-rect="reportStepTwo"></rect>
+								<rect class="example-bar-gold" x="90" y="132" width="224" height="28" rx="6" data-example-rect="reportStepLast"></rect>
+								<line class="svg-line" x1="650" y1="44" x2="650" y2="170"></line>
+								<text class="svg-small" x="650" y="190" text-anchor="end" data-example-text="haltMarker">halt 2500 REP</text>
+									<text class="svg-small" x="90" y="214" data-example-text="bribeText">latest bribe 2.50 ETH-notional</text>
+							</svg>
+						</div>
+						<div class="example-output-grid">
+							<div><span>Final report size</span><output data-example-output="finalReportSize">2500.000000000000000002 REP</output></div>
+							<div><span>Growth mode</span><output data-example-output="growthMode">halt reached; +1 wei of REP per step</output></div>
+							<div><span>Latest per-step bribe</span><output data-example-output="latestBribe">2.50 ETH-notional</output></div>
+							<div><span>Cumulative bribe proxy</span><output data-example-output="cumulativeBribe">23.77 ETH-notional</output></div>
+						</div>
+					</details>
+				</section>
 
 			<section id="parameters">
 				<h2>OpenOracle Parameters Used</h2>
@@ -668,13 +827,13 @@
 						</tr>
 						<tr>
 							<td><code>exactToken1Report</code></td>
-							<td><math aria-label="250 times price precision scale" data-source="250 \cdot pow10(18)"><mn>250</mn><mo>&#x22C5;</mo><msup><mn>10</mn><mn>18</mn></msup></math> REP</td>
+								<td>250 REP (<math aria-label="250 times 10 to the 18 atomic REP units" data-source="250 \cdot pow10(18) atomic REP units"><mn>250</mn><mo>&#x22C5;</mo><msup><mn>10</mn><mn>18</mn></msup></math> atomic REP units)</td>
 							<td>Sets the initial report size and feeds the price-round budget.</td>
 						</tr>
 						<tr>
 							<td><code>escalationHalt</code></td>
-							<td><math aria-label="exact token one report times 100000 divided by 10000" data-source="exactToken1Report \cdot 100000 / 10000"><mi>exactToken1Report</mi><mo>&#x22C5;</mo><mn>100000</mn><mo>/</mo><mn>10000</mn></math></td>
-							<td>Stops required report-size escalation at <code>10x</code> the initial REP report amount.</td>
+								<td>2,500 REP (<math aria-label="2500 times 10 to the 18 atomic REP units" data-source="2500 \cdot pow10(18) atomic REP units"><mn>2500</mn><mo>&#x22C5;</mo><msup><mn>10</mn><mn>18</mn></msup></math> atomic REP units)</td>
+							<td>Stops multiplicative report-size escalation at <code>10x</code>; later disputes add one atomic REP unit at a time.</td>
 						</tr>
 						<tr>
 							<td><code>settlerReward</code></td>
@@ -725,81 +884,251 @@
 				</table>
 			</section>
 		</main>
-		<script>
-			const binaryCensorshipExample = document.querySelector('#binary-censorship-example')
-			if (binaryCensorshipExample) {
-				const exampleInputs = Object.fromEntries(
-					Array.from(binaryCensorshipExample.querySelectorAll('[data-example-input]')).map((inputElement) => [
-						inputElement.dataset.exampleInput,
-						inputElement,
-					]),
-				)
-				const exampleOutputs = Object.fromEntries(
-					Array.from(binaryCensorshipExample.querySelectorAll('[data-example-output]')).map((outputElement) => [
-						outputElement.dataset.exampleOutput,
-						outputElement,
-					]),
-				)
-				const readExampleNumber = (inputName) => {
-					const inputElement = exampleInputs[inputName]
-					if (!inputElement) {
-						return 0
+			<script>
+				const collectExample = (exampleId) => {
+					const root = document.querySelector(exampleId)
+					if (!root) {
+						return undefined
 					}
-					const inputValue = Number(inputElement.value)
-					return Number.isFinite(inputValue) ? inputValue : 0
-				}
-					const formatPercent = (fractionValue) => `${(fractionValue * 100).toFixed(2)}%`
-					const formatEth = (ethValue) => `${ethValue.toFixed(2)} ETH`
-					const formatExecutionThreshold = (thresholdValue) => {
-						if (!Number.isFinite(thresholdValue)) {
-							return 'no finite threshold'
+					const collect = (selector, key) =>
+						Object.fromEntries(Array.from(root.querySelectorAll(selector)).map(element => [element.dataset[key], element]))
+					const inputs = collect('[data-example-input]', 'exampleInput')
+					const outputs = collect('[data-example-output]', 'exampleOutput')
+					const values = collect('[data-example-value]', 'exampleValue')
+					const rects = collect('[data-example-rect]', 'exampleRect')
+					const texts = collect('[data-example-text]', 'exampleText')
+					const read = (inputName) => {
+						const inputElement = inputs[inputName]
+						if (!inputElement) {
+							return 0
 						}
-						return formatPercent(thresholdValue)
+						const inputValue = Number(inputElement.value)
+						return Number.isFinite(inputValue) ? inputValue : 0
 					}
-					const formatDuration = (durationValue) => {
-						if (!Number.isFinite(durationValue)) {
-							return 'unbounded when censorship rate is zero'
+					const writeOutput = (outputName, value) => {
+						const outputElement = outputs[outputName]
+						if (outputElement) {
+							outputElement.value = value
+						}
+					}
+					const writeValue = (valueName, value) => {
+						const valueElement = values[valueName]
+						if (valueElement) {
+							valueElement.textContent = value
+						}
+					}
+					const writeText = (textName, value) => {
+						const textElement = texts[textName]
+						if (textElement) {
+							textElement.textContent = value
+						}
+					}
+					const setRect = (rectName, attributes) => {
+						const rectElement = rects[rectName]
+						if (!rectElement) {
+							return
+						}
+						for (const [attributeName, attributeValue] of Object.entries(attributes)) {
+							rectElement.setAttribute(attributeName, String(attributeValue))
+						}
+					}
+					const setRectWidth = (rectName, width) => setRect(rectName, { width: Math.max(0, width) })
+					const setRectX = (rectName, x) => setRect(rectName, { x })
+					return { inputs, read, setRect, setRectWidth, setRectX, writeOutput, writeText, writeValue }
+				}
+				const bindExample = (exampleId, update) => {
+					const context = collectExample(exampleId)
+					if (!context) {
+						return
+					}
+					for (const inputElement of Object.values(context.inputs)) {
+						inputElement.addEventListener('input', () => update(context))
+					}
+					update(context)
+				}
+				const formatPercent = (fractionValue) => `${(fractionValue * 100).toFixed(2)}%`
+				const formatEth = (ethValue) => `${ethValue.toFixed(2)} ETH`
+				const formatExecutionThreshold = (thresholdValue) => {
+					if (!Number.isFinite(thresholdValue)) {
+						return 'no finite threshold'
+					}
+					return formatPercent(thresholdValue)
+				}
+				const formatDuration = (durationValue) => {
+					if (!Number.isFinite(durationValue)) {
+						return 'unbounded when censorship rate is zero'
 					}
 					return durationValue.toFixed(2)
 				}
-				const updateBinaryCensorshipExample = () => {
-					const honestPrice = Math.max(readExampleNumber('honestPrice'), 0.0001)
-					const manipulatedPrice = Math.max(readExampleNumber('manipulatedPrice'), 0.0001)
-					const liquidationThresholdPrice = Math.max(readExampleNumber('liquidationThresholdPrice'), 0.0001)
-					const minLiquidationPriceDistanceBps = Math.max(readExampleNumber('minLiquidationPriceDistanceBps'), 0)
-						const externalPayoffNotional = Math.max(readExampleNumber('externalPayoffNotional'), 0.0001)
-						const oracleReportLiquidity = Math.max(readExampleNumber('oracleReportLiquidity'), 0.0001)
-						const honestDisputeBarrierFraction = Math.max(readExampleNumber('honestDisputeBarrierFraction'), 0)
-						const censorshipDuration = Math.max(readExampleNumber('censorshipDuration'), 0)
-						const targetGriefRatio = Math.max(readExampleNumber('targetGriefRatio'), 0)
-						const boundedLiquidationDistanceBps = Math.min(minLiquidationPriceDistanceBps, 10000)
-						const liquidationDistanceFraction = boundedLiquidationDistanceBps / 10000
-						const discountedHonestPrice = honestPrice * (1 - liquidationDistanceFraction)
-						const executionErrorThreshold =
-							discountedHonestPrice === 0
-								? Number.POSITIVE_INFINITY
-								: Math.max(0, liquidationThresholdPrice / discountedHonestPrice - 1)
-						const manipulatedPriceError = Math.max(0, (manipulatedPrice - honestPrice) / honestPrice)
-						const attackerProfit = manipulatedPriceError >= executionErrorThreshold ? externalPayoffNotional : 0
+				bindExample('#binary-censorship-example', context => {
+					const honestPrice = Math.max(context.read('honestPrice'), 0.0001)
+					const manipulatedPrice = Math.max(context.read('manipulatedPrice'), 0.0001)
+					const liquidationThresholdPrice = Math.max(context.read('liquidationThresholdPrice'), 0.0001)
+					const minLiquidationPriceDistanceBps = Math.max(context.read('minLiquidationPriceDistanceBps'), 0)
+					const externalPayoffNotional = Math.max(context.read('externalPayoffNotional'), 0.0001)
+					const oracleReportLiquidity = Math.max(context.read('oracleReportLiquidity'), 0.0001)
+					const honestDisputeBarrierFraction = Math.max(context.read('honestDisputeBarrierFraction'), 0)
+					const censorshipDuration = Math.max(context.read('censorshipDuration'), 0)
+					const targetGriefRatio = Math.max(context.read('targetGriefRatio'), 0)
+					const boundedLiquidationDistanceBps = Math.min(minLiquidationPriceDistanceBps, 10000)
+					const liquidationDistanceFraction = boundedLiquidationDistanceBps / 10000
+					const discountedHonestPrice = honestPrice * (1 - liquidationDistanceFraction)
+					const executionErrorThreshold =
+						discountedHonestPrice === 0 ? Number.POSITIVE_INFINITY : Math.max(0, liquidationThresholdPrice / discountedHonestPrice - 1)
+					const manipulatedPriceError = Math.max(0, (manipulatedPrice - honestPrice) / honestPrice)
+					const liquidationExecutable = manipulatedPrice > liquidationThresholdPrice && manipulatedPriceError >= executionErrorThreshold
+					const attackerProfit = liquidationExecutable ? externalPayoffNotional : 0
 					const censorshipRate = Math.max(0, manipulatedPriceError - honestDisputeBarrierFraction)
 					const censorshipCost = censorshipDuration * censorshipRate * oracleReportLiquidity
 					const oracleLiquidityRatio = oracleReportLiquidity / externalPayoffNotional
 					const safeCensorshipDuration =
 						censorshipRate === 0 ? Number.POSITIVE_INFINITY : (targetGriefRatio + 1) / (censorshipRate * oracleLiquidityRatio)
-
-						exampleOutputs.executionErrorThreshold.value = formatExecutionThreshold(executionErrorThreshold)
-					exampleOutputs.manipulatedPriceError.value = formatPercent(manipulatedPriceError)
-					exampleOutputs.attackerProfit.value = formatEth(attackerProfit)
-					exampleOutputs.censorshipCost.value = formatEth(censorshipCost)
-					exampleOutputs.oracleLiquidityRatio.value = oracleLiquidityRatio.toFixed(2)
-					exampleOutputs.safeCensorshipDuration.value = formatDuration(safeCensorshipDuration)
-				}
-				for (const inputElement of Object.values(exampleInputs)) {
-					inputElement.addEventListener('input', updateBinaryCensorshipExample)
-				}
-				updateBinaryCensorshipExample()
-			}
-		</script>
+					context.writeValue('honestPrice', honestPrice.toFixed(0))
+					context.writeValue('manipulatedPrice', manipulatedPrice.toFixed(0))
+					context.writeValue('liquidationThresholdPrice', liquidationThresholdPrice.toFixed(0))
+					context.writeValue('minLiquidationPriceDistanceBps', `${boundedLiquidationDistanceBps.toFixed(0)} bps`)
+					context.writeValue('externalPayoffNotional', formatEth(externalPayoffNotional))
+					context.writeValue('oracleReportLiquidity', formatEth(oracleReportLiquidity))
+					context.writeValue('honestDisputeBarrierFraction', formatPercent(honestDisputeBarrierFraction))
+					context.writeValue('censorshipDuration', `${censorshipDuration.toFixed(0)} steps`)
+					context.writeValue('targetGriefRatio', targetGriefRatio.toFixed(1))
+					context.writeOutput('executionErrorThreshold', formatExecutionThreshold(executionErrorThreshold))
+					context.writeOutput('manipulatedPriceError', formatPercent(manipulatedPriceError))
+					context.writeOutput('liquidationExecutable', liquidationExecutable ? 'yes' : 'no')
+					context.writeOutput('attackerProfit', formatEth(attackerProfit))
+					context.writeOutput('censorshipCost', formatEth(censorshipCost))
+					context.writeOutput('oracleLiquidityRatio', oracleLiquidityRatio.toFixed(2))
+					context.writeOutput('safeCensorshipDuration', formatDuration(safeCensorshipDuration))
+					const thresholdForVisual = Number.isFinite(executionErrorThreshold) ? executionErrorThreshold : manipulatedPriceError
+					const priceErrorScale = Math.max(thresholdForVisual, manipulatedPriceError, 0.01)
+					context.setRectWidth('executionErrorThreshold', Math.min(thresholdForVisual / priceErrorScale * 520, 520))
+					context.setRectWidth('manipulatedPriceError', Math.min(manipulatedPriceError / priceErrorScale * 520, 520))
+					context.setRectWidth('censorshipCost', Math.min(censorshipCost / Math.max(externalPayoffNotional, 1) * 520, 520))
+					context.writeText('thresholdText', `threshold ${formatExecutionThreshold(executionErrorThreshold)}`)
+					context.writeText('errorText', `error ${formatPercent(manipulatedPriceError)}`)
+					context.writeText('payoffText', `payoff ${formatEth(attackerProfit)}`)
+				})
+				bindExample('#price-round-budget-example', context => {
+					const reportLiquidity = context.read('reportLiquidity')
+					const budgetMultiplierBps = context.read('budgetMultiplierBps')
+					const withdrawalNotional = context.read('withdrawalNotional')
+					const liquidationNotional = context.read('liquidationNotional')
+					const allowanceNotional = context.read('allowanceNotional')
+					const roundBudget = reportLiquidity * budgetMultiplierBps / 10000
+					let remainingBudget = roundBudget
+					let consumedNotional = 0
+					const consumedByOperation = []
+					const operationResult = notional => {
+						if (notional <= remainingBudget) {
+							remainingBudget -= notional
+							consumedNotional += notional
+							consumedByOperation.push(notional)
+							return `executes; ${formatEth(remainingBudget)} remains`
+						}
+						consumedByOperation.push(0)
+						return `operation fails and is removed; ${formatEth(remainingBudget)} remains`
+					}
+					context.writeValue('reportLiquidity', formatEth(reportLiquidity))
+					context.writeValue('budgetMultiplierBps', `${(budgetMultiplierBps / 10000).toFixed(1)}x`)
+					context.writeValue('withdrawalNotional', formatEth(withdrawalNotional))
+					context.writeValue('liquidationNotional', formatEth(liquidationNotional))
+					context.writeValue('allowanceNotional', formatEth(allowanceNotional))
+					context.writeOutput('roundBudget', formatEth(roundBudget))
+					context.writeOutput('withdrawalResult', operationResult(withdrawalNotional))
+					context.writeOutput('liquidationResult', operationResult(liquidationNotional))
+					context.writeOutput('allowanceResult', operationResult(allowanceNotional))
+					context.writeOutput('consumedNotional', formatEth(consumedNotional))
+					const budgetScale = roundBudget <= 0 ? 0 : 540 / roundBudget
+					const withdrawalWidth = consumedByOperation[0] * budgetScale
+					const liquidationWidth = consumedByOperation[1] * budgetScale
+					const allowanceWidth = consumedByOperation[2] * budgetScale
+					context.setRect('withdrawalBudget', { x: 110, width: withdrawalWidth })
+					context.setRect('liquidationBudget', { x: 110 + withdrawalWidth, width: liquidationWidth })
+					context.setRect('allowanceBudget', { x: 110 + withdrawalWidth + liquidationWidth, width: allowanceWidth })
+					context.writeText('budgetCapText', `budget ${formatEth(roundBudget)}`)
+					context.writeText('budgetStatusText', `${formatEth(remainingBudget)} remains after successful operations`)
+				})
+				bindExample('#report-escalation-example', context => {
+					const reportAtomicDisplayScale = 1_000_000n
+					const weiPerReportDisplayUnit = 1_000_000_000_000n
+					const reportAtomicPerRep = reportAtomicDisplayScale * weiPerReportDisplayUnit
+					const toReportAtomic = (repValue) =>
+						BigInt(Math.round(repValue * Number(reportAtomicDisplayScale))) * weiPerReportDisplayUnit
+					const fromReportAtomic = (atomicValue) => Number(atomicValue / weiPerReportDisplayUnit) / Number(reportAtomicDisplayScale)
+					const formatReportRep = (repValue) => `${repValue.toFixed(2)} REP`
+					const formatReportAtomic = (atomicValue) => {
+						const wholePart = atomicValue / reportAtomicPerRep
+						const fractionalPart = atomicValue % reportAtomicPerRep
+						const fractionalText = fractionalPart.toString().padStart(18, '0')
+						if (fractionalPart === 0n) {
+							return `${wholePart.toString()} REP`
+						}
+						return `${wholePart.toString()}.${fractionalText} REP`
+					}
+					const formatReportPercent = (fractionValue) => `${(fractionValue * 100).toFixed(2)}%`
+						const initialReportSize = Math.max(context.read('initialReportSize'), 0.0001)
+						const reportMultiplier = Math.max(context.read('reportMultiplier'), 1)
+						const escalationHalt = Math.max(context.read('escalationHalt'), initialReportSize)
+						const reportSteps = Math.max(context.read('reportSteps'), 1)
+						const reportError = Math.max(context.read('reportError'), 0)
+						const reportBarrier = Math.max(context.read('reportBarrier'), 0)
+						const repPerEthPrice = Math.max(context.read('repPerEthPrice'), 0.0001)
+						const initialReportSizeAtomic = toReportAtomic(initialReportSize)
+						const escalationHaltAtomic = toReportAtomic(escalationHalt)
+						const reportMultiplierUnits = BigInt(Math.round(reportMultiplier * 100))
+						const reportSizes = [initialReportSizeAtomic]
+						let capped = initialReportSizeAtomic >= escalationHaltAtomic
+						let usedAtomicIncrement = false
+						for (let stepIndex = 1; stepIndex < reportSteps; stepIndex += 1) {
+							const previousSize = reportSizes[reportSizes.length - 1]
+							const multipliedSize = previousSize * reportMultiplierUnits / 100n
+							let nextSize = multipliedSize
+							if (capped) {
+								nextSize = previousSize + 1n
+							} else if (multipliedSize > escalationHaltAtomic) {
+								nextSize = escalationHaltAtomic
+							}
+							if (capped) {
+								usedAtomicIncrement = true
+							}
+							if (nextSize >= escalationHaltAtomic) {
+								capped = true
+							}
+							reportSizes.push(nextSize)
+						}
+						const effectiveError = Math.max(0, reportError - reportBarrier)
+						const latestReportSize = reportSizes[reportSizes.length - 1]
+						const latestReportSizeRep = fromReportAtomic(latestReportSize)
+						const latestBribe = latestReportSizeRep / repPerEthPrice * effectiveError
+						const cumulativeBribe = reportSizes.reduce(
+							(sum, reportSize) => sum + fromReportAtomic(reportSize) / repPerEthPrice * effectiveError,
+							0,
+						)
+						const visualScale = 560 / Math.max(escalationHalt, latestReportSizeRep, 1)
+						context.writeValue('initialReportSize', formatReportRep(initialReportSize))
+						context.writeValue('reportMultiplier', `${reportMultiplier.toFixed(2)}x`)
+						context.writeValue('escalationHalt', formatReportRep(escalationHalt))
+						context.writeValue('reportSteps', `${reportSteps.toFixed(0)} steps`)
+						context.writeValue('reportError', formatReportPercent(reportError))
+						context.writeValue('reportBarrier', formatReportPercent(reportBarrier))
+						context.writeValue('repPerEthPrice', `${repPerEthPrice.toFixed(0)} REP/ETH`)
+						context.setRectWidth('reportStepOne', fromReportAtomic(reportSizes[0]) * visualScale)
+						context.setRectWidth('reportStepTwo', fromReportAtomic(reportSizes[Math.min(1, reportSizes.length - 1)]) * visualScale)
+						context.setRectWidth('reportStepLast', latestReportSizeRep * visualScale)
+						context.writeText('haltMarker', `halt ${formatReportRep(escalationHalt)}`)
+						context.writeText('bribeText', `latest bribe ${latestBribe.toFixed(2)} ETH-notional`)
+						context.writeOutput('finalReportSize', formatReportAtomic(latestReportSize))
+						let growthMode = 'multiplicative below halt'
+						if (usedAtomicIncrement) {
+							growthMode = 'halt reached; +1 wei of REP per step'
+						} else if (capped) {
+							growthMode = 'halt reached on final step'
+						}
+						context.writeOutput('growthMode', growthMode)
+						context.writeOutput('latestBribe', `${latestBribe.toFixed(2)} ETH-notional`)
+						context.writeOutput('cumulativeBribe', `${cumulativeBribe.toFixed(2)} ETH-notional`)
+					})
+			</script>
 		<script src="./protocolTerms.js"></script>
 		<script src="./termTooltips.js"></script>
 	</body>

--- a/docs/shared-docs.css
+++ b/docs/shared-docs.css
@@ -254,9 +254,79 @@ body.doc-openoracle .example-grid input {
 	color: var(--ink);
 	font: inherit;
 }
+body.doc-openoracle .example-grid input[type="range"] {
+	padding: 0;
+	border: 0;
+	accent-color: var(--accent);
+}
+body.doc-openoracle .example-value {
+	color: var(--ink);
+	font-size: 0.86rem;
+	font-weight: 800;
+}
 body.doc-openoracle .example-output {
 	margin: 0;
 	padding-left: 1.1rem;
+}
+body.doc-openoracle .example-output-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+	gap: 0.75rem;
+	margin-top: 1rem;
+}
+body.doc-openoracle .example-output-grid div {
+	padding: 0.75rem;
+	border: 1px solid var(--line);
+	border-radius: var(--radius);
+	background: var(--card-bg);
+}
+body.doc-openoracle .example-output-grid span {
+	display: block;
+	color: var(--muted);
+	font-size: 0.82rem;
+	font-weight: 700;
+}
+body.doc-openoracle .example-output-grid output {
+	display: block;
+	margin-top: 0.25rem;
+	color: var(--ink);
+	font-weight: 800;
+}
+body.doc-openoracle .example-visual {
+	margin: 1rem 0;
+	border: 1px solid var(--line);
+	border-radius: var(--radius);
+	background: var(--section-bg);
+	overflow-x: auto;
+}
+body.doc-openoracle .example-visual svg {
+	display: block;
+	width: 100%;
+	min-width: 34rem;
+	height: auto;
+}
+body.doc-openoracle .example-bar-base {
+	fill: color-mix(in srgb, var(--line) 58%, transparent);
+}
+body.doc-openoracle .example-bar-green {
+	fill: var(--green-soft);
+	stroke: var(--green);
+	stroke-width: 1.5;
+}
+body.doc-openoracle .example-bar-blue {
+	fill: var(--blue-soft);
+	stroke: var(--blue);
+	stroke-width: 1.5;
+}
+body.doc-openoracle .example-bar-gold {
+	fill: var(--gold-soft);
+	stroke: var(--gold);
+	stroke-width: 1.5;
+}
+body.doc-openoracle .example-bar-red {
+	fill: var(--red-soft);
+	stroke: var(--red);
+	stroke-width: 1.5;
 }
 body.doc-openoracle .figure-label,
 body.doc-openoracle .equation-label {
@@ -862,6 +932,105 @@ body.paper-placeholder .callout {
 body.paper-placeholder .callout strong {
 	display: block;
 	margin-bottom: 0.25rem;
+}
+body.paper-placeholder .interactive-example {
+	max-width: 76ch;
+	margin: 1.25rem 0;
+	padding: 1rem;
+	border: 1px solid var(--soft-line);
+	border-radius: var(--radius);
+	background: var(--card-bg);
+}
+body.paper-placeholder .interactive-example summary {
+	cursor: pointer;
+	font-weight: 800;
+}
+body.paper-placeholder .interactive-example > p {
+	margin: 0.75rem 0 0;
+}
+body.paper-placeholder .example-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(min(100%, 13rem), 1fr));
+	gap: 0.85rem;
+	margin: 1rem 0;
+}
+body.paper-placeholder .example-grid label {
+	display: grid;
+	gap: 0.35rem;
+	color: var(--muted);
+	font-size: 0.9rem;
+	font-weight: 700;
+}
+body.paper-placeholder .example-grid input[type="range"] {
+	width: 100%;
+	accent-color: var(--accent);
+}
+body.paper-placeholder .example-value {
+	color: var(--ink);
+	font-size: 0.86rem;
+	font-weight: 800;
+}
+body.paper-placeholder .example-output-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(min(100%, 12rem), 1fr));
+	gap: 0.7rem;
+	margin: 0.85rem 0 0;
+}
+body.paper-placeholder .example-output-grid div {
+	padding: 0.75rem;
+	border: 1px solid var(--soft-line);
+	border-radius: calc(var(--radius) * 0.75);
+	background: var(--paper);
+}
+body.paper-placeholder .example-output-grid span {
+	display: block;
+	color: var(--muted);
+	font-size: 0.74rem;
+	font-weight: 850;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+}
+body.paper-placeholder .example-output-grid output {
+	display: block;
+	margin-top: 0.25rem;
+	color: var(--ink);
+	font-weight: 850;
+}
+body.paper-placeholder .example-visual {
+	margin-top: 1rem;
+	border: 1px solid var(--soft-line);
+	border-radius: var(--radius);
+	background: var(--section-bg);
+	overflow-x: auto;
+}
+body.paper-placeholder .example-visual svg {
+	display: block;
+	width: 100%;
+	min-width: 34rem;
+	height: auto;
+}
+body.paper-placeholder .example-bar-base {
+	fill: color-mix(in srgb, var(--line) 58%, transparent);
+}
+body.paper-placeholder .example-bar-green {
+	fill: var(--green-soft);
+	stroke: var(--green);
+	stroke-width: 1.5;
+}
+body.paper-placeholder .example-bar-blue {
+	fill: var(--blue-soft);
+	stroke: var(--blue);
+	stroke-width: 1.5;
+}
+body.paper-placeholder .example-bar-gold {
+	fill: var(--gold-soft);
+	stroke: var(--gold);
+	stroke-width: 1.5;
+}
+body.paper-placeholder .example-bar-red {
+	fill: var(--red-soft);
+	stroke: var(--red);
+	stroke-width: 1.5;
 }
 body.paper-placeholder .equation,
 body.paper-placeholder .diagram {

--- a/docs/whitepaper_placeholder.html
+++ b/docs/whitepaper_placeholder.html
@@ -993,6 +993,51 @@
 						</svg>
 						<p class="diagram-caption"><span class="figure-label">Share Migration</span>Share migration is not a pro-rata split across selected branches. The source balance is burned once and reproduced in each valid selected child token id.</p>
 					</figure>
+					<details class="interactive-example" id="share-migration-example">
+						<summary>Adjust a share migration reproduction example</summary>
+						<p>
+								The migration call burns the full parent token balance and reproduces that same
+								balance into each selected child outcome. The contract accepts any non-empty,
+								strictly increasing list of valid non-malformed fork-question outcome indexes;
+								this compact diagram caps the displayed branches at three to show why migration is
+								not a pro-rata split.
+						</p>
+									<div class="example-grid">
+							<label>
+								Parent share balance
+								<input type="range" min="1" max="100" step="1" value="30" data-example-input="parentBalance">
+								<span class="example-value" data-example-value="parentBalance">30 shares</span>
+							</label>
+							<label>
+									Displayed selected child outcomes
+								<input type="range" min="1" max="3" step="1" value="2" data-example-input="selectedChildren">
+								<span class="example-value" data-example-value="selectedChildren">2 branches</span>
+							</label>
+						</div>
+						<div class="example-visual">
+							<svg viewBox="0 0 760 220" role="img" aria-label="Share migration balance reproduction">
+								<rect class="example-bar-base" x="80" y="42" width="220" height="32" rx="6"></rect>
+								<rect class="example-bar-red" x="80" y="42" width="66" height="32" rx="6" data-example-rect="parent"></rect>
+								<text class="svg-label" x="80" y="30">Parent burned</text>
+								<text class="svg-small" x="314" y="64" data-example-text="parentText">30</text>
+								<path class="svg-line" d="M 350 58 H 420"></path>
+								<rect class="example-bar-base" x="460" y="30" width="220" height="28" rx="6"></rect>
+								<rect class="example-bar-green" x="460" y="30" width="66" height="28" rx="6" data-example-rect="childA"></rect>
+								<text class="svg-small" x="690" y="50" data-example-text="childAText">30</text>
+								<rect class="example-bar-base" x="460" y="82" width="220" height="28" rx="6"></rect>
+								<rect class="example-bar-blue" x="460" y="82" width="66" height="28" rx="6" data-example-rect="childB"></rect>
+								<text class="svg-small" x="690" y="102" data-example-text="childBText">30</text>
+								<rect class="example-bar-base" x="460" y="134" width="220" height="28" rx="6"></rect>
+								<rect class="example-bar-gold" x="460" y="134" width="66" height="28" rx="6" data-example-rect="childC"></rect>
+								<text class="svg-small" x="690" y="154" data-example-text="childCText">0</text>
+							</svg>
+						</div>
+						<div class="example-output-grid">
+							<div><span>Parent balance after call</span><output data-example-output="parentAfter">0 shares</output></div>
+							<div><span>Child balance per selected branch</span><output data-example-output="childBalance">30 shares</output></div>
+							<div><span>Total displayed child balances</span><output data-example-output="totalChildBalances">60 shares</output></div>
+						</div>
+					</details>
 					<ul>
 						<li>The selected target list must be non-empty.</li>
 						<li>The caller must hold a positive balance of the parent token id.</li>
@@ -1125,6 +1170,127 @@
 								and the game applies a small tie-avoidance adjustment when a below-threshold
 								deposit would otherwise make two outcomes share the maximum balance.
 							</p>
+							<details class="interactive-example" id="escalation-deposit-example">
+								<summary>Adjust escalation deposit clipping and tie avoidance</summary>
+								<p>
+									The accepted deposit is capped by remaining room under the non-decision
+									threshold. If a below-threshold deposit would tie the current leading
+									outcome, the game reduces the accepted amount by one atomic REP unit
+									(<code>1 wei</code> of REP precision).
+								</p>
+								<div class="example-grid">
+									<label>
+										Invalid balance
+										<input type="range" min="0" max="20" step="1" value="1" data-example-input="invalidBalance">
+										<span class="example-value" data-example-value="invalidBalance">1 REP</span>
+									</label>
+									<label>
+										Yes balance
+										<input type="range" min="0" max="20" step="1" value="9" data-example-input="yesBalance">
+										<span class="example-value" data-example-value="yesBalance">9 REP</span>
+									</label>
+									<label>
+										No balance
+										<input type="range" min="0" max="20" step="1" value="7" data-example-input="noBalance">
+										<span class="example-value" data-example-value="noBalance">7 REP</span>
+									</label>
+									<label>
+										Proposed deposit to No
+										<input type="range" min="0" max="20" step="1" value="5" data-example-input="proposedDeposit">
+										<span class="example-value" data-example-value="proposedDeposit">5 REP</span>
+									</label>
+									<label>
+										Start bond
+										<input type="range" min="1" max="10" step="1" value="2" data-example-input="startBond">
+										<span class="example-value" data-example-value="startBond">2 REP</span>
+									</label>
+									<label>
+										Non-decision threshold
+										<input type="range" min="5" max="25" step="1" value="10" data-example-input="nonDecisionThreshold">
+										<span class="example-value" data-example-value="nonDecisionThreshold">10 REP</span>
+									</label>
+								</div>
+								<div class="example-visual">
+									<svg viewBox="0 0 760 230" role="img" aria-label="Escalation deposit accepted amount">
+										<text class="svg-label" x="70" y="34">Before</text>
+										<text class="svg-label" x="405" y="34">After accepted deposit</text>
+										<rect class="example-bar-base" x="80" y="58" width="220" height="24" rx="5"></rect>
+										<rect class="example-bar-blue" x="80" y="58" width="11" height="24" rx="5" data-example-rect="invalidBefore"></rect>
+										<text class="svg-small" x="315" y="76">Invalid</text>
+										<rect class="example-bar-base" x="80" y="102" width="220" height="24" rx="5"></rect>
+										<rect class="example-bar-green" x="80" y="102" width="99" height="24" rx="5" data-example-rect="yesBefore"></rect>
+										<text class="svg-small" x="315" y="120">Yes</text>
+										<rect class="example-bar-base" x="80" y="146" width="220" height="24" rx="5"></rect>
+										<rect class="example-bar-red" x="80" y="146" width="77" height="24" rx="5" data-example-rect="noBefore"></rect>
+										<text class="svg-small" x="315" y="164">No</text>
+										<rect class="example-bar-base" x="420" y="58" width="220" height="24" rx="5"></rect>
+										<rect class="example-bar-blue" x="420" y="58" width="11" height="24" rx="5" data-example-rect="invalidAfter"></rect>
+										<rect class="example-bar-base" x="420" y="102" width="220" height="24" rx="5"></rect>
+										<rect class="example-bar-green" x="420" y="102" width="99" height="24" rx="5" data-example-rect="yesAfter"></rect>
+										<rect class="example-bar-base" x="420" y="146" width="220" height="24" rx="5"></rect>
+										<rect class="example-bar-red" x="420" y="146" width="110" height="24" rx="5" data-example-rect="noAfter"></rect>
+										<line class="svg-line" x1="80" y1="190" x2="640" y2="190"></line>
+										<text class="svg-small" x="640" y="211" text-anchor="end" data-example-text="thresholdText">threshold 10 REP</text>
+									</svg>
+								</div>
+								<div class="example-output-grid">
+									<div><span>Room on No</span><output data-example-output="remainingRoom">3 REP</output></div>
+									<div><span>Accepted amount</span><output data-example-output="acceptedAmount">3 REP</output></div>
+									<div><span>Adjustment</span><output data-example-output="depositAdjustment">clipped to threshold</output></div>
+									<div><span>Post-deposit condition</span><output data-example-output="depositCondition">No reaches threshold</output></div>
+								</div>
+							</details>
+							<details class="interactive-example" id="resolution-edge-example">
+								<summary>Adjust escalation resolution edge cases</summary>
+								<p>
+									The resolution helper first checks whether at least two outcomes meet the
+									running cost. If not unresolved, strict <code>Invalid</code> or
+									<code>Yes</code> leads win before the fallback to <code>No</code>.
+								</p>
+								<div class="example-grid">
+									<label>
+										Invalid balance
+										<input type="range" min="0" max="20" step="1" value="4" data-example-input="invalidBalance">
+										<span class="example-value" data-example-value="invalidBalance">4 REP</span>
+									</label>
+									<label>
+										Yes balance
+										<input type="range" min="0" max="20" step="1" value="6" data-example-input="yesBalance">
+										<span class="example-value" data-example-value="yesBalance">6 REP</span>
+									</label>
+									<label>
+										No balance
+										<input type="range" min="0" max="20" step="1" value="6" data-example-input="noBalance">
+										<span class="example-value" data-example-value="noBalance">6 REP</span>
+									</label>
+										<label>
+											Running total cost
+											<input type="range" min="1" max="20" step="1" value="5" data-example-input="runningCost">
+											<span class="example-value" data-example-value="runningCost">5 REP</span>
+										</label>
+									</div>
+									<div class="example-visual">
+										<svg viewBox="0 0 760 210" role="img" aria-label="Resolution balances against running cost">
+											<text class="svg-label" x="80" y="30">Balances compared with running cost</text>
+											<rect class="example-bar-base" x="90" y="50" width="520" height="24" rx="5"></rect>
+											<rect class="example-bar-blue" x="90" y="50" width="104" height="24" rx="5" data-example-rect="resolutionInvalid"></rect>
+											<text class="svg-small" x="625" y="68">Invalid</text>
+											<rect class="example-bar-base" x="90" y="92" width="520" height="24" rx="5"></rect>
+											<rect class="example-bar-green" x="90" y="92" width="156" height="24" rx="5" data-example-rect="resolutionYes"></rect>
+											<text class="svg-small" x="625" y="110">Yes</text>
+											<rect class="example-bar-base" x="90" y="134" width="520" height="24" rx="5"></rect>
+											<rect class="example-bar-red" x="90" y="134" width="156" height="24" rx="5" data-example-rect="resolutionNo"></rect>
+											<text class="svg-small" x="625" y="152">No</text>
+											<line class="svg-line" x1="220" y1="40" x2="220" y2="174"></line>
+											<text class="svg-small" x="220" y="194" text-anchor="middle" data-example-text="resolutionCostMarker">cost 5 REP</text>
+										</svg>
+									</div>
+									<div class="example-output-grid">
+									<div><span>Outcomes at or above cost</span><output data-example-output="outcomesAtCost">2</output></div>
+									<div><span>Resolution helper returns</span><output data-example-output="resolutionResult">None</output></div>
+									<div><span>Reason</span><output data-example-output="resolutionReason">two outcomes still contest the cost</output></div>
+								</div>
+							</details>
 					<p>
 						The contract exposes both directions of this curve: it can compute the required
 								cost from elapsed time, and it can derive the effective end time from the final
@@ -1370,6 +1536,66 @@
 						game’s configured <code>nonDecisionThreshold</code>, the payout is scaled down by
 						<code>actualForkThreshold / nonDecisionThreshold</code>.
 					</p>
+					<details class="interactive-example" id="payout-region-example">
+						<summary>Adjust escalation payout regions and threshold scaling</summary>
+							<p>
+								Winning capital up to the reward cap shares the fixed reward pool. Winning
+								capital above the cap receives principal only, and a lower actual fork threshold
+								scales the withdrawal down. If the fallback <code>No</code> outcome wins after
+								<code>Invalid</code> and <code>Yes</code> tie at larger balances, the binding
+								capital can be greater than the winning principal; the contract still computes
+								the payout from those two values.
+							</p>
+						<div class="example-grid">
+							<label>
+								Binding capital
+								<input type="range" min="1" max="50" step="1" value="10" data-example-input="bindingCapital">
+								<span class="example-value" data-example-value="bindingCapital">10 REP</span>
+							</label>
+							<label>
+								Winning principal
+								<input type="range" min="1" max="80" step="1" value="18" data-example-input="winningPrincipal">
+								<span class="example-value" data-example-value="winningPrincipal">18 REP</span>
+							</label>
+							<label>
+								This deposit amount
+								<input type="range" min="1" max="30" step="1" value="5" data-example-input="depositAmount">
+								<span class="example-value" data-example-value="depositAmount">5 REP</span>
+							</label>
+							<label>
+								Deposit starts after
+								<input type="range" min="0" max="80" step="1" value="10" data-example-input="depositStart">
+								<span class="example-value" data-example-value="depositStart">10 REP</span>
+							</label>
+							<label>
+								Actual fork threshold share
+								<input type="range" min="20" max="100" step="5" value="100" data-example-input="actualForkThresholdPercent">
+								<span class="example-value" data-example-value="actualForkThresholdPercent">100%</span>
+							</label>
+						</div>
+						<div class="example-visual">
+							<svg viewBox="0 0 760 190" role="img" aria-label="Escalation payout regions">
+								<rect class="example-bar-base" x="80" y="62" width="600" height="36" rx="7"></rect>
+								<rect class="example-bar-green" x="80" y="62" width="333" height="36" rx="7" data-example-rect="bindingRegion"></rect>
+								<rect class="example-bar-gold" x="413" y="62" width="167" height="36" rx="0" data-example-rect="safetyRegion"></rect>
+								<rect class="example-bar-red" x="580" y="62" width="80" height="36" rx="0" data-example-rect="excessRegion"></rect>
+								<line class="svg-line" x1="80" y1="124" x2="680" y2="124"></line>
+								<text class="svg-small" x="80" y="145">0</text>
+								<text class="svg-small" x="413" y="145" text-anchor="middle" data-example-text="bindingMarker">binding 10</text>
+								<text class="svg-small" x="580" y="145" text-anchor="middle" data-example-text="capMarker">cap 15</text>
+								<text class="svg-small" x="680" y="145" text-anchor="end" data-example-text="winningMarker">winning 18</text>
+							</svg>
+						</div>
+						<div class="example-output-grid">
+							<div><span>Reward-eligible cap</span><output data-example-output="rewardCap">15 REP</output></div>
+							<div><span>Reward bonus pool</span><output data-example-output="rewardPool">6 REP</output></div>
+							<div><span>Reward-eligible part of this deposit</span><output data-example-output="eligibleDeposit">5 REP</output></div>
+							<div><span>Excess principal</span><output data-example-output="excessPrincipal">3 REP</output></div>
+								<div><span>This deposit withdrawal</span><output data-example-output="depositWithdrawal">7 REP</output></div>
+								<div><span>Scaled withdrawal</span><output data-example-output="scaledWithdrawal">7 REP</output></div>
+							<div><span>Payout state</span><output data-example-output="payoutState">reachable game state</output></div>
+						</div>
+					</details>
 						<p>
 							Settlement uses different calls for local games, own-fork claims, external-fork
 							migration, and child continuation games. The distinction matters because some
@@ -2079,6 +2305,57 @@
 								</math>
 								<p class="equation-caption"><span class="equation-label">Forked Escrow Scaling</span>Forked escrow claims scale source principal into child REP with ceiling division, and cumulative claimed state prevents each partial proof from restarting the rounding calculation.</p>
 							</div>
+							<details class="interactive-example" id="forked-escrow-example">
+								<summary>Adjust forked escrow cumulative rounding</summary>
+								<p>
+									Each claim computes the cumulative child REP that should have been released,
+									then subtracts what was already claimed. This prevents each partial proof from
+									restarting the ceiling division. Rounding is at atomic REP precision, so each
+									ceiling step rounds up by at most one atomic unit.
+								</p>
+								<div class="example-grid">
+									<label>
+										Escrow source principal
+										<input type="range" min="1" max="100" step="1" value="17" data-example-input="escrowPrincipal">
+										<span class="example-value" data-example-value="escrowPrincipal">17 REP</span>
+									</label>
+									<label>
+										Escrow child REP
+										<input type="range" min="1" max="100" step="1" value="23" data-example-input="escrowChildRep">
+										<span class="example-value" data-example-value="escrowChildRep">23 REP</span>
+									</label>
+									<label>
+										Already claimed source
+										<input type="range" min="0" max="100" step="1" value="5" data-example-input="claimedSource">
+										<span class="example-value" data-example-value="claimedSource">5 REP</span>
+									</label>
+									<label>
+										New source claim
+										<input type="range" min="1" max="50" step="1" value="4" data-example-input="newSourceClaim">
+										<span class="example-value" data-example-value="newSourceClaim">4 REP</span>
+										</label>
+									</div>
+									<div class="example-visual">
+										<svg viewBox="0 0 760 210" role="img" aria-label="Forked escrow cumulative rounding">
+											<text class="svg-label" x="80" y="32">Cumulative release minus already claimed</text>
+											<rect class="example-bar-base" x="90" y="58" width="560" height="28" rx="6"></rect>
+											<rect class="example-bar-blue" x="90" y="58" width="165" height="28" rx="6" data-example-rect="alreadyReleasedBar"></rect>
+											<rect class="example-bar-green" x="255" y="58" width="132" height="28" rx="0" data-example-rect="releasedNowBar"></rect>
+											<text class="svg-small" x="650" y="78" text-anchor="end" data-example-text="cumulativeText">cumulative 12.176471 REP</text>
+											<text class="svg-label" x="80" y="126">If this claim restarted rounding alone</text>
+											<rect class="example-bar-base" x="90" y="148" width="560" height="24" rx="6"></rect>
+											<rect class="example-bar-gold" x="90" y="148" width="132" height="24" rx="6" data-example-rect="restartRoundingBar"></rect>
+											<text class="svg-small" x="650" y="168" text-anchor="end" data-example-text="restartText">restart 5.411765 REP</text>
+										</svg>
+									</div>
+									<div class="example-output-grid">
+									<div><span>Child REP already released</span><output data-example-output="alreadyReleased">6.764706 REP</output></div>
+									<div><span>Cumulative child REP after claim</span><output data-example-output="cumulativeRelease">12.176471 REP</output></div>
+									<div><span>Child REP released now</span><output data-example-output="releasedNow">5.411765 REP</output></div>
+									<div><span>If rounding restarted</span><output data-example-output="restartRounding">5.411765 REP if each claim rounded alone</output></div>
+									<div><span>Claim bounds</span><output data-example-output="claimBounds">within escrow principal</output></div>
+								</div>
+							</details>
 							<h3>Recursive Continuation Example</h3>
 						<div class="table-wrap">
 							<table class="wide-table">
@@ -2169,7 +2446,7 @@
 						<p class="diagram-caption"><span class="figure-label">System Decision Flow</span>The main path is simple, but the continuation loop matters: a child escalation game can become the parent of the next fork generation.</p>
 					</figure>
 					<div class="equation" id="eq-placeholder-truth-auction-shortfall">
-						<math display="block" aria-label="ETH collateral to buy equals parent collateral amount minus parent collateral amount times migrated REP amount divided by REP at fork amount" data-source="ethCollateralToBuy = parentCollateralAmount - parentCollateralAmount \cdot migratedRepAmount / repAtForkAmount">
+						<math display="block" aria-label="ETH collateral to buy equals parent collateral amount minus parent collateral amount times migrated REP amount divided by repair denominator REP at fork amount" data-source="ethCollateralToBuy = parentCollateralAmount - parentCollateralAmount \cdot migratedRepAmount / repairDenominatorRepAtForkAmount">
 							<mrow>
 								<mi>ethCollateralToBuy</mi>
 								<mo>=</mo>
@@ -2181,16 +2458,16 @@
 										<mo>&#x22C5;</mo>
 										<mi>migratedRepAmount</mi>
 									</mrow>
-									<mi>repAtForkAmount</mi>
+										<mi>repairDenominatorRepAtForkAmount</mi>
 								</mfrac>
 							</mrow>
 						</math>
-						<p class="equation-caption"><span class="equation-label">Auction Shortfall</span>The truth auction targets the parent collateral not already covered by migrated REP.</p>
+							<p class="equation-caption"><span class="equation-label">Auction Shortfall</span>The truth auction targets the parent collateral not already covered by migrated REP. The denominator is the contract’s repair denominator: own-fork repair uses <code>vaultRepAtFork</code>, while external-fork repair uses <code>auctionableRepAtFork</code>.</p>
 					</div>
 					<h3>Worked Example: Child-Universe Collateral Repair</h3>
 					<div class="callout">
 						Worked repair example: if a parent pool has <code>50 ETH</code> supporting clean
-						redemption and <code>200 REP</code> at fork, then a split where
+						redemption and <code>200 REP</code> of parent auctionable pool REP at fork, then a split where
 						<code>190 REP</code> moves to the user-preferred child and <code>10 REP</code>
 						moves elsewhere gives the preferred child <code>47.5 ETH</code> by proportional
 						collateral migration. The child is short <code>2.5 ETH</code>. If the truth
@@ -2198,6 +2475,55 @@
 						returns to the full <code>50 ETH</code> collateral base; if the auction is
 						underfunded, collateral repair is incomplete.
 					</div>
+					<details class="interactive-example" id="collateral-repair-example">
+						<summary>Adjust child collateral repair</summary>
+						<p>
+							Migration moves collateral in proportion to migrated REP. The auction can repair
+							the remaining ETH shortfall only up to the ETH it actually raises.
+							For own-fork children the denominator is the parent pool's
+							<code>vaultRepAtFork</code>; for external-fork children it is the parent pool's
+							full <code>auctionableRepAtFork</code>.
+						</p>
+						<div class="example-grid">
+							<label>
+								Parent collateral
+								<input type="range" min="10" max="200" step="1" value="50" data-example-input="parentCollateral">
+								<span class="example-value" data-example-value="parentCollateral">50 ETH</span>
+							</label>
+							<label>
+								Repair denominator REP at fork
+								<input type="range" min="10" max="500" step="1" value="200" data-example-input="repairDenominatorRepAtFork">
+								<span class="example-value" data-example-value="repairDenominatorRepAtFork">200 REP</span>
+							</label>
+							<label>
+								Migrated REP
+								<input type="range" min="0" max="500" step="1" value="190" data-example-input="migratedRep">
+								<span class="example-value" data-example-value="migratedRep">190 REP</span>
+							</label>
+							<label>
+								Auction ETH raised
+								<input type="range" min="0" max="100" step="0.5" value="2.5" data-example-input="auctionRaised">
+								<span class="example-value" data-example-value="auctionRaised">2.5 ETH</span>
+							</label>
+						</div>
+						<div class="example-visual">
+							<svg viewBox="0 0 760 170" role="img" aria-label="Child collateral repair progress">
+								<rect class="example-bar-base" x="80" y="58" width="600" height="34" rx="7"></rect>
+								<rect class="example-bar-green" x="80" y="58" width="570" height="34" rx="7" data-example-rect="migratedCollateral"></rect>
+								<rect class="example-bar-blue" x="650" y="58" width="30" height="34" rx="0" data-example-rect="auctionRepair"></rect>
+								<line class="svg-line" x1="680" y1="42" x2="680" y2="108"></line>
+								<text class="svg-small" x="80" y="126">0 ETH</text>
+								<text class="svg-small" x="680" y="126" text-anchor="end" data-example-text="repairTarget">target 50 ETH</text>
+							</svg>
+						</div>
+						<div class="example-output-grid">
+							<div><span>Migrated collateral</span><output data-example-output="migratedCollateral">47.50 ETH</output></div>
+							<div><span>Initial shortfall</span><output data-example-output="initialShortfall">2.50 ETH</output></div>
+							<div><span>Remaining shortfall</span><output data-example-output="remainingShortfall">0.00 ETH</output></div>
+							<div><span>Repair status</span><output data-example-output="repairStatus">full repair</output></div>
+							<div><span>Migration bounds</span><output data-example-output="migrationBounds">within repair denominator REP</output></div>
+						</div>
+					</details>
 				</section>
 
 				<section class="paper-section" id="auction">
@@ -2656,6 +2982,69 @@
 						vault claims. It converts part of the child-universe security capital into the
 						ETH collateral required for the child market to continue operating cleanly.
 					</p>
+					<details class="interactive-example" id="auction-clearing-example">
+						<summary>Adjust funded and underfunded auction clearing</summary>
+							<p>
+								The auction sells REP at a uniform clearing price when demand is strong enough.
+									The contract input is an integer tick; this example uses a three-level
+									tick-derived ladder displayed near <code>5</code>, <code>4</code>, and
+									<code>3 ETH/REP</code> to keep the arithmetic readable. If qualifying demand is
+									below the ETH raise cap, the qualifying bidders share the full REP inventory pro
+									rata by ETH contribution. The calculator shows human-unit allocations; exact
+									withdrawals use integer REP-wei division with remainder carry across paged
+									withdrawals.
+								</p>
+						<div class="example-grid">
+							<label>
+								ETH raise cap
+								<input type="range" min="1" max="60" step="1" value="20" data-example-input="ethRaiseCap">
+								<span class="example-value" data-example-value="ethRaiseCap">20 ETH</span>
+							</label>
+							<label>
+								REP inventory
+								<input type="range" min="1" max="20" step="1" value="4" data-example-input="repInventory">
+								<span class="example-value" data-example-value="repInventory">4 REP</span>
+								</label>
+								<label>
+									Alice ETH at high tick (~5 ETH/REP)
+									<input type="range" min="0" max="30" step="1" value="3" data-example-input="aliceEth">
+									<span class="example-value" data-example-value="aliceEth">3 ETH</span>
+								</label>
+								<label>
+									Bob ETH at middle tick (~4 ETH/REP)
+									<input type="range" min="0" max="30" step="1" value="4" data-example-input="bobEth">
+									<span class="example-value" data-example-value="bobEth">4 ETH</span>
+								</label>
+								<label>
+									Carol ETH at low tick (~3 ETH/REP)
+									<input type="range" min="0" max="30" step="1" value="6" data-example-input="carolEth">
+									<span class="example-value" data-example-value="carolEth">6 ETH</span>
+								</label>
+						</div>
+						<div class="example-visual">
+							<svg viewBox="0 0 760 210" role="img" aria-label="Auction clearing allocation">
+								<rect class="example-bar-base" x="100" y="44" width="560" height="28" rx="6"></rect>
+								<rect class="example-bar-green" x="100" y="44" width="140" height="28" rx="6" data-example-rect="aliceRep"></rect>
+								<rect class="example-bar-blue" x="240" y="44" width="187" height="28" rx="0" data-example-rect="bobRep"></rect>
+								<rect class="example-bar-gold" x="427" y="44" width="233" height="28" rx="0" data-example-rect="carolRep"></rect>
+								<text class="svg-label" x="100" y="30">REP allocation</text>
+								<rect class="example-bar-base" x="100" y="118" width="560" height="28" rx="6"></rect>
+								<rect class="example-bar-green" x="100" y="118" width="168" height="28" rx="6" data-example-rect="ethRaised"></rect>
+								<line class="svg-line" x1="660" y1="100" x2="660" y2="160"></line>
+								<text class="svg-label" x="100" y="104">ETH raised toward cap</text>
+								<text class="svg-small" x="660" y="176" text-anchor="end" data-example-text="ethCapMarker">cap 20 ETH</text>
+							</svg>
+						</div>
+						<div class="example-output-grid">
+								<div><span>Clearing mode</span><output data-example-output="clearingMode">funded near 3 ETH/REP</output></div>
+							<div><span>ETH raised</span><output data-example-output="ethRaised">12 ETH</output></div>
+							<div><span>Derived underfunded threshold</span><output data-example-output="underfundedThreshold">not underfunded</output></div>
+							<div><span>Alice receives</span><output data-example-output="aliceReceives">1.00 REP</output></div>
+							<div><span>Bob receives</span><output data-example-output="bobReceives">1.33 REP</output></div>
+							<div><span>Carol receives</span><output data-example-output="carolReceives">1.67 REP</output></div>
+							<div><span>Refunds</span><output data-example-output="refunds">1.00 ETH</output></div>
+						</div>
+					</details>
 				</section>
 
 				<section class="paper-section" id="oracle">
@@ -3270,8 +3659,8 @@
 							<tr><td><code>gasConsumedSettlement</code></td><td><code>1000000</code></td><td>Per-operation settlement gas estimate used by the coordinator.</td></tr>
 							<tr><td><code>MAX_PENDING_SETTLEMENT_OPERATIONS</code></td><td><code>4</code></td><td>Maximum staged operations executed from one OpenOracle settlement callback.</td></tr>
 							<tr><td><code>MAX_OPERATION_VALID_FOR_SECONDS</code></td><td><code>5 minutes</code></td><td>Maximum self-service validity window for staged oracle-gated operations.</td></tr>
-							<tr><td>OpenOracle <code>exactToken1Report</code></td><td><math aria-label="250 times price precision scale" data-source="250 \cdot pow10(18)"><mn>250</mn><mo>&#x22C5;</mo><msup><mn>10</mn><mn>18</mn></msup></math></td><td>Initial report liquidity parameter, denominated in REP token units.</td></tr>
-							<tr><td>OpenOracle <code>escalationHalt</code></td><td><math aria-label="exact token one report times 100000 divided by 10000" data-source="exactToken1Report \cdot 100000 / 10000"><mi>exactToken1Report</mi><mo>&#x22C5;</mo><mn>100000</mn><mo>/</mo><mn>10000</mn></math></td><td>Dynamic halt threshold for report escalation, equal to <code>10x</code> the initial REP report amount.</td></tr>
+								<tr><td>OpenOracle <code>exactToken1Report</code></td><td>250 REP (<math aria-label="250 times 10 to the 18 atomic REP units" data-source="250 \cdot pow10(18) atomic REP units"><mn>250</mn><mo>&#x22C5;</mo><msup><mn>10</mn><mn>18</mn></msup></math> atomic REP units)</td><td>Initial report liquidity parameter, stored as an ERC-20 atomic REP amount.</td></tr>
+								<tr><td>OpenOracle <code>escalationHalt</code></td><td>2,500 REP (<math aria-label="2500 times 10 to the 18 atomic REP units" data-source="2500 \cdot pow10(18) atomic REP units"><mn>2500</mn><mo>&#x22C5;</mo><msup><mn>10</mn><mn>18</mn></msup></math> atomic REP units)</td><td>Dynamic halt threshold for multiplicative report escalation; later reports add one atomic REP unit at a time.</td></tr>
 							<tr><td>OpenOracle <code>settlerReward</code></td><td><math aria-label="block base fee times 2 times gas consumed open oracle report price" data-source="block.basefee \cdot 2 \cdot gasConsumedOpenOracleReportPrice"><mi>block.basefee</mi><mo>&#x22C5;</mo><mn>2</mn><mo>&#x22C5;</mo><mi>gasConsumedOpenOracleReportPrice</mi></math></td><td>Dynamic ETH reward paid to settler.</td></tr>
 							<tr><td>OpenOracle <code>settlementTime</code></td><td><math aria-label="40 times 12" data-source="40 \cdot 12"><mn>40</mn><mo>&#x22C5;</mo><mn>12</mn></math></td><td>Settlement delay encoded as <code>480</code>.</td></tr>
 							<tr><td>OpenOracle <code>disputeDelay</code></td><td><code>0</code></td><td>No extra waiting period after each report.</td></tr>
@@ -3326,9 +3715,443 @@
 					</ul>
 				</section>
 			</main>
-		</div>
-		<script>
-			const navLinks = Array.from(document.querySelectorAll('.sidebar nav a[href^="#"]'))
+			</div>
+			<script>
+				const formatFixed = (value, digits = 2) => {
+					if (Number.isInteger(value)) {
+						return value.toFixed(0)
+					}
+					return value.toFixed(digits)
+				}
+				const formatRep = (value, digits = 2) => `${formatFixed(value, digits)} REP`
+				const formatEth = value => `${formatFixed(value)} ETH`
+				const formatShares = value => `${formatFixed(value, 0)} shares`
+				const formatPercent = value => `${formatFixed(value, 0)}%`
+				const atomicDisplayScale = 1_000_000n
+				const weiPerDisplayUnit = 1_000_000_000_000n
+				const toAtomic = value => BigInt(Math.round(value * Number(atomicDisplayScale))) * weiPerDisplayUnit
+				const fromAtomic = atomicValue => Number(atomicValue / weiPerDisplayUnit) / Number(atomicDisplayScale)
+				const formatAtomicRep = (atomicValue, digits = 18) => {
+					const wholePart = atomicValue / (atomicDisplayScale * weiPerDisplayUnit)
+					const fractionalPart = atomicValue % (atomicDisplayScale * weiPerDisplayUnit)
+					const paddedFraction = fractionalPart.toString().padStart(18, '0').slice(0, digits)
+					return `${wholePart.toString()}.${paddedFraction} REP`
+				}
+				const ceilDiv = (numerator, denominator) => (numerator + denominator - 1n) / denominator
+				const collectExample = exampleId => {
+					const example = document.getElementById(exampleId)
+					if (example === null) {
+						return undefined
+					}
+					const inputs = Object.fromEntries(
+						Array.from(example.querySelectorAll('[data-example-input]')).map(inputElement => [
+							inputElement.dataset.exampleInput,
+							inputElement,
+						]),
+					)
+					const outputs = Object.fromEntries(
+						Array.from(example.querySelectorAll('[data-example-output]')).map(outputElement => [
+							outputElement.dataset.exampleOutput,
+							outputElement,
+						]),
+					)
+					const values = Object.fromEntries(
+						Array.from(example.querySelectorAll('[data-example-value]')).map(valueElement => [
+							valueElement.dataset.exampleValue,
+							valueElement,
+						]),
+					)
+					const rects = Object.fromEntries(
+						Array.from(example.querySelectorAll('[data-example-rect]')).map(rectElement => [
+							rectElement.dataset.exampleRect,
+							rectElement,
+						]),
+					)
+					const texts = Object.fromEntries(
+						Array.from(example.querySelectorAll('[data-example-text]')).map(textElement => [
+							textElement.dataset.exampleText,
+							textElement,
+						]),
+					)
+					const read = inputName => {
+						const inputElement = inputs[inputName]
+						if (inputElement === undefined) {
+							return 0
+						}
+						const inputValue = Number(inputElement.value)
+						return Number.isFinite(inputValue) ? inputValue : 0
+					}
+					const write = (outputName, value) => {
+						const outputElement = outputs[outputName]
+						if (outputElement !== undefined) {
+							outputElement.value = value
+						}
+					}
+					const writeValue = (valueName, value) => {
+						const valueElement = values[valueName]
+						if (valueElement !== undefined) {
+							valueElement.textContent = value
+						}
+					}
+					const writeText = (textName, value) => {
+						const textElement = texts[textName]
+						if (textElement !== undefined) {
+							textElement.textContent = value
+						}
+					}
+					const setRectWidth = (rectName, width) => {
+						const rectElement = rects[rectName]
+						if (rectElement !== undefined) {
+							rectElement.setAttribute('width', String(Math.max(0, width)))
+						}
+					}
+					const setRectX = (rectName, rectX) => {
+						const rectElement = rects[rectName]
+						if (rectElement !== undefined) {
+							rectElement.setAttribute('x', String(rectX))
+						}
+					}
+					return { inputs, read, write, writeValue, writeText, setRectWidth, setRectX }
+				}
+				const bindExample = (exampleId, update) => {
+					const context = collectExample(exampleId)
+					if (context === undefined) {
+						return
+					}
+					for (const inputElement of Object.values(context.inputs)) {
+						inputElement.addEventListener('input', () => update(context))
+					}
+					update(context)
+				}
+				bindExample('share-migration-example', context => {
+					const parentBalance = context.read('parentBalance')
+					const selectedChildren = context.read('selectedChildren')
+					const childWidth = parentBalance * 2.2
+					context.writeValue('parentBalance', formatShares(parentBalance))
+					context.writeValue('selectedChildren', `${selectedChildren} ${selectedChildren === 1 ? 'branch' : 'branches'}`)
+					context.setRectWidth('parent', childWidth)
+					context.setRectWidth('childA', selectedChildren >= 1 ? childWidth : 0)
+					context.setRectWidth('childB', selectedChildren >= 2 ? childWidth : 0)
+					context.setRectWidth('childC', selectedChildren >= 3 ? childWidth : 0)
+					context.writeText('parentText', formatFixed(parentBalance, 0))
+					context.writeText('childAText', selectedChildren >= 1 ? formatFixed(parentBalance, 0) : '0')
+					context.writeText('childBText', selectedChildren >= 2 ? formatFixed(parentBalance, 0) : '0')
+					context.writeText('childCText', selectedChildren >= 3 ? formatFixed(parentBalance, 0) : '0')
+					context.write('parentAfter', formatShares(0))
+					context.write('childBalance', formatShares(parentBalance))
+					context.write('totalChildBalances', formatShares(parentBalance * selectedChildren))
+				})
+				bindExample('escalation-deposit-example', context => {
+					const invalidBalance = context.read('invalidBalance')
+					const yesBalance = context.read('yesBalance')
+					const noBalance = context.read('noBalance')
+					const proposedDeposit = context.read('proposedDeposit')
+					const startBond = context.read('startBond')
+					const threshold = Math.max(context.read('nonDecisionThreshold'), 1)
+					const invalidStartParameters = startBond >= threshold
+					const room = Math.max(0, threshold - noBalance)
+					const clipped = Math.min(proposedDeposit, room)
+					const maxBefore = Math.max(invalidBalance, yesBalance, noBalance)
+					const outcomeFull = noBalance >= threshold
+					const tieAdjusted = noBalance + clipped === maxBefore && noBalance + clipped < threshold
+					const clippedAtomic = toAtomic(clipped)
+					const acceptedAtomicPreview = tieAdjusted && clippedAtomic > 0n ? clippedAtomic - 1n : clippedAtomic
+					const noAfterAtomicPreview = toAtomic(noBalance) + acceptedAtomicPreview
+					const previewReverts =
+						invalidStartParameters ||
+						outcomeFull ||
+						proposedDeposit < startBond ||
+						(acceptedAtomicPreview < toAtomic(startBond) && noAfterAtomicPreview !== toAtomic(threshold))
+					const acceptedAtomic = previewReverts ? 0n : acceptedAtomicPreview
+					const accepted = fromAtomic(acceptedAtomic)
+					const noAfterAtomic = toAtomic(noBalance) + acceptedAtomic
+					const noAfter = fromAtomic(noAfterAtomic)
+					const scale = 220 / threshold
+					context.writeValue('invalidBalance', formatRep(invalidBalance))
+					context.writeValue('yesBalance', formatRep(yesBalance))
+					context.writeValue('noBalance', formatRep(noBalance))
+					context.writeValue('proposedDeposit', formatRep(proposedDeposit))
+					context.writeValue('startBond', formatRep(startBond))
+					context.writeValue('nonDecisionThreshold', formatRep(threshold))
+					context.setRectWidth('invalidBefore', Math.min(invalidBalance * scale, 220))
+					context.setRectWidth('yesBefore', Math.min(yesBalance * scale, 220))
+					context.setRectWidth('noBefore', Math.min(noBalance * scale, 220))
+					context.setRectWidth('invalidAfter', Math.min(invalidBalance * scale, 220))
+					context.setRectWidth('yesAfter', Math.min(yesBalance * scale, 220))
+					context.setRectWidth('noAfter', Math.min(noAfter * scale, 220))
+					context.writeText('thresholdText', `threshold ${formatRep(threshold)}`)
+					context.write('remainingRoom', formatRep(room))
+					const acceptedAmountText = tieAdjusted && !previewReverts ? formatAtomicRep(acceptedAtomic, 18) : formatRep(accepted)
+					context.write('acceptedAmount', previewReverts ? 'preview reverts' : acceptedAmountText)
+					let adjustment = 'accepted as proposed'
+					if (invalidStartParameters) {
+						adjustment = 'invalid game parameters'
+					} else if (outcomeFull) {
+						adjustment = 'Outcome full'
+					} else if (proposedDeposit > room) {
+						adjustment = 'clipped to threshold'
+					} else if (tieAdjusted) {
+						adjustment = 'reduced by 0.000000000000000001 REP (1 wei) to avoid tie'
+					}
+					if (previewReverts && !invalidStartParameters && !outcomeFull) {
+						adjustment = 'Below start bond'
+					}
+					context.write('depositAdjustment', adjustment)
+					let depositCondition = tieAdjusted ? `No ends at ${formatAtomicRep(noAfterAtomic, 18)}` : `No ends at ${formatRep(noAfter)}`
+					if (invalidStartParameters) {
+						depositCondition = 'game setup reverts: Threshold too low'
+					} else if (outcomeFull) {
+						depositCondition = 'operation reverts because No is full'
+					} else if (previewReverts) {
+						depositCondition = 'operation reverts before recording'
+					} else if (noAfter >= threshold) {
+						depositCondition = 'No reaches threshold'
+					}
+					context.write('depositCondition', depositCondition)
+				})
+				bindExample('resolution-edge-example', context => {
+					const invalidBalance = context.read('invalidBalance')
+					const yesBalance = context.read('yesBalance')
+					const noBalance = context.read('noBalance')
+					const runningCost = context.read('runningCost')
+					context.writeValue('invalidBalance', formatRep(invalidBalance))
+					context.writeValue('yesBalance', formatRep(yesBalance))
+					context.writeValue('noBalance', formatRep(noBalance))
+					context.writeValue('runningCost', formatRep(runningCost))
+					const balances = [invalidBalance, yesBalance, noBalance]
+					const atCost = balances.filter(balance => balance >= runningCost).length
+					const allZero = balances.every(balance => balance === 0)
+					let result = 'No'
+					let reason = 'no strict Invalid or Yes lead, so the helper falls through'
+					if (atCost >= 2) {
+						result = 'None'
+						reason = 'two or more outcomes still contest the cost'
+					} else if (allZero) {
+						result = 'Invalid'
+						reason = 'empty game after cost is non-zero'
+					} else if (invalidBalance > yesBalance && invalidBalance > noBalance) {
+						result = 'Invalid'
+						reason = 'Invalid has a strict lead'
+						} else if (yesBalance > invalidBalance && yesBalance > noBalance) {
+							result = 'Yes'
+							reason = 'Yes has a strict lead'
+						}
+						const resolutionScale = 520 / Math.max(invalidBalance, yesBalance, noBalance, runningCost, 1)
+						context.setRectWidth('resolutionInvalid', invalidBalance * resolutionScale)
+						context.setRectWidth('resolutionYes', yesBalance * resolutionScale)
+						context.setRectWidth('resolutionNo', noBalance * resolutionScale)
+						context.writeText('resolutionCostMarker', `cost ${formatRep(runningCost)}`)
+						context.write('outcomesAtCost', String(atCost))
+						context.write('resolutionResult', result)
+						context.write('resolutionReason', reason)
+					})
+					bindExample('payout-region-example', context => {
+						const bindingCapital = context.read('bindingCapital')
+						const winningPrincipal = context.read('winningPrincipal')
+						const depositAmount = Math.min(context.read('depositAmount'), winningPrincipal)
+					const depositStart = Math.min(context.read('depositStart'), Math.max(0, winningPrincipal - depositAmount))
+					const cumulativeAmount = depositStart + depositAmount
+					const thresholdPercent = context.read('actualForkThresholdPercent')
+					const bindingAtomic = toAtomic(bindingCapital)
+					const rewardCap = fromAtomic(bindingAtomic + bindingAtomic / 2n)
+					const rewardPool = fromAtomic(bindingAtomic * 3n / 5n)
+					const rewardEligiblePrincipal = Math.max(Math.min(winningPrincipal, rewardCap), 0.000001)
+					const eligibleEnd = Math.min(cumulativeAmount, rewardCap)
+					const eligibleDeposit = Math.max(0, Math.min(depositAmount, eligibleEnd - depositStart))
+					const depositWithdrawal = depositAmount + eligibleDeposit * rewardPool / rewardEligiblePrincipal
+					const scaledWithdrawal = depositWithdrawal * thresholdPercent / 100
+					const excessPrincipal = Math.max(0, winningPrincipal - rewardCap)
+					const visualMax = Math.max(winningPrincipal, rewardCap, 1)
+					const visualScale = 600 / visualMax
+					context.writeValue('bindingCapital', formatRep(bindingCapital))
+					context.writeValue('winningPrincipal', formatRep(winningPrincipal))
+					context.writeValue('depositAmount', formatRep(depositAmount))
+					context.writeValue('depositStart', formatRep(depositStart))
+					context.writeValue('actualForkThresholdPercent', formatPercent(thresholdPercent))
+					context.setRectWidth('bindingRegion', Math.min(bindingCapital * visualScale, 600))
+					context.setRectWidth('safetyRegion', Math.max(0, Math.min((rewardCap - bindingCapital) * visualScale, 600)))
+					context.setRectX('safetyRegion', 80 + Math.min(bindingCapital * visualScale, 600))
+					context.setRectWidth('excessRegion', Math.max(0, Math.min(excessPrincipal * visualScale, 600)))
+					context.setRectX('excessRegion', 80 + Math.min(rewardCap * visualScale, 600))
+					context.writeText('bindingMarker', `binding ${formatFixed(bindingCapital, 0)}`)
+					context.writeText('capMarker', `cap ${formatFixed(rewardCap, 0)}`)
+					context.writeText('winningMarker', `winning ${formatFixed(winningPrincipal, 0)}`)
+					context.write('rewardCap', formatRep(rewardCap))
+						context.write('rewardPool', formatRep(rewardPool))
+						context.write('eligibleDeposit', formatRep(eligibleDeposit))
+						context.write('excessPrincipal', formatRep(excessPrincipal))
+						context.write('depositWithdrawal', formatRep(depositWithdrawal))
+						context.write('scaledWithdrawal', formatRep(scaledWithdrawal))
+						context.write(
+							'payoutState',
+							bindingCapital > winningPrincipal ? 'reachable No fallback/tied-leader edge case' : 'reachable ordinary winner state',
+						)
+					})
+				bindExample('forked-escrow-example', context => {
+					const escrowPrincipal = Math.max(context.read('escrowPrincipal'), 1)
+					const escrowChildRep = context.read('escrowChildRep')
+					const claimedSource = Math.min(context.read('claimedSource'), escrowPrincipal)
+					const newSourceClaim = Math.min(context.read('newSourceClaim'), escrowPrincipal - claimedSource)
+					const escrowPrincipalAtomic = toAtomic(escrowPrincipal)
+					const escrowChildRepAtomic = toAtomic(escrowChildRep)
+					const claimedSourceAtomic = toAtomic(claimedSource)
+					const newSourceClaimAtomic = toAtomic(newSourceClaim)
+					const alreadyReleasedAtomic = ceilDiv(claimedSourceAtomic * escrowChildRepAtomic, escrowPrincipalAtomic)
+					const cumulativeReleaseAtomic = ceilDiv(
+						(claimedSourceAtomic + newSourceClaimAtomic) * escrowChildRepAtomic,
+						escrowPrincipalAtomic,
+					)
+					const releasedNowAtomic = cumulativeReleaseAtomic - alreadyReleasedAtomic
+					const restartRoundingAtomic = ceilDiv(newSourceClaimAtomic * escrowChildRepAtomic, escrowPrincipalAtomic)
+					context.writeValue('escrowPrincipal', formatRep(escrowPrincipal))
+					context.writeValue('escrowChildRep', formatRep(escrowChildRep))
+					context.writeValue('claimedSource', formatRep(claimedSource))
+					context.writeValue('newSourceClaim', formatRep(newSourceClaim))
+					context.write('alreadyReleased', formatAtomicRep(alreadyReleasedAtomic, 18))
+						context.write('cumulativeRelease', formatAtomicRep(cumulativeReleaseAtomic, 18))
+						context.write('releasedNow', formatAtomicRep(releasedNowAtomic, 18))
+						context.write('restartRounding', `${formatAtomicRep(restartRoundingAtomic, 18)} if each claim rounded alone`)
+						const escrowVisualScale = 560 / Math.max(fromAtomic(cumulativeReleaseAtomic), fromAtomic(restartRoundingAtomic), 1)
+						const alreadyReleasedWidth = fromAtomic(alreadyReleasedAtomic) * escrowVisualScale
+						const releasedNowWidth = fromAtomic(releasedNowAtomic) * escrowVisualScale
+						context.setRectWidth('alreadyReleasedBar', alreadyReleasedWidth)
+						context.setRectWidth('releasedNowBar', releasedNowWidth)
+						context.setRectX('releasedNowBar', 90 + alreadyReleasedWidth)
+						context.setRectWidth('restartRoundingBar', fromAtomic(restartRoundingAtomic) * escrowVisualScale)
+						context.writeText('cumulativeText', `cumulative ${formatAtomicRep(cumulativeReleaseAtomic, 6)}`)
+						context.writeText('restartText', `restart ${formatAtomicRep(restartRoundingAtomic, 6)}`)
+						const claimBounds =
+						context.read('claimedSource') > escrowPrincipal || context.read('newSourceClaim') > escrowPrincipal - claimedSource
+							? 'claim limited to remaining escrow principal'
+							: 'within escrow principal'
+					context.write('claimBounds', claimBounds)
+				})
+				bindExample('collateral-repair-example', context => {
+					const parentCollateral = context.read('parentCollateral')
+					const repairDenominatorRepAtFork = Math.max(context.read('repairDenominatorRepAtFork'), 1)
+					const migratedRep = Math.min(context.read('migratedRep'), repairDenominatorRepAtFork)
+					const auctionRaised = context.read('auctionRaised')
+					const migratedCollateral = parentCollateral * migratedRep / repairDenominatorRepAtFork
+					const initialShortfall = Math.max(0, parentCollateral - migratedCollateral)
+					const repairEth = Math.min(auctionRaised, initialShortfall)
+					const remainingShortfall = Math.max(0, initialShortfall - repairEth)
+					const scale = 600 / Math.max(parentCollateral, 1)
+					context.writeValue('parentCollateral', formatEth(parentCollateral))
+					context.writeValue('repairDenominatorRepAtFork', formatRep(repairDenominatorRepAtFork))
+					context.writeValue('migratedRep', formatRep(migratedRep))
+					context.writeValue('auctionRaised', formatEth(auctionRaised))
+					context.setRectWidth('migratedCollateral', Math.min(migratedCollateral * scale, 600))
+					context.setRectX('auctionRepair', 80 + Math.min(migratedCollateral * scale, 600))
+					context.setRectWidth('auctionRepair', Math.min(repairEth * scale, Math.max(0, 600 - migratedCollateral * scale)))
+					context.writeText('repairTarget', `target ${formatEth(parentCollateral)}`)
+					context.write('migratedCollateral', formatEth(migratedCollateral))
+					context.write('initialShortfall', formatEth(initialShortfall))
+					context.write('remainingShortfall', formatEth(remainingShortfall))
+					context.write('repairStatus', remainingShortfall === 0 ? 'full repair' : 'partial repair')
+					context.write(
+						'migrationBounds',
+						context.read('migratedRep') > repairDenominatorRepAtFork
+							? 'migration limited to repair denominator REP'
+							: 'within repair denominator REP',
+					)
+				})
+				bindExample('auction-clearing-example', context => {
+					const ethRaiseCap = context.read('ethRaiseCap')
+					const repInventory = context.read('repInventory')
+					const aliceEth = context.read('aliceEth')
+					const bobEth = context.read('bobEth')
+					const carolEth = context.read('carolEth')
+					context.writeValue('ethRaiseCap', formatEth(ethRaiseCap))
+					context.writeValue('repInventory', formatRep(repInventory))
+					context.writeValue('aliceEth', formatEth(aliceEth))
+					context.writeValue('bobEth', formatEth(bobEth))
+					context.writeValue('carolEth', formatEth(carolEth))
+					const bids = [
+						{ name: 'alice', eth: aliceEth, price: 5 },
+						{ name: 'bob', eth: bobEth, price: 4 },
+						{ name: 'carol', eth: carolEth, price: 3 },
+					]
+					let ethRaised = 0
+					let refunds = 0
+					const repResults = { alice: 0, bob: 0, carol: 0 }
+					let accumulatedEth = 0
+					let clearingPrice = 0
+					let ethFilledAtClearing = 0
+					let funded = false
+					let lastValidPrice = 0
+					let lastValidEthAtTick = 0
+					for (const bid of bids) {
+						if (accumulatedEth > 0 && accumulatedEth / bid.price > repInventory) {
+							funded = true
+							clearingPrice = lastValidPrice
+							ethFilledAtClearing = lastValidEthAtTick
+							ethRaised = accumulatedEth
+							break
+						}
+						const ethToTake = Math.min(bid.eth, Math.max(0, ethRaiseCap - accumulatedEth))
+						const newAccumulatedEth = accumulatedEth + ethToTake
+						if (newAccumulatedEth / bid.price >= repInventory) {
+							funded = true
+							clearingPrice = bid.price
+							ethFilledAtClearing = Math.max(0, Math.min(ethToTake, repInventory * bid.price - accumulatedEth))
+							ethRaised = accumulatedEth + ethFilledAtClearing
+							break
+						}
+						if (newAccumulatedEth >= ethRaiseCap) {
+							funded = true
+							clearingPrice = bid.price
+							ethFilledAtClearing = ethToTake
+							ethRaised = newAccumulatedEth
+							break
+						}
+						accumulatedEth = newAccumulatedEth
+						lastValidPrice = bid.price
+						lastValidEthAtTick = ethToTake
+					}
+					if (funded) {
+						for (const bid of bids) {
+							if (bid.price > clearingPrice) {
+								repResults[bid.name] = bid.eth / clearingPrice
+							} else if (bid.price === clearingPrice) {
+								const fillEth = Math.min(bid.eth, ethFilledAtClearing)
+								repResults[bid.name] = fillEth / clearingPrice
+								refunds += bid.eth - fillEth
+							} else {
+								refunds += bid.eth
+							}
+						}
+						context.write('clearingMode', `funded near ${formatFixed(clearingPrice)} ETH/REP`)
+						context.write('underfundedThreshold', 'not underfunded')
+					} else {
+						ethRaised = accumulatedEth
+						const underfundedThreshold = repInventory === 0 ? Number.POSITIVE_INFINITY : ethRaised / repInventory
+						const qualifyingBids = bids.filter(bid => bid.price >= underfundedThreshold)
+						const qualifyingEth = qualifyingBids.reduce((sum, bid) => sum + bid.eth, 0)
+						refunds = bids.reduce((sum, bid) => sum + bid.eth, 0) - qualifyingEth
+						for (const bid of qualifyingBids) {
+							repResults[bid.name] = qualifyingEth === 0 ? 0 : repInventory * bid.eth / qualifyingEth
+						}
+						context.write('clearingMode', 'underfunded pro rata')
+						context.write('underfundedThreshold', `${formatFixed(underfundedThreshold)} ETH/REP`)
+					}
+					const repScale = 560 / Math.max(repInventory, 1)
+					const aliceWidth = repResults.alice * repScale
+					const bobWidth = repResults.bob * repScale
+					const carolWidth = repResults.carol * repScale
+					context.setRectWidth('aliceRep', aliceWidth)
+					context.setRectWidth('bobRep', bobWidth)
+					context.setRectX('bobRep', 100 + aliceWidth)
+					context.setRectWidth('carolRep', carolWidth)
+					context.setRectX('carolRep', 100 + aliceWidth + bobWidth)
+					context.setRectWidth('ethRaised', Math.min(ethRaised / Math.max(ethRaiseCap, 1) * 560, 560))
+					context.writeText('ethCapMarker', `cap ${formatEth(ethRaiseCap)}`)
+					context.write('ethRaised', formatEth(ethRaised))
+					context.write('aliceReceives', formatRep(repResults.alice))
+					context.write('bobReceives', formatRep(repResults.bob))
+					context.write('carolReceives', formatRep(repResults.carol))
+					context.write('refunds', formatEth(refunds))
+				})
+				const navLinks = Array.from(document.querySelectorAll('.sidebar nav a[href^="#"]'))
 			const sectionLinks = navLinks
 				.map(link => {
 					const href = link.getAttribute('href')


### PR DESCRIPTION
## Summary
- Added slider-driven, visual examples for Placeholder contract mechanics: share migration, escalation deposit clipping and tie avoidance, resolution edge cases, payout regions, forked escrow rounding, collateral repair, and auction clearing.
- Expanded the OpenOracle integration docs with interactive examples for binary censorship economics, pending callback budget consumption, and report escalation/halt behavior.
- Updated shared docs styling and inline calculator helpers so the examples are easier to read, adjust, and keep aligned with contract math and units.

## Validation
- `bun run format`
- `bun run check`
- `git diff --check`
- `bun run docs:check-html`
- Inline script parse for changed docs
- Targeted calculator smoke checks for the documented contract edge cases
