### PR TITLE
Polish security pool and question preview displays

### DIFF
--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -5238,15 +5238,17 @@ button:focus-visible {
 }
 
 .question-preview-timeline {
-	grid-template-columns: repeat(2, minmax(0, max-content));
-	gap: 1rem 1.5rem;
+	grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+	gap: 0.75rem;
 }
 
 .question-preview-timeline-item {
-	display: flex;
-	flex-wrap: wrap;
-	align-items: baseline;
-	gap: 0.45rem;
+	display: grid;
+	gap: 0.35rem;
+	padding: 0.8rem 0.9rem;
+	border: 1px solid rgba(255, 255, 255, 0.08);
+	border-radius: 0.95rem;
+	background: linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.015));
 }
 
 .question-preview-timeline-label,
@@ -5262,6 +5264,16 @@ button:focus-visible {
 	font-size: var(--font-caption);
 	font-weight: 600;
 	color: var(--text-secondary);
+}
+
+.question-preview-timeline-value .timestamp-value {
+	display: grid;
+	gap: 0.18rem;
+}
+
+.question-preview-timeline-value .timestamp-value-relative {
+	font-size: var(--font-label);
+	color: var(--muted);
 }
 
 .question-preview-meta {
@@ -5660,6 +5672,39 @@ button:focus-visible {
 	border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
+.security-pool-ribbon-stat {
+	display: grid;
+	gap: 0.35rem;
+	padding: 0.8rem 0.9rem;
+	border: 1px solid rgba(255, 255, 255, 0.08);
+	border-radius: 1rem;
+	background: linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0.015));
+}
+
+.security-pool-ribbon-stat-label {
+	font-size: var(--font-label);
+	letter-spacing: 0.14em;
+	text-transform: uppercase;
+	color: var(--muted);
+}
+
+.security-pool-ribbon-stat-value {
+	display: block;
+	font-size: var(--font-h4);
+	line-height: 1.2;
+	color: var(--text-primary);
+}
+
+.security-pool-ribbon-stat-value .currency-value-wrap,
+.security-pool-ribbon-stat-value .currency-value {
+	max-width: 100%;
+}
+
+.security-pool-ribbon-stat-value .currency-value {
+	font-size: inherit;
+	font-weight: inherit;
+}
+
 .security-pool-hero-main {
 	display: grid;
 	gap: 1rem;
@@ -5832,6 +5877,13 @@ button:focus-visible {
 .vault-preview-meta .metric-field,
 .vault-detail-meta .metric-field {
 	min-width: 0;
+}
+
+.security-pool-secondary-facts .metric-field {
+	padding: 0.8rem 0.9rem;
+	border: 1px solid rgba(255, 255, 255, 0.08);
+	border-radius: 0.95rem;
+	background: linear-gradient(180deg, rgba(255, 255, 255, 0.025), rgba(255, 255, 255, 0.01));
 }
 
 .trading-holdings-stage {

--- a/ui/ts/components/SecurityPoolSummaryMetrics.tsx
+++ b/ui/ts/components/SecurityPoolSummaryMetrics.tsx
@@ -82,23 +82,23 @@ export function SecurityPoolSummaryMetrics({
 			{showCollateralizationGauge ? <CollateralizationCircle className='security-pool-hero-collateralization' collateralizationPercent={collateralizationPercent} size='medium' targetCollateralizationPercent={targetCollateralizationPercent} /> : undefined}
 			<div className='security-pool-hero-ribbon'>
 				<div className='security-pool-ribbon-stat'>
-					<span>Vault Count</span>
-					<strong>{pool.vaultCount.toString()}</strong>
+					<span className='security-pool-ribbon-stat-label'>Vault Count</span>
+					<strong className='security-pool-ribbon-stat-value'>{pool.vaultCount.toString()}</strong>
 				</div>
 				<div className='security-pool-ribbon-stat'>
-					<span>Security Multiplier</span>
-					<strong>{pool.securityMultiplier.toString()}x</strong>
+					<span className='security-pool-ribbon-stat-label'>Security Multiplier</span>
+					<strong className='security-pool-ribbon-stat-value'>{pool.securityMultiplier.toString()}x</strong>
 				</div>
 				<div className='security-pool-ribbon-stat'>
-					<span>Annual Fee</span>
-					<strong>
+					<span className='security-pool-ribbon-stat-label'>Annual Fee</span>
+					<strong className='security-pool-ribbon-stat-value'>
 						<CurrencyValue value={openInterestFeePerYearBigint(pool.currentRetentionRate)} suffix='%' />
 					</strong>
 				</div>
 				<div className='security-pool-ribbon-stat'>
-					<span>Total REP Backing</span>
-					<strong>
-						<CurrencyValue value={pool.totalRepDeposit} suffix='REP' />
+					<span className='security-pool-ribbon-stat-label'>Total REP Backing</span>
+					<strong className='security-pool-ribbon-stat-value'>
+						<CurrencyValue compactWhenOverflow copyable={false} value={pool.totalRepDeposit} suffix='REP' />
 					</strong>
 				</div>
 			</div>

--- a/ui/ts/tests/questionComponent.test.tsx
+++ b/ui/ts/tests/questionComponent.test.tsx
@@ -69,4 +69,21 @@ describe('Question component', () => {
 		expect(document.body.textContent?.includes('No resolution notes or supporting context provided.')).toBe(true)
 		expect(document.body.textContent?.includes('Add resolution notes, evidence sources, and edge-case handling before users rely on this question.')).toBe(true)
 	})
+
+	test('renders preview timestamps as separate timeline cards with relative sublabels', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<ChainTimestampContext.Provider value={240n}>
+				<Question question={createQuestion()} variant='preview' />
+			</ChainTimestampContext.Provider>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const timelineItems = document.body.querySelectorAll('.question-preview-timeline-item')
+		const relativeValues = document.body.querySelectorAll('.question-preview-timeline-value .timestamp-value-relative')
+
+		expect(timelineItems).toHaveLength(2)
+		expect(relativeValues).toHaveLength(2)
+		expect(relativeValues[0]?.textContent).toContain('2m ago')
+		expect(relativeValues[1]?.textContent).toContain('1m ago')
+	})
 })


### PR DESCRIPTION
## Summary
- Restyled the question preview timeline into card-like cards that adapt better to wider layouts.
- Added relative timestamp sublabels to preview timeline entries for clearer time context.
- Improved the security pool summary ribbon with clearer metric styling and prevented REP backing values from overflowing.
- Added a UI test covering the preview timestamp layout and relative labels.

## Testing
- Not run