### PR TITLE
Fix currency value overflow in buttons

### DIFF
--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -790,6 +790,9 @@ button.currency-value.copyable {
 	cursor: copy;
 	text-align: inherit;
 	touch-action: manipulation;
+	overflow: visible;
+	text-overflow: clip;
+	white-space: normal;
 }
 
 button.currency-value.copyable:hover:not(:disabled) {

--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -778,9 +778,10 @@ button .loading-value {
 }
 
 button.currency-value.copyable {
-	display: inline-flex;
-	align-items: center;
+	display: inline-block;
 	min-height: 2rem;
+	max-width: 100%;
+	box-sizing: border-box;
 	border: 0;
 	border-radius: 0.35rem;
 	margin: -0.2rem -0.25rem;


### PR DESCRIPTION
## Summary
- Changed currency value copy buttons from `inline-flex` to `inline-block` so long values wrap more predictably.
- Added `max-width: 100%` and `box-sizing: border-box` to prevent the button from overflowing its container.
- Preserved the existing button sizing and visual styling.

## Testing
- Not run (CSS-only change).