### PR TITLE
Remove backend read/write metrics from overview panels

### DIFF
--- a/ui/ts/components/OverviewPanels.tsx
+++ b/ui/ts/components/OverviewPanels.tsx
@@ -49,28 +49,8 @@ export function OverviewPanels({
 	const showAccountBalances = walletBootstrapComplete && accountState.address !== undefined
 	const shouldShowParentUniverse = parentUniverseId !== undefined && activeUniverseId !== 0n && parentUniverseId !== activeUniverseId
 	const isBrowserSimulationReadBackend = effectiveReadBackendStatus.rpcUrl === 'browser-simulation'
-	const isProviderReadBackend = effectiveReadBackendStatus.transportMode === 'provider' && !isBrowserSimulationReadBackend
 	const walletOnMainnet = isMainnetChain(accountState.chainId)
 	const hasWrongWalletNetwork = accountState.address !== undefined && !walletOnMainnet && !isBrowserSimulationReadBackend
-	const readBackendHost = (() => {
-		if (isBrowserSimulationReadBackend) return 'browser simulation'
-		if (isProviderReadBackend) return 'wallet provider'
-		try {
-			return new URL(effectiveReadBackendStatus.rpcUrl).host
-		} catch (error) {
-			if (!(error instanceof TypeError)) throw error
-			return effectiveReadBackendStatus.rpcUrl
-		}
-	})()
-	const readBackendLabel = isProviderReadBackend ? 'wallet provider reads' : `${effectiveReadBackendStatus.transportMode} via ${effectiveReadBackendStatus.rpcSource}`
-	const readBackendTitle = isProviderReadBackend ? `Reads are using the connected wallet provider. Configured fallback RPC: ${effectiveReadBackendStatus.rpcUrl}` : effectiveReadBackendStatus.rpcUrl
-	const readBackendSummary = isProviderReadBackend ? readBackendLabel : `${readBackendHost} · ${readBackendLabel}`
-	const writeNetworkLabel = (() => {
-		if (isBrowserSimulationReadBackend) return 'Browser simulation'
-		if (accountState.address === undefined) return 'No wallet connected'
-		if (walletOnMainnet) return 'Ethereum mainnet'
-		return `Wallet chain ${accountState.chainId ?? 'unknown'}`
-	})()
 	const environmentBadge = (() => {
 		if (isBrowserSimulationReadBackend) return <Badge tone='warning'>Simulation</Badge>
 		if (hasWrongWalletNetwork) return <Badge tone='danger'>Wrong Network</Badge>
@@ -166,13 +146,6 @@ export function OverviewPanels({
 						<CurrencyValue value={repUsdcPrice} loading={isLoadingRepPrices} suffix='USDC' units={6} />
 					</MetricField>
 					<MetricField label='Universe'>{universeLabel}</MetricField>
-					<MetricField label='Write Network'>{writeNetworkLabel}</MetricField>
-					<MetricField label='Read Source'>
-						<span title={readBackendTitle}>
-							{readBackendSummary}
-							{effectiveReadBackendStatus.blockNumber === undefined ? '' : ` @ ${effectiveReadBackendStatus.blockNumber.toString()}`}
-						</span>
-					</MetricField>
 					{shouldShowParentUniverse ? (
 						<MetricField label='Parent Universe'>
 							<UniverseLink universeId={parentUniverseId} />

--- a/ui/ts/tests/overviewPanels.test.tsx
+++ b/ui/ts/tests/overviewPanels.test.tsx
@@ -236,6 +236,10 @@ describe('OverviewPanels', () => {
 
 		expect(documentQueries.getByText('Simulation')).toBeDefined()
 		expect(document.body.textContent ?? '').toContain('Simulation mode uses browser-local contract state.')
+		expect(documentQueries.queryByText('Write Network')).toBeNull()
+		expect(documentQueries.queryByText('Read Source')).toBeNull()
+		expect(documentQueries.queryByText('Browser simulation')).toBeNull()
+		expect(documentQueries.queryByText('browser simulation · provider via default @ 12')).toBeNull()
 	})
 
 	test('shows the parent universe metric for child universes', async () => {
@@ -257,37 +261,6 @@ describe('OverviewPanels', () => {
 		})
 
 		expect(documentQueries.queryByText('Parent Universe')).toBeNull()
-	})
-
-	test('labels provider-mode reads as the wallet provider instead of the fallback RPC host', async () => {
-		const documentQueries = await renderOverviewPanels({
-			readBackendStatus: {
-				blockNumber: 100n,
-				blockTimestamp: undefined,
-				rpcSource: 'default',
-				rpcUrl: 'https://ethereum.dark.florist',
-				transportMode: 'provider',
-			},
-		})
-
-		const readSource = documentQueries.getByText('wallet provider reads @ 100')
-		expect(readSource.getAttribute('title')).toBe('Reads are using the connected wallet provider. Configured fallback RPC: https://ethereum.dark.florist')
-		expect(document.body.textContent?.includes('ethereum.dark.florist')).toBe(false)
-	})
-
-	test('keeps browser-simulation reads labeled as browser simulation', async () => {
-		const documentQueries = await renderOverviewPanels({
-			readBackendStatus: {
-				blockNumber: 12n,
-				blockTimestamp: undefined,
-				rpcSource: 'default',
-				rpcUrl: 'browser-simulation',
-				transportMode: 'provider',
-			},
-		})
-
-		expect(documentQueries.getByText('browser simulation · provider via default @ 12')).toBeDefined()
-		expect(document.body.textContent?.includes('wallet provider')).toBe(false)
 	})
 
 	test('compacts a large ETH balance without affecting the adjacent WETH metric', async () => {


### PR DESCRIPTION
## Summary
- Removed the `Write Network` and `Read Source` metrics from the overview panels UI.
- Simplified `OverviewPanels` by dropping the backend-labeling logic that only supported those metrics.
- Updated overview panel tests to assert the metrics are no longer rendered.

## Testing
- Not run