### PR TITLE
Hide escalation-active lifecycle banner in reporting

### DIFF
--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -483,8 +483,9 @@ export function ReportingSection({
 				reportingDetails: effectiveReportingDetails,
 			})
 		: undefined
+	const reportingStageBanner = reportingStage?.key === 'escalation-active' ? undefined : reportingStage
 	const reportingWorkflowSummary = reportingStage?.detail ?? 'Select the answer you believe should finalize, lock REP behind it, and return after finalization to settle deposits.'
-	const showReportingHeaderStack = showFullReporting && (showSecurityPoolAddressInput || reportingStage !== undefined || reportingOpenNotice !== undefined)
+	const showReportingHeaderStack = showFullReporting && (showSecurityPoolAddressInput || reportingStageBanner !== undefined || reportingOpenNotice !== undefined)
 	const sections = (
 		<>
 			{showFullReporting ? (
@@ -518,7 +519,7 @@ export function ReportingSection({
 							}
 						/>
 					) : undefined}
-					{reportingOpenNotice === undefined ? <LifecycleStageBanner stage={reportingStage} /> : <p className='notice success'>{reportingOpenNotice}</p>}
+					{reportingOpenNotice === undefined ? <LifecycleStageBanner stage={reportingStageBanner} /> : <p className='notice success'>{reportingOpenNotice}</p>}
 				</div>
 			) : undefined}
 

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -282,18 +282,17 @@ describe('ReportingSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		expect(documentQueries.getAllByText('Active').length).toBeGreaterThan(0)
+		expect(documentQueries.queryByRole('heading', { name: 'Active' })).toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Reporting Workflow' })).not.toBeNull()
 		expect(document.body.textContent?.includes('Current guidance')).toBe(true)
-		expect(document.body.textContent?.includes('Available now')).toBe(true)
-		expect(document.body.textContent?.includes('Blocked')).toBe(true)
+		expect(document.body.textContent?.includes('Escalation is live. Review the bond, side balances, and time remaining before contributing or withdrawing.')).toBe(true)
 		expect(document.body.textContent?.includes('Selected side currently has')).toBe(false)
 		expect(documentQueries.queryByRole('button', { name: 'Outcome Side' })).toBeNull()
 		expect(document.body.querySelectorAll('.escalation-side.selected').length).toBe(0)
 		expect(document.body.textContent?.includes('Select an outcome side above to enable reporting.')).toBe(true)
 	})
 
-	test('renders active reporting with a lifecycle banner and no reporting context card', async () => {
+	test('renders active reporting without the lifecycle banner and no reporting context card', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(
 				ReportingSection,
@@ -309,7 +308,8 @@ describe('ReportingSection', () => {
 
 		const documentQueries = within(document.body)
 		expect(documentQueries.queryByRole('heading', { name: 'Reporting Context' })).toBeNull()
-		expect(documentQueries.getByRole('heading', { name: 'Active' })).not.toBeNull()
+		expect(documentQueries.queryByRole('heading', { name: 'Active' })).toBeNull()
+		expect(document.body.querySelector('.reporting-header-stack')).toBeNull()
 		expect(documentQueries.getByRole('button', { name: 'Min to take the lead' })).not.toBeNull()
 		expect(documentQueries.getByRole('button', { name: 'Max profit' })).not.toBeNull()
 		expect(document.body.textContent?.includes('Selected side currently has')).toBe(false)
@@ -690,7 +690,7 @@ describe('ReportingSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		expect(documentQueries.getByRole('heading', { name: 'Active' })).not.toBeNull()
+		expect(documentQueries.queryByRole('heading', { name: 'Active' })).toBeNull()
 		expect(document.body.textContent?.includes('Escalation ended by timeout. The winner is computed from the current stakes; refresh reporting if the resolved outcome is not loaded yet.')).toBe(false)
 		expect(document.body.textContent?.includes(formatDuration(0n))).toBe(true)
 	})


### PR DESCRIPTION
## Summary
- Hide the lifecycle banner when reporting is in the `escalation-active` stage.
- Keep the reporting header stack collapsed in that stage when no other header content is present.
- Update reporting section tests to reflect the removed banner and the new header-stack behavior.

## Testing
- Not run (PR summary generated from the provided diff only).