### PR TITLE
Remove question notes and streamline security pool state

### DIFF
--- a/solidity/ts/tests/anvilWindowEthereum.test.ts
+++ b/solidity/ts/tests/anvilWindowEthereum.test.ts
@@ -158,7 +158,7 @@ test('send transaction waits for a delayed receipt and mines pending Anvil trans
 test('send transaction throws a targeted error when Anvil never returns a receipt', async () => {
 	delete process.env['SOLIDITY_BYTECODE_COVERAGE']
 	const originalDateNow = Date.now
-	const clockValues = [0, 1, 60_001, 60_002]
+	const clockValues = [0, 1, 180_001, 180_002]
 	const transactionHash = `0x${'34'.repeat(32)}`
 
 	const mockedFetch = createMockedFetch(async (_input: URL | RequestInfo, init?: RequestInit | BunFetchRequestInit) => {
@@ -173,7 +173,7 @@ test('send transaction throws a targeted error when Anvil never returns a receip
 	})
 	globalThis.fetch = mockedFetch
 
-	Date.now = () => clockValues.shift() ?? 60_002
+	Date.now = () => clockValues.shift() ?? 180_002
 	try {
 		const anvilWindow = await getMockedEthSimulateWindowEthereum()
 		await expect(
@@ -187,7 +187,7 @@ test('send transaction throws a targeted error when Anvil never returns a receip
 					},
 				],
 			}),
-		).rejects.toThrow(`Anvil did not return a receipt for sent transaction ${transactionHash} within 60000ms.`)
+		).rejects.toThrow(`Anvil did not return a receipt for sent transaction ${transactionHash} within 180000ms.`)
 	} finally {
 		Date.now = originalDateNow
 	}

--- a/solidity/ts/testsuite/simulator/AnvilWindowEthereum.ts
+++ b/solidity/ts/testsuite/simulator/AnvilWindowEthereum.ts
@@ -54,7 +54,9 @@ type EthCallCoverageRequest = {
 }
 
 const DEFAULT_ANVIL_TRANSACTION_GAS = '0x1c9c380'
-const SEND_TRANSACTION_RECEIPT_TIMEOUT_MS = 60_000
+// CI can keep Anvil receipts pending well past a minute when multiple shards
+// are driving simulator-backed transactions concurrently.
+const SEND_TRANSACTION_RECEIPT_TIMEOUT_MS = 180_000
 const SEND_TRANSACTION_RECEIPT_POLL_INTERVAL_MS = 10
 const SEND_TRANSACTION_RECEIPT_MINE_INTERVAL_MS = 1_000
 

--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -1712,16 +1712,6 @@ button.currency-value.copyable:hover:not(:disabled) {
 	line-height: 1.45;
 }
 
-.question-context-note {
-	padding: 0.65rem 0.8rem;
-	border: 1px solid var(--warning-border);
-	border-radius: var(--radius-control);
-	background: rgba(245, 200, 106, 0.08);
-	font-size: var(--font-caption);
-	line-height: 1.5;
-	color: var(--text-secondary);
-}
-
 .question-summary-header {
 	gap: 0.45rem;
 }
@@ -2175,8 +2165,8 @@ button.currency-value.copyable:hover:not(:disabled) {
 }
 
 .security-pool-card {
-	padding: 0.28rem 0.85rem;
-	gap: 0.32rem;
+	padding: 0.68rem 0.95rem 0.9rem;
+	gap: 0.45rem;
 }
 
 .security-pool-card .entity-card-body {
@@ -2185,6 +2175,7 @@ button.currency-value.copyable:hover:not(:disabled) {
 
 .security-pool-card .entity-card-header {
 	gap: 0.3rem;
+	padding: 0 0.1rem;
 }
 
 .security-pool-card-title-copy {
@@ -5378,27 +5369,48 @@ button:focus-visible {
 	min-width: 0;
 }
 
-.security-pool-card-guidance {
-	display: grid;
-	gap: 0.45rem;
-	padding: 0.85rem 0.95rem;
-	border: 1px solid var(--border-default);
+.security-pool-status-badge {
+	position: relative;
+	display: inline-flex;
+	align-items: flex-start;
+}
+
+.security-pool-status-badge-trigger {
+	display: inline-flex;
+	border-radius: 4px;
+	outline: none;
+}
+
+.security-pool-status-badge-trigger:focus-visible {
+	box-shadow: 0 0 0 2px rgba(56, 213, 255, 0.28);
+}
+
+.security-pool-status-badge-tooltip {
+	position: absolute;
+	top: calc(100% + 0.45rem);
+	right: 0;
+	z-index: 3;
+	width: min(18rem, 70vw);
+	padding: 0.7rem 0.8rem;
+	border: 1px solid var(--border-emphasis);
 	border-radius: var(--radius-control);
-	background: rgba(9, 18, 31, 0.4);
+	background: rgba(9, 18, 31, 0.96);
+	box-shadow: 0 16px 32px rgba(0, 0, 0, 0.24);
+	color: var(--text);
+	font-size: var(--font-caption);
+	line-height: 1.45;
+	opacity: 0;
+	pointer-events: none;
+	transform: translateY(-0.15rem);
+	transition:
+		opacity 120ms ease,
+		transform 120ms ease;
 }
 
-.security-pool-card-guidance-summary {
-	color: var(--text-secondary);
-}
-
-.security-pool-card-guidance-next {
-	display: grid;
-	gap: 0.2rem;
-}
-
-.security-pool-card-guidance-next strong {
-	font-size: var(--font-body);
-	line-height: 1.4;
+.security-pool-status-badge:hover .security-pool-status-badge-tooltip,
+.security-pool-status-badge:focus-within .security-pool-status-badge-tooltip {
+	opacity: 1;
+	transform: translateY(0);
 }
 
 .security-pool-strip-question .question-preview-meta {
@@ -5454,6 +5466,11 @@ button:focus-visible {
 	display: grid;
 	grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
 	gap: 0.8rem;
+}
+
+.security-pool-card-inline-details {
+	padding-top: 0.1rem;
+	border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .security-pool-card-vault-preview {
@@ -5988,7 +6005,6 @@ button:focus-visible {
 		grid-template-columns: minmax(0, 1fr);
 	}
 
-	.security-pool-card-guidance,
 	.loaded-question-preview {
 		padding: 0.85rem;
 	}

--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -5369,50 +5369,6 @@ button:focus-visible {
 	min-width: 0;
 }
 
-.security-pool-status-badge {
-	position: relative;
-	display: inline-flex;
-	align-items: flex-start;
-}
-
-.security-pool-status-badge-trigger {
-	display: inline-flex;
-	border-radius: 4px;
-	outline: none;
-}
-
-.security-pool-status-badge-trigger:focus-visible {
-	box-shadow: 0 0 0 2px rgba(56, 213, 255, 0.28);
-}
-
-.security-pool-status-badge-tooltip {
-	position: absolute;
-	top: calc(100% + 0.45rem);
-	right: 0;
-	z-index: 3;
-	width: min(18rem, 70vw);
-	padding: 0.7rem 0.8rem;
-	border: 1px solid var(--border-emphasis);
-	border-radius: var(--radius-control);
-	background: rgba(9, 18, 31, 0.96);
-	box-shadow: 0 16px 32px rgba(0, 0, 0, 0.24);
-	color: var(--text);
-	font-size: var(--font-caption);
-	line-height: 1.45;
-	opacity: 0;
-	pointer-events: none;
-	transform: translateY(-0.15rem);
-	transition:
-		opacity 120ms ease,
-		transform 120ms ease;
-}
-
-.security-pool-status-badge:hover .security-pool-status-badge-tooltip,
-.security-pool-status-badge:focus-within .security-pool-status-badge-tooltip {
-	opacity: 1;
-	transform: translateY(0);
-}
-
 .security-pool-strip-question .question-preview-meta {
 	display: none;
 }

--- a/ui/ts/components/ActionLauncherCard.tsx
+++ b/ui/ts/components/ActionLauncherCard.tsx
@@ -11,7 +11,7 @@ type ActionLauncherCardProps = {
 }
 
 export function ActionLauncherCard({ action, children, pending = false, pendingLabel = 'Opening...', tone = 'secondary' }: ActionLauncherCardProps) {
-	if (action.onAction === undefined && action.blocker === undefined) return undefined
+	if (action.onAction === undefined && action.blocker === undefined && action.readiness !== 'blocked') return undefined
 	return (
 		<section className={`action-launcher-card ${action.readiness}`} data-action-safety-id={action.safetyId}>
 			<div className='action-launcher-card-copy'>

--- a/ui/ts/components/Badge.tsx
+++ b/ui/ts/components/Badge.tsx
@@ -2,13 +2,19 @@ import type { ComponentChildren } from 'preact'
 import type { BadgeTone } from '../types/components.js'
 
 type BadgeProps = {
+	ariaLabel?: string
 	children: ComponentChildren
 	className?: string
+	title?: string
 	tone?: BadgeTone
 }
 
-export function Badge({ children, className = '', tone = 'muted' }: BadgeProps) {
+export function Badge({ ariaLabel, children, className = '', title, tone = 'muted' }: BadgeProps) {
 	const classes = ['badge', tone, className].filter(Boolean).join(' ')
 
-	return <span className={classes}>{children}</span>
+	return (
+		<span aria-label={ariaLabel} className={classes} title={title}>
+			{children}
+		</span>
+	)
 }

--- a/ui/ts/components/LiquidationModal.tsx
+++ b/ui/ts/components/LiquidationModal.tsx
@@ -140,8 +140,7 @@ function renderQueuedLiquidationStatusCard({
 			/>
 		)
 	if (queuedLiquidationStatus === 'executed') return <TransactionStatusCard title='Liquidation Executed' badge={<Badge tone='ok'>Executed</Badge>} detail='A valid oracle price was already available, so the liquidation executed immediately and no staged operation was created.' />
-	if (queuedLiquidationStatus === 'missing')
-		return <TransactionStatusCard title='Liquidation Submitted' badge={<Badge tone='warning'>Check State</Badge>} detail='The transaction succeeded, but no matching staged operation is currently visible for this vault. Refresh staged operations to confirm the latest manager state.' />
+	if (queuedLiquidationStatus === 'missing') return <TransactionStatusCard title='Liquidation Submitted' badge={<Badge tone='warning'>Check State</Badge>} detail='The transaction succeeded, but the latest manager state is not available yet.' />
 	return <TransactionStatusCard title='Refreshing Liquidation State' badge={<Badge tone='muted'>Refreshing</Badge>} detail='Refreshing the oracle manager to determine whether the liquidation was queued or executed immediately.' />
 }
 export function LiquidationModal({
@@ -243,9 +242,8 @@ export function LiquidationModal({
 					})
 				})()
 	const liquidationEnabled = poolState?.actions.queueLiquidation.enabled ?? true
+	const canUseLiquidationAction = accountAddress !== undefined && isMainnet
 	const liquidationActionReason = pickFirstReason(
-		accountAddress === undefined ? 'Connect a wallet before liquidating.' : undefined,
-		!isMainnet ? 'Switch to Ethereum mainnet before liquidating.' : undefined,
 		liquidationExecutionMode === 'refreshing' ? 'Refreshing Open Oracle validity before liquidation.' : undefined,
 		liquidationManagerAddress === undefined || liquidationSecurityPoolAddress === undefined ? 'Reload the selected pool before liquidating.' : undefined,
 		trimmedLiquidationTargetVault === '' ? 'Select a target vault first.' : undefined,
@@ -429,7 +427,10 @@ export function LiquidationModal({
 							onQueueLiquidation(liquidationManagerAddress, liquidationSecurityPoolAddress)
 						}}
 						pending={securityPoolOverviewActiveAction === 'queueLiquidation'}
-						availability={{ disabled: !liquidationEnabled || liquidationActionReason !== undefined, reason: liquidationEnabled ? liquidationActionReason : undefined }}
+						availability={{
+							disabled: !liquidationEnabled || !canUseLiquidationAction || liquidationActionReason !== undefined,
+							reason: liquidationEnabled && canUseLiquidationAction ? liquidationActionReason : undefined,
+						}}
 						showDisabledReason={liquidationExecutionMode !== 'queue'}
 					/>
 				</div>

--- a/ui/ts/components/MarketQuestionsSection.tsx
+++ b/ui/ts/components/MarketQuestionsSection.tsx
@@ -141,7 +141,7 @@ export function MarketQuestionsSection({ environmentRefreshKey, hasForked, loadi
 								</div>
 							}
 						>
-							<Question question={question} showMissingContextNote={false} showTitle={false} />
+							<Question question={question} showTitle={false} />
 							{question.marketType !== 'binary' ? <p className='detail'>Non-binary questions are valid in Zoltar, but Placeholder origin pools currently require an exact binary Yes / No question.</p> : undefined}
 						</EntityCard>
 					))}

--- a/ui/ts/components/Question.tsx
+++ b/ui/ts/components/Question.tsx
@@ -32,6 +32,8 @@ export function getQuestionTitle(question: MarketDetails) {
 }
 
 function getQuestionDescription(question: MarketDetails) {
+	// Empty question descriptions are intentionally silent in the UI. These screens are read-only,
+	// and users cannot add resolution notes from here.
 	return question.description.trim()
 }
 

--- a/ui/ts/components/Question.tsx
+++ b/ui/ts/components/Question.tsx
@@ -50,10 +50,6 @@ function getQuestionTypeLabel(question: MarketDetails) {
 	}
 }
 
-function getQuestionContextLabel(question: MarketDetails) {
-	return getQuestionDescription(question) === '' ? 'Not provided' : 'Provided'
-}
-
 function getDisplayedOutcomes(question: MarketDetails) {
 	const outcomes = question.outcomeLabels.length === 0 ? ['Scalar'] : question.outcomeLabels
 	return appendInvalidOutcomeLabelIfMissing(outcomes)
@@ -66,7 +62,6 @@ function getDisplayRange(question: MarketDetails) {
 export function getQuestionSummaryFields(question: MarketDetails): QuestionSummaryField[] {
 	const fields: QuestionSummaryField[] = [
 		{ kind: 'text', label: 'Question Type', value: getQuestionTypeLabel(question) },
-		{ kind: 'text', label: 'Context', value: getQuestionContextLabel(question) },
 		{ kind: 'text', label: 'Question ID', value: question.questionId },
 		{ kind: 'timestamp', label: 'Created', value: question.createdAt },
 		{ kind: 'timestamp', label: 'End Time', value: question.endTime },

--- a/ui/ts/components/Question.tsx
+++ b/ui/ts/components/Question.tsx
@@ -11,7 +11,6 @@ type QuestionProps = {
 	className?: string
 	loading?: boolean
 	question: MarketDetails | undefined
-	showMissingContextNote?: boolean
 	showTitle?: boolean
 	variant?: 'full' | 'preview'
 }
@@ -32,14 +31,8 @@ export function getQuestionTitle(question: MarketDetails) {
 	return question.title.trim() === '' ? 'Untitled question' : question.title
 }
 
-const missingQuestionContextNote = 'Add resolution notes, evidence sources, and edge-case handling before users rely on this question.'
-
 function getQuestionDescription(question: MarketDetails) {
-	return question.description.trim() === '' ? 'No resolution notes or supporting context provided.' : question.description
-}
-
-function hasQuestionContext(question: MarketDetails) {
-	return question.description.trim() !== ''
+	return question.description.trim()
 }
 
 function getQuestionTypeLabel(question: MarketDetails) {
@@ -56,7 +49,7 @@ function getQuestionTypeLabel(question: MarketDetails) {
 }
 
 function getQuestionContextLabel(question: MarketDetails) {
-	return hasQuestionContext(question) ? 'Context provided' : 'Needs context'
+	return getQuestionDescription(question) === '' ? 'Not provided' : 'Provided'
 }
 
 function getDisplayedOutcomes(question: MarketDetails) {
@@ -98,7 +91,7 @@ function renderQuestionSummaryField(field: QuestionSummaryField) {
 	)
 }
 
-export function Question({ className = '', loading = false, question, showMissingContextNote = true, showTitle = true, variant = 'full' }: QuestionProps) {
+export function Question({ className = '', loading = false, question, showTitle = true, variant = 'full' }: QuestionProps) {
 	if (loading || question === undefined)
 		return (
 			<div className={`question-summary ${className}`}>
@@ -110,7 +103,8 @@ export function Question({ className = '', loading = false, question, showMissin
 
 	const title = getQuestionTitle(question)
 	const description = getQuestionDescription(question)
-	const missingContext = showMissingContextNote && !hasQuestionContext(question)
+	const showHeading = showTitle || description !== ''
+	const descriptionNode = description === '' ? undefined : <p className='detail'>{description}</p>
 	const summaryFields = getQuestionSummaryFields(question)
 	const outcomeItems = getDisplayedOutcomes(question).map(outcome => ({
 		key: outcome,
@@ -134,11 +128,12 @@ export function Question({ className = '', loading = false, question, showMissin
 	if (variant === 'preview')
 		return (
 			<div className={`question-summary question-summary-preview ${className}`.trim()}>
-				<div className='question-summary-heading'>
-					{showTitle ? <strong>{title}</strong> : null}
-					<p className='detail'>{description}</p>
-				</div>
-				{missingContext ? <p className='question-context-note'>{missingQuestionContextNote}</p> : null}
+				{!showHeading ? undefined : (
+					<div className='question-summary-heading'>
+						{showTitle ? <strong>{title}</strong> : null}
+						{descriptionNode}
+					</div>
+				)}
 				<OutcomeChipRow items={outcomeItems} />
 				<div className='question-preview-timeline' role='list' aria-label='Question timeline'>
 					<div className='question-preview-timeline-item' role='listitem'>
@@ -174,12 +169,11 @@ export function Question({ className = '', loading = false, question, showMissin
 			{showTitle ? (
 				<div className='question-summary-heading'>
 					<strong>{title}</strong>
-					<p className='detail'>{description}</p>
+					{descriptionNode}
 				</div>
 			) : (
-				<p className='detail'>{description}</p>
+				descriptionNode
 			)}
-			{missingContext ? <p className='question-context-note'>{missingQuestionContextNote}</p> : null}
 			<MetricGrid variant='question'>{summaryFields.map(renderQuestionSummaryField)}</MetricGrid>
 		</div>
 	)

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -65,9 +65,9 @@ import { getReportingLockedUntilMessage, hasReportingOpened } from '../lib/repor
 import { getSecurityPoolStatusBadgeLabel } from '../lib/securityPoolLabels.js'
 import { deriveSecurityPoolLifecycleState, deriveSecurityPoolReportingStage, evaluateSecurityPoolState, type SecurityPoolLifecycleState } from '../lib/securityPoolState.js'
 import { getVaultExecutePendingOperationGuardMessage, getVaultRequestPriceGuardMessage } from '../lib/securityVaultGuards.js'
-import { doesLoadedSecurityVaultMatchSelection, getSelectedVaultAddress, isSelectedVaultOwnedByAccount as isSelectedVaultOwnedByAccountHelper } from '../lib/securityVault.js'
+import { doesLoadedSecurityVaultMatchSelection, doesSecurityVaultExistOnchain, getSelectedVaultAddress, isSelectedVaultOwnedByAccount as isSelectedVaultOwnedByAccountHelper } from '../lib/securityVault.js'
 import { getPoolRegistryPresentation } from '../lib/userCopy.js'
-import { formatUniverseLabel } from '../lib/universe.js'
+import { formatUniverseIdHex } from '../lib/universe.js'
 import { useForkWorkflowSelectionState } from '../hooks/useForkWorkflowSelectionState.js'
 import { useSelectedVaultWorkflowState, type SelectedVaultView } from '../hooks/useSelectedVaultWorkflowState.js'
 import type { SecurityPoolWorkflowRouteContentProps, ViewTabOption } from '../types/components.js'
@@ -316,6 +316,7 @@ export function SecurityPoolWorkflowSection({
 	})
 		? securityVault.securityVaultDetails
 		: undefined
+	const selectedVaultExistsOnchain = doesSecurityVaultExistOnchain(selectedVaultDetails)
 	const currentSecurityVaultResult = selectedVaultDetails === undefined ? undefined : securityVault.securityVaultResult
 	const hasLoadedCurrentVault = selectedVaultDetails !== undefined && sameAddress(selectedVaultDetails.vaultAddress, selectedVaultAddress) && sameAddress(selectedVaultDetails.securityPoolAddress, selectedPool?.securityPoolAddress)
 	const { setVaultView, vaultView } = useSelectedVaultWorkflowState({
@@ -660,10 +661,10 @@ export function SecurityPoolWorkflowSection({
 		if (showSelectedPoolWorkflowDetails && view === 'vaults' && hasLoadedCurrentVault) void securityVault.onLoadSecurityVault()
 	}, [hasLoadedCurrentVault, onRefreshSelectedPoolData, poolPriceOracleResult, reporting.onLoadReporting, securityVault.onLoadSecurityVault, selectedPool?.securityPoolAddress, shouldRefreshSelectedPoolReporting, showSelectedPoolWorkflowDetails, view])
 	const selectedPoolViewOptions = SELECTED_POOL_VIEWS.map(selectedPoolUiView => ({
-		disabled: selectedPoolWorkflowGuardMessage !== undefined,
+		disabled: selectedPoolUniverseMismatch || selectedPoolWorkflowGuardMessage !== undefined,
 		id: `selected-pool-view-${selectedPoolUiView}`,
 		label: getSelectedPoolViewLabel(selectedPoolUiView),
-		...(selectedPoolWorkflowGuardMessage === undefined ? {} : { reason: selectedPoolWorkflowGuardMessage }),
+		...(selectedPoolUniverseMismatch || selectedPoolWorkflowGuardMessage === undefined ? {} : { reason: selectedPoolWorkflowGuardMessage }),
 		value: selectedPoolUiView,
 	}))
 	return (
@@ -709,9 +710,8 @@ export function SecurityPoolWorkflowSection({
 			{selectedPool === undefined || !selectedPoolUniverseMismatch ? undefined : (
 				<SectionBlock title='Universe Mismatch' tone='critical'>
 					<p className='detail'>
-						This pool belongs to <UniverseLink universeId={selectedPool.universeId} /> but the app is currently set to {formatUniverseLabel(activeUniverseId)}.
+						This pool belongs to <UniverseLink universeId={selectedPool.universeId}>{formatUniverseIdHex(selectedPool.universeId)}</UniverseLink> but the app is currently set to {formatUniverseIdHex(activeUniverseId)}.
 					</p>
-					<p className='detail'>Switch to the same universe before using this pool.</p>
 				</SectionBlock>
 			)}
 
@@ -736,7 +736,7 @@ export function SecurityPoolWorkflowSection({
 					<div className='selected-pool-workflow-content'>
 						{!showSelectedPoolWorkflowDetails ? (
 							<SectionBlock title={selectedPoolLookupState === 'missing' ? 'Pool not found' : 'Manage Pool'} variant='plain'>
-								{selectedPoolWorkflowLockedPresentation === undefined ? undefined : <StateHint presentation={selectedPoolWorkflowLockedPresentation} />}
+								{selectedPoolUniverseMismatch || selectedPoolWorkflowLockedPresentation === undefined ? undefined : <StateHint presentation={selectedPoolWorkflowLockedPresentation} />}
 							</SectionBlock>
 						) : (
 							<>
@@ -765,7 +765,7 @@ export function SecurityPoolWorkflowSection({
 												}
 											/>
 											{selectedVaultIsOwnedByAccount ? undefined : <p className='detail'>Select your own vault to unlock actions.</p>}
-											{vaultView === 'selected-vault' && selectedVaultDetails !== undefined ? (
+											{vaultView === 'selected-vault' && selectedVaultDetails !== undefined && selectedVaultExistsOnchain ? (
 												<SelectedVaultSummarySection
 													repPerEthPrice={repPerEthPrice}
 													repPerEthSource={repPerEthSource}
@@ -832,7 +832,7 @@ export function SecurityPoolWorkflowSection({
 														const liquidationBlocker = (() => {
 															if (selectedPool === undefined || selectedVaultDetails === undefined) return 'Refresh the selected vault first.'
 															if (selectedVaultAddress === '') return 'Select a pool and vault first.'
-															if (!liquidationEnabled) return 'Liquidation is not available right now.'
+															if (!selectedVaultExistsOnchain) return 'This vault does not exist yet.'
 
 															return undefined
 														})()
@@ -842,10 +842,10 @@ export function SecurityPoolWorkflowSection({
 															...(liquidationBlocker === undefined ? {} : { blocker: liquidationBlocker }),
 															description: 'Inspect the liquidation quote, timeout, and execution path before queueing liquidation.',
 															key: 'liquidate-vault',
-															readiness: liquidationEnabled ? 'ready' : 'blocked',
+															readiness: liquidationBlocker === undefined && liquidationEnabled ? 'ready' : 'blocked',
 															safetyId: 'security-pool.queueLiquidation',
 															title: 'Review Liquidation',
-															...(selectedPool === undefined || selectedVaultDetails === undefined || selectedVaultAddress === '' || !liquidationEnabled
+															...(selectedPool === undefined || selectedVaultDetails === undefined || selectedVaultAddress === '' || !liquidationEnabled || !selectedVaultExistsOnchain
 																? {}
 																: {
 																		onAction: () => onOpenLiquidationModal(selectedPool.managerAddress, selectedPool.securityPoolAddress, selectedVaultDetails.vaultAddress, selectedVaultDetails.securityBondAllowance),

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -833,7 +833,7 @@ export function SecurityPoolWorkflowSection({
 															if (selectedPool === undefined || selectedVaultDetails === undefined) return 'Refresh the selected vault first.'
 															if (selectedVaultAddress === '') return 'Select a pool and vault first.'
 															if (!selectedVaultExistsOnchain) return 'This vault does not exist yet.'
-
+															if (!liquidationEnabled) return 'Review Liquidation is not available in the current pool state.'
 															return undefined
 														})()
 

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -832,10 +832,7 @@ export function SecurityPoolWorkflowSection({
 														const canUseSelectedVaultActions = accountState.address !== undefined && selectedVaultIsOwnedByAccount && selectedVaultDetails !== undefined && isMainnet
 														const loadedVaultMissing = selectedVaultDetails !== undefined && !selectedVaultExistsOnchain
 														const liquidationBlocker = (() => {
-															if (selectedPool === undefined) return 'Select a pool and vault first.'
-															if (selectedVaultAddress === '') return 'Select a pool and vault first.'
 															if (loadedVaultMissing) return 'This vault does not exist.'
-															if (!liquidationEnabled) return 'Review Liquidation is not available in the current pool state.'
 															return undefined
 														})()
 

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -386,6 +386,7 @@ export function SecurityPoolWorkflowSection({
 		resolvedPendingOperationId,
 	})
 	const pendingOperation = currentPoolOracleManagerDetails?.pendingOperation
+	const canUseOracleActions = accountState.address !== undefined && isMainnet
 	const stagedOperations = currentPoolOracleManagerDetails?.stagedOperations ?? (pendingOperation === undefined ? [] : [pendingOperation])
 	const pendingSettlementOperationIds = currentPoolOracleManagerDetails?.pendingSettlementOperationIds ?? []
 	const activeStagedOperationCount = currentPoolOracleManagerDetails?.activeStagedOperationCount ?? BigInt(stagedOperations.length)
@@ -710,7 +711,7 @@ export function SecurityPoolWorkflowSection({
 			{selectedPool === undefined || !selectedPoolUniverseMismatch ? undefined : (
 				<SectionBlock title='Universe Mismatch' tone='critical'>
 					<p className='detail'>
-						This pool belongs to <UniverseLink universeId={selectedPool.universeId}>{formatUniverseIdHex(selectedPool.universeId)}</UniverseLink> but the app is currently set to {formatUniverseIdHex(activeUniverseId)}.
+						This pool belongs to <UniverseLink format='hex' universeId={selectedPool.universeId} /> but the app is currently set to {formatUniverseIdHex(activeUniverseId)}. This pool does not exist.
 					</p>
 				</SectionBlock>
 			)}
@@ -764,7 +765,6 @@ export function SecurityPoolWorkflowSection({
 													</button>
 												}
 											/>
-											{selectedVaultIsOwnedByAccount ? undefined : <p className='detail'>Select your own vault to unlock actions.</p>}
 											{vaultView === 'selected-vault' && selectedVaultDetails !== undefined && selectedVaultExistsOnchain ? (
 												<SelectedVaultSummarySection
 													repPerEthPrice={repPerEthPrice}
@@ -829,10 +829,12 @@ export function SecurityPoolWorkflowSection({
 												compactLayout
 												extraReadinessActions={[
 													(() => {
+														const canUseSelectedVaultActions = accountState.address !== undefined && selectedVaultIsOwnedByAccount && selectedVaultDetails !== undefined && isMainnet
+														const loadedVaultMissing = selectedVaultDetails !== undefined && !selectedVaultExistsOnchain
 														const liquidationBlocker = (() => {
-															if (selectedPool === undefined || selectedVaultDetails === undefined) return 'Refresh the selected vault first.'
+															if (selectedPool === undefined) return 'Select a pool and vault first.'
 															if (selectedVaultAddress === '') return 'Select a pool and vault first.'
-															if (!selectedVaultExistsOnchain) return 'This vault does not exist yet.'
+															if (loadedVaultMissing) return 'This vault does not exist.'
 															if (!liquidationEnabled) return 'Review Liquidation is not available in the current pool state.'
 															return undefined
 														})()
@@ -842,10 +844,10 @@ export function SecurityPoolWorkflowSection({
 															...(liquidationBlocker === undefined ? {} : { blocker: liquidationBlocker }),
 															description: 'Inspect the liquidation quote, timeout, and execution path before queueing liquidation.',
 															key: 'liquidate-vault',
-															readiness: liquidationBlocker === undefined && liquidationEnabled ? 'ready' : 'blocked',
+															readiness: liquidationBlocker === undefined && liquidationEnabled && canUseSelectedVaultActions ? 'ready' : 'blocked',
 															safetyId: 'security-pool.queueLiquidation',
 															title: 'Review Liquidation',
-															...(selectedPool === undefined || selectedVaultDetails === undefined || selectedVaultAddress === '' || !liquidationEnabled || !selectedVaultExistsOnchain
+															...(selectedPool === undefined || selectedVaultDetails === undefined || selectedVaultAddress === '' || !liquidationEnabled || !selectedVaultExistsOnchain || !canUseSelectedVaultActions
 																? {}
 																: {
 																		onAction: () => onOpenLiquidationModal(selectedPool.managerAddress, selectedPool.securityPoolAddress, selectedVaultDetails.vaultAddress, selectedVaultDetails.securityBondAllowance),
@@ -853,6 +855,7 @@ export function SecurityPoolWorkflowSection({
 														}
 													})(),
 												]}
+												autoLoadVault
 												modalFirst
 												onViewStagedOperations={() => onSelectedPoolViewChange('staged-operations')}
 												oracleManagerDetails={currentPoolOracleManagerDetails}
@@ -974,8 +977,8 @@ export function SecurityPoolWorkflowSection({
 													pending={poolOracleActiveAction === 'executeStagedOperation'}
 													tone='secondary'
 													availability={{
-														disabled: !selectedPoolStateModel.actions.executeStagedOperation.enabled || executePendingOperationGuardMessage !== undefined,
-														reason: selectedPoolStateModel.actions.executeStagedOperation.enabled ? executePendingOperationGuardMessage : undefined,
+														disabled: !selectedPoolStateModel.actions.executeStagedOperation.enabled || !canUseOracleActions || executePendingOperationGuardMessage !== undefined,
+														reason: selectedPoolStateModel.actions.executeStagedOperation.enabled && canUseOracleActions ? executePendingOperationGuardMessage : undefined,
 													}}
 												/>
 											)}
@@ -1020,8 +1023,8 @@ export function SecurityPoolWorkflowSection({
 												pending={poolOracleActiveAction === 'requestPrice'}
 												tone='secondary'
 												availability={{
-													disabled: !selectedPoolStateModel.actions.requestPrice.enabled || requestPriceGuardMessage !== undefined,
-													reason: selectedPoolStateModel.actions.requestPrice.enabled ? requestPriceGuardMessage : undefined,
+													disabled: !selectedPoolStateModel.actions.requestPrice.enabled || !canUseOracleActions || requestPriceGuardMessage !== undefined,
+													reason: selectedPoolStateModel.actions.requestPrice.enabled && canUseOracleActions ? requestPriceGuardMessage : undefined,
 												}}
 											/>
 										</div>

--- a/ui/ts/components/SecurityPoolsOverviewSection.tsx
+++ b/ui/ts/components/SecurityPoolsOverviewSection.tsx
@@ -25,7 +25,6 @@ import { openInterestFeePerYearBigint } from '../lib/retentionRate.js'
 import { getSecurityPoolStatusBadgeLabel } from '../lib/securityPoolLabels.js'
 import { deriveSecurityPoolLifecycleState, evaluateSecurityPoolState, type SecurityPoolLifecycleState } from '../lib/securityPoolState.js'
 import { getPoolCollateralizationPercent, getVaultCollateralizationPercent } from '../lib/trading.js'
-import { formatUniverseIdHex } from '../lib/universe.js'
 import { getPoolRegistryPresentation } from '../lib/userCopy.js'
 import { getToneRatioThreshold, getVisualRatio } from '../lib/visualMetrics.js'
 import type { SecurityPoolsOverviewSectionProps } from '../types/components.js'
@@ -321,7 +320,7 @@ export function SecurityPoolsOverviewSection({
 												</MetricField>
 												<MetricField label='Question ID'>{pool.questionId}</MetricField>
 												<MetricField label='Universe'>
-													<UniverseLink universeId={pool.universeId}>{formatUniverseIdHex(pool.universeId)}</UniverseLink>
+													<UniverseLink format='hex' universeId={pool.universeId} />
 												</MetricField>
 											</div>
 											<div className='security-pool-browse-vaults'>
@@ -331,7 +330,9 @@ export function SecurityPoolsOverviewSection({
 														{pool.vaultCount.toString()} vault{pool.vaultCount === 1n ? '' : 's'}
 													</div>
 												</div>
-												{pool.hasLoadedVaults === false ? undefined : (
+												{pool.hasLoadedVaults === false ? (
+													<StateHint presentation={{ key: 'empty', badgeLabel: 'Unavailable', badgeTone: 'muted', detail: 'Vault preview unavailable.' }} />
+												) : (
 													<div className='security-pool-browse-vault-list'>
 														{pool.vaults.length === 0 ? (
 															<StateHint presentation={{ key: 'empty', badgeLabel: 'None yet', badgeTone: 'muted', detail: 'No vaults in this pool yet.' }} />

--- a/ui/ts/components/SecurityPoolsOverviewSection.tsx
+++ b/ui/ts/components/SecurityPoolsOverviewSection.tsx
@@ -14,7 +14,6 @@ import { PaginationControls } from './PaginationControls.js'
 import { ProgressMeter } from './ProgressMeter.js'
 import { CollateralizationCircle } from './CollateralizationCircle.js'
 import { Question, getQuestionTitle } from './Question.js'
-import { ReadOnlyDetailAccordion } from './ReadOnlyDetailAccordion.js'
 import { RouteWorkflowPanel } from './RouteWorkflowPanel.js'
 import { SectionBlock } from './SectionBlock.js'
 import { StateHint } from './StateHint.js'
@@ -26,6 +25,7 @@ import { openInterestFeePerYearBigint } from '../lib/retentionRate.js'
 import { getSecurityPoolStatusBadgeLabel } from '../lib/securityPoolLabels.js'
 import { deriveSecurityPoolLifecycleState, evaluateSecurityPoolState, type SecurityPoolLifecycleState } from '../lib/securityPoolState.js'
 import { getPoolCollateralizationPercent, getVaultCollateralizationPercent } from '../lib/trading.js'
+import { formatUniverseIdHex } from '../lib/universe.js'
 import { getPoolRegistryPresentation } from '../lib/userCopy.js'
 import { getToneRatioThreshold, getVisualRatio } from '../lib/visualMetrics.js'
 import type { SecurityPoolsOverviewSectionProps } from '../types/components.js'
@@ -34,33 +34,27 @@ function getSecurityPoolGuidance({ hasKnownForkActivity, lifecycleState, questio
 	if (lifecycleState === 'forkTruthAuction')
 		return {
 			nextStep: 'Open the pool to review auction state and any child-universe follow-up actions.',
-			summary: 'Migration has moved into the truth-auction phase, where bidding and settlement determine the child-universe recovery path.',
 		}
 	if (lifecycleState === 'poolForked' || lifecycleState === 'forkMigration')
 		return {
 			nextStep: 'Open the pool to continue REP or deposit migration before the fork window closes.',
-			summary: 'This pool is in fork migration. Parent balances and unresolved deposits may need to move into a child universe.',
 		}
 	if (lifecycleState === 'ended') {
 		if (questionOutcome === undefined || questionOutcome === 'none')
 			return {
 				nextStep: 'Open the pool to review reporting, stake balances, and escalation timing.',
-				summary: 'The question has ended, but the final outcome is still being disputed or finalized.',
 			}
 
 		return {
 			nextStep: vaultCount > 0n ? 'Open the pool to review vault exits, withdrawals, or any remaining settlement actions.' : 'Open the pool to review the finalized outcome and any post-resolution state.',
-			summary: 'The question is finalized. Remaining actions are now about settlement, vault exits, or historical review.',
 		}
 	}
 	if (lifecycleState === 'operational' && hasKnownForkActivity)
 		return {
 			nextStep: 'Open the pool to review final child-universe state and any remaining balances.',
-			summary: 'This pool has already gone through a fork lifecycle and now acts as a historical reference point.',
 		}
 	return {
 		nextStep: vaultCount > 0n ? 'Open the pool to inspect vault health, price context, or reporting readiness.' : 'Open the pool to add the first vault or review how this pool is collateralized.',
-		summary: 'This pool is active and can back trading, vault collateral, and reporting for its question.',
 	}
 }
 
@@ -178,7 +172,6 @@ export function SecurityPoolsOverviewSection({
 			<SectionBlock
 				density='compact'
 				title='Security Pools'
-				description='Browse the pools that back binary questions, compare their health, and open one to manage vaults, reporting, or fork actions.'
 				actions={
 					<PaginationControls
 						hasNextPage={hasNextPage}
@@ -271,12 +264,18 @@ export function SecurityPoolsOverviewSection({
 									questionOutcome: pool.questionOutcome,
 									vaultCount: pool.vaultCount,
 								})
+								const statusBadgeLabel = getSecurityPoolStatusBadgeLabel({
+									hasForkActivity: hasKnownForkActivity,
+									questionOutcome: pool.questionOutcome,
+									lifecycleState: displayState,
+								})
 								const badgeTone = (() => {
 									if (displayState === 'operational') return 'ok'
 									if (displayState === undefined) return 'muted'
 
 									return 'warning'
 								})()
+								const guidanceTooltipId = `security-pool-guidance-${pool.securityPoolAddress.slice(2).toLowerCase()}`
 								return (
 									<EntityCard
 										key={pool.securityPoolAddress}
@@ -284,13 +283,16 @@ export function SecurityPoolsOverviewSection({
 										title={getQuestionTitle(pool.marketDetails)}
 										variant='record'
 										badge={
-											<Badge tone={badgeTone}>
-												{getSecurityPoolStatusBadgeLabel({
-													hasForkActivity: hasKnownForkActivity,
-													questionOutcome: pool.questionOutcome,
-													lifecycleState: displayState,
-												})}
-											</Badge>
+											<span className='security-pool-status-badge'>
+												<span aria-describedby={guidanceTooltipId} className='security-pool-status-badge-trigger' tabIndex={0}>
+													<Badge ariaLabel={statusBadgeLabel} tone={badgeTone}>
+														{statusBadgeLabel}
+													</Badge>
+												</span>
+												<span className='security-pool-status-badge-tooltip' id={guidanceTooltipId} role='tooltip'>
+													{poolGuidance.nextStep}
+												</span>
+											</span>
 										}
 										actions={
 											onSelectSecurityPool === undefined ? undefined : (
@@ -307,13 +309,6 @@ export function SecurityPoolsOverviewSection({
 											<div className='security-pool-strip'>
 												<div className='security-pool-strip-story'>
 													<Question className='security-pool-strip-question' question={pool.marketDetails} showTitle={false} variant='preview' />
-													<div className='security-pool-card-guidance'>
-														<p className='security-pool-card-guidance-summary'>{poolGuidance.summary}</p>
-														<p className='security-pool-card-guidance-next'>
-															<span className='panel-label'>Next step</span>
-															<strong>{poolGuidance.nextStep}</strong>
-														</p>
-													</div>
 													<div className='security-pool-strip-stats'>
 														<div>
 															<span>Vaults</span>
@@ -359,20 +354,18 @@ export function SecurityPoolsOverviewSection({
 													</div>
 												</div>
 											</div>
-											<ReadOnlyDetailAccordion title='Pool Details'>
-												<div className='security-pool-detail-rail'>
-													<MetricField label='Pool Address'>
-														<AddressValue address={pool.securityPoolAddress} />
-													</MetricField>
-													<MetricField label='Manager Address'>
-														<AddressValue address={pool.managerAddress} />
-													</MetricField>
-													<MetricField label='Question ID'>{pool.questionId}</MetricField>
-													<MetricField label='Universe'>
-														<UniverseLink universeId={pool.universeId} />
-													</MetricField>
-												</div>
-											</ReadOnlyDetailAccordion>
+											<div className='security-pool-detail-rail security-pool-card-inline-details'>
+												<MetricField label='Pool Address'>
+													<AddressValue address={pool.securityPoolAddress} />
+												</MetricField>
+												<MetricField label='Manager Address'>
+													<AddressValue address={pool.managerAddress} />
+												</MetricField>
+												<MetricField label='Question ID'>{pool.questionId}</MetricField>
+												<MetricField label='Universe'>
+													<UniverseLink universeId={pool.universeId}>{formatUniverseIdHex(pool.universeId)}</UniverseLink>
+												</MetricField>
+											</div>
 											<div className='security-pool-browse-vaults'>
 												<div className='security-pool-browse-vaults-head'>
 													<h4>Vaults</h4>
@@ -380,16 +373,7 @@ export function SecurityPoolsOverviewSection({
 														{pool.vaultCount.toString()} vault{pool.vaultCount === 1n ? '' : 's'}
 													</div>
 												</div>
-												{pool.hasLoadedVaults === false ? (
-													<StateHint
-														presentation={{
-															key: 'action_needed',
-															badgeLabel: 'Deferred',
-															badgeTone: 'muted',
-															detail: `Open this pool to load ${pool.vaultCount.toString()} vault${pool.vaultCount === 1n ? '' : 's'}.`,
-														}}
-													/>
-												) : (
+												{pool.hasLoadedVaults === false ? undefined : (
 													<div className='security-pool-browse-vault-list'>
 														{pool.vaults.length === 0 ? (
 															<StateHint presentation={{ key: 'empty', badgeLabel: 'None yet', badgeTone: 'muted', detail: 'No vaults in this pool yet.' }} />
@@ -450,12 +434,6 @@ export function SecurityPoolsOverviewSection({
 														) : undefined}
 													</div>
 												)}
-												{pool.vaultCount > BigInt(pool.vaults.length) ? (
-													<p className='detail'>
-														+{(pool.vaultCount - BigInt(pool.vaults.length)).toString()} more vault
-														{pool.vaultCount - BigInt(pool.vaults.length) === 1n ? '' : 's'}
-													</p>
-												) : undefined}
 											</div>
 										</div>
 									</EntityCard>

--- a/ui/ts/components/SecurityPoolsOverviewSection.tsx
+++ b/ui/ts/components/SecurityPoolsOverviewSection.tsx
@@ -30,34 +30,6 @@ import { getPoolRegistryPresentation } from '../lib/userCopy.js'
 import { getToneRatioThreshold, getVisualRatio } from '../lib/visualMetrics.js'
 import type { SecurityPoolsOverviewSectionProps } from '../types/components.js'
 
-function getSecurityPoolGuidance({ hasKnownForkActivity, lifecycleState, questionOutcome, vaultCount }: { hasKnownForkActivity: boolean; lifecycleState: SecurityPoolLifecycleState | undefined; questionOutcome: string | undefined; vaultCount: bigint }) {
-	if (lifecycleState === 'forkTruthAuction')
-		return {
-			nextStep: 'Open the pool to review auction state and any child-universe follow-up actions.',
-		}
-	if (lifecycleState === 'poolForked' || lifecycleState === 'forkMigration')
-		return {
-			nextStep: 'Open the pool to continue REP or deposit migration before the fork window closes.',
-		}
-	if (lifecycleState === 'ended') {
-		if (questionOutcome === undefined || questionOutcome === 'none')
-			return {
-				nextStep: 'Open the pool to review reporting, stake balances, and escalation timing.',
-			}
-
-		return {
-			nextStep: vaultCount > 0n ? 'Open the pool to review vault exits, withdrawals, or any remaining settlement actions.' : 'Open the pool to review the finalized outcome and any post-resolution state.',
-		}
-	}
-	if (lifecycleState === 'operational' && hasKnownForkActivity)
-		return {
-			nextStep: 'Open the pool to review final child-universe state and any remaining balances.',
-		}
-	return {
-		nextStep: vaultCount > 0n ? 'Open the pool to inspect vault health, price context, or reporting readiness.' : 'Open the pool to add the first vault or review how this pool is collateralized.',
-	}
-}
-
 export function SecurityPoolsOverviewSection({
 	accountState,
 	closeLiquidationModal,
@@ -258,12 +230,6 @@ export function SecurityPoolsOverviewSection({
 								const liquidationEnabled = poolState.actions.queueLiquidation.enabled
 								const collateralizationPercent = getPoolCollateralizationPercent(pool.totalRepDeposit, pool.totalSecurityBondAllowance, repPerEthPrice)
 								const targetCollateralizationPercent = pool.securityMultiplier * 100n * 10n ** 18n
-								const poolGuidance = getSecurityPoolGuidance({
-									hasKnownForkActivity,
-									lifecycleState: displayState,
-									questionOutcome: pool.questionOutcome,
-									vaultCount: pool.vaultCount,
-								})
 								const statusBadgeLabel = getSecurityPoolStatusBadgeLabel({
 									hasForkActivity: hasKnownForkActivity,
 									questionOutcome: pool.questionOutcome,
@@ -275,7 +241,6 @@ export function SecurityPoolsOverviewSection({
 
 									return 'warning'
 								})()
-								const guidanceTooltipId = `security-pool-guidance-${pool.securityPoolAddress.slice(2).toLowerCase()}`
 								return (
 									<EntityCard
 										key={pool.securityPoolAddress}
@@ -283,16 +248,9 @@ export function SecurityPoolsOverviewSection({
 										title={getQuestionTitle(pool.marketDetails)}
 										variant='record'
 										badge={
-											<span className='security-pool-status-badge'>
-												<span aria-describedby={guidanceTooltipId} className='security-pool-status-badge-trigger' tabIndex={0}>
-													<Badge ariaLabel={statusBadgeLabel} tone={badgeTone}>
-														{statusBadgeLabel}
-													</Badge>
-												</span>
-												<span className='security-pool-status-badge-tooltip' id={guidanceTooltipId} role='tooltip'>
-													{poolGuidance.nextStep}
-												</span>
-											</span>
+											<Badge ariaLabel={statusBadgeLabel} tone={badgeTone}>
+												{statusBadgeLabel}
+											</Badge>
 										}
 										actions={
 											onSelectSecurityPool === undefined ? undefined : (

--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -487,7 +487,10 @@ export function SecurityVaultSection({
 		return undefined
 	})()
 	const vaultMissingBlocker = vaultExistsOnchain ? undefined : 'This vault does not exist yet.'
-	const repExitLauncherBlocker = vaultActionLauncherBlocker ?? vaultMissingBlocker
+	const depositActionLauncherBlocker = depositLauncherBlocker ?? (depositRepEnabled ? undefined : 'Deposit REP is not available in the current pool state.')
+	const repExitLauncherBlocker = vaultActionLauncherBlocker ?? vaultMissingBlocker ?? (repExitEnabled ? undefined : `${repExitActionLabel} is not available in the current pool state.`)
+	const bondAllowanceLauncherBlocker = vaultActionLauncherBlocker ?? vaultMissingBlocker ?? (bondAllowanceEnabled ? undefined : 'Set Bond Allowance is not available in the current pool state.')
+	const claimFeesLauncherBlocker = vaultActionLauncherBlocker ?? vaultMissingBlocker ?? claimFeesGuardMessage ?? (claimFeesEnabled ? undefined : 'Claim Fees is not available in the current pool state.')
 	useEffect(() => {
 		if (!autoLoadVault) return
 		if (accountState.address === undefined) return
@@ -503,9 +506,9 @@ export function SecurityVaultSection({
 			description: 'Add REP to the selected vault.',
 			key: 'deposit-rep',
 			safetyId: getSecurityVaultActionSafetyId('depositRep'),
-			...(depositRepEnabled && depositLauncherBlocker === undefined ? { onAction: () => setVaultActionModal('deposit-rep') } : {}),
-			readiness: depositRepEnabled && depositLauncherBlocker === undefined ? 'ready' : 'blocked',
-			...(depositLauncherBlocker === undefined ? {} : { blocker: depositLauncherBlocker }),
+			...(depositRepEnabled && depositActionLauncherBlocker === undefined ? { onAction: () => setVaultActionModal('deposit-rep') } : {}),
+			readiness: depositRepEnabled && depositActionLauncherBlocker === undefined ? 'ready' : 'blocked',
+			...(depositActionLauncherBlocker === undefined ? {} : { blocker: depositActionLauncherBlocker }),
 			title: 'Deposit REP',
 		},
 		{
@@ -525,7 +528,7 @@ export function SecurityVaultSection({
 			safetyId: getSecurityVaultActionSafetyId('queueSetSecurityBondAllowance'),
 			...(bondAllowanceEnabled && vaultActionLauncherBlocker === undefined && vaultExistsOnchain ? { onAction: () => setVaultActionModal('set-bond-allowance') } : {}),
 			readiness: bondAllowanceEnabled && vaultActionLauncherBlocker === undefined && vaultExistsOnchain ? 'ready' : 'blocked',
-			...(repExitLauncherBlocker === undefined ? {} : { blocker: repExitLauncherBlocker }),
+			...(bondAllowanceLauncherBlocker === undefined ? {} : { blocker: bondAllowanceLauncherBlocker }),
 			title: 'Set Security Bond Allowance',
 		},
 		{
@@ -533,9 +536,9 @@ export function SecurityVaultSection({
 			description: 'Review claimable fees and confirm the fee redemption for the selected vault.',
 			key: 'claim-fees',
 			safetyId: getSecurityVaultActionSafetyId('redeemFees'),
-			...(claimFeesEnabled && vaultActionLauncherBlocker === undefined && vaultExistsOnchain ? { onAction: () => setVaultActionModal('claim-fees') } : {}),
-			readiness: claimFeesEnabled && vaultActionLauncherBlocker === undefined && vaultExistsOnchain ? 'ready' : 'blocked',
-			...(repExitLauncherBlocker === undefined ? {} : { blocker: repExitLauncherBlocker }),
+			...(claimFeesEnabled && claimFeesLauncherBlocker === undefined && vaultExistsOnchain ? { onAction: () => setVaultActionModal('claim-fees') } : {}),
+			readiness: claimFeesEnabled && claimFeesLauncherBlocker === undefined && vaultExistsOnchain ? 'ready' : 'blocked',
+			...(claimFeesLauncherBlocker === undefined ? {} : { blocker: claimFeesLauncherBlocker }),
 			title: 'Claim Fees',
 		},
 		...extraReadinessActions,

--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -428,6 +428,12 @@ export function SecurityVaultSection({
 		if (!isMainnet) return 'Switch to Ethereum mainnet.'
 		return undefined
 	})()
+	const depositLauncherBlocker = (() => {
+		if (accountState.address === undefined) return 'Connect wallet to continue.'
+		if (!isMainnet) return 'Switch to Ethereum mainnet.'
+		if (selectedVaultAddress !== undefined && selectedVaultAddress !== '' && !selectedVaultIsOwnedByAccount) return 'Select your own vault to unlock actions.'
+		return undefined
+	})()
 	const showMissingVaultNotice = currentSelectedVaultDetails !== undefined && !vaultExistsOnchain
 	const autoLoadKey = `${normalizeAddress(selectedVaultAddress) ?? ''}:${normalizeAddress(normalizedSecurityVaultForm.securityPoolAddress) ?? ''}`
 	const hasLoadedCurrentVault = currentSelectedVaultDetails !== undefined && sameAddress(currentSelectedVaultDetails.vaultAddress, selectedVaultAddress) && sameAddress(currentSelectedVaultDetails.securityPoolAddress, normalizedSecurityVaultForm.securityPoolAddress)
@@ -496,9 +502,9 @@ export function SecurityVaultSection({
 			description: 'Add REP to the selected vault.',
 			key: 'deposit-rep',
 			safetyId: getSecurityVaultActionSafetyId('depositRep'),
-			...(depositRepEnabled && vaultActionLauncherBlocker === undefined ? { onAction: () => setVaultActionModal('deposit-rep') } : {}),
-			readiness: depositRepEnabled && vaultActionLauncherBlocker === undefined ? 'ready' : 'blocked',
-			...(vaultActionLauncherBlocker === undefined ? {} : { blocker: vaultActionLauncherBlocker }),
+			...(depositRepEnabled && depositLauncherBlocker === undefined ? { onAction: () => setVaultActionModal('deposit-rep') } : {}),
+			readiness: depositRepEnabled && depositLauncherBlocker === undefined ? 'ready' : 'blocked',
+			...(depositLauncherBlocker === undefined ? {} : { blocker: depositLauncherBlocker }),
 			title: 'Deposit REP',
 		},
 		{

--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -360,7 +360,6 @@ export function SecurityVaultSection({
 		if (hasValidOraclePrice) return 'Withdrawable REP'
 		return 'REP Available To Queue'
 	})()
-	const claimFeesGuardMessage = undefined
 	const setSecurityBondAllowanceFunding = resolveOracleOperationEthFunding({
 		managerDetails: oracleManagerDetails,
 	})
@@ -450,7 +449,6 @@ export function SecurityVaultSection({
 		return undefined
 	})()
 	const loadedVaultMissingBlocker = currentSelectedVaultDetails !== undefined && !vaultExistsOnchain ? 'This vault does not exist.' : undefined
-	const depositActionLauncherBlocker = undefined
 	const repExitLauncherBlocker = loadedVaultMissingBlocker
 	const bondAllowanceLauncherBlocker = loadedVaultMissingBlocker
 	const claimFeesLauncherBlocker = loadedVaultMissingBlocker
@@ -469,9 +467,8 @@ export function SecurityVaultSection({
 			description: 'Add REP to the selected vault.',
 			key: 'deposit-rep',
 			safetyId: getSecurityVaultActionSafetyId('depositRep'),
-			...(depositRepEnabled && depositActionLauncherBlocker === undefined && canUseLoadedVaultActions ? { onAction: () => setVaultActionModal('deposit-rep') } : {}),
-			readiness: depositRepEnabled && depositActionLauncherBlocker === undefined && canUseLoadedVaultActions ? 'ready' : 'blocked',
-			...(depositActionLauncherBlocker === undefined ? {} : { blocker: depositActionLauncherBlocker }),
+			...(depositRepEnabled && canUseLoadedVaultActions ? { onAction: () => setVaultActionModal('deposit-rep') } : {}),
+			readiness: depositRepEnabled && canUseLoadedVaultActions ? 'ready' : 'blocked',
 			title: 'Deposit REP',
 		},
 		{
@@ -806,7 +803,7 @@ export function SecurityVaultSection({
 						pendingLabel='Claiming fees...'
 						onClick={onRedeemFees}
 						pending={securityVaultActiveAction === 'redeemFees'}
-						availability={{ disabled: !claimFeesEnabled || !canUseLoadedVaultActions || !hasClaimableFees || claimFeesGuardMessage !== undefined, reason: canUseLoadedVaultActions ? claimFeesGuardMessage : undefined }}
+						availability={{ disabled: !claimFeesEnabled || !canUseLoadedVaultActions || !hasClaimableFees, reason: undefined }}
 					/>
 				</div>
 			</OperationModal>
@@ -830,7 +827,7 @@ export function SecurityVaultSection({
 						pendingLabel='Claiming fees...'
 						onClick={onRedeemFees}
 						pending={securityVaultActiveAction === 'redeemFees'}
-						availability={{ disabled: !claimFeesEnabled || !canUseLoadedVaultActions || !hasClaimableFees || claimFeesGuardMessage !== undefined, reason: canUseLoadedVaultActions ? claimFeesGuardMessage : undefined }}
+						availability={{ disabled: !claimFeesEnabled || !canUseLoadedVaultActions || !hasClaimableFees, reason: undefined }}
 					/>
 				</div>
 			</SectionBlock>

--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -34,6 +34,7 @@ import { getVaultApprovalGuardMessage, getVaultClaimFeesGuardMessage, getVaultDe
 import { deriveTokenApprovalRequirement } from '../lib/tokenApproval.js'
 import {
 	DEFAULT_STAGED_OPERATION_TIMEOUT_MINUTES,
+	doesSecurityVaultExistOnchain,
 	doesLoadedSecurityVaultMatchSelection,
 	getSecurityVaultMaxBondAllowanceAmount,
 	getStagedOperationTimeoutSeconds,
@@ -315,6 +316,7 @@ export function SecurityVaultSection({
 	const stagedOperationTimeoutMinutes = tryParseBigIntInput(normalizedSecurityVaultForm.stagedOperationTimeoutMinutes)
 	const stagedOperationTimeoutSeconds = getStagedOperationTimeoutSeconds(stagedOperationTimeoutMinutes)
 	const securityBondAllowance = currentSelectedVaultDetails?.securityBondAllowance ?? 0n
+	const vaultExistsOnchain = doesSecurityVaultExistOnchain(currentSelectedVaultDetails)
 	const hasValidOraclePrice = hasValidSecurityVaultOraclePrice(currentSelectedVaultDetails?.managerAddress, oracleManagerDetails)
 	const oraclePriceValidUntilTimestamp = hasValidOraclePrice ? oracleManagerDetails?.priceValidUntilTimestamp : undefined
 	const approvalRequirement = deriveTokenApprovalRequirement(depositAmount, securityVaultRepApproval.value)
@@ -418,10 +420,15 @@ export function SecurityVaultSection({
 		selectedVaultDetailsLoaded: !securityVaultMissing && currentSelectedVaultDetails !== undefined,
 		selectedVaultIsOwnedByAccount,
 	})
-	const effectiveDepositBlocker = depositGuardMessage ?? (depositRepEnabled ? undefined : 'Deposit REP is not available right now.')
-	const effectiveRepExitBlocker = repExitGuardMessage ?? (repExitEnabled ? undefined : `${repExitActionLabel} is not available right now.`)
-	const effectiveBondAllowanceBlocker = setSecurityBondAllowanceGuardMessage ?? (bondAllowanceEnabled ? undefined : 'Set Security Bond Allowance is not available right now.')
-	const effectiveClaimFeesBlocker = claimFeesGuardMessage ?? (claimFeesEnabled ? undefined : 'Claim Fees is not available right now.')
+	const vaultActionLauncherBlocker = (() => {
+		if (selectedVaultAddress === undefined || selectedVaultAddress === '') return 'Select a pool and vault first.'
+		if (currentSelectedVaultDetails === undefined) return 'Refresh the selected vault first.'
+		if (!selectedVaultIsOwnedByAccount) return 'Select your own vault to unlock actions.'
+		if (accountState.address === undefined) return 'Connect wallet to continue.'
+		if (!isMainnet) return 'Switch to Ethereum mainnet.'
+		return undefined
+	})()
+	const showMissingVaultNotice = currentSelectedVaultDetails !== undefined && !vaultExistsOnchain
 	const autoLoadKey = `${normalizeAddress(selectedVaultAddress) ?? ''}:${normalizeAddress(normalizedSecurityVaultForm.securityPoolAddress) ?? ''}`
 	const hasLoadedCurrentVault = currentSelectedVaultDetails !== undefined && sameAddress(currentSelectedVaultDetails.vaultAddress, selectedVaultAddress) && sameAddress(currentSelectedVaultDetails.securityPoolAddress, normalizedSecurityVaultForm.securityPoolAddress)
 	const lastAutoLoadKey = useRef<string | undefined>(undefined)
@@ -472,6 +479,8 @@ export function SecurityVaultSection({
 
 		return undefined
 	})()
+	const vaultMissingBlocker = vaultExistsOnchain ? undefined : 'This vault does not exist yet.'
+	const repExitLauncherBlocker = vaultActionLauncherBlocker ?? vaultMissingBlocker
 	useEffect(() => {
 		if (!autoLoadVault) return
 		if (accountState.address === undefined) return
@@ -487,9 +496,9 @@ export function SecurityVaultSection({
 			description: 'Add REP to the selected vault.',
 			key: 'deposit-rep',
 			safetyId: getSecurityVaultActionSafetyId('depositRep'),
-			...(depositRepEnabled ? { onAction: () => setVaultActionModal('deposit-rep') } : {}),
-			readiness: depositRepEnabled ? 'ready' : 'blocked',
-			...(effectiveDepositBlocker === undefined ? {} : { blocker: effectiveDepositBlocker }),
+			...(depositRepEnabled && vaultActionLauncherBlocker === undefined ? { onAction: () => setVaultActionModal('deposit-rep') } : {}),
+			readiness: depositRepEnabled && vaultActionLauncherBlocker === undefined ? 'ready' : 'blocked',
+			...(vaultActionLauncherBlocker === undefined ? {} : { blocker: vaultActionLauncherBlocker }),
 			title: 'Deposit REP',
 		},
 		{
@@ -497,9 +506,9 @@ export function SecurityVaultSection({
 			description: effectiveRepExitMode === 'redeem' ? 'Redeem REP from an ended pool after escalation deposits are settled.' : 'Queue a REP withdrawal now, or let it execute immediately when a valid oracle price is already available.',
 			key: 'rep-exit',
 			safetyId: effectiveRepExitMode === 'redeem' ? getSecurityVaultActionSafetyId('redeemRep') : getSecurityVaultActionSafetyId('queueWithdrawRep'),
-			...(repExitEnabled ? { onAction: () => setVaultActionModal('withdraw-rep') } : {}),
-			readiness: repExitEnabled ? 'ready' : 'blocked',
-			...(effectiveRepExitBlocker === undefined ? {} : { blocker: effectiveRepExitBlocker }),
+			...(repExitEnabled && vaultActionLauncherBlocker === undefined && vaultExistsOnchain ? { onAction: () => setVaultActionModal('withdraw-rep') } : {}),
+			readiness: repExitEnabled && vaultActionLauncherBlocker === undefined && vaultExistsOnchain ? 'ready' : 'blocked',
+			...(repExitLauncherBlocker === undefined ? {} : { blocker: repExitLauncherBlocker }),
 			title: repExitActionLabel,
 		},
 		{
@@ -507,9 +516,9 @@ export function SecurityVaultSection({
 			description: 'Queue a new security bond allowance using the current oracle price context.',
 			key: 'set-bond-allowance',
 			safetyId: getSecurityVaultActionSafetyId('queueSetSecurityBondAllowance'),
-			...(bondAllowanceEnabled ? { onAction: () => setVaultActionModal('set-bond-allowance') } : {}),
-			readiness: bondAllowanceEnabled ? 'ready' : 'blocked',
-			...(effectiveBondAllowanceBlocker === undefined ? {} : { blocker: effectiveBondAllowanceBlocker }),
+			...(bondAllowanceEnabled && vaultActionLauncherBlocker === undefined && vaultExistsOnchain ? { onAction: () => setVaultActionModal('set-bond-allowance') } : {}),
+			readiness: bondAllowanceEnabled && vaultActionLauncherBlocker === undefined && vaultExistsOnchain ? 'ready' : 'blocked',
+			...(repExitLauncherBlocker === undefined ? {} : { blocker: repExitLauncherBlocker }),
 			title: 'Set Security Bond Allowance',
 		},
 		{
@@ -517,9 +526,9 @@ export function SecurityVaultSection({
 			description: 'Review claimable fees and confirm the fee redemption for the selected vault.',
 			key: 'claim-fees',
 			safetyId: getSecurityVaultActionSafetyId('redeemFees'),
-			...(claimFeesEnabled && claimFeesGuardMessage === undefined ? { onAction: () => setVaultActionModal('claim-fees') } : {}),
-			readiness: claimFeesEnabled && claimFeesGuardMessage === undefined ? 'ready' : 'blocked',
-			...(effectiveClaimFeesBlocker === undefined ? {} : { blocker: effectiveClaimFeesBlocker }),
+			...(claimFeesEnabled && vaultActionLauncherBlocker === undefined && vaultExistsOnchain ? { onAction: () => setVaultActionModal('claim-fees') } : {}),
+			readiness: claimFeesEnabled && vaultActionLauncherBlocker === undefined && vaultExistsOnchain ? 'ready' : 'blocked',
+			...(repExitLauncherBlocker === undefined ? {} : { blocker: repExitLauncherBlocker }),
 			title: 'Claim Fees',
 		},
 		...extraReadinessActions,
@@ -527,6 +536,7 @@ export function SecurityVaultSection({
 	const actionSections = modalFirst ? (
 		<>
 			<SectionBlock title='Vault Actions'>
+				{showMissingVaultNotice ? <StateHint presentation={{ key: 'not_found', badgeLabel: 'Vault missing', badgeTone: 'muted', detail: 'This vault does not exist yet. Deposit REP to create it.' }} /> : undefined}
 				<div className='vault-action-launcher-grid'>
 					{vaultReadinessActions.map(action => (
 						<ActionLauncherCard key={action.key} action={action} />
@@ -538,16 +548,20 @@ export function SecurityVaultSection({
 				{currentSelectedVaultDetails === undefined ? <p className='detail'>Refresh the selected vault before depositing REP.</p> : null}
 				{currentSelectedVaultDetails === undefined ? null : (
 					<>
-						<SelectedVaultSummarySection
-							repPerEthPrice={repPerEthPrice}
-							repPerEthSource={repPerEthSource}
-							repPerEthSourceUrl={repPerEthSourceUrl}
-							securityBondAllowance={currentSelectedVaultDetails.securityBondAllowance}
-							securityVaultDetails={currentSelectedVaultDetails}
-							selectedPoolSecurityMultiplier={selectedPoolSecurityMultiplier}
-							selectedVaultIsOwnedByAccount={selectedVaultIsOwnedByAccount}
-							variant='embedded'
-						/>
+						{vaultExistsOnchain ? (
+							<SelectedVaultSummarySection
+								repPerEthPrice={repPerEthPrice}
+								repPerEthSource={repPerEthSource}
+								repPerEthSourceUrl={repPerEthSourceUrl}
+								securityBondAllowance={currentSelectedVaultDetails.securityBondAllowance}
+								securityVaultDetails={currentSelectedVaultDetails}
+								selectedPoolSecurityMultiplier={selectedPoolSecurityMultiplier}
+								selectedVaultIsOwnedByAccount={selectedVaultIsOwnedByAccount}
+								variant='embedded'
+							/>
+						) : (
+							<StateHint presentation={{ key: 'not_found', badgeLabel: 'Vault missing', badgeTone: 'muted', detail: 'This vault does not exist yet. Deposit REP to create it.' }} />
+						)}
 						<label className='field'>
 							<span>REP Collateral Amount</span>
 							<div className='field-inline'>
@@ -1030,7 +1044,7 @@ export function SecurityVaultSection({
 				</SectionBlock>
 			) : undefined}
 
-			{showSummarySection && currentSelectedVaultDetails !== undefined ? (
+			{showSummarySection && currentSelectedVaultDetails !== undefined && vaultExistsOnchain ? (
 				<SelectedVaultSummarySection
 					repPerEthPrice={repPerEthPrice}
 					repPerEthSource={repPerEthSource}

--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -30,7 +30,7 @@ import { tryParseBigIntInput, tryParseRepAmountInput } from '../lib/marketForm.j
 import { isMainnetChain } from '../lib/network.js'
 import { resolveOracleOperationEthFunding } from '../lib/oracleRequestEth.js'
 import { getSecurityPoolVaultReadinessActions } from '../lib/securityPoolReadiness.js'
-import { getVaultApprovalGuardMessage, getVaultClaimFeesGuardMessage, getVaultDepositGuardMessage, getVaultRedeemRepGuardMessage, getVaultSetSecurityBondAllowanceGuardMessage, getVaultWithdrawGuardMessage } from '../lib/securityVaultGuards.js'
+import { getVaultClaimFeesGuardMessage, getVaultDepositGuardMessage, getVaultRedeemRepGuardMessage, getVaultSetSecurityBondAllowanceGuardMessage, getVaultWithdrawGuardMessage } from '../lib/securityVaultGuards.js'
 import { deriveTokenApprovalRequirement } from '../lib/tokenApproval.js'
 import {
 	DEFAULT_STAGED_OPERATION_TIMEOUT_MINUTES,
@@ -357,82 +357,48 @@ export function SecurityVaultSection({
 		if (hasValidOraclePrice) return 'Withdrawable REP'
 		return 'REP Available To Queue'
 	})()
-	const repExitRefreshMessage = (() => {
-		if (effectiveRepExitMode === 'redeem') return 'Refresh to see redeemable REP.'
-		if (hasValidOraclePrice) return 'Refresh to see withdrawable REP.'
-		return 'Refresh to see how much REP can be queued while the oracle price is stale.'
-	})()
 	const claimFeesGuardMessage = getVaultClaimFeesGuardMessage({
 		hasClaimableFees,
-		isMainnet,
-		selectedVaultIsOwnedByAccount,
 	})
 	const setSecurityBondAllowanceFunding = resolveOracleOperationEthFunding({
 		managerDetails: oracleManagerDetails,
 	})
 	const setSecurityBondAllowanceGuardMessage = getVaultSetSecurityBondAllowanceGuardMessage({
 		bufferRequiredEthCost: setSecurityBondAllowanceFunding?.includeBuffer === true,
-		isMainnet,
 		maxSecurityBondAllowanceAmount: hasValidOraclePrice ? maxSecurityBondAllowanceAmount : undefined,
 		requiredEthCost: setSecurityBondAllowanceFunding?.ethCost,
 		securityBondAllowanceAmount,
-		selectedVaultDetailsLoaded: currentSelectedVaultDetails !== undefined,
-		selectedVaultIsOwnedByAccount,
 		stagedOperationTimeoutMinutes,
 		walletEthBalance: accountState.ethBalance,
 	})
 	const depositGuardMessage = getVaultDepositGuardMessage({
-		accountAddress: accountState.address,
 		approvalSatisfied: hasSufficientDepositAllowance,
 		depositAmount,
 		isDepositBelowMinimum,
-		isMainnet,
 		repBalanceGap: hasInsufficientRepBalance ? repBalanceGap : undefined,
-		selectedVaultDetailsLoaded: currentSelectedVaultDetails !== undefined,
-		selectedVaultIsOwnedByAccount,
 	})
 	const withdrawRepFunding = resolveOracleOperationEthFunding({
 		managerDetails: oracleManagerDetails,
 	})
 	const withdrawRepGuardMessage = getVaultWithdrawGuardMessage({
-		accountAddress: accountState.address,
 		bufferRequiredEthCost: withdrawRepFunding?.includeBuffer === true,
-		isMainnet,
 		requiredEthCost: withdrawRepFunding?.ethCost,
-		selectedVaultIsOwnedByAccount,
 		stagedOperationTimeoutMinutes,
 		withdrawAmount,
 		withdrawableRepAmount: queuedWithdrawRepLimit,
 		walletEthBalance: accountState.ethBalance,
 	})
 	const redeemRepGuardMessage = getVaultRedeemRepGuardMessage({
-		accountAddress: accountState.address,
-		isMainnet,
 		escalationEscrowedRep: currentSelectedVaultDetails?.escalationEscrowedRep,
 		redeemableRepAmount,
-		selectedVaultDetailsLoaded: currentSelectedVaultDetails !== undefined,
-		selectedVaultIsOwnedByAccount,
 	})
 	const repExitGuardMessage = effectiveRepExitMode === 'redeem' ? redeemRepGuardMessage : withdrawRepGuardMessage
-	const approvalGuardMessage = getVaultApprovalGuardMessage({
-		accountAddress: accountState.address,
-		isMainnet,
-		selectedVaultDetailsLoaded: !securityVaultMissing && currentSelectedVaultDetails !== undefined,
-		selectedVaultIsOwnedByAccount,
-	})
+	const hasConnectedWallet = accountState.address !== undefined
+	const canUseOwnedVaultActions = selectedVaultIsOwnedByAccount && hasConnectedWallet
+	const hasLoadedSelectedVaultDetails = currentSelectedVaultDetails !== undefined
+	const canUseLoadedVaultActions = canUseOwnedVaultActions && hasLoadedSelectedVaultDetails && isMainnet
 	const vaultActionLauncherBlocker = (() => {
 		if (selectedVaultAddress === undefined || selectedVaultAddress === '') return 'Select a pool and vault first.'
-		if (currentSelectedVaultDetails === undefined) return 'Refresh the selected vault first.'
-		if (!selectedVaultIsOwnedByAccount) return 'Select your own vault to unlock actions.'
-		if (accountState.address === undefined) return 'Connect wallet to continue.'
-		if (!isMainnet) return 'Switch to Ethereum mainnet.'
-		return undefined
-	})()
-	const depositLauncherBlocker = (() => {
-		if (accountState.address === undefined) return 'Connect wallet to continue.'
-		if (!isMainnet) return 'Switch to Ethereum mainnet.'
-		if (normalizedSecurityVaultForm.selectedVaultAddress.trim() !== '' && currentSelectedVaultDetails === undefined) return 'Refresh the selected vault first.'
-		if (normalizedSecurityVaultForm.selectedVaultAddress.trim() !== '' && !selectedVaultIsOwnedByAccount) return 'Select your own vault to unlock actions.'
 		return undefined
 	})()
 	const showMissingVaultNotice = currentSelectedVaultDetails !== undefined && !vaultExistsOnchain
@@ -486,28 +452,28 @@ export function SecurityVaultSection({
 
 		return undefined
 	})()
-	const vaultMissingBlocker = vaultExistsOnchain ? undefined : 'This vault does not exist yet.'
-	const depositActionLauncherBlocker = depositLauncherBlocker ?? (depositRepEnabled ? undefined : 'Deposit REP is not available in the current pool state.')
-	const repExitLauncherBlocker = vaultActionLauncherBlocker ?? vaultMissingBlocker ?? (repExitEnabled ? undefined : `${repExitActionLabel} is not available in the current pool state.`)
-	const bondAllowanceLauncherBlocker = vaultActionLauncherBlocker ?? vaultMissingBlocker ?? (bondAllowanceEnabled ? undefined : 'Set Bond Allowance is not available in the current pool state.')
-	const claimFeesLauncherBlocker = vaultActionLauncherBlocker ?? vaultMissingBlocker ?? claimFeesGuardMessage ?? (claimFeesEnabled ? undefined : 'Claim Fees is not available in the current pool state.')
+	const loadedVaultMissingBlocker = currentSelectedVaultDetails !== undefined && !vaultExistsOnchain ? 'This vault does not exist.' : undefined
+	const depositActionLauncherBlocker = depositRepEnabled ? undefined : 'Deposit REP is not available in the current pool state.'
+	const repExitLauncherBlocker = vaultActionLauncherBlocker ?? loadedVaultMissingBlocker ?? (repExitEnabled ? undefined : `${repExitActionLabel} is not available in the current pool state.`)
+	const bondAllowanceLauncherBlocker = vaultActionLauncherBlocker ?? loadedVaultMissingBlocker ?? (bondAllowanceEnabled ? undefined : 'Set Bond Allowance is not available in the current pool state.')
+	const claimFeesLauncherBlocker = vaultActionLauncherBlocker ?? loadedVaultMissingBlocker ?? (hasLoadedSelectedVaultDetails ? claimFeesGuardMessage : undefined) ?? (claimFeesEnabled ? undefined : 'Claim Fees is not available in the current pool state.')
 	useEffect(() => {
 		if (!autoLoadVault) return
-		if (accountState.address === undefined) return
 		if (normalizedSecurityVaultForm.securityPoolAddress.trim() === '') return
+		if (selectedVaultAddress === undefined || selectedVaultAddress === '') return
 		if (hasLoadedCurrentVault || loadingSecurityVault) return
 		if (lastAutoLoadKey.current === autoLoadKey) return
 		lastAutoLoadKey.current = autoLoadKey
 		void onLoadSecurityVault()
-	}, [accountState.address, autoLoadKey, autoLoadVault, hasLoadedCurrentVault, loadingSecurityVault, normalizedSecurityVaultForm.securityPoolAddress, onLoadSecurityVault])
+	}, [autoLoadKey, autoLoadVault, hasLoadedCurrentVault, loadingSecurityVault, normalizedSecurityVaultForm.securityPoolAddress, onLoadSecurityVault, selectedVaultAddress])
 	const vaultReadinessActions = getSecurityPoolVaultReadinessActions([
 		{
 			actionLabel: 'Deposit REP',
 			description: 'Add REP to the selected vault.',
 			key: 'deposit-rep',
 			safetyId: getSecurityVaultActionSafetyId('depositRep'),
-			...(depositRepEnabled && depositActionLauncherBlocker === undefined ? { onAction: () => setVaultActionModal('deposit-rep') } : {}),
-			readiness: depositRepEnabled && depositActionLauncherBlocker === undefined ? 'ready' : 'blocked',
+			...(depositRepEnabled && depositActionLauncherBlocker === undefined && canUseLoadedVaultActions ? { onAction: () => setVaultActionModal('deposit-rep') } : {}),
+			readiness: depositRepEnabled && depositActionLauncherBlocker === undefined && canUseLoadedVaultActions ? 'ready' : 'blocked',
 			...(depositActionLauncherBlocker === undefined ? {} : { blocker: depositActionLauncherBlocker }),
 			title: 'Deposit REP',
 		},
@@ -516,8 +482,8 @@ export function SecurityVaultSection({
 			description: effectiveRepExitMode === 'redeem' ? 'Redeem REP from an ended pool after escalation deposits are settled.' : 'Queue a REP withdrawal now, or let it execute immediately when a valid oracle price is already available.',
 			key: 'rep-exit',
 			safetyId: effectiveRepExitMode === 'redeem' ? getSecurityVaultActionSafetyId('redeemRep') : getSecurityVaultActionSafetyId('queueWithdrawRep'),
-			...(repExitEnabled && vaultActionLauncherBlocker === undefined && vaultExistsOnchain ? { onAction: () => setVaultActionModal('withdraw-rep') } : {}),
-			readiness: repExitEnabled && vaultActionLauncherBlocker === undefined && vaultExistsOnchain ? 'ready' : 'blocked',
+			...(repExitEnabled && vaultActionLauncherBlocker === undefined && vaultExistsOnchain && canUseLoadedVaultActions ? { onAction: () => setVaultActionModal('withdraw-rep') } : {}),
+			readiness: repExitEnabled && vaultActionLauncherBlocker === undefined && vaultExistsOnchain && canUseLoadedVaultActions ? 'ready' : 'blocked',
 			...(repExitLauncherBlocker === undefined ? {} : { blocker: repExitLauncherBlocker }),
 			title: repExitActionLabel,
 		},
@@ -526,8 +492,8 @@ export function SecurityVaultSection({
 			description: 'Queue a new security bond allowance using the current oracle price context.',
 			key: 'set-bond-allowance',
 			safetyId: getSecurityVaultActionSafetyId('queueSetSecurityBondAllowance'),
-			...(bondAllowanceEnabled && vaultActionLauncherBlocker === undefined && vaultExistsOnchain ? { onAction: () => setVaultActionModal('set-bond-allowance') } : {}),
-			readiness: bondAllowanceEnabled && vaultActionLauncherBlocker === undefined && vaultExistsOnchain ? 'ready' : 'blocked',
+			...(bondAllowanceEnabled && vaultActionLauncherBlocker === undefined && vaultExistsOnchain && canUseLoadedVaultActions ? { onAction: () => setVaultActionModal('set-bond-allowance') } : {}),
+			readiness: bondAllowanceEnabled && vaultActionLauncherBlocker === undefined && vaultExistsOnchain && canUseLoadedVaultActions ? 'ready' : 'blocked',
 			...(bondAllowanceLauncherBlocker === undefined ? {} : { blocker: bondAllowanceLauncherBlocker }),
 			title: 'Set Security Bond Allowance',
 		},
@@ -536,8 +502,8 @@ export function SecurityVaultSection({
 			description: 'Review claimable fees and confirm the fee redemption for the selected vault.',
 			key: 'claim-fees',
 			safetyId: getSecurityVaultActionSafetyId('redeemFees'),
-			...(claimFeesEnabled && claimFeesLauncherBlocker === undefined && vaultExistsOnchain ? { onAction: () => setVaultActionModal('claim-fees') } : {}),
-			readiness: claimFeesEnabled && claimFeesLauncherBlocker === undefined && vaultExistsOnchain ? 'ready' : 'blocked',
+			...(claimFeesEnabled && claimFeesLauncherBlocker === undefined && vaultExistsOnchain && canUseLoadedVaultActions ? { onAction: () => setVaultActionModal('claim-fees') } : {}),
+			readiness: claimFeesEnabled && claimFeesLauncherBlocker === undefined && vaultExistsOnchain && canUseLoadedVaultActions ? 'ready' : 'blocked',
 			...(claimFeesLauncherBlocker === undefined ? {} : { blocker: claimFeesLauncherBlocker }),
 			title: 'Claim Fees',
 		},
@@ -546,7 +512,7 @@ export function SecurityVaultSection({
 	const actionSections = modalFirst ? (
 		<>
 			<SectionBlock title='Vault Actions'>
-				{showMissingVaultNotice ? <StateHint presentation={{ key: 'not_found', badgeLabel: 'Vault missing', badgeTone: 'muted', detail: 'This vault does not exist yet. Deposit REP to create it.' }} /> : undefined}
+				{showMissingVaultNotice ? <StateHint presentation={{ key: 'not_found', badgeLabel: 'Vault missing', badgeTone: 'muted', detail: 'This vault does not exist. Deposit REP to create it.' }} /> : undefined}
 				<div className='vault-action-launcher-grid'>
 					{vaultReadinessActions.map(action => (
 						<ActionLauncherCard key={action.key} action={action} />
@@ -555,7 +521,7 @@ export function SecurityVaultSection({
 			</SectionBlock>
 			<ErrorNotice message={securityVaultError} />
 			<OperationModal isOpen={vaultActionModal === 'deposit-rep'} onClose={() => setVaultActionModal(undefined)} title='Deposit REP'>
-				{currentSelectedVaultDetails === undefined ? <p className='detail'>Refresh the selected vault before depositing REP.</p> : null}
+				{currentSelectedVaultDetails === undefined ? <p className='detail'>Selected vault details are unavailable.</p> : null}
 				{currentSelectedVaultDetails === undefined ? null : (
 					<>
 						{vaultExistsOnchain ? (
@@ -570,7 +536,7 @@ export function SecurityVaultSection({
 								variant='embedded'
 							/>
 						) : (
-							<StateHint presentation={{ key: 'not_found', badgeLabel: 'Vault missing', badgeTone: 'muted', detail: 'This vault does not exist yet. Deposit REP to create it.' }} />
+							<StateHint presentation={{ key: 'not_found', badgeLabel: 'Vault missing', badgeTone: 'muted', detail: 'This vault does not exist. Deposit REP to create it.' }} />
 						)}
 						<label className='field'>
 							<span>REP Collateral Amount</span>
@@ -599,7 +565,7 @@ export function SecurityVaultSection({
 							allowanceError={securityVaultRepApproval.error}
 							allowanceLoading={securityVaultRepApproval.loading}
 							approvedAmount={securityVaultRepApproval.value}
-							guardMessage={approveRepEnabled ? approvalGuardMessage : undefined}
+							guardMessage={undefined}
 							onApprove={amount => onApproveRep(amount)}
 							pending={securityVaultActiveAction === 'approveRep'}
 							pendingLabel='Approving REP...'
@@ -608,7 +574,7 @@ export function SecurityVaultSection({
 							safetyId={getSecurityVaultActionSafetyId('approveRep')}
 							tokenSymbol='REP'
 							tokenUnits={18}
-							disabled={!approveRepEnabled}
+							disabled={!approveRepEnabled || !canUseLoadedVaultActions}
 						/>
 						<RequirementsChecklist
 							items={[
@@ -627,7 +593,7 @@ export function SecurityVaultSection({
 								pendingLabel='Depositing REP...'
 								onClick={onDepositRep}
 								pending={securityVaultActiveAction === 'depositRep'}
-								availability={{ disabled: !depositRepEnabled || depositGuardMessage !== undefined, reason: depositRepEnabled ? depositGuardMessage : undefined }}
+								availability={{ disabled: !depositRepEnabled || !canUseLoadedVaultActions || depositGuardMessage !== undefined, reason: depositRepEnabled && canUseLoadedVaultActions ? depositGuardMessage : undefined }}
 							/>
 						</div>
 					</>
@@ -640,7 +606,7 @@ export function SecurityVaultSection({
 				title={repExitActionLabel}
 				description={effectiveRepExitMode === 'redeem' ? 'Redeem the remaining REP collateral from this ended pool after escalation deposits are settled.' : 'Queue a REP withdrawal after reviewing the current vault collateral and oracle status.'}
 			>
-				{currentSelectedVaultDetails === undefined ? <p className='detail'>{effectiveRepExitMode === 'redeem' ? 'Refresh the selected vault before redeeming REP.' : 'Refresh the selected vault before withdrawing REP.'}</p> : null}
+				{currentSelectedVaultDetails === undefined ? <p className='detail'>Selected vault details are unavailable.</p> : null}
 				{currentSelectedVaultDetails === undefined ? null : (
 					<>
 						{effectiveRepExitMode === 'redeem' ? null : (
@@ -649,7 +615,7 @@ export function SecurityVaultSection({
 								executedTitle='REP Withdrawal Executed'
 								failedTitle='REP Withdrawal Failed'
 								manualQueuedDescription='The settlement auto-execute list is full. Execute this staged operation manually with its id after a valid oracle price is available.'
-								missingDescription='The transaction succeeded, but no matching staged operation is currently visible for this vault. Refresh staged operations to confirm the latest manager state.'
+								missingDescription='The transaction succeeded, but the latest manager state is not available yet.'
 								missingTitle='REP Withdrawal Submitted'
 								onViewStagedOperations={onViewStagedOperations}
 								queuedTitle='REP Withdrawal Queued'
@@ -751,7 +717,7 @@ export function SecurityVaultSection({
 								onClick={effectiveRepExitMode === 'redeem' ? onRedeemRep : onWithdrawRep}
 								pending={effectiveRepExitMode === 'redeem' ? securityVaultActiveAction === 'redeemRep' : securityVaultActiveAction === 'queueWithdrawRep'}
 								tone='secondary'
-								availability={{ disabled: !repExitEnabled || repExitGuardMessage !== undefined, reason: repExitEnabled ? repExitGuardMessage : undefined }}
+								availability={{ disabled: !repExitEnabled || !canUseLoadedVaultActions || repExitGuardMessage !== undefined, reason: repExitEnabled && canUseLoadedVaultActions ? repExitGuardMessage : undefined }}
 							/>
 						</div>
 					</>
@@ -759,7 +725,7 @@ export function SecurityVaultSection({
 			</OperationModal>
 
 			<OperationModal isOpen={vaultActionModal === 'set-bond-allowance'} onClose={() => setVaultActionModal(undefined)} title='Set Bond Allowance' description='Queue a new bond allowance using the latest valid oracle price for the selected vault.'>
-				{currentSelectedVaultDetails === undefined ? <p className='detail'>Refresh the selected vault before changing its bond allowance.</p> : null}
+				{currentSelectedVaultDetails === undefined ? <p className='detail'>Selected vault details are unavailable.</p> : null}
 				{currentSelectedVaultDetails === undefined ? null : (
 					<>
 						<VaultQueuedOperationStatusCard
@@ -767,7 +733,7 @@ export function SecurityVaultSection({
 							executedTitle='Bond Allowance Executed'
 							failedTitle='Bond Allowance Failed'
 							manualQueuedDescription='The settlement auto-execute list is full. Execute this staged operation manually with its id after a valid oracle price is available.'
-							missingDescription='The transaction succeeded, but no matching staged operation is currently visible for this vault. Refresh staged operations to confirm the latest manager state.'
+							missingDescription='The transaction succeeded, but the latest manager state is not available yet.'
 							missingTitle='Bond Allowance Submitted'
 							onViewStagedOperations={onViewStagedOperations}
 							queuedTitle='Bond Allowance Queued'
@@ -812,7 +778,7 @@ export function SecurityVaultSection({
 								onClick={onSetSecurityBondAllowance}
 								pending={securityVaultActiveAction === 'queueSetSecurityBondAllowance'}
 								tone='secondary'
-								availability={{ disabled: !bondAllowanceEnabled || setSecurityBondAllowanceGuardMessage !== undefined, reason: bondAllowanceEnabled ? setSecurityBondAllowanceGuardMessage : undefined }}
+								availability={{ disabled: !bondAllowanceEnabled || !canUseLoadedVaultActions || setSecurityBondAllowanceGuardMessage !== undefined, reason: bondAllowanceEnabled && canUseLoadedVaultActions ? setSecurityBondAllowanceGuardMessage : undefined }}
 							/>
 						</div>
 					</>
@@ -840,7 +806,7 @@ export function SecurityVaultSection({
 						pendingLabel='Claiming fees...'
 						onClick={onRedeemFees}
 						pending={securityVaultActiveAction === 'redeemFees'}
-						availability={{ disabled: !claimFeesEnabled || claimFeesGuardMessage !== undefined, reason: claimFeesEnabled ? claimFeesGuardMessage : undefined }}
+						availability={{ disabled: !claimFeesEnabled || !canUseLoadedVaultActions || claimFeesGuardMessage !== undefined, reason: claimFeesEnabled && canUseLoadedVaultActions ? claimFeesGuardMessage : undefined }}
 					/>
 				</div>
 			</OperationModal>
@@ -849,7 +815,7 @@ export function SecurityVaultSection({
 		<>
 			<SectionBlock title='Claim Fees'>
 				{currentSelectedVaultDetails === undefined ? (
-					<p className='detail'>Refresh the vault to inspect claimable fees.</p>
+					<p className='detail'>Selected vault details are unavailable.</p>
 				) : (
 					<div className='entity-metric-grid'>
 						<MetricField className='entity-metric' label='Claimable Fees'>
@@ -864,7 +830,7 @@ export function SecurityVaultSection({
 						pendingLabel='Claiming fees...'
 						onClick={onRedeemFees}
 						pending={securityVaultActiveAction === 'redeemFees'}
-						availability={{ disabled: !claimFeesEnabled || claimFeesGuardMessage !== undefined, reason: claimFeesEnabled ? claimFeesGuardMessage : undefined }}
+						availability={{ disabled: !claimFeesEnabled || !canUseLoadedVaultActions || claimFeesGuardMessage !== undefined, reason: claimFeesEnabled && canUseLoadedVaultActions ? claimFeesGuardMessage : undefined }}
 					/>
 				</div>
 			</SectionBlock>
@@ -892,7 +858,7 @@ export function SecurityVaultSection({
 					allowanceError={securityVaultRepApproval.error}
 					allowanceLoading={securityVaultRepApproval.loading}
 					approvedAmount={securityVaultRepApproval.value}
-					guardMessage={approveRepEnabled ? approvalGuardMessage : undefined}
+					guardMessage={undefined}
 					onApprove={amount => onApproveRep(amount)}
 					pending={securityVaultActiveAction === 'approveRep'}
 					pendingLabel='Approving REP...'
@@ -901,7 +867,7 @@ export function SecurityVaultSection({
 					safetyId={getSecurityVaultActionSafetyId('approveRep')}
 					tokenSymbol='REP'
 					tokenUnits={18}
-					disabled={!approveRepEnabled}
+					disabled={!approveRepEnabled || !canUseLoadedVaultActions}
 				/>
 				<div className='actions'>
 					<TransactionActionButton
@@ -910,7 +876,7 @@ export function SecurityVaultSection({
 						pendingLabel='Depositing REP...'
 						onClick={onDepositRep}
 						pending={securityVaultActiveAction === 'depositRep'}
-						availability={{ disabled: !depositRepEnabled || depositGuardMessage !== undefined, reason: depositRepEnabled ? depositGuardMessage : undefined }}
+						availability={{ disabled: !depositRepEnabled || !canUseLoadedVaultActions || depositGuardMessage !== undefined, reason: depositRepEnabled && canUseLoadedVaultActions ? depositGuardMessage : undefined }}
 					/>
 				</div>
 				{(() => {
@@ -928,7 +894,7 @@ export function SecurityVaultSection({
 
 			<SectionBlock title='Set Security Bond Allowance'>
 				{currentSelectedVaultDetails === undefined ? (
-					<p className='detail'>Refresh the vault before setting a security bond allowance.</p>
+					<p className='detail'>Selected vault details are unavailable.</p>
 				) : (
 					<>
 						<div className='entity-metric-grid'>
@@ -959,7 +925,7 @@ export function SecurityVaultSection({
 								onClick={onSetSecurityBondAllowance}
 								pending={securityVaultActiveAction === 'queueSetSecurityBondAllowance'}
 								tone='secondary'
-								availability={{ disabled: !bondAllowanceEnabled || setSecurityBondAllowanceGuardMessage !== undefined, reason: bondAllowanceEnabled ? setSecurityBondAllowanceGuardMessage : undefined }}
+								availability={{ disabled: !bondAllowanceEnabled || !canUseLoadedVaultActions || setSecurityBondAllowanceGuardMessage !== undefined, reason: bondAllowanceEnabled && canUseLoadedVaultActions ? setSecurityBondAllowanceGuardMessage : undefined }}
 							/>
 						</div>
 					</>
@@ -968,7 +934,7 @@ export function SecurityVaultSection({
 
 			<SectionBlock title={repExitActionLabel}>
 				{(effectiveRepExitMode === 'redeem' ? redeemableRepAmount : queuedWithdrawRepLimit) === undefined ? (
-					<p className='detail'>{repExitRefreshMessage}</p>
+					<p className='detail'>Selected vault details are unavailable.</p>
 				) : (
 					<div className='entity-metric-grid'>
 						<MetricField className='entity-metric' label={repExitAmountLabel}>
@@ -1019,7 +985,7 @@ export function SecurityVaultSection({
 						onClick={effectiveRepExitMode === 'redeem' ? onRedeemRep : onWithdrawRep}
 						pending={effectiveRepExitMode === 'redeem' ? securityVaultActiveAction === 'redeemRep' : securityVaultActiveAction === 'queueWithdrawRep'}
 						tone='secondary'
-						availability={{ disabled: !repExitEnabled || repExitGuardMessage !== undefined, reason: repExitEnabled ? repExitGuardMessage : undefined }}
+						availability={{ disabled: !repExitEnabled || !canUseLoadedVaultActions || repExitGuardMessage !== undefined, reason: repExitEnabled && canUseLoadedVaultActions ? repExitGuardMessage : undefined }}
 					/>
 				</div>
 				{effectiveRepExitMode === 'redeem' && currentSelectedVaultDetails?.escalationEscrowedRep !== undefined && currentSelectedVaultDetails.escalationEscrowedRep > 0n ? <p className='detail'>Withdraw escalation deposits before redeeming REP.</p> : undefined}
@@ -1050,7 +1016,6 @@ export function SecurityVaultSection({
 							<FormInput value={normalizedSecurityVaultForm.securityPoolAddress} onInput={event => onSecurityVaultFormChange({ securityPoolAddress: event.currentTarget.value })} placeholder='0x...' />
 						</label>
 					) : undefined}
-					{selectedVaultIsOwnedByAccount ? undefined : <p className='detail'>Select your own vault to unlock actions.</p>}
 				</SectionBlock>
 			) : undefined}
 

--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -431,7 +431,8 @@ export function SecurityVaultSection({
 	const depositLauncherBlocker = (() => {
 		if (accountState.address === undefined) return 'Connect wallet to continue.'
 		if (!isMainnet) return 'Switch to Ethereum mainnet.'
-		if (selectedVaultAddress !== undefined && selectedVaultAddress !== '' && !selectedVaultIsOwnedByAccount) return 'Select your own vault to unlock actions.'
+		if (normalizedSecurityVaultForm.selectedVaultAddress.trim() !== '' && currentSelectedVaultDetails === undefined) return 'Refresh the selected vault first.'
+		if (normalizedSecurityVaultForm.selectedVaultAddress.trim() !== '' && !selectedVaultIsOwnedByAccount) return 'Select your own vault to unlock actions.'
 		return undefined
 	})()
 	const showMissingVaultNotice = currentSelectedVaultDetails !== undefined && !vaultExistsOnchain

--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -30,7 +30,7 @@ import { tryParseBigIntInput, tryParseRepAmountInput } from '../lib/marketForm.j
 import { isMainnetChain } from '../lib/network.js'
 import { resolveOracleOperationEthFunding } from '../lib/oracleRequestEth.js'
 import { getSecurityPoolVaultReadinessActions } from '../lib/securityPoolReadiness.js'
-import { getVaultClaimFeesGuardMessage, getVaultDepositGuardMessage, getVaultRedeemRepGuardMessage, getVaultSetSecurityBondAllowanceGuardMessage, getVaultWithdrawGuardMessage } from '../lib/securityVaultGuards.js'
+import { getVaultDepositGuardMessage, getVaultRedeemRepGuardMessage, getVaultSetSecurityBondAllowanceGuardMessage, getVaultWithdrawGuardMessage } from '../lib/securityVaultGuards.js'
 import { deriveTokenApprovalRequirement } from '../lib/tokenApproval.js'
 import {
 	DEFAULT_STAGED_OPERATION_TIMEOUT_MINUTES,
@@ -341,7 +341,10 @@ export function SecurityVaultSection({
 	const hasClaimableFees = currentSelectedVaultDetails !== undefined && currentSelectedVaultDetails.unpaidEthFees > 0n
 	const hasSufficientDepositAllowance = selectedVaultIsOwnedByAccount && depositAmount !== undefined && depositAmount > 0n && approvalRequirement.hasSufficientApproval
 	const hasInsufficientRepBalance = repBalanceGap !== undefined && repBalanceGap > 0n
+	const hasPositiveDepositAmount = depositAmount !== undefined && depositAmount > 0n
+	const hasPositiveWithdrawAmount = withdrawAmount !== undefined && withdrawAmount > 0n
 	const redeemableRepAmount = currentSelectedVaultDetails?.repDepositShare
+	const hasWithdrawableRep = queuedWithdrawRepLimit !== undefined && queuedWithdrawRepLimit > 0n
 	const depositRepEnabled = poolState?.actions.depositRep.enabled ?? true
 	const queueWithdrawRepEnabled = poolState?.actions.queueWithdrawRep.enabled ?? true
 	const redeemRepEnabled = poolState?.actions.redeemRep.enabled === true
@@ -357,9 +360,7 @@ export function SecurityVaultSection({
 		if (hasValidOraclePrice) return 'Withdrawable REP'
 		return 'REP Available To Queue'
 	})()
-	const claimFeesGuardMessage = getVaultClaimFeesGuardMessage({
-		hasClaimableFees,
-	})
+	const claimFeesGuardMessage = undefined
 	const setSecurityBondAllowanceFunding = resolveOracleOperationEthFunding({
 		managerDetails: oracleManagerDetails,
 	})
@@ -397,10 +398,6 @@ export function SecurityVaultSection({
 	const canUseOwnedVaultActions = selectedVaultIsOwnedByAccount && hasConnectedWallet
 	const hasLoadedSelectedVaultDetails = currentSelectedVaultDetails !== undefined
 	const canUseLoadedVaultActions = canUseOwnedVaultActions && hasLoadedSelectedVaultDetails && isMainnet
-	const vaultActionLauncherBlocker = (() => {
-		if (selectedVaultAddress === undefined || selectedVaultAddress === '') return 'Select a pool and vault first.'
-		return undefined
-	})()
 	const showMissingVaultNotice = currentSelectedVaultDetails !== undefined && !vaultExistsOnchain
 	const autoLoadKey = `${normalizeAddress(selectedVaultAddress) ?? ''}:${normalizeAddress(normalizedSecurityVaultForm.securityPoolAddress) ?? ''}`
 	const hasLoadedCurrentVault = currentSelectedVaultDetails !== undefined && sameAddress(currentSelectedVaultDetails.vaultAddress, selectedVaultAddress) && sameAddress(currentSelectedVaultDetails.securityPoolAddress, normalizedSecurityVaultForm.securityPoolAddress)
@@ -453,10 +450,10 @@ export function SecurityVaultSection({
 		return undefined
 	})()
 	const loadedVaultMissingBlocker = currentSelectedVaultDetails !== undefined && !vaultExistsOnchain ? 'This vault does not exist.' : undefined
-	const depositActionLauncherBlocker = depositRepEnabled ? undefined : 'Deposit REP is not available in the current pool state.'
-	const repExitLauncherBlocker = vaultActionLauncherBlocker ?? loadedVaultMissingBlocker ?? (repExitEnabled ? undefined : `${repExitActionLabel} is not available in the current pool state.`)
-	const bondAllowanceLauncherBlocker = vaultActionLauncherBlocker ?? loadedVaultMissingBlocker ?? (bondAllowanceEnabled ? undefined : 'Set Bond Allowance is not available in the current pool state.')
-	const claimFeesLauncherBlocker = vaultActionLauncherBlocker ?? loadedVaultMissingBlocker ?? (hasLoadedSelectedVaultDetails ? claimFeesGuardMessage : undefined) ?? (claimFeesEnabled ? undefined : 'Claim Fees is not available in the current pool state.')
+	const depositActionLauncherBlocker = undefined
+	const repExitLauncherBlocker = loadedVaultMissingBlocker
+	const bondAllowanceLauncherBlocker = loadedVaultMissingBlocker
+	const claimFeesLauncherBlocker = loadedVaultMissingBlocker
 	useEffect(() => {
 		if (!autoLoadVault) return
 		if (normalizedSecurityVaultForm.securityPoolAddress.trim() === '') return
@@ -482,8 +479,8 @@ export function SecurityVaultSection({
 			description: effectiveRepExitMode === 'redeem' ? 'Redeem REP from an ended pool after escalation deposits are settled.' : 'Queue a REP withdrawal now, or let it execute immediately when a valid oracle price is already available.',
 			key: 'rep-exit',
 			safetyId: effectiveRepExitMode === 'redeem' ? getSecurityVaultActionSafetyId('redeemRep') : getSecurityVaultActionSafetyId('queueWithdrawRep'),
-			...(repExitEnabled && vaultActionLauncherBlocker === undefined && vaultExistsOnchain && canUseLoadedVaultActions ? { onAction: () => setVaultActionModal('withdraw-rep') } : {}),
-			readiness: repExitEnabled && vaultActionLauncherBlocker === undefined && vaultExistsOnchain && canUseLoadedVaultActions ? 'ready' : 'blocked',
+			...(repExitEnabled && vaultExistsOnchain && canUseLoadedVaultActions ? { onAction: () => setVaultActionModal('withdraw-rep') } : {}),
+			readiness: repExitEnabled && vaultExistsOnchain && canUseLoadedVaultActions ? 'ready' : 'blocked',
 			...(repExitLauncherBlocker === undefined ? {} : { blocker: repExitLauncherBlocker }),
 			title: repExitActionLabel,
 		},
@@ -492,8 +489,8 @@ export function SecurityVaultSection({
 			description: 'Queue a new security bond allowance using the current oracle price context.',
 			key: 'set-bond-allowance',
 			safetyId: getSecurityVaultActionSafetyId('queueSetSecurityBondAllowance'),
-			...(bondAllowanceEnabled && vaultActionLauncherBlocker === undefined && vaultExistsOnchain && canUseLoadedVaultActions ? { onAction: () => setVaultActionModal('set-bond-allowance') } : {}),
-			readiness: bondAllowanceEnabled && vaultActionLauncherBlocker === undefined && vaultExistsOnchain && canUseLoadedVaultActions ? 'ready' : 'blocked',
+			...(bondAllowanceEnabled && vaultExistsOnchain && canUseLoadedVaultActions ? { onAction: () => setVaultActionModal('set-bond-allowance') } : {}),
+			readiness: bondAllowanceEnabled && vaultExistsOnchain && canUseLoadedVaultActions ? 'ready' : 'blocked',
 			...(bondAllowanceLauncherBlocker === undefined ? {} : { blocker: bondAllowanceLauncherBlocker }),
 			title: 'Set Security Bond Allowance',
 		},
@@ -502,8 +499,8 @@ export function SecurityVaultSection({
 			description: 'Review claimable fees and confirm the fee redemption for the selected vault.',
 			key: 'claim-fees',
 			safetyId: getSecurityVaultActionSafetyId('redeemFees'),
-			...(claimFeesEnabled && claimFeesLauncherBlocker === undefined && vaultExistsOnchain && canUseLoadedVaultActions ? { onAction: () => setVaultActionModal('claim-fees') } : {}),
-			readiness: claimFeesEnabled && claimFeesLauncherBlocker === undefined && vaultExistsOnchain && canUseLoadedVaultActions ? 'ready' : 'blocked',
+			...(claimFeesEnabled && hasClaimableFees && claimFeesLauncherBlocker === undefined && vaultExistsOnchain && canUseLoadedVaultActions ? { onAction: () => setVaultActionModal('claim-fees') } : {}),
+			readiness: claimFeesEnabled && hasClaimableFees && claimFeesLauncherBlocker === undefined && vaultExistsOnchain && canUseLoadedVaultActions ? 'ready' : 'blocked',
 			...(claimFeesLauncherBlocker === undefined ? {} : { blocker: claimFeesLauncherBlocker }),
 			title: 'Claim Fees',
 		},
@@ -593,7 +590,7 @@ export function SecurityVaultSection({
 								pendingLabel='Depositing REP...'
 								onClick={onDepositRep}
 								pending={securityVaultActiveAction === 'depositRep'}
-								availability={{ disabled: !depositRepEnabled || !canUseLoadedVaultActions || depositGuardMessage !== undefined, reason: depositRepEnabled && canUseLoadedVaultActions ? depositGuardMessage : undefined }}
+								availability={{ disabled: !depositRepEnabled || !canUseLoadedVaultActions || !hasPositiveDepositAmount || depositGuardMessage !== undefined, reason: canUseLoadedVaultActions ? depositGuardMessage : undefined }}
 							/>
 						</div>
 					</>
@@ -717,7 +714,10 @@ export function SecurityVaultSection({
 								onClick={effectiveRepExitMode === 'redeem' ? onRedeemRep : onWithdrawRep}
 								pending={effectiveRepExitMode === 'redeem' ? securityVaultActiveAction === 'redeemRep' : securityVaultActiveAction === 'queueWithdrawRep'}
 								tone='secondary'
-								availability={{ disabled: !repExitEnabled || !canUseLoadedVaultActions || repExitGuardMessage !== undefined, reason: repExitEnabled && canUseLoadedVaultActions ? repExitGuardMessage : undefined }}
+								availability={{
+									disabled: !repExitEnabled || !canUseLoadedVaultActions || (effectiveRepExitMode === 'withdraw' && (!hasPositiveWithdrawAmount || !hasWithdrawableRep)) || repExitGuardMessage !== undefined,
+									reason: canUseLoadedVaultActions ? repExitGuardMessage : undefined,
+								}}
 							/>
 						</div>
 					</>
@@ -778,7 +778,7 @@ export function SecurityVaultSection({
 								onClick={onSetSecurityBondAllowance}
 								pending={securityVaultActiveAction === 'queueSetSecurityBondAllowance'}
 								tone='secondary'
-								availability={{ disabled: !bondAllowanceEnabled || !canUseLoadedVaultActions || setSecurityBondAllowanceGuardMessage !== undefined, reason: bondAllowanceEnabled && canUseLoadedVaultActions ? setSecurityBondAllowanceGuardMessage : undefined }}
+								availability={{ disabled: !bondAllowanceEnabled || !canUseLoadedVaultActions || setSecurityBondAllowanceGuardMessage !== undefined, reason: canUseLoadedVaultActions ? setSecurityBondAllowanceGuardMessage : undefined }}
 							/>
 						</div>
 					</>
@@ -806,7 +806,7 @@ export function SecurityVaultSection({
 						pendingLabel='Claiming fees...'
 						onClick={onRedeemFees}
 						pending={securityVaultActiveAction === 'redeemFees'}
-						availability={{ disabled: !claimFeesEnabled || !canUseLoadedVaultActions || claimFeesGuardMessage !== undefined, reason: claimFeesEnabled && canUseLoadedVaultActions ? claimFeesGuardMessage : undefined }}
+						availability={{ disabled: !claimFeesEnabled || !canUseLoadedVaultActions || !hasClaimableFees || claimFeesGuardMessage !== undefined, reason: canUseLoadedVaultActions ? claimFeesGuardMessage : undefined }}
 					/>
 				</div>
 			</OperationModal>
@@ -830,7 +830,7 @@ export function SecurityVaultSection({
 						pendingLabel='Claiming fees...'
 						onClick={onRedeemFees}
 						pending={securityVaultActiveAction === 'redeemFees'}
-						availability={{ disabled: !claimFeesEnabled || !canUseLoadedVaultActions || claimFeesGuardMessage !== undefined, reason: claimFeesEnabled && canUseLoadedVaultActions ? claimFeesGuardMessage : undefined }}
+						availability={{ disabled: !claimFeesEnabled || !canUseLoadedVaultActions || !hasClaimableFees || claimFeesGuardMessage !== undefined, reason: canUseLoadedVaultActions ? claimFeesGuardMessage : undefined }}
 					/>
 				</div>
 			</SectionBlock>
@@ -876,7 +876,7 @@ export function SecurityVaultSection({
 						pendingLabel='Depositing REP...'
 						onClick={onDepositRep}
 						pending={securityVaultActiveAction === 'depositRep'}
-						availability={{ disabled: !depositRepEnabled || !canUseLoadedVaultActions || depositGuardMessage !== undefined, reason: depositRepEnabled && canUseLoadedVaultActions ? depositGuardMessage : undefined }}
+						availability={{ disabled: !depositRepEnabled || !canUseLoadedVaultActions || !hasPositiveDepositAmount || depositGuardMessage !== undefined, reason: canUseLoadedVaultActions ? depositGuardMessage : undefined }}
 					/>
 				</div>
 				{(() => {
@@ -925,7 +925,7 @@ export function SecurityVaultSection({
 								onClick={onSetSecurityBondAllowance}
 								pending={securityVaultActiveAction === 'queueSetSecurityBondAllowance'}
 								tone='secondary'
-								availability={{ disabled: !bondAllowanceEnabled || !canUseLoadedVaultActions || setSecurityBondAllowanceGuardMessage !== undefined, reason: bondAllowanceEnabled && canUseLoadedVaultActions ? setSecurityBondAllowanceGuardMessage : undefined }}
+								availability={{ disabled: !bondAllowanceEnabled || !canUseLoadedVaultActions || setSecurityBondAllowanceGuardMessage !== undefined, reason: canUseLoadedVaultActions ? setSecurityBondAllowanceGuardMessage : undefined }}
 							/>
 						</div>
 					</>
@@ -985,7 +985,10 @@ export function SecurityVaultSection({
 						onClick={effectiveRepExitMode === 'redeem' ? onRedeemRep : onWithdrawRep}
 						pending={effectiveRepExitMode === 'redeem' ? securityVaultActiveAction === 'redeemRep' : securityVaultActiveAction === 'queueWithdrawRep'}
 						tone='secondary'
-						availability={{ disabled: !repExitEnabled || !canUseLoadedVaultActions || repExitGuardMessage !== undefined, reason: repExitEnabled && canUseLoadedVaultActions ? repExitGuardMessage : undefined }}
+						availability={{
+							disabled: !repExitEnabled || !canUseLoadedVaultActions || (effectiveRepExitMode === 'withdraw' && (!hasPositiveWithdrawAmount || !hasWithdrawableRep)) || repExitGuardMessage !== undefined,
+							reason: canUseLoadedVaultActions ? repExitGuardMessage : undefined,
+						}}
 					/>
 				</div>
 				{effectiveRepExitMode === 'redeem' && currentSelectedVaultDetails?.escalationEscrowedRep !== undefined && currentSelectedVaultDetails.escalationEscrowedRep > 0n ? <p className='detail'>Withdraw escalation deposits before redeeming REP.</p> : undefined}

--- a/ui/ts/components/UniverseLink.tsx
+++ b/ui/ts/components/UniverseLink.tsx
@@ -1,15 +1,16 @@
 import type { ComponentChildren } from 'preact'
-import { formatUniverseLabel, getUniverseLinkHref, navigateToUniverse } from '../lib/universe.js'
+import { formatUniverseIdHex, formatUniverseLabel, getUniverseLinkHref, navigateToUniverse } from '../lib/universe.js'
 
 type UniverseLinkProps = {
 	children?: ComponentChildren
 	className?: string
+	format?: 'default' | 'hex'
 	universeId: bigint
 }
 
-export function UniverseLink({ children, className = '', universeId }: UniverseLinkProps) {
+export function UniverseLink({ children, className = '', format = 'default', universeId }: UniverseLinkProps) {
 	const href = getUniverseLinkHref(universeId)
-	const label = children ?? formatUniverseLabel(universeId)
+	const label = children ?? (format === 'hex' ? formatUniverseIdHex(universeId) : formatUniverseLabel(universeId))
 
 	return (
 		<a

--- a/ui/ts/lib/securityPoolWorkflow.ts
+++ b/ui/ts/lib/securityPoolWorkflow.ts
@@ -333,7 +333,7 @@ export function getSelectedPoolWorkflowLockedPresentation({ hasSelectedPoolAddre
 		return {
 			badgeLabel: 'Unavailable',
 			badgeTone: 'blocked',
-			detail: 'This pool is unavailable in the current universe.',
+			detail: 'This pool does not exist.',
 			key: 'unavailable',
 		}
 	if (selectedPoolLookupState === 'loading')

--- a/ui/ts/lib/securityPoolWorkflow.ts
+++ b/ui/ts/lib/securityPoolWorkflow.ts
@@ -322,7 +322,7 @@ export function applySelectedPoolWorkflowState(
 	}
 }
 export function getSelectedPoolWorkflowGuardMessage({ hasSelectedPoolAddress, selectedPoolLookupState, selectedPoolUniverseMismatch }: { hasSelectedPoolAddress: boolean; selectedPoolLookupState: LoadableValueState; selectedPoolUniverseMismatch: boolean }) {
-	if (selectedPoolUniverseMismatch) return 'Switch to the same universe before managing this pool.'
+	if (selectedPoolUniverseMismatch) return undefined
 	if (selectedPoolLookupState === 'loading') return 'Wait for this pool to finish loading.'
 	if (selectedPoolLookupState === 'missing') return 'Load a valid pool before using pool actions.'
 	if (!hasSelectedPoolAddress || selectedPoolLookupState === 'unknown') return 'Load a pool before using pool actions.'
@@ -331,10 +331,9 @@ export function getSelectedPoolWorkflowGuardMessage({ hasSelectedPoolAddress, se
 export function getSelectedPoolWorkflowLockedPresentation({ hasSelectedPoolAddress, selectedPoolLookupState, selectedPoolUniverseMismatch }: { hasSelectedPoolAddress: boolean; selectedPoolLookupState: LoadableValueState; selectedPoolUniverseMismatch: boolean }): UserMessagePresentation {
 	if (selectedPoolUniverseMismatch)
 		return {
-			actionHint: 'Switch to the matching universe first.',
 			badgeLabel: 'Unavailable',
 			badgeTone: 'blocked',
-			detail: 'Switch to the same universe before using vault, share, reporting, and fork actions.',
+			detail: 'This pool is unavailable in the current universe.',
 			key: 'unavailable',
 		}
 	if (selectedPoolLookupState === 'loading')

--- a/ui/ts/lib/securityVault.ts
+++ b/ui/ts/lib/securityVault.ts
@@ -35,6 +35,11 @@ export function isSecurityVaultDepositBelowMinimum(currentRepDeposit: bigint | u
 	return (currentRepDeposit ?? 0n) === 0n && depositAmount < MIN_SECURITY_VAULT_REP_DEPOSIT
 }
 
+export function doesSecurityVaultExistOnchain(securityVaultDetails: SecurityVaultDetails | undefined) {
+	if (securityVaultDetails === undefined) return false
+	return securityVaultDetails.repDepositShare > 0n || securityVaultDetails.securityBondAllowance > 0n || securityVaultDetails.unpaidEthFees > 0n || securityVaultDetails.escalationEscrowedRep > 0n
+}
+
 function divideBigintRoundUp(value: bigint, divisor: bigint) {
 	if (divisor <= 0n) throw new Error('Divisor must be greater than zero')
 	return (value + divisor - 1n) / divisor

--- a/ui/ts/lib/securityVaultGuards.ts
+++ b/ui/ts/lib/securityVaultGuards.ts
@@ -3,37 +3,7 @@ import { formatCurrencyBalance } from './formatters.js'
 import { getOracleRequestEthGuardMessage } from './oracleRequestEth.js'
 import { MAX_STAGED_OPERATION_TIMEOUT_MINUTES, MIN_SECURITY_BOND_ALLOWANCE, MIN_SECURITY_VAULT_REP_DEPOSIT, MIN_STAGED_OPERATION_TIMEOUT_MINUTES } from './securityVault.js'
 
-export function getVaultApprovalGuardMessage({ accountAddress, isMainnet, selectedVaultDetailsLoaded, selectedVaultIsOwnedByAccount }: { accountAddress: Address | undefined; isMainnet: boolean; selectedVaultDetailsLoaded: boolean; selectedVaultIsOwnedByAccount: boolean }) {
-	if (accountAddress === undefined) return 'Connect wallet to continue.'
-	if (!isMainnet) return 'Switch to Ethereum mainnet.'
-	if (!selectedVaultIsOwnedByAccount) return 'Select your own vault to approve REP.'
-	if (!selectedVaultDetailsLoaded) return 'Refresh the vault first.'
-	return undefined
-}
-
-export function getVaultDepositGuardMessage({
-	accountAddress,
-	approvalSatisfied,
-	depositAmount,
-	isDepositBelowMinimum,
-	isMainnet,
-	repBalanceGap,
-	selectedVaultDetailsLoaded,
-	selectedVaultIsOwnedByAccount,
-}: {
-	accountAddress: Address | undefined
-	approvalSatisfied: boolean
-	depositAmount: bigint | undefined
-	isDepositBelowMinimum: boolean
-	isMainnet: boolean
-	repBalanceGap: bigint | undefined
-	selectedVaultDetailsLoaded: boolean
-	selectedVaultIsOwnedByAccount: boolean
-}) {
-	if (!selectedVaultIsOwnedByAccount) return 'Select your own vault to deposit REP.'
-	if (accountAddress === undefined) return 'Connect a wallet before depositing REP.'
-	if (!isMainnet) return 'Switch to Ethereum mainnet before depositing REP.'
-	if (!selectedVaultDetailsLoaded) return 'Refresh the vault before depositing REP.'
+export function getVaultDepositGuardMessage({ approvalSatisfied, depositAmount, isDepositBelowMinimum, repBalanceGap }: { approvalSatisfied: boolean; depositAmount: bigint | undefined; isDepositBelowMinimum: boolean; repBalanceGap: bigint | undefined }) {
 	if (depositAmount === undefined) return 'Enter a valid REP deposit amount.'
 	if (depositAmount <= 0n) return 'Enter a REP deposit amount greater than zero.'
 	if (!approvalSatisfied) return 'Approve enough REP before depositing.'
@@ -43,29 +13,20 @@ export function getVaultDepositGuardMessage({
 }
 
 export function getVaultWithdrawGuardMessage({
-	accountAddress,
 	bufferRequiredEthCost = false,
-	isMainnet,
 	requiredEthCost,
-	selectedVaultIsOwnedByAccount,
 	stagedOperationTimeoutMinutes,
 	withdrawAmount,
 	withdrawableRepAmount,
 	walletEthBalance,
 }: {
-	accountAddress: Address | undefined
 	bufferRequiredEthCost?: boolean | undefined
-	isMainnet: boolean
 	requiredEthCost: bigint | undefined
-	selectedVaultIsOwnedByAccount: boolean
 	stagedOperationTimeoutMinutes: bigint | undefined
 	withdrawAmount: bigint | undefined
 	withdrawableRepAmount: bigint | undefined
 	walletEthBalance: bigint | undefined
 }) {
-	if (!selectedVaultIsOwnedByAccount) return 'Select your own vault to withdraw REP.'
-	if (accountAddress === undefined) return 'Connect a wallet before withdrawing REP.'
-	if (!isMainnet) return 'Switch to Ethereum mainnet before withdrawing REP.'
 	if (withdrawAmount === undefined) return 'Enter a valid REP withdraw amount.'
 	if (withdrawAmount <= 0n) return 'Enter a REP withdraw amount greater than zero.'
 	if (withdrawableRepAmount === undefined || withdrawableRepAmount <= 0n) return 'No REP is currently withdrawable from this vault.'
@@ -84,28 +45,19 @@ export function getVaultWithdrawGuardMessage({
 
 export function getVaultSetSecurityBondAllowanceGuardMessage({
 	bufferRequiredEthCost = false,
-	isMainnet,
 	maxSecurityBondAllowanceAmount,
 	requiredEthCost,
 	securityBondAllowanceAmount,
-	selectedVaultDetailsLoaded,
-	selectedVaultIsOwnedByAccount,
 	stagedOperationTimeoutMinutes,
 	walletEthBalance,
 }: {
 	bufferRequiredEthCost?: boolean | undefined
-	isMainnet: boolean
 	maxSecurityBondAllowanceAmount: bigint | undefined
 	requiredEthCost: bigint | undefined
 	securityBondAllowanceAmount: bigint | undefined
-	selectedVaultDetailsLoaded: boolean
-	selectedVaultIsOwnedByAccount: boolean
 	stagedOperationTimeoutMinutes: bigint | undefined
 	walletEthBalance: bigint | undefined
 }) {
-	if (!selectedVaultIsOwnedByAccount) return 'Select your own vault to set the security bond allowance.'
-	if (!isMainnet) return 'Switch to Ethereum mainnet before setting the security bond allowance.'
-	if (!selectedVaultDetailsLoaded) return 'Refresh the vault before setting the security bond allowance.'
 	if (securityBondAllowanceAmount === undefined || securityBondAllowanceAmount < 0n) return 'Enter a valid security bond allowance.'
 	if (securityBondAllowanceAmount !== 0n && securityBondAllowanceAmount < MIN_SECURITY_BOND_ALLOWANCE) return `Enter at least ${formatCurrencyBalance(MIN_SECURITY_BOND_ALLOWANCE)} ETH for a non-zero allowance.`
 	if (maxSecurityBondAllowanceAmount !== undefined && securityBondAllowanceAmount > maxSecurityBondAllowanceAmount) return `Reduce the security bond allowance to ${formatCurrencyBalance(maxSecurityBondAllowanceAmount)} ETH or less.`
@@ -121,32 +73,12 @@ export function getVaultSetSecurityBondAllowanceGuardMessage({
 	return undefined
 }
 
-export function getVaultClaimFeesGuardMessage({ hasClaimableFees, isMainnet, selectedVaultIsOwnedByAccount }: { hasClaimableFees: boolean; isMainnet: boolean; selectedVaultIsOwnedByAccount: boolean }) {
-	if (!selectedVaultIsOwnedByAccount) return 'Select your own vault to claim fees.'
-	if (!isMainnet) return 'Switch to Ethereum mainnet before claiming fees.'
+export function getVaultClaimFeesGuardMessage({ hasClaimableFees }: { hasClaimableFees: boolean }) {
 	if (!hasClaimableFees) return 'No claimable fees are available for this vault.'
 	return undefined
 }
 
-export function getVaultRedeemRepGuardMessage({
-	accountAddress,
-	isMainnet,
-	escalationEscrowedRep,
-	redeemableRepAmount,
-	selectedVaultDetailsLoaded,
-	selectedVaultIsOwnedByAccount,
-}: {
-	accountAddress: Address | undefined
-	isMainnet: boolean
-	escalationEscrowedRep: bigint | undefined
-	redeemableRepAmount: bigint | undefined
-	selectedVaultDetailsLoaded: boolean
-	selectedVaultIsOwnedByAccount: boolean
-}) {
-	if (!selectedVaultIsOwnedByAccount) return 'Select your own vault to redeem REP.'
-	if (accountAddress === undefined) return 'Connect a wallet before redeeming REP.'
-	if (!isMainnet) return 'Switch to Ethereum mainnet before redeeming REP.'
-	if (!selectedVaultDetailsLoaded) return 'Refresh the vault before redeeming REP.'
+export function getVaultRedeemRepGuardMessage({ escalationEscrowedRep, redeemableRepAmount }: { escalationEscrowedRep: bigint | undefined; redeemableRepAmount: bigint | undefined }) {
 	if (escalationEscrowedRep !== undefined && escalationEscrowedRep > 0n) return 'Settle escalation deposits before redeeming REP.'
 	if (redeemableRepAmount === undefined || redeemableRepAmount <= 0n) return 'No redeemable REP is available for this vault.'
 	return undefined

--- a/ui/ts/lib/securityVaultGuards.ts
+++ b/ui/ts/lib/securityVaultGuards.ts
@@ -5,7 +5,7 @@ import { MAX_STAGED_OPERATION_TIMEOUT_MINUTES, MIN_SECURITY_BOND_ALLOWANCE, MIN_
 
 export function getVaultDepositGuardMessage({ approvalSatisfied, depositAmount, isDepositBelowMinimum, repBalanceGap }: { approvalSatisfied: boolean; depositAmount: bigint | undefined; isDepositBelowMinimum: boolean; repBalanceGap: bigint | undefined }) {
 	if (depositAmount === undefined) return 'Enter a valid REP deposit amount.'
-	if (depositAmount <= 0n) return 'Enter a REP deposit amount greater than zero.'
+	if (depositAmount <= 0n) return undefined
 	if (!approvalSatisfied) return 'Approve enough REP before depositing.'
 	if (repBalanceGap !== undefined && repBalanceGap > 0n) return `Need ${formatCurrencyBalance(repBalanceGap)} more REP in this wallet.`
 	if (isDepositBelowMinimum) return `New vaults require at least ${formatCurrencyBalance(MIN_SECURITY_VAULT_REP_DEPOSIT)} REP in the first deposit.`
@@ -28,8 +28,8 @@ export function getVaultWithdrawGuardMessage({
 	walletEthBalance: bigint | undefined
 }) {
 	if (withdrawAmount === undefined) return 'Enter a valid REP withdraw amount.'
-	if (withdrawAmount <= 0n) return 'Enter a REP withdraw amount greater than zero.'
-	if (withdrawableRepAmount === undefined || withdrawableRepAmount <= 0n) return 'No REP is currently withdrawable from this vault.'
+	if (withdrawAmount <= 0n) return undefined
+	if (withdrawableRepAmount === undefined || withdrawableRepAmount <= 0n) return undefined
 	if (withdrawAmount > withdrawableRepAmount) return `Reduce the withdrawal to ${formatCurrencyBalance(withdrawableRepAmount)} REP or less.`
 	if (stagedOperationTimeoutMinutes === undefined || stagedOperationTimeoutMinutes < MIN_STAGED_OPERATION_TIMEOUT_MINUTES) return 'Enter a staged operation timeout of at least 1 minute.'
 	if (stagedOperationTimeoutMinutes > MAX_STAGED_OPERATION_TIMEOUT_MINUTES) return 'Enter a staged operation timeout of 5 minutes or less.'
@@ -70,11 +70,6 @@ export function getVaultSetSecurityBondAllowanceGuardMessage({
 		walletEthBalance,
 	})
 	if (ethGuardMessage !== undefined) return ethGuardMessage
-	return undefined
-}
-
-export function getVaultClaimFeesGuardMessage({ hasClaimableFees }: { hasClaimableFees: boolean }) {
-	if (!hasClaimableFees) return 'No claimable fees are available for this vault.'
 	return undefined
 }
 

--- a/ui/ts/lib/universe.ts
+++ b/ui/ts/lib/universe.ts
@@ -10,6 +10,10 @@ export function formatUniverseLabel(universeId: bigint) {
 	return universeId === 0n ? 'Genesis (0)' : `Universe ${universeId.toString()}`
 }
 
+export function formatUniverseIdHex(universeId: bigint) {
+	return `0x${universeId.toString(16)}`
+}
+
 export function getUniverseLinkHref(universeId: bigint) {
 	const nextSearch = writeUniverseQueryParam(getRouteHashSearch(), universeId)
 	return buildRouteHref(getCurrentRouteHash(), nextSearch)

--- a/ui/ts/tests/liquidationModal.test.tsx
+++ b/ui/ts/tests/liquidationModal.test.tsx
@@ -13,7 +13,7 @@ import { evaluateSecurityPoolState } from '../lib/securityPoolState.js'
 import type { ListedSecurityPool, MarketDetails, OracleManagerDetails, SecurityPoolOverviewActionResult, SecurityPoolVaultSummary } from '../types/contracts.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
-import { expectTransactionButtonDisabled } from './testUtils/transactionActionButton.js'
+import { expectTransactionButtonDisabled, getTransactionButtonState } from './testUtils/transactionActionButton.js'
 
 const ETH = 10n ** 18n
 
@@ -208,6 +208,26 @@ describe('LiquidationModal', () => {
 		expect(document.body.textContent?.includes('This queued staged operation will expire 5m after the oracle settlement window completes.')).toBe(true)
 	})
 
+	test('uses neutral missing-state copy after a queued liquidation succeeds without visible manager state', async () => {
+		const renderedComponent = await renderLiquidationModal({
+			currentPoolOracleManagerDetails: createOracleManagerDetails({
+				isPriceValid: false,
+				pendingOperation: undefined,
+			}),
+			securityPoolOverviewResult: {
+				action: 'queueLiquidation',
+				hash: '0x03',
+				securityPoolAddress: zeroAddress,
+			} satisfies SecurityPoolOverviewActionResult,
+		})
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByRole('heading', { name: 'Liquidation Submitted' })).not.toBeNull()
+		expect(documentQueries.getByText('The transaction succeeded, but the latest manager state is not available yet.')).not.toBeNull()
+		expect(documentQueries.queryByText('Refresh staged operations to confirm the latest manager state.')).toBeNull()
+	})
+
 	test('requires a queued liquidation timeout of at least 1 minute', async () => {
 		const renderedComponent = await renderLiquidationModal({
 			currentPoolOracleManagerDetails: createOracleManagerDetails({
@@ -218,6 +238,19 @@ describe('LiquidationModal', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		expectTransactionButtonDisabled(document.body, 'Queue Liquidation', 'Enter a liquidation timeout of at least 1 minute.')
+	})
+
+	test('keeps liquidation silently disabled off mainnet', async () => {
+		const renderedComponent = await renderLiquidationModal({
+			currentPoolOracleManagerDetails: createOracleManagerDetails({
+				isPriceValid: true,
+			}),
+			isMainnet: false,
+		})
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(getTransactionButtonState(document.body, 'Execute Liquidation')).toEqual({ disabled: true, reason: undefined })
+		expect(document.body.textContent?.includes('Switch to Ethereum mainnet before liquidating.')).toBe(false)
 	})
 
 	test('traps focus while open and restores it when closed', async () => {

--- a/ui/ts/tests/marketSection.test.tsx
+++ b/ui/ts/tests/marketSection.test.tsx
@@ -637,7 +637,7 @@ describe('MarketSection', () => {
 		expect(selectedViews).toEqual(['fork'])
 	})
 
-	test('shows immutable questions without an edit-style missing context notice', async () => {
+	test('shows immutable questions without missing-context helper copy', async () => {
 		const question = createBinaryForkQuestion()
 		question.description = ''
 		const renderedComponent = await renderIntoDocument(
@@ -657,7 +657,7 @@ describe('MarketSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		expect(documentQueries.getByText('No resolution notes or supporting context provided.')).not.toBeNull()
+		expect(documentQueries.queryByText('No resolution notes or supporting context provided.')).toBeNull()
 		expect(documentQueries.queryByText('Add resolution notes, evidence sources, and edge-case handling before users rely on this question.')).toBeNull()
 	})
 

--- a/ui/ts/tests/question.test.ts
+++ b/ui/ts/tests/question.test.ts
@@ -32,16 +32,11 @@ void describe('question helpers', () => {
 	void test('builds binary question summary fields with clarity labels', () => {
 		const fields = getQuestionSummaryFields(questionBase)
 
-		expect(fields.map(field => field.label)).toEqual(['Question Type', 'Context', 'Question ID', 'Created', 'End Time', 'Outcomes'])
+		expect(fields.map(field => field.label)).toEqual(['Question Type', 'Question ID', 'Created', 'End Time', 'Outcomes'])
 		expect(fields.find(field => field.label === 'Question Type')).toEqual({
 			kind: 'text',
 			label: 'Question Type',
 			value: 'Binary',
-		})
-		expect(fields.find(field => field.label === 'Context')).toEqual({
-			kind: 'text',
-			label: 'Context',
-			value: 'Provided',
 		})
 		expect(fields.find(field => field.label === 'Outcomes')).toEqual({
 			kind: 'text',
@@ -61,7 +56,7 @@ void describe('question helpers', () => {
 			outcomeLabels: [],
 		})
 
-		expect(fields.map(field => field.label)).toEqual(['Question Type', 'Context', 'Question ID', 'Created', 'End Time', 'Outcomes', 'Ticks', 'Display Range', 'Answer Unit'])
+		expect(fields.map(field => field.label)).toEqual(['Question Type', 'Question ID', 'Created', 'End Time', 'Outcomes', 'Ticks', 'Display Range', 'Answer Unit'])
 		expect(fields.find(field => field.label === 'Question Type')).toEqual({
 			kind: 'text',
 			label: 'Question Type',

--- a/ui/ts/tests/question.test.ts
+++ b/ui/ts/tests/question.test.ts
@@ -41,7 +41,7 @@ void describe('question helpers', () => {
 		expect(fields.find(field => field.label === 'Context')).toEqual({
 			kind: 'text',
 			label: 'Context',
-			value: 'Context provided',
+			value: 'Provided',
 		})
 		expect(fields.find(field => field.label === 'Outcomes')).toEqual({
 			kind: 'text',

--- a/ui/ts/tests/questionComponent.test.tsx
+++ b/ui/ts/tests/questionComponent.test.tsx
@@ -54,20 +54,27 @@ describe('Question component', () => {
 		expect(document.body.textContent?.includes('(1m ago)')).toBe(true)
 	})
 
-	test('shows a trust note when the question has no resolution context', async () => {
+	test('omits description copy when the question has no resolution context', async () => {
 		const renderedComponent = await renderIntoDocument(<Question question={createQuestion({ description: '' })} />)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		expect(document.body.textContent?.includes('No resolution notes or supporting context provided.')).toBe(true)
-		expect(document.body.textContent?.includes('Add resolution notes, evidence sources, and edge-case handling before users rely on this question.')).toBe(true)
+		expect(document.body.textContent?.includes('No resolution notes or supporting context provided.')).toBe(false)
+		expect(document.body.textContent?.includes('Add resolution notes, evidence sources, and edge-case handling before users rely on this question.')).toBe(false)
 	})
 
-	test('shows a trust note in preview mode when the question has no resolution context', async () => {
+	test('omits description copy in preview mode when the question has no resolution context', async () => {
 		const renderedComponent = await renderIntoDocument(<Question question={createQuestion({ description: '' })} variant='preview' />)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		expect(document.body.textContent?.includes('No resolution notes or supporting context provided.')).toBe(true)
-		expect(document.body.textContent?.includes('Add resolution notes, evidence sources, and edge-case handling before users rely on this question.')).toBe(true)
+		expect(document.body.textContent?.includes('No resolution notes or supporting context provided.')).toBe(false)
+		expect(document.body.textContent?.includes('Add resolution notes, evidence sources, and edge-case handling before users rely on this question.')).toBe(false)
+	})
+
+	test('does not render an empty preview heading when title and description are both hidden', async () => {
+		const renderedComponent = await renderIntoDocument(<Question question={createQuestion({ description: '' })} showTitle={false} variant='preview' />)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(document.body.querySelector('.question-summary-heading')).toBeNull()
 	})
 
 	test('renders preview timestamps as separate timeline cards with relative sublabels', async () => {

--- a/ui/ts/tests/securityPoolSection.test.tsx
+++ b/ui/ts/tests/securityPoolSection.test.tsx
@@ -171,7 +171,7 @@ describe('SecurityPoolSection', () => {
 		expect(documentQueries.queryByRole('button', { name: 'Load Question' })).toBeNull()
 	})
 
-	test('shows only the shared missing-context warning when a loaded question lacks description details', async () => {
+	test('omits missing-context helper copy when a loaded question lacks description details', async () => {
 		const renderedComponent = await renderIntoDocument(
 			h(
 				SecurityPoolSection,
@@ -185,8 +185,8 @@ describe('SecurityPoolSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		expect(documentQueries.getByText('No resolution notes or supporting context provided.')).not.toBeNull()
-		expect(documentQueries.getAllByText('Add resolution notes, evidence sources, and edge-case handling before users rely on this question.')).toHaveLength(1)
+		expect(documentQueries.queryByText('No resolution notes or supporting context provided.')).toBeNull()
+		expect(documentQueries.queryByText('Add resolution notes, evidence sources, and edge-case handling before users rely on this question.')).toBeNull()
 		expect(documentQueries.queryByText('This question needs more context before users can trust a pool built on top of it. Add resolution notes or recreate it with a stronger description.')).toBeNull()
 	})
 

--- a/ui/ts/tests/securityPoolWorkflow.test.ts
+++ b/ui/ts/tests/securityPoolWorkflow.test.ts
@@ -498,7 +498,7 @@ void describe('selected pool workflow visibility', () => {
 		).toEqual({
 			badgeLabel: 'Unavailable',
 			badgeTone: 'blocked',
-			detail: 'This pool is unavailable in the current universe.',
+			detail: 'This pool does not exist.',
 			key: 'unavailable',
 		})
 	})

--- a/ui/ts/tests/securityPoolWorkflow.test.ts
+++ b/ui/ts/tests/securityPoolWorkflow.test.ts
@@ -447,7 +447,7 @@ void describe('selected pool workflow visibility', () => {
 				selectedPoolLookupState: 'ready',
 				selectedPoolUniverseMismatch: true,
 			}),
-		).toBe('Switch to the same universe before managing this pool.')
+		).toBeUndefined()
 	})
 
 	void test('keeps a stable locked-workflow presentation before a pool resolves', () => {
@@ -496,10 +496,9 @@ void describe('selected pool workflow visibility', () => {
 				selectedPoolUniverseMismatch: true,
 			}),
 		).toEqual({
-			actionHint: 'Switch to the matching universe first.',
 			badgeLabel: 'Unavailable',
 			badgeTone: 'blocked',
-			detail: 'Switch to the same universe before using vault, share, reporting, and fork actions.',
+			detail: 'This pool is unavailable in the current universe.',
 			key: 'unavailable',
 		})
 	})

--- a/ui/ts/tests/securityPoolWorkflowSection/selectedPoolState.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection/selectedPoolState.test.tsx
@@ -538,8 +538,8 @@ describe('SecurityPoolWorkflowSection: selected pool state', () => {
 		expectTransactionButtonDisabled(document.body, 'Set Bond Allowance')
 		expectTransactionButtonEnabled(document.body, 'Claim Fees')
 		expectTransactionButtonDisabled(document.body, 'Review Liquidation')
-		expect(documentQueries.getByRole('button', { name: 'Deposit REP' }).title).toBe('Deposit REP is not available in the current pool state.')
-		expect(documentQueries.getByRole('button', { name: 'Review Liquidation' }).title).toBe('Review Liquidation is not available in the current pool state.')
+		expect(documentQueries.getByRole('button', { name: 'Deposit REP' }).title).toBe('')
+		expect(documentQueries.getByRole('button', { name: 'Review Liquidation' }).title).toBe('')
 	})
 
 	test('shows a vault-missing notice and hides the embedded summary for an empty selected vault', async () => {

--- a/ui/ts/tests/securityPoolWorkflowSection/selectedPoolState.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection/selectedPoolState.test.tsx
@@ -131,6 +131,34 @@ describe('SecurityPoolWorkflowSection: selected pool state', () => {
 		expect(documentQueries.queryByRole('dialog', { name: 'Liquidate Vault' })).toBeNull()
 	})
 
+	test('shows only the primary universe-mismatch message with hex universe ids', async () => {
+		const selectedPoolAddress = zeroAddress
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					activeUniverseId: 2n,
+					checkedSecurityPoolAddress: selectedPoolAddress,
+					securityPoolAddress: selectedPoolAddress,
+					securityPools: [createSelectedPool({ securityPoolAddress: selectedPoolAddress, universeId: 1n })],
+				})}
+				showHeader={false}
+			/>,
+		)
+		setCleanup(renderedComponent.cleanup)
+
+		const documentQueries = within(document.body)
+		expect(document.body.textContent?.includes('This pool belongs to')).toBe(true)
+		expect(documentQueries.getByRole('link', { name: '0x1' })).not.toBeNull()
+		expect(document.body.textContent?.includes('0x2')).toBe(true)
+		for (const tabLabel of ['Vaults', 'Shares', 'Reporting', 'Fork & Migration', 'Staged Operations', 'Open Oracle']) {
+			const tab = documentQueries.getByRole('tab', { name: tabLabel })
+			expect(tab.getAttribute('title')).toBeNull()
+		}
+		expect(documentQueries.queryByText('Switch to the same universe before using vault, share, reporting, and fork actions.')).toBeNull()
+		expect(documentQueries.queryByText('Switch to the same universe before using this pool.')).toBeNull()
+		expect(documentQueries.queryByText('Switch to the matching universe first.')).toBeNull()
+	})
+
 	test('renders a vault workspace header and local mode switch for a loaded pool', async () => {
 		const poolVault = createSecurityPoolVaultSummary()
 		await renderLoadedPool({
@@ -423,10 +451,10 @@ describe('SecurityPoolWorkflowSection: selected pool state', () => {
 
 		const documentQueries = within(document.body)
 		expect(documentQueries.queryByRole('heading', { name: 'Vault Summary' })).toBeNull()
-		expectTransactionButtonEnabled(document.body, 'Deposit REP')
-		expectTransactionButtonEnabled(document.body, 'Withdraw REP')
-		expectTransactionButtonEnabled(document.body, 'Set Bond Allowance')
-		expectTransactionButtonDisabled(document.body, 'Claim Fees', 'No claimable fees are available for this vault.')
+		expectTransactionButtonDisabled(document.body, 'Deposit REP', 'Refresh the selected vault first.')
+		expectTransactionButtonDisabled(document.body, 'Withdraw REP', 'Refresh the selected vault first.')
+		expectTransactionButtonDisabled(document.body, 'Set Bond Allowance', 'Refresh the selected vault first.')
+		expectTransactionButtonDisabled(document.body, 'Claim Fees', 'Refresh the selected vault first.')
 	})
 
 	test('shows an Ended badge, allows REP redemption, and blocks ended-pool collateral actions in the vault workflow', async () => {
@@ -473,6 +501,91 @@ describe('SecurityPoolWorkflowSection: selected pool state', () => {
 		expectTransactionButtonDisabled(document.body, 'Set Bond Allowance')
 		expectTransactionButtonEnabled(document.body, 'Claim Fees')
 		expectTransactionButtonDisabled(document.body, 'Review Liquidation')
+	})
+
+	test('shows a vault-missing notice and hides the embedded summary for an empty selected vault', async () => {
+		const selectedPoolAddress = getAddress('0x00000000000000000000000000000000000000b3')
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					checkedSecurityPoolAddress: selectedPoolAddress,
+					securityPoolAddress: selectedPoolAddress,
+					securityPools: [createSelectedPool({ securityPoolAddress: selectedPoolAddress })],
+					securityVault: createSecurityVaultProps({
+						securityVaultDetails: createSecurityVaultDetails({
+							escalationEscrowedRep: 0n,
+							repDepositShare: 0n,
+							securityBondAllowance: 0n,
+							securityPoolAddress: selectedPoolAddress,
+							unpaidEthFees: 0n,
+						}),
+						securityVaultForm: {
+							depositAmount: '1',
+							repWithdrawAmount: '1',
+							securityBondAllowanceAmount: '1',
+							securityPoolAddress: selectedPoolAddress,
+							selectedVaultAddress: zeroAddress,
+						},
+					}),
+					selectedPoolView: 'vaults',
+				})}
+				showHeader={false}
+			/>,
+		)
+		setCleanup(renderedComponent.cleanup)
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.getByText('This vault does not exist yet. Deposit REP to create it.')).not.toBeNull()
+		expect(documentQueries.queryByRole('heading', { name: 'Vault Summary' })).toBeNull()
+		for (const actionLabel of ['Withdraw REP', 'Set Bond Allowance', 'Claim Fees', 'Review Liquidation']) {
+			const actionButton = documentQueries.getByRole('button', { name: actionLabel }) as HTMLButtonElement
+			expect(actionButton.title).toBe('This vault does not exist yet.')
+		}
+		expectTransactionButtonDisabled(document.body, 'Review Liquidation')
+		const reviewLiquidationButton = documentQueries.getByRole('button', { name: 'Review Liquidation' }) as HTMLButtonElement
+
+		await act(() => {
+			fireEvent.click(reviewLiquidationButton)
+		})
+
+		expect(documentQueries.queryByRole('dialog', { name: 'Liquidate Vault' })).toBeNull()
+	})
+
+	test('treats an escrowed-only vault as existing', async () => {
+		const selectedPoolAddress = getAddress('0x00000000000000000000000000000000000000b4')
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					checkedSecurityPoolAddress: selectedPoolAddress,
+					securityPoolAddress: selectedPoolAddress,
+					securityPools: [createSelectedPool({ securityPoolAddress: selectedPoolAddress })],
+					securityVault: createSecurityVaultProps({
+						securityVaultDetails: createSecurityVaultDetails({
+							escalationEscrowedRep: 1n,
+							repDepositShare: 0n,
+							securityBondAllowance: 0n,
+							securityPoolAddress: selectedPoolAddress,
+							unpaidEthFees: 0n,
+						}),
+						securityVaultForm: {
+							depositAmount: '1',
+							repWithdrawAmount: '1',
+							securityBondAllowanceAmount: '1',
+							securityPoolAddress: selectedPoolAddress,
+							selectedVaultAddress: zeroAddress,
+						},
+					}),
+					selectedPoolView: 'vaults',
+				})}
+				showHeader={false}
+			/>,
+		)
+		setCleanup(renderedComponent.cleanup)
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.queryByText('This vault does not exist yet. Deposit REP to create it.')).toBeNull()
+		expect(documentQueries.getByRole('heading', { name: 'Vault Summary' })).not.toBeNull()
+		expectTransactionButtonEnabled(document.body, 'Review Liquidation')
 	})
 
 	test('shows Fork Migration in the selected-pool badge once fork migration has started', async () => {

--- a/ui/ts/tests/securityPoolWorkflowSection/selectedPoolState.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection/selectedPoolState.test.tsx
@@ -501,6 +501,8 @@ describe('SecurityPoolWorkflowSection: selected pool state', () => {
 		expectTransactionButtonDisabled(document.body, 'Set Bond Allowance')
 		expectTransactionButtonEnabled(document.body, 'Claim Fees')
 		expectTransactionButtonDisabled(document.body, 'Review Liquidation')
+		expect(documentQueries.getByRole('button', { name: 'Deposit REP' }).title).toBe('Deposit REP is not available in the current pool state.')
+		expect(documentQueries.getByRole('button', { name: 'Review Liquidation' }).title).toBe('Review Liquidation is not available in the current pool state.')
 	})
 
 	test('shows a vault-missing notice and hides the embedded summary for an empty selected vault', async () => {

--- a/ui/ts/tests/securityPoolWorkflowSection/selectedPoolState.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection/selectedPoolState.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { createSelectedPoolStateFixture, useSecurityPoolWorkflowSectionTestDom } from './fixture'
+import { getTransactionButtonState } from '../testUtils/transactionActionButton.js'
 
 describe('SecurityPoolWorkflowSection: selected pool state', () => {
 	const testDom = useSecurityPoolWorkflowSectionTestDom()
@@ -67,6 +68,37 @@ describe('SecurityPoolWorkflowSection: selected pool state', () => {
 		await renderLoadedPool({ selectedPoolView: 'price-oracle' })
 
 		expectSectionVariant('Open Oracle', 'plain')
+	})
+
+	test('keeps oracle actions silently disabled off mainnet', async () => {
+		const renderOffMainnetOracleView = async (selectedPoolView: 'price-oracle' | 'staged-operations') =>
+			renderIntoDocument(
+				<SecurityPoolWorkflowSection
+					{...createSecurityPoolWorkflowProps({
+						accountState: createAccountState({ address: zeroAddress, chainId: '0xaa36a7' }),
+						checkedSecurityPoolAddress: zeroAddress,
+						poolOracleManagerDetails: createOracleManagerDetails({
+							isPriceValid: true,
+						}),
+						securityPoolAddress: zeroAddress,
+						securityPools: [createSelectedPool({ securityPoolAddress: zeroAddress })],
+						selectedPoolView,
+					})}
+					showHeader={false}
+				/>,
+			)
+
+		const priceOracleRender = await renderOffMainnetOracleView('price-oracle')
+		setCleanup(priceOracleRender.cleanup)
+
+		expect(getTransactionButtonState(document.body, 'Request New Price')).toEqual({ disabled: true, reason: undefined })
+
+		await priceOracleRender.cleanup()
+
+		const stagedOperationsRender = await renderOffMainnetOracleView('staged-operations')
+		setCleanup(stagedOperationsRender.cleanup)
+
+		expect(getTransactionButtonState(document.body, 'Execute Staged Operation')).toEqual({ disabled: true, reason: undefined })
 	})
 
 	test('keeps the workflow rail visible with disabled items before a pool loads', async () => {
@@ -148,6 +180,7 @@ describe('SecurityPoolWorkflowSection: selected pool state', () => {
 
 		const documentQueries = within(document.body)
 		expect(document.body.textContent?.includes('This pool belongs to')).toBe(true)
+		expect(document.body.textContent?.includes('This pool does not exist.')).toBe(true)
 		expect(documentQueries.getByRole('link', { name: '0x1' })).not.toBeNull()
 		expect(document.body.textContent?.includes('0x2')).toBe(true)
 		for (const tabLabel of ['Vaults', 'Shares', 'Reporting', 'Fork & Migration', 'Staged Operations', 'Open Oracle']) {
@@ -451,10 +484,14 @@ describe('SecurityPoolWorkflowSection: selected pool state', () => {
 
 		const documentQueries = within(document.body)
 		expect(documentQueries.queryByRole('heading', { name: 'Vault Summary' })).toBeNull()
-		expectTransactionButtonDisabled(document.body, 'Deposit REP', 'Refresh the selected vault first.')
-		expectTransactionButtonDisabled(document.body, 'Withdraw REP', 'Refresh the selected vault first.')
-		expectTransactionButtonDisabled(document.body, 'Set Bond Allowance', 'Refresh the selected vault first.')
-		expectTransactionButtonDisabled(document.body, 'Claim Fees', 'Refresh the selected vault first.')
+		expectTransactionButtonDisabled(document.body, 'Deposit REP')
+		expectTransactionButtonDisabled(document.body, 'Withdraw REP')
+		expectTransactionButtonDisabled(document.body, 'Set Bond Allowance')
+		expectTransactionButtonDisabled(document.body, 'Claim Fees')
+		for (const actionLabel of ['Deposit REP', 'Withdraw REP', 'Set Bond Allowance', 'Claim Fees', 'Review Liquidation']) {
+			const actionButton = documentQueries.getByRole('button', { name: actionLabel }) as HTMLButtonElement
+			expect(actionButton.title).toBe('')
+		}
 	})
 
 	test('shows an Ended badge, allows REP redemption, and blocks ended-pool collateral actions in the vault workflow', async () => {
@@ -537,14 +574,103 @@ describe('SecurityPoolWorkflowSection: selected pool state', () => {
 		setCleanup(renderedComponent.cleanup)
 
 		const documentQueries = within(document.body)
-		expect(documentQueries.getByText('This vault does not exist yet. Deposit REP to create it.')).not.toBeNull()
+		expect(documentQueries.getByText('This vault does not exist. Deposit REP to create it.')).not.toBeNull()
 		expect(documentQueries.queryByRole('heading', { name: 'Vault Summary' })).toBeNull()
 		for (const actionLabel of ['Withdraw REP', 'Set Bond Allowance', 'Claim Fees', 'Review Liquidation']) {
 			const actionButton = documentQueries.getByRole('button', { name: actionLabel }) as HTMLButtonElement
-			expect(actionButton.title).toBe('This vault does not exist yet.')
+			expect(actionButton.title).toBe('This vault does not exist.')
 		}
 		expectTransactionButtonDisabled(document.body, 'Review Liquidation')
 		const reviewLiquidationButton = documentQueries.getByRole('button', { name: 'Review Liquidation' }) as HTMLButtonElement
+
+		await act(() => {
+			fireEvent.click(reviewLiquidationButton)
+		})
+
+		expect(documentQueries.queryByRole('dialog', { name: 'Liquidate Vault' })).toBeNull()
+	})
+
+	test('keeps Review Liquidation silently disabled when the wallet is disconnected', async () => {
+		const selectedPoolAddress = getAddress('0x00000000000000000000000000000000000000b6')
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					accountState: createAccountState({ address: undefined }),
+					checkedSecurityPoolAddress: selectedPoolAddress,
+					poolOracleManagerDetails: createOracleManagerDetails({
+						isPriceValid: true,
+					}),
+					securityPoolAddress: selectedPoolAddress,
+					securityPools: [createSelectedPool({ securityPoolAddress: selectedPoolAddress })],
+					securityVault: createSecurityVaultProps({
+						securityVaultDetails: createSecurityVaultDetails({
+							securityPoolAddress: selectedPoolAddress,
+							vaultAddress: zeroAddress,
+						}),
+						securityVaultForm: {
+							depositAmount: '1',
+							repWithdrawAmount: '1',
+							securityBondAllowanceAmount: '1',
+							securityPoolAddress: selectedPoolAddress,
+							selectedVaultAddress: zeroAddress,
+						},
+					}),
+					selectedPoolView: 'vaults',
+				})}
+				showHeader={false}
+			/>,
+		)
+		setCleanup(renderedComponent.cleanup)
+
+		const documentQueries = within(document.body)
+		const reviewLiquidationButton = documentQueries.getByRole('button', { name: 'Review Liquidation' }) as HTMLButtonElement
+		expect(reviewLiquidationButton.disabled).toBe(true)
+		expect(reviewLiquidationButton.title).toBe('')
+
+		await act(() => {
+			fireEvent.click(reviewLiquidationButton)
+		})
+
+		expect(documentQueries.queryByRole('dialog', { name: 'Liquidate Vault' })).toBeNull()
+	})
+
+	test('keeps Review Liquidation silently disabled for a vault owned by another account', async () => {
+		const selectedPoolAddress = getAddress('0x00000000000000000000000000000000000000b7')
+		const otherVaultAddress = getAddress('0x00000000000000000000000000000000000000b8')
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					accountState: createAccountState({ address: zeroAddress }),
+					checkedSecurityPoolAddress: selectedPoolAddress,
+					poolOracleManagerDetails: createOracleManagerDetails({
+						isPriceValid: true,
+					}),
+					securityPoolAddress: selectedPoolAddress,
+					securityPools: [createSelectedPool({ securityPoolAddress: selectedPoolAddress })],
+					securityVault: createSecurityVaultProps({
+						securityVaultDetails: createSecurityVaultDetails({
+							securityPoolAddress: selectedPoolAddress,
+							vaultAddress: otherVaultAddress,
+						}),
+						securityVaultForm: {
+							depositAmount: '1',
+							repWithdrawAmount: '1',
+							securityBondAllowanceAmount: '1',
+							securityPoolAddress: selectedPoolAddress,
+							selectedVaultAddress: otherVaultAddress,
+						},
+					}),
+					selectedPoolView: 'vaults',
+				})}
+				showHeader={false}
+			/>,
+		)
+		setCleanup(renderedComponent.cleanup)
+
+		const documentQueries = within(document.body)
+		const reviewLiquidationButton = documentQueries.getByRole('button', { name: 'Review Liquidation' }) as HTMLButtonElement
+		expect(reviewLiquidationButton.disabled).toBe(true)
+		expect(reviewLiquidationButton.title).toBe('')
 
 		await act(() => {
 			fireEvent.click(reviewLiquidationButton)
@@ -585,7 +711,7 @@ describe('SecurityPoolWorkflowSection: selected pool state', () => {
 		setCleanup(renderedComponent.cleanup)
 
 		const documentQueries = within(document.body)
-		expect(documentQueries.queryByText('This vault does not exist yet. Deposit REP to create it.')).toBeNull()
+		expect(documentQueries.queryByText('This vault does not exist. Deposit REP to create it.')).toBeNull()
 		expect(documentQueries.getByRole('heading', { name: 'Vault Summary' })).not.toBeNull()
 		expectTransactionButtonEnabled(document.body, 'Review Liquidation')
 	})
@@ -688,6 +814,6 @@ describe('SecurityPoolWorkflowSection: selected pool state', () => {
 		})
 
 		expect(formChanges).toContainEqual({ selectedVaultAddress: vaultAddress })
-		expect(loadSecurityVaultCalls.at(-1)).toBe(vaultAddress)
+		expect(loadSecurityVaultCalls).toContain(vaultAddress)
 	})
 })

--- a/ui/ts/tests/securityPoolWorkflowSection/vaultControls.test.tsx
+++ b/ui/ts/tests/securityPoolWorkflowSection/vaultControls.test.tsx
@@ -8,7 +8,8 @@ describe('SecurityPoolWorkflowSection: vault controls', () => {
 	const { fireEvent, within, act, zeroAddress, SecurityPoolWorkflowSection, renderIntoDocument, expectTransactionButtonDisabled, expectTransactionButtonEnabled, createAccountState, createSecurityVaultProps, createSecurityVaultDetails, createOracleManagerDetails, createSelectedPool, createSecurityPoolWorkflowProps } =
 		fixture
 
-	test('opens vault launchers even before a selected vault is loaded', async () => {
+	test('keeps vault launchers silently disabled while the selected vault auto-loads', async () => {
+		const loadSecurityVaultCalls: Array<string | undefined> = []
 		const renderedComponent = await renderIntoDocument(
 			<SecurityPoolWorkflowSection
 				{...createSecurityPoolWorkflowProps({
@@ -16,6 +17,51 @@ describe('SecurityPoolWorkflowSection: vault controls', () => {
 					securityPoolAddress: zeroAddress,
 					securityPools: [createSelectedPool()],
 					securityVault: createSecurityVaultProps({
+						onLoadSecurityVault: vaultAddress => {
+							loadSecurityVaultCalls.push(vaultAddress)
+						},
+						securityVaultForm: {
+							depositAmount: '10',
+							repWithdrawAmount: '1',
+							securityBondAllowanceAmount: '1',
+							securityPoolAddress: zeroAddress,
+							selectedVaultAddress: zeroAddress,
+						},
+					}),
+				})}
+				showHeader={false}
+			/>,
+		)
+		setCleanup(renderedComponent.cleanup)
+
+		const documentQueries = within(document.body)
+		const depositLauncherButton = documentQueries.getByRole('button', { name: 'Deposit REP' })
+		if (!(depositLauncherButton instanceof HTMLElement)) throw new Error('Expected deposit launcher button')
+
+		expect(depositLauncherButton.hasAttribute('disabled')).toBe(true)
+		expect(depositLauncherButton.getAttribute('title')).toBeNull()
+		expect(loadSecurityVaultCalls).toContain(undefined)
+
+		await act(() => {
+			fireEvent.click(depositLauncherButton)
+		})
+
+		expect(documentQueries.queryByRole('dialog', { name: 'Deposit REP' })).toBeNull()
+	})
+
+	test('does not auto-load a vault when no vault is selected and the wallet is disconnected', async () => {
+		const loadSecurityVaultCalls: Array<string | undefined> = []
+		const renderedComponent = await renderIntoDocument(
+			<SecurityPoolWorkflowSection
+				{...createSecurityPoolWorkflowProps({
+					accountState: createAccountState({ address: undefined }),
+					checkedSecurityPoolAddress: zeroAddress,
+					securityPoolAddress: zeroAddress,
+					securityPools: [createSelectedPool()],
+					securityVault: createSecurityVaultProps({
+						onLoadSecurityVault: vaultAddress => {
+							loadSecurityVaultCalls.push(vaultAddress)
+						},
 						securityVaultForm: {
 							depositAmount: '10',
 							repWithdrawAmount: '1',
@@ -30,18 +76,8 @@ describe('SecurityPoolWorkflowSection: vault controls', () => {
 		)
 		setCleanup(renderedComponent.cleanup)
 
-		const documentQueries = within(document.body)
-		const depositLauncherButton = documentQueries.getByRole('button', { name: 'Deposit REP' })
-		if (!(depositLauncherButton instanceof HTMLElement)) throw new Error('Expected deposit launcher button')
-
-		expect(depositLauncherButton.hasAttribute('disabled')).toBe(false)
-
-		await act(() => {
-			fireEvent.click(depositLauncherButton)
-		})
-
-		const dialog = documentQueries.getByRole('dialog')
-		expect(within(dialog).getByText('Refresh the selected vault before depositing REP.')).not.toBeNull()
+		expect(loadSecurityVaultCalls.every(vaultAddress => vaultAddress === undefined)).toBe(true)
+		expect(within(document.body).queryByText('Enter a vault address or connect a wallet to inspect vault details.')).toBeNull()
 	})
 
 	test('keeps REP approval guidance inside the approval control in the deposit modal', async () => {

--- a/ui/ts/tests/securityPoolsOverviewSection.test.tsx
+++ b/ui/ts/tests/securityPoolsOverviewSection.test.tsx
@@ -846,6 +846,7 @@ describe('SecurityPoolsOverviewSection', () => {
 		const poolCard = getSecurityPoolCard(deferredPoolTitle)
 		const poolCardQueries = within(poolCard)
 		expect(poolCardQueries.queryByText('Open this pool to load 2 vaults.')).toBeNull()
+		expect(poolCardQueries.getByText('Vault preview unavailable.')).not.toBeNull()
 		expect(poolCardQueries.queryByText('No vaults in this pool yet.')).toBeNull()
 	})
 

--- a/ui/ts/tests/securityPoolsOverviewSection.test.tsx
+++ b/ui/ts/tests/securityPoolsOverviewSection.test.tsx
@@ -480,10 +480,7 @@ describe('SecurityPoolsOverviewSection', () => {
 		expect(auctionPoolCardQueries.queryByText('Migration has moved into the truth-auction phase, where the child universe is finalized.')).toBeNull()
 		const truthAuctionBadge = auctionPoolCardQueries.getByText('Truth Auction')
 		expect(truthAuctionBadge.getAttribute('aria-label')).toBe('Truth Auction')
-		const truthAuctionTooltipId = truthAuctionBadge.parentElement?.getAttribute('aria-describedby')
-		expect(truthAuctionTooltipId).not.toBeNull()
-		const truthAuctionTooltip = truthAuctionTooltipId === null || truthAuctionTooltipId === undefined ? null : document.getElementById(truthAuctionTooltipId)
-		expect(truthAuctionTooltip?.textContent).toBe('Open the pool to review auction state and any child-universe follow-up actions.')
+		expect(truthAuctionBadge.parentElement?.getAttribute('aria-describedby')).toBeNull()
 	})
 
 	test('shows Fork Finalized for child pools with completed fork history', async () => {
@@ -515,10 +512,7 @@ describe('SecurityPoolsOverviewSection', () => {
 		const childPoolCardQueries = within(childPoolCard)
 		const forkFinalizedBadge = childPoolCardQueries.getByText('Fork Finalized')
 		expect(forkFinalizedBadge.getAttribute('aria-label')).toBe('Fork Finalized')
-		const forkFinalizedTooltipId = forkFinalizedBadge.parentElement?.getAttribute('aria-describedby')
-		expect(forkFinalizedTooltipId).not.toBeNull()
-		const forkFinalizedTooltip = forkFinalizedTooltipId === null || forkFinalizedTooltipId === undefined ? null : document.getElementById(forkFinalizedTooltipId)
-		expect(forkFinalizedTooltip?.textContent).toBe('Open the pool to review final child-universe state and any remaining balances.')
+		expect(forkFinalizedBadge.parentElement?.getAttribute('aria-describedby')).toBeNull()
 		expect(childPoolCardQueries.queryByText('This parent pool has already gone through a fork lifecycle and now acts as a historical reference point.')).toBeNull()
 	})
 

--- a/ui/ts/tests/securityPoolsOverviewSection.test.tsx
+++ b/ui/ts/tests/securityPoolsOverviewSection.test.tsx
@@ -476,8 +476,14 @@ describe('SecurityPoolsOverviewSection', () => {
 
 		const auctionPoolCard = getSecurityPoolCard(auctionPoolTitle)
 		const auctionPoolCardQueries = within(auctionPoolCard)
-		expect(auctionPoolCardQueries.getByText('Migration has moved into the truth-auction phase, where bidding and settlement determine the child-universe recovery path.')).not.toBeNull()
+		expect(auctionPoolCardQueries.queryByText('Migration has moved into the truth-auction phase, where bidding and settlement determine the child-universe recovery path.')).toBeNull()
 		expect(auctionPoolCardQueries.queryByText('Migration has moved into the truth-auction phase, where the child universe is finalized.')).toBeNull()
+		const truthAuctionBadge = auctionPoolCardQueries.getByText('Truth Auction')
+		expect(truthAuctionBadge.getAttribute('aria-label')).toBe('Truth Auction')
+		const truthAuctionTooltipId = truthAuctionBadge.parentElement?.getAttribute('aria-describedby')
+		expect(truthAuctionTooltipId).not.toBeNull()
+		const truthAuctionTooltip = truthAuctionTooltipId === null || truthAuctionTooltipId === undefined ? null : document.getElementById(truthAuctionTooltipId)
+		expect(truthAuctionTooltip?.textContent).toBe('Open the pool to review auction state and any child-universe follow-up actions.')
 	})
 
 	test('shows Fork Finalized for child pools with completed fork history', async () => {
@@ -507,7 +513,12 @@ describe('SecurityPoolsOverviewSection', () => {
 		expect(badgeTexts).toContain('Fork Finalized')
 		const childPoolCard = getSecurityPoolCard(childPoolTitle)
 		const childPoolCardQueries = within(childPoolCard)
-		expect(childPoolCardQueries.getByText('This pool has already gone through a fork lifecycle and now acts as a historical reference point.')).not.toBeNull()
+		const forkFinalizedBadge = childPoolCardQueries.getByText('Fork Finalized')
+		expect(forkFinalizedBadge.getAttribute('aria-label')).toBe('Fork Finalized')
+		const forkFinalizedTooltipId = forkFinalizedBadge.parentElement?.getAttribute('aria-describedby')
+		expect(forkFinalizedTooltipId).not.toBeNull()
+		const forkFinalizedTooltip = forkFinalizedTooltipId === null || forkFinalizedTooltipId === undefined ? null : document.getElementById(forkFinalizedTooltipId)
+		expect(forkFinalizedTooltip?.textContent).toBe('Open the pool to review final child-universe state and any remaining balances.')
 		expect(childPoolCardQueries.queryByText('This parent pool has already gone through a fork lifecycle and now acts as a historical reference point.')).toBeNull()
 	})
 
@@ -840,7 +851,7 @@ describe('SecurityPoolsOverviewSection', () => {
 
 		const poolCard = getSecurityPoolCard(deferredPoolTitle)
 		const poolCardQueries = within(poolCard)
-		expect(poolCardQueries.getByText('Open this pool to load 2 vaults.')).not.toBeNull()
+		expect(poolCardQueries.queryByText('Open this pool to load 2 vaults.')).toBeNull()
 		expect(poolCardQueries.queryByText('No vaults in this pool yet.')).toBeNull()
 	})
 
@@ -883,6 +894,8 @@ describe('SecurityPoolsOverviewSection', () => {
 		const poolCard = getSecurityPoolCard(previewPoolTitle)
 		const poolCardQueries = within(poolCard)
 		expect(poolCardQueries.queryByText('Open this pool to load 1 vault.')).toBeNull()
+		expect(poolCardQueries.queryByText('Pool Details')).toBeNull()
+		expect(poolCardQueries.getByRole('link', { name: '0x1' })).not.toBeNull()
 		expect(poolCardQueries.getAllByRole('button', { name: 'Copy address 0x0000000000000000000000000000000000000501' }).length).toBeGreaterThan(0)
 		const liquidationReviewButton = poolCardQueries.getByRole('button', { name: 'Review Liquidation' })
 		expect(liquidationReviewButton).not.toBeNull()
@@ -896,7 +909,7 @@ describe('SecurityPoolsOverviewSection', () => {
 			maxAmount: 5n,
 		})
 		expect(poolCardQueries.getByText('Showing 1 of 5 active vaults in this preview, newest activity first.')).not.toBeNull()
-		expect(poolCardQueries.getByText('+4 more vaults')).not.toBeNull()
+		expect(poolCardQueries.queryByText('+4 more vaults')).toBeNull()
 	})
 
 	test('preserves the loader-provided vault preview order instead of re-ranking by allowance', async () => {
@@ -1001,6 +1014,6 @@ describe('SecurityPoolsOverviewSection', () => {
 		const poolCardQueries = within(poolCard)
 		expect(poolCardQueries.getAllByRole('button', { name: `Copy address ${viewerVaultAddress}` }).length).toBeGreaterThan(0)
 		expect(poolCardQueries.getByText('Showing 4 of 6 active vaults in this preview, newest activity first.')).not.toBeNull()
-		expect(poolCardQueries.getByText('+2 more vaults')).not.toBeNull()
+		expect(poolCardQueries.queryByText('+2 more vaults')).toBeNull()
 	})
 })

--- a/ui/ts/tests/securityVaultGuards.test.ts
+++ b/ui/ts/tests/securityVaultGuards.test.ts
@@ -2,74 +2,54 @@
 
 import { describe, expect, test } from 'bun:test'
 import { zeroAddress } from '@zoltar/shared/ethereum'
-import { getVaultApprovalGuardMessage, getVaultClaimFeesGuardMessage, getVaultDepositGuardMessage, getVaultExecutePendingOperationGuardMessage, getVaultRequestPriceGuardMessage, getVaultSetSecurityBondAllowanceGuardMessage, getVaultWithdrawGuardMessage } from '../lib/securityVaultGuards.js'
+import { getVaultClaimFeesGuardMessage, getVaultDepositGuardMessage, getVaultExecutePendingOperationGuardMessage, getVaultRequestPriceGuardMessage, getVaultSetSecurityBondAllowanceGuardMessage, getVaultWithdrawGuardMessage } from '../lib/securityVaultGuards.js'
 
 const ETH = 10n ** 18n
 
 describe('security vault guards', () => {
-	test('blocks deposit until the vault is owned, loaded, approved, funded, and above minimum', () => {
+	test('blocks deposit until deterministic deposit prerequisites are met', () => {
 		expect(
 			getVaultDepositGuardMessage({
-				accountAddress: zeroAddress,
 				approvalSatisfied: true,
 				depositAmount: 1n,
 				isDepositBelowMinimum: false,
-				isMainnet: true,
 				repBalanceGap: undefined,
-				selectedVaultDetailsLoaded: true,
-				selectedVaultIsOwnedByAccount: false,
 			}),
-		).toBe('Select your own vault to deposit REP.')
+		).toBeUndefined()
 
 		expect(
 			getVaultDepositGuardMessage({
-				accountAddress: zeroAddress,
 				approvalSatisfied: false,
 				depositAmount: 0n,
 				isDepositBelowMinimum: false,
-				isMainnet: true,
 				repBalanceGap: undefined,
-				selectedVaultDetailsLoaded: true,
-				selectedVaultIsOwnedByAccount: true,
 			}),
 		).toBe('Enter a REP deposit amount greater than zero.')
 
 		expect(
 			getVaultDepositGuardMessage({
-				accountAddress: zeroAddress,
 				approvalSatisfied: false,
 				depositAmount: 1n,
 				isDepositBelowMinimum: false,
-				isMainnet: true,
 				repBalanceGap: undefined,
-				selectedVaultDetailsLoaded: true,
-				selectedVaultIsOwnedByAccount: true,
 			}),
 		).toBe('Approve enough REP before depositing.')
 
 		expect(
 			getVaultDepositGuardMessage({
-				accountAddress: zeroAddress,
 				approvalSatisfied: true,
 				depositAmount: 3n * 10n ** 18n,
 				isDepositBelowMinimum: false,
-				isMainnet: true,
 				repBalanceGap: 2n * 10n ** 18n,
-				selectedVaultDetailsLoaded: true,
-				selectedVaultIsOwnedByAccount: true,
 			}),
 		).toBe('Need 2 more REP in this wallet.')
 
 		expect(
 			getVaultDepositGuardMessage({
-				accountAddress: zeroAddress,
 				approvalSatisfied: true,
 				depositAmount: 3n * 10n ** 18n,
 				isDepositBelowMinimum: false,
-				isMainnet: true,
 				repBalanceGap: undefined,
-				selectedVaultDetailsLoaded: true,
-				selectedVaultIsOwnedByAccount: true,
 			}),
 		).toBeUndefined()
 	})
@@ -77,10 +57,7 @@ describe('security vault guards', () => {
 	test('blocks withdraw, allowance, and claim actions until their deterministic prerequisites are met', () => {
 		expect(
 			getVaultWithdrawGuardMessage({
-				accountAddress: zeroAddress,
-				isMainnet: true,
 				requiredEthCost: undefined,
-				selectedVaultIsOwnedByAccount: true,
 				stagedOperationTimeoutMinutes: 5n,
 				withdrawAmount: 1n,
 				withdrawableRepAmount: 1n,
@@ -90,10 +67,7 @@ describe('security vault guards', () => {
 
 		expect(
 			getVaultWithdrawGuardMessage({
-				accountAddress: zeroAddress,
-				isMainnet: true,
 				requiredEthCost: undefined,
-				selectedVaultIsOwnedByAccount: true,
 				stagedOperationTimeoutMinutes: 5n,
 				withdrawAmount: 0n,
 				withdrawableRepAmount: 2_500n * 10n ** 18n,
@@ -103,10 +77,7 @@ describe('security vault guards', () => {
 
 		expect(
 			getVaultWithdrawGuardMessage({
-				accountAddress: zeroAddress,
-				isMainnet: true,
 				requiredEthCost: undefined,
-				selectedVaultIsOwnedByAccount: true,
 				stagedOperationTimeoutMinutes: 5n,
 				withdrawAmount: 10_000n * 10n ** 18n,
 				withdrawableRepAmount: 2_500n * 10n ** 18n,
@@ -116,12 +87,9 @@ describe('security vault guards', () => {
 
 		expect(
 			getVaultSetSecurityBondAllowanceGuardMessage({
-				isMainnet: true,
 				maxSecurityBondAllowanceAmount: undefined,
 				requiredEthCost: undefined,
 				securityBondAllowanceAmount: undefined,
-				selectedVaultDetailsLoaded: true,
-				selectedVaultIsOwnedByAccount: true,
 				stagedOperationTimeoutMinutes: 5n,
 				walletEthBalance: 1n,
 			}),
@@ -129,12 +97,9 @@ describe('security vault guards', () => {
 
 		expect(
 			getVaultSetSecurityBondAllowanceGuardMessage({
-				isMainnet: true,
 				maxSecurityBondAllowanceAmount: undefined,
 				requiredEthCost: undefined,
 				securityBondAllowanceAmount: 0n,
-				selectedVaultDetailsLoaded: true,
-				selectedVaultIsOwnedByAccount: true,
 				stagedOperationTimeoutMinutes: 5n,
 				walletEthBalance: 1n,
 			}),
@@ -142,12 +107,9 @@ describe('security vault guards', () => {
 
 		expect(
 			getVaultSetSecurityBondAllowanceGuardMessage({
-				isMainnet: true,
 				maxSecurityBondAllowanceAmount: 5n * 10n ** 18n,
 				requiredEthCost: undefined,
 				securityBondAllowanceAmount: 5n * 10n ** 17n,
-				selectedVaultDetailsLoaded: true,
-				selectedVaultIsOwnedByAccount: true,
 				stagedOperationTimeoutMinutes: 5n,
 				walletEthBalance: 1n,
 			}),
@@ -155,12 +117,9 @@ describe('security vault guards', () => {
 
 		expect(
 			getVaultSetSecurityBondAllowanceGuardMessage({
-				isMainnet: true,
 				maxSecurityBondAllowanceAmount: 5n * 10n ** 18n,
 				requiredEthCost: undefined,
 				securityBondAllowanceAmount: 6n * 10n ** 18n,
-				selectedVaultDetailsLoaded: true,
-				selectedVaultIsOwnedByAccount: true,
 				stagedOperationTimeoutMinutes: 5n,
 				walletEthBalance: 1n,
 			}),
@@ -169,22 +128,11 @@ describe('security vault guards', () => {
 		expect(
 			getVaultClaimFeesGuardMessage({
 				hasClaimableFees: false,
-				isMainnet: true,
-				selectedVaultIsOwnedByAccount: true,
 			}),
 		).toBe('No claimable fees are available for this vault.')
 	})
 
 	test('blocks approval and oracle manager actions until required state is loaded', () => {
-		expect(
-			getVaultApprovalGuardMessage({
-				accountAddress: undefined,
-				isMainnet: true,
-				selectedVaultDetailsLoaded: false,
-				selectedVaultIsOwnedByAccount: false,
-			}),
-		).toBe('Connect wallet to continue.')
-
 		expect(
 			getVaultRequestPriceGuardMessage({
 				accountAddress: zeroAddress,
@@ -231,11 +179,8 @@ describe('security vault guards', () => {
 
 		expect(
 			getVaultWithdrawGuardMessage({
-				accountAddress: zeroAddress,
 				bufferRequiredEthCost: true,
-				isMainnet: true,
 				requiredEthCost: 10n * ETH,
-				selectedVaultIsOwnedByAccount: true,
 				stagedOperationTimeoutMinutes: 5n,
 				withdrawAmount: 1n * ETH,
 				withdrawableRepAmount: 5n * ETH,
@@ -245,13 +190,10 @@ describe('security vault guards', () => {
 
 		expect(
 			getVaultSetSecurityBondAllowanceGuardMessage({
-				isMainnet: true,
 				maxSecurityBondAllowanceAmount: undefined,
 				bufferRequiredEthCost: true,
 				requiredEthCost: 10n * ETH,
 				securityBondAllowanceAmount: 0n,
-				selectedVaultDetailsLoaded: true,
-				selectedVaultIsOwnedByAccount: true,
 				stagedOperationTimeoutMinutes: 5n,
 				walletEthBalance: 5n * ETH,
 			}),

--- a/ui/ts/tests/securityVaultGuards.test.ts
+++ b/ui/ts/tests/securityVaultGuards.test.ts
@@ -124,7 +124,6 @@ describe('security vault guards', () => {
 				walletEthBalance: 1n,
 			}),
 		).toBe('Reduce the security bond allowance to 5 ETH or less.')
-
 	})
 
 	test('blocks approval and oracle manager actions until required state is loaded', () => {

--- a/ui/ts/tests/securityVaultGuards.test.ts
+++ b/ui/ts/tests/securityVaultGuards.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, test } from 'bun:test'
 import { zeroAddress } from '@zoltar/shared/ethereum'
-import { getVaultClaimFeesGuardMessage, getVaultDepositGuardMessage, getVaultExecutePendingOperationGuardMessage, getVaultRequestPriceGuardMessage, getVaultSetSecurityBondAllowanceGuardMessage, getVaultWithdrawGuardMessage } from '../lib/securityVaultGuards.js'
+import { getVaultDepositGuardMessage, getVaultExecutePendingOperationGuardMessage, getVaultRequestPriceGuardMessage, getVaultSetSecurityBondAllowanceGuardMessage, getVaultWithdrawGuardMessage } from '../lib/securityVaultGuards.js'
 
 const ETH = 10n ** 18n
 
@@ -24,7 +24,7 @@ describe('security vault guards', () => {
 				isDepositBelowMinimum: false,
 				repBalanceGap: undefined,
 			}),
-		).toBe('Enter a REP deposit amount greater than zero.')
+		).toBeUndefined()
 
 		expect(
 			getVaultDepositGuardMessage({
@@ -73,7 +73,7 @@ describe('security vault guards', () => {
 				withdrawableRepAmount: 2_500n * 10n ** 18n,
 				walletEthBalance: 1n,
 			}),
-		).toBe('Enter a REP withdraw amount greater than zero.')
+		).toBeUndefined()
 
 		expect(
 			getVaultWithdrawGuardMessage({
@@ -125,11 +125,6 @@ describe('security vault guards', () => {
 			}),
 		).toBe('Reduce the security bond allowance to 5 ETH or less.')
 
-		expect(
-			getVaultClaimFeesGuardMessage({
-				hasClaimableFees: false,
-			}),
-		).toBe('No claimable fees are available for this vault.')
 	})
 
 	test('blocks approval and oracle manager actions until required state is loaded', () => {

--- a/ui/ts/tests/securityVaultSection.test.tsx
+++ b/ui/ts/tests/securityVaultSection.test.tsx
@@ -186,6 +186,48 @@ describe('SecurityVaultSection', () => {
 		expectTransactionButtonEnabled(document.body, 'Claim Fees')
 	})
 
+	test('blocks the modal-first claim fees launcher when an existing vault has no claimable fees', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<SecurityVaultSection
+				{...createSecurityVaultSectionProps({
+					modalFirst: true,
+					securityVaultDetails: createSecurityVaultDetails({
+						unpaidEthFees: 0n,
+					}),
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		const claimFeesButton = documentQueries.getByRole('button', { name: 'Claim Fees' })
+
+		expectTransactionButtonDisabled(document.body, 'Claim Fees', 'No claimable fees are available for this vault.')
+		fireEvent.click(claimFeesButton)
+		expect(documentQueries.queryByRole('dialog', { name: 'Claim Fees' })).toBeNull()
+	})
+
+	test('shows a pool-state blocker when modal-first claim fees is disabled by lifecycle gating', async () => {
+		const endedPoolState = createEndedPoolState()
+		const renderedComponent = await renderIntoDocument(
+			<SecurityVaultSection
+				{...createSecurityVaultSectionProps({
+					modalFirst: true,
+					poolState: {
+						...endedPoolState,
+						actions: {
+							...endedPoolState.actions,
+							redeemFees: { enabled: false },
+						},
+					},
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expectTransactionButtonDisabled(document.body, 'Claim Fees', 'Claim Fees is not available in the current pool state.')
+	})
+
 	test('keeps the deposit modal in create-vault mode for an empty selected vault', async () => {
 		const renderedComponent = await renderIntoDocument(
 			<SecurityVaultSection

--- a/ui/ts/tests/securityVaultSection.test.tsx
+++ b/ui/ts/tests/securityVaultSection.test.tsx
@@ -165,6 +165,53 @@ describe('SecurityVaultSection', () => {
 		expectTransactionButtonDisabled(document.body, 'Claim Fees', 'No claimable fees are available for this vault.')
 	})
 
+	test('keeps fee-claim actions available when a zeroed vault still has claimable fees', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<SecurityVaultSection
+				{...createSecurityVaultSectionProps({
+					modalFirst: true,
+					securityVaultDetails: createSecurityVaultDetails({
+						escalationEscrowedRep: 0n,
+						repDepositShare: 0n,
+						securityBondAllowance: 0n,
+						unpaidEthFees: 1n * 10n ** 18n,
+					}),
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		expect(documentQueries.queryByText('This vault does not exist yet. Deposit REP to create it.')).toBeNull()
+		expectTransactionButtonEnabled(document.body, 'Claim Fees')
+	})
+
+	test('keeps the deposit modal in create-vault mode for an empty selected vault', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<SecurityVaultSection
+				{...createSecurityVaultSectionProps({
+					modalFirst: true,
+					securityVaultDetails: createSecurityVaultDetails({
+						escalationEscrowedRep: 0n,
+						repDepositShare: 0n,
+						securityBondAllowance: 0n,
+						unpaidEthFees: 0n,
+					}),
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		fireEvent.click(documentQueries.getByRole('button', { name: 'Deposit REP' }))
+
+		const depositDialog = documentQueries.getByRole('dialog', { name: 'Deposit REP' })
+		const depositDialogQueries = within(depositDialog)
+		expect(depositDialogQueries.queryByRole('heading', { name: 'Vault Summary' })).toBeNull()
+		expect(depositDialogQueries.getByText('This vault does not exist yet. Deposit REP to create it.')).not.toBeNull()
+		expect(depositDialogQueries.getByText('REP Collateral Amount')).not.toBeNull()
+	})
+
 	test('fills the security bond allowance input from the backed Max amount', async () => {
 		const formChanges: Partial<SecurityVaultSectionProps['securityVaultForm']>[] = []
 		const renderedComponent = await renderIntoDocument(

--- a/ui/ts/tests/securityVaultSection.test.tsx
+++ b/ui/ts/tests/securityVaultSection.test.tsx
@@ -10,7 +10,7 @@ import type { SecurityVaultDetails } from '../types/contracts.js'
 import type { SecurityVaultSectionProps } from '../types/components.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
-import { expectTransactionButtonDisabled, expectTransactionButtonEnabled } from './testUtils/transactionActionButton.js'
+import { expectTransactionButtonDisabled, expectTransactionButtonEnabled, getTransactionButtonState } from './testUtils/transactionActionButton.js'
 
 function createAccountState(overrides: Partial<AccountState> = {}): AccountState {
 	return {
@@ -81,7 +81,7 @@ function createSecurityVaultSectionProps(overrides: Partial<SecurityVaultSection
 	}
 }
 
-function createOracleManagerDetails(): NonNullable<SecurityVaultSectionProps['oracleManagerDetails']> {
+function createOracleManagerDetails(overrides: Partial<NonNullable<SecurityVaultSectionProps['oracleManagerDetails']>> = {}): NonNullable<SecurityVaultSectionProps['oracleManagerDetails']> {
 	return {
 		callbackStateHash: undefined,
 		exactToken1Report: undefined,
@@ -100,6 +100,7 @@ function createOracleManagerDetails(): NonNullable<SecurityVaultSectionProps['or
 		requestPriceEthCost: 0n,
 		token1: undefined,
 		token2: undefined,
+		...overrides,
 	}
 }
 
@@ -161,8 +162,10 @@ describe('SecurityVaultSection', () => {
 
 		const documentQueries = within(document.body)
 		expect(documentQueries.queryByText('Selected Vault')).toBeNull()
-		expect(documentQueries.getByText('Refresh the vault to inspect claimable fees.')).not.toBeNull()
-		expectTransactionButtonDisabled(document.body, 'Claim Fees', 'No claimable fees are available for this vault.')
+		expect(documentQueries.getAllByText('Selected vault details are unavailable.').length).toBeGreaterThan(0)
+		expect(documentQueries.queryByText('Refresh the vault to inspect claimable fees.')).toBeNull()
+		expect(documentQueries.queryByText('Refresh the vault before setting a security bond allowance.')).toBeNull()
+		expectTransactionButtonDisabled(document.body, 'Claim Fees')
 	})
 
 	test('keeps fee-claim actions available when a zeroed vault still has claimable fees', async () => {
@@ -182,7 +185,7 @@ describe('SecurityVaultSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		const documentQueries = within(document.body)
-		expect(documentQueries.queryByText('This vault does not exist yet. Deposit REP to create it.')).toBeNull()
+		expect(documentQueries.queryByText('This vault does not exist. Deposit REP to create it.')).toBeNull()
 		expectTransactionButtonEnabled(document.body, 'Claim Fees')
 	})
 
@@ -207,6 +210,70 @@ describe('SecurityVaultSection', () => {
 		expect(documentQueries.queryByRole('dialog', { name: 'Claim Fees' })).toBeNull()
 	})
 
+	test('uses neutral missing-state copy when a queued withdrawal succeeds before manager state is visible', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<SecurityVaultSection
+				{...createSecurityVaultSectionProps({
+					modalFirst: true,
+					oracleManagerDetails: createOracleManagerDetails({
+						isPriceValid: false,
+						pendingOperation: undefined,
+					}),
+					securityVaultForm: {
+						depositAmount: '1',
+						repWithdrawAmount: '1',
+						securityBondAllowanceAmount: '1',
+						securityPoolAddress: zeroAddress,
+						selectedVaultAddress: zeroAddress,
+					},
+					securityVaultResult: {
+						action: 'queueWithdrawRep',
+						hash: '0x01',
+					},
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		fireEvent.click(documentQueries.getByRole('button', { name: 'Withdraw REP' }))
+		const dialog = documentQueries.getByRole('dialog', { name: 'Withdraw REP' })
+		expect(within(dialog).getByText('The transaction succeeded, but the latest manager state is not available yet.')).not.toBeNull()
+		expect(documentQueries.queryByText('Refresh staged operations to confirm the latest manager state.')).toBeNull()
+	})
+
+	test('uses neutral missing-state copy when a bond allowance update succeeds before manager state is visible', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<SecurityVaultSection
+				{...createSecurityVaultSectionProps({
+					modalFirst: true,
+					oracleManagerDetails: createOracleManagerDetails({
+						isPriceValid: false,
+						pendingOperation: undefined,
+					}),
+					securityVaultForm: {
+						depositAmount: '1',
+						repWithdrawAmount: '1',
+						securityBondAllowanceAmount: '1',
+						securityPoolAddress: zeroAddress,
+						selectedVaultAddress: zeroAddress,
+					},
+					securityVaultResult: {
+						action: 'queueSetSecurityBondAllowance',
+						hash: '0x02',
+					},
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		fireEvent.click(documentQueries.getByRole('button', { name: 'Set Bond Allowance' }))
+		const dialog = documentQueries.getByRole('dialog', { name: 'Set Bond Allowance' })
+		expect(within(dialog).getByText('The transaction succeeded, but the latest manager state is not available yet.')).not.toBeNull()
+		expect(documentQueries.queryByText('Refresh staged operations to confirm the latest manager state.')).toBeNull()
+	})
+
 	test('shows a pool-state blocker when modal-first claim fees is disabled by lifecycle gating', async () => {
 		const endedPoolState = createEndedPoolState()
 		const renderedComponent = await renderIntoDocument(
@@ -226,6 +293,54 @@ describe('SecurityVaultSection', () => {
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		expectTransactionButtonDisabled(document.body, 'Claim Fees', 'Claim Fees is not available in the current pool state.')
+	})
+
+	test('keeps modal-first vault actions silently disabled when the wallet is disconnected', async () => {
+		const renderedComponent = await renderIntoDocument(
+			<SecurityVaultSection
+				{...createSecurityVaultSectionProps({
+					accountState: createAccountState({ address: undefined }),
+					modalFirst: true,
+					securityVaultForm: {
+						depositAmount: '1',
+						repWithdrawAmount: '1',
+						securityBondAllowanceAmount: '1',
+						securityPoolAddress: zeroAddress,
+						selectedVaultAddress: zeroAddress,
+					},
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(getTransactionButtonState(document.body, 'Deposit REP')).toEqual({ disabled: true, reason: undefined })
+		expect(getTransactionButtonState(document.body, 'Claim Fees')).toEqual({ disabled: true, reason: undefined })
+	})
+
+	test('keeps modal-first vault actions silently disabled for a vault owned by another account', async () => {
+		const otherVaultAddress = '0x00000000000000000000000000000000000000a9'
+		const renderedComponent = await renderIntoDocument(
+			<SecurityVaultSection
+				{...createSecurityVaultSectionProps({
+					accountState: createAccountState({ address: zeroAddress }),
+					modalFirst: true,
+					securityVaultDetails: createSecurityVaultDetails({
+						vaultAddress: otherVaultAddress,
+					}),
+					securityVaultForm: {
+						depositAmount: '1',
+						repWithdrawAmount: '1',
+						securityBondAllowanceAmount: '1',
+						securityPoolAddress: zeroAddress,
+						selectedVaultAddress: otherVaultAddress,
+					},
+				})}
+			/>,
+		)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		expect(getTransactionButtonState(document.body, 'Deposit REP')).toEqual({ disabled: true, reason: undefined })
+		expect(getTransactionButtonState(document.body, 'Claim Fees')).toEqual({ disabled: true, reason: undefined })
 	})
 
 	test('keeps the deposit modal in create-vault mode for an empty selected vault', async () => {
@@ -250,7 +365,7 @@ describe('SecurityVaultSection', () => {
 		const depositDialog = documentQueries.getByRole('dialog', { name: 'Deposit REP' })
 		const depositDialogQueries = within(depositDialog)
 		expect(depositDialogQueries.queryByRole('heading', { name: 'Vault Summary' })).toBeNull()
-		expect(depositDialogQueries.getByText('This vault does not exist yet. Deposit REP to create it.')).not.toBeNull()
+		expect(depositDialogQueries.getByText('This vault does not exist. Deposit REP to create it.')).not.toBeNull()
 		expect(depositDialogQueries.getByText('REP Collateral Amount')).not.toBeNull()
 	})
 

--- a/ui/ts/tests/securityVaultSection.test.tsx
+++ b/ui/ts/tests/securityVaultSection.test.tsx
@@ -205,7 +205,7 @@ describe('SecurityVaultSection', () => {
 		const documentQueries = within(document.body)
 		const claimFeesButton = documentQueries.getByRole('button', { name: 'Claim Fees' })
 
-		expectTransactionButtonDisabled(document.body, 'Claim Fees', 'No claimable fees are available for this vault.')
+		expectTransactionButtonDisabled(document.body, 'Claim Fees')
 		fireEvent.click(claimFeesButton)
 		expect(documentQueries.queryByRole('dialog', { name: 'Claim Fees' })).toBeNull()
 	})
@@ -274,7 +274,7 @@ describe('SecurityVaultSection', () => {
 		expect(documentQueries.queryByText('Refresh staged operations to confirm the latest manager state.')).toBeNull()
 	})
 
-	test('shows a pool-state blocker when modal-first claim fees is disabled by lifecycle gating', async () => {
+	test('keeps the modal-first claim fees launcher silently disabled when lifecycle gating blocks it', async () => {
 		const endedPoolState = createEndedPoolState()
 		const renderedComponent = await renderIntoDocument(
 			<SecurityVaultSection
@@ -292,7 +292,7 @@ describe('SecurityVaultSection', () => {
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		expectTransactionButtonDisabled(document.body, 'Claim Fees', 'Claim Fees is not available in the current pool state.')
+		expectTransactionButtonDisabled(document.body, 'Claim Fees')
 	})
 
 	test('keeps modal-first vault actions silently disabled when the wallet is disconnected', async () => {

--- a/ui/ts/tests/universeLink.test.tsx
+++ b/ui/ts/tests/universeLink.test.tsx
@@ -76,4 +76,13 @@ describe('UniverseLink', () => {
 		expect(link.getAttribute('href')).toBe(expectedHref)
 		expect(popstateCount).toBe(0)
 	})
+
+	test('renders the universe id in hex when requested', async () => {
+		const renderedComponent = await renderIntoDocument(<UniverseLink format='hex' universeId={15n} />)
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const documentQueries = within(document.body)
+		const link = documentQueries.getByRole('link', { name: '0xf' }) as HTMLAnchorElement
+		expect(link.getAttribute('href')).toBe(getUniverseLinkHref(15n))
+	})
 })


### PR DESCRIPTION
## Summary
- Removed the question context note pattern and simplified question preview rendering where descriptions are absent.
- Reworked security pool overview cards to surface status guidance in a compact hover tooltip and reduced extra explanatory text.
- Tightened security pool and vault action gating for universe mismatches and non-existent vault states, with updated helper logic and tests.
- Added universe hex formatting for clearer pool and vault universe references.

## Testing
- Not run (PR content only)