### PR TITLE
Implement repair-cap liquidations and docs

### DIFF
--- a/docs/liquidation.html
+++ b/docs/liquidation.html
@@ -1,0 +1,431 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Liquidation Design</title>
+		<link rel="stylesheet" href="./shared-docs.css" />
+	</head>
+	<body class="doc-openoracle">
+		<main>
+			<header>
+				<h1>Liquidation Design</h1>
+				<p>
+					A liquidation moves unsafe security-bond allowance from an
+					undercollateralized target vault to a solvent liquidator vault. The
+					repair-cap rule moves only enough debt to make the target safe at the
+					execution REP/ETH price, and no target REP moves on that path.
+				</p>
+				<p>
+					Terms used below:
+					<code>targetUnlockedRep</code> = target vault unlocked REP claim,
+					<code>targetAllowanceEth</code> = target vault allowance,
+					<code>securityMultiplier</code> = security multiplier,
+					<code>currentRepPerEthPrice</code> = current REP/ETH price,
+					<code>PRICE_PRECISION</code> = <code>1e18</code>.
+				</p>
+			</header>
+
+			<section id="rule">
+				<h2>Liquidatable Condition</h2>
+				<p>
+					A vault is liquidatable when its unlocked REP backing is below the
+					required threshold:
+				</p>
+				<figure class="diagram" id="fig-liquidation-repair-flow">
+					<svg viewBox="0 0 900 200" role="img" aria-label="Unsafe vault debt moves to a solvent liquidator vault until the target reaches the collateral boundary while REP stays with the target on the repair path.">
+						<defs>
+							<marker id="liquidation-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+								<path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"></path>
+							</marker>
+						</defs>
+						<rect class="svg-red" x="40" y="50" width="220" height="90" rx="10"></rect>
+						<text class="svg-label" x="150" y="82" text-anchor="middle">Target Vault</text>
+						<text class="svg-small" x="150" y="108" text-anchor="middle">unsafe debt</text>
+						<text class="svg-small" x="150" y="128" text-anchor="middle">keeps unlocked REP</text>
+						<path class="svg-line" marker-end="url(#liquidation-arrow)" d="M 270 95 H 610"></path>
+						<text class="svg-small" x="440" y="82" text-anchor="middle">repair-capped debt only</text>
+						<rect class="svg-green" x="620" y="50" width="220" height="90" rx="10"></rect>
+						<text class="svg-label" x="730" y="82" text-anchor="middle">Liquidator Vault</text>
+						<text class="svg-small" x="730" y="108" text-anchor="middle">absorbs debt</text>
+						<text class="svg-small" x="730" y="128" text-anchor="middle">must stay solvent</text>
+					</svg>
+					<p class="diagram-caption">
+						<span class="figure-label">Repair Flow</span>The repair path moves
+						only debt. Target REP stays in the target vault, so one max
+						liquidation at a fixed price can make the target safe again.
+					</p>
+				</figure>
+				<div class="equation" id="eq-liquidatable-condition">
+					<math display="block" aria-label="target vault is liquidatable when target allowance times security multiplier times current REP per ETH price is greater than target unlocked REP times PRICE_PRECISION" data-source="targetAllowanceEth * securityMultiplier * currentRepPerEthPrice > targetUnlockedRep * PRICE_PRECISION">
+						<mrow>
+							<mi>targetAllowanceEth</mi>
+							<mo>&#x22C5;</mo>
+							<mi>securityMultiplier</mi>
+							<mo>&#x22C5;</mo>
+							<mi>currentRepPerEthPrice</mi>
+							<mo>&gt;</mo>
+							<mi>targetUnlockedRep</mi>
+							<mo>&#x22C5;</mo>
+							<mi>PRICE_PRECISION</mi>
+						</mrow>
+					</math>
+					<p class="equation-caption">
+						<span class="equation-label">Liquidatable Condition</span>The vault
+						is unsafe when required REP backing exceeds unlocked REP.
+					</p>
+				</div>
+				<p>
+					The contract snapshots the target vault when liquidation is queued.
+					Execution reuses that snapshot, so adding REP later cannot block the
+					pending liquidation.
+				</p>
+				<h3>Execution Gates</h3>
+				<p>
+					The solvency inequality is necessary but not sufficient for execution.
+					A staged liquidation also needs a valid current oracle price, an
+					unexpired staging window, target allowance unchanged and target
+					ownership not below the queued snapshot, and enough
+					distance beyond the threshold to satisfy
+					<code>minLiquidationPriceDistanceBps</code>. These gates fail in
+					different ways. If the current price is stale, execution reverts and the
+					staged operation stays pending. If coordinator-level checks fail after a
+					valid price is available, such as expiry, stale snapshot data, or too
+					little distance from the threshold, the coordinator consumes the staged
+					operation without calling the pool. If the pool call itself fails after
+					consumption, for example because the caller would become liquidatable or
+					because a requested chunk leaves forbidden debt dust, the coordinator
+					emits a failed execution result. See
+					<a href="./openOracleIntegration.html">OpenOracle integration</a> for
+					the full settlement and distance-check flow.
+				</p>
+			</section>
+
+			<section id="repair-cap">
+				<h2>Repair-Cap Math</h2>
+				<p>
+					The current liquidation path does not move REP on the repair path. It
+					moves only enough debt to make the target vault safe again at the
+					execution price.
+				</p>
+				<div class="equation" id="eq-repair-debt-cap">
+					<math display="block" aria-label="unsafe value numerator equals target allowance times security multiplier times current REP per ETH price minus target unlocked REP times PRICE_PRECISION; repair debt cap equals ceiling of that value divided by security multiplier times current REP per ETH price" data-source="unsafeValueNumerator = targetAllowanceEth * securityMultiplier * currentRepPerEthPrice - targetUnlockedRep * PRICE_PRECISION; repairDebtCap = ceil(unsafeValueNumerator / (securityMultiplier * currentRepPerEthPrice))">
+						<mtable>
+							<mtr>
+								<mtd><mi>unsafeValueNumerator</mi></mtd>
+								<mtd><mo>=</mo></mtd>
+								<mtd>
+									<mi>targetAllowanceEth</mi><mo>&#x22C5;</mo><mi>securityMultiplier</mi><mo>&#x22C5;</mo><mi>currentRepPerEthPrice</mi>
+									<mo>-</mo>
+									<mi>targetUnlockedRep</mi><mo>&#x22C5;</mo><mi>PRICE_PRECISION</mi>
+								</mtd>
+							</mtr>
+							<mtr>
+								<mtd><mi>repairDebtCap</mi></mtd>
+								<mtd><mo>=</mo></mtd>
+								<mtd>
+									<mi>ceil</mi>
+									<mo>(</mo>
+									<mfrac>
+										<mi>unsafeValueNumerator</mi>
+										<mrow><mi>securityMultiplier</mi><mo>&#x22C5;</mo><mi>currentRepPerEthPrice</mi></mrow>
+									</mfrac>
+									<mo>)</mo>
+								</mtd>
+							</mtr>
+						</mtable>
+					</math>
+					<p class="equation-caption">
+						<span class="equation-label">Repair Debt Cap</span>This is the
+						minimum debt transfer that repairs the vault at the current price.
+					</p>
+				</div>
+				<p>
+					If leaving
+					<code>targetAllowanceEth - repairDebtCap</code> would strand a
+					non-zero allowance below the minimum debt floor, the contract rounds up
+					to a full allowance transfer instead.
+				</p>
+				<div class="equation" id="eq-liquidation-dust-rounding">
+					<math display="block" aria-label="max debt to move equals full target allowance when the repaired remainder is positive but below minimum debt, otherwise repair debt cap; rep to move equals zero" data-source="maxDebtToMove = 0 < targetAllowanceEth - repairDebtCap < MIN_SECURITY_BOND_DEBT ? targetAllowanceEth : repairDebtCap; debtToMove = min(requestedDebt, maxDebtToMove); repToMove = 0">
+						<mtable>
+							<mtr>
+								<mtd><mi>maxDebtToMove</mi></mtd>
+								<mtd><mo>=</mo></mtd>
+								<mtd>
+									<mi>if</mi>
+									<mo>&#xA0;</mo>
+									<mn>0</mn><mo>&lt;</mo><mi>targetAllowanceEth</mi><mo>-</mo><mi>repairDebtCap</mi><mo>&lt;</mo><mi>MIN_SECURITY_BOND_DEBT</mi>
+									<mo>,</mo>
+									<mo>&#xA0;</mo><mi>targetAllowanceEth</mi>
+									<mo>&#xA0;</mo><mi>else</mi><mo>&#xA0;</mo><mi>repairDebtCap</mi>
+								</mtd>
+							</mtr>
+							<mtr>
+								<mtd><mi>debtToMove</mi></mtd>
+								<mtd><mo>=</mo></mtd>
+								<mtd><mi>min</mi><mo>(</mo><mi>requestedDebt</mi><mo>,</mo><mi>maxDebtToMove</mi><mo>)</mo></mtd>
+							</mtr>
+							<mtr>
+								<mtd><mi>repToMove</mi></mtd>
+								<mtd><mo>=</mo></mtd>
+								<mtd><mn>0</mn></mtd>
+							</mtr>
+						</mtable>
+					</math>
+					<p class="equation-caption">
+						<span class="equation-label">Dust Rounding</span>If the exact repair
+						point would leave forbidden debt dust, the protocol rounds up to a
+						full debt transfer. REP still does not move on that path.
+					</p>
+				</div>
+				<p>
+					There is one more chunking constraint at execution time:
+					<code>remainingDebt = targetAllowanceEth - debtToMove</code> must be
+					zero or at least <code>MIN_SECURITY_BOND_DEBT</code>. A smaller
+					requested chunk can still revert if it would leave forbidden non-zero
+					debt dust.
+				</p>
+			</section>
+
+			<section id="why-once">
+				<h2>Why One Max Liquidation Is Enough</h2>
+				<p>
+					If the liquidator asks for at least <code>maxDebtToMove</code>, the
+					target vault ends exactly at the collateral boundary, or at zero debt if
+					dust rounding forces a full transfer. With price unchanged, the vault is
+					no longer liquidatable after that one execution, so a second max
+					liquidation at the same price cannot change the state.
+				</p>
+			</section>
+
+			<section id="examples">
+				<h2>Worked Examples</h2>
+				<table>
+					<thead>
+						<tr>
+							<th>Case</th>
+							<th>Inputs</th>
+							<th>Result</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>Repair without dust</td>
+							<td><code>targetUnlockedRep = 1000 REP</code>, <code>targetAllowanceEth = 75 ETH</code>, <code>securityMultiplier = 2</code>, <code>currentRepPerEthPrice = 10 REP/ETH</code></td>
+							<td>
+								Required backing is <code>75 * 2 * 10 = 1500 REP</code>, so the
+								shortfall is <code>500 REP</code>. The repair cap is
+								<code>ceil(500 / 20) = 25 ETH</code>. After moving
+								<code>25 ETH</code>, the vault has <code>50 ETH</code> of debt and
+								<code>1000 REP</code> of backing, exactly at the boundary.
+							</td>
+						</tr>
+						<tr>
+							<td>Repair with locked escalation REP</td>
+							<td><code>targetUnlockedRep = 300 REP</code> unlocked, <code>targetAllowanceEth = 200 ETH</code>, <code>securityMultiplier = 2</code>, <code>currentRepPerEthPrice = 1 REP/ETH</code></td>
+							<td>
+								Required backing is <code>400 REP</code>, so the shortfall is
+								<code>100 REP</code>. The repair cap is <code>50 ETH</code>.
+								Escalation-locked REP is ignored, so the target keeps its
+								<code>300 REP</code> unlocked claim and becomes safe at
+								<code>150 ETH</code> debt.
+							</td>
+						</tr>
+						<tr>
+							<td>Dust rounding</td>
+							<td><code>targetAllowanceEth = 1.4 ETH</code>, repair cap would leave <code>0.6 ETH</code>, min non-zero debt is <code>1 ETH</code></td>
+							<td>
+								The repair point would strand forbidden dust, so the protocol rounds
+								up to a full <code>1.4 ETH</code> liquidation.
+							</td>
+						</tr>
+						<tr>
+							<td>Dust-reverting partial request</td>
+							<td><code>targetAllowanceEth = 1.4 ETH</code>, liquidator requests <code>0.8 ETH</code></td>
+							<td>
+								That chunk leaves <code>0.6 ETH</code> of debt. The remainder is
+								non-zero and below <code>MIN_SECURITY_BOND_DEBT</code>, so the
+								execution reverts instead of leaving forbidden dust behind.
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</section>
+
+			<section id="sliders">
+				<h2>Slider Examples</h2>
+				<p>
+					These calculators use whole ETH and REP units for readability. The
+					equations above describe the scaled integer math used onchain.
+				</p>
+				<details class="interactive-example" open>
+					<summary>Repair-cap calculator</summary>
+					<div class="example-grid">
+						<label>
+							Unlocked REP
+							<input data-liquidation-input="rep" type="range" min="0" max="2000" step="10" value="1000" />
+							<span class="example-value" data-liquidation-value="rep">1000 REP</span>
+						</label>
+						<label>
+							Allowance
+							<input data-liquidation-input="debt" type="range" min="1" max="200" step="1" value="75" />
+							<span class="example-value" data-liquidation-value="debt">75 ETH</span>
+						</label>
+						<label>
+							Multiplier
+							<input data-liquidation-input="multiplier" type="range" min="1" max="4" step="1" value="2" />
+							<span class="example-value" data-liquidation-value="multiplier">2x</span>
+						</label>
+						<label>
+							Price
+							<input data-liquidation-input="price" type="range" min="1" max="20" step="1" value="10" />
+							<span class="example-value" data-liquidation-value="price">10 REP / ETH</span>
+						</label>
+					</div>
+					<div class="example-output">
+						<p><strong>Status:</strong> <span data-liquidation-output="status">Liquidatable</span></p>
+						<p><strong>Required REP:</strong> <span data-liquidation-output="required">1500 REP</span></p>
+						<p><strong>REP shortfall:</strong> <span data-liquidation-output="shortfall">500 REP</span></p>
+						<p><strong>Repair debt cap:</strong> <span data-liquidation-output="cap">25 ETH</span></p>
+						<p><strong>Post-max debt:</strong> <span data-liquidation-output="postDebt">50 ETH</span></p>
+						<p><strong>REP moved:</strong> <span data-liquidation-output="repMoved">0 REP</span></p>
+					</div>
+				</details>
+
+				<details class="interactive-example">
+					<summary>Path independence check</summary>
+					<div class="example-grid">
+						<label>
+							Requested debt, first liquidation
+							<input data-path-input="first" type="range" min="1" max="100" step="1" value="10" />
+							<span class="example-value" data-path-value="first">10 ETH</span>
+						</label>
+						<label>
+							Requested debt, second liquidation
+							<input data-path-input="second" type="range" min="1" max="100" step="1" value="15" />
+							<span class="example-value" data-path-value="second">15 ETH</span>
+						</label>
+					</div>
+					<p>
+						Base case is fixed at
+						<code>targetUnlockedRep = 1000 REP</code>,
+						<code>targetAllowanceEth = 75 ETH</code>,
+						<code>securityMultiplier = 2</code>, and
+						<code>currentRepPerEthPrice = 10 REP/ETH</code>.
+					</p>
+					<div class="example-output">
+						<p><strong>Single liquidation using first + second:</strong> <span data-path-output="single">50 ETH debt remaining</span></p>
+						<p><strong>Two-step path:</strong> <span data-path-output="twoStep">50 ETH debt remaining</span></p>
+						<p><strong>Same state?</strong> <span data-path-output="same">Yes</span></p>
+					</div>
+				</details>
+			</section>
+
+			<section id="incentives">
+				<h2>Incentive Implications</h2>
+				<p>
+					A repair-capped liquidation cannot also pay an immediate target-funded
+					REP bonus without making the target unsafe again. The design gets the
+					path-independence property the protocol wants by removing any
+					target-funded REP bonus from the healing path.
+				</p>
+				<p>
+					If a liquidation both:
+				</p>
+				<ul>
+					<li>leaves the target vault safe again at the same price, and</li>
+					<li>pays the liquidator an immediate positive bonus from the target’s own REP,</li>
+				</ul>
+				<p>
+					then the target loses collateral faster than debt, so the repair point
+					does not work. A positive immediate incentive therefore needs a different
+					source of value:
+				</p>
+				<ul>
+					<li>an explicit protocol-funded bounty, paid in ETH or REP from a reserve,</li>
+					<li>a queue-execution reward funded by requesters, or</li>
+					<li>a separate backstop that buys bad debt and earns future upside elsewhere.</li>
+				</ul>
+				<p>
+					Without that external value source, the liquidator is simply choosing to
+					absorb under-backed debt because their own vault is overcollateralized
+					enough to do it.
+				</p>
+			</section>
+		</main>
+
+		<script>
+			const MIN_SECURITY_BOND_DEBT = 1
+
+			function ceilDiv(numerator, denominator) {
+				return Math.floor((numerator + denominator - 1) / denominator)
+			}
+
+			function getRepairCap({ debt, multiplier, price, rep }) {
+				const shortfall = debt * multiplier * price - rep
+				if (shortfall <= 0) return 0
+				let cap = ceilDiv(shortfall, multiplier * price)
+				if (cap > debt) cap = debt
+				const remaining = debt - cap
+				if (remaining > 0 && remaining < MIN_SECURITY_BOND_DEBT) return debt
+				return cap
+			}
+
+			function updateRepairExample() {
+				const rep = Number(document.querySelector('[data-liquidation-input="rep"]').value)
+				const debt = Number(document.querySelector('[data-liquidation-input="debt"]').value)
+				const multiplier = Number(document.querySelector('[data-liquidation-input="multiplier"]').value)
+				const price = Number(document.querySelector('[data-liquidation-input="price"]').value)
+				const required = debt * multiplier * price
+				const shortfall = Math.max(0, required - rep)
+				const cap = getRepairCap({ debt, multiplier, price, rep })
+				const postDebt = debt - cap
+
+				document.querySelector('[data-liquidation-value="rep"]').textContent = `${rep} REP`
+				document.querySelector('[data-liquidation-value="debt"]').textContent = `${debt} ETH`
+				document.querySelector('[data-liquidation-value="multiplier"]').textContent = `${multiplier}x`
+				document.querySelector('[data-liquidation-value="price"]').textContent = `${price} REP / ETH`
+				document.querySelector('[data-liquidation-output="status"]').textContent = shortfall > 0 ? 'Liquidatable' : 'Safe'
+				document.querySelector('[data-liquidation-output="required"]').textContent = `${required} REP`
+				document.querySelector('[data-liquidation-output="shortfall"]').textContent = `${shortfall} REP`
+				document.querySelector('[data-liquidation-output="cap"]').textContent = `${cap} ETH`
+				document.querySelector('[data-liquidation-output="postDebt"]').textContent = `${postDebt} ETH`
+				document.querySelector('[data-liquidation-output="repMoved"]').textContent = '0 REP'
+			}
+
+			function applyCap(base, requested) {
+				return Math.min(requested, getRepairCap(base))
+			}
+
+			function updatePathExample() {
+				const base = { rep: 1000, debt: 75, multiplier: 2, price: 10 }
+				const first = Number(document.querySelector('[data-path-input="first"]').value)
+				const second = Number(document.querySelector('[data-path-input="second"]').value)
+
+				const firstMoved = applyCap(base, first)
+				const afterFirst = { ...base, debt: base.debt - firstMoved }
+				const secondMoved = applyCap(afterFirst, second)
+				const twoStepDebt = afterFirst.debt - secondMoved
+				const combinedMoved = applyCap(base, first + second)
+				const singleDebt = base.debt - combinedMoved
+
+				document.querySelector('[data-path-value="first"]').textContent = `${first} ETH`
+				document.querySelector('[data-path-value="second"]').textContent = `${second} ETH`
+				document.querySelector('[data-path-output="single"]').textContent = `${singleDebt} ETH debt remaining`
+				document.querySelector('[data-path-output="twoStep"]').textContent = `${twoStepDebt} ETH debt remaining`
+				document.querySelector('[data-path-output="same"]').textContent = singleDebt === twoStepDebt ? 'Yes' : 'No'
+			}
+
+			for (const input of document.querySelectorAll('[data-liquidation-input]')) {
+				input.addEventListener('input', updateRepairExample)
+			}
+			for (const input of document.querySelectorAll('[data-path-input]')) {
+				input.addEventListener('input', updatePathExample)
+			}
+
+			updateRepairExample()
+			updatePathExample()
+		</script>
+	</body>
+</html>

--- a/docs/mainnet-deployment-addresses.json
+++ b/docs/mainnet-deployment-addresses.json
@@ -13,7 +13,7 @@
 		{
 			"id": "deploymentStatusOracle",
 			"label": "Deployment Status Oracle",
-			"address": "0xb5f0d79B7CF4DB1096FBBeE326473967b9f6CD27"
+			"address": "0x3dE2337D882CaaDc9afe65654790328cB8b2Fb6B"
 		},
 		{
 			"id": "multicall3",
@@ -33,7 +33,7 @@
 		{
 			"id": "securityPoolUtils",
 			"label": "SecurityPoolUtils",
-			"address": "0x04349f6A0302F32f8c87bb8555648AD77634343C"
+			"address": "0x925Eaf4512D192498fF2638c36E84200469615a9"
 		},
 		{
 			"id": "openOracle",
@@ -53,34 +53,34 @@
 		{
 			"id": "shareTokenFactory",
 			"label": "ShareTokenFactory",
-			"address": "0x3CBdbadA88fA7AD474E13044AD32e9ceE56Ca219"
+			"address": "0x063Cbb4BE407A176b39496327D032DA00436BC36"
 		},
 		{
 			"id": "priceOracleManagerAndOperatorQueuerFactory",
 			"label": "OpenOracle Price Coordinator Factory",
-			"address": "0x4f8fF6585EF37FE58DEa84D390013CE4Efbfce81"
+			"address": "0xdb815F26F1318DceE0aB53E5a71f65D99F6fa486"
 		},
 		{
 			"id": "securityPoolForker",
 			"label": "Security Pool Forker",
-			"address": "0x2ca02A35e487Fe16654696A5CF29b8E9Cf8c3114"
+			"address": "0x5Cc794e65e305A4120017295d9FBa72E26d7C8aE"
 		},
 		{
 			"id": "escalationGameFactory",
 			"label": "Escalation Game Factory",
-			"address": "0xC97E1Fe2943411e678754e996FB7dc3F673add84"
+			"address": "0x92E5C863A717d9574492C21505Dfe6730e710CCB"
 		},
 		{
 			"id": "securityPoolFactory",
 			"label": "Security Pool Factory",
-			"address": "0xa5066F855B80093d311110e5972cC5C8C647FCe4"
+			"address": "0x0911f065be18eEfAc5AD7a16882f21E2Ee27eC11"
 		}
 	],
 	"derivedContracts": [
 		{
 			"id": "escalationGameProofVerifier",
 			"label": "Escalation Game Proof Verifier",
-			"address": "0x40A015f5aA0c35F841C6aa893fA50cD75f3A6b9e"
+			"address": "0xa5BC7d46eb97F6d2b2e411d66c482154337F177e"
 		}
 	]
 }

--- a/docs/start-here.html
+++ b/docs/start-here.html
@@ -498,6 +498,10 @@
 							<td><a href="./openOracleIntegration.html">OpenOracle integration</a></td>
 						</tr>
 						<tr>
+							<td>Understand repair-cap liquidation math, chunking limits, and incentives.</td>
+							<td><a href="./liquidation.html">Liquidation design</a></td>
+						</tr>
+						<tr>
 							<td>Look up edge cases and contract guardrails.</td>
 							<td><a href="./operator-reference.md">Operator reference</a></td>
 						</tr>

--- a/docs/whitepaper_placeholder.html
+++ b/docs/whitepaper_placeholder.html
@@ -2019,11 +2019,22 @@
 						distance check.
 					</p>
 					<p>
-						Economically, liquidation moves debt and corresponding REP-backed
-						ownership from the unsafe vault to the caller vault. The receiving
-						vault must remain solvent after taking on that additional debt, and
-						both sides must still satisfy the minimum deposit requirements
-						enforced by the pool.
+						Economically, liquidation now moves debt first and only as far as is
+						needed to repair the target vault at the current price. The target’s
+						snapshot-derived unlocked vault REP claim stays with the target on
+						that repair path, so the caller vault is absorbing the under-backed
+						debt rather than extracting target REP. If the exact repair point
+						would leave a non-zero allowance below the pool’s minimum debt floor,
+						the cap rounds up to a full allowance transfer instead. REP
+						committed to escalation is never part of the liquidation transfer.
+						The receiving vault must remain solvent after taking on the moved
+						debt, and both sides must still satisfy the minimum deposit
+						requirements enforced by the pool.
+					</p>
+					<p>
+						For a focused walkthrough of the repair-cap math, chunking limits,
+						and incentive tradeoffs, see
+						<a href="./liquidation.html">Liquidation Design</a>.
 					</p>
 					<figure class="diagram" id="fig-placeholder-liquidation-transfer">
 						<svg
@@ -2032,12 +2043,13 @@
 							aria-labelledby="liquidation-transfer-title liquidation-transfer-desc"
 						>
 							<title id="liquidation-transfer-title">
-								Liquidation transfer proportions
+								Liquidation repair transfer
 							</title>
 							<desc id="liquidation-transfer-desc">
-								Liquidation caps moved debt to the target allowance and
-								transfers the corresponding proportional REP claim to the caller
-								vault.
+								Liquidation moves only the debt shortfall needed to repair the
+								target vault at the current price, leaves unlocked target REP in
+								place, and rounds up to a full debt transfer only when the repair
+								point would otherwise leave forbidden debt dust.
 							</desc>
 							<defs>
 								<marker
@@ -2074,16 +2086,11 @@
 								marker-end="url(#arrow-liquidation-transfer)"
 								d="M 304 118 H 610"
 							></path>
-							<path
-								class="svg-line"
-								marker-end="url(#arrow-liquidation-transfer)"
-								d="M 304 160 H 610"
-							></path>
 							<text class="svg-small" x="457" y="99" text-anchor="middle">
 								debtToMove
 							</text>
 							<text class="svg-small" x="457" y="184" text-anchor="middle">
-								matching REP claim
+								no REP moves on the repair path
 							</text>
 							<rect
 								class="svg-green"
@@ -2097,7 +2104,7 @@
 								Caller Vault
 							</text>
 							<text class="svg-small" x="735" y="140" text-anchor="middle">
-								takes debt and REP
+								takes debt
 							</text>
 							<text class="svg-small" x="735" y="164" text-anchor="middle">
 								must remain solvent
@@ -2111,25 +2118,66 @@
 								rx="10"
 							></rect>
 							<text class="svg-label" x="460" y="256" text-anchor="middle">
-								Transfer ratio = moved debt / target allowance
+								Repair cap = target debt shortfall at the execution price
 							</text>
 							<text class="svg-small" x="460" y="276" text-anchor="middle">
-								the same ratio is applied to the target REP claim
+								full transfer only when the repair point would leave debt dust
 							</text>
 						</svg>
 						<p class="diagram-caption">
 							<span class="figure-label">Liquidation Transfer</span>Liquidation
-							moves a capped slice of target allowance and the matching
-							proportional REP claim to the caller vault.
+							moves a capped slice of snapshot target allowance to the caller
+							vault and leaves the target vault’s unlocked REP in place on the
+							repair path.
 						</p>
 					</figure>
 					<div class="equation" id="eq-placeholder-liquidation-transfer">
 						<math
 							display="block"
-							aria-label="debt to move equals minimum of requested debt and target allowance, and REP to move equals debt to move times target REP divided by target allowance"
-							data-source="debtToMove = min(requestedDebt, targetAllowance); repToMove = debtToMove \cdot targetRep / targetAllowance"
+							aria-label="unsafe value numerator equals snapshot target allowance times security multiplier times current price minus snapshot target REP times price precision, repair debt cap equals the ceiling of unsafe value numerator divided by security multiplier times current price, debt to move equals the minimum of requested debt and the repair debt cap after dust rounding, and REP to move equals zero on the repair path"
+							data-source="unsafeValueNumerator = snapshotTargetAllowance \cdot securityMultiplier \cdot currentPrice - snapshotTargetRep \cdot PRICE_PRECISION; repairDebtCap = ceil(unsafeValueNumerator / (securityMultiplier \cdot currentPrice)); debtToMove = min(requestedDebt, maxDebtToMoveAfterDustRounding); repToMove = 0"
 						>
 							<mtable>
+								<mtr>
+									<mtd>
+										<mi>unsafeValueNumerator</mi>
+									</mtd>
+									<mtd>
+										<mo>=</mo>
+									</mtd>
+									<mtd>
+										<mi>snapshotTargetAllowance</mi>
+										<mo>&#x22C5;</mo>
+										<mi>securityMultiplier</mi>
+										<mo>&#x22C5;</mo>
+										<mi>currentPrice</mi>
+										<mo>-</mo>
+										<mi>snapshotTargetRep</mi>
+										<mo>&#x22C5;</mo>
+										<mi>PRICE_PRECISION</mi>
+									</mtd>
+								</mtr>
+								<mtr>
+									<mtd>
+										<mi>repairDebtCap</mi>
+									</mtd>
+									<mtd>
+										<mo>=</mo>
+									</mtd>
+									<mtd>
+										<mi>ceil</mi>
+										<mo>(</mo>
+										<mfrac>
+											<mi>unsafeValueNumerator</mi>
+											<mrow>
+												<mi>securityMultiplier</mi>
+												<mo>&#x22C5;</mo>
+												<mi>currentPrice</mi>
+											</mrow>
+										</mfrac>
+										<mo>)</mo>
+									</mtd>
+								</mtr>
 								<mtr>
 									<mtd>
 										<mi>debtToMove</mi>
@@ -2142,7 +2190,7 @@
 										<mo>(</mo>
 										<mi>requestedDebt</mi>
 										<mo>,</mo>
-										<mi>targetAllowance</mi>
+										<mi>maxDebtToMoveAfterDustRounding</mi>
 										<mo>)</mo>
 									</mtd>
 								</mtr>
@@ -2153,23 +2201,16 @@
 									<mtd>
 										<mo>=</mo>
 									</mtd>
-									<mtd>
-										<mfrac>
-											<mrow>
-												<mi>debtToMove</mi>
-												<mo>&#x22C5;</mo>
-												<mi>targetRep</mi>
-											</mrow>
-											<mi>targetAllowance</mi>
-										</mfrac>
-									</mtd>
+									<mtd><mn>0</mn></mtd>
 								</mtr>
 							</mtable>
 						</math>
 						<p class="equation-caption">
 							<span class="equation-label">Liquidation Transfer</span>The debt
-							transfer is capped by the target allowance, then REP ownership
-							moves in the same proportion as the debt slice.
+							transfer is capped at the minimum amount needed to repair the
+							target vault at the execution price, except when that repair point
+							would leave non-zero debt dust below the minimum allowance. The
+							repair path moves no REP.
 						</p>
 					</div>
 					<p>

--- a/solidity/contracts/peripherals/OpenOraclePriceCoordinator.sol
+++ b/solidity/contracts/peripherals/OpenOraclePriceCoordinator.sol
@@ -10,7 +10,6 @@ import { SecurityPoolUtils } from './SecurityPoolUtils.sol';
 // price oracle
 uint256 constant PRICE_VALID_FOR_SECONDS = 5 minutes;
 uint256 constant PRICE_PRECISION = 1e18;
-uint256 constant BPS_DENOMINATOR = 10000;
 uint256 constant MAX_OPERATION_VALID_FOR_SECONDS = 5 minutes;
 
 enum OperationType {
@@ -152,11 +151,11 @@ contract OpenOraclePriceCoordinator {
 		require(_escalationHaltMultiplierBps > 0, 'Escalation halt multiplier must be greater than zero');
 		escalationHaltMultiplierBps = _escalationHaltMultiplierBps;
 		require(
-			_maxSettlementBaseFeeMultiplierBps >= BPS_DENOMINATOR,
+			_maxSettlementBaseFeeMultiplierBps >= SecurityPoolUtils.BPS_DENOMINATOR,
 			'Max settlement base fee multiplier must be at least one hundred percent'
 		);
 		require(
-			_minLiquidationPriceDistanceBps <= BPS_DENOMINATOR,
+			_minLiquidationPriceDistanceBps <= SecurityPoolUtils.BPS_DENOMINATOR,
 			'Minimum liquidation price distance cannot exceed one hundred percent'
 		);
 		maxSettlementBaseFeeMultiplierBps = _maxSettlementBaseFeeMultiplierBps;
@@ -205,12 +204,13 @@ contract OpenOraclePriceCoordinator {
 
 	function _requestPrice(address sponsor, uint256 ethCost) private {
 		require(pendingReportId == 0, 'Oracle price request is already pending');
-		uint256 escalationHalt = (exactToken1Report * escalationHaltMultiplierBps) / BPS_DENOMINATOR;
+		uint256 escalationHalt = (exactToken1Report * escalationHaltMultiplierBps) / SecurityPoolUtils.BPS_DENOMINATOR;
 		uint256 settlerReward = block.basefee * 2 * gasConsumedOpenOracleReportPrice;
 		require(exactToken1Report <= type(uint128).max, 'Oracle exact token1 report amount exceeds uint128 maximum');
 		require(escalationHalt <= type(uint128).max, 'Oracle escalation halt amount exceeds uint128 maximum');
 		require(settlerReward <= type(uint96).max, 'Oracle settler reward exceeds uint96 maximum');
-		pendingReportMaxSettlementBaseFee = (block.basefee * maxSettlementBaseFeeMultiplierBps) / BPS_DENOMINATOR;
+		pendingReportMaxSettlementBaseFee =
+			(block.basefee * maxSettlementBaseFeeMultiplierBps) / SecurityPoolUtils.BPS_DENOMINATOR;
 
 		OpenOracle.CreateReportParams memory reportparams = OpenOracle.CreateReportParams({
 			exactToken1Report: uint128(exactToken1Report),
@@ -606,7 +606,9 @@ contract OpenOraclePriceCoordinator {
 		uint256 securityMultiplier = securityPool.securityMultiplier();
 		uint256 thresholdPrice = (vaultRep * PRICE_PRECISION) / (snapshotTargetAllowance * securityMultiplier);
 		if (currentPrice <= thresholdPrice) return false;
-		return ((currentPrice - thresholdPrice) * BPS_DENOMINATOR) / currentPrice >= minLiquidationPriceDistanceBps;
+		return
+			((currentPrice - thresholdPrice) * SecurityPoolUtils.BPS_DENOMINATOR) / currentPrice >=
+			minLiquidationPriceDistanceBps;
 	}
 
 	function _consumeStagedOperation(uint256 operationId) private {

--- a/solidity/contracts/peripherals/SecurityPool.sol
+++ b/solidity/contracts/peripherals/SecurityPool.sol
@@ -500,8 +500,9 @@ contract SecurityPool is ISecurityPool {
 	////////////////////////////////////////
 	//price = (amount1 * PRICE_PRECISION) / amount2;
 	// price = REP * PRICE_PRECISION / ETH
-	// liquidation moves share of debt and rep to another pool which need to remain non-liquidable
-	// this is currently very harsh, as we steal all the rep and debt from the pool
+	// Liquidation moves only the debt shortfall needed to repair solvency at the
+	// current price, unless clearing the shortfall would strand a forbidden dust
+	// allowance, in which case it moves the full remaining allowance.
 	function performLiquidation(
 		address callerVault,
 		address targetVaultAddress,
@@ -530,9 +531,21 @@ contract SecurityPool is ISecurityPool {
 			'Target vault not liquidatable'
 		);
 
-		uint256 debtToMove = debtAmount > snapshotTargetAllowance ? snapshotTargetAllowance : debtAmount;
+		uint256 unsafeValueNumerator =
+			(snapshotTargetAllowance * securityMultiplier * repEthPrice) -
+				(vaultsRepDeposit * SecurityPoolUtils.PRICE_PRECISION);
+		uint256 repairDebtToMove =
+			(unsafeValueNumerator + (securityMultiplier * repEthPrice) - 1) / (securityMultiplier * repEthPrice);
+		if (
+			snapshotTargetAllowance > repairDebtToMove &&
+			snapshotTargetAllowance - repairDebtToMove < SecurityPoolUtils.MIN_SECURITY_BOND_DEBT
+		) {
+			repairDebtToMove = snapshotTargetAllowance;
+		}
+		uint256 maxDebtToMove = repairDebtToMove > snapshotTargetAllowance ? snapshotTargetAllowance : repairDebtToMove;
+		uint256 debtToMove = debtAmount > maxDebtToMove ? maxDebtToMove : debtAmount;
 		require(debtToMove > 0, 'No debt to liquidate');
-		uint256 repToMove = (debtToMove * vaultsRepDeposit) / snapshotTargetAllowance;
+		uint256 repToMove = 0;
 		uint256 ownershipToMove = repToPoolOwnership(repToMove);
 		require(
 			(securityVaults[callerVault].securityBondAllowance + debtToMove) * securityMultiplier * repEthPrice <=
@@ -550,7 +563,8 @@ contract SecurityPool is ISecurityPool {
 		// target vault needs to be above thresholds after liquidation
 		_requireMinimumVaultRep(
 			poolOwnershipToRep(securityVaults[targetVaultAddress].poolOwnership),
-			securityVaults[targetVaultAddress].poolOwnership == 0,
+			securityVaults[targetVaultAddress].poolOwnership == 0 &&
+				securityVaults[targetVaultAddress].securityBondAllowance == 0,
 			'Target vault REP below minimum'
 		);
 		_requireMinimumSecurityBondAllowance(

--- a/solidity/contracts/peripherals/SecurityPoolUtils.sol
+++ b/solidity/contracts/peripherals/SecurityPoolUtils.sol
@@ -7,6 +7,7 @@ library SecurityPoolUtils {
 
 	// fees
 	uint256 constant PRICE_PRECISION = 1e18;
+	uint256 constant BPS_DENOMINATOR = 10_000;
 
 	uint256 constant MAX_RETENTION_RATE = 999_999_996_848_000_000; // ≈90% yearly (10% fees)
 	uint256 constant MIN_RETENTION_RATE = 999_999_977_880_000_000; // ≈50% yearly (50% fees)

--- a/solidity/ts/tests/peripherals/forkMigration.test.ts
+++ b/solidity/ts/tests/peripherals/forkMigration.test.ts
@@ -252,11 +252,10 @@ describe('Peripherals: fork migration', () => {
 
 			const originalVault = await getSecurityVault(client, securityPoolAddresses.securityPool, client.account.address)
 			const liquidatorVault = await getSecurityVault(client, securityPoolAddresses.securityPool, liquidatorClient.account.address)
-			const expectedRepMoved = (liquidationAmount * repDeposit) / securityPoolAllowance
 			strictEqualTypeSafe(originalVault.securityBondAllowance, securityPoolAllowance - liquidationAmount, 'original vault should keep only the non-liquidated security bonds')
-			strictEqualTypeSafe(originalVault.repDepositShare / PRICE_PRECISION, repDeposit - expectedRepMoved, 'original vault should keep the non-liquidated REP')
+			strictEqualTypeSafe(originalVault.repDepositShare / PRICE_PRECISION, repDeposit, 'repair liquidation should leave the targets REP in place')
 			strictEqualTypeSafe(liquidatorVault.securityBondAllowance, liquidationAmount, "liquidator doesn't have the liquidated security pool allowance")
-			strictEqualTypeSafe(liquidatorVault.repDepositShare / PRICE_PRECISION, repDeposit * 10n + expectedRepMoved, 'liquidator should receive the liquidated REP')
+			strictEqualTypeSafe(liquidatorVault.repDepositShare / PRICE_PRECISION, repDeposit * 10n, 'repair liquidation should not transfer REP to the liquidator')
 		})
 
 		test('liquidation should use snapshot to prevent blocking via additional rep deposit', async () => {
@@ -281,7 +280,6 @@ describe('Peripherals: fork migration', () => {
 			// Snapshot state before attack (just before queuing liquidation)
 			const vaultBefore = await getSecurityVault(client, securityPoolAddresses.securityPool, client.account.address)
 			const snapshotTargetOwnership = vaultBefore.repDepositShare
-			const snapshotTargetAllowance = vaultBefore.securityBondAllowance
 			const snapshotTotalRep = await getTotalRepBalance(client, securityPoolAddresses.securityPool)
 			const snapshotDenominator = await getPoolOwnershipDenominator(client, securityPoolAddresses.securityPool)
 
@@ -315,26 +313,109 @@ describe('Peripherals: fork migration', () => {
 
 			strictEqualTypeSafe(targetVaultAfter.securityBondAllowance, securityPoolAllowance - liquidationAmount, 'target security bond allowance should decrease by the liquidated amount')
 
-			// Compute expected changes based on snapshot
-			const debtToMove = liquidationAmount
-			const effectiveDebtToMove = debtToMove < snapshotTargetAllowance ? debtToMove : snapshotTargetAllowance
-			const repToMove = (effectiveDebtToMove * snapshotExpectedRepDeposit) / snapshotTargetAllowance
-			const ownershipToMove = (repToMove * denominatorAfter) / totalRepAfter
-
-			// The target's ownership should decrease by approximately ownershipToMove
 			const targetOwnershipChange = afterDepositOwnership - targetVaultAfter.repDepositShare
-			approximatelyEqual(targetOwnershipChange, ownershipToMove, 1n, 'Target ownership decrease should match ownershipToMove')
-
-			// The liquidator's ownership should increase by the same amount
 			const liquidatorOwnershipChange = liquidatorVaultAfter.repDepositShare - liquidatorBeforeOwnership
-			approximatelyEqual(liquidatorOwnershipChange, ownershipToMove, 1n, 'Liquidator ownership increase should match ownershipToMove')
 
-			// Verify that the REP amount taken (repToMove) matches the reduction in target's claim
-			const claimReduction = (targetOwnershipChange * totalRepAfter) / denominatorAfter
-			approximatelyEqual(claimReduction, repToMove, 1n, 'Claim reduction should equal repToMove')
+			strictEqualTypeSafe(targetOwnershipChange, 0n, 'repair liquidation should not reduce the targets ownership')
+			strictEqualTypeSafe(liquidatorOwnershipChange, 0n, 'repair liquidation should not increase the liquidators ownership')
+			approximatelyEqual(snapshotExpectedRepDeposit, repDeposit, 1n, 'the snapshot claim should still match the original REP deposit before the attack deposit')
+			approximatelyEqual(totalRepAfter, repDeposit * 16n, 1n, 'the pool REP balance should include the additional attack deposit')
+			approximatelyEqual(denominatorAfter, PRICE_PRECISION * repDeposit * 16n, 1n, 'ownership denominator should reflect the additional attack deposit')
 		})
 
-		test('liquidation only moves REP that is not committed to escalation', async () => {
+		test('max repair liquidation only needs one execution at a fixed price', async () => {
+			const endTime = await getQuestionEndDate(client, questionId)
+			await mockWindow.setTime(endTime + 10000n)
+			const securityPoolAllowance = 75n * 10n ** 18n
+			await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, securityPoolAllowance)
+
+			const liquidatorClient = createWriteClient(mockWindow, TEST_ADDRESSES[1], 0)
+			await approveToken(liquidatorClient, addressString(GENESIS_REPUTATION_TOKEN), securityPoolAddresses.securityPool)
+			await depositRep(liquidatorClient, securityPoolAddresses.securityPool, repDeposit * 2n)
+			await mockWindow.advanceTime(100000n)
+
+			const targetVaultBefore = await getSecurityVault(client, securityPoolAddresses.securityPool, client.account.address)
+			const liquidatorVaultBefore = await getSecurityVault(client, securityPoolAddresses.securityPool, liquidatorClient.account.address)
+			const targetClaimBefore = await getVaultRepClaim(client.account.address)
+			const liquidationAmount = securityPoolAllowance
+
+			await requestPriceIfNeededAndStageOperation(liquidatorClient, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.Liquidation, client.account.address, liquidationAmount)
+			await handleOracleReporting(liquidatorClient, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, PRICE_PRECISION * 10n)
+
+			const targetVaultAfterFirstLiquidation = await getSecurityVault(client, securityPoolAddresses.securityPool, client.account.address)
+			const liquidatorVaultAfterFirstLiquidation = await getSecurityVault(client, securityPoolAddresses.securityPool, liquidatorClient.account.address)
+			const targetClaimAfterFirstLiquidation = await getVaultRepClaim(client.account.address)
+
+			strictEqualTypeSafe(targetVaultAfterFirstLiquidation.securityBondAllowance, 50n * 10n ** 18n, 'max repair liquidation should only move the debt shortfall needed to restore solvency')
+			strictEqualTypeSafe(targetVaultAfterFirstLiquidation.repDepositShare, targetVaultBefore.repDepositShare, 'max repair liquidation should leave target ownership unchanged')
+			strictEqualTypeSafe(liquidatorVaultAfterFirstLiquidation.securityBondAllowance, liquidatorVaultBefore.securityBondAllowance + 25n * 10n ** 18n, 'the liquidator should only absorb the repair debt amount')
+			strictEqualTypeSafe(targetClaimAfterFirstLiquidation, targetClaimBefore, 'repair liquidation should leave the target REP claim unchanged')
+
+			await requestPriceIfNeededAndStageOperation(liquidatorClient, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.Liquidation, client.account.address, liquidationAmount)
+			await handleOracleReporting(liquidatorClient, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, PRICE_PRECISION * 10n)
+
+			const targetVaultAfterSecondLiquidation = await getSecurityVault(client, securityPoolAddresses.securityPool, client.account.address)
+			const liquidatorVaultAfterSecondLiquidation = await getSecurityVault(client, securityPoolAddresses.securityPool, liquidatorClient.account.address)
+
+			strictEqualTypeSafe(targetVaultAfterSecondLiquidation.securityBondAllowance, targetVaultAfterFirstLiquidation.securityBondAllowance, 'once repaired, the vault should not change under the same price')
+			strictEqualTypeSafe(targetVaultAfterSecondLiquidation.repDepositShare, targetVaultAfterFirstLiquidation.repDepositShare, 'a second same-price liquidation should not move REP')
+			strictEqualTypeSafe(liquidatorVaultAfterSecondLiquidation.securityBondAllowance, liquidatorVaultAfterFirstLiquidation.securityBondAllowance, 'a second same-price liquidation should not move more debt')
+		})
+
+		test('repair liquidation rounds up to the full allowance when the exact repair leaves debt dust', async () => {
+			const endTime = await getQuestionEndDate(client, questionId)
+			await mockWindow.setTime(endTime + 10000n)
+			const securityPoolAllowance = 14n * 10n ** 17n
+			await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, securityPoolAllowance)
+
+			const liquidatorClient = createWriteClient(mockWindow, TEST_ADDRESSES[1], 0)
+			await approveToken(liquidatorClient, addressString(GENESIS_REPUTATION_TOKEN), securityPoolAddresses.securityPool)
+			await depositRep(liquidatorClient, securityPoolAddresses.securityPool, repDeposit * 10n)
+
+			const targetVaultBefore = await getSecurityVault(client, securityPoolAddresses.securityPool, client.account.address)
+			const liquidationAmount = securityPoolAllowance
+			const dustRoundingPrice = PRICE_PRECISION * 1000n
+
+			await manipulatePriceOracle(liquidatorClient, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, dustRoundingPrice)
+			await requestPriceIfNeededAndStageOperation(liquidatorClient, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.Liquidation, client.account.address, liquidationAmount)
+
+			const targetVaultAfter = await getSecurityVault(client, securityPoolAddresses.securityPool, client.account.address)
+			const liquidatorVaultAfter = await getSecurityVault(client, securityPoolAddresses.securityPool, liquidatorClient.account.address)
+
+			strictEqualTypeSafe(targetVaultBefore.securityBondAllowance, securityPoolAllowance, 'setup should leave the target at the configured allowance')
+			strictEqualTypeSafe(targetVaultAfter.securityBondAllowance, 0n, 'dust rounding should clear the full allowance instead of leaving forbidden dust')
+			strictEqualTypeSafe(targetVaultAfter.repDepositShare, targetVaultBefore.repDepositShare, 'dust-rounded repair liquidation should still leave the target REP claim in place')
+			strictEqualTypeSafe(liquidatorVaultAfter.securityBondAllowance, securityPoolAllowance, 'the liquidator should absorb the full allowance when dust rounding escalates to a full liquidation')
+		})
+
+		test('repair liquidation leaves state unchanged when a smaller chunk would leave forbidden debt dust', async () => {
+			const endTime = await getQuestionEndDate(client, questionId)
+			await mockWindow.setTime(endTime + 10000n)
+			const securityPoolAllowance = 14n * 10n ** 17n
+			await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, securityPoolAllowance)
+
+			const liquidatorClient = createWriteClient(mockWindow, TEST_ADDRESSES[1], 0)
+			await approveToken(liquidatorClient, addressString(GENESIS_REPUTATION_TOKEN), securityPoolAddresses.securityPool)
+			await depositRep(liquidatorClient, securityPoolAddresses.securityPool, repDeposit * 10n)
+
+			const targetVaultBefore = await getSecurityVault(client, securityPoolAddresses.securityPool, client.account.address)
+			const liquidatorVaultBefore = await getSecurityVault(client, securityPoolAddresses.securityPool, liquidatorClient.account.address)
+			const dustRevertingAmount = 8n * 10n ** 17n
+			const dustRoundingPrice = PRICE_PRECISION * 1000n
+
+			await manipulatePriceOracle(liquidatorClient, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, dustRoundingPrice)
+			await requestPriceIfNeededAndStageOperation(liquidatorClient, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.Liquidation, client.account.address, dustRevertingAmount)
+
+			const targetVaultAfter = await getSecurityVault(client, securityPoolAddresses.securityPool, client.account.address)
+			const liquidatorVaultAfter = await getSecurityVault(client, securityPoolAddresses.securityPool, liquidatorClient.account.address)
+
+			strictEqualTypeSafe(targetVaultAfter.securityBondAllowance, targetVaultBefore.securityBondAllowance, 'a dust-reverting liquidation should leave the target allowance unchanged')
+			strictEqualTypeSafe(targetVaultAfter.repDepositShare, targetVaultBefore.repDepositShare, 'a dust-reverting liquidation should leave the target REP claim unchanged')
+			strictEqualTypeSafe(liquidatorVaultAfter.securityBondAllowance, liquidatorVaultBefore.securityBondAllowance, 'a dust-reverting liquidation should not move debt to the liquidator')
+			strictEqualTypeSafe(liquidatorVaultAfter.repDepositShare, liquidatorVaultBefore.repDepositShare, 'a dust-reverting liquidation should not move REP to the liquidator')
+		})
+
+		test('liquidation repairs unlocked-vault shortfall without moving REP committed to escalation', async () => {
 			const securityPoolAllowance = 200n * 10n ** 18n
 			await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, securityPoolAllowance)
 
@@ -367,10 +448,10 @@ describe('Peripherals: fork migration', () => {
 			const liquidatorClaimAfterLiquidation = await getVaultRepClaim(liquidatorClient.account.address)
 
 			strictEqualTypeSafe(targetVaultAfterLiquidation.repInEscalationGame, lockedDeposit, 'liquidation should leave the targets escalation commitment untouched')
-			strictEqualTypeSafe(targetVaultAfterLiquidation.securityBondAllowance, 0n, 'liquidation should only move the debt backed by unlocked REP')
-			strictEqualTypeSafe(targetClaimAfterLiquidation, 0n, 'liquidation should leave the target with only the REP committed to escalation')
-			strictEqualTypeSafe(liquidatorVaultAfterLiquidation.securityBondAllowance, securityPoolAllowance, 'the liquidator should absorb only the debt backed by unlocked REP')
-			strictEqualTypeSafe(liquidatorClaimAfterLiquidation, repDeposit * 2n + (repDeposit - lockedDeposit), 'the liquidator should receive only the targets unlocked REP claim')
+			strictEqualTypeSafe(targetVaultAfterLiquidation.securityBondAllowance, 150n * 10n ** 18n, 'liquidation should move only the unlocked-vault debt shortfall needed to repair solvency')
+			strictEqualTypeSafe(targetClaimAfterLiquidation, repDeposit - lockedDeposit, 'repair liquidation should leave the unlocked vault REP claim in place')
+			strictEqualTypeSafe(liquidatorVaultAfterLiquidation.securityBondAllowance, 50n * 10n ** 18n, 'the liquidator should absorb only the repair debt amount')
+			strictEqualTypeSafe(liquidatorClaimAfterLiquidation, repDeposit * 2n, 'repair liquidation should not transfer unlocked vault REP to the liquidator')
 		})
 
 		test('locking REP in escalation preserves total collateral claims and only reduces the lockers withdrawable balance', async () => {

--- a/solidity/ts/tests/peripherals/truthAuction.test.ts
+++ b/solidity/ts/tests/peripherals/truthAuction.test.ts
@@ -1201,10 +1201,12 @@ describe('Peripherals: truth auction', () => {
 				throw new Error(`pre-claim liquidation did not reduce allowance; coordinator results=${executionReasons.join('|')}`)
 			}
 
-			strictEqualTypeSafe(targetVaultAfterLiquidation.securityBondAllowance, targetVaultBeforeLiquidation.securityBondAllowance - liquidationChunk, 'partial liquidation before claim should reduce the migrated vault allowance by the executed chunk')
-			assert.ok(targetRepAfterLiquidation < targetRepBeforeLiquidation, 'partial liquidation before claim should reduce the migrated vault REP')
-			assert.ok(liquidatorVaultAfterLiquidation.repDepositShare > liquidatorVaultBeforeLiquidation.repDepositShare, 'the liquidator should absorb the migrated vault ownership')
-			strictEqualTypeSafe(liquidatorVaultAfterLiquidation.securityBondAllowance, liquidatorVaultBeforeLiquidation.securityBondAllowance + liquidationChunk, 'the liquidator should absorb the liquidated allowance chunk')
+			const actualDebtMoved = targetVaultBeforeLiquidation.securityBondAllowance - targetVaultAfterLiquidation.securityBondAllowance
+
+			strictEqualTypeSafe(actualDebtMoved > 0n, true, 'partial liquidation before claim should reduce the migrated vault allowance')
+			strictEqualTypeSafe(targetRepAfterLiquidation, targetRepBeforeLiquidation, 'repair liquidation should leave the migrated vault REP in place before claim')
+			strictEqualTypeSafe(liquidatorVaultAfterLiquidation.repDepositShare, liquidatorVaultBeforeLiquidation.repDepositShare, 'repair liquidation should not transfer the migrated vault ownership')
+			strictEqualTypeSafe(liquidatorVaultAfterLiquidation.securityBondAllowance, liquidatorVaultBeforeLiquidation.securityBondAllowance + actualDebtMoved, 'the liquidator should absorb the executed allowance reduction')
 
 			const childCollateralAfterLiquidation = await getCompleteSetCollateralAmount(client, yesSecurityPool.securityPool)
 			const childAllowanceAfterLiquidation = await getTotalSecurityBondAllowance(client, yesSecurityPool.securityPool)

--- a/ui/ts/components/LiquidationModal.tsx
+++ b/ui/ts/components/LiquidationModal.tsx
@@ -19,7 +19,7 @@ import { sameAddress } from '../lib/address.js'
 import { pickFirstReason } from '../lib/actionAvailability.js'
 import { useChainTimestamp } from '../lib/chainTimestamp.js'
 import { formatCurrencyInputBalance, formatDuration } from '../lib/formatters.js'
-import { getLiquidationFailureReason, simulateLiquidation } from '../lib/liquidation.js'
+import { getDeterministicLiquidationFailureReason, getLiquidationFailureReason, getMaxLiquidationAmount, simulateLiquidation } from '../lib/liquidation.js'
 import { tryParseBigIntInput, tryParseRepAmountInput } from '../lib/marketForm.js'
 import { getOracleRequestEthGuardMessage, resolveOracleOperationEthFunding } from '../lib/oracleRequestEth.js'
 import { getRepPriceSourceCopy, renderRepPriceSourceLabel, type RepPriceSource } from '../lib/repPriceSource.js'
@@ -201,6 +201,7 @@ export function LiquidationModal({
 	const repPriceSourceCopy = getRepPriceSourceCopy(repPerEthSource)
 	const liquidationExecutionMode = getLiquidationExecutionMode(currentPoolOracleManagerDetails)
 	const buttonLabels = getLiquidationButtonLabels(currentPoolOracleManagerDetails)
+	const hasUsableOraclePrice = currentPoolOracleManagerDetails !== undefined && isOracleManagerPriceUsable(currentPoolOracleManagerDetails)
 	const trimmedLiquidationTargetVault = liquidationTargetVault.trim()
 	const liquidationTimeoutDisplayValue = liquidationTimeoutMinutes === '' ? '' : liquidationTimeoutMinutes
 	const liquidationTimeoutSeconds = getStagedOperationTimeoutSeconds(tryParseBigIntInput(liquidationTimeoutDisplayValue))
@@ -213,8 +214,21 @@ export function LiquidationModal({
 					callerVaultSummary,
 					liquidationAmount: liquidationAmountValue,
 					repPerEthPrice: poolOraclePrice,
+					securityMultiplier: selectedPool.securityMultiplier,
 					targetVaultSummary,
 				})
+	const computedLiquidationMaxAmount = getMaxLiquidationAmount({
+		repPerEthPrice: poolOraclePrice,
+		securityMultiplier: selectedPool?.securityMultiplier,
+		targetVaultSummary,
+	})
+	const liquidationMaxActionAmount = hasUsableOraclePrice ? (computedLiquidationMaxAmount ?? liquidationMaxAmount) : liquidationMaxAmount
+	const deterministicLiquidationReason = getDeterministicLiquidationFailureReason({
+		callerVaultSummary,
+		liquidationAmount: liquidationAmountValue,
+		maxDebtToMove: hasUsableOraclePrice && computedLiquidationMaxAmount !== undefined && computedLiquidationMaxAmount > 0n ? computedLiquidationMaxAmount : undefined,
+		targetVaultSummary,
+	})
 	const directLiquidationReason = (() => {
 		if (liquidationExecutionMode !== 'execute') return undefined
 		if (selectedPool?.securityMultiplier === undefined) return UI_STRINGS.liquidationModal.reloadPoolBeforeExecutingReason
@@ -250,6 +264,7 @@ export function LiquidationModal({
 		sameVaultWarning,
 		liquidationAmount.trim() === '' ? UI_STRINGS.liquidationModal.enterLiquidationAmountReason : undefined,
 		liquidationExecutionMode === 'queue' && liquidationTimeoutSeconds === undefined ? UI_STRINGS.liquidationModal.enterLiquidationTimeoutReason : undefined,
+		deterministicLiquidationReason,
 		directLiquidationReason,
 		queueLiquidationEthGuardMessage,
 	)
@@ -369,7 +384,7 @@ export function LiquidationModal({
 						<span>{UI_STRINGS.liquidationModal.liquidationAmountLabel}</span>
 						<div className='field-inline'>
 							<FormInput className='field-inline-input' value={liquidationAmount} onInput={event => onLiquidationAmountChange(event.currentTarget.value)} placeholder={UI_STRINGS.liquidationModal.liquidationAmountPlaceholder} />
-							<button className='quiet field-inline-action' type='button' onClick={() => onLiquidationAmountChange(liquidationMaxAmount === undefined ? '' : formatCurrencyInputBalance(liquidationMaxAmount))} disabled={liquidationMaxAmount === undefined || liquidationMaxAmount <= 0n}>
+							<button className='quiet field-inline-action' type='button' onClick={() => onLiquidationAmountChange(liquidationMaxActionAmount === undefined ? '' : formatCurrencyInputBalance(liquidationMaxActionAmount))} disabled={liquidationMaxActionAmount === undefined || liquidationMaxActionAmount <= 0n}>
 								{UI_STRINGS.common.maxLabel}
 							</button>
 						</div>

--- a/ui/ts/lib/liquidation.ts
+++ b/ui/ts/lib/liquidation.ts
@@ -5,9 +5,28 @@ const PRICE_PRECISION = 10n ** 18n
 const MIN_SECURITY_BOND_DEBT = 1n * 10n ** 18n
 const MIN_REP_DEPOSIT = 10n * 10n ** 18n
 
+function ceilDiv(numerator: bigint, denominator: bigint) {
+	return (numerator + denominator - 1n) / denominator
+}
+
 function isVaultLiquidatable(lastPrice: bigint | undefined, securityBondAllowance: bigint | undefined, repDepositShare: bigint | undefined, securityMultiplier: bigint | undefined) {
 	if (lastPrice === undefined || securityBondAllowance === undefined || repDepositShare === undefined || securityMultiplier === undefined) return false
 	return securityBondAllowance * lastPrice * securityMultiplier > repDepositShare * PRICE_PRECISION
+}
+
+export function getMaxLiquidationAmount({ repPerEthPrice, securityMultiplier, targetVaultSummary }: { repPerEthPrice: bigint | undefined; securityMultiplier: bigint | undefined; targetVaultSummary: SecurityPoolVaultSummary | undefined }) {
+	if (repPerEthPrice === undefined || securityMultiplier === undefined || targetVaultSummary === undefined) return undefined
+	if (repPerEthPrice <= 0n || securityMultiplier <= 0n) return 0n
+	const targetRepDeposit = targetVaultSummary.repDepositShare
+	const targetAllowance = targetVaultSummary.securityBondAllowance
+	if (targetAllowance === 0n) return 0n
+	const shortfallNumerator = targetAllowance * repPerEthPrice * securityMultiplier - targetRepDeposit * PRICE_PRECISION
+	if (shortfallNumerator <= 0n) return 0n
+	let maxDebtToMove = ceilDiv(shortfallNumerator, repPerEthPrice * securityMultiplier)
+	if (maxDebtToMove > targetAllowance) maxDebtToMove = targetAllowance
+	const remainingAllowance = targetAllowance - maxDebtToMove
+	if (remainingAllowance !== 0n && remainingAllowance < MIN_SECURITY_BOND_DEBT) return targetAllowance
+	return maxDebtToMove
 }
 
 type LiquidationSimulation = {
@@ -33,14 +52,31 @@ type LiquidationSimulation = {
 	}
 }
 
-export function simulateLiquidation({ callerVaultSummary, liquidationAmount, repPerEthPrice, targetVaultSummary }: { callerVaultSummary: SecurityPoolVaultSummary | undefined; liquidationAmount: bigint; repPerEthPrice: bigint; targetVaultSummary: SecurityPoolVaultSummary }): LiquidationSimulation {
+export function simulateLiquidation({
+	callerVaultSummary,
+	liquidationAmount,
+	repPerEthPrice,
+	securityMultiplier,
+	targetVaultSummary,
+}: {
+	callerVaultSummary: SecurityPoolVaultSummary | undefined
+	liquidationAmount: bigint
+	repPerEthPrice: bigint
+	securityMultiplier: bigint
+	targetVaultSummary: SecurityPoolVaultSummary
+}): LiquidationSimulation {
 	const callerRepDeposit = callerVaultSummary?.repDepositShare ?? 0n
 	const callerAllowance = callerVaultSummary?.securityBondAllowance ?? 0n
 	const targetRepDeposit = targetVaultSummary.repDepositShare
 	const targetAllowance = targetVaultSummary.securityBondAllowance
-	const maxDebtToMove = targetAllowance
+	const maxDebtToMove =
+		getMaxLiquidationAmount({
+			repPerEthPrice,
+			securityMultiplier,
+			targetVaultSummary,
+		}) ?? targetAllowance
 	const debtToMove = liquidationAmount < maxDebtToMove ? liquidationAmount : maxDebtToMove
-	const repToMove = targetAllowance === 0n ? 0n : (debtToMove * targetRepDeposit) / targetAllowance
+	const repToMove = 0n
 	const targetAfterRepDeposit = targetRepDeposit - repToMove
 	const targetAfterAllowance = targetAllowance - debtToMove
 	const callerAfterRepDeposit = callerRepDeposit + repToMove
@@ -70,6 +106,35 @@ export function simulateLiquidation({ callerVaultSummary, liquidationAmount, rep
 	}
 }
 
+export function getDeterministicLiquidationFailureReason({
+	callerVaultSummary,
+	liquidationAmount,
+	maxDebtToMove,
+	targetVaultSummary,
+}: {
+	callerVaultSummary: SecurityPoolVaultSummary | undefined
+	liquidationAmount: bigint | undefined
+	maxDebtToMove?: bigint | undefined
+	targetVaultSummary: SecurityPoolVaultSummary | undefined
+}) {
+	if (liquidationAmount === undefined) return 'Enter a valid liquidation amount.'
+	if (liquidationAmount <= 0n) return 'Enter a liquidation amount greater than zero.'
+	if (targetVaultSummary === undefined) return 'Reload the target vault before executing liquidation.'
+	if (targetVaultSummary.securityBondAllowance === 0n) return 'This vault has no active security bond allowance to liquidate.'
+	const targetMaxDebtToMove = maxDebtToMove === undefined || maxDebtToMove > targetVaultSummary.securityBondAllowance ? targetVaultSummary.securityBondAllowance : maxDebtToMove
+	const debtToMove = liquidationAmount < targetMaxDebtToMove ? liquidationAmount : targetMaxDebtToMove
+	if (debtToMove <= 0n) return 'This vault has no debt available to move.'
+	const targetAfterAllowance = targetVaultSummary.securityBondAllowance - debtToMove
+	const callerAfterRepDeposit = callerVaultSummary?.repDepositShare ?? 0n
+	const callerAfterAllowance = (callerVaultSummary?.securityBondAllowance ?? 0n) + debtToMove
+	if (targetVaultSummary.repDepositShare === 0n && targetAfterAllowance !== 0n) return 'The target vault would fall below the minimum REP collateral after liquidation.'
+	if (targetVaultSummary.repDepositShare !== 0n && targetVaultSummary.repDepositShare < MIN_REP_DEPOSIT) return 'The target vault would fall below the minimum REP collateral after liquidation.'
+	if (targetAfterAllowance !== 0n && targetAfterAllowance < MIN_SECURITY_BOND_DEBT) return 'The target vault would fall below the minimum security bond allowance after liquidation.'
+	if (callerAfterRepDeposit < MIN_REP_DEPOSIT) return 'The caller vault would remain below the minimum REP collateral after liquidation.'
+	if (callerAfterAllowance < MIN_SECURITY_BOND_DEBT) return 'The caller vault would remain below the minimum security bond allowance after liquidation.'
+	return undefined
+}
+
 export function getLiquidationFailureReason({
 	callerVaultSummary,
 	liquidationAmount,
@@ -83,27 +148,35 @@ export function getLiquidationFailureReason({
 	securityMultiplier: bigint | undefined
 	targetVaultSummary: SecurityPoolVaultSummary | undefined
 }) {
+	const deterministicFailureReason = getDeterministicLiquidationFailureReason({
+		callerVaultSummary,
+		liquidationAmount,
+		maxDebtToMove: (() => {
+			const computedMaxDebtToMove = getMaxLiquidationAmount({
+				repPerEthPrice,
+				securityMultiplier,
+				targetVaultSummary,
+			})
+			return computedMaxDebtToMove === undefined || computedMaxDebtToMove <= 0n ? undefined : computedMaxDebtToMove
+		})(),
+		targetVaultSummary,
+	})
+	if (deterministicFailureReason !== undefined) return deterministicFailureReason
 	if (liquidationAmount === undefined) return 'Enter a valid liquidation amount.'
-	if (liquidationAmount <= 0n) return 'Enter a liquidation amount greater than zero.'
-	if (targetVaultSummary === undefined) return 'Reload the target vault before executing liquidation.'
 	if (repPerEthPrice === undefined || securityMultiplier === undefined) return 'Refresh the Open Oracle before executing liquidation.'
-	if (targetVaultSummary.securityBondAllowance === 0n) return 'This vault has no active security bond allowance to liquidate.'
+	if (targetVaultSummary === undefined) return 'Reload the target vault before executing liquidation.'
 	if (!isVaultLiquidatable(repPerEthPrice, targetVaultSummary.securityBondAllowance, targetVaultSummary.repDepositShare, securityMultiplier)) return 'This vault is not undercollateralized at the current Open Oracle price.'
 
 	const simulation = simulateLiquidation({
 		callerVaultSummary,
 		liquidationAmount,
 		repPerEthPrice,
+		securityMultiplier,
 		targetVaultSummary,
 	})
-	if (simulation.debtToMove <= 0n) return 'This vault has no debt available to move.'
 	if (isVaultLiquidatable(repPerEthPrice, simulation.callerAfter.securityBondAllowance, simulation.callerAfter.repDepositShare, securityMultiplier)) {
 		if (isVaultLiquidatable(repPerEthPrice, simulation.callerBefore.securityBondAllowance, simulation.callerBefore.repDepositShare, securityMultiplier)) return 'The caller vault would remain liquidatable after this liquidation.'
 		return 'The caller vault would become liquidatable after this liquidation.'
 	}
-	if (simulation.targetAfter.repDepositShare !== 0n && simulation.targetAfter.repDepositShare < MIN_REP_DEPOSIT) return 'The target vault would fall below the minimum REP collateral after liquidation.'
-	if (simulation.targetAfter.securityBondAllowance !== 0n && simulation.targetAfter.securityBondAllowance < MIN_SECURITY_BOND_DEBT) return 'The target vault would fall below the minimum security bond allowance after liquidation.'
-	if (simulation.callerAfter.repDepositShare < MIN_REP_DEPOSIT) return 'The caller vault would remain below the minimum REP collateral after liquidation.'
-	if (simulation.callerAfter.securityBondAllowance < MIN_SECURITY_BOND_DEBT) return 'The caller vault would remain below the minimum security bond allowance after liquidation.'
 	return undefined
 }

--- a/ui/ts/tests/liquidationModal.test.tsx
+++ b/ui/ts/tests/liquidationModal.test.tsx
@@ -640,15 +640,85 @@ describe('LiquidationModal', () => {
 
 	test('disables queued liquidation when the wallet lacks the buffered oracle bounty ETH', async () => {
 		const renderedComponent = await renderLiquidationModal({
+			callerVaultSummary: createTargetVaultSummary({
+				repDepositShare: 100n * 10n ** 18n,
+				securityBondAllowance: 0n,
+				vaultAddress: defaultCallerVaultAddress,
+			}),
 			currentPoolOracleManagerDetails: createOracleManagerDetails({
 				isPriceValid: false,
 				requestPriceEthCost: 10n * ETH,
+			}),
+			targetVaultSummary: createTargetVaultSummary({
+				repDepositShare: 100n * 10n ** 18n,
+				securityBondAllowance: 100n * 10n ** 18n,
 			}),
 			walletEthBalance: 5n * ETH,
 		})
 		cleanupRenderedComponent = renderedComponent.cleanup
 
 		expectTransactionButtonDisabled(document.body, 'Queue Liquidation', 'Need 7 more ETH in this wallet to queue liquidation.')
+	})
+
+	test('allows queued liquidation when the entered amount exceeds the repair cap because execution will clamp it', async () => {
+		const callerVaultAddress = getAddress('0x0000000000000000000000000000000000000001')
+		const renderedComponent = await renderLiquidationModal({
+			accountAddress: callerVaultAddress,
+			currentPoolOracleManagerDetails: createOracleManagerDetails({
+				isPriceValid: false,
+			}),
+			liquidationAmount: '100',
+			selectedPool: createSelectedPool({
+				securityMultiplier: 2n,
+			}),
+			callerVaultSummary: createTargetVaultSummary({
+				repDepositShare: 2_000n * 10n ** 18n,
+				securityBondAllowance: 0n,
+				vaultAddress: callerVaultAddress,
+			}),
+			targetVaultSummary: createTargetVaultSummary({
+				repDepositShare: 100n * 10n ** 18n,
+				securityBondAllowance: 100n * 10n ** 18n,
+			}),
+			walletEthBalance: 100n * ETH,
+		})
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const queueButton = within(document.body).getByRole('button', { name: 'Queue Liquidation' }) as HTMLButtonElement
+		expect(queueButton.disabled).toBe(false)
+	})
+
+	test('uses the full queued allowance for Max when the current oracle price is stale', async () => {
+		const amountChanges: string[] = []
+		const renderedComponent = await renderLiquidationModal({
+			currentPoolOracleManagerDetails: createOracleManagerDetails({
+				isPriceValid: false,
+				lastPrice: 10n * 10n ** 18n,
+			}),
+			liquidationAmount: '1',
+			liquidationMaxAmount: 100n * 10n ** 18n,
+			onLiquidationAmountChange: value => {
+				amountChanges.push(value)
+			},
+			selectedPool: createSelectedPool({
+				lastOraclePrice: 10n * 10n ** 18n,
+				securityMultiplier: 2n,
+			}),
+			targetVaultSummary: createTargetVaultSummary({
+				repDepositShare: 100n * 10n ** 18n,
+				securityBondAllowance: 100n * 10n ** 18n,
+				vaultAddress: defaultTargetVaultAddress,
+			}),
+		})
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await act(() => {
+			const maxButton = document.body.querySelector('.field-inline-action')
+			if (!(maxButton instanceof HTMLElement)) throw new Error('Expected liquidation Max button')
+			fireEvent.click(maxButton)
+		})
+
+		expect(amountChanges).toEqual(['100'])
 	})
 
 	test('shows liquidation failure details when the staged execution event reports a rejection', async () => {
@@ -740,7 +810,7 @@ describe('LiquidationModal', () => {
 						vaultAddress: defaultCallerVaultAddress,
 					})}
 					targetVaultSummary={createTargetVaultSummary({
-						repDepositShare: 11n * 10n ** 18n,
+						repDepositShare: 12n * 10n ** 18n,
 						securityBondAllowance: 11n * 10n ** 18n,
 						vaultAddress: defaultTargetVaultAddress,
 					})}
@@ -822,7 +892,7 @@ describe('LiquidationModal', () => {
 						vaultAddress: defaultCallerVaultAddress,
 					})}
 					targetVaultSummary={createTargetVaultSummary({
-						repDepositShare: 11n * 10n ** 18n,
+						repDepositShare: 12n * 10n ** 18n,
 						securityBondAllowance: 11n * 10n ** 18n,
 						vaultAddress: defaultTargetVaultAddress,
 					})}
@@ -849,9 +919,13 @@ describe('LiquidationModal', () => {
 		container.remove()
 	})
 
-	test('fills the liquidation amount from the provided Max value', async () => {
+	test('fills the liquidation amount from the computed repair Max value', async () => {
 		const amountChanges: string[] = []
 		const renderedComponent = await renderLiquidationModal({
+			currentPoolOracleManagerDetails: createOracleManagerDetails({
+				isPriceValid: true,
+				lastPrice: 3n * 10n ** 18n,
+			}),
 			liquidationAmount: '1',
 			liquidationMaxAmount: 25n * 10n ** 18n,
 			onLiquidationAmountChange: value => {
@@ -866,11 +940,49 @@ describe('LiquidationModal', () => {
 			fireEvent.click(maxButton)
 		})
 
-		expect(amountChanges).toEqual(['25'])
+		expect(amountChanges).toEqual(['2'])
+	})
+
+	test('fills the liquidation amount from the full allowance when dust rounding forces a full repair', async () => {
+		const amountChanges: string[] = []
+		const renderedComponent = await renderLiquidationModal({
+			currentPoolOracleManagerDetails: createOracleManagerDetails({
+				isPriceValid: true,
+				lastPrice: 10n * 10n ** 18n,
+			}),
+			liquidationAmount: '1',
+			liquidationMaxAmount: 995n * 10n ** 17n,
+			onLiquidationAmountChange: value => {
+				amountChanges.push(value)
+			},
+			selectedPool: createSelectedPool({
+				lastOraclePrice: 10n * 10n ** 18n,
+				securityMultiplier: 2n,
+			}),
+			targetVaultSummary: createTargetVaultSummary({
+				repDepositShare: 10n * 10n ** 18n,
+				securityBondAllowance: 100n * 10n ** 18n,
+				vaultAddress: defaultTargetVaultAddress,
+			}),
+		})
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await act(() => {
+			const maxButton = document.body.querySelector('.field-inline-action')
+			if (!(maxButton instanceof HTMLElement)) throw new Error('Expected liquidation Max button')
+			fireEvent.click(maxButton)
+		})
+
+		expect(amountChanges).toEqual(['100'])
 	})
 
 	test('disables direct liquidation when the current Open Oracle price does not make the vault liquidatable', async () => {
 		const renderedComponent = await renderLiquidationModal({
+			callerVaultSummary: createTargetVaultSummary({
+				repDepositShare: 100n * 10n ** 18n,
+				securityBondAllowance: 0n,
+				vaultAddress: defaultCallerVaultAddress,
+			}),
 			currentPoolOracleManagerDetails: createOracleManagerDetails({
 				isPriceValid: true,
 				lastPrice: 1n * 10n ** 18n,
@@ -879,7 +991,7 @@ describe('LiquidationModal', () => {
 				securityMultiplier: 2n,
 			}),
 			targetVaultSummary: createTargetVaultSummary({
-				repDepositShare: 10n * 10n ** 18n,
+				repDepositShare: 100n * 10n ** 18n,
 				securityBondAllowance: 2n * 10n ** 18n,
 			}),
 		})
@@ -1084,7 +1196,96 @@ describe('LiquidationModal', () => {
 		expect(documentQueries.getByText('Rep Moved')).not.toBeNull()
 	})
 
-	test('uses simulation labels for mock prices and updates the caller collateralization as the liquidation amount changes', async () => {
+	test('shows zero REP moved for a repair liquidation preview', async () => {
+		const callerVaultAddress = getAddress('0x0000000000000000000000000000000000000001')
+		const renderedComponent = await renderLiquidationModal({
+			accountAddress: callerVaultAddress,
+			currentPoolOracleManagerDetails: createOracleManagerDetails({
+				isPriceValid: true,
+				lastPrice: 10n * 10n ** 18n,
+			}),
+			liquidationAmount: '2',
+			selectedPool: createSelectedPool({
+				securityMultiplier: 2n,
+			}),
+			callerVaultSummary: createTargetVaultSummary({
+				repDepositShare: 100n * 10n ** 18n,
+				securityBondAllowance: 2n * 10n ** 18n,
+				vaultAddress: callerVaultAddress,
+			}),
+			targetVaultSummary: createTargetVaultSummary({
+				repDepositShare: 2n * 10n ** 18n,
+				securityBondAllowance: 2n * 10n ** 18n,
+			}),
+		})
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const repMovedLabel = Array.from(document.body.querySelectorAll('.metric-label')).find(element => element.textContent === 'Rep Moved')
+		if (!(repMovedLabel instanceof HTMLElement)) throw new Error('Expected Rep Moved label')
+		const repMovedValue = repMovedLabel.nextElementSibling
+		if (!(repMovedValue instanceof HTMLElement)) throw new Error('Expected Rep Moved value')
+
+		expect(repMovedValue.textContent).toBe('≈ 0.00 REP')
+	})
+
+	test('allows execution when the entered amount exceeds the repair cap because execution will clamp it', async () => {
+		const callerVaultAddress = getAddress('0x0000000000000000000000000000000000000001')
+		const renderedComponent = await renderLiquidationModal({
+			accountAddress: callerVaultAddress,
+			currentPoolOracleManagerDetails: createOracleManagerDetails({
+				isPriceValid: true,
+				lastPrice: 10n * 10n ** 18n,
+			}),
+			liquidationAmount: '100',
+			selectedPool: createSelectedPool({
+				securityMultiplier: 2n,
+			}),
+			callerVaultSummary: createTargetVaultSummary({
+				repDepositShare: 2_000n * 10n ** 18n,
+				securityBondAllowance: 0n,
+				vaultAddress: callerVaultAddress,
+			}),
+			targetVaultSummary: createTargetVaultSummary({
+				repDepositShare: 100n * 10n ** 18n,
+				securityBondAllowance: 100n * 10n ** 18n,
+			}),
+		})
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const executeButton = within(document.body).getByRole('button', { name: 'Execute Vault Liquidation' }) as HTMLButtonElement
+		expect(executeButton.disabled).toBe(false)
+	})
+
+	test('allows execution when the entered amount would leave dust before the repair cap clamp', async () => {
+		const callerVaultAddress = getAddress('0x0000000000000000000000000000000000000001')
+		const renderedComponent = await renderLiquidationModal({
+			accountAddress: callerVaultAddress,
+			currentPoolOracleManagerDetails: createOracleManagerDetails({
+				isPriceValid: true,
+				lastPrice: 10n * 10n ** 18n,
+			}),
+			liquidationAmount: '99.6',
+			selectedPool: createSelectedPool({
+				securityMultiplier: 2n,
+			}),
+			callerVaultSummary: createTargetVaultSummary({
+				repDepositShare: 2_000n * 10n ** 18n,
+				securityBondAllowance: 0n,
+				vaultAddress: callerVaultAddress,
+			}),
+			targetVaultSummary: createTargetVaultSummary({
+				repDepositShare: 100n * 10n ** 18n,
+				securityBondAllowance: 100n * 10n ** 18n,
+			}),
+		})
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		const executeButton = within(document.body).getByRole('button', { name: 'Execute Vault Liquidation' }) as HTMLButtonElement
+		expect(executeButton.disabled).toBe(false)
+		expect(document.body.textContent?.includes('The target vault would fall below the minimum security bond allowance after liquidation.')).toBe(false)
+	})
+
+	test('uses simulation labels for mock prices and clamps the preview once the entered amount exceeds the repair cap', async () => {
 		function LiquidationSimulationHarness() {
 			const [liquidationAmount, setLiquidationAmount] = useState('1000')
 
@@ -1149,14 +1350,13 @@ describe('LiquidationModal', () => {
 		expect(executeButton.disabled).toBe(false)
 		expect(documentQueries.getByText(/Simulation REP \/ ETH/)).not.toBeNull()
 		expect(documentQueries.getByText(/Target Collateralization @ Simulation Price/)).not.toBeNull()
-		expect(documentQueries.getByText(/266\.67 %/)).not.toBeNull()
+		expect(documentQueries.getByText(/218\./)).not.toBeNull()
 
 		await act(() => {
 			fireEvent.input(amountInput, { target: { value: '2500' } })
 		})
 
-		expect(documentQueries.getByText(/209\.52 %/)).not.toBeNull()
-		expect(documentQueries.queryByText(/266\.67 %/)).toBeNull()
+		expect(documentQueries.getByText(/218\./)).not.toBeNull()
 
 		render(null, container)
 		container.remove()


### PR DESCRIPTION
## Summary
- Reworked liquidation behavior so the repair path moves only debt needed to restore solvency at the execution price, with REP staying in the target vault.
- Added dust-aware rounding so a liquidation rounds up to a full allowance transfer when the exact repair point would leave forbidden debt dust.
- Updated oracle, pool, and migration logic to use the new repair-cap semantics and shared BPS constant.
- Added and revised tests for liquidation behavior, snapshot handling, and UI liquidation math.
- Added new liquidation documentation and linked it from the start-here guide and whitepaper placeholder.
- Refreshed mainnet deployment addresses in the docs.

## Testing
- `bun run tsc`
- `bun run test`
- `bun run format`
- `bun run check`
- `bun run knip`