### PR TITLE
Link README docs to GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,7 @@ The codebase is split into two main parts:
 
 Protocol documentation lives in `docs/`:
 
-- [Start here guide](./docs/start-here.html)
-- [Zoltar visual whitepaper](./docs/whitepaper_zoltar.html)
-- [Augur Placeholder visual whitepaper](./docs/whitepaper_placeholder.html)
-- [Truth auction design](./docs/auction-design.html)
+- [Start here guide](https://augurproject.github.io/zoltar/docs/start-here.html)
 
 Deterministic deployment outputs live in
 [`docs/mainnet-deployment-addresses.json`](./docs/mainnet-deployment-addresses.json).


### PR DESCRIPTION
## Summary
- Updated the README protocol docs section to point the Start here guide at the GitHub Pages site.
- Removed the other local README doc links from that short list to keep the entry focused on the hosted docs path.

## Testing
- Not run (README-only change).