### PR TITLE
Clarify child fork supply accounting

### DIFF
--- a/docs/mainnet-deployment-addresses.json
+++ b/docs/mainnet-deployment-addresses.json
@@ -13,7 +13,7 @@
 		{
 			"id": "deploymentStatusOracle",
 			"label": "Deployment Status Oracle",
-			"address": "0x3dE2337D882CaaDc9afe65654790328cB8b2Fb6B"
+			"address": "0x5E252fD85FcDDf3f5429c3d8d1f5674E88837DA3"
 		},
 		{
 			"id": "multicall3",
@@ -48,39 +48,39 @@
 		{
 			"id": "zoltar",
 			"label": "Zoltar",
-			"address": "0x5FaE7E52e81250Fad0fCF05db42eCCCB3B0Bed95"
+			"address": "0x5749644a78046f8F30a269c82Af1C9f113C4243B"
 		},
 		{
 			"id": "shareTokenFactory",
 			"label": "ShareTokenFactory",
-			"address": "0x063Cbb4BE407A176b39496327D032DA00436BC36"
+			"address": "0x8D0A8bAaC6216eF3A124984587aA2F90A7060620"
 		},
 		{
 			"id": "priceOracleManagerAndOperatorQueuerFactory",
 			"label": "OpenOracle Price Coordinator Factory",
-			"address": "0xdb815F26F1318DceE0aB53E5a71f65D99F6fa486"
+			"address": "0x73F63294D7A3c16D49BB02bA0845f02B1e5cEbae"
 		},
 		{
 			"id": "securityPoolForker",
 			"label": "Security Pool Forker",
-			"address": "0x5Cc794e65e305A4120017295d9FBa72E26d7C8aE"
+			"address": "0x39E9B974f7B3c3E95B30eA86F7Cb3d593817b4C7"
 		},
 		{
 			"id": "escalationGameFactory",
 			"label": "Escalation Game Factory",
-			"address": "0x92E5C863A717d9574492C21505Dfe6730e710CCB"
+			"address": "0xC33f36e7fE99Fcd585Cb439DeE79A65eC1C31650"
 		},
 		{
 			"id": "securityPoolFactory",
 			"label": "Security Pool Factory",
-			"address": "0x0911f065be18eEfAc5AD7a16882f21E2Ee27eC11"
+			"address": "0xb77427222995a4DF2874F7424b0F1f7914b58cef"
 		}
 	],
 	"derivedContracts": [
 		{
 			"id": "escalationGameProofVerifier",
 			"label": "Escalation Game Proof Verifier",
-			"address": "0xa5BC7d46eb97F6d2b2e411d66c482154337F177e"
+			"address": "0xd18CaF18419602393b858aeB56B320F9986a9E09"
 		}
 	]
 }

--- a/docs/whitepaper_zoltar.html
+++ b/docs/whitepaper_zoltar.html
@@ -481,6 +481,53 @@
 						<a href="../solidity/contracts/ReputationToken.sol"><code>ReputationToken</code></a>
 						under Zoltar’s control.
 					</p>
+					<p>
+						A child's theoretical supply is a maximum for REP that can be minted in that
+						branch. It starts from the parent's pre-fork theoretical supply and subtracts
+						only the uncredited haircut. The initiator's remaining threshold deposit is
+						migration credit, so it remains part of the maximum amount that could be minted
+						in each child.
+					</p>
+
+					<h3>Repeated-fork threshold decay</h3>
+					<p>
+						Along one lineage, let <code>theoreticalSupplyBeforeForkₙ</code> be the
+						theoretical supply before fork <code>n</code>. With the mainnet threshold divisor
+						of <code>20</code> and burn divisor of <code>5</code>, the exact integer recurrence is
+						<code>forkThresholdₙ = floor(theoreticalSupplyBeforeForkₙ / 20)</code>,
+						<code>haircutₙ = floor(forkThresholdₙ / 5)</code>, and
+						<code>theoreticalSupplyBeforeForkₙ₊₁ = theoreticalSupplyBeforeForkₙ - haircutₙ</code>.
+						This is close to multiplying supply by <code>0.99</code> at each generation,
+						but both Solidity flooring operations matter once supply becomes small.
+					</p>
+					<div class="callout">
+						<strong>Launch-supply-dependent limit</strong>
+						The number of generations is not a universal constant because the genesis
+						supply snapshot is read when Zoltar is deployed. At Ethereum block
+						<code>25,501,749</code> on July 10, 2026, calling
+						<code>getTotalTheoreticalSupply()</code> on REPv2 at
+						<code>0x221657776846890989a759BA2973e427DfF5C9bB</code> returned
+						<code>7,825,488.326666847200078019 REP</code>. Starting from that value, the
+						default recurrence reaches three relevant boundaries: at child depth
+						<code>1,213</code>, the fork threshold is approximately <code>1.986 REP</code>, so
+						half of it no longer exceeds the configured <code>1 REP</code> escalation
+						starting bond; at depth <code>1,282</code>, the fork threshold is below
+						<code>1 REP</code>; and at depth <code>5,303</code>, theoretical supply is
+						<code>99 wei</code>, the fork threshold is <code>4 wei</code>, and the haircut
+						floors to zero. Supply then stops decreasing along further descendants rather
+						than reaching a zero fork threshold.
+					</div>
+					<p>
+						These depths require more than a thousand consecutive forks along the same
+						surviving branch before escalation parameters become incompatible. They are
+						therefore remote limits rather than near-term fork incentives. Implementers
+						should nevertheless treat the first boundary as an explicit parameter limit:
+						<code>SecurityPool</code> initializes an escalation game's non-decision threshold
+						as half the current fork threshold, while <code>EscalationGame</code> requires that
+						value to be strictly greater than its starting bond. A deployment expected to
+						survive thousands of recursive forks needs either a minimum fork threshold or
+						a compatible rule for scaling escalation parameters.
+					</p>
 
 					<div class="table-wrap">
 						<table>
@@ -639,6 +686,38 @@
 						costs of doing so. The economic pressure is therefore value concentration:
 						REP in an abandoned branch may keep existing, but it is expected to have little
 						long-term value compared with REP in the branch that markets keep using.
+					</p>
+					<h3>Global forks are migrations, not permanent shutdowns</h3>
+					<p>
+						Zoltar questions are global protocol objects: any existing question whose end
+						time has passed can identify the branches of any still-unforked universe.
+						Recording the fork stops new operational changes in parent-universe pools so
+						that their accounting cannot move while it is being snapshotted. Placeholder
+						provides permissionless, user-driven paths to migrate REP, shares, vault
+						positions, collateral, and unresolved escalation state into child-universe
+						pools. A child pool can return to the operational state once the migration
+						window and any required truth-auction and finalization transactions complete.
+						Timely progress therefore depends on callers submitting those transactions and
+						on the available migration participation. The parent boundary is a transition
+						into child universes, not an intended permanent freeze of market activity.
+					</p>
+					<p>
+						A caller cannot trigger that transition for free under normal parameters. The
+						caller supplies the full fork threshold in parent REP, loses the uncredited
+						haircut, and receives migration credit for only the remainder. Existing REP
+						holders can migrate their own positions and benefit from the reduced supply in
+						the branches where economic activity continues. Consequently, an unrelated
+						fork is economically evaluated as a costly forced migration: its risk is
+						operational migration latency and coordination burden, while its deterrent is
+						the initiator's threshold commitment and permanent haircut.
+					</p>
+					<p>
+						Likewise, a question with many valid outcomes creates more possible children,
+						but it does not multiply value in the branch that ultimately retains economic
+						coordination. Deploying and using many children costs gas, and REP in abandoned
+						branches is expected to have little value. Outcome count by itself is therefore
+						a gas and state-growth consideration, not a demonstrated value-extraction
+						attack.
 					</p>
 				</section>
 

--- a/scripts/check-docs-reference-values.mts
+++ b/scripts/check-docs-reference-values.mts
@@ -1,7 +1,9 @@
 import { readFile } from 'node:fs/promises'
 import assert from 'node:assert/strict'
+import { getMainnetProtocolConfig } from '../shared/ts/protocolConfig'
 
 const html = await readFile('docs/escalation-game-architecture.html', 'utf8')
+const zoltarWhitepaper = await readFile('docs/whitepaper_zoltar.html', 'utf8')
 const bytecodeSnapshot = readBytecodeSnapshot(await readFile('solidity/ts/tests/fixtures/escalationGameBytecode.snapshot.json', 'utf8'))
 const interfaceRegressionTest = await readFile('solidity/ts/tests/escalationGameInterfaceRegression.test.ts', 'utf8')
 
@@ -12,6 +14,43 @@ assertSimpleByteRow('Creation bytecode', formatNumber(bytecodeSnapshot.creationB
 assertSimpleByteRow('Deployed bytecode', formatNumber(bytecodeSnapshot.deployedBytes))
 assertBudgetHeadroomRow('Project deployed-bytecode budget headroom', formatNumber(expectedProjectBudget - bytecodeSnapshot.deployedBytes), formatNumber(expectedProjectBudget))
 assertBudgetHeadroomRow('EIP-170 headroom', formatNumber(expectedEip170Budget - bytecodeSnapshot.deployedBytes), formatNumber(expectedEip170Budget))
+assertZoltarForkDepths()
+
+function assertZoltarForkDepths(): void {
+	const initialSupply = 7_825_488_326_666_847_200_078_019n
+	const oneRep = 10n ** 18n
+	const protocolConfig = getMainnetProtocolConfig()
+	let supply = initialSupply
+	let escalationBoundary: number | undefined
+	let subOneRepBoundary: number | undefined
+	let zeroHaircutBoundary: number | undefined
+
+	for (let depth = 0; zeroHaircutBoundary === undefined; depth += 1) {
+		const threshold = supply / protocolConfig.forkThresholdDivisor
+		const haircut = threshold / protocolConfig.forkBurnDivisor
+		if (escalationBoundary === undefined && threshold / 2n <= oneRep) escalationBoundary = depth
+		if (subOneRepBoundary === undefined && threshold < oneRep) subOneRepBoundary = depth
+		if (haircut === 0n) {
+			zeroHaircutBoundary = depth
+			break
+		}
+		supply -= haircut
+	}
+
+	assert.equal(escalationBoundary, 1_213, 'Zoltar escalation boundary depth changed')
+	assert.equal(subOneRepBoundary, 1_282, 'Zoltar sub-1-REP threshold depth changed')
+	assert.equal(zeroHaircutBoundary, 5_303, 'Zoltar zero-haircut boundary depth changed')
+	assert.equal(supply, 99n, 'Zoltar zero-haircut fixed-point supply changed')
+	assert.equal(supply / protocolConfig.forkThresholdDivisor, 4n, 'Zoltar zero-haircut fixed-point threshold changed')
+	const normalizedWhitepaper = zoltarWhitepaper.replaceAll(/\s+/g, ' ')
+	for (const documentedClaim of [
+		'at child depth <code>1,213</code>, the fork threshold is approximately <code>1.986 REP</code>',
+		'at depth <code>1,282</code>, the fork threshold is below <code>1 REP</code>',
+		'at depth <code>5,303</code>, theoretical supply is <code>99 wei</code>, the fork threshold is <code>4 wei</code>, and the haircut floors to zero',
+	]) {
+		assert.ok(normalizedWhitepaper.includes(documentedClaim), `Missing Zoltar fork-depth claim: ${documentedClaim}`)
+	}
+}
 
 function assertSimpleByteRow(label: string, expectedValue: string): void {
 	const escapedLabel = escapeRegExp(label)

--- a/solidity/contracts/Zoltar.sol
+++ b/solidity/contracts/Zoltar.sol
@@ -132,8 +132,11 @@ contract Zoltar {
 		uint256 forkThreshold = getForkThreshold(universeId);
 		burnRep(universes[universeId].reputationToken, msg.sender, forkThreshold);
 		universeTheoreticalSupplies[universeId] -= forkThreshold;
-		childUniverseTheoreticalSupplySnapshots[universeId] = universeTheoreticalSupplies[universeId];
 		uint256 migrationRepBalance = forkThreshold - forkThreshold / forkBurnDivisor;
+		// The child maximum retains the initiator's credited migration REP. Only the
+		// uncredited haircut is permanently absent from every child universe.
+		childUniverseTheoreticalSupplySnapshots[universeId] =
+			universeTheoreticalSupplies[universeId] + migrationRepBalance;
 		migrationRepBalances[msg.sender][universeId].migrationRepBalance = migrationRepBalance;
 		emit UniverseForked(
 			msg.sender,

--- a/solidity/ts/tests/peripheralsInvariant.test.ts
+++ b/solidity/ts/tests/peripheralsInvariant.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, beforeEach, describe, setDefaultTimeout, test } from 'bun:test'
 import assert from '../testsuite/simulator/utils/assert'
 import type { Address } from '@zoltar/shared/ethereum'
+import { DEFAULT_PROTOCOL_CONFIG } from '@zoltar/shared/protocolConfig'
 import { AnvilWindowEthereum } from '../testsuite/simulator/AnvilWindowEthereum'
 import { TEST_TIMEOUT_MS, useIsolatedAnvilNode } from '../testsuite/simulator/useIsolatedAnvilNode'
 import { createWriteClient, WriteClient } from '../testsuite/simulator/utils/clients'
@@ -223,7 +224,8 @@ describe('Peripherals invariant harness', () => {
 		const parentSupplyBeforeFork = await getTotalTheoreticalSupply(client, parentRepToken)
 		const burnAddressBalanceBeforeFork = await getERC20Balance(client, parentRepToken, addressString(BURN_ADDRESS))
 		const forkThreshold = await getZoltarForkThreshold(client, genesisUniverse)
-		const expectedChildSupplySnapshot = parentSupplyBeforeFork - forkThreshold
+		const permanentHaircut = forkThreshold / DEFAULT_PROTOCOL_CONFIG.forkBurnDivisor
+		const expectedChildSupplySnapshot = parentSupplyBeforeFork - permanentHaircut
 		const branchOrder = shuffle([QuestionOutcome.Invalid, QuestionOutcome.Yes, QuestionOutcome.No], 0xdecafbadn)
 		const attackerClient = createClient(1)
 		await approveAndDepositRep(attackerClient, repDeposit, context.questionId)
@@ -248,7 +250,7 @@ describe('Peripherals invariant harness', () => {
 			strictEqualTypeSafe(childUniverse.forkingOutcomeIndex, BigInt(outcome), 'child should retain its outcome index')
 			const childUniverseSupply = await getUniverseTheoreticalSupply(client, childUniverseId)
 			assert.ok(childUniverseSupply > 0n, 'child universe supply should stay positive')
-			strictEqualTypeSafe(childUniverseSupply, expectedChildSupplySnapshot, 'child universe supply should equal the parent snapshot immediately after fork burn')
+			strictEqualTypeSafe(childUniverseSupply, expectedChildSupplySnapshot, 'child universe supply should subtract only the permanent fork haircut')
 		}
 
 		const childUniverseIds = branchOrder.map(outcome => getChildUniverseIdForOutcome(outcome))

--- a/solidity/ts/tests/zoltar.test.ts
+++ b/solidity/ts/tests/zoltar.test.ts
@@ -67,6 +67,36 @@ describe('Contract Test Suite', () => {
 		assert.strictEqual(await getZoltarForkBurnDivisor(client), DEFAULT_PROTOCOL_CONFIG.forkBurnDivisor, 'fork burn divisor mismatch')
 	})
 
+	test('child theoretical supply subtracts only the permanent fork haircut', async () => {
+		const zoltar = getZoltarAddress()
+		await approveToken(client, addressString(GENESIS_REPUTATION_TOKEN), zoltar)
+
+		const questionData = {
+			title: 'child theoretical maximum supply',
+			description: '',
+			startTime: 0n,
+			endTime: 0n,
+			numTicks: 0n,
+			displayValueMin: 0n,
+			displayValueMax: 0n,
+			answerUnit: '',
+		}
+		const outcomes = sortStringArrayByKeccak(['Yes', 'No'])
+		await createQuestion(client, questionData, outcomes)
+
+		const parentSupplyBeforeFork = await getUniverseTheoreticalSupply(client, genesisUniverse)
+		const forkThreshold = parentSupplyBeforeFork / DEFAULT_PROTOCOL_CONFIG.forkThresholdDivisor
+		const permanentHaircut = forkThreshold / DEFAULT_PROTOCOL_CONFIG.forkBurnDivisor
+		await forkUniverse(client, genesisUniverse, getQuestionId(questionData, outcomes))
+
+		const outcomeIndex = 1n
+		await deployChild(client, genesisUniverse, outcomeIndex)
+		const childUniverseId = getChildUniverseId(genesisUniverse, outcomeIndex)
+		const expectedMaximumSupply = parentSupplyBeforeFork - permanentHaircut
+		assert.strictEqual(await getUniverseTheoreticalSupply(client, childUniverseId), expectedMaximumSupply, 'child theoretical maximum should retain the initiator migration credit and subtract only the permanent haircut')
+		assert.strictEqual(await getTotalTheoreticalSupply(client, getRepTokenAddress(childUniverseId)), expectedMaximumSupply, 'child REP token maximum should match the child universe theoretical supply')
+	})
+
 	test('constructor rejects invalid fork divisors', async () => {
 		const zoltarQuestionDataAddress = await client.readContract({
 			abi: Zoltar_Zoltar.abi,


### PR DESCRIPTION
## Summary
- Fix Zoltar child-universe supply accounting so the child maximum retains the initiator’s migration credit and subtracts only the permanent haircut.
- Update invariant and contract tests to assert the new fork accounting behavior.
- Refresh docs and reference-value checks to explain repeated fork decay and the resulting depth limits.
- Update mainnet deployment address metadata.

## Testing
- Not run (PR content generation only).
- Existing test coverage updated in `solidity/ts/tests/zoltar.test.ts` and `solidity/ts/tests/peripheralsInvariant.test.ts`.
- Docs reference checks updated in `scripts/check-docs-reference-values.mts`.