### PR TITLE
Enforce REP supply cap and refresh UI copy

### DIFF
--- a/docs/mainnet-deployment-addresses.json
+++ b/docs/mainnet-deployment-addresses.json
@@ -13,7 +13,7 @@
 		{
 			"id": "deploymentStatusOracle",
 			"label": "Deployment Status Oracle",
-			"address": "0xFc6aE690a62398A427b05C929c718d7E3702F070"
+			"address": "0x5561f668DaED6f1A31bA83Cf450F842C6C921A7F"
 		},
 		{
 			"id": "multicall3",
@@ -48,39 +48,39 @@
 		{
 			"id": "zoltar",
 			"label": "Zoltar",
-			"address": "0x5749644a78046f8F30a269c82Af1C9f113C4243B"
+			"address": "0x99B04b933512F95711Db02A163742C8468C6D0b5"
 		},
 		{
 			"id": "shareTokenFactory",
 			"label": "ShareTokenFactory",
-			"address": "0x6bcf32294406c63E336fC1Ef4BdbF4c4777F784B"
+			"address": "0xFE76cb4a5Df7C20c8c71BdA31A243a21Dd40eDa7"
 		},
 		{
 			"id": "priceOracleManagerAndOperatorQueuerFactory",
 			"label": "OpenOracle Price Coordinator Factory",
-			"address": "0xea6Ac29A30275c3749d3a46441B71d72Fad74a29"
+			"address": "0x53549F52578C67b84FFa6EA16B5dE85Ea4BF95B2"
 		},
 		{
 			"id": "securityPoolForker",
 			"label": "Security Pool Forker",
-			"address": "0x8dc24BeeD1Db5630b0d833a9DE272cc6113E75B0"
+			"address": "0xF50b3cf192B155085050fF107b21Aa0b6E39cC71"
 		},
 		{
 			"id": "escalationGameFactory",
 			"label": "Escalation Game Factory",
-			"address": "0x41E4D99059218dF6943777416Da49cccD462e8A1"
+			"address": "0x8cb282741cE860e9c93c256B176746AC252dE830"
 		},
 		{
 			"id": "securityPoolFactory",
 			"label": "Security Pool Factory",
-			"address": "0xE4232859250cB576F8C8955466798c922D359C66"
+			"address": "0x071D120657D5Cd261F36fF4EEA3AD63917fF0E89"
 		}
 	],
 	"derivedContracts": [
 		{
 			"id": "escalationGameProofVerifier",
 			"label": "Escalation Game Proof Verifier",
-			"address": "0x99A16fbFe5c06ABB813565e0600355474141Dbad"
+			"address": "0xcbBB0262c97bFf536fF902fA40790fAaED9C8A5B"
 		}
 	]
 }

--- a/solidity/contracts/ReputationToken.sol
+++ b/solidity/contracts/ReputationToken.sol
@@ -25,6 +25,9 @@ contract ReputationToken is ERC20 {
 	}
 
 	function mint(address account, uint256 value) external isZoltar {
+		// Defense in depth: preserve the theoretical-supply invariant even if future
+		// migration accounting changes accidentally route an oversized mint here.
+		require(totalSupply() + value <= totalTheoreticalSupply, 'Mint exceeds theoretical supply');
 		_mint(account, value);
 		emit Mint(account, value);
 	}

--- a/solidity/ts/tests/coverageHelpers.test.ts
+++ b/solidity/ts/tests/coverageHelpers.test.ts
@@ -447,6 +447,39 @@ describe('Solidity bytecode coverage helpers', () => {
 		)
 	})
 
+	test('reputation token mint rejects supply growth beyond the theoretical cap', async () => {
+		const reputationTokenAddress = await deployReputationToken()
+
+		await transact(
+			reputationTokenAddress,
+			encodeFunctionData({
+				abi: ReputationToken_ReputationToken.abi,
+				functionName: 'setMaxTheoreticalSupply',
+				args: [10n],
+			}),
+		)
+		await transact(
+			reputationTokenAddress,
+			encodeFunctionData({
+				abi: ReputationToken_ReputationToken.abi,
+				functionName: 'mint',
+				args: [client.account.address, 9n],
+			}),
+		)
+
+		await assert.rejects(
+			transact(
+				reputationTokenAddress,
+				encodeFunctionData({
+					abi: ReputationToken_ReputationToken.abi,
+					functionName: 'mint',
+					args: [client.account.address, 2n],
+				}),
+			),
+			/Mint exceeds theoretical supply/i,
+		)
+	})
+
 	test('reuses cached address profiles without repeated getCode lookups for the same deployed contract', async () => {
 		if (!isCoverageEnabled()) return
 

--- a/ui/ts/simulation/bootstrap.ts
+++ b/ui/ts/simulation/bootstrap.ts
@@ -163,9 +163,15 @@ async function seedGenesisRepTokenState({
 	try {
 		return await withSimulationAuthorityAccount(memoryClient, zoltarAddress, async () => {
 			const zoltarWriteClient = createWriteClient(zoltarAddress)
-			let totalSupply = 0n
+			const totalSupply = BigInt(accounts.length) * REP_TOKEN_MINT_AMOUNT
+			const syncHash = await zoltarWriteClient.writeContract({
+				address: repAddress,
+				abi: ReputationToken_ReputationToken.abi,
+				functionName: 'setMaxTheoreticalSupply',
+				args: [totalSupply],
+			})
+			await zoltarWriteClient.waitForTransactionReceipt({ hash: syncHash })
 			for (const [index, account] of accounts.entries()) {
-				totalSupply += REP_TOKEN_MINT_AMOUNT
 				const hash = await zoltarWriteClient.writeContract({
 					address: repAddress,
 					abi: ReputationToken_ReputationToken.abi,
@@ -175,14 +181,6 @@ async function seedGenesisRepTokenState({
 				await zoltarWriteClient.waitForTransactionReceipt({ hash })
 				await reportBootstrapProgress(onProgress, `Seeding REP balances ${index + 1} of ${accounts.length}`, 0.16 + ((index + 1) / Math.max(accounts.length, 1)) * 0.06)
 			}
-
-			const syncHash = await zoltarWriteClient.writeContract({
-				address: repAddress,
-				abi: ReputationToken_ReputationToken.abi,
-				functionName: 'setMaxTheoreticalSupply',
-				args: [totalSupply],
-			})
-			await zoltarWriteClient.waitForTransactionReceipt({ hash: syncHash })
 			await reportBootstrapProgress(onProgress, 'Finalizing REP token state', 0.23)
 			return totalSupply
 		})
@@ -255,13 +253,6 @@ export async function mintSimulationGenesisRep({ accountAddress, amount, createW
 	try {
 		await withSimulationAuthorityAccount(memoryClient, zoltarAddress, async () => {
 			const zoltarWriteClient = createWriteClient(zoltarAddress)
-			const mintHash = await zoltarWriteClient.writeContract({
-				address: repAddress,
-				abi: ReputationToken_ReputationToken.abi,
-				functionName: 'mint',
-				args: [accountAddress, amount],
-			})
-			await zoltarWriteClient.waitForTransactionReceipt({ hash: mintHash })
 			const totalSupply = await zoltarWriteClient.readContract({
 				address: repAddress,
 				abi: ReputationToken_ReputationToken.abi,
@@ -272,9 +263,16 @@ export async function mintSimulationGenesisRep({ accountAddress, amount, createW
 				address: repAddress,
 				abi: ReputationToken_ReputationToken.abi,
 				functionName: 'setMaxTheoreticalSupply',
-				args: [totalSupply],
+				args: [totalSupply + amount],
 			})
 			await zoltarWriteClient.waitForTransactionReceipt({ hash: syncHash })
+			const mintHash = await zoltarWriteClient.writeContract({
+				address: repAddress,
+				abi: ReputationToken_ReputationToken.abi,
+				functionName: 'mint',
+				args: [accountAddress, amount],
+			})
+			await zoltarWriteClient.waitForTransactionReceipt({ hash: mintHash })
 
 			const zoltarCode = await memoryClient.getCode({
 				address: zoltarAddress,

--- a/ui/ts/tests/simulationBootstrap.test.ts
+++ b/ui/ts/tests/simulationBootstrap.test.ts
@@ -85,6 +85,7 @@ function createRepTokenWriteClient({ accountAddress, repAddress, repState, zolta
 					const recipient = args?.[0]
 					const amount = args?.[1]
 					if (typeof recipient !== 'string' || typeof amount !== 'bigint') throw new Error('Invalid mint arguments')
+					if (repState.totalSupply + amount > repState.theoreticalSupply) throw new Error('Mint exceeds theoretical supply')
 					const normalizedRecipient = recipient.toLowerCase()
 					repState.balances.set(normalizedRecipient, (repState.balances.get(normalizedRecipient) ?? 0n) + amount)
 					repState.totalSupply += amount
@@ -579,6 +580,7 @@ function createMockedBootstrapDependencies({ accounts, scenario, profile }: { ac
 						const recipient = args?.[0]
 						const amount = args?.[1]
 						if (typeof recipient !== 'string' || typeof amount !== 'bigint') throw new Error('Invalid mint arguments')
+						if (repState.totalSupply + amount > repState.theoreticalSupply) throw new Error('Mint exceeds theoretical supply')
 						const normalizedRecipient = recipient.toLowerCase()
 						repState.balances.set(normalizedRecipient, (repState.balances.get(normalizedRecipient) ?? 0n) + amount)
 						repState.totalSupply += amount


### PR DESCRIPTION
## Summary
- Enforce the ReputationToken theoretical supply ceiling at mint time to prevent oversized mints, with a regression test covering the cap check.
- Update mainnet deployment addresses for the newly deployed contracts.
- Refactor UI text handling across the app to use centralized curated string sources and improve copy consistency.
- Adjust simulation bootstrap and presentation helpers to match the updated copy and transaction messaging.

## Testing
- `bun run tsc`
- `bun run test`
- `bun run format`
- `bun run check`
- `bun run knip`