### PR TITLE
Clarify fork flow, auction behavior, and share redemption

### DIFF
--- a/docs/auction-design.html
+++ b/docs/auction-design.html
@@ -32,11 +32,12 @@
 					child pool may inherit the correct share balances, vault state, and
 					REP-backed obligations while still lacking enough ETH to reopen cleanly.
 					When that happens, the protocol sells child-universe REP for ETH through a
-					truth auction, applying the proceeds toward the collateral shortfall.
-					When demand reaches the ETH target, open-interest holders can be made
-					whole; weak demand can leave only a partial repair even though the auction
-					still clears the full REP cap. The auction repairs the pool's funding gap;
-					it does not determine which branch is true.
+					truth auction, using the proceeds to raise as much repair ETH as market
+					demand supports. Strong demand can fully restore the collateral shortfall;
+					when weak demand still produces a non-empty feasible winning prefix, the
+					auction clears the full REP cap at a lower synthetic price and can leave share
+					collateral below its pre-fork level. With no bids, it sells no REP. The auction
+					discovers that repair price; it does not determine which branch is true.
 				</p>
 
 				<p>
@@ -47,10 +48,14 @@
 					When finalization finds a non-empty winning prefix, weak demand does
 					not leave unsold REP behind. Instead, the auction fixes that winning
 					bid prefix, refunds lower bids, and still clears the full REP cap at
-					one synthetic uniform price. Placeholder runs this process through
+					one synthetic uniform price. A bidder at the minimum tick receives the full
+					REP cap only when it is the sole member of the finalized winning prefix. A
+					later qualifying bid can make the bidders share the cap, exclude the
+					minimum-tick bid, or move the auction into normal funded clearing during the
+					one-week auction. Placeholder runs this process through
 					the <code>UniformPriceDualCapBatchAuction</code> contract, then
 					writes winning claims back into vault state rather than paying out
-					simple token transfers, so bidders buy into the repaired child pool
+					simple token transfers, so bidders buy into the child pool
 					and its matching security-bond allowance instead of merely receiving
 					REP.
 				</p>

--- a/docs/start-here.html
+++ b/docs/start-here.html
@@ -33,11 +33,19 @@
 						source balance.
 					</p>
 					<p>
-						A normal market begins in one pool, forks only after sustained local
-						non-decision, and then resumes in whichever child branches users keep
-						using. That same sequence drives the rest of Placeholder: pool
-						creation, trading, escalation, fork migration, then repair or
-						redemption.
+						After sustained local non-decision, a caller can invoke the security-pool
+						fork path, which makes Zoltar fork the market's current universe. Before that
+						happens, a caller may use a different market's ended question to make Zoltar
+						fork that universe first; in that case, the
+						unresolved escalation migrates into selected child universes as paused
+						continuation games. Each continuation still disputes the original question
+						and, after it resumes, can reach non-decision. A caller can then invoke the
+						security-pool fork path, which forks that child universe using the original
+						question. The first fork's branches represent the
+						unrelated question's outcomes, while the recursive fork's branches represent
+						the original question's outcomes. That sequence drives the rest of
+						Placeholder: pool creation, trading, escalation, fork migration, then repair
+						or redemption.
 					</p>
 					<p>
 						Keep one distinction in mind throughout: Zoltar decides how

--- a/docs/whitepaper_placeholder.html
+++ b/docs/whitepaper_placeholder.html
@@ -5363,17 +5363,21 @@
 						recursively along with Zoltar universes.
 					</p>
 					<p>
-						For example, suppose a security pool is escalating the Market Weather
-						question in the Genesis universe. Before that escalation resolves, a caller
-						invokes <code>Zoltar.forkUniverse</code> with an unrelated ended Governance
-						Upgrade question, causing Zoltar to fork the Genesis universe. The pool's
-						unresolved Market Weather escalation migrates into
-						selected Governance Upgrade child universes as paused continuation games.
-						After one continuation resumes, it still disputes Market Weather. If it
-						reaches non-decision, a caller can invoke the security-pool fork path, causing
-						Zoltar to fork that Governance Upgrade child universe using Market Weather.
-						The first fork's branches encode Governance Upgrade outcomes; the recursive
-						fork's branches encode Market Weather outcomes.
+						For example, suppose the Genesis universe contains two ended questions: “Did
+						Helsinki record a temperature of at least 30 °C on August 1, 2030?” and “Did
+						the Atlas protocol upgrade activate by July 1, 2031?” A security pool is still
+						escalating the Helsinki-temperature question. Before that escalation resolves,
+						a caller invokes <code>Zoltar.forkUniverse</code> with the unrelated, already
+						ended Atlas-upgrade question, causing Zoltar to fork the Genesis universe. Each
+						resulting child universe represents one possible answer to the Atlas-upgrade
+						question. The pool's unresolved Helsinki-temperature escalation migrates into
+						selected child universes as separate paused continuation games, one in each
+						selected child universe. After a continuation resumes, it still disputes the
+						Helsinki-temperature question. If it reaches non-decision, a caller can invoke
+						the security-pool fork path, causing Zoltar to fork that child universe again.
+						The first fork therefore creates branches for the possible answers to the
+						unrelated Atlas-upgrade question; the recursive fork creates branches for the
+						possible answers to the pool's original Helsinki-temperature question.
 					</p>
 					<figure class="diagram" id="fig-placeholder-recursive-continuation">
 						<svg
@@ -5385,8 +5389,10 @@
 								Recursive fork-continuation flow
 							</title>
 							<desc id="recursive-desc">
-								An unresolved escalation game can fork, initialize several child
-								continuation games, and those child games can fork again.
+								A caller initiates a Zoltar fork for a universe containing an unresolved
+								escalation, creating child continuation games. If a resumed continuation
+								reaches non-decision, a caller can invoke the security-pool fork path and
+								Zoltar forks that child universe again.
 							</desc>
 							<defs>
 								<marker

--- a/docs/whitepaper_placeholder.html
+++ b/docs/whitepaper_placeholder.html
@@ -5362,6 +5362,19 @@
 						games, so escalation does not end at a single fork; it can branch
 						recursively along with Zoltar universes.
 					</p>
+					<p>
+						For example, suppose a security pool is escalating the Market Weather
+						question in the Genesis universe. Before that escalation resolves, a caller
+						invokes <code>Zoltar.forkUniverse</code> with an unrelated ended Governance
+						Upgrade question, causing Zoltar to fork the Genesis universe. The pool's
+						unresolved Market Weather escalation migrates into
+						selected Governance Upgrade child universes as paused continuation games.
+						After one continuation resumes, it still disputes Market Weather. If it
+						reaches non-decision, a caller can invoke the security-pool fork path, causing
+						Zoltar to fork that Governance Upgrade child universe using Market Weather.
+						The first fork's branches encode Governance Upgrade outcomes; the recursive
+						fork's branches encode Market Weather outcomes.
+					</p>
 					<figure class="diagram" id="fig-placeholder-recursive-continuation">
 						<svg
 							viewBox="0 0 980 520"

--- a/docs/whitepaper_placeholder.html
+++ b/docs/whitepaper_placeholder.html
@@ -5363,21 +5363,21 @@
 						recursively along with Zoltar universes.
 					</p>
 					<p>
-						For example, suppose the Genesis universe contains two ended questions: “Did
-						Helsinki record a temperature of at least 30 °C on August 1, 2030?” and “Did
-						the Atlas protocol upgrade activate by July 1, 2031?” A security pool is still
-						escalating the Helsinki-temperature question. Before that escalation resolves,
+						For example, suppose Zoltar has two ended questions: “Did London record a
+						temperature of at least 30 °C on August 1, 2030?” and “Did the Atlas protocol
+						upgrade activate by July 1, 2031?” A security pool in the Genesis universe is
+						still escalating the London-temperature question. Before that escalation resolves,
 						a caller invokes <code>Zoltar.forkUniverse</code> with the unrelated, already
 						ended Atlas-upgrade question, causing Zoltar to fork the Genesis universe. Each
 						resulting child universe represents one possible answer to the Atlas-upgrade
-						question. The pool's unresolved Helsinki-temperature escalation migrates into
+						question. The pool's unresolved London-temperature escalation migrates into
 						selected child universes as separate paused continuation games, one in each
 						selected child universe. After a continuation resumes, it still disputes the
-						Helsinki-temperature question. If it reaches non-decision, a caller can invoke
+						London-temperature question. If it reaches non-decision, a caller can invoke
 						the security-pool fork path, causing Zoltar to fork that child universe again.
 						The first fork therefore creates branches for the possible answers to the
 						unrelated Atlas-upgrade question; the recursive fork creates branches for the
-						possible answers to the pool's original Helsinki-temperature question.
+						possible answers to the pool's original London-temperature question.
 					</p>
 					<figure class="diagram" id="fig-placeholder-recursive-continuation">
 						<svg
@@ -5389,10 +5389,11 @@
 								Recursive fork-continuation flow
 							</title>
 							<desc id="recursive-desc">
-								A caller initiates a Zoltar fork for a universe containing an unresolved
-								escalation, creating child continuation games. If a resumed continuation
-								reaches non-decision, a caller can invoke the security-pool fork path and
-								Zoltar forks that child universe again.
+								A caller invokes Zoltar to fork a universe while one of its security pools has
+								an unresolved escalation. Later, migration into selected child branches deploys child pools
+								and initializes paused continuation games. If a resumed continuation reaches
+								non-decision, a caller can invoke the security-pool fork path and Zoltar forks
+								that child universe again.
 							</desc>
 							<defs>
 								<marker


### PR DESCRIPTION
## Summary
- Clarified documentation for recursive fork behavior and how unrelated forks can precede a security-pool fork.
- Refined truth-auction wording to explain partial repair, synthetic clearing, and when no REP is sold.
- Simplified share redemption internals by replacing the combined burn/supply-return path with a direct burn + `sharesToCash` calculation.
- Updated ERC1155 tests to use the new `burnTokenId` interface and removed obsolete fork-migration coverage that no longer matched the contract behavior.
- Refreshed mainnet deployment addresses and expanded the whitepaper example for recursive continuation games.

## Testing
- Not run (documentation and contract/interface cleanup only in this summary request).
- Not run (no validation commands were executed for this PR summary).