### PR TITLE
Handle delayed security pool fork initialization

### DIFF
--- a/docs/mainnet-deployment-addresses.json
+++ b/docs/mainnet-deployment-addresses.json
@@ -13,7 +13,7 @@
 		{
 			"id": "deploymentStatusOracle",
 			"label": "Deployment Status Oracle",
-			"address": "0xc9FEB7A5BE941b5938750d6B8d9AC179eAF4aDD2"
+			"address": "0x6571585965E2705AFcD5EADD3019058Fc98efdf9"
 		},
 		{
 			"id": "multicall3",
@@ -63,7 +63,7 @@
 		{
 			"id": "securityPoolForker",
 			"label": "Security Pool Forker",
-			"address": "0xa61f9f59E90F00D5Ea5e93ad83a4D1ED12fe1390"
+			"address": "0x1e1d05571AaD7b7083Ab98EAc1E1d70D32f44cE0"
 		},
 		{
 			"id": "escalationGameFactory",
@@ -73,7 +73,7 @@
 		{
 			"id": "securityPoolFactory",
 			"label": "Security Pool Factory",
-			"address": "0x3D980d371Ea237E5C1dBaC3051ed61bf82B12398"
+			"address": "0xD03C65D77eD33F8E275476c4195862E044B50127"
 		}
 	],
 	"derivedContracts": [

--- a/solidity/contracts/peripherals/SecurityPoolForker.sol
+++ b/solidity/contracts/peripherals/SecurityPoolForker.sol
@@ -192,9 +192,17 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 		escalationGameForkerDelegate = address(new EscalationGameForker(_zoltar));
 	}
 
-	function _forkOccurredBeforeEscalationSettled(EscalationGame escalationGame) private view returns (bool) {
+	function _forkOccurredBeforeEscalationSettled(
+		EscalationGame escalationGame,
+		uint256 forkTime
+	) private view returns (bool) {
 		if (address(escalationGame) == address(0x0)) return false;
-		return escalationGame.getQuestionResolution() == BinaryOutcomes.BinaryOutcome.None;
+		// SecurityPool.isOperational prevents creating or funding a game after the universe fork.
+		// The current unresolved check therefore preserves pre-existing non-decision games;
+		// a game finalized before the fork fails both this check and the fork-time end-date check.
+		return
+			escalationGame.getQuestionResolution() == BinaryOutcomes.BinaryOutcome.None ||
+			escalationGame.getEscalationGameEndDate() >= forkTime;
 	}
 
 	function _getEscalationElapsedAtFork(
@@ -224,7 +232,7 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 		EscalationGame escalationGame,
 		uint256 forkTime
 	) private {
-		if (!_forkOccurredBeforeEscalationSettled(escalationGame)) return;
+		if (!_forkOccurredBeforeEscalationSettled(escalationGame, forkTime)) return;
 		data.unresolvedEscalationAtFork = true;
 		data.escalationStartBondAtFork = escalationGame.startBond();
 		data.escalationNonDecisionThresholdAtFork = escalationGame.nonDecisionThreshold();
@@ -245,8 +253,7 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 		require(securityPool.systemState() != SystemState.PoolForked, 'Already forked');
 		require(securityPool.systemState() == SystemState.Operational, 'Not operational');
 		require(
-			address(escalationGame) == address(0x0) ||
-				escalationGame.getQuestionResolution() == BinaryOutcomes.BinaryOutcome.None,
+			address(escalationGame) == address(0x0) || _forkOccurredBeforeEscalationSettled(escalationGame, forkTime),
 			'Resolved'
 		);
 		data = forkDataByPool[securityPool];

--- a/solidity/ts/tests/peripherals/forkMigration.test.ts
+++ b/solidity/ts/tests/peripherals/forkMigration.test.ts
@@ -4,6 +4,7 @@ import { usePeripheralsForkMigrationFixture, type PeripheralsForkMigrationFixtur
 import { getExpectedLiquidationRepMove } from './liquidationTestHelpers'
 import { getUniverseData } from '../../testsuite/simulator/utils/contracts/zoltar'
 import { queueLiquidationAtForcedPrice } from '../../testsuite/simulator/utils/contracts/peripherals'
+import { getQuestionResolution } from '../../testsuite/simulator/utils/contracts/escalationGame'
 import { peripherals_SecurityPool_SecurityPool } from '../../types/contractArtifact'
 import { test_peripherals_SecurityPoolForkerAttackMocks_SecurityPoolForkerAttackFactoryMock, test_peripherals_SecurityPoolForkerAttackMocks_SecurityPoolForkerAttackParentMock } from '../../types/contractArtifact'
 
@@ -137,6 +138,67 @@ describe('Peripherals: fork migration', () => {
 	})
 
 	describe('child universe and own-fork entry', () => {
+		test('allows delayed fork initialization for an escalation game unresolved at the universe fork', async () => {
+			const endTime = await getQuestionEndDate(client, questionId)
+			await mockWindow.setTime(endTime + 10000n)
+			await depositToEscalationGame(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes, reportBond)
+
+			const escalationGameEndDate = await client.readContract({
+				abi: peripherals_EscalationGame_EscalationGame.abi,
+				functionName: 'getEscalationGameEndDate',
+				address: securityPoolAddresses.escalationGame,
+				args: [],
+			})
+			const forkTimeAtResolution = escalationGameEndDate
+			const forkSourceQuestionData = {
+				...questionData,
+				title: 'delayed initialization fork source',
+				endTime: forkTimeAtResolution - 1n,
+			}
+			const forkSourceQuestionId = getQuestionId(forkSourceQuestionData, outcomes)
+			await createQuestion(client, forkSourceQuestionData, outcomes)
+			await approveToken(client, addressString(GENESIS_REPUTATION_TOKEN), getZoltarAddress())
+			await mockWindow.setTime(forkTimeAtResolution - 1n)
+			await forkUniverse(client, genesisUniverse, forkSourceQuestionId)
+
+			strictEqualTypeSafe((await getUniverseData(client, genesisUniverse)).forkTime, escalationGameEndDate, 'the external fork should occur exactly at escalation resolution')
+			await mockWindow.setTime(escalationGameEndDate + 1n)
+			strictEqualTypeSafe(await getQuestionResolution(client, securityPoolAddresses.escalationGame), QuestionOutcome.Yes, 'the escalation game should resolve after the universe fork')
+			strictEqualTypeSafe(await getQuestionOutcome(client, securityPoolAddresses.securityPool), QuestionOutcome.None, 'the local outcome should remain unavailable after a fork-time-unresolved escalation game')
+			await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
+			strictEqualTypeSafe(await getSystemState(client, securityPoolAddresses.securityPool), SystemState.PoolForked, 'delayed initialization should enter fork mode')
+			strictEqualTypeSafe((await getSecurityPoolForkerForkData(client, securityPoolAddresses.securityPool)).unresolvedEscalationAtFork, true, 'the fork should preserve the unresolved escalation snapshot')
+		})
+
+		test('rejects delayed fork initialization for an escalation game resolved before the universe fork', async () => {
+			const endTime = await getQuestionEndDate(client, questionId)
+			await mockWindow.setTime(endTime + 10000n)
+			await depositToEscalationGame(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes, reportBond)
+			const escalationGameEndDate = await client.readContract({
+				abi: peripherals_EscalationGame_EscalationGame.abi,
+				functionName: 'getEscalationGameEndDate',
+				address: securityPoolAddresses.escalationGame,
+				args: [],
+			})
+			await mockWindow.setTime(escalationGameEndDate + 1n)
+			strictEqualTypeSafe(await getQuestionResolution(client, securityPoolAddresses.escalationGame), QuestionOutcome.Yes, 'the escalation game should resolve before the universe fork')
+
+			const forkSourceQuestionData = {
+				...questionData,
+				title: 'resolved before initialization fork source',
+				endTime: (await mockWindow.getTime()) + DAY,
+			}
+			const forkSourceQuestionId = getQuestionId(forkSourceQuestionData, outcomes)
+			await createQuestion(client, forkSourceQuestionData, outcomes)
+			await mockWindow.setTime(forkSourceQuestionData.endTime + 1n)
+			await approveToken(client, addressString(GENESIS_REPUTATION_TOKEN), getZoltarAddress())
+			await forkUniverse(client, genesisUniverse, forkSourceQuestionId)
+
+			await assert.rejects(initiateSecurityPoolFork(client, securityPoolAddresses.securityPool), /Resolved/)
+			strictEqualTypeSafe(await getSystemState(client, securityPoolAddresses.securityPool), SystemState.Operational, 'a pre-fork-resolved game should leave the pool operational')
+			strictEqualTypeSafe((await getSecurityPoolForkerForkData(client, securityPoolAddresses.securityPool)).unresolvedEscalationAtFork, false, 'a pre-fork-resolved game should not be snapshotted as unresolved')
+		})
+
 		test('create child universe test', async () => {
 			const endTime = await getQuestionEndDate(client, questionId)
 			await mockWindow.setTime(endTime + 10000n)


### PR DESCRIPTION
## Summary
- Allow `SecurityPoolForker` to treat an escalation game as fork-relevant when it was unresolved at the universe fork, even if it resolves later.
- Keep already-resolved escalation games from being snapshotted into delayed fork initialization.
- Add fork migration coverage for both delayed-unresolved and pre-fork-resolved escalation game cases.

## Testing
- `bun run tsc` not run
- `bun run test` not run
- `bun run format` not run
- `bun run check` not run