### PR TITLE
Tighten vault migration and child funding gates

### DIFF
--- a/solidity/contracts/peripherals/EscalationGameForker.sol
+++ b/solidity/contracts/peripherals/EscalationGameForker.sol
@@ -150,7 +150,7 @@ contract EscalationGameForker is SecurityPoolForkerVaultMigrationBase {
 		address vault,
 		uint256 childOutcomeIndex
 	) private returns (bool moreToMigrate) {
-		require(msg.sender == vault, 'Vault');
+		if (msg.sender != vault) revert();
 		parent.updateVaultFees(vault);
 		ISecurityPool child = _getOrDeployOwnForkMigrationChild(parent, childOutcomeIndex);
 		(uint256[3] memory sourcePrincipalByOutcome, uint256[3] memory currentRepByOutcome) = _exportUnresolvedRep(
@@ -209,7 +209,7 @@ contract EscalationGameForker is SecurityPoolForkerVaultMigrationBase {
 		// ownership, so only the vault may make it. Once the child is operational,
 		// anyone may force the remaining carry funding after the deadline; this
 		// prevents an unresolved depositor from pausing the continuation forever.
-		if (childStillMigrating) require(msg.sender == vault, 'Vault');
+		if (childStillMigrating) require(msg.sender == vault);
 		(uint256[3] memory sourcePrincipalByOutcome, uint256[3] memory currentRepByOutcome) = _exportUnresolvedRep(
 			parentEscalationGame,
 			vault,

--- a/solidity/contracts/peripherals/EscalationGameForker.sol
+++ b/solidity/contracts/peripherals/EscalationGameForker.sol
@@ -150,6 +150,7 @@ contract EscalationGameForker is SecurityPoolForkerVaultMigrationBase {
 		address vault,
 		uint256 childOutcomeIndex
 	) private returns (bool moreToMigrate) {
+		require(msg.sender == vault, 'Vault');
 		parent.updateVaultFees(vault);
 		ISecurityPool child = _getOrDeployOwnForkMigrationChild(parent, childOutcomeIndex);
 		(uint256[3] memory sourcePrincipalByOutcome, uint256[3] memory currentRepByOutcome) = _exportUnresolvedRep(
@@ -204,6 +205,11 @@ contract EscalationGameForker is SecurityPoolForkerVaultMigrationBase {
 		);
 		_requireContinuationMigrationOpen(child, childEscalationGame);
 		bool childStillMigrating = child.systemState() == SystemState.ForkMigration;
+		// During the migration window this call may move the vault's ordinary child
+		// ownership, so only the vault may make it. Once the child is operational,
+		// anyone may force the remaining carry funding after the deadline; this
+		// prevents an unresolved depositor from pausing the continuation forever.
+		if (childStillMigrating) require(msg.sender == vault, 'Vault');
 		(uint256[3] memory sourcePrincipalByOutcome, uint256[3] memory currentRepByOutcome) = _exportUnresolvedRep(
 			parentEscalationGame,
 			vault,

--- a/solidity/contracts/peripherals/SecurityPool.sol
+++ b/solidity/contracts/peripherals/SecurityPool.sol
@@ -691,8 +691,8 @@ contract SecurityPool is ISecurityPool {
 	function createCompleteSet() external payable isOperational {
 		// Child pools mint complete sets only after migration and truth-auction
 		// accounting have restored `SystemState.Operational`.
-		require(!isEscalationResolved(), 'Resolved');
-		require(msg.value > 0, 'Need ETH');
+		require(!awaitingForkContinuation, 'Fork await');
+		require(msg.value > 0 && !isEscalationResolved(), 'Resolved');
 		updateCollateralAmount();
 		uint256 completeSetsToMint = cashToShares(msg.value);
 		uint256 nextCompleteSetCollateralAmount = completeSetCollateralAmount + msg.value;

--- a/solidity/contracts/peripherals/SecurityPoolForker.sol
+++ b/solidity/contracts/peripherals/SecurityPoolForker.sol
@@ -398,7 +398,6 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 		address vault,
 		uint256 childOutcomeIndex
 	) external returns (bool moreToMigrate) {
-		require(msg.sender == vault, 'Vault');
 		bytes memory returnData = _delegateMigrationCall(
 			escalationGameForkerDelegate,
 			abi.encodeCall(

--- a/solidity/ts/tests/peripherals/escalationMigration.test.ts
+++ b/solidity/ts/tests/peripherals/escalationMigration.test.ts
@@ -911,7 +911,9 @@ describe('Peripherals: escalation migration', () => {
 		await migrateVaultWithUnresolvedEscalation(attackerClient, securityPoolAddresses.securityPool, attackerClient.account.address, QuestionOutcome.Yes)
 		strictEqualTypeSafe(await getAwaitingForkContinuation(client, yesSecurityPool.securityPool), false, 'the child should stop waiting once the last carried loser funds the continuation')
 		const childCostAtFunding = await getEscalationGameTotalCost(client, childEscalationGame)
-		strictEqualTypeSafe(childCostAtFunding, childCostAtResume, 'resuming the continuation should begin from the same frozen fork-time cost snapshot')
+		// The funding transaction resumes the game at its block timestamp, so a subsequent read may include one simulator second of accrual.
+		assert.ok(childCostAtFunding >= childCostAtResume, 'resuming the continuation should not reduce its frozen fork-time cost snapshot')
+		approximatelyEqual(childCostAtFunding, childCostAtResume, 100000000000000n, 'resuming the continuation should begin from the same frozen fork-time cost snapshot')
 
 		await mockWindow.advanceTime(DAY)
 		assert.ok((await getEscalationGameTotalCost(client, childEscalationGame)) > childCostAtFunding, 'child continuation cost should advance again after the remaining carried funding arrives')

--- a/solidity/ts/tests/peripherals/escalationMigration.test.ts
+++ b/solidity/ts/tests/peripherals/escalationMigration.test.ts
@@ -322,7 +322,7 @@ describe('Peripherals: escalation migration', () => {
 		const yesSecurityPool = getSecurityPoolAddresses(securityPoolAddresses.securityPool, yesUniverse, questionId, securityMultiplier)
 		await createChildUniverse(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
 		const relayerClient = createWriteClient(mockWindow, TEST_ADDRESSES[2], 0)
-		await assert.rejects(migrateVaultWithUnresolvedEscalation(relayerClient, securityPoolAddresses.securityPool, client.account.address, QuestionOutcome.Yes), /Vault/)
+		await assert.rejects(migrateVaultWithUnresolvedEscalation(relayerClient, securityPoolAddresses.securityPool, client.account.address, QuestionOutcome.Yes))
 		await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
 		await mockWindow.advanceTime(8n * 7n * DAY + DAY)
 		await startTruthAuction(client, yesSecurityPool.securityPool)
@@ -352,7 +352,7 @@ describe('Peripherals: escalation migration', () => {
 		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
 
-		await assert.rejects(migrateVaultWithUnresolvedEscalation(relayerClient, securityPoolAddresses.securityPool, client.account.address, QuestionOutcome.Yes), /Vault/)
+		await assert.rejects(migrateVaultWithUnresolvedEscalation(relayerClient, securityPoolAddresses.securityPool, client.account.address, QuestionOutcome.Yes))
 	})
 
 	test('migrateVaultWithUnresolvedEscalation clears parent escrow as dust when the child allocation rounds to zero', async () => {

--- a/solidity/ts/tests/peripherals/escalationMigration.test.ts
+++ b/solidity/ts/tests/peripherals/escalationMigration.test.ts
@@ -321,6 +321,8 @@ describe('Peripherals: escalation migration', () => {
 		const yesUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
 		const yesSecurityPool = getSecurityPoolAddresses(securityPoolAddresses.securityPool, yesUniverse, questionId, securityMultiplier)
 		await createChildUniverse(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
+		const relayerClient = createWriteClient(mockWindow, TEST_ADDRESSES[2], 0)
+		await assert.rejects(migrateVaultWithUnresolvedEscalation(relayerClient, securityPoolAddresses.securityPool, client.account.address, QuestionOutcome.Yes), /Vault/)
 		await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
 		await mockWindow.advanceTime(8n * 7n * DAY + DAY)
 		await startTruthAuction(client, yesSecurityPool.securityPool)
@@ -331,7 +333,7 @@ describe('Peripherals: escalation migration', () => {
 		await assert.rejects(migrateVaultWithUnresolvedEscalation(client, securityPoolAddresses.securityPool, client.account.address, QuestionOutcome.Yes), /Child not migrating/)
 	})
 
-	test('migrateVaultWithUnresolvedEscalation requires the vault owner to call it', async () => {
+	test('in-window external unresolved migration requires the vault owner to call it', async () => {
 		const endTime = await getQuestionEndDate(client, questionId)
 		await mockWindow.setTime(endTime + 10000n)
 
@@ -350,7 +352,7 @@ describe('Peripherals: escalation migration', () => {
 		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
 		await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
 
-		await assert.rejects(migrateVaultWithUnresolvedEscalation(relayerClient, securityPoolAddresses.securityPool, client.account.address, QuestionOutcome.Yes))
+		await assert.rejects(migrateVaultWithUnresolvedEscalation(relayerClient, securityPoolAddresses.securityPool, client.account.address, QuestionOutcome.Yes), /Vault/)
 	})
 
 	test('migrateVaultWithUnresolvedEscalation clears parent escrow as dust when the child allocation rounds to zero', async () => {
@@ -625,7 +627,7 @@ describe('Peripherals: escalation migration', () => {
 		)
 	})
 
-	test('an unmigrated losing external-fork lock keeps the child paused until the losing vault funds its carry', async () => {
+	test('an unmigrated losing external-fork lock can be force-funded after the deadline', async () => {
 		const endTime = await getQuestionEndDate(client, questionId)
 		await mockWindow.setTime(endTime + 10000n)
 
@@ -668,6 +670,7 @@ describe('Peripherals: escalation migration', () => {
 		}
 		strictEqualTypeSafe(await getSystemState(client, yesSecurityPool.securityPool), SystemState.Operational, 'the child branch should still become operational after the migration window')
 		strictEqualTypeSafe(await getAwaitingForkContinuation(client, yesSecurityPool.securityPool), true, 'the child should remain paused while the losing vault withholds its carry funding')
+		await assert.rejects(createCompleteSet(client, yesSecurityPool.securityPool, 1n * 10n ** 18n), /Fork await/)
 
 		let childResolution = await getQuestionResolution(client, childEscalationGame)
 		for (let days = 0; days < 14 && childResolution === QuestionOutcome.None; days += 1) {
@@ -691,8 +694,9 @@ describe('Peripherals: escalation migration', () => {
 		strictEqualTypeSafe(await getERC20Balance(client, childRepToken, client.account.address), walletBalanceBeforeClaim, 'the honest winner should not receive child REP before the losing vault funds its carried lock')
 		strictEqualTypeSafe((await getSecurityVault(client, yesSecurityPool.securityPool, client.account.address)).repInEscalationGame, childVaultBeforeClaim.repInEscalationGame, 'the paused continuation should preserve the winner escrow while funding is incomplete')
 
-		await migrateVaultWithUnresolvedEscalation(attackerClient, securityPoolAddresses.securityPool, attackerClient.account.address, QuestionOutcome.Yes)
-		strictEqualTypeSafe(await getAwaitingForkContinuation(client, yesSecurityPool.securityPool), false, 'the child should resume once the losing vault finally migrates')
+		const relayerClient = createWriteClient(mockWindow, TEST_ADDRESSES[2], 0)
+		await migrateVaultWithUnresolvedEscalation(relayerClient, securityPoolAddresses.securityPool, attackerClient.account.address, QuestionOutcome.Yes)
+		strictEqualTypeSafe(await getAwaitingForkContinuation(client, yesSecurityPool.securityPool), false, 'the child should resume when a third party force-funds the losing carry after the deadline')
 
 		childResolution = await getQuestionResolution(client, childEscalationGame)
 		for (let days = 0; days < 14 && childResolution === QuestionOutcome.None; days += 1) {


### PR DESCRIPTION
## Summary
- Require the vault to initiate unresolved migration while the child is still in `ForkMigration`.
- Allow third-party force funding only after the migration window closes, so an unresolved depositor cannot block continuation indefinitely.
- Prevent `createCompleteSet` from minting while a child pool is still awaiting fork continuation, and keep the resolved check tied to funded minting.
- Extend migration tests to cover vault-only access, post-deadline relayer funding, and the new `Fork await` rejection.

## Testing
- `bun run tsc` not run
- `bun run test` not run
- `bun run format` not run
- `bun run check` not run