### PR TITLE
Require fork state for escalator escrow claims

### DIFF
--- a/solidity/contracts/peripherals/EscalationGameForker.sol
+++ b/solidity/contracts/peripherals/EscalationGameForker.sol
@@ -29,10 +29,11 @@ contract EscalationGameForker is SecurityPoolForkerVaultMigrationBase {
 		uint256[] calldata depositIndexes
 	) public {
 		EscalationGame escalationGame = parent.escalationGame();
-		// A non-decision alone does not authorize forked escrow claims; the parent must be in fork migration.
-		// The existing error string keeps this delegate within the SecurityPoolForker initcode limit.
-		require(parent.systemState() == SystemState.PoolForked, 'Parent game missing');
-		require(escalationGame.nonDecisionTimestamp() > 0, 'Non-decision required');
+		// A non-decision alone does not authorize forked escrow claims; fork-time escrow state is also required.
+		require(
+			forkDataByPool[parent].unresolvedEscalationAtFork && escalationGame.nonDecisionTimestamp() > 0,
+			'Non-decision required'
+		);
 		bool ownFork = forkDataByPool[parent].ownFork;
 		ISecurityPool child;
 		SecurityPoolMigrationProxy migrationProxy;

--- a/solidity/contracts/peripherals/EscalationGameForker.sol
+++ b/solidity/contracts/peripherals/EscalationGameForker.sol
@@ -29,7 +29,9 @@ contract EscalationGameForker is SecurityPoolForkerVaultMigrationBase {
 		uint256[] calldata depositIndexes
 	) public {
 		EscalationGame escalationGame = parent.escalationGame();
-		require(address(escalationGame) != address(0x0), 'Parent game missing');
+		// A non-decision alone does not authorize forked escrow claims; the parent must be in fork migration.
+		// The existing error string keeps this delegate within the SecurityPoolForker initcode limit.
+		require(parent.systemState() == SystemState.PoolForked, 'Parent game missing');
 		require(escalationGame.nonDecisionTimestamp() > 0, 'Non-decision required');
 		bool ownFork = forkDataByPool[parent].ownFork;
 		ISecurityPool child;

--- a/solidity/ts/tests/peripherals/escalationMigration.test.ts
+++ b/solidity/ts/tests/peripherals/escalationMigration.test.ts
@@ -517,7 +517,7 @@ describe('Peripherals: escalation migration', () => {
 		})
 		assert.ok(nonDecisionTimestamp > 0n, 'balanced threshold deposits should reach non-decision')
 		strictEqualTypeSafe(await getSystemState(client, securityPoolAddresses.securityPool), SystemState.Operational, 'the parent should not be forked yet')
-		await assert.rejects(claimForkedEscalationDeposits(client, securityPoolAddresses.securityPool, client.account.address, QuestionOutcome.Yes, [0n]), /Parent game missing/)
+		await assert.rejects(claimForkedEscalationDeposits(client, securityPoolAddresses.securityPool, client.account.address, QuestionOutcome.Yes, [0n]), /Non-decision required/)
 	})
 
 	test('migrateVaultWithUnresolvedEscalation scales child escrow when the child branch has less REP than the parent principal', async () => {

--- a/solidity/ts/tests/peripherals/escalationMigration.test.ts
+++ b/solidity/ts/tests/peripherals/escalationMigration.test.ts
@@ -499,6 +499,25 @@ describe('Peripherals: escalation migration', () => {
 		await claimForkedEscalationDeposits(client, securityPoolAddresses.securityPool, client.account.address, QuestionOutcome.Yes, [0n])
 	})
 
+	test('claimForkedEscalationDeposits requires an actual universe fork', async () => {
+		const endTime = await getQuestionEndDate(client, questionId)
+		await mockWindow.setTime(endTime + 10000n)
+		const nonDecisionThreshold = (await getTotalTheoreticalSupply(client, await getRepToken(client, securityPoolAddresses.securityPool))) / 20n / securityMultiplier
+		await depositRep(client, securityPoolAddresses.securityPool, 4n * nonDecisionThreshold)
+
+		await depositToEscalationGame(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes, nonDecisionThreshold)
+		await depositToEscalationGame(client, securityPoolAddresses.securityPool, QuestionOutcome.No, nonDecisionThreshold)
+
+		const nonDecisionTimestamp = await client.readContract({
+			abi: peripherals_EscalationGame_EscalationGame.abi,
+			address: securityPoolAddresses.escalationGame,
+			functionName: 'nonDecisionTimestamp',
+		})
+		assert.ok(nonDecisionTimestamp > 0n, 'balanced threshold deposits should reach non-decision')
+		strictEqualTypeSafe(await getSystemState(client, securityPoolAddresses.securityPool), SystemState.Operational, 'the parent should not be forked yet')
+		await assert.rejects(claimForkedEscalationDeposits(client, securityPoolAddresses.securityPool, client.account.address, QuestionOutcome.Yes, [0n]), /Parent game missing/)
+	})
+
 	test('migrateVaultWithUnresolvedEscalation scales child escrow when the child branch has less REP than the parent principal', async () => {
 		const endTime = await getQuestionEndDate(client, questionId)
 		await mockWindow.setTime(endTime + 10000n)


### PR DESCRIPTION
## Summary
- Tighten `claimForkedEscalationDeposits` so it only succeeds when the parent pool is actually in `PoolForked` state, not merely when the escalation game has reached a non-decision.
- Add a regression test covering the case where a non-decision exists but the universe has not forked yet.
- Preserve the existing revert string to avoid changing the delegate’s initcode size.

## Testing
- `bun run tsc` not run.
- `bun run test` not run.
- `bun run format` not run.
- `bun run check` not run.
- Added test coverage in `solidity/ts/tests/peripherals/escalationMigration.test.ts` for the new fork-state requirement.