### PR TITLE
Handle fork question semantics in pool migration

### DIFF
--- a/solidity/contracts/Zoltar.sol
+++ b/solidity/contracts/Zoltar.sol
@@ -98,6 +98,10 @@ contract Zoltar {
 		return universe.forkTime;
 	}
 
+	function forkQuestionMatches(uint248 universeId, uint256 questionId) external view returns (bool) {
+		return universes[universeId].forkQuestionId == questionId;
+	}
+
 	function getRepToken(uint248 universeId) external view returns (ReputationToken) {
 		Universe memory universe = universes[universeId];
 		return universe.reputationToken;

--- a/solidity/contracts/peripherals/SecurityPoolForker.sol
+++ b/solidity/contracts/peripherals/SecurityPoolForker.sol
@@ -241,9 +241,9 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 	) private returns (SecurityPoolForkerForkData storage data) {
 		uint248 universe = securityPool.universeId();
 		uint256 forkTime = zoltar.getForkTime(universe);
-		require(forkTime > 0, 'No fork');
-		require(securityPool.systemState() != SystemState.PoolForked, 'Already forked');
-		require(securityPool.systemState() == SystemState.Operational, 'Not operational');
+		require(forkTime > 0, 'Unforked');
+		require(securityPool.systemState() != SystemState.PoolForked, 'Forked');
+		require(securityPool.systemState() == SystemState.Operational, 'Inactive');
 		require(
 			address(escalationGame) == address(0x0) ||
 				escalationGame.getQuestionResolution() == BinaryOutcomes.BinaryOutcome.None,
@@ -309,6 +309,7 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 		SecurityPoolForkerForkData storage data = _prepareForkState(securityPool, escalationGame);
 		ReputationToken rep = securityPool.repToken();
 		uint248 universe = securityPool.universeId();
+		data.forkQuestionMatchesPoolQuestion = zoltar.forkQuestionMatches(universe, securityPool.questionId());
 		uint256 repBalanceBefore = rep.balanceOf(address(this));
 		securityPool.activateForkMode();
 		SecurityPoolMigrationProxy migrationProxy = _getOrDeployMigrationProxy(securityPool);
@@ -326,8 +327,8 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 
 	function migrateRepToZoltar(ISecurityPool securityPool, uint256[] calldata outcomeIndices) external {
 		SecurityPoolMigrationProxy migrationProxy = migrationProxyByPool[securityPool];
-		require(address(migrationProxy) != address(0x0), 'No proxy');
-		require(securityPool.systemState() == SystemState.PoolForked, 'Not forked');
+		require(address(migrationProxy) != address(0x0), 'Proxy');
+		require(securityPool.systemState() == SystemState.PoolForked, 'Unforked');
 		SecurityPoolForkerForkData storage data = forkDataByPool[securityPool];
 		uint256 migrationAmount = data.ownFork ? data.vaultRepAtFork : data.auctionableRepAtFork;
 		if (migrationAmount > 0) {
@@ -431,7 +432,7 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 			uint256 parentCollateral
 		)
 	{
-		require(securityPool.systemState() == SystemState.ForkMigration, 'Not migrating');
+		require(securityPool.systemState() == SystemState.ForkMigration, 'Not mig');
 		parent = securityPool.parent();
 		// The truth auction ends the parent's migration phase for this child branch.
 		// A child universe has no fork time until it forks again, so using the child
@@ -506,7 +507,7 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 	}
 
 	function _finalizeTruthAuction(ISecurityPool securityPool) private {
-		require(securityPool.systemState() == SystemState.ForkTruthAuction, 'Not in auction');
+		require(securityPool.systemState() == SystemState.ForkTruthAuction, 'Not auction');
 		SecurityPoolForkerForkData storage data = _getForkData(securityPool);
 		SecurityPoolForkerForkData storage parentData = _getForkData(securityPool.parent());
 		ISecurityPool parent = securityPool.parent();
@@ -529,7 +530,7 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 			uint256 ethReceived = address(this).balance - balanceBeforeFinalize;
 			if (ethReceived > 0) {
 				(bool sent, ) = payable(address(securityPool)).call{ value: ethReceived }('');
-				require(sent, 'ETH transfer');
+				require(sent, 'ETH');
 			}
 			repPurchased = data.truthAuction.totalRepPurchased();
 		}
@@ -630,9 +631,9 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 
 	function forkZoltarWithOwnEscalationGame(ISecurityPool securityPool) external {
 		EscalationGame escalationGame = securityPool.escalationGame();
-		require(address(escalationGame) != address(0x0) && escalationGame.nonDecisionTimestamp() > 0, 'Need fork game');
-		require(securityPool.systemState() != SystemState.PoolForked, 'Already forked');
-		require(securityPool.systemState() == SystemState.Operational, 'Not operational');
+		require(address(escalationGame) != address(0x0) && escalationGame.nonDecisionTimestamp() > 0, 'Need game');
+		require(securityPool.systemState() != SystemState.PoolForked, 'Forked');
+		require(securityPool.systemState() == SystemState.Operational, 'Inactive');
 		ReputationToken rep = securityPool.repToken();
 		uint256 poolRepToFork = rep.balanceOf(address(securityPool));
 		uint256 repBalanceBefore = rep.balanceOf(address(this));
@@ -640,6 +641,7 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 		uint256 escalationRepToFork = escalationGame.drainAllRep(address(this));
 		SecurityPoolForkerForkData storage data = forkDataByPool[securityPool];
 		data.ownFork = true;
+		data.forkQuestionMatchesPoolQuestion = true;
 		SecurityPoolMigrationProxy migrationProxy = _getOrDeployMigrationProxy(securityPool);
 		uint256 repBalanceAfter = rep.balanceOf(address(this));
 		uint256 repToFork = repBalanceAfter - repBalanceBefore;
@@ -692,7 +694,7 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 		IUniformPriceDualCapBatchAuction.TickIndex[] calldata claimTickIndices,
 		IUniformPriceDualCapBatchAuction.TickIndex[] calldata refundTickIndices
 	) external {
-		require(claimTickIndices.length > 0 || refundTickIndices.length > 0, 'Need claim/refund');
+		require(claimTickIndices.length > 0 || refundTickIndices.length > 0, 'Need action');
 		if (forkDataByPool[securityPool].truthAuction.finalized()) {
 			IUniformPriceDualCapBatchAuction.TickIndex[]
 				memory allTickIndices = new IUniformPriceDualCapBatchAuction.TickIndex[](
@@ -721,12 +723,12 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 		(uint256 amount, ) = data.truthAuction.withdrawBids(vault, tickIndices);
 		if (amount == 0) return;
 		uint256 auctionPoolOwnershipPerRep = data.auctionPoolOwnershipPerRep;
-		require(auctionPoolOwnershipPerRep > 0, 'No rate');
+		require(auctionPoolOwnershipPerRep > 0, 'Rate');
 		uint256 poolOwnershipAmount = amount * auctionPoolOwnershipPerRep;
 		uint256 nextClaimedAuctionPoolOwnership = data.claimedAuctionPoolOwnership + poolOwnershipAmount;
 		require(
 			nextClaimedAuctionPoolOwnership <= data.truthAuction.totalRepPurchased() * auctionPoolOwnershipPerRep,
-			'Claim exceeds REP'
+			'REP'
 		);
 		(uint256 poolOwnership, uint256 currentSecurityBondAllowance, , uint256 currentFeeIndex) = securityPool
 			.securityVaults(vault);
@@ -781,7 +783,7 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 		if (address(parent) != address(0x0)) {
 			SecurityPoolForkerForkData storage parentData = _getForkData(parent);
 			SecurityPoolForkerForkData storage childData = _getForkData(securityPool);
-			if (parentData.ownFork) {
+			if (parentData.forkQuestionMatchesPoolQuestion) {
 				require(childData.outcomeIndex <= uint256(BinaryOutcomes.BinaryOutcome.No), 'Bad outcome');
 				return BinaryOutcomes.BinaryOutcome(childData.outcomeIndex);
 			}

--- a/solidity/contracts/peripherals/SecurityPoolForker.sol
+++ b/solidity/contracts/peripherals/SecurityPoolForker.sol
@@ -664,7 +664,7 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 		uint256 leftoverProxyRep = rep.balanceOf(address(migrationProxy));
 		if (leftoverProxyRep > 0) migrationProxy.lockRep(leftoverProxyRep);
 		uint256 forkTime = zoltar.getForkTime(securityPool.universeId());
-		require(forkTime > 0, 'No time');
+		require(forkTime > 0, 'Time');
 		_snapshotEscalationAtFork(data, escalationGame, forkTime);
 		uint256 auctionableRepAtFork = zoltar.getMigrationRepBalance(
 			address(migrationProxy),
@@ -798,7 +798,7 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 			SecurityPoolForkerForkData storage parentData = _getForkData(parent);
 			SecurityPoolForkerForkData storage childData = _getForkData(securityPool);
 			if (parentData.forkQuestionMatchesPoolQuestion) {
-				require(childData.outcomeIndex <= uint256(BinaryOutcomes.BinaryOutcome.No), 'Bad outcome');
+				require(childData.outcomeIndex <= uint256(BinaryOutcomes.BinaryOutcome.No), 'Bad out');
 				return BinaryOutcomes.BinaryOutcome(childData.outcomeIndex);
 			}
 		}
@@ -815,6 +815,6 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 	}
 
 	receive() external payable {
-		require(trustedAuctionAddresses[msg.sender], 'Trusted only');
+		require(trustedAuctionAddresses[msg.sender], 'Trusted');
 	}
 }

--- a/solidity/contracts/peripherals/SecurityPoolForkerTypes.sol
+++ b/solidity/contracts/peripherals/SecurityPoolForkerTypes.sol
@@ -20,6 +20,7 @@ struct SecurityPoolForkerForkData {
 	uint256 vaultRepAtFork;
 	bool unresolvedEscalationAtFork;
 	uint256 outcomeIndex;
+	bool forkQuestionMatchesPoolQuestion;
 	uint256 ownForkCollateralAtFork;
 	uint256 ownForkMigratedRepCollateralized;
 	uint256 ownForkCollateralTransferred;

--- a/solidity/ts/tests/peripherals/forkMigration.test.ts
+++ b/solidity/ts/tests/peripherals/forkMigration.test.ts
@@ -216,7 +216,7 @@ describe('Peripherals: fork migration', () => {
 
 			const { forkData: forkDataBeforeStrayRep } = await setupOwnForkWithEscrow()
 			await transferRepToAddress(client, getInfraContractAddresses().securityPoolForker, strayRep)
-			await assert.rejects(initiateSecurityPoolFork(client, securityPoolAddresses.securityPool), /Already forked/)
+			await assert.rejects(initiateSecurityPoolFork(client, securityPoolAddresses.securityPool), /Forked/)
 
 			const forkData = await getSecurityPoolForkerForkData(client, securityPoolAddresses.securityPool)
 			strictEqualTypeSafe(await getSystemState(client, securityPoolAddresses.securityPool), SystemState.PoolForked, 're-initiating after the own-game fork should leave the parent pool in PoolForked')
@@ -2055,6 +2055,24 @@ describe('Peripherals: fork migration', () => {
 			const childEthAfter = await getETHBalance(client, yesSecurityPool.securityPool)
 			strictEqualTypeSafe(parentEthBefore - parentEthAfter, expectedCollateralTransfer, 'unlocked vault migration should transfer ETH collateral from parent to child')
 			strictEqualTypeSafe(childEthAfter - childEthBefore, expectedCollateralTransfer, 'unlocked vault migration should fund the child with the transferred ETH collateral')
+		})
+
+		test('directly forking the pool question preserves child branch semantics', async () => {
+			const endTime = await getQuestionEndDate(client, questionId)
+			await mockWindow.setTime(endTime + 10000n)
+			await approveToken(client, addressString(GENESIS_REPUTATION_TOKEN), getZoltarAddress())
+			await forkUniverse(client, genesisUniverse, questionId)
+			await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
+
+			const forkData = await getSecurityPoolForkerForkData(client, securityPoolAddresses.securityPool)
+			assert.strictEqual(forkData.ownFork, false, 'direct Zoltar fork should not use own-fork accounting')
+
+			await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
+			await createChildUniverse(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
+			const yesUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
+			const yesSecurityPool = getSecurityPoolAddresses(securityPoolAddresses.securityPool, yesUniverse, questionId, securityMultiplier)
+
+			strictEqualTypeSafe(await getQuestionOutcome(client, yesSecurityPool.securityPool), QuestionOutcome.Yes, 'matching-question child should resolve to its branch outcome')
 		})
 
 		test('migrateVault transfers unlocked REP collateral for own forks', async () => {

--- a/solidity/ts/tests/securityPoolForkerInitcodeSize.test.ts
+++ b/solidity/ts/tests/securityPoolForkerInitcodeSize.test.ts
@@ -1,0 +1,21 @@
+import { test } from 'bun:test'
+import assert from '../testsuite/simulator/utils/assert'
+import { getContractOutput, getRecord, getString, loadContractsJson } from './contractArtifactHelpers'
+
+const eip3860InitcodeLimitBytes = 49_152
+const securityPoolForkerConstructorArgumentBytes = 32
+
+function getCreationBytecodeBytes() {
+	const artifacts = loadContractsJson(import.meta.dir)
+	const output = getContractOutput(artifacts, 'contracts/peripherals/SecurityPoolForker.sol', 'SecurityPoolForker')
+	const evm = getRecord(output.evm, 'SecurityPoolForker output is missing EVM bytecode')
+	const bytecode = getRecord(evm.bytecode, 'SecurityPoolForker output is missing creation bytecode')
+	return getString(bytecode.object, 'SecurityPoolForker creation bytecode is missing').length / 2
+}
+
+test('SecurityPoolForker initcode stays within the EIP-3860 limit', () => {
+	const creationBytecodeBytes = getCreationBytecodeBytes()
+	const initcodeBytes = creationBytecodeBytes + securityPoolForkerConstructorArgumentBytes
+
+	assert.ok(initcodeBytes <= eip3860InitcodeLimitBytes, `SecurityPoolForker initcode exceeds EIP-3860: ${initcodeBytes} bytes (limit ${eip3860InitcodeLimitBytes})`)
+})


### PR DESCRIPTION
## Summary
- Preserve child-branch semantics when a security pool is forked directly from the Zoltar question.
- Track whether the fork question matches the pool question and use that flag when resolving child outcomes.
- Tighten and shorten several revert messages in the fork migration path.
- Add regression coverage for direct Zoltar forks and matching-question child universes.

## Testing
- `solidity/ts/tests/peripherals/forkMigration.test.ts`: added a regression test for direct pool-question forks.
- Not run: automated validation was not executed for this summary-only PR description.