### PR TITLE
Inline named UI strings across the UI

### DIFF
--- a/scripts/lint-ui-tsx-strings.mts
+++ b/scripts/lint-ui-tsx-strings.mts
@@ -332,7 +332,7 @@ export function lintSourceText(filePath: string, sourceText: string, changedLine
 					ts.forEachChild(node, visit)
 					return
 				}
-				failures.push(`${filePath}:${line + 1}:${character + 1} JSX text must come from UI_STRINGS`)
+				failures.push(`${filePath}:${line + 1}:${character + 1} JSX text must come from a named uiStrings export`)
 			}
 		}
 		if ((ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node) || ts.isTemplateExpression(node)) && shouldReportLiteral(node)) {

--- a/scripts/lint-ui-tsx-strings.test.ts
+++ b/scripts/lint-ui-tsx-strings.test.ts
@@ -75,10 +75,10 @@ test('lint-ui-tsx-strings ignores local prop-object keys that are not direct use
 	)
 
 	expect(failures).toHaveLength(1)
-	expect(failures[0]).toContain('JSX text must come from UI_STRINGS')
+	expect(failures[0]).toContain('JSX text must come from a named uiStrings export')
 	expect(jsxPayloadFailures).toHaveLength(0)
 	expect(localDescriptionPropsFailures).toHaveLength(1)
-	expect(localDescriptionPropsFailures[0]).toContain('JSX text must come from UI_STRINGS')
+	expect(localDescriptionPropsFailures[0]).toContain('JSX text must come from a named uiStrings export')
 })
 
 test('lint-ui-tsx-strings rejects nested user-facing object payload literals inside JSX attributes', () => {
@@ -121,7 +121,7 @@ test('lint-ui-tsx-strings rejects direct suffix props and acronym JSX text', () 
 	expect(wrappedSuffixFailures[0]).toContain('direct UI string literal must come from ui/ts/lib/uiStrings.ts')
 	expect(wrappedAcronymFailures[0]).toContain('direct UI string literal must come from ui/ts/lib/uiStrings.ts')
 	expect(summaryFailures[0]).toContain('direct UI string literal must come from ui/ts/lib/uiStrings.ts')
-	expect(acronymTextFailures[0]).toContain('JSX text must come from UI_STRINGS')
+	expect(acronymTextFailures[0]).toContain('JSX text must come from a named uiStrings export')
 	expect(helperFailures[0]).toContain('direct UI string literal must come from ui/ts/lib/uiStrings.ts')
 	expect(lowercaseHelperFailures[0]).toContain('direct UI string literal must come from ui/ts/lib/uiStrings.ts')
 })
@@ -154,7 +154,7 @@ test('lint-ui-tsx-strings rejects lowercase visible JSX text', () => {
 
 	expect(failures).toHaveLength(1)
 	expect(failures[0]).toStartWith('ui/ts/components/TestText.tsx:')
-	expect(failures[0]).toContain('JSX text must come from UI_STRINGS')
+	expect(failures[0]).toContain('JSX text must come from a named uiStrings export')
 })
 
 test('lint-ui-tsx-strings rejects expression-wrapped visible JSX text', () => {
@@ -203,7 +203,7 @@ test('lint-ui-tsx-strings rejects assigned user-facing reasons', () => {
 	)
 	const propertyAssignmentFailures = lintSourceText('ui/ts/components/TestPropertyAssignedReason.tsx', "export function TestPropertyAssignedReason() { const copy = { reason: '' }; copy.reason = 'Settle later.'; return <Panel reason={copy.reason} /> }")
 	const elementAssignmentFailures = lintSourceText('ui/ts/components/TestElementAssignedReason.tsx', "export function TestElementAssignedReason() { const copy: Record<string, string> = {}; copy['aria-label'] = 'Close dialog'; return <button /> }")
-	const allowedElementAssignmentFailures = lintSourceText('ui/ts/components/TestAllowedElementAssignedReason.tsx', "export function TestAllowedElementAssignedReason() { const copy: Record<string, string> = {}; copy['aria-label'] = UI_STRINGS.common.closeLabel; return <button /> }")
+	const allowedElementAssignmentFailures = lintSourceText('ui/ts/components/TestAllowedElementAssignedReason.tsx', "export function TestAllowedElementAssignedReason() { const copy: Record<string, string> = {}; copy['aria-label'] = UI_STRING_CLOSE; return <button /> }")
 
 	expect(directAssignmentFailures).toHaveLength(1)
 	expect(ternaryAssignmentFailures).toHaveLength(1)
@@ -249,7 +249,7 @@ test('lint-ui-tsx-strings ignores comparison literals inside JSX expressions', (
 	const failures = lintSourceText('ui/ts/components/TestComparison.tsx', "export function TestComparison({ view }: { view: string }) { return <>{view === 'questions' ? <span>Shown</span> : <span>Hidden</span>}</> }")
 
 	expect(failures).toHaveLength(2)
-	expect(failures.every(failure => failure.includes('JSX text must come from UI_STRINGS'))).toBe(true)
+	expect(failures.every(failure => failure.includes('JSX text must come from a named uiStrings export'))).toBe(true)
 })
 
 test('lint-ui-tsx-strings includes committed branch changes from origin/main', () => {
@@ -272,7 +272,7 @@ test('lint-ui-tsx-strings reports multiline JSX text when a later tracked line c
 	const failures = lintSourceText('ui/ts/components/TestMultilineJsxText.tsx', ['export function TestMultilineJsxText() {', '\treturn <span>', '\t\tLegacy', '\t\tCopy', '\t</span>', '}'].join('\n'), new Set([4]))
 
 	expect(failures).toHaveLength(1)
-	expect(failures[0]).toContain('JSX text must come from UI_STRINGS')
+	expect(failures[0]).toContain('JSX text must come from a named uiStrings export')
 })
 
 test('lint-ui-tsx-strings reports multiline template literals when a later tracked line changes', () => {

--- a/ui/ts/App.tsx
+++ b/ui/ts/App.tsx
@@ -39,7 +39,22 @@ import type { TransactionRequestPreview } from './lib/chainBackend.js'
 import { buildRouteHref, DEPLOY_ROUTE, getRouteHashSearch, OPEN_ORACLE_ROUTE, SECURITY_POOLS_ROUTE, ZOLTAR_ROUTE } from './lib/routing.js'
 import { writeOpenOracleViewQueryParam, writeSecurityPoolsViewQueryParam, writeZoltarViewQueryParam } from './lib/urlParams.js'
 import { getUniversePresentation } from './lib/userCopy.js'
-import { UI_STRINGS } from './lib/uiStrings.js'
+import {
+	UI_STRING_BROWSE,
+	UI_STRING_BROWSE_POOLS,
+	UI_STRING_CREATE_POOL,
+	UI_STRING_CREATE_QUESTION,
+	UI_STRING_CREATE_REPORT,
+	UI_STRING_FORK_ZOLTAR,
+	UI_STRING_MANAGE_POOL,
+	UI_STRING_MARKET_VIEWS,
+	UI_STRING_MIGRATE_REP,
+	UI_STRING_ORACLE_REPORT_VIEWS,
+	UI_STRING_QUESTIONS_AND_MARKETS,
+	UI_STRING_REP_MIGRATION_UNAVAILABLE_BECAUSE_UNIVERSE_HAS_NOT_FORKED,
+	UI_STRING_REPORT_DETAILS,
+	UI_STRING_SECURITY_POOLS_VIEWS,
+} from './lib/uiStrings.js'
 import { formatUniverseCollectionLabel } from './lib/universe.js'
 import { resolveEnumValue, resolveFirstMatchingValue } from './lib/viewState.js'
 import type { ReportingFormState } from './types/app.js'
@@ -710,18 +725,18 @@ export function App() {
 	if (route === 'zoltar') {
 		routeSubNavigation = (
 			<RouteSubNavigation
-				ariaLabel={UI_STRINGS.app.zoltar.subNavigationAriaLabel}
+				ariaLabel={UI_STRING_MARKET_VIEWS}
 				value={activeZoltarView}
 				onChange={view => setZoltarView(view)}
 				options={[
-					{ href: buildRouteHref(ZOLTAR_ROUTE, writeZoltarViewQueryParam(getRouteHashSearch(), 'questions')), label: UI_STRINGS.app.zoltar.questionsAndMarketsLabel, value: 'questions' },
-					{ href: buildRouteHref(ZOLTAR_ROUTE, writeZoltarViewQueryParam(getRouteHashSearch(), 'create')), label: UI_STRINGS.app.zoltar.createQuestionLabel, value: 'create' },
-					{ href: buildRouteHref(ZOLTAR_ROUTE, writeZoltarViewQueryParam(getRouteHashSearch(), 'fork')), label: UI_STRINGS.app.zoltar.forkOracleLabel, value: 'fork' },
+					{ href: buildRouteHref(ZOLTAR_ROUTE, writeZoltarViewQueryParam(getRouteHashSearch(), 'questions')), label: UI_STRING_QUESTIONS_AND_MARKETS, value: 'questions' },
+					{ href: buildRouteHref(ZOLTAR_ROUTE, writeZoltarViewQueryParam(getRouteHashSearch(), 'create')), label: UI_STRING_CREATE_QUESTION, value: 'create' },
+					{ href: buildRouteHref(ZOLTAR_ROUTE, writeZoltarViewQueryParam(getRouteHashSearch(), 'fork')), label: UI_STRING_FORK_ZOLTAR, value: 'fork' },
 					{
-						label: UI_STRINGS.app.zoltar.migrateRepLabel,
+						label: UI_STRING_MIGRATE_REP,
 						value: 'migrate',
 						disabled: zoltarUniverse?.hasForked !== true,
-						...(zoltarUniverse?.hasForked === true ? { href: buildRouteHref(ZOLTAR_ROUTE, writeZoltarViewQueryParam(getRouteHashSearch(), 'migrate')) } : { reason: UI_STRINGS.app.zoltar.forkOracleRequiredForRepMigrationReason }),
+						...(zoltarUniverse?.hasForked === true ? { href: buildRouteHref(ZOLTAR_ROUTE, writeZoltarViewQueryParam(getRouteHashSearch(), 'migrate')) } : { reason: UI_STRING_REP_MIGRATION_UNAVAILABLE_BECAUSE_UNIVERSE_HAS_NOT_FORKED }),
 					},
 				]}
 			/>
@@ -729,26 +744,26 @@ export function App() {
 	} else if (route === 'security-pools') {
 		routeSubNavigation = (
 			<RouteSubNavigation
-				ariaLabel={UI_STRINGS.app.securityPools.subNavigationAriaLabel}
+				ariaLabel={UI_STRING_SECURITY_POOLS_VIEWS}
 				value={activeSecurityPoolsView}
 				onChange={view => setSecurityPoolsView(view)}
 				options={[
-					{ href: buildRouteHref(SECURITY_POOLS_ROUTE, writeSecurityPoolsViewQueryParam(getRouteHashSearch(), 'browse')), label: UI_STRINGS.app.securityPools.browsePoolsLabel, value: 'browse' },
-					{ href: buildRouteHref(SECURITY_POOLS_ROUTE, writeSecurityPoolsViewQueryParam(getRouteHashSearch(), 'create')), label: UI_STRINGS.app.securityPools.createPoolLabel, value: 'create' },
-					{ href: buildRouteHref(SECURITY_POOLS_ROUTE, writeSecurityPoolsViewQueryParam(getRouteHashSearch(), 'operate')), label: UI_STRINGS.app.securityPools.managePoolLabel, value: 'operate' },
+					{ href: buildRouteHref(SECURITY_POOLS_ROUTE, writeSecurityPoolsViewQueryParam(getRouteHashSearch(), 'browse')), label: UI_STRING_BROWSE_POOLS, value: 'browse' },
+					{ href: buildRouteHref(SECURITY_POOLS_ROUTE, writeSecurityPoolsViewQueryParam(getRouteHashSearch(), 'create')), label: UI_STRING_CREATE_POOL, value: 'create' },
+					{ href: buildRouteHref(SECURITY_POOLS_ROUTE, writeSecurityPoolsViewQueryParam(getRouteHashSearch(), 'operate')), label: UI_STRING_MANAGE_POOL, value: 'operate' },
 				]}
 			/>
 		)
 	} else if (route === 'open-oracle') {
 		routeSubNavigation = (
 			<RouteSubNavigation
-				ariaLabel={UI_STRINGS.app.openOracle.subNavigationAriaLabel}
+				ariaLabel={UI_STRING_ORACLE_REPORT_VIEWS}
 				value={activeOpenOracleView}
 				onChange={view => setOpenOracleView(view)}
 				options={[
-					{ href: buildRouteHref(OPEN_ORACLE_ROUTE, writeOpenOracleViewQueryParam(getRouteHashSearch(), 'browse')), label: UI_STRINGS.app.openOracle.browseLabel, value: 'browse' },
-					{ href: buildRouteHref(OPEN_ORACLE_ROUTE, writeOpenOracleViewQueryParam(getRouteHashSearch(), 'create')), label: UI_STRINGS.app.openOracle.createReportLabel, value: 'create' },
-					{ href: buildRouteHref(OPEN_ORACLE_ROUTE, writeOpenOracleViewQueryParam(getRouteHashSearch(), 'selected-report')), label: UI_STRINGS.app.openOracle.reportDetailsLabel, value: 'selected-report' },
+					{ href: buildRouteHref(OPEN_ORACLE_ROUTE, writeOpenOracleViewQueryParam(getRouteHashSearch(), 'browse')), label: UI_STRING_BROWSE, value: 'browse' },
+					{ href: buildRouteHref(OPEN_ORACLE_ROUTE, writeOpenOracleViewQueryParam(getRouteHashSearch(), 'create')), label: UI_STRING_CREATE_REPORT, value: 'create' },
+					{ href: buildRouteHref(OPEN_ORACLE_ROUTE, writeOpenOracleViewQueryParam(getRouteHashSearch(), 'selected-report')), label: UI_STRING_REPORT_DETAILS, value: 'selected-report' },
 				]}
 			/>
 		)

--- a/ui/ts/components/AppStatusNotices.tsx
+++ b/ui/ts/components/AppStatusNotices.tsx
@@ -1,6 +1,30 @@
 import { NoticeStack } from './NoticeStack.js'
 import { TimestampValue } from './TimestampValue.js'
-import { UI_STRINGS } from '../lib/uiStrings.js'
+import {
+	UI_STRING_ACTIVE_READ_RPC,
+	UI_STRING_CONFIGURED_FALLBACK_READ_RPC,
+	UI_STRING_DEFAULT,
+	UI_STRING_DISPLAYED_ONCHAIN_STATE_MAY_BE_BEHIND_THE_LATEST_CHAIN_STATE_REFRESH_OR_SWITCH_RPC_BEFORE_ACTING_ON_BALANCES_SETTLEMENT_OR_LIQUIDATION,
+	UI_STRING_DISPLAYED_ONCHAIN_STATE_MAY_NOT_MATCH_THE_NETWORK_THIS_INTERFACE_WRITES_TO,
+	UI_STRING_ENVIRONMENT,
+	UI_STRING_ERROR,
+	UI_STRING_EXPLICIT_OVERRIDE,
+	UI_STRING_GLOBAL_RUNTIME,
+	UI_STRING_HAS_FORKED_ON,
+	UI_STRING_LOCAL_STORAGE,
+	UI_STRING_PAGE_URL,
+	UI_STRING_READ_RPC_MISMATCH,
+	UI_STRING_READ_RPC_OVERRIDE_ACTIVE,
+	UI_STRING_READ_RPC_OVERRIDE_IGNORED,
+	UI_STRING_REQUIRED_APPLICATION_CONTRACTS_ARE_NOT_DEPLOYED,
+	UI_STRING_SETUP_INCOMPLETE,
+	UI_STRING_SIMULATION_BOOTSTRAP_FAILED,
+	UI_STRING_UNIVERSE_FORKED,
+	UI_STRING_URL_PROVIDED_READ_RPC,
+	UI_TEMPLATE_READ_RPC_OVERRIDE_ACTIVE_DETAIL,
+	UI_TEMPLATE_READ_RPC_OVERRIDE_FROM_URL_DETAIL,
+	UI_TEMPLATE_READ_RPC_OVERRIDE_IGNORED_DETAIL,
+} from '../lib/uiStrings.js'
 import { formatUniverseLabel } from '../lib/universe.js'
 import type { ZoltarUniverseSummary } from '../types/contracts.js'
 import type { NoticeItem } from '../types/components.js'
@@ -17,21 +41,21 @@ type AppStatusNoticesProps = {
 }
 
 function formatRpcSourceLabel(source: ReadBackendStatus['rpcSource']) {
-	if (source === 'url') return UI_STRINGS.appStatusNotices.pageUrlRpcSourceLabel
-	if (source === 'localStorage') return UI_STRINGS.appStatusNotices.localStorageRpcSourceLabel
-	if (source === 'environment') return UI_STRINGS.appStatusNotices.environmentRpcSourceLabel
-	if (source === 'global') return UI_STRINGS.appStatusNotices.globalRuntimeRpcSourceLabel
-	if (source === 'override') return UI_STRINGS.appStatusNotices.explicitOverrideRpcSourceLabel
-	return UI_STRINGS.appStatusNotices.defaultRpcSourceLabel
+	if (source === 'url') return UI_STRING_PAGE_URL
+	if (source === 'localStorage') return UI_STRING_LOCAL_STORAGE
+	if (source === 'environment') return UI_STRING_ENVIRONMENT
+	if (source === 'global') return UI_STRING_GLOBAL_RUNTIME
+	if (source === 'override') return UI_STRING_EXPLICIT_OVERRIDE
+	return UI_STRING_DEFAULT
 }
 
 function getConfiguredRpcLabel(readBackendStatus: ReadBackendStatus) {
-	return readBackendStatus.transportMode === 'provider' ? UI_STRINGS.appStatusNotices.configuredFallbackReadRpcLabel : UI_STRINGS.appStatusNotices.activeReadRpcLabel
+	return readBackendStatus.transportMode === 'provider' ? UI_STRING_CONFIGURED_FALLBACK_READ_RPC : UI_STRING_ACTIVE_READ_RPC
 }
 
 function getReadBackendNoticeDetail(readBackendMessage: string) {
-	if (readBackendMessage.includes('stale')) return `${readBackendMessage} ${UI_STRINGS.appStatusNotices.staleReadBackendSuffix}`
-	return `${readBackendMessage} ${UI_STRINGS.appStatusNotices.readBackendMismatchSuffix}`
+	if (readBackendMessage.includes('stale')) return `${readBackendMessage} ${UI_STRING_DISPLAYED_ONCHAIN_STATE_MAY_BE_BEHIND_THE_LATEST_CHAIN_STATE_REFRESH_OR_SWITCH_RPC_BEFORE_ACTING_ON_BALANCES_SETTLEMENT_OR_LIQUIDATION}`
+	return `${readBackendMessage} ${UI_STRING_DISPLAYED_ONCHAIN_STATE_MAY_NOT_MATCH_THE_NETWORK_THIS_INTERFACE_WRITES_TO}`
 }
 
 function buildRpcOverrideNotice(readBackendStatus: ReadBackendStatus | undefined): NoticeItem | undefined {
@@ -40,46 +64,46 @@ function buildRpcOverrideNotice(readBackendStatus: ReadBackendStatus | undefined
 		const rejectedOverride = readBackendStatus.rejectedRpcOverride
 		const configuredRpcLabel = getConfiguredRpcLabel(readBackendStatus)
 		return {
-			detail: UI_STRINGS.appStatusNotices.readRpcOverrideIgnoredDetail(formatRpcSourceLabel(rejectedOverride.source), rejectedOverride.url, rejectedOverride.reason, configuredRpcLabel, readBackendStatus.rpcUrl),
+			detail: UI_TEMPLATE_READ_RPC_OVERRIDE_IGNORED_DETAIL(formatRpcSourceLabel(rejectedOverride.source), rejectedOverride.url, rejectedOverride.reason, configuredRpcLabel, readBackendStatus.rpcUrl),
 			id: 'read-rpc-override-ignored',
 			tone: 'warning',
-			title: UI_STRINGS.appStatusNotices.ignoredReadRpcOverrideTitle,
+			title: UI_STRING_READ_RPC_OVERRIDE_IGNORED,
 		}
 	}
 	if (readBackendStatus.rpcSource === 'url')
 		return {
-			detail: UI_STRINGS.appStatusNotices.readRpcOverrideFromUrlDetail(getConfiguredRpcLabel(readBackendStatus), readBackendStatus.rpcUrl),
+			detail: UI_TEMPLATE_READ_RPC_OVERRIDE_FROM_URL_DETAIL(getConfiguredRpcLabel(readBackendStatus), readBackendStatus.rpcUrl),
 			id: 'url-read-rpc-override',
 			tone: 'warning',
-			title: UI_STRINGS.appStatusNotices.urlProvidedReadRpcTitle,
+			title: UI_STRING_URL_PROVIDED_READ_RPC,
 		}
 	if (readBackendStatus.rpcSource === 'default') return undefined
 	return {
-		detail: UI_STRINGS.appStatusNotices.readRpcOverrideActiveDetail(getConfiguredRpcLabel(readBackendStatus), formatRpcSourceLabel(readBackendStatus.rpcSource), readBackendStatus.rpcUrl),
+		detail: UI_TEMPLATE_READ_RPC_OVERRIDE_ACTIVE_DETAIL(getConfiguredRpcLabel(readBackendStatus), formatRpcSourceLabel(readBackendStatus.rpcSource), readBackendStatus.rpcUrl),
 		id: 'read-rpc-override-active',
 		tone: 'pending',
-		title: UI_STRINGS.appStatusNotices.readRpcOverrideActiveTitle,
+		title: UI_STRING_READ_RPC_OVERRIDE_ACTIVE,
 	}
 }
 
 export function AppStatusNotices({ errorMessage, readBackendMessage, readBackendStatus, simulationBootstrapError, showAugurPlaceHolderDeploymentWarning, showZoltarUniverseForkedWarning, zoltarUniverse }: AppStatusNoticesProps) {
 	const items: NoticeItem[] = []
 	const rpcOverrideNotice = buildRpcOverrideNotice(readBackendStatus)
-	if (simulationBootstrapError !== undefined) items.push({ detail: simulationBootstrapError, id: 'simulation-bootstrap-error', tone: 'blocking', title: UI_STRINGS.appStatusNotices.simulationBootstrapFailedTitle })
+	if (simulationBootstrapError !== undefined) items.push({ detail: simulationBootstrapError, id: 'simulation-bootstrap-error', tone: 'blocking', title: UI_STRING_SIMULATION_BOOTSTRAP_FAILED })
 	if (showZoltarUniverseForkedWarning && zoltarUniverse !== undefined)
 		items.push({
 			detail: (
 				<>
-					{formatUniverseLabel(zoltarUniverse.universeId)} {UI_STRINGS.appStatusNotices.universeForkedOnDetailSuffix} <TimestampValue timestamp={zoltarUniverse.forkTime} />.
+					{formatUniverseLabel(zoltarUniverse.universeId)} {UI_STRING_HAS_FORKED_ON} <TimestampValue timestamp={zoltarUniverse.forkTime} />.
 				</>
 			),
 			id: 'zoltar-forked',
 			tone: 'blocking',
-			title: UI_STRINGS.appStatusNotices.universeForkedTitle,
+			title: UI_STRING_UNIVERSE_FORKED,
 		})
-	if (showAugurPlaceHolderDeploymentWarning) items.push({ detail: UI_STRINGS.appStatusNotices.finishSetupBeforeUsingAppDetail, id: 'setup-incomplete', tone: 'blocking', title: UI_STRINGS.appStatusNotices.setupIncompleteTitle })
-	if (readBackendMessage !== undefined) items.push({ detail: getReadBackendNoticeDetail(readBackendMessage), id: 'read-backend-mismatch', tone: 'blocking', title: UI_STRINGS.appStatusNotices.readRpcMismatchTitle })
-	if (errorMessage !== undefined) items.push({ detail: errorMessage, id: 'app-error', tone: 'blocking', title: UI_STRINGS.appStatusNotices.appErrorTitle })
+	if (showAugurPlaceHolderDeploymentWarning) items.push({ detail: UI_STRING_REQUIRED_APPLICATION_CONTRACTS_ARE_NOT_DEPLOYED, id: 'setup-incomplete', tone: 'blocking', title: UI_STRING_SETUP_INCOMPLETE })
+	if (readBackendMessage !== undefined) items.push({ detail: getReadBackendNoticeDetail(readBackendMessage), id: 'read-backend-mismatch', tone: 'blocking', title: UI_STRING_READ_RPC_MISMATCH })
+	if (errorMessage !== undefined) items.push({ detail: errorMessage, id: 'app-error', tone: 'blocking', title: UI_STRING_ERROR })
 	if (rpcOverrideNotice !== undefined) items.push(rpcOverrideNotice)
 
 	return <NoticeStack items={items} />

--- a/ui/ts/components/ChildUniversesSection.tsx
+++ b/ui/ts/components/ChildUniversesSection.tsx
@@ -4,7 +4,7 @@ import { EntityCard } from './EntityCard.js'
 import { TransactionActionButton } from './TransactionActionButton.js'
 import { UniverseLink } from './UniverseLink.js'
 import { WorkflowSubsection } from './WorkflowSubsection.js'
-import { UI_STRINGS } from '../lib/uiStrings.js'
+import { UI_STRING_EXISTS, UI_STRING_NOT_DEPLOYED, UI_STRING_WORKING } from '../lib/uiStrings.js'
 import type { ActionAvailability } from '../types/components.js'
 import type { ZoltarChildUniverseSummary } from '../types/contracts.js'
 
@@ -30,7 +30,7 @@ type ChildUniversesSectionProps = {
 }
 
 export function ChildUniverseStatusBadge({ child }: { child: ZoltarChildUniverseSummary }) {
-	return <Badge tone={child.exists ? 'ok' : 'pending'}>{child.exists ? UI_STRINGS.childUniversesSection.existsLabel : UI_STRINGS.childUniversesSection.notDeployedLabel}</Badge>
+	return <Badge tone={child.exists ? 'ok' : 'pending'}>{child.exists ? UI_STRING_EXISTS : UI_STRING_NOT_DEPLOYED}</Badge>
 }
 
 export function ChildUniversesSection({ action, childUniverses, emptyMessage, headerSubtitle, headerTitle, renderBody, renderBadge, renderTitle }: ChildUniversesSectionProps) {
@@ -52,7 +52,7 @@ export function ChildUniversesSection({ action, childUniverses, emptyMessage, he
 									childAction === undefined ? undefined : (
 										<TransactionActionButton
 											idleLabel={childAction.label}
-											pendingLabel={childAction.pendingLabel ?? UI_STRINGS.childUniversesSection.workingLabel}
+											pendingLabel={childAction.pendingLabel ?? UI_STRING_WORKING}
 											onClick={childAction.onClick}
 											pending={childAction.pending === true}
 											tone={childAction.tone ?? 'secondary'}

--- a/ui/ts/components/DeploymentRouteContent.tsx
+++ b/ui/ts/components/DeploymentRouteContent.tsx
@@ -7,7 +7,23 @@ import { SectionBlock } from './SectionBlock.js'
 import { DataGrid } from './DataGrid.js'
 import { TransactionActionButton } from './TransactionActionButton.js'
 import { findNextDeployableStep, getDeployNextMissingAvailability } from '../lib/deployment.js'
-import { UI_STRINGS } from '../lib/uiStrings.js'
+import {
+	UI_STRING_ALL_DEPLOYED,
+	UI_STRING_ALL_DETERMINISTIC_CONTRACTS_ARE_DEPLOYED_IN_GROUPED_SECTIONS,
+	UI_STRING_CONTRACTS_DEPLOYED,
+	UI_STRING_DEPLOY,
+	UI_STRING_DEPLOY_AND_VERIFY_THE_SHARED_DETERMINISTIC_CONTRACTS_THAT_BACK_THE_APPLICATION,
+	UI_STRING_DEPLOY_NEXT_MISSING,
+	UI_STRING_DEPLOYING,
+	UI_STRING_DEPLOYMENT_GROUPS,
+	UI_STRING_DEPLOYMENT_IN_PROGRESS_DEPLOYMENT_ROUTE_CONTENT_DEPLOYMENT_IN_PROGRESS_LABEL,
+	UI_STRING_DETERMINISTIC_CONTRACT_DEPLOYMENT,
+	UI_STRING_LOADING_DEPLOYMENT_STATUS,
+	UI_STRING_LOADING_WITH_ELLIPSIS,
+	UI_STRING_NEXT_DEPLOYABLE,
+	UI_STRING_NEXT_DEPLOYABLE_CONTRACT,
+	UI_TEMPLATE_COMPLETED_SECTION_TITLE,
+} from '../lib/uiStrings.js'
 import type { DeploymentRouteContentProps } from '../types/components.js'
 
 export function DeploymentRouteContent({ accountAddress, busyStepId, deployNextMissingPending, deploymentSections, deploymentStatuses, isLoadingDeploymentStatuses, isMainnet, onDeploy, onDeployNextMissing }: DeploymentRouteContentProps) {
@@ -21,36 +37,36 @@ export function DeploymentRouteContent({ accountAddress, busyStepId, deployNextM
 		isMainnet,
 		nextMissingStep,
 	})
-	let buttonContent: ComponentChildren = UI_STRINGS.deploymentRouteContent.deployButtonIdleLabel
+	let buttonContent: ComponentChildren = UI_STRING_DEPLOY_NEXT_MISSING
 	if (deployNextMissingPending) {
-		buttonContent = UI_STRINGS.deploymentRouteContent.deployButtonPendingLabel
-	} else if (busyStepId !== undefined) buttonContent = UI_STRINGS.deploymentRouteContent.deploymentInProgressLabel
+		buttonContent = UI_STRING_DEPLOYING
+	} else if (busyStepId !== undefined) buttonContent = UI_STRING_DEPLOYMENT_IN_PROGRESS_DEPLOYMENT_ROUTE_CONTENT_DEPLOYMENT_IN_PROGRESS_LABEL
 
 	return (
 		<>
 			<RouteHeader
-				eyebrow={UI_STRINGS.deploymentRouteContent.deployRouteEyebrow}
-				title={UI_STRINGS.deploymentRouteContent.deterministicContractDeploymentTitle}
-				description={UI_STRINGS.deploymentRouteContent.deterministicContractDeploymentDescription}
-				actions={<TransactionActionButton idleLabel={buttonContent} pendingLabel={UI_STRINGS.deploymentRouteContent.deployButtonPendingLabel} onClick={onDeployNextMissing} pending={deployNextMissingPending} availability={deployNextAvailability} />}
+				eyebrow={UI_STRING_DEPLOY}
+				title={UI_STRING_DETERMINISTIC_CONTRACT_DEPLOYMENT}
+				description={UI_STRING_DEPLOY_AND_VERIFY_THE_SHARED_DETERMINISTIC_CONTRACTS_THAT_BACK_THE_APPLICATION}
+				actions={<TransactionActionButton idleLabel={buttonContent} pendingLabel={UI_STRING_DEPLOYING} onClick={onDeployNextMissing} pending={deployNextMissingPending} availability={deployNextAvailability} />}
 				summary={
 					<DataGrid columns='auto'>
 						<div>
-							<p className='detail'>{UI_STRINGS.deploymentRouteContent.contractsDeployedLabel}</p>
+							<p className='detail'>{UI_STRING_CONTRACTS_DEPLOYED}</p>
 							<strong>
-								<LoadableValue loading={isLoadingDeploymentStatuses} placeholder={UI_STRINGS.deploymentRouteContent.loadingDeploymentStatusLabel}>
+								<LoadableValue loading={isLoadingDeploymentStatuses} placeholder={UI_STRING_LOADING_DEPLOYMENT_STATUS}>
 									{deployedContractCount} / {totalContractCount}
 								</LoadableValue>
 							</strong>
 						</div>
 						<div>
-							<p className='detail'>{UI_STRINGS.deploymentRouteContent.nextDeployableLabel}</p>
-							<strong>{isLoadingDeploymentStatuses ? UI_STRINGS.deploymentRouteContent.loadingLabel : (nextMissingStep?.label ?? UI_STRINGS.deploymentRouteContent.allDeployedLabel)}</strong>
+							<p className='detail'>{UI_STRING_NEXT_DEPLOYABLE}</p>
+							<strong>{isLoadingDeploymentStatuses ? UI_STRING_LOADING_WITH_ELLIPSIS : (nextMissingStep?.label ?? UI_STRING_ALL_DEPLOYED)}</strong>
 						</div>
 					</DataGrid>
 				}
 			/>
-			<SectionBlock title={UI_STRINGS.deploymentRouteContent.deploymentGroupsTitle} description={!isLoadingDeploymentStatuses && nextMissingStep !== undefined ? `${UI_STRINGS.deploymentRouteContent.nextDeployablePrefix} ${nextMissingStep.label}` : UI_STRINGS.deploymentRouteContent.deploymentGroupsDescription}>
+			<SectionBlock title={UI_STRING_DEPLOYMENT_GROUPS} description={!isLoadingDeploymentStatuses && nextMissingStep !== undefined ? `${UI_STRING_NEXT_DEPLOYABLE_CONTRACT} ${nextMissingStep.label}` : UI_STRING_ALL_DETERMINISTIC_CONTRACTS_ARE_DEPLOYED_IN_GROUPED_SECTIONS}>
 				<div className='workflow-stack'>
 					{deploymentSections.map(section => {
 						const allDeployed = section.steps.length > 0 && section.steps.every(step => step.deployed)
@@ -59,7 +75,7 @@ export function DeploymentRouteContent({ accountAddress, busyStepId, deployNextM
 						if (!allDeployed) return <div key={section.title}>{sectionContent}</div>
 
 						return (
-							<ReadOnlyDetailAccordion key={section.title} title={UI_STRINGS.deploymentRouteContent.completedSectionTitle(section.title)}>
+							<ReadOnlyDetailAccordion key={section.title} title={UI_TEMPLATE_COMPLETED_SECTION_TITLE(section.title)}>
 								{sectionContent}
 							</ReadOnlyDetailAccordion>
 						)

--- a/ui/ts/components/DeploymentSection.tsx
+++ b/ui/ts/components/DeploymentSection.tsx
@@ -3,7 +3,18 @@ import { Badge } from './Badge.js'
 import { SectionBlock } from './SectionBlock.js'
 import { TransactionActionButton } from './TransactionActionButton.js'
 import { getDeploymentStepAvailability, getPrerequisiteLabel } from '../lib/deployment.js'
-import { UI_STRINGS } from '../lib/uiStrings.js'
+import {
+	UI_STRING_CAN_DEPLOY_NOW,
+	UI_STRING_CODE_FOUND_AT_EXPECTED_ADDRESS,
+	UI_STRING_CONNECT_WALLET_TO_CONTINUE,
+	UI_STRING_DEPLOY,
+	UI_STRING_DEPLOYED,
+	UI_STRING_DEPLOYING,
+	UI_STRING_DEPLOYMENT_IN_PROGRESS,
+	UI_STRING_NOT_DEPLOYED_DEPLOYMENT_SECTION_NOT_DEPLOYED_BADGE_LABEL,
+	UI_STRING_WAITING,
+	UI_TEMPLATE_WAITING_FOR_PREREQUISITE_DETAIL,
+} from '../lib/uiStrings.js'
 
 type StepStatus = {
 	badgeTone: BadgeTone
@@ -16,46 +27,46 @@ function getStepStatus(stepDeployed: boolean, prerequisiteLabel: string | undefi
 	if (stepDeployed)
 		return {
 			badgeTone: 'ok',
-			detail: UI_STRINGS.deploymentSection.codeFoundAtExpectedAddressDetail,
-			label: UI_STRINGS.deploymentSection.deployedBadgeLabel,
-			buttonLabel: UI_STRINGS.deploymentSection.deployedBadgeLabel,
+			detail: UI_STRING_CODE_FOUND_AT_EXPECTED_ADDRESS,
+			label: UI_STRING_DEPLOYED,
+			buttonLabel: UI_STRING_DEPLOYED,
 		}
 
 	if (isBusy)
 		return {
 			badgeTone: 'pending',
-			detail: UI_STRINGS.deploymentSection.deployingDetail,
-			label: UI_STRINGS.deploymentSection.deployingBadgeLabel,
-			buttonLabel: UI_STRINGS.deploymentSection.deployingPendingLabel,
+			detail: UI_STRING_DEPLOYMENT_IN_PROGRESS,
+			label: UI_STRING_DEPLOYING,
+			buttonLabel: UI_STRING_DEPLOYING,
 		}
 
 	if (prerequisiteLabel === undefined) {
 		if (accountAddress === undefined)
 			return {
 				badgeTone: 'pending',
-				detail: UI_STRINGS.deploymentSection.connectWalletToContinueDetail,
-				label: UI_STRINGS.deploymentSection.notDeployedBadgeLabel,
-				buttonLabel: UI_STRINGS.deploymentSection.deployButtonLabel,
+				detail: UI_STRING_CONNECT_WALLET_TO_CONTINUE,
+				label: UI_STRING_NOT_DEPLOYED_DEPLOYMENT_SECTION_NOT_DEPLOYED_BADGE_LABEL,
+				buttonLabel: UI_STRING_DEPLOY,
 			}
 		if (!isMainnet)
 			return {
 				badgeTone: 'pending',
-				label: UI_STRINGS.deploymentSection.notDeployedBadgeLabel,
-				buttonLabel: UI_STRINGS.deploymentSection.deployButtonLabel,
+				label: UI_STRING_NOT_DEPLOYED_DEPLOYMENT_SECTION_NOT_DEPLOYED_BADGE_LABEL,
+				buttonLabel: UI_STRING_DEPLOY,
 			}
 		return {
 			badgeTone: 'pending',
-			detail: UI_STRINGS.deploymentSection.canDeployNowDetail,
-			label: UI_STRINGS.deploymentSection.notDeployedBadgeLabel,
-			buttonLabel: UI_STRINGS.deploymentSection.deployButtonLabel,
+			detail: UI_STRING_CAN_DEPLOY_NOW,
+			label: UI_STRING_NOT_DEPLOYED_DEPLOYMENT_SECTION_NOT_DEPLOYED_BADGE_LABEL,
+			buttonLabel: UI_STRING_DEPLOY,
 		}
 	}
 
 	return {
 		badgeTone: 'blocked',
-		detail: UI_STRINGS.deploymentSection.waitingForPrerequisiteDetail(prerequisiteLabel),
-		label: UI_STRINGS.deploymentSection.waitingBadgeLabel,
-		buttonLabel: UI_STRINGS.deploymentSection.deployButtonLabel,
+		detail: UI_TEMPLATE_WAITING_FOR_PREREQUISITE_DETAIL(prerequisiteLabel),
+		label: UI_STRING_WAITING,
+		buttonLabel: UI_STRING_DEPLOY,
 	}
 }
 
@@ -86,7 +97,7 @@ export function DeploymentSection({ title, steps, allSteps, accountAddress, busy
 								<p className='address'>{step.address}</p>
 								{stepStatus.detail === undefined ? undefined : <p className='detail'>{stepStatus.detail}</p>}
 							</div>
-							<TransactionActionButton idleLabel={stepStatus.buttonLabel} pendingLabel={UI_STRINGS.deploymentSection.deployingPendingLabel} onClick={() => void onDeploy(step.id)} pending={isBusy} availability={availability} />
+							<TransactionActionButton idleLabel={stepStatus.buttonLabel} pendingLabel={UI_STRING_DEPLOYING} onClick={() => void onDeploy(step.id)} pending={isBusy} availability={availability} />
 						</div>
 					)
 				})}

--- a/ui/ts/components/LiquidationModal.tsx
+++ b/ui/ts/components/LiquidationModal.tsx
@@ -25,7 +25,71 @@ import { getOracleRequestEthGuardMessage, resolveOracleOperationEthFunding } fro
 import { getRepPriceSourceCopy, renderRepPriceSourceLabel, type RepPriceSource } from '../lib/repPriceSource.js'
 import { getStagedOperationTimeoutSeconds, isOracleManagerPriceUsable } from '../lib/securityVault.js'
 import { getVaultCollateralizationPercent } from '../lib/trading.js'
-import { UI_STRINGS } from '../lib/uiStrings.js'
+import {
+	UI_STRING_A_VALID_ORACLE_PRICE_WAS_ALREADY_AVAILABLE_SO_THE_LIQUIDATION_EXECUTED_IMMEDIATELY_AND_NO_STAGED_OPERATION_WAS_CREATED,
+	UI_STRING_AMOUNT,
+	UI_STRING_CALLER_COLLATERALIZATION_AT_OPEN_ORACLE,
+	UI_STRING_CALLER_VAULT,
+	UI_STRING_CALLER_VAULT_AFTER_LIQUIDATION,
+	UI_STRING_CANCEL,
+	UI_STRING_CHECK_STATE,
+	UI_STRING_CLOSE,
+	UI_STRING_COLLATERALIZATION_AT_OPEN_ORACLE,
+	UI_STRING_CONNECT_WALLET,
+	UI_STRING_ENTER_A_LIQUIDATION_AMOUNT,
+	UI_STRING_ENTER_A_LIQUIDATION_TIMEOUT_OF_AT_LEAST_1_MINUTE,
+	UI_STRING_ENTER_WHOLE_MINUTES_QUEUED_STAGED_OPERATIONS_MUST_STAY_EXECUTABLE_FOR_AT_LEAST_1_MINUTE_AFTER_THE_ORACLE_SETTLEMENT_WINDOW_COMPLETES,
+	UI_STRING_ETH,
+	UI_STRING_EXECUTE_VAULT_LIQUIDATION,
+	UI_STRING_EXECUTED,
+	UI_STRING_EXECUTING_LIQUIDATION,
+	UI_STRING_FAILED,
+	UI_STRING_INVALID_LIQUIDATION_PAIR,
+	UI_STRING_LIQUIDATE_VAULT,
+	UI_STRING_LIQUIDATION_AMOUNT_ETH,
+	UI_STRING_LIQUIDATION_EXECUTED,
+	UI_STRING_LIQUIDATION_FAILED,
+	UI_STRING_LIQUIDATION_QUEUED,
+	UI_STRING_LIQUIDATION_SUBMITTED,
+	UI_STRING_MANUAL_EXECUTION_TIMEOUT,
+	UI_STRING_MANUAL_QUEUED_OPERATION,
+	UI_STRING_MAX,
+	UI_STRING_MINUTES,
+	UI_STRING_MULTIPLIER_SUFFIX,
+	UI_STRING_NONE_SELECTED,
+	UI_STRING_OPEN_ORACLE_PRICE,
+	UI_STRING_QUEUE_LIQUIDATION,
+	UI_STRING_QUEUE_LIQUIDATION_LIQUIDATION_MODAL_QUEUE_LIQUIDATION_ACTION_LABEL,
+	UI_STRING_QUEUE_VAULT_LIQUIDATION,
+	UI_STRING_QUEUED,
+	UI_STRING_QUEUEING_LIQUIDATION,
+	UI_STRING_REFRESHING_LIQUIDATION_STATE,
+	UI_STRING_REFRESHING_LIQUIDATION_STATE_LIQUIDATION_MODAL_REFRESHING_LIQUIDATION_STATE_TITLE,
+	UI_STRING_REFRESHING_PRICE_VALIDITY,
+	UI_STRING_REFRESHING_WITHOUT_ELLIPSIS,
+	UI_STRING_RELOAD_THE_SELECTED_POOL_BEFORE_EXECUTING_LIQUIDATION,
+	UI_STRING_RELOAD_THE_SELECTED_POOL_BEFORE_LIQUIDATING,
+	UI_STRING_REP,
+	UI_STRING_REP_COLLATERAL,
+	UI_STRING_REP_MOVED,
+	UI_STRING_REP_PER_ETH,
+	UI_STRING_SECURITY_BOND_ALLOWANCE,
+	UI_STRING_SECURITY_MULTIPLIER,
+	UI_STRING_SECURITY_POOL,
+	UI_STRING_SELECT_A_TARGET_VAULT_FIRST,
+	UI_STRING_SELECT_A_TARGET_VAULT_THAT_IS_DIFFERENT_FROM_THE_CALLER_VAULT,
+	UI_STRING_STAGED_OPERATION,
+	UI_STRING_STAGED_OPERATION_RETRY,
+	UI_STRING_SUBMITTING_LIQUIDATION_LIQUIDATION_MODAL_LIQUIDATE_VAULT_PENDING_LABEL,
+	UI_STRING_TARGET_COLLATERALIZATION_AT_OPEN_ORACLE,
+	UI_STRING_TARGET_VAULT,
+	UI_STRING_THE_ORACLE_MANAGER_ATTEMPTED_THE_LIQUIDATION_IMMEDIATELY_BUT_THE_SECURITY_POOL_REJECTED_IT,
+	UI_STRING_TRANSACTION_STATE_UNAVAILABLE,
+	UI_STRING_UNAVAILABLE,
+	UI_STRING_VIEW_IN_STAGED_OPERATIONS,
+	UI_STRING_ZERO_DECIMAL_PLACEHOLDER,
+	UI_TEMPLATE_TIMEOUT_HELP_TEXT_RESOLVED,
+} from '../lib/uiStrings.js'
 import { useModalFocusIsolation } from '../hooks/useModalFocusIsolation.js'
 import type { SecurityPoolStateModel } from '../lib/securityPoolState.js'
 import type { ListedSecurityPool, OracleManagerDetails, SecurityPoolOverviewActionResult, SecurityPoolVaultSummary } from '../types/contracts.js'
@@ -72,11 +136,11 @@ function getLiquidationModalTitle(currentPoolOracleManagerDetails: OracleManager
 	const executionMode = getLiquidationExecutionMode(currentPoolOracleManagerDetails)
 	switch (executionMode) {
 		case 'execute':
-			return UI_STRINGS.liquidationModal.executeVaultLiquidationTitle
+			return UI_STRING_EXECUTE_VAULT_LIQUIDATION
 		case 'queue':
-			return UI_STRINGS.liquidationModal.queueVaultLiquidationTitle
+			return UI_STRING_QUEUE_VAULT_LIQUIDATION
 		case 'refreshing':
-			return UI_STRINGS.liquidationModal.liquidateVaultTitle
+			return UI_STRING_LIQUIDATE_VAULT
 		default:
 			return assertNever(executionMode)
 	}
@@ -85,11 +149,11 @@ function getLiquidationButtonLabels(currentPoolOracleManagerDetails: OracleManag
 	const executionMode = getLiquidationExecutionMode(currentPoolOracleManagerDetails)
 	switch (executionMode) {
 		case 'execute':
-			return { idle: UI_STRINGS.liquidationModal.executeVaultLiquidationTitle, pending: UI_STRINGS.liquidationModal.executeLiquidationPendingLabel }
+			return { idle: UI_STRING_EXECUTE_VAULT_LIQUIDATION, pending: UI_STRING_EXECUTING_LIQUIDATION }
 		case 'queue':
-			return { idle: UI_STRINGS.liquidationModal.queueLiquidationIdleLabel, pending: UI_STRINGS.liquidationModal.queueLiquidationPendingLabel }
+			return { idle: UI_STRING_QUEUE_LIQUIDATION, pending: UI_STRING_QUEUEING_LIQUIDATION }
 		case 'refreshing':
-			return { idle: UI_STRINGS.liquidationModal.liquidateVaultIdleLabel, pending: UI_STRINGS.liquidationModal.liquidateVaultPendingLabel }
+			return { idle: UI_STRING_LIQUIDATE_VAULT, pending: UI_STRING_SUBMITTING_LIQUIDATION_LIQUIDATION_MODAL_LIQUIDATE_VAULT_PENDING_LABEL }
 		default:
 			return assertNever(executionMode)
 	}
@@ -111,22 +175,22 @@ function renderQueuedLiquidationStatusCard({
 		if (queuedLiquidationOperation === undefined) return null
 		return (
 			<TransactionStatusCard
-				title={UI_STRINGS.liquidationModal.liquidationQueuedTitle}
-				badge={<Badge tone='warning'>{UI_STRINGS.liquidationModal.queuedBadgeLabel}</Badge>}
+				title={UI_STRING_LIQUIDATION_QUEUED}
+				badge={<Badge tone='warning'>{UI_STRING_QUEUED}</Badge>}
 				metrics={
 					<MetricGrid>
-						<MetricField label={UI_STRINGS.securityVaultSection.stagedOperationLabel}>#{queuedLiquidationOperation.operationId.toString()}</MetricField>
+						<MetricField label={UI_STRING_STAGED_OPERATION}>#{queuedLiquidationOperation.operationId.toString()}</MetricField>
 						{queuedLiquidationOperation.amount === undefined ? null : (
-							<MetricField label={UI_STRINGS.liquidationModal.metricAmountLabel}>
+							<MetricField label={UI_STRING_AMOUNT}>
 								<CurrencyValue value={queuedLiquidationOperation.amount} />
 							</MetricField>
 						)}
 					</MetricGrid>
 				}
-				detail={queuedLiquidationStatus === 'manual-queued' ? UI_STRINGS.liquidationModal.manualQueuedLiquidationDetail : undefined}
+				detail={queuedLiquidationStatus === 'manual-queued' ? UI_STRING_MANUAL_QUEUED_OPERATION : undefined}
 				actions={
 					<button className='secondary' type='button' onClick={onViewInStagedOperations}>
-						{UI_STRINGS.liquidationModal.viewInStagedOperationsLabel}
+						{UI_STRING_VIEW_IN_STAGED_OPERATIONS}
 					</button>
 				}
 			/>
@@ -135,15 +199,15 @@ function renderQueuedLiquidationStatusCard({
 	if (queuedLiquidationStatus === 'failed')
 		return (
 			<TransactionStatusCard
-				title={UI_STRINGS.liquidationModal.liquidationFailedTitle}
-				badge={<Badge tone='blocked'>{UI_STRINGS.liquidationModal.failedBadgeLabel}</Badge>}
-				detail={getLiquidationExecutionFailureDetail(securityPoolOverviewResult?.stagedExecution?.errorMessage) ?? UI_STRINGS.liquidationModal.liquidationFailedDetail}
-				secondaryDetail={UI_STRINGS.liquidationModal.submitNewStagedOperationDetail}
+				title={UI_STRING_LIQUIDATION_FAILED}
+				badge={<Badge tone='blocked'>{UI_STRING_FAILED}</Badge>}
+				detail={getLiquidationExecutionFailureDetail(securityPoolOverviewResult?.stagedExecution?.errorMessage) ?? UI_STRING_THE_ORACLE_MANAGER_ATTEMPTED_THE_LIQUIDATION_IMMEDIATELY_BUT_THE_SECURITY_POOL_REJECTED_IT}
+				secondaryDetail={UI_STRING_STAGED_OPERATION_RETRY}
 			/>
 		)
-	if (queuedLiquidationStatus === 'executed') return <TransactionStatusCard title={UI_STRINGS.liquidationModal.liquidationExecutedTitle} badge={<Badge tone='ok'>{UI_STRINGS.liquidationModal.operationExecutedBadgeLabel}</Badge>} detail={UI_STRINGS.liquidationModal.validOracleExecutedDetail} />
-	if (queuedLiquidationStatus === 'missing') return <TransactionStatusCard title={UI_STRINGS.liquidationModal.liquidationSubmittedTitle} badge={<Badge tone='warning'>{UI_STRINGS.liquidationModal.checkStateBadgeLabel}</Badge>} detail={UI_STRINGS.liquidationModal.transactionStateUnavailableDetail} />
-	return <TransactionStatusCard title={UI_STRINGS.liquidationModal.refreshingLiquidationStateTitle} badge={<Badge tone='muted'>{UI_STRINGS.liquidationModal.refreshingBadgeLabel}</Badge>} detail={UI_STRINGS.liquidationModal.refreshingLiquidationStateDetail} />
+	if (queuedLiquidationStatus === 'executed') return <TransactionStatusCard title={UI_STRING_LIQUIDATION_EXECUTED} badge={<Badge tone='ok'>{UI_STRING_EXECUTED}</Badge>} detail={UI_STRING_A_VALID_ORACLE_PRICE_WAS_ALREADY_AVAILABLE_SO_THE_LIQUIDATION_EXECUTED_IMMEDIATELY_AND_NO_STAGED_OPERATION_WAS_CREATED} />
+	if (queuedLiquidationStatus === 'missing') return <TransactionStatusCard title={UI_STRING_LIQUIDATION_SUBMITTED} badge={<Badge tone='warning'>{UI_STRING_CHECK_STATE}</Badge>} detail={UI_STRING_TRANSACTION_STATE_UNAVAILABLE} />
+	return <TransactionStatusCard title={UI_STRING_REFRESHING_LIQUIDATION_STATE_LIQUIDATION_MODAL_REFRESHING_LIQUIDATION_STATE_TITLE} badge={<Badge tone='muted'>{UI_STRING_REFRESHING_WITHOUT_ELLIPSIS}</Badge>} detail={UI_STRING_REFRESHING_LIQUIDATION_STATE} />
 }
 export function LiquidationModal({
 	accountAddress,
@@ -206,8 +270,8 @@ export function LiquidationModal({
 	const trimmedLiquidationTargetVault = liquidationTargetVault.trim()
 	const liquidationTimeoutDisplayValue = liquidationTimeoutMinutes === '' ? '' : liquidationTimeoutMinutes
 	const liquidationTimeoutSeconds = getStagedOperationTimeoutSeconds(tryParseBigIntInput(liquidationTimeoutDisplayValue))
-	const liquidationTimeoutHelpText = liquidationTimeoutSeconds === undefined ? UI_STRINGS.liquidationModal.timeoutHelpTextInvalid : UI_STRINGS.liquidationModal.timeoutHelpTextResolved(formatDuration(liquidationTimeoutSeconds))
-	const sameVaultWarning = accountAddress === undefined || trimmedLiquidationTargetVault === '' || !sameAddress(accountAddress, trimmedLiquidationTargetVault) ? undefined : UI_STRINGS.liquidationModal.selectDifferentTargetVaultReason
+	const liquidationTimeoutHelpText = liquidationTimeoutSeconds === undefined ? UI_STRING_ENTER_WHOLE_MINUTES_QUEUED_STAGED_OPERATIONS_MUST_STAY_EXECUTABLE_FOR_AT_LEAST_1_MINUTE_AFTER_THE_ORACLE_SETTLEMENT_WINDOW_COMPLETES : UI_TEMPLATE_TIMEOUT_HELP_TEXT_RESOLVED(formatDuration(liquidationTimeoutSeconds))
+	const sameVaultWarning = accountAddress === undefined || trimmedLiquidationTargetVault === '' || !sameAddress(accountAddress, trimmedLiquidationTargetVault) ? undefined : UI_STRING_SELECT_A_TARGET_VAULT_THAT_IS_DIFFERENT_FROM_THE_CALLER_VAULT
 	const liquidationSimulation =
 		targetVaultSummary === undefined || poolOraclePrice === undefined || selectedPool?.securityMultiplier === undefined || liquidationAmountValue === undefined
 			? undefined
@@ -234,7 +298,7 @@ export function LiquidationModal({
 	})
 	const directLiquidationReason = (() => {
 		if (liquidationExecutionMode !== 'execute') return undefined
-		if (selectedPool?.securityMultiplier === undefined) return UI_STRINGS.liquidationModal.reloadPoolBeforeExecutingReason
+		if (selectedPool?.securityMultiplier === undefined) return UI_STRING_RELOAD_THE_SELECTED_POOL_BEFORE_EXECUTING_LIQUIDATION
 
 		return getLiquidationFailureReason({
 			callerVaultSummary,
@@ -252,7 +316,7 @@ export function LiquidationModal({
 						managerDetails: currentPoolOracleManagerDetails,
 					})
 					return getOracleRequestEthGuardMessage({
-						actionLabel: UI_STRINGS.liquidationModal.queueLiquidationActionLabel,
+						actionLabel: UI_STRING_QUEUE_LIQUIDATION_LIQUIDATION_MODAL_QUEUE_LIQUIDATION_ACTION_LABEL,
 						includeBuffer: funding?.includeBuffer === true,
 						requiredEthCost: funding?.ethCost,
 						walletEthBalance,
@@ -261,12 +325,12 @@ export function LiquidationModal({
 	const liquidationEnabled = poolState?.actions.queueLiquidation.enabled ?? true
 	const canUseLiquidationAction = accountAddress !== undefined && isMainnet
 	const liquidationActionReason = pickFirstReason(
-		liquidationExecutionMode === 'refreshing' ? UI_STRINGS.liquidationModal.refreshingOpenOracleValidityReason : undefined,
-		liquidationManagerAddress === undefined || liquidationSecurityPoolAddress === undefined ? UI_STRINGS.liquidationModal.reloadPoolBeforeLiquidatingReason : undefined,
-		trimmedLiquidationTargetVault === '' ? UI_STRINGS.liquidationModal.selectTargetVaultReason : undefined,
+		liquidationExecutionMode === 'refreshing' ? UI_STRING_REFRESHING_PRICE_VALIDITY : undefined,
+		liquidationManagerAddress === undefined || liquidationSecurityPoolAddress === undefined ? UI_STRING_RELOAD_THE_SELECTED_POOL_BEFORE_LIQUIDATING : undefined,
+		trimmedLiquidationTargetVault === '' ? UI_STRING_SELECT_A_TARGET_VAULT_FIRST : undefined,
 		sameVaultWarning,
-		liquidationAmount.trim() === '' ? UI_STRINGS.liquidationModal.enterLiquidationAmountReason : undefined,
-		liquidationExecutionMode === 'queue' && liquidationTimeoutSeconds === undefined ? UI_STRINGS.liquidationModal.enterLiquidationTimeoutReason : undefined,
+		liquidationAmount.trim() === '' ? UI_STRING_ENTER_A_LIQUIDATION_AMOUNT : undefined,
+		liquidationExecutionMode === 'queue' && liquidationTimeoutSeconds === undefined ? UI_STRING_ENTER_A_LIQUIDATION_TIMEOUT_OF_AT_LEAST_1_MINUTE : undefined,
 		deterministicLiquidationReason,
 		directLiquidationReason,
 		queueLiquidationEthGuardMessage,
@@ -312,7 +376,7 @@ export function LiquidationModal({
 					<div className='modal-header-title'>
 						<h3 id={titleId}>{getLiquidationModalTitle(currentPoolOracleManagerDetails)}</h3>
 					</div>
-					<button ref={closeButtonRef} className='quiet modal-close-button' type='button' aria-label={UI_STRINGS.liquidationModal.closeButtonAriaLabel} title={UI_STRINGS.liquidationModal.closeButtonAriaLabel} onClick={closeLiquidationModal}>
+					<button ref={closeButtonRef} className='quiet modal-close-button' type='button' aria-label={UI_STRING_CLOSE} title={UI_STRING_CLOSE} onClick={closeLiquidationModal}>
 						×
 					</button>
 				</div>
@@ -324,21 +388,21 @@ export function LiquidationModal({
 				})}
 				<ErrorNotice message={securityPoolLiquidationError} />
 				<DataGrid className='modal-summary-grid' columns={2}>
-					<AddressInfo address={liquidationSecurityPoolAddress} label={UI_STRINGS.liquidationModal.securityPoolLabel} />
-					<MetricField label={UI_STRINGS.liquidationModal.securityMultiplierLabel}>{selectedPool?.securityMultiplier === undefined ? UI_STRINGS.common.unavailableLabel : `${selectedPool.securityMultiplier.toString()}${UI_STRINGS.common.multiplierSuffix}`}</MetricField>
-					<MetricField label={UI_STRINGS.liquidationModal.callerVaultLabel}>{accountAddress === undefined ? UI_STRINGS.userCopy.wallet.connectWalletBadgeLabel : <AddressValue address={accountAddress} />}</MetricField>
-					<MetricField label={UI_STRINGS.liquidationModal.targetVaultLabel}>{trimmedLiquidationTargetVault === '' ? UI_STRINGS.common.noneSelectedLabel : <AddressValue address={trimmedLiquidationTargetVault} />}</MetricField>
-					<MetricField label={UI_STRINGS.liquidationModal.openOraclePriceLabel} valueTagName='span'>
+					<AddressInfo address={liquidationSecurityPoolAddress} label={UI_STRING_SECURITY_POOL} />
+					<MetricField label={UI_STRING_SECURITY_MULTIPLIER}>{selectedPool?.securityMultiplier === undefined ? UI_STRING_UNAVAILABLE : `${selectedPool.securityMultiplier.toString()}${UI_STRING_MULTIPLIER_SUFFIX}`}</MetricField>
+					<MetricField label={UI_STRING_CALLER_VAULT}>{accountAddress === undefined ? UI_STRING_CONNECT_WALLET : <AddressValue address={accountAddress} />}</MetricField>
+					<MetricField label={UI_STRING_TARGET_VAULT}>{trimmedLiquidationTargetVault === '' ? UI_STRING_NONE_SELECTED : <AddressValue address={trimmedLiquidationTargetVault} />}</MetricField>
+					<MetricField label={UI_STRING_OPEN_ORACLE_PRICE} valueTagName='span'>
 						<OpenOraclePriceValue currentTimestamp={currentTimestamp} lastPrice={poolOraclePrice} lastSettlementTimestamp={poolOracleSettlementTimestamp} priceValidUntilTimestamp={currentPoolOracleManagerDetails?.priceValidUntilTimestamp} />
 					</MetricField>
 					<CollateralizationMetricField
 						collateralizationPercent={poolOracleCollateralization}
-						label={UI_STRINGS.liquidationModal.targetCollateralizationAtOpenOracleLabel}
+						label={UI_STRING_TARGET_COLLATERALIZATION_AT_OPEN_ORACLE}
 						repPerEthSource={undefined}
 						repPerEthSourceUrl={undefined}
 						securityBondAllowance={targetVaultSummary?.securityBondAllowance}
 						securityMultiplier={selectedPool?.securityMultiplier}
-						unavailableCopy={UI_STRINGS.common.unavailableLabel}
+						unavailableCopy={UI_STRING_UNAVAILABLE}
 					/>
 					<MetricField
 						label={
@@ -347,7 +411,7 @@ export function LiquidationModal({
 							</span>
 						}
 					>
-						{repPerEthPrice === undefined ? UI_STRINGS.common.unavailableLabel : <CurrencyValue value={repPerEthPrice} suffix={UI_STRINGS.common.repPerEthSuffix} copyable={false} />}
+						{repPerEthPrice === undefined ? UI_STRING_UNAVAILABLE : <CurrencyValue value={repPerEthPrice} suffix={UI_STRING_REP_PER_ETH} copyable={false} />}
 					</MetricField>
 					<CollateralizationMetricField
 						collateralizationPercent={quotedPriceCollateralization}
@@ -360,23 +424,23 @@ export function LiquidationModal({
 						repPerEthSourceUrl={repPerEthSourceUrl}
 						securityBondAllowance={targetVaultSummary?.securityBondAllowance}
 						securityMultiplier={selectedPool?.securityMultiplier}
-						unavailableCopy={UI_STRINGS.common.unavailableLabel}
+						unavailableCopy={UI_STRING_UNAVAILABLE}
 					/>
 					<CollateralizationMetricField
 						collateralizationPercent={callerPoolOracleCollateralization}
-						label={UI_STRINGS.liquidationModal.callerCollateralizationAtOpenOracleLabel}
+						label={UI_STRING_CALLER_COLLATERALIZATION_AT_OPEN_ORACLE}
 						repPerEthSource={undefined}
 						repPerEthSourceUrl={undefined}
 						securityBondAllowance={callerVaultSummary?.securityBondAllowance}
 						securityMultiplier={selectedPool?.securityMultiplier}
-						unavailableCopy={UI_STRINGS.common.unavailableLabel}
+						unavailableCopy={UI_STRING_UNAVAILABLE}
 					/>
 				</DataGrid>
 				{sameVaultWarning === undefined ? null : (
 					<WarningSurface as='section' variant='compact'>
 						<div className='entity-card-header'>
 							<div>
-								<h4>{UI_STRINGS.liquidationModal.invalidLiquidationPairTitle}</h4>
+								<h4>{UI_STRING_INVALID_LIQUIDATION_PAIR}</h4>
 							</div>
 						</div>
 						<p className='detail'>{sameVaultWarning}</p>
@@ -384,20 +448,20 @@ export function LiquidationModal({
 				)}
 				<div className='form-grid'>
 					<label className='field'>
-						<span>{UI_STRINGS.liquidationModal.liquidationAmountLabel}</span>
+						<span>{UI_STRING_LIQUIDATION_AMOUNT_ETH}</span>
 						<div className='field-inline'>
-							<FormInput className='field-inline-input' value={liquidationAmount} onInput={event => onLiquidationAmountChange(event.currentTarget.value)} placeholder={UI_STRINGS.liquidationModal.liquidationAmountPlaceholder} />
+							<FormInput className='field-inline-input' value={liquidationAmount} onInput={event => onLiquidationAmountChange(event.currentTarget.value)} placeholder={UI_STRING_ZERO_DECIMAL_PLACEHOLDER} />
 							<button className='quiet field-inline-action' type='button' onClick={() => onLiquidationAmountChange(liquidationMaxActionAmount === undefined ? '' : formatCurrencyInputBalance(liquidationMaxActionAmount))} disabled={liquidationMaxActionAmount === undefined || liquidationMaxActionAmount <= 0n}>
-								{UI_STRINGS.common.maxLabel}
+								{UI_STRING_MAX}
 							</button>
 						</div>
 					</label>
 					{liquidationExecutionMode === 'execute' ? null : (
 						<label className='field'>
-							<span>{UI_STRINGS.liquidationModal.manualExecutionTimeoutLabel}</span>
+							<span>{UI_STRING_MANUAL_EXECUTION_TIMEOUT}</span>
 							<div className='field-inline'>
 								<FormInput className='field-inline-input' inputMode='numeric' min='1' pattern='[0-9]*' step='1' value={liquidationTimeoutDisplayValue} onInput={event => onLiquidationTimeoutMinutesChange(event.currentTarget.value)} />
-								<span className='field-inline-action'>{UI_STRINGS.common.minutesLabel}</span>
+								<span className='field-inline-action'>{UI_STRING_MINUTES}</span>
 							</div>
 						</label>
 					)}
@@ -407,34 +471,34 @@ export function LiquidationModal({
 					<section className='entity-card compact'>
 						<div className='entity-card-header'>
 							<div>
-								<h4>{UI_STRINGS.liquidationModal.callerVaultAfterLiquidationTitle}</h4>
+								<h4>{UI_STRING_CALLER_VAULT_AFTER_LIQUIDATION}</h4>
 							</div>
 						</div>
 						<MetricGrid>
-							<MetricField label={UI_STRINGS.liquidationModal.repCollateralLabel}>
-								<CurrencyValue value={liquidationSimulation.callerAfter.repDepositShare} suffix={UI_STRINGS.common.repLabel} />
+							<MetricField label={UI_STRING_REP_COLLATERAL}>
+								<CurrencyValue value={liquidationSimulation.callerAfter.repDepositShare} suffix={UI_STRING_REP} />
 							</MetricField>
-							<MetricField label={UI_STRINGS.liquidationModal.securityBondAllowanceLabel}>
-								<CurrencyValue value={liquidationSimulation.callerAfter.securityBondAllowance} suffix={UI_STRINGS.common.ethSuffix} />
+							<MetricField label={UI_STRING_SECURITY_BOND_ALLOWANCE}>
+								<CurrencyValue value={liquidationSimulation.callerAfter.securityBondAllowance} suffix={UI_STRING_ETH} />
 							</MetricField>
 							<CollateralizationMetricField
 								collateralizationPercent={liquidationSimulation.callerAfter.collateralization}
-								label={UI_STRINGS.liquidationModal.collateralizationAtOpenOracleLabel}
+								label={UI_STRING_COLLATERALIZATION_AT_OPEN_ORACLE}
 								repPerEthSource={undefined}
 								repPerEthSourceUrl={undefined}
 								securityBondAllowance={liquidationSimulation.callerAfter.securityBondAllowance}
 								securityMultiplier={selectedPool?.securityMultiplier}
-								unavailableCopy={UI_STRINGS.common.unavailableLabel}
+								unavailableCopy={UI_STRING_UNAVAILABLE}
 							/>
-							<MetricField label={UI_STRINGS.liquidationModal.repMovedLabel}>
-								<CurrencyValue value={liquidationSimulation.repToMove} suffix={UI_STRINGS.common.repLabel} />
+							<MetricField label={UI_STRING_REP_MOVED}>
+								<CurrencyValue value={liquidationSimulation.repToMove} suffix={UI_STRING_REP} />
 							</MetricField>
 						</MetricGrid>
 					</section>
 				)}
 				<div className='actions liquidation-modal-actions'>
 					<button className='secondary' onClick={closeLiquidationModal}>
-						{UI_STRINGS.common.cancelLabel}
+						{UI_STRING_CANCEL}
 					</button>
 					<TransactionActionButton
 						idleLabel={buttonLabels.idle}

--- a/ui/ts/components/MarketCreateQuestionSection.tsx
+++ b/ui/ts/components/MarketCreateQuestionSection.tsx
@@ -14,15 +14,93 @@ import { assertNever } from '../lib/assert.js'
 import { getMarketCreationOutcomeLabels, validateMarketForm } from '../lib/marketCreation.js'
 import { appendInvalidOutcomeLabelIfMissing, isInvalidOutcomeLabel } from '../lib/outcomeLabels.js'
 import { clampScalarTickIndex, parseScalarFormInputs } from '../lib/scalarOutcome.js'
-import { UI_STRINGS } from '../lib/uiStrings.js'
+import {
+	UI_STRING_0_1,
+	UI_STRING_1,
+	UI_STRING_1_DEFINE_THE_EVENT_CLEARLY,
+	UI_STRING_10,
+	UI_STRING_2_EXPLAIN_HOW_IT_RESOLVES,
+	UI_STRING_3_SET_THE_TIMING_WINDOW,
+	UI_STRING_ADD_A_CLEAR_QUESTION_TITLE,
+	UI_STRING_ADD_AT_LEAST_2_OUTCOMES,
+	UI_STRING_ADD_OUTCOME,
+	UI_STRING_ADD_RESOLUTION_NOTES_EVIDENCE_SOURCES_AND_EDGE_CASE_HANDLING_SO_OTHER_USERS_KNOW_HOW_THIS_QUESTION_WILL_SETTLE,
+	UI_STRING_ALREADY_FORKED,
+	UI_STRING_ANSWER_UNIT,
+	UI_STRING_ASK_A_YES_OR_NO_QUESTION_THAT_CAN_BE_RESOLVED_FROM_ONE_PUBLIC_SOURCE_OF_TRUTH,
+	UI_STRING_ASK_FOR_A_MEASURABLE_NUMBER_WITH_A_UNIT_RANGE_AND_INCREMENT_THAT_USERS_CAN_UNDERSTAND,
+	UI_STRING_BINARY,
+	UI_STRING_CATEGORICAL,
+	UI_STRING_CATEGORICAL_QUESTIONS_ARE_VALID_IN_ZOLTAR_BUT_PLACEHOLDER_ORIGIN_SECURITY_POOLS_CURRENTLY_REQUIRE_AN_EXACT_BINARY_YES_NO_QUESTION,
+	UI_STRING_CHOOSE_AN_END_TIME,
+	UI_STRING_CONNECT_A_WALLET_BEFORE_CREATING_A_QUESTION,
+	UI_STRING_CONTEXT_IS_PRESENT_FOR_REVIEW,
+	UI_STRING_CONTEXT_PROVIDED,
+	UI_STRING_CREATE_ANOTHER_QUESTION,
+	UI_STRING_CREATE_POOL_FROM_QUESTION,
+	UI_STRING_CREATE_QUESTION,
+	UI_STRING_CREATING_QUESTION_MARKET_CREATE_QUESTION_SECTION_CREATE_QUESTION_BUTTON_PENDING_LABEL,
+	UI_STRING_CREATION_TRANSACTION_HASH,
+	UI_STRING_DEFINE_THE_MARKET_TYPE_TIMING_AND_OUTCOMES_FOR_A_NEW_ZOLTAR_QUESTION,
+	UI_STRING_DESCRIPTION,
+	UI_STRING_DRAFT_PREVIEW,
+	UI_STRING_DRAFT_PREVIEW_SHOWS_THE_LEVEL_OF_CLARITY_TRADERS_AND_REPORTERS_WILL_SEE_BEFORE_TRUSTING_THE_QUESTION,
+	UI_STRING_DRAFT_QUESTION_STATUS,
+	UI_STRING_DRAFT_QUESTION_SUMMARY,
+	UI_STRING_END_TIME,
+	UI_STRING_ENDS,
+	UI_STRING_ENTER_SCALAR_MIN_MAX_AND_INCREMENT_TO_PREVIEW_THE_TICK_SLIDER,
+	UI_STRING_IMMEDIATELY_AFTER_CREATION,
+	UI_STRING_INCLUDE_THE_RESOLUTION_SOURCE_ANY_EDGE_CASES_AND_WHAT_SHOULD_MAKE_THE_QUESTION_RESOLVE_AS_INVALID,
+	UI_STRING_INVALID,
+	UI_STRING_KEEP_OUTCOMES_SHORT_AND_CLEARLY_DISTINCT_FROM_EACH_OTHER,
+	UI_STRING_KEEP_THE_TITLE_SELF_CONTAINED_SO_USERS_CAN_UNDERSTAND_THE_EXACT_QUESTION_BEFORE_OPENING_DETAILS,
+	UI_STRING_LIST_THE_MUTUALLY_EXCLUSIVE_OUTCOMES_THAT_COULD_WIN_THIS_QUESTION,
+	UI_STRING_LOADING_QUESTION_DETAILS,
+	UI_STRING_LOW_TRUST_UNTIL_CONTEXT_IS_ADDED,
+	UI_STRING_NAME_THE_EVENT_WINDOW_CLEARLY_IN_THE_TITLE_OR_DESCRIPTION,
+	UI_STRING_NEEDS_CONTEXT,
+	UI_STRING_ONLY_INCLUDE_OUTCOMES_THAT_A_RESOLVER_CAN_VERIFY_FROM_A_PUBLIC_SOURCE,
+	UI_STRING_OPTIONAL_QUESTION_CONTEXT,
+	UI_STRING_OUTCOME,
+	UI_STRING_OUTCOMES,
+	UI_STRING_PICK_A_RANGE_THAT_COVERS_REALISTIC_ANSWERS_WITHOUT_BEING_OVERLY_BROAD,
+	UI_STRING_PLACEHOLDER_ORIGIN_SECURITY_POOLS_SUPPORT_THIS_EXACT_YES_NO_QUESTION_SHAPE,
+	UI_STRING_QUESTION,
+	UI_STRING_QUESTION_DETAILS_ARE_NOT_AVAILABLE,
+	UI_STRING_QUESTION_TYPE,
+	UI_STRING_QUESTION_TYPE_GUIDANCE,
+	UI_STRING_REMOVE,
+	UI_STRING_RISK_CUE,
+	UI_STRING_SCALAR,
+	UI_STRING_SCALAR_INCREMENT,
+	UI_STRING_SCALAR_MAX,
+	UI_STRING_SCALAR_MIN,
+	UI_STRING_SCALAR_QUESTIONS_ARE_VALID_IN_ZOLTAR_BUT_PLACEHOLDER_ORIGIN_SECURITY_POOLS_CURRENTLY_REQUIRE_AN_EXACT_BINARY_YES_NO_QUESTION,
+	UI_STRING_SCALAR_QUESTIONS_SETTLE_TO_A_NUMERIC_RESULT_INSIDE_THE_RANGE_ABOVE_USE_A_UNIT_THAT_MATCHES_THE_PUBLIC_SOURCE_YOU_EXPECT_TO_CITE,
+	UI_STRING_SET_THE_ANSWER_UNIT_SO_USERS_KNOW_WHAT_THE_NUMBER_REPRESENTS,
+	UI_STRING_START_TIME,
+	UI_STRING_STARTS,
+	UI_STRING_TIMES_USE_YOUR_BROWSER_TIMEZONE_LEAVE_START_TIME_BLANK_TO_ALLOW_ACTIVITY_IMMEDIATELY_AFTER_CREATION,
+	UI_STRING_TITLE,
+	UI_STRING_USD,
+	UI_STRING_USE_CONCISE_MUTUALLY_EXCLUSIVE_LABELS_USERS_SHOULD_BE_ABLE_TO_TELL_AT_A_GLANCE_WHICH_OUTCOME_WOULD_WIN,
+	UI_STRING_USE_FOR_FORK,
+	UI_STRING_USE_THE_DESCRIPTION_FOR_THE_EXACT_RESOLUTION_SOURCE_AND_EDGE_CASES,
+	UI_STRING_USE_THE_DESCRIPTION_TO_EXPLAIN_HOW_TIES_CANCELLATIONS_OR_EXCEPTIONS_RESOLVE,
+	UI_STRING_USE_THE_DESCRIPTION_TO_EXPLAIN_ROUNDING_SOURCE_DATA_AND_INVALID_CONDITIONS,
+	UI_STRING_WILL_EVENT_X_HAPPEN,
+	UI_STRING_WRITE_THE_QUESTION_THE_WAY_A_RESOLVER_WILL_READ_IT,
+	UI_STRING_WRITE_THE_TITLE_SO_IT_CAN_BE_ANSWERED_WITH_YES_NO_OR_INVALID,
+} from '../lib/uiStrings.js'
 import type { MarketFormState } from '../types/app.js'
 import type { MarketCreationResult, MarketDetails } from '../types/contracts.js'
 import { ScalarCreatePreview, type ScalarCreatePreviewDetails } from './ScalarCreatePreview.js'
 
 const MARKET_TYPE_OPTIONS: EnumDropdownOption<MarketFormState['marketType']>[] = [
-	{ value: 'binary', label: UI_STRINGS.marketCreateQuestionSection.marketTypeOptions.binaryLabel },
-	{ value: 'categorical', label: UI_STRINGS.marketCreateQuestionSection.marketTypeOptions.categoricalLabel },
-	{ value: 'scalar', label: UI_STRINGS.marketCreateQuestionSection.marketTypeOptions.scalarLabel },
+	{ value: 'binary', label: UI_STRING_BINARY },
+	{ value: 'categorical', label: UI_STRING_CATEGORICAL },
+	{ value: 'scalar', label: UI_STRING_SCALAR },
 ]
 type MarketFormFieldName = keyof ReturnType<typeof validateMarketForm>['fieldErrors']
 type MarketCreateQuestionSectionProps = {
@@ -53,9 +131,9 @@ function getScalarCreatePreviewDetails(marketForm: MarketFormState, scalarInputs
 }
 
 function getPoolEligibilityMessage(marketType: MarketFormState['marketType']) {
-	if (marketType === 'binary') return UI_STRINGS.marketCreateQuestionSection.poolEligibilityBinaryQuestionText
-	if (marketType === 'categorical') return UI_STRINGS.marketCreateQuestionSection.poolEligibilityCategoricalQuestionText
-	return UI_STRINGS.marketCreateQuestionSection.poolEligibilityScalarQuestionText
+	if (marketType === 'binary') return UI_STRING_PLACEHOLDER_ORIGIN_SECURITY_POOLS_SUPPORT_THIS_EXACT_YES_NO_QUESTION_SHAPE
+	if (marketType === 'categorical') return UI_STRING_CATEGORICAL_QUESTIONS_ARE_VALID_IN_ZOLTAR_BUT_PLACEHOLDER_ORIGIN_SECURITY_POOLS_CURRENTLY_REQUIRE_AN_EXACT_BINARY_YES_NO_QUESTION
+	return UI_STRING_SCALAR_QUESTIONS_ARE_VALID_IN_ZOLTAR_BUT_PLACEHOLDER_ORIGIN_SECURITY_POOLS_CURRENTLY_REQUIRE_AN_EXACT_BINARY_YES_NO_QUESTION
 }
 
 function getFieldErrorId(field: MarketFormFieldName) {
@@ -79,18 +157,18 @@ function getMarketTypeGuidance(marketType: MarketFormState['marketType']) {
 	switch (marketType) {
 		case 'binary':
 			return {
-				description: UI_STRINGS.marketCreateQuestionSection.marketTypeGuidance.binary.description,
-				steps: [UI_STRINGS.marketCreateQuestionSection.marketTypeGuidance.binary.stepOne, UI_STRINGS.marketCreateQuestionSection.marketTypeGuidance.binary.stepTwo, UI_STRINGS.marketCreateQuestionSection.marketTypeGuidance.binary.stepThree],
+				description: UI_STRING_ASK_A_YES_OR_NO_QUESTION_THAT_CAN_BE_RESOLVED_FROM_ONE_PUBLIC_SOURCE_OF_TRUTH,
+				steps: [UI_STRING_WRITE_THE_TITLE_SO_IT_CAN_BE_ANSWERED_WITH_YES_NO_OR_INVALID, UI_STRING_NAME_THE_EVENT_WINDOW_CLEARLY_IN_THE_TITLE_OR_DESCRIPTION, UI_STRING_USE_THE_DESCRIPTION_FOR_THE_EXACT_RESOLUTION_SOURCE_AND_EDGE_CASES],
 			}
 		case 'categorical':
 			return {
-				description: UI_STRINGS.marketCreateQuestionSection.marketTypeGuidance.categorical.description,
-				steps: [UI_STRINGS.marketCreateQuestionSection.marketTypeGuidance.categorical.stepOne, UI_STRINGS.marketCreateQuestionSection.marketTypeGuidance.categorical.stepTwo, UI_STRINGS.marketCreateQuestionSection.marketTypeGuidance.categorical.stepThree],
+				description: UI_STRING_LIST_THE_MUTUALLY_EXCLUSIVE_OUTCOMES_THAT_COULD_WIN_THIS_QUESTION,
+				steps: [UI_STRING_KEEP_OUTCOMES_SHORT_AND_CLEARLY_DISTINCT_FROM_EACH_OTHER, UI_STRING_USE_THE_DESCRIPTION_TO_EXPLAIN_HOW_TIES_CANCELLATIONS_OR_EXCEPTIONS_RESOLVE, UI_STRING_ONLY_INCLUDE_OUTCOMES_THAT_A_RESOLVER_CAN_VERIFY_FROM_A_PUBLIC_SOURCE],
 			}
 		case 'scalar':
 			return {
-				description: UI_STRINGS.marketCreateQuestionSection.marketTypeGuidance.scalar.description,
-				steps: [UI_STRINGS.marketCreateQuestionSection.marketTypeGuidance.scalar.stepOne, UI_STRINGS.marketCreateQuestionSection.marketTypeGuidance.scalar.stepTwo, UI_STRINGS.marketCreateQuestionSection.marketTypeGuidance.scalar.stepThree],
+				description: UI_STRING_ASK_FOR_A_MEASURABLE_NUMBER_WITH_A_UNIT_RANGE_AND_INCREMENT_THAT_USERS_CAN_UNDERSTAND,
+				steps: [UI_STRING_PICK_A_RANGE_THAT_COVERS_REALISTIC_ANSWERS_WITHOUT_BEING_OVERLY_BROAD, UI_STRING_SET_THE_ANSWER_UNIT_SO_USERS_KNOW_WHAT_THE_NUMBER_REPRESENTS, UI_STRING_USE_THE_DESCRIPTION_TO_EXPLAIN_ROUNDING_SOURCE_DATA_AND_INVALID_CONDITIONS],
 			}
 		default:
 			return assertNever(marketType)
@@ -107,10 +185,10 @@ function getDraftOutcomeLabels(marketForm: MarketFormState, categoricalOutcomesE
 			}
 
 			const normalizedOutcomes = marketForm.categoricalOutcomes.map(outcome => outcome.trim()).filter(outcome => outcome !== '')
-			return normalizedOutcomes.length > 0 ? appendInvalidOutcomeLabelIfMissing(normalizedOutcomes) : [UI_STRINGS.marketCreateQuestionSection.addAtLeastTwoOutcomesLabel, UI_STRINGS.question.invalidOutcomeLabel]
+			return normalizedOutcomes.length > 0 ? appendInvalidOutcomeLabelIfMissing(normalizedOutcomes) : [UI_STRING_ADD_AT_LEAST_2_OUTCOMES, UI_STRING_INVALID]
 		}
 		case 'scalar':
-			return [UI_STRINGS.marketCreateQuestionSection.marketTypeOptions.scalarLabel, UI_STRINGS.question.invalidOutcomeLabel]
+			return [UI_STRING_SCALAR, UI_STRING_INVALID]
 		default:
 			return assertNever(marketForm.marketType)
 	}
@@ -139,16 +217,16 @@ export function MarketCreateQuestionSection({
 	const marketTypeGuidance = getMarketTypeGuidance(marketForm.marketType)
 	const scalarInputsValid = marketFormValidation.fieldErrors.scalarIncrement === undefined && marketFormValidation.fieldErrors.scalarMax === undefined && marketFormValidation.fieldErrors.scalarMin === undefined
 	const scalarCreatePreviewDetails = getScalarCreatePreviewDetails(marketForm, scalarInputsValid)
-	const selectedQuestionTitle = selectedQuestionDetails === undefined ? UI_STRINGS.marketCreateQuestionSection.questionFallbackTitle : getQuestionTitle(selectedQuestionDetails)
+	const selectedQuestionTitle = selectedQuestionDetails === undefined ? UI_STRING_QUESTION : getQuestionTitle(selectedQuestionDetails)
 	const draftOutcomeItems = getDraftOutcomeLabels(marketForm, marketFormValidation.fieldErrors.categoricalOutcomes).map((outcome, outcomeIndex) => ({
 		key: `${outcomeIndex}-${outcome}`,
 		label: outcome,
 		tone: isInvalidOutcomeLabel(outcome) ? ('warning' as const) : ('default' as const),
 	}))
 	const normalizedDescription = marketForm.description.trim()
-	const draftDescription = normalizedDescription === '' ? UI_STRINGS.marketCreateQuestionSection.questionDefaultDescriptionText : marketForm.description
-	const draftTitle = marketForm.title.trim() === '' ? UI_STRINGS.marketCreateQuestionSection.questionDefaultTitleText : marketForm.title
-	const draftQuestionContextLabel = normalizedDescription === '' ? UI_STRINGS.marketCreateQuestionSection.draftQuestionNeedsContextLabel : UI_STRINGS.marketCreateQuestionSection.draftQuestionContextProvidedLabel
+	const draftDescription = normalizedDescription === '' ? UI_STRING_ADD_RESOLUTION_NOTES_EVIDENCE_SOURCES_AND_EDGE_CASE_HANDLING_SO_OTHER_USERS_KNOW_HOW_THIS_QUESTION_WILL_SETTLE : marketForm.description
+	const draftTitle = marketForm.title.trim() === '' ? UI_STRING_ADD_A_CLEAR_QUESTION_TITLE : marketForm.title
+	const draftQuestionContextLabel = normalizedDescription === '' ? UI_STRING_NEEDS_CONTEXT : UI_STRING_CONTEXT_PROVIDED
 	useEffect(() => {
 		if (scalarCreatePreviewDetails === undefined) return
 		const clampedTick = clampScalarTickIndex(BigInt(scalarCreatePreviewTick), scalarCreatePreviewDetails.numTicks).toString()
@@ -186,13 +264,13 @@ export function MarketCreateQuestionSection({
 									onOpenForkTab()
 								}}
 							>
-								{hasForked ? UI_STRINGS.marketCreateQuestionSection.alreadyForkedLabel : UI_STRINGS.marketCreateQuestionSection.useForForkLabel}
+								{hasForked ? UI_STRING_ALREADY_FORKED : UI_STRING_USE_FOR_FORK}
 							</button>
 							<button className='secondary' onClick={() => onUseQuestionForPool(marketResult.questionId)} disabled={marketResult.marketType !== 'binary'}>
-								{UI_STRINGS.marketCreateQuestionSection.createPoolFromQuestionLabel}
+								{UI_STRING_CREATE_POOL_FROM_QUESTION}
 							</button>
 							<button className='secondary' onClick={onResetMarket}>
-								{UI_STRINGS.marketCreateQuestionSection.createAnotherQuestionLabel}
+								{UI_STRING_CREATE_ANOTHER_QUESTION}
 							</button>
 						</div>
 					}
@@ -202,17 +280,17 @@ export function MarketCreateQuestionSection({
 							if (selectedQuestionDetails === undefined) {
 								if (loadingZoltarQuestions)
 									return (
-										<span className='loading-value' role='status' aria-label={UI_STRINGS.marketCreateQuestionSection.questionDetailsLoadingAriaLabel}>
+										<span className='loading-value' role='status' aria-label={UI_STRING_LOADING_QUESTION_DETAILS}>
 											<span className='spinner' aria-hidden='true' />
 										</span>
 									)
 
-								return <p className='detail'>{UI_STRINGS.marketCreateQuestionSection.questionDetailsNotLoadedText}</p>
+								return <p className='detail'>{UI_STRING_QUESTION_DETAILS_ARE_NOT_AVAILABLE}</p>
 							}
 
 							return <Question question={selectedQuestionDetails} showTitle={false} />
 						})()}
-						<MetricField label={UI_STRINGS.marketCreateQuestionSection.creationTransactionHashLabel}>
+						<MetricField label={UI_STRING_CREATION_TRANSACTION_HASH}>
 							<TransactionHashLink hash={marketResult.createQuestionHash} />
 						</MetricField>
 						<p className='detail'>{getPoolEligibilityMessage(marketResult.marketType)}</p>
@@ -221,20 +299,20 @@ export function MarketCreateQuestionSection({
 			)}
 
 			{marketResult === undefined ? (
-				<SectionBlock title={UI_STRINGS.marketCreateQuestionSection.createQuestionTitle} variant='plain' description={UI_STRINGS.marketCreateQuestionSection.createQuestionDescription}>
+				<SectionBlock title={UI_STRING_CREATE_QUESTION} variant='plain' description={UI_STRING_DEFINE_THE_MARKET_TYPE_TIMING_AND_OUTCOMES_FOR_A_NEW_ZOLTAR_QUESTION}>
 					<div className='workflow-summary-strip workflow-guide'>
 						<div className='workflow-guide-intro'>
-							<strong>{UI_STRINGS.marketCreateQuestionSection.workflowIntroTitle}</strong>
+							<strong>{UI_STRING_WRITE_THE_QUESTION_THE_WAY_A_RESOLVER_WILL_READ_IT}</strong>
 							<p className='detail'>{marketTypeGuidance.description}</p>
 						</div>
 						<div className='workflow-summary-strip-steps'>
-							<span className='current'>{UI_STRINGS.marketCreateQuestionSection.workflowStepDefineEventLabel}</span>
-							<span>{UI_STRINGS.marketCreateQuestionSection.workflowStepExplainResolutionLabel}</span>
-							<span>{UI_STRINGS.marketCreateQuestionSection.workflowStepSetTimingWindowLabel}</span>
+							<span className='current'>{UI_STRING_1_DEFINE_THE_EVENT_CLEARLY}</span>
+							<span>{UI_STRING_2_EXPLAIN_HOW_IT_RESOLVES}</span>
+							<span>{UI_STRING_3_SET_THE_TIMING_WINDOW}</span>
 						</div>
 					</div>
 
-					<SectionBlock headingLevel={4} title={UI_STRINGS.marketCreateQuestionSection.questionTypeGuidanceTitle} variant='embedded'>
+					<SectionBlock headingLevel={4} title={UI_STRING_QUESTION_TYPE_GUIDANCE} variant='embedded'>
 						<ul className='requirements-checklist'>
 							{marketTypeGuidance.steps.map(step => (
 								<li key={step}>{step}</li>
@@ -244,38 +322,38 @@ export function MarketCreateQuestionSection({
 
 					<div className='form-grid'>
 						<div className='field'>
-							<span>{UI_STRINGS.marketCreateQuestionSection.questionTypeLabel}</span>
-							<EnumDropdown ariaLabel={UI_STRINGS.marketCreateQuestionSection.questionTypeAriaLabel} options={MARKET_TYPE_OPTIONS} value={marketForm.marketType} onChange={marketType => onMarketFormChange({ marketType })} />
+							<span>{UI_STRING_QUESTION_TYPE}</span>
+							<EnumDropdown ariaLabel={UI_STRING_QUESTION_TYPE} options={MARKET_TYPE_OPTIONS} value={marketForm.marketType} onChange={marketType => onMarketFormChange({ marketType })} />
 							<p className='field-help'>{marketTypeGuidance.description}</p>
 						</div>
 
 						<div className='field'>
 							<label>
-								<span>{UI_STRINGS.marketCreateQuestionSection.titleFieldLabel}</span>
+								<span>{UI_STRING_TITLE}</span>
 								<FormInput
 									aria-describedby={getFieldErrorDescribedBy('title', marketFormValidation.fieldErrors.title)}
 									invalid={marketFormValidation.fieldErrors.title !== undefined}
 									value={marketForm.title}
 									onInput={event => onMarketFormChange({ title: event.currentTarget.value })}
-									placeholder={UI_STRINGS.marketCreateQuestionSection.titleFieldPlaceholder}
+									placeholder={UI_STRING_WILL_EVENT_X_HAPPEN}
 								/>
 							</label>
-							<p className='field-help'>{UI_STRINGS.marketCreateQuestionSection.titleFieldHelpText}</p>
+							<p className='field-help'>{UI_STRING_KEEP_THE_TITLE_SELF_CONTAINED_SO_USERS_CAN_UNDERSTAND_THE_EXACT_QUESTION_BEFORE_OPENING_DETAILS}</p>
 							{renderFieldError('title', marketFormValidation.fieldErrors.title)}
 						</div>
 
 						<div className='field'>
 							<label htmlFor='market-create-description'>
-								<span>{UI_STRINGS.marketCreateQuestionSection.descriptionFieldLabel}</span>
+								<span>{UI_STRING_DESCRIPTION}</span>
 							</label>
-							<textarea id='market-create-description' value={marketForm.description} onInput={event => onMarketFormChange({ description: event.currentTarget.value })} placeholder={UI_STRINGS.marketCreateQuestionSection.descriptionFieldPlaceholder} />
-							<p className='field-help'>{UI_STRINGS.marketCreateQuestionSection.descriptionFieldHelpText}</p>
+							<textarea id='market-create-description' value={marketForm.description} onInput={event => onMarketFormChange({ description: event.currentTarget.value })} placeholder={UI_STRING_OPTIONAL_QUESTION_CONTEXT} />
+							<p className='field-help'>{UI_STRING_INCLUDE_THE_RESOLUTION_SOURCE_ANY_EDGE_CASES_AND_WHAT_SHOULD_MAKE_THE_QUESTION_RESOLVE_AS_INVALID}</p>
 						</div>
 
 						<div className='field-row'>
 							<div className='field'>
 								<label>
-									<span>{UI_STRINGS.marketCreateQuestionSection.startTimeFieldLabel}</span>
+									<span>{UI_STRING_START_TIME}</span>
 									<FormInput
 										aria-describedby={getFieldErrorDescribedBy('startTime', marketFormValidation.fieldErrors.startTime)}
 										invalid={marketFormValidation.fieldErrors.startTime !== undefined}
@@ -288,41 +366,41 @@ export function MarketCreateQuestionSection({
 							</div>
 							<div className='field'>
 								<label>
-									<span>{UI_STRINGS.marketCreateQuestionSection.endTimeFieldLabel}</span>
+									<span>{UI_STRING_END_TIME}</span>
 									<FormInput aria-describedby={getFieldErrorDescribedBy('endTime', marketFormValidation.fieldErrors.endTime)} invalid={marketFormValidation.fieldErrors.endTime !== undefined} type='datetime-local' value={marketForm.endTime} onInput={event => onMarketFormChange({ endTime: event.currentTarget.value })} />
 								</label>
 								{renderFieldError('endTime', marketFormValidation.fieldErrors.endTime)}
 							</div>
 						</div>
-						<p className='field-help'>{UI_STRINGS.marketCreateQuestionSection.timingFieldHelpText}</p>
+						<p className='field-help'>{UI_STRING_TIMES_USE_YOUR_BROWSER_TIMEZONE_LEAVE_START_TIME_BLANK_TO_ALLOW_ACTIVITY_IMMEDIATELY_AFTER_CREATION}</p>
 						<p className='field-help'>{getPoolEligibilityMessage(marketForm.marketType)}</p>
 
 						{marketForm.marketType === 'categorical' ? (
 							<div className='field'>
-								<span>{UI_STRINGS.marketCreateQuestionSection.outcomesFieldLabel}</span>
+								<span>{UI_STRING_OUTCOMES}</span>
 								<div className='categorical-outcomes'>
 									{marketForm.categoricalOutcomes.map((outcome, outcomeIndex) => (
 										<div className='categorical-outcome-row' key={`categorical-outcome-${outcomeIndex}`}>
 											<label className='field'>
-												<span className='visually-hidden'>{`${UI_STRINGS.marketCreateQuestionSection.outcomeFieldLabelPrefix} ${outcomeIndex + 1}`}</span>
+												<span className='visually-hidden'>{`${UI_STRING_OUTCOME} ${outcomeIndex + 1}`}</span>
 												<FormInput
 													aria-describedby={getFieldErrorDescribedBy('categoricalOutcomes', marketFormValidation.fieldErrors.categoricalOutcomes)}
 													invalid={marketFormValidation.fieldErrors.categoricalOutcomes !== undefined}
 													value={outcome}
 													onInput={event => updateCategoricalOutcome(outcomeIndex, event.currentTarget.value)}
-													placeholder={`${UI_STRINGS.marketCreateQuestionSection.outcomeFieldLabelPrefix} ${outcomeIndex + 1}`}
+													placeholder={`${UI_STRING_OUTCOME} ${outcomeIndex + 1}`}
 												/>
 											</label>
 											<button className='secondary categorical-outcome-remove' type='button' onClick={() => removeCategoricalOutcome(outcomeIndex)}>
-												{UI_STRINGS.marketCreateQuestionSection.removeOutcomeLabel}
+												{UI_STRING_REMOVE}
 											</button>
 										</div>
 									))}
 								</div>
 								{renderFieldError('categoricalOutcomes', marketFormValidation.fieldErrors.categoricalOutcomes)}
-								<p className='field-help'>{UI_STRINGS.marketCreateQuestionSection.outcomesFieldHelpText}</p>
+								<p className='field-help'>{UI_STRING_USE_CONCISE_MUTUALLY_EXCLUSIVE_LABELS_USERS_SHOULD_BE_ABLE_TO_TELL_AT_A_GLANCE_WHICH_OUTCOME_WOULD_WIN}</p>
 								<button className='secondary categorical-outcome-add' type='button' onClick={addCategoricalOutcome}>
-									{UI_STRINGS.marketCreateQuestionSection.addOutcomeLabel}
+									{UI_STRING_ADD_OUTCOME}
 								</button>
 							</div>
 						) : undefined}
@@ -331,20 +409,20 @@ export function MarketCreateQuestionSection({
 							<div className='field-row'>
 								<div className='field'>
 									<label>
-										<span>{UI_STRINGS.marketCreateQuestionSection.scalarMinFieldLabel}</span>
+										<span>{UI_STRING_SCALAR_MIN}</span>
 										<FormInput
 											aria-describedby={getFieldErrorDescribedBy('scalarMin', marketFormValidation.fieldErrors.scalarMin)}
 											invalid={marketFormValidation.fieldErrors.scalarMin !== undefined}
 											value={marketForm.scalarMin}
 											onInput={event => onMarketFormChange({ scalarMin: event.currentTarget.value })}
-											placeholder={UI_STRINGS.marketCreateQuestionSection.scalarMinFieldPlaceholder}
+											placeholder={UI_STRING_1}
 										/>
 									</label>
 									{renderFieldError('scalarMin', marketFormValidation.fieldErrors.scalarMin)}
 								</div>
 								<label className='field'>
-									<span>{UI_STRINGS.marketCreateQuestionSection.answerUnitFieldLabel}</span>
-									<FormInput value={marketForm.answerUnit} onInput={event => onMarketFormChange({ answerUnit: event.currentTarget.value })} placeholder={UI_STRINGS.marketCreateQuestionSection.answerUnitFieldPlaceholder} />
+									<span>{UI_STRING_ANSWER_UNIT}</span>
+									<FormInput value={marketForm.answerUnit} onInput={event => onMarketFormChange({ answerUnit: event.currentTarget.value })} placeholder={UI_STRING_USD} />
 								</label>
 							</div>
 						) : undefined}
@@ -353,37 +431,37 @@ export function MarketCreateQuestionSection({
 							<div className='field-row'>
 								<div className='field'>
 									<label>
-										<span>{UI_STRINGS.marketCreateQuestionSection.scalarIncrementFieldLabel}</span>
+										<span>{UI_STRING_SCALAR_INCREMENT}</span>
 										<FormInput
 											aria-describedby={getFieldErrorDescribedBy('scalarIncrement', marketFormValidation.fieldErrors.scalarIncrement)}
 											invalid={marketFormValidation.fieldErrors.scalarIncrement !== undefined}
 											value={marketForm.scalarIncrement}
 											onInput={event => onMarketFormChange({ scalarIncrement: event.currentTarget.value })}
-											placeholder={UI_STRINGS.marketCreateQuestionSection.scalarIncrementFieldPlaceholder}
+											placeholder={UI_STRING_0_1}
 										/>
 									</label>
 									{renderFieldError('scalarIncrement', marketFormValidation.fieldErrors.scalarIncrement)}
 								</div>
 								<div className='field'>
 									<label>
-										<span>{UI_STRINGS.marketCreateQuestionSection.scalarMaxFieldLabel}</span>
+										<span>{UI_STRING_SCALAR_MAX}</span>
 										<FormInput
 											aria-describedby={getFieldErrorDescribedBy('scalarMax', marketFormValidation.fieldErrors.scalarMax)}
 											invalid={marketFormValidation.fieldErrors.scalarMax !== undefined}
 											value={marketForm.scalarMax}
 											onInput={event => onMarketFormChange({ scalarMax: event.currentTarget.value })}
-											placeholder={UI_STRINGS.marketCreateQuestionSection.scalarMaxFieldPlaceholder}
+											placeholder={UI_STRING_10}
 										/>
 									</label>
 									{renderFieldError('scalarMax', marketFormValidation.fieldErrors.scalarMax)}
 								</div>
 							</div>
 						) : undefined}
-						{marketForm.marketType === 'scalar' ? <p className='field-help'>{UI_STRINGS.marketCreateQuestionSection.scalarFieldHelpText}</p> : undefined}
+						{marketForm.marketType === 'scalar' ? <p className='field-help'>{UI_STRING_SCALAR_QUESTIONS_SETTLE_TO_A_NUMERIC_RESULT_INSIDE_THE_RANGE_ABOVE_USE_A_UNIT_THAT_MATCHES_THE_PUBLIC_SOURCE_YOU_EXPECT_TO_CITE}</p> : undefined}
 
 						{(() => {
 							if (marketForm.marketType === 'scalar') {
-								if (scalarCreatePreviewDetails === undefined) return <p className='detail'>{UI_STRINGS.marketCreateQuestionSection.scalarPreviewPromptText}</p>
+								if (scalarCreatePreviewDetails === undefined) return <p className='detail'>{UI_STRING_ENTER_SCALAR_MIN_MAX_AND_INCREMENT_TO_PREVIEW_THE_TICK_SLIDER}</p>
 
 								return <ScalarCreatePreview details={scalarCreatePreviewDetails} selectedTick={scalarCreatePreviewTick} onSelectedTickChange={setScalarCreatePreviewTick} />
 							}
@@ -391,14 +469,14 @@ export function MarketCreateQuestionSection({
 							return undefined
 						})()}
 
-						<SectionBlock headingLevel={4} title={UI_STRINGS.marketCreateQuestionSection.draftPreviewTitle} variant='embedded' description={UI_STRINGS.marketCreateQuestionSection.draftPreviewDescription}>
+						<SectionBlock headingLevel={4} title={UI_STRING_DRAFT_PREVIEW} variant='embedded' description={UI_STRING_DRAFT_PREVIEW_SHOWS_THE_LEVEL_OF_CLARITY_TRADERS_AND_REPORTERS_WILL_SEE_BEFORE_TRUSTING_THE_QUESTION}>
 							<div className='question-draft-preview'>
 								<div className='question-draft-preview-header'>
 									<div className='question-summary-heading'>
 										<strong>{draftTitle}</strong>
 										<p className='detail'>{draftDescription}</p>
 									</div>
-									<div className='question-draft-preview-statuses' role='list' aria-label={UI_STRINGS.marketCreateQuestionSection.draftQuestionStatusAriaLabel}>
+									<div className='question-draft-preview-statuses' role='list' aria-label={UI_STRING_DRAFT_QUESTION_STATUS}>
 										<span className='question-draft-preview-chip' role='listitem'>
 											{marketForm.marketType}
 										</span>
@@ -408,18 +486,18 @@ export function MarketCreateQuestionSection({
 									</div>
 								</div>
 								<OutcomeChipRow items={draftOutcomeItems} />
-								<div className='question-draft-preview-meta' role='list' aria-label={UI_STRINGS.marketCreateQuestionSection.draftQuestionSummaryAriaLabel}>
+								<div className='question-draft-preview-meta' role='list' aria-label={UI_STRING_DRAFT_QUESTION_SUMMARY}>
 									<div className='question-draft-preview-meta-item' role='listitem'>
-										<span>{UI_STRINGS.marketCreateQuestionSection.startsLabel}</span>
-										<strong>{marketForm.startTime.trim() === '' ? UI_STRINGS.marketCreateQuestionSection.immediatelyAfterCreationLabel : marketForm.startTime}</strong>
+										<span>{UI_STRING_STARTS}</span>
+										<strong>{marketForm.startTime.trim() === '' ? UI_STRING_IMMEDIATELY_AFTER_CREATION : marketForm.startTime}</strong>
 									</div>
 									<div className='question-draft-preview-meta-item' role='listitem'>
-										<span>{UI_STRINGS.marketCreateQuestionSection.endsLabel}</span>
-										<strong>{marketForm.endTime.trim() === '' ? UI_STRINGS.marketCreateQuestionSection.chooseEndTimeLabel : marketForm.endTime}</strong>
+										<span>{UI_STRING_ENDS}</span>
+										<strong>{marketForm.endTime.trim() === '' ? UI_STRING_CHOOSE_AN_END_TIME : marketForm.endTime}</strong>
 									</div>
 									<div className='question-draft-preview-meta-item' role='listitem'>
-										<span>{UI_STRINGS.marketCreateQuestionSection.riskCueFieldLabel}</span>
-										<strong>{normalizedDescription === '' ? UI_STRINGS.marketCreateQuestionSection.lowTrustUntilContextAddedLabel : UI_STRINGS.marketCreateQuestionSection.contextPresentForReviewLabel}</strong>
+										<span>{UI_STRING_RISK_CUE}</span>
+										<strong>{normalizedDescription === '' ? UI_STRING_LOW_TRUST_UNTIL_CONTEXT_IS_ADDED : UI_STRING_CONTEXT_IS_PRESENT_FOR_REVIEW}</strong>
 									</div>
 								</div>
 							</div>
@@ -427,14 +505,14 @@ export function MarketCreateQuestionSection({
 
 						<div className='actions'>
 							<TransactionActionButton
-								idleLabel={UI_STRINGS.marketCreateQuestionSection.createQuestionButtonIdleLabel}
-								pendingLabel={UI_STRINGS.marketCreateQuestionSection.createQuestionButtonPendingLabel}
+								idleLabel={UI_STRING_CREATE_QUESTION}
+								pendingLabel={UI_STRING_CREATING_QUESTION_MARKET_CREATE_QUESTION_SECTION_CREATE_QUESTION_BUTTON_PENDING_LABEL}
 								onClick={onCreateMarket}
 								pending={marketCreating}
 								availability={{
 									disabled: accountAddress === undefined || !isMainnet || marketCreating || !marketFormValidation.isValid,
 									reason: (() => {
-										if (accountAddress === undefined) return UI_STRINGS.marketCreateQuestionSection.walletRequiredReason
+										if (accountAddress === undefined) return UI_STRING_CONNECT_A_WALLET_BEFORE_CREATING_A_QUESTION
 										if (!isMainnet) return undefined
 
 										return marketFormValidation.notice

--- a/ui/ts/components/MarketQuestionsSection.tsx
+++ b/ui/ts/components/MarketQuestionsSection.tsx
@@ -6,7 +6,18 @@ import { Question, getQuestionTitle } from './Question.js'
 import { SectionBlock } from './SectionBlock.js'
 import { StateHint } from './StateHint.js'
 import { formatPaginationSummary, getHasNextPaginationPage, getPaginationPageCount, QUESTION_PAGE_SIZE } from '../lib/pagination.js'
-import { UI_STRINGS } from '../lib/uiStrings.js'
+import {
+	UI_STRING_ALREADY_FORKED,
+	UI_STRING_CREATE_POOL_FROM_QUESTION,
+	UI_STRING_CREATE_QUESTION,
+	UI_STRING_LOADING_QUESTIONS,
+	UI_STRING_MARKETS,
+	UI_STRING_NO_QUESTIONS,
+	UI_STRING_NO_QUESTIONS_MARKET_QUESTIONS_SECTION_NO_QUESTIONS_DETAIL,
+	UI_STRING_NON_BINARY_QUESTIONS_ARE_VALID_IN_ZOLTAR_BUT_PLACEHOLDER_ORIGIN_POOLS_CURRENTLY_REQUIRE_AN_EXACT_BINARY_YES_NO_QUESTION,
+	UI_STRING_QUESTION_PAGE_UNAVAILABLE,
+	UI_STRING_USE_FOR_FORK,
+} from '../lib/uiStrings.js'
 import type { MarketDetailsPage } from '../types/contracts.js'
 
 function isCurrentQuestionPage(page: MarketDetailsPage | undefined, pageIndex: number, questionCount: bigint | undefined) {
@@ -76,7 +87,7 @@ export function MarketQuestionsSection({ environmentRefreshKey, hasForked, loadi
 	return (
 		<SectionBlock
 			density='compact'
-			title={UI_STRINGS.marketQuestionsSection.marketsTitle}
+			title={UI_STRING_MARKETS}
 			actions={
 				<PaginationControls
 					hasNextPage={hasNextPage}
@@ -93,7 +104,7 @@ export function MarketQuestionsSection({ environmentRefreshKey, hasForked, loadi
 					if (loadingZoltarQuestionCount || loadingZoltarQuestions || isWaitingForPageData)
 						return (
 							<p className='detail'>
-								<LoadingText>{UI_STRINGS.marketQuestionsSection.loadingQuestionsLabel}</LoadingText>
+								<LoadingText>{UI_STRING_LOADING_QUESTIONS}</LoadingText>
 							</p>
 						)
 					if (noQuestionsAvailable)
@@ -101,19 +112,19 @@ export function MarketQuestionsSection({ environmentRefreshKey, hasForked, loadi
 							<StateHint
 								presentation={{
 									key: 'empty',
-									badgeLabel: UI_STRINGS.marketQuestionsSection.noQuestionsEmptyBadgeLabel,
+									badgeLabel: UI_STRING_NO_QUESTIONS,
 									badgeTone: 'muted',
-									detail: UI_STRINGS.marketQuestionsSection.noQuestionsDetail,
+									detail: UI_STRING_NO_QUESTIONS_MARKET_QUESTIONS_SECTION_NO_QUESTIONS_DETAIL,
 								}}
-								title={UI_STRINGS.marketQuestionsSection.noQuestionsBadgeLabel}
+								title={UI_STRING_NO_QUESTIONS}
 								actions={
 									<button className='primary' type='button' onClick={onCreateQuestion}>
-										{UI_STRINGS.marketCreateQuestionSection.createQuestionButtonIdleLabel}
+										{UI_STRING_CREATE_QUESTION}
 									</button>
 								}
 							/>
 						)
-					if (effectiveQuestionCount !== undefined && effectiveQuestionCount > 0n) return <p className='detail'>{UI_STRINGS.marketQuestionsSection.pageUnavailableDetail}</p>
+					if (effectiveQuestionCount !== undefined && effectiveQuestionCount > 0n) return <p className='detail'>{UI_STRING_QUESTION_PAGE_UNAVAILABLE}</p>
 
 					return undefined
 				})()
@@ -134,16 +145,16 @@ export function MarketQuestionsSection({ environmentRefreshKey, hasForked, loadi
 											onOpenForkTab()
 										}}
 									>
-										{hasForked ? UI_STRINGS.marketQuestionsSection.alreadyForkedLabel : UI_STRINGS.marketCreateQuestionSection.useForForkLabel}
+										{hasForked ? UI_STRING_ALREADY_FORKED : UI_STRING_USE_FOR_FORK}
 									</button>
 									<button className='secondary' onClick={() => onUseQuestionForPool(question.questionId)} disabled={question.marketType !== 'binary'}>
-										{UI_STRINGS.marketCreateQuestionSection.createPoolFromQuestionLabel}
+										{UI_STRING_CREATE_POOL_FROM_QUESTION}
 									</button>
 								</div>
 							}
 						>
 							<Question question={question} showTitle={false} />
-							{question.marketType !== 'binary' ? <p className='detail'>{UI_STRINGS.marketQuestionsSection.nonBinaryPoolRestrictionDetail}</p> : undefined}
+							{question.marketType !== 'binary' ? <p className='detail'>{UI_STRING_NON_BINARY_QUESTIONS_ARE_VALID_IN_ZOLTAR_BUT_PLACEHOLDER_ORIGIN_POOLS_CURRENTLY_REQUIRE_AN_EXACT_BINARY_YES_NO_QUESTION}</p> : undefined}
 						</EntityCard>
 					))}
 				</div>

--- a/ui/ts/components/MarketSection.tsx
+++ b/ui/ts/components/MarketSection.tsx
@@ -8,7 +8,22 @@ import { OperationModal } from './OperationModal.js'
 import { SectionBlock } from './SectionBlock.js'
 import { ZoltarMigrationSection } from './ZoltarMigrationSection.js'
 import { isMainnetChain } from '../lib/network.js'
-import { UI_STRINGS } from '../lib/uiStrings.js'
+import {
+	UI_STRING_FORK,
+	UI_STRING_FORK_ZOLTAR,
+	UI_STRING_FORKED,
+	UI_STRING_LOADING_WITH_ELLIPSIS,
+	UI_STRING_MARKETS,
+	UI_STRING_METRIC_UNAVAILABLE_PLACEHOLDER,
+	UI_STRING_OPEN_REP_MIGRATION,
+	UI_STRING_POST_FORK_ACTIONS,
+	UI_STRING_QUESTIONS,
+	UI_STRING_SELECTED_FORK_QUESTION_MARKET_SECTION_SELECTED_FORK_QUESTION_PREFIX,
+	UI_STRING_STATUS,
+	UI_STRING_THE_UNIVERSE_IS_FORKED_MIGRATION_IS_NOW_THE_PRIMARY_FOLLOW_UP_ACTION,
+	UI_STRING_UNFORKED,
+	UI_STRING_UNIVERSE,
+} from '../lib/uiStrings.js'
 import type { MarketSectionProps } from '../types/components.js'
 
 export function MarketSection({
@@ -74,7 +89,7 @@ export function MarketSection({
 
 	return (
 		<div className='route-view-flow'>
-			<SectionBlock density='compact' title={UI_STRINGS.marketSection.marketsSectionTitle}>
+			<SectionBlock density='compact' title={UI_STRING_MARKETS}>
 				{showUniverseSummary ? (
 					<MarketOverviewSection
 						accountAddress={accountState.address}
@@ -89,16 +104,16 @@ export function MarketSection({
 				) : (
 					<DataGrid columns='auto'>
 						<div>
-							<p className='detail'>{UI_STRINGS.marketSection.universeLabel}</p>
-							<strong>{zoltarUniverse?.universeId.toString() ?? UI_STRINGS.common.loadingLabel}</strong>
+							<p className='detail'>{UI_STRING_UNIVERSE}</p>
+							<strong>{zoltarUniverse?.universeId.toString() ?? UI_STRING_LOADING_WITH_ELLIPSIS}</strong>
 						</div>
 						<div>
-							<p className='detail'>{UI_STRINGS.marketSection.statusLabel}</p>
-							<strong>{hasForked ? UI_STRINGS.marketSection.statusForkedLabel : UI_STRINGS.marketSection.statusUnforkedLabel}</strong>
+							<p className='detail'>{UI_STRING_STATUS}</p>
+							<strong>{hasForked ? UI_STRING_FORKED : UI_STRING_UNFORKED}</strong>
 						</div>
 						<div>
-							<p className='detail'>{UI_STRINGS.marketSection.questionsLabel}</p>
-							<strong>{zoltarQuestionCount?.toString() ?? UI_STRINGS.common.metricUnavailablePlaceholder}</strong>
+							<p className='detail'>{UI_STRING_QUESTIONS}</p>
+							<strong>{zoltarQuestionCount?.toString() ?? UI_STRING_METRIC_UNAVAILABLE_PLACEHOLDER}</strong>
 						</div>
 					</DataGrid>
 				)}
@@ -107,10 +122,10 @@ export function MarketSection({
 				{view === 'questions' ? (
 					<>
 						{hasForked ? (
-							<SectionBlock title={UI_STRINGS.marketSection.postForkActionsTitle} description={UI_STRINGS.marketSection.postForkActionsDescription}>
+							<SectionBlock title={UI_STRING_POST_FORK_ACTIONS} description={UI_STRING_THE_UNIVERSE_IS_FORKED_MIGRATION_IS_NOW_THE_PRIMARY_FOLLOW_UP_ACTION}>
 								<div className='actions'>
 									<button className='primary' type='button' onClick={() => onActiveViewChange('migrate')}>
-										{UI_STRINGS.marketSection.openRepMigrationLabel}
+										{UI_STRING_OPEN_REP_MIGRATION}
 									</button>
 								</div>
 							</SectionBlock>
@@ -153,19 +168,19 @@ export function MarketSection({
 
 				{view === 'fork' ? (
 					<>
-						<SectionBlock title={UI_STRINGS.marketSection.forkSectionTitle}>
+						<SectionBlock title={UI_STRING_FORK}>
 							<div className='actions'>
 								<button className='primary' type='button' onClick={() => setForkModalOpen(true)}>
-									{UI_STRINGS.marketSection.forkActionLabel}
+									{UI_STRING_FORK_ZOLTAR}
 								</button>
 							</div>
 							{zoltarForkQuestionId.trim() === '' ? undefined : (
 								<p className='detail'>
-									{UI_STRINGS.marketSection.selectedForkQuestionPrefix} {zoltarForkQuestionId}
+									{UI_STRING_SELECTED_FORK_QUESTION_MARKET_SECTION_SELECTED_FORK_QUESTION_PREFIX} {zoltarForkQuestionId}
 								</p>
 							)}
 						</SectionBlock>
-						<OperationModal isOpen={forkModalOpen} onClose={() => setForkModalOpen(false)} title={UI_STRINGS.marketSection.forkZoltarModalTitle}>
+						<OperationModal isOpen={forkModalOpen} onClose={() => setForkModalOpen(false)} title={UI_STRING_FORK_ZOLTAR}>
 							<ForkZoltarSection
 								accountAddress={accountState.address}
 								hasLoadedZoltarQuestions={hasLoadedZoltarQuestions}

--- a/ui/ts/components/OpenOracleSection.tsx
+++ b/ui/ts/components/OpenOracleSection.tsx
@@ -46,7 +46,151 @@ import { getOpenOracleStagePresentation } from '../lib/openOracleStage.js'
 import { formatPaginationSummary, getHasNextPaginationPage, getPaginationPageCount } from '../lib/pagination.js'
 import { loadOpenOracleReportSummaries } from '../contracts.js'
 import { isMainnetChain } from '../lib/network.js'
-import { UI_STRINGS } from '../lib/uiStrings.js'
+import {
+	UI_STRING_1_00,
+	UI_STRING_ALL_STATUSES,
+	UI_STRING_AWAITING_INITIAL_REPORT,
+	UI_STRING_AWAITING_INITIAL_REPORT_OPEN_ORACLE_SECTION_AWAITING_INITIAL_REPORT_LABEL,
+	UI_STRING_BASE_TOKEN_FOR_THE_REPORTED_PAIR,
+	UI_STRING_BLOCKS_OPEN_ORACLE_SECTION_TIME_IN_BLOCKS_SUFFIX,
+	UI_STRING_BROWSE_REPORTS,
+	UI_STRING_CALLBACK_CONTRACT,
+	UI_STRING_CALLBACK_EXTRA,
+	UI_STRING_CALLBACK_GAS_LIMIT,
+	UI_STRING_CONFIRM_SETTLEMENT_ONCE_THE_SELECTED_REPORT_IS_READY,
+	UI_STRING_CONNECT_A_WALLET_BEFORE_DISPUTING_THE_REPORT,
+	UI_STRING_CONNECT_A_WALLET_BEFORE_SETTLING_THE_REPORT,
+	UI_STRING_CONNECT_A_WALLET_BEFORE_SUBMITTING_THE_INITIAL_REPORT,
+	UI_STRING_CONNECT_A_WALLET_BEFORE_WRAPPING_ETH,
+	UI_STRING_CREATE_ANOTHER,
+	UI_STRING_CREATE_STANDALONE_ORACLE_GAME,
+	UI_STRING_CREATE_SUCCESS,
+	UI_STRING_CREATING,
+	UI_STRING_CURRENT_PRICE,
+	UI_STRING_CURRENT_REPORT_STATE,
+	UI_STRING_CURRENT_REPORTER,
+	UI_STRING_DELAY_IN_SECONDS_AFTER_THE_INITIAL_REPORT_BEFORE_DISPUTES_CAN_BEGIN,
+	UI_STRING_DELAY_IN_SECONDS_AFTER_THE_INITIAL_REPORT_BEFORE_SETTLEMENT_CAN_BEGIN,
+	UI_STRING_DIRECT_OPEN_ORACLE_CREATION_FOR_PROTOCOL_TESTING_THIS_BYPASSES_POOL_MANAGED_ORACLE_MANAGER_STAGING_SO_CONFIRM_ADDRESSES_TOKEN_AMOUNTS_FEES_AND_TIMING_BEFORE_SUBMITTING,
+	UI_STRING_DISPUTE_AND_SWAP,
+	UI_STRING_DISPUTE_DELAY,
+	UI_STRING_DISPUTE_OCCURRED,
+	UI_STRING_DISPUTE_REPORT,
+	UI_STRING_DISPUTED,
+	UI_STRING_DISPUTING_THE_REPORT,
+	UI_STRING_ECONOMICS,
+	UI_STRING_ESCALATION_HALT,
+	UI_STRING_ESCALATION_MULTIPLIER_FOR_DISPUTE_ECONOMICS,
+	UI_STRING_ETH,
+	UI_STRING_ETH_PAID_TO_THE_ACCOUNT_THAT_SETTLES_THE_REPORT,
+	UI_STRING_ETH_SENT_WITH_CREATION_MUST_COVER_REQUIRED_FUNDING_AND_THE_SETTLER_REWARD,
+	UI_STRING_ETH_VALUE_TO_SEND,
+	UI_STRING_EXACT_TOKEN1_REPORT,
+	UI_STRING_FAILED_TO_LOAD_OPEN_ORACLE_REPORTS,
+	UI_STRING_FEE,
+	UI_STRING_FEE_CHARGED_DURING_DISPUTE_ECONOMICS_ENTERED_AS_A_PERCENTAGE,
+	UI_STRING_FEE_PERCENTAGE,
+	UI_STRING_FETCH_PRICE_FROM_UNISWAP,
+	UI_STRING_FETCHING,
+	UI_STRING_HEX_VALUE_PLACEHOLDER,
+	UI_STRING_IDENTITY,
+	UI_STRING_INITIAL_ECONOMICS,
+	UI_STRING_INITIAL_REPORT,
+	UI_STRING_INITIAL_REPORTER,
+	UI_STRING_LAST_REPORT_OPPORTUNITY,
+	UI_STRING_LOAD_A_REPORT_FIRST,
+	UI_STRING_LOADING,
+	UI_STRING_LOADING_WITH_ELLIPSIS,
+	UI_STRING_MORE_WETH_FOR_THIS_REPORT,
+	UI_STRING_MULTIPLIER,
+	UI_STRING_NEED,
+	UI_STRING_NO,
+	UI_STRING_NO_MATCHES,
+	UI_STRING_NO_OPEN_ORACLE_GAMES_FOUND,
+	UI_STRING_NO_REPORTS_MATCH_THE_CURRENT_SEARCH_AND_STATUS_FILTERS,
+	UI_STRING_NONE,
+	UI_STRING_NONE_AWAITING_INITIAL_REPORT,
+	UI_STRING_NOT_SETTLED,
+	UI_STRING_NUMBER_OF_REPORTS,
+	UI_STRING_OPEN_A_FOCUSED_ACTION_FLOW_FOR_THE_SELECTED_REPORT_WHEN_IT_IS_AVAILABLE,
+	UI_STRING_OPEN_ORACLE_GAME,
+	UI_STRING_OPEN_ORACLE_REPORT_DETAILS,
+	UI_STRING_OPEN_REPORT,
+	UI_STRING_ORACLE_ADDRESS,
+	UI_STRING_PENDING,
+	UI_STRING_PLURAL_SUFFIX,
+	UI_STRING_PRICE,
+	UI_STRING_PRICE_SOURCE,
+	UI_STRING_PROTOCOL_FEE,
+	UI_STRING_PROTOCOL_FEE_CHARGED_DURING_DISPUTES_ENTERED_AS_A_PERCENTAGE,
+	UI_STRING_PROTOCOL_FEE_RECIPIENT,
+	UI_STRING_PROVIDE_THE_REPLACEMENT_SWAP_AMOUNTS_FOR_THE_SELECTED_REPORT,
+	UI_STRING_QUOTE_TOKEN_FOR_THE_REPORTED_PAIR,
+	UI_STRING_REFRESH_REPORT,
+	UI_STRING_REFRESHING_REPORT_SUMMARIES,
+	UI_STRING_REPORT,
+	UI_STRING_REPORT_ACTIONS,
+	UI_STRING_REPORT_AMOUNTS,
+	UI_STRING_REPORT_CONTEXT,
+	UI_STRING_REPORT_DETAILS,
+	UI_STRING_REPORT_ID,
+	UI_STRING_REPORT_TIMESTAMP,
+	UI_STRING_REPORTER,
+	UI_STRING_RETURN_TO_BROWSE,
+	UI_STRING_REVIEW_PRICE_SOURCE_APPROVALS_AND_TOKEN_BALANCES_BEFORE_SUBMITTING_THE_INITIAL_REPORT,
+	UI_STRING_SEARCH_BY_REPORT_ID_TOKEN_SYMBOL_OR_TOKEN_ADDRESS,
+	UI_STRING_SEARCH_REPORTS,
+	UI_STRING_SETTLE_REPORT,
+	UI_STRING_SETTLED,
+	UI_STRING_SETTLED_REPORT,
+	UI_STRING_SETTLEMENT,
+	UI_STRING_SETTLEMENT_IS_CONFIRMATION_FIRST_REVIEW_THE_CURRENT_REPORT_STATE_AND_CONFIRM_ONLY_WHEN_THE_DISPUTE_WINDOW_IS_CLOSED,
+	UI_STRING_SETTLEMENT_SUMMARY,
+	UI_STRING_SETTLEMENT_TIME,
+	UI_STRING_SETTLEMENT_TIMESTAMP,
+	UI_STRING_SETTLER_REWARD,
+	UI_STRING_SETTLING_REPORT,
+	UI_STRING_STAGE,
+	UI_STRING_STATE_HASH,
+	UI_STRING_STATUS,
+	UI_STRING_SUBMIT_INITIAL_REPORT,
+	UI_STRING_SUBMITTING,
+	UI_STRING_SUBMITTING_DISPUTE,
+	UI_STRING_SUBMITTING_THE_INITIAL_REPORT,
+	UI_STRING_THE_REPORT_INSTANCE_WAS_CREATED_SUCCESSFULLY,
+	UI_STRING_THIS_QUOTE_IS_STALE_AND_WILL_BE_REFRESHED_BEFORE_SUBMISSION,
+	UI_STRING_THIS_REPORT_IS_SETTLED_NO_WRITE_ACTIONS_ARE_AVAILABLE,
+	UI_STRING_TIMING,
+	UI_STRING_TOKEN_PAIR,
+	UI_STRING_TOKEN_TO_SWAP_OUT,
+	UI_STRING_TOKEN1_ADDRESS,
+	UI_STRING_TOKEN1_AMOUNT_TO_REPORT_ENTERED_AS_A_DECIMAL_VALUE_FOR_THE_TOKEN1_ADDRESS,
+	UI_STRING_TOKEN1_AMOUNT_WHERE_DISPUTE_ESCALATION_STOPS_ENTERED_AS_A_DECIMAL_VALUE_FOR_THE_TOKEN1_ADDRESS,
+	UI_STRING_TOKEN2_ADDRESS,
+	UI_STRING_TRACK_DISPUTES,
+	UI_STRING_USE_THIS_ONLY_WHEN_YOU_INTEND_TO_CREATE_A_STANDALONE_ORACLE_GAME_DIRECTLY_FROM_THE_CONNECTED_WALLET_POOL_MANAGED_ORACLE_REQUESTS_SHOULD_BE_STARTED_FROM_A_SELECTED_SECURITY_POOL,
+	UI_STRING_WETH,
+	UI_STRING_WRAP_NEEDED_ETH_TO_WETH,
+	UI_STRING_WRAPPING_ETH,
+	UI_STRING_YES,
+	UI_TEMPLATE_APPROVING_TOKEN_PENDING_LABEL,
+	UI_TEMPLATE_BROWSE_REPORTS_DESCRIPTION,
+	UI_TEMPLATE_BROWSE_SHOWN_COUNT_SUMMARY,
+	UI_TEMPLATE_CURRENT_AMOUNT1_LABEL,
+	UI_TEMPLATE_CURRENT_AMOUNT2_LABEL,
+	UI_TEMPLATE_DISCONNECTED_WALLET_APPROVAL_REASON,
+	UI_TEMPLATE_ENTER_VALID_DISPUTE_AMOUNTS_BEFORE_APPROVING_REASON,
+	UI_TEMPLATE_ENTER_VALID_PRICE_BEFORE_APPROVING_REASON,
+	UI_TEMPLATE_EXACT_TOKEN_REQUIRED_LABEL,
+	UI_TEMPLATE_NEW_AMOUNT_MUST_BE_EXACT_DETAIL,
+	UI_TEMPLATE_NEW_TOKEN_AMOUNT_FIELD_LABEL,
+	UI_TEMPLATE_PRICE_FIELD_LABEL,
+	UI_TEMPLATE_QUOTE_AGE_TEXT,
+	UI_TEMPLATE_QUOTE_LOADED_DETAIL,
+	UI_TEMPLATE_REPORT_NUMBER_TITLE,
+	UI_TEMPLATE_TOKEN_APPROVAL_TITLE,
+	UI_TEMPLATE_TOKEN_PAIR_SUFFIX,
+} from '../lib/uiStrings.js'
 import { getReportPresentation } from '../lib/userCopy.js'
 import type { OpenOracleFormState } from '../types/app.js'
 import type { OpenOracleReportDetails, OpenOracleReportSummary, OpenOracleReportSummaryPage } from '../types/contracts.js'
@@ -112,8 +256,8 @@ function renderInitialPriceFreshness(openOracleInitialReportState: OpenOracleSec
 	if (openOracleInitialReportState.quoteLoadedAtMs === undefined) return undefined
 	return (
 		<p className='detail'>
-			{UI_STRINGS.openOracleSection.quoteLoadedDetail(openOracleInitialReportState.quoteBlockNumber?.toString(), UI_STRINGS.openOracleSection.quoteAgeText(openOracleInitialReportState.quoteLoadedAtMs))}
-			{openOracleInitialReportState.quoteStale === true ? ` ${UI_STRINGS.openOracleSection.staleQuoteRefreshDetail}` : ''}
+			{UI_TEMPLATE_QUOTE_LOADED_DETAIL(openOracleInitialReportState.quoteBlockNumber?.toString(), UI_TEMPLATE_QUOTE_AGE_TEXT(openOracleInitialReportState.quoteLoadedAtMs))}
+			{openOracleInitialReportState.quoteStale === true ? ` ${UI_STRING_THIS_QUOTE_IS_STALE_AND_WILL_BE_REFRESHED_BEFORE_SUBMISSION}` : ''}
 		</p>
 	)
 }
@@ -124,29 +268,29 @@ function renderReportSummaryCard(report: OpenOracleReportSummary, onSelectReport
 		<EntityCard
 			key={report.reportId.toString()}
 			className='compact'
-			title={UI_STRINGS.openOracleSection.reportNumberTitle(report.reportId.toString())}
+			title={UI_TEMPLATE_REPORT_NUMBER_TITLE(report.reportId.toString())}
 			badge={<Badge tone={statusTone}>{status}</Badge>}
 			actions={
 				<div className='actions'>
 					<button className='secondary' type='button' onClick={() => onSelectReport(report.reportId)}>
-						{UI_STRINGS.openOracleSection.openReportButtonLabel}
+						{UI_STRING_OPEN_REPORT}
 					</button>
 				</div>
 			}
 		>
 			<MetricGrid variant='question'>
 				{renderReportField(
-					UI_STRINGS.openOracleSection.tokenPairLabel,
+					UI_STRING_TOKEN_PAIR,
 					<>
 						<AddressValue address={report.token1} /> / <AddressValue address={report.token2} />
 					</>,
 				)}
-				{renderReportField(UI_STRINGS.openOracleSection.currentPriceLabel, <CurrencyValue value={report.price} suffix={UI_STRINGS.openOracleSection.tokenPairSuffix(report.token1Symbol, report.token2Symbol)} units={OPEN_ORACLE_PRICE_UNITS} copyable={false} />)}
-				{renderReportField(UI_STRINGS.openOracleSection.currentReporterLabel, report.currentReporter === zeroAddress ? UI_STRINGS.common.noneLabel : <AddressValue address={report.currentReporter} />)}
-				{renderReportField(UI_STRINGS.openOracleSection.currentAmount1Label(report.token1Symbol), <CurrencyValue value={report.currentAmount1} suffix={report.token1Symbol} units={report.token1Decimals} copyable={false} />)}
-				{renderReportField(UI_STRINGS.openOracleSection.currentAmount2Label(report.token2Symbol), <CurrencyValue value={report.currentAmount2} suffix={report.token2Symbol} units={report.token2Decimals} copyable={false} />)}
-				{renderReportField(UI_STRINGS.openOracleSection.reportTimestampLabel, <TimestampValue timestamp={report.reportTimestamp} zeroText={UI_STRINGS.openOracleSection.awaitingInitialReportLabel} />)}
-				{renderReportField(UI_STRINGS.openOracleSection.settlementTimestampLabel, <TimestampValue timestamp={report.settlementTimestamp} zeroText={UI_STRINGS.openOracleSection.notSettledLabel} />)}
+				{renderReportField(UI_STRING_CURRENT_PRICE, <CurrencyValue value={report.price} suffix={UI_TEMPLATE_TOKEN_PAIR_SUFFIX(report.token1Symbol, report.token2Symbol)} units={OPEN_ORACLE_PRICE_UNITS} copyable={false} />)}
+				{renderReportField(UI_STRING_CURRENT_REPORTER, report.currentReporter === zeroAddress ? UI_STRING_NONE : <AddressValue address={report.currentReporter} />)}
+				{renderReportField(UI_TEMPLATE_CURRENT_AMOUNT1_LABEL(report.token1Symbol), <CurrencyValue value={report.currentAmount1} suffix={report.token1Symbol} units={report.token1Decimals} copyable={false} />)}
+				{renderReportField(UI_TEMPLATE_CURRENT_AMOUNT2_LABEL(report.token2Symbol), <CurrencyValue value={report.currentAmount2} suffix={report.token2Symbol} units={report.token2Decimals} copyable={false} />)}
+				{renderReportField(UI_STRING_REPORT_TIMESTAMP, <TimestampValue timestamp={report.reportTimestamp} zeroText={UI_STRING_AWAITING_INITIAL_REPORT_OPEN_ORACLE_SECTION_AWAITING_INITIAL_REPORT_LABEL} />)}
+				{renderReportField(UI_STRING_SETTLEMENT_TIMESTAMP, <TimestampValue timestamp={report.settlementTimestamp} zeroText={UI_STRING_NOT_SETTLED} />)}
 			</MetricGrid>
 		</EntityCard>
 	)
@@ -202,59 +346,59 @@ export function renderSelectedReportActionSection({
 	switch (actionMode) {
 		case 'initial-report':
 			const token2ApprovalGuardMessage = (() => {
-				if (!isConnected) return UI_STRINGS.openOracleSection.disconnectedWalletApprovalReason(token2Symbol)
+				if (!isConnected) return UI_TEMPLATE_DISCONNECTED_WALLET_APPROVAL_REASON(token2Symbol)
 				if (!isMainnet) return undefined
-				if (initialReportSubmission.amount2 === undefined) return UI_STRINGS.openOracleSection.enterValidPriceBeforeApprovingReason(token1Symbol, token2Symbol)
+				if (initialReportSubmission.amount2 === undefined) return UI_TEMPLATE_ENTER_VALID_PRICE_BEFORE_APPROVING_REASON(token1Symbol, token2Symbol)
 				return undefined
 			})()
 			const wrapDisabledReason = (() => {
-				if (!isConnected) return UI_STRINGS.openOracleSection.disconnectedWalletWrapEthReason
+				if (!isConnected) return UI_STRING_CONNECT_A_WALLET_BEFORE_WRAPPING_ETH
 				if (!isMainnet) return undefined
 				if (initialReportSubmission.wrapRequiredWethMessage?.kind === 'visible') return initialReportSubmission.wrapRequiredWethMessage.message
 				return undefined
 			})()
 			const submitInitialReportDisabledReason = (() => {
-				if (!isConnected) return UI_STRINGS.openOracleSection.disconnectedWalletSubmitInitialReportReason
+				if (!isConnected) return UI_STRING_CONNECT_A_WALLET_BEFORE_SUBMITTING_THE_INITIAL_REPORT
 				if (!isMainnet) return undefined
 				if (initialReportSubmission.blockMessage?.kind === 'visible') return initialReportSubmission.blockMessage.message
 				return undefined
 			})()
 			return (
-				<SectionBlock headingLevel={4} title={UI_STRINGS.openOracleSection.initialReportTitle} variant='embedded'>
+				<SectionBlock headingLevel={4} title={UI_STRING_INITIAL_REPORT} variant='embedded'>
 					<div className='form-grid'>
 						{openOracleReportDetails === undefined
 							? undefined
-							: renderReportSection(UI_STRINGS.openOracleSection.initialReportContextTitle, [
-									{ label: UI_STRINGS.openOracleSection.reportLabel, value: `#${openOracleReportDetails.reportId.toString()}` },
-									{ label: UI_STRINGS.openOracleSection.tokenPairLabel, value: `${token1Symbol} / ${token2Symbol}` },
-									{ label: UI_STRINGS.openOracleSection.stickyContextFields.stageLabel, value: UI_STRINGS.openOracleSection.awaitingInitialReportLabel },
+							: renderReportSection(UI_STRING_REPORT_CONTEXT, [
+									{ label: UI_STRING_REPORT, value: `#${openOracleReportDetails.reportId.toString()}` },
+									{ label: UI_STRING_TOKEN_PAIR, value: `${token1Symbol} / ${token2Symbol}` },
+									{ label: UI_STRING_STAGE, value: UI_STRING_AWAITING_INITIAL_REPORT_OPEN_ORACLE_SECTION_AWAITING_INITIAL_REPORT_LABEL },
 								])}
 						<div className='field-row'>
 							<label className='field'>
-								<span>{UI_STRINGS.openOracleSection.priceFieldLabel(token1Symbol, token2Symbol)}</span>
-								<FormInput value={openOracleForm.price} onInput={event => onOpenOracleFormChange({ price: event.currentTarget.value })} placeholder={UI_STRINGS.openOracleSection.priceFieldPlaceholder} />
+								<span>{UI_TEMPLATE_PRICE_FIELD_LABEL(token1Symbol, token2Symbol)}</span>
+								<FormInput value={openOracleForm.price} onInput={event => onOpenOracleFormChange({ price: event.currentTarget.value })} placeholder={UI_STRING_1_00} />
 							</label>
 							<div className='actions'>
 								<button className='secondary' onClick={onRefreshPrice} disabled={openOracleInitialReportState.quoteLoading}>
-									{openOracleInitialReportState.quoteLoading ? UI_STRINGS.openOracleSection.fetchPriceFromUniswapPendingLabel : UI_STRINGS.openOracleSection.fetchPriceFromUniswapIdleLabel}
+									{openOracleInitialReportState.quoteLoading ? UI_STRING_FETCHING : UI_STRING_FETCH_PRICE_FROM_UNISWAP}
 								</button>
 							</div>
 						</div>
 						<p className='detail'>
-							{UI_STRINGS.openOracleSection.priceSourceLabelPrefix} {showQuoteLoadingPlaceholder ? <strong>{UI_STRINGS.common.loadingLabel}</strong> : renderInitialPriceSourceLabel(initialReportSubmission.priceSource, initialReportSubmission.priceSourceUrl)}
+							{UI_STRING_PRICE_SOURCE} {showQuoteLoadingPlaceholder ? <strong>{UI_STRING_LOADING_WITH_ELLIPSIS}</strong> : renderInitialPriceSourceLabel(initialReportSubmission.priceSource, initialReportSubmission.priceSourceUrl)}
 						</p>
 						{renderInitialPriceFreshness(openOracleInitialReportState, initialReportSubmission.priceSource)}
-						<SectionBlock headingLevel={4} title={UI_STRINGS.openOracleSection.tokenApprovalTitle(token1Symbol)} variant='embedded'>
+						<SectionBlock headingLevel={4} title={UI_TEMPLATE_TOKEN_APPROVAL_TITLE(token1Symbol)} variant='embedded'>
 							<TokenApprovalControl
-								actionLabel={UI_STRINGS.openOracleSection.initialReportTokenApprovalActionLabel}
+								actionLabel={UI_STRING_SUBMITTING_THE_INITIAL_REPORT}
 								allowanceError={openOracleInitialReportState.token1Approval.error}
 								allowanceLoading={openOracleInitialReportState.token1Approval.loading}
 								approvedAmount={openOracleInitialReportState.token1Approval.value}
 								disabled={!isConnected || !isMainnet}
-								guardMessage={!isConnected ? UI_STRINGS.openOracleSection.disconnectedWalletApprovalReason(token1Symbol) : undefined}
+								guardMessage={!isConnected ? UI_TEMPLATE_DISCONNECTED_WALLET_APPROVAL_REASON(token1Symbol) : undefined}
 								onApprove={amount => onApproveToken1(amount)}
 								pending={openOracleActiveAction === 'approveToken1'}
-								pendingLabel={UI_STRINGS.openOracleSection.approvingTokenPendingLabel(token1Symbol)}
+								pendingLabel={UI_TEMPLATE_APPROVING_TOKEN_PENDING_LABEL(token1Symbol)}
 								requiredAmount={initialReportSubmission.amount1}
 								resetKey={`token1:${token1Symbol}:${initialReportSubmission.amount1?.toString() ?? ''}:${openOracleForm.reportId}`}
 								tokenSymbol={token1Symbol}
@@ -262,9 +406,9 @@ export function renderSelectedReportActionSection({
 							/>
 						</SectionBlock>
 
-						<SectionBlock headingLevel={4} title={UI_STRINGS.openOracleSection.tokenApprovalTitle(token2Symbol)} variant='embedded'>
+						<SectionBlock headingLevel={4} title={UI_TEMPLATE_TOKEN_APPROVAL_TITLE(token2Symbol)} variant='embedded'>
 							<TokenApprovalControl
-								actionLabel={UI_STRINGS.openOracleSection.initialReportTokenApprovalActionLabel}
+								actionLabel={UI_STRING_SUBMITTING_THE_INITIAL_REPORT}
 								allowanceError={openOracleInitialReportState.token2Approval.error}
 								allowanceLoading={openOracleInitialReportState.token2Approval.loading}
 								approvedAmount={openOracleInitialReportState.token2Approval.value}
@@ -272,7 +416,7 @@ export function renderSelectedReportActionSection({
 								guardMessage={token2ApprovalGuardMessage}
 								onApprove={amount => onApproveToken2(amount)}
 								pending={openOracleActiveAction === 'approveToken2'}
-								pendingLabel={UI_STRINGS.openOracleSection.approvingTokenPendingLabel(token2Symbol)}
+								pendingLabel={UI_TEMPLATE_APPROVING_TOKEN_PENDING_LABEL(token2Symbol)}
 								requiredAmount={initialReportSubmission.amount2}
 								resetKey={`token2:${token2Symbol}:${initialReportSubmission.amount2?.toString() ?? ''}:${openOracleForm.reportId}`}
 								tokenSymbol={token2Symbol}
@@ -281,7 +425,7 @@ export function renderSelectedReportActionSection({
 						</SectionBlock>
 						{initialReportSubmission.requiredWethWrapAmount === undefined || initialReportSubmission.requiredWethWrapAmount <= 0n ? undefined : (
 							<p className='detail'>
-								{UI_STRINGS.openOracleSection.requiredWethWrapDetailPrefix} <CurrencyValue value={initialReportSubmission.requiredWethWrapAmount} suffix={UI_STRINGS.common.wethSuffix} copyable={false} /> {UI_STRINGS.openOracleSection.requiredWethWrapDetailSuffix}
+								{UI_STRING_NEED} <CurrencyValue value={initialReportSubmission.requiredWethWrapAmount} suffix={UI_STRING_WETH} copyable={false} /> {UI_STRING_MORE_WETH_FOR_THIS_REPORT}
 							</p>
 						)}
 						{!isMainnet || initialReportSubmission.wrapRequiredWethMessage?.kind !== 'visible' ? undefined : <p className='detail'>{initialReportSubmission.wrapRequiredWethMessage.message}</p>}
@@ -289,8 +433,8 @@ export function renderSelectedReportActionSection({
 						<div className='actions'>
 							{!initialReportSubmission.hasWethWrapAction ? undefined : (
 								<TransactionActionButton
-									idleLabel={UI_STRINGS.openOracleSection.wrapEthToWethIdleLabel}
-									pendingLabel={UI_STRINGS.openOracleSection.wrapEthToWethPendingLabel}
+									idleLabel={UI_STRING_WRAP_NEEDED_ETH_TO_WETH}
+									pendingLabel={UI_STRING_WRAPPING_ETH}
 									onClick={onWrapWethForInitialReport}
 									pending={openOracleActiveAction === 'wrapWeth'}
 									tone='secondary'
@@ -301,8 +445,8 @@ export function renderSelectedReportActionSection({
 								/>
 							)}
 							<TransactionActionButton
-								idleLabel={UI_STRINGS.openOracleSection.submitInitialReportIdleLabel}
-								pendingLabel={UI_STRINGS.openOracleSection.submitInitialReportPendingLabel}
+								idleLabel={UI_STRING_SUBMIT_INITIAL_REPORT}
+								pendingLabel={UI_STRING_SUBMITTING}
 								onClick={onSubmitInitialReport}
 								pending={openOracleActiveAction === 'submitInitialReport'}
 								availability={{
@@ -316,65 +460,65 @@ export function renderSelectedReportActionSection({
 			)
 		case 'dispute': {
 			const disputeDisabledMessage = (() => {
-				if (openOracleForm.reportId.trim() === '') return UI_STRINGS.openOracleSection.loadReportFirstReason
+				if (openOracleForm.reportId.trim() === '') return UI_STRING_LOAD_A_REPORT_FIRST
 
 				return disputeAvailability.message
 			})()
 			const token1ApprovalGuardMessage = (() => {
-				if (openOracleReportDetails === undefined) return UI_STRINGS.openOracleSection.loadReportFirstReason
-				if (disputeSubmission?.token1ContributionAmount === undefined) return UI_STRINGS.openOracleSection.enterValidDisputeAmountsBeforeApprovingReason(token1Symbol)
+				if (openOracleReportDetails === undefined) return UI_STRING_LOAD_A_REPORT_FIRST
+				if (disputeSubmission?.token1ContributionAmount === undefined) return UI_TEMPLATE_ENTER_VALID_DISPUTE_AMOUNTS_BEFORE_APPROVING_REASON(token1Symbol)
 
 				return undefined
 			})()
 			const token2ApprovalGuardMessage = (() => {
-				if (openOracleReportDetails === undefined) return UI_STRINGS.openOracleSection.loadReportFirstReason
-				if (disputeSubmission?.token2ContributionAmount === undefined) return UI_STRINGS.openOracleSection.enterValidDisputeAmountsBeforeApprovingReason(token2Symbol)
+				if (openOracleReportDetails === undefined) return UI_STRING_LOAD_A_REPORT_FIRST
+				if (disputeSubmission?.token2ContributionAmount === undefined) return UI_TEMPLATE_ENTER_VALID_DISPUTE_AMOUNTS_BEFORE_APPROVING_REASON(token2Symbol)
 
 				return undefined
 			})()
 			const disputeToken1ApprovalGuardMessage = (() => {
-				if (!isConnected) return UI_STRINGS.openOracleSection.disconnectedWalletApprovalReason(token1Symbol)
+				if (!isConnected) return UI_TEMPLATE_DISCONNECTED_WALLET_APPROVAL_REASON(token1Symbol)
 				if (!isMainnet) return undefined
 				return token1ApprovalGuardMessage
 			})()
 			const disputeToken2ApprovalGuardMessage = (() => {
-				if (!isConnected) return UI_STRINGS.openOracleSection.disconnectedWalletApprovalReason(token2Symbol)
+				if (!isConnected) return UI_TEMPLATE_DISCONNECTED_WALLET_APPROVAL_REASON(token2Symbol)
 				if (!isMainnet) return undefined
 				return token2ApprovalGuardMessage
 			})()
 			const disputeActionDisabledReason = (() => {
-				if (!isConnected) return UI_STRINGS.openOracleSection.disconnectedWalletDisputeReason
+				if (!isConnected) return UI_STRING_CONNECT_A_WALLET_BEFORE_DISPUTING_THE_REPORT
 				if (!isMainnet) return undefined
 				return disputeDisabledMessage ?? (disputeSubmission?.blockMessage?.kind === 'visible' ? disputeSubmission.blockMessage.message : undefined)
 			})()
 			return (
-				<SectionBlock headingLevel={4} title={UI_STRINGS.openOracleSection.disputeReportTitle} variant='embedded'>
+				<SectionBlock headingLevel={4} title={UI_STRING_DISPUTE_REPORT} variant='embedded'>
 					<div className='form-grid'>
 						{openOracleReportDetails === undefined
 							? undefined
-							: renderReportSection(UI_STRINGS.openOracleSection.currentReportStateTitle, [
-									{ label: UI_STRINGS.openOracleSection.reportLabel, value: `#${openOracleReportDetails.reportId.toString()}` },
-									{ label: UI_STRINGS.openOracleSection.currentReporterLabel, value: openOracleReportDetails.currentReporter === zeroAddress ? UI_STRINGS.common.noneLabel : <AddressValue address={openOracleReportDetails.currentReporter} /> },
-									{ label: UI_STRINGS.openOracleSection.currentPriceLabel, value: <CurrencyValue value={openOracleReportDetails.price} suffix={UI_STRINGS.openOracleSection.tokenPairSuffix(token1Symbol, token2Symbol)} copyable={false} /> },
+							: renderReportSection(UI_STRING_CURRENT_REPORT_STATE, [
+									{ label: UI_STRING_REPORT, value: `#${openOracleReportDetails.reportId.toString()}` },
+									{ label: UI_STRING_CURRENT_REPORTER, value: openOracleReportDetails.currentReporter === zeroAddress ? UI_STRING_NONE : <AddressValue address={openOracleReportDetails.currentReporter} /> },
+									{ label: UI_STRING_CURRENT_PRICE, value: <CurrencyValue value={openOracleReportDetails.price} suffix={UI_TEMPLATE_TOKEN_PAIR_SUFFIX(token1Symbol, token2Symbol)} copyable={false} /> },
 								])}
 						<label className='field'>
-							<span>{UI_STRINGS.openOracleSection.tokenSwapOutLabel}</span>
+							<span>{UI_STRING_TOKEN_TO_SWAP_OUT}</span>
 							<EnumDropdown options={disputeTokenOptions} value={openOracleForm.disputeTokenToSwap} onChange={disputeTokenToSwap => onOpenOracleFormChange({ disputeTokenToSwap })} />
 						</label>
 						<div className='field-row'>
 							<label className='field'>
-								<span>{UI_STRINGS.openOracleSection.newTokenAmountFieldLabel(token1Symbol)}</span>
+								<span>{UI_TEMPLATE_NEW_TOKEN_AMOUNT_FIELD_LABEL(token1Symbol)}</span>
 								<FormInput value={openOracleForm.disputeNewAmount1} onInput={event => onOpenOracleFormChange({ disputeNewAmount1: event.currentTarget.value })} />
 							</label>
 							<label className='field'>
-								<span>{UI_STRINGS.openOracleSection.newTokenAmountFieldLabel(token2Symbol)}</span>
+								<span>{UI_TEMPLATE_NEW_TOKEN_AMOUNT_FIELD_LABEL(token2Symbol)}</span>
 								<FormInput value={openOracleForm.disputeNewAmount2} onInput={event => onOpenOracleFormChange({ disputeNewAmount2: event.currentTarget.value })} />
 							</label>
 						</div>
-						{disputeSubmission?.expectedNewAmount1 === undefined ? undefined : <p className='detail'>{UI_STRINGS.openOracleSection.newAmountMustBeExactDetail(token1Symbol, disputeSubmission.expectedNewAmount1.toString())}</p>}
-						<SectionBlock headingLevel={4} title={UI_STRINGS.openOracleSection.tokenApprovalTitle(token1Symbol)} variant='embedded'>
+						{disputeSubmission?.expectedNewAmount1 === undefined ? undefined : <p className='detail'>{UI_TEMPLATE_NEW_AMOUNT_MUST_BE_EXACT_DETAIL(token1Symbol, disputeSubmission.expectedNewAmount1.toString())}</p>}
+						<SectionBlock headingLevel={4} title={UI_TEMPLATE_TOKEN_APPROVAL_TITLE(token1Symbol)} variant='embedded'>
 							<TokenApprovalControl
-								actionLabel={UI_STRINGS.openOracleSection.disputingReportActionLabel}
+								actionLabel={UI_STRING_DISPUTING_THE_REPORT}
 								allowanceError={openOracleInitialReportState.token1Approval.error}
 								allowanceLoading={openOracleInitialReportState.token1Approval.loading}
 								approvedAmount={openOracleInitialReportState.token1Approval.value}
@@ -382,16 +526,16 @@ export function renderSelectedReportActionSection({
 								guardMessage={disputeToken1ApprovalGuardMessage}
 								onApprove={amount => onApproveToken1(amount)}
 								pending={openOracleActiveAction === 'approveToken1'}
-								pendingLabel={UI_STRINGS.openOracleSection.approvingTokenPendingLabel(token1Symbol)}
+								pendingLabel={UI_TEMPLATE_APPROVING_TOKEN_PENDING_LABEL(token1Symbol)}
 								requiredAmount={disputeSubmission?.token1ContributionAmount}
 								resetKey={`dispute:token1:${token1Symbol}:${disputeSubmission?.token1ContributionAmount?.toString() ?? ''}:${openOracleForm.reportId}`}
 								tokenSymbol={token1Symbol}
 								tokenUnits={disputeSubmission?.token1Decimals ?? 18}
 							/>
 						</SectionBlock>
-						<SectionBlock headingLevel={4} title={UI_STRINGS.openOracleSection.tokenApprovalTitle(token2Symbol)} variant='embedded'>
+						<SectionBlock headingLevel={4} title={UI_TEMPLATE_TOKEN_APPROVAL_TITLE(token2Symbol)} variant='embedded'>
 							<TokenApprovalControl
-								actionLabel={UI_STRINGS.openOracleSection.disputingReportActionLabel}
+								actionLabel={UI_STRING_DISPUTING_THE_REPORT}
 								allowanceError={openOracleInitialReportState.token2Approval.error}
 								allowanceLoading={openOracleInitialReportState.token2Approval.loading}
 								approvedAmount={openOracleInitialReportState.token2Approval.value}
@@ -399,7 +543,7 @@ export function renderSelectedReportActionSection({
 								guardMessage={disputeToken2ApprovalGuardMessage}
 								onApprove={amount => onApproveToken2(amount)}
 								pending={openOracleActiveAction === 'approveToken2'}
-								pendingLabel={UI_STRINGS.openOracleSection.approvingTokenPendingLabel(token2Symbol)}
+								pendingLabel={UI_TEMPLATE_APPROVING_TOKEN_PENDING_LABEL(token2Symbol)}
 								requiredAmount={disputeSubmission?.token2ContributionAmount}
 								resetKey={`dispute:token2:${token2Symbol}:${disputeSubmission?.token2ContributionAmount?.toString() ?? ''}:${openOracleForm.reportId}`}
 								tokenSymbol={token2Symbol}
@@ -409,8 +553,8 @@ export function renderSelectedReportActionSection({
 						{!isMainnet || disputeSubmission?.blockMessage?.kind !== 'visible' ? undefined : <p className='detail'>{disputeSubmission.blockMessage.message}</p>}
 						<div className='actions'>
 							<TransactionActionButton
-								idleLabel={UI_STRINGS.openOracleSection.disputeReportActionLabel}
-								pendingLabel={UI_STRINGS.openOracleSection.disputeAndSwapPendingLabel}
+								idleLabel={UI_STRING_DISPUTE_AND_SWAP}
+								pendingLabel={UI_STRING_SUBMITTING_DISPUTE}
 								onClick={onDisputeReport}
 								pending={openOracleActiveAction === 'dispute'}
 								tone='secondary'
@@ -426,30 +570,30 @@ export function renderSelectedReportActionSection({
 		}
 		case 'settle': {
 			const settleDisabledMessage = (() => {
-				if (openOracleForm.reportId.trim() === '') return UI_STRINGS.openOracleSection.loadReportFirstReason
+				if (openOracleForm.reportId.trim() === '') return UI_STRING_LOAD_A_REPORT_FIRST
 
 				return settleAvailability.message
 			})()
 			const settleActionDisabledReason = (() => {
-				if (!isConnected) return UI_STRINGS.openOracleSection.disconnectedWalletSettleReason
+				if (!isConnected) return UI_STRING_CONNECT_A_WALLET_BEFORE_SETTLING_THE_REPORT
 				if (!isMainnet) return undefined
 				return settleDisabledMessage
 			})()
 			return (
-				<SectionBlock headingLevel={4} title={UI_STRINGS.openOracleSection.settleReportTitle} variant='embedded'>
+				<SectionBlock headingLevel={4} title={UI_STRING_SETTLE_REPORT} variant='embedded'>
 					<div className='form-grid'>
 						{openOracleReportDetails === undefined
 							? undefined
-							: renderReportSection(UI_STRINGS.openOracleSection.settlementSummaryTitle, [
-									{ label: UI_STRINGS.openOracleSection.reportLabel, value: `#${openOracleReportDetails.reportId.toString()}` },
-									{ label: UI_STRINGS.openOracleSection.currentReporterLabel, value: openOracleReportDetails.currentReporter === zeroAddress ? UI_STRINGS.common.noneLabel : <AddressValue address={openOracleReportDetails.currentReporter} /> },
-									{ label: UI_STRINGS.openOracleSection.settlementTimestampLabel, value: <TimestampValue currentTimestamp={openOracleReportDetails.currentTime} timestamp={openOracleReportDetails.settlementTimestamp} zeroText={UI_STRINGS.openOracleSection.notSettledLabel} /> },
+							: renderReportSection(UI_STRING_SETTLEMENT_SUMMARY, [
+									{ label: UI_STRING_REPORT, value: `#${openOracleReportDetails.reportId.toString()}` },
+									{ label: UI_STRING_CURRENT_REPORTER, value: openOracleReportDetails.currentReporter === zeroAddress ? UI_STRING_NONE : <AddressValue address={openOracleReportDetails.currentReporter} /> },
+									{ label: UI_STRING_SETTLEMENT_TIMESTAMP, value: <TimestampValue currentTimestamp={openOracleReportDetails.currentTime} timestamp={openOracleReportDetails.settlementTimestamp} zeroText={UI_STRING_NOT_SETTLED} /> },
 								])}
-						<p className='detail'>{UI_STRINGS.openOracleSection.settleConfirmationDetail}</p>
+						<p className='detail'>{UI_STRING_SETTLEMENT_IS_CONFIRMATION_FIRST_REVIEW_THE_CURRENT_REPORT_STATE_AND_CONFIRM_ONLY_WHEN_THE_DISPUTE_WINDOW_IS_CLOSED}</p>
 						<div className='actions'>
 							<TransactionActionButton
-								idleLabel={UI_STRINGS.openOracleSection.settleReportIdleLabel}
-								pendingLabel={UI_STRINGS.openOracleSection.settleReportPendingLabel}
+								idleLabel={UI_STRING_SETTLE_REPORT}
+								pendingLabel={UI_STRING_SETTLING_REPORT}
 								onClick={onSettleReport}
 								pending={openOracleActiveAction === 'settle'}
 								tone='secondary'
@@ -465,8 +609,8 @@ export function renderSelectedReportActionSection({
 		}
 		case 'read-only':
 			return (
-				<SectionBlock headingLevel={4} title={UI_STRINGS.openOracleSection.settledReportTitle} variant='embedded'>
-					<p className='detail'>{UI_STRINGS.openOracleSection.noWriteActionsAvailableDetail}</p>
+				<SectionBlock headingLevel={4} title={UI_STRING_SETTLED_REPORT} variant='embedded'>
+					<p className='detail'>{UI_STRING_THIS_REPORT_IS_SETTLED_NO_WRITE_ACTIONS_ARE_AVAILABLE}</p>
 				</SectionBlock>
 			)
 		default:
@@ -498,16 +642,16 @@ function renderReportDetailsCard(
 	const reportControls = (
 		<div className='form-grid'>
 			<LookupFieldRow
-				label={UI_STRINGS.openOracleSection.reportIdFieldLabel}
+				label={UI_STRING_REPORT_ID}
 				value={openOracleForm.reportId}
 				onInput={reportId => onOpenOracleFormChange({ reportId })}
 				action={
 					<button className='secondary' onClick={() => onLoadOracleReport(openOracleForm.reportId)} disabled={loadingOracleReport}>
 						{(() => {
-							if (loadingOracleReport) return <LoadingText>{UI_STRINGS.common.loadingLabel}</LoadingText>
-							if (openOracleReportDetails === undefined) return UI_STRINGS.openOracleSection.openReportButtonLabel
+							if (loadingOracleReport) return <LoadingText>{UI_STRING_LOADING_WITH_ELLIPSIS}</LoadingText>
+							if (openOracleReportDetails === undefined) return UI_STRING_OPEN_REPORT
 
-							return UI_STRINGS.openOracleSection.refreshReportButtonLabel
+							return UI_STRING_REFRESH_REPORT
 						})()}
 					</button>
 				}
@@ -525,7 +669,7 @@ function renderReportDetailsCard(
 			})(),
 		})
 		return (
-			<SectionBlock title={UI_STRINGS.openOracleSection.reportDetailsTitle}>
+			<SectionBlock title={UI_STRING_REPORT_DETAILS}>
 				{reportControls}
 				{reportPresentation === undefined ? undefined : <StateHint presentation={reportPresentation} />}
 			</SectionBlock>
@@ -560,41 +704,41 @@ function renderReportDetailsCard(
 	return (
 		<>
 			<StickyObjectContext
-				eyebrow={UI_STRINGS.openOracleSection.selectedReportEyebrow}
-				title={UI_STRINGS.openOracleSection.reportNumberTitle(openOracleReportDetails.reportId.toString())}
+				eyebrow={UI_STRING_OPEN_ORACLE_REPORT_DETAILS}
+				title={UI_TEMPLATE_REPORT_NUMBER_TITLE(openOracleReportDetails.reportId.toString())}
 				items={[
-					{ label: UI_STRINGS.openOracleSection.stickyContextFields.stageLabel, value: stage.label },
-					{ label: UI_STRINGS.openOracleSection.stickyContextFields.tokenPairLabel, value: UI_STRINGS.openOracleSection.tokenPairSuffix(openOracleReportDetails.token1Symbol, openOracleReportDetails.token2Symbol) },
-					{ label: UI_STRINGS.openOracleSection.stickyContextFields.reporterLabel, value: openOracleReportDetails.currentReporter === zeroAddress ? UI_STRINGS.common.noneLabel : <AddressValue address={openOracleReportDetails.currentReporter} /> },
+					{ label: UI_STRING_STAGE, value: stage.label },
+					{ label: UI_STRING_TOKEN_PAIR, value: UI_TEMPLATE_TOKEN_PAIR_SUFFIX(openOracleReportDetails.token1Symbol, openOracleReportDetails.token2Symbol) },
+					{ label: UI_STRING_REPORTER, value: openOracleReportDetails.currentReporter === zeroAddress ? UI_STRING_NONE : <AddressValue address={openOracleReportDetails.currentReporter} /> },
 					{
-						label: UI_STRINGS.openOracleSection.stickyContextFields.priceLabel,
-						value: <CurrencyValue value={openOracleReportDetails.price} suffix={UI_STRINGS.openOracleSection.tokenPairSuffix(openOracleReportDetails.token1Symbol, openOracleReportDetails.token2Symbol)} units={OPEN_ORACLE_PRICE_UNITS} copyable={false} />,
+						label: UI_STRING_PRICE,
+						value: <CurrencyValue value={openOracleReportDetails.price} suffix={UI_TEMPLATE_TOKEN_PAIR_SUFFIX(openOracleReportDetails.token1Symbol, openOracleReportDetails.token2Symbol)} units={OPEN_ORACLE_PRICE_UNITS} copyable={false} />,
 					},
 				]}
 			/>
 			<LifecycleStageBanner stage={stage} />
-			<SectionBlock title={UI_STRINGS.openOracleSection.reportActionsTitle} description={UI_STRINGS.openOracleSection.reportActionsDescription}>
+			<SectionBlock title={UI_STRING_REPORT_ACTIONS} description={UI_STRING_OPEN_A_FOCUSED_ACTION_FLOW_FOR_THE_SELECTED_REPORT_WHEN_IT_IS_AVAILABLE}>
 				<div className='action-readiness-grid'>
 					{readinessActions.map(action => (
 						<ActionLauncherCard key={action.key} action={action} />
 					))}
 				</div>
 			</SectionBlock>
-			<SectionBlock badge={<Badge tone={statusTone}>{status}</Badge>} title={UI_STRINGS.openOracleSection.reportDetailsTitle}>
+			<SectionBlock badge={<Badge tone={statusTone}>{status}</Badge>} title={UI_STRING_REPORT_DETAILS}>
 				{reportControls}
 				<MetricGrid variant='question'>
-					{renderReportField(UI_STRINGS.openOracleSection.reportIdLabel, openOracleReportDetails.reportId.toString())}
-					{renderReportField(UI_STRINGS.openOracleSection.oracleAddressLabel, <AddressValue address={openOracleReportDetails.openOracleAddress} />)}
-					{renderReportField(UI_STRINGS.openOracleSection.currentReporterLabel, openOracleReportDetails.currentReporter === zeroAddress ? UI_STRINGS.openOracleSection.currentReporterAwaitingInitialReportLabel : <AddressValue address={openOracleReportDetails.currentReporter} />)}
-					{renderReportField(UI_STRINGS.openOracleSection.currentPriceLabel, <CurrencyValue value={openOracleReportDetails.price} suffix={UI_STRINGS.openOracleSection.tokenPairSuffix(openOracleReportDetails.token1Symbol, openOracleReportDetails.token2Symbol)} units={OPEN_ORACLE_PRICE_UNITS} copyable={false} />)}
-					{renderReportField(UI_STRINGS.openOracleSection.settlementTimestampLabel, <TimestampValue currentTimestamp={openOracleReportDetails.currentTime} timestamp={openOracleReportDetails.settlementTimestamp} zeroText={UI_STRINGS.openOracleSection.notSettledLabel} />)}
+					{renderReportField(UI_STRING_REPORT_ID, openOracleReportDetails.reportId.toString())}
+					{renderReportField(UI_STRING_ORACLE_ADDRESS, <AddressValue address={openOracleReportDetails.openOracleAddress} />)}
+					{renderReportField(UI_STRING_CURRENT_REPORTER, openOracleReportDetails.currentReporter === zeroAddress ? UI_STRING_NONE_AWAITING_INITIAL_REPORT : <AddressValue address={openOracleReportDetails.currentReporter} />)}
+					{renderReportField(UI_STRING_CURRENT_PRICE, <CurrencyValue value={openOracleReportDetails.price} suffix={UI_TEMPLATE_TOKEN_PAIR_SUFFIX(openOracleReportDetails.token1Symbol, openOracleReportDetails.token2Symbol)} units={OPEN_ORACLE_PRICE_UNITS} copyable={false} />)}
+					{renderReportField(UI_STRING_SETTLEMENT_TIMESTAMP, <TimestampValue currentTimestamp={openOracleReportDetails.currentTime} timestamp={openOracleReportDetails.settlementTimestamp} zeroText={UI_STRING_NOT_SETTLED} />)}
 				</MetricGrid>
 			</SectionBlock>
 			<div className='report-detail-stack'>
-				<ReadOnlyDetailAccordion defaultOpen title={UI_STRINGS.openOracleSection.identityTitle}>
-					{renderReportSection(UI_STRINGS.openOracleSection.identityTitle, [
+				<ReadOnlyDetailAccordion defaultOpen title={UI_STRING_IDENTITY}>
+					{renderReportSection(UI_STRING_IDENTITY, [
 						{
-							label: UI_STRINGS.openOracleSection.oracleAddressLabel,
+							label: UI_STRING_ORACLE_ADDRESS,
 							value: <AddressValue address={openOracleReportDetails.openOracleAddress} />,
 						},
 						{
@@ -606,130 +750,130 @@ function renderReportDetailsCard(
 							value: <AddressValue address={openOracleReportDetails.token2} />,
 						},
 						{
-							label: UI_STRINGS.openOracleSection.currentReporterLabel,
-							value: openOracleReportDetails.currentReporter === zeroAddress ? UI_STRINGS.openOracleSection.currentReporterAwaitingInitialReportLabel : <AddressValue address={openOracleReportDetails.currentReporter} />,
+							label: UI_STRING_CURRENT_REPORTER,
+							value: openOracleReportDetails.currentReporter === zeroAddress ? UI_STRING_NONE_AWAITING_INITIAL_REPORT : <AddressValue address={openOracleReportDetails.currentReporter} />,
 						},
 						{
-							label: UI_STRINGS.openOracleSection.initialReporterLabel,
-							value: openOracleReportDetails.initialReporter === zeroAddress ? UI_STRINGS.common.noneLabel : <AddressValue address={openOracleReportDetails.initialReporter} />,
+							label: UI_STRING_INITIAL_REPORTER,
+							value: openOracleReportDetails.initialReporter === zeroAddress ? UI_STRING_NONE : <AddressValue address={openOracleReportDetails.initialReporter} />,
 						},
 					])}
 				</ReadOnlyDetailAccordion>
 
-				<ReadOnlyDetailAccordion title={UI_STRINGS.openOracleSection.economicsTitle}>
-					{renderReportSection(UI_STRINGS.openOracleSection.reportAmountsTitle, [
+				<ReadOnlyDetailAccordion title={UI_STRING_ECONOMICS}>
+					{renderReportSection(UI_STRING_REPORT_AMOUNTS, [
 						{
-							label: UI_STRINGS.openOracleSection.exactTokenRequiredLabel(openOracleReportDetails.token1Symbol),
+							label: UI_TEMPLATE_EXACT_TOKEN_REQUIRED_LABEL(openOracleReportDetails.token1Symbol),
 							value: <CurrencyValue value={openOracleReportDetails.exactToken1Report} suffix={openOracleReportDetails.token1Symbol} units={openOracleReportDetails.token1Decimals} copyable={false} />,
 						},
 						{
-							label: UI_STRINGS.openOracleSection.currentAmount1Label(openOracleReportDetails.token1Symbol),
+							label: UI_TEMPLATE_CURRENT_AMOUNT1_LABEL(openOracleReportDetails.token1Symbol),
 							value: <CurrencyValue value={openOracleReportDetails.currentAmount1} suffix={openOracleReportDetails.token1Symbol} units={openOracleReportDetails.token1Decimals} copyable={false} />,
 						},
 						{
-							label: UI_STRINGS.openOracleSection.currentAmount2Label(openOracleReportDetails.token2Symbol),
+							label: UI_TEMPLATE_CURRENT_AMOUNT2_LABEL(openOracleReportDetails.token2Symbol),
 							value: <CurrencyValue value={openOracleReportDetails.currentAmount2} suffix={openOracleReportDetails.token2Symbol} units={openOracleReportDetails.token2Decimals} copyable={false} />,
 						},
 						{
-							label: UI_STRINGS.openOracleSection.priceLabel,
-							value: <CurrencyValue value={openOracleReportDetails.price} suffix={UI_STRINGS.openOracleSection.tokenPairSuffix(openOracleReportDetails.token1Symbol, openOracleReportDetails.token2Symbol)} units={OPEN_ORACLE_PRICE_UNITS} copyable={false} />,
+							label: UI_STRING_PRICE,
+							value: <CurrencyValue value={openOracleReportDetails.price} suffix={UI_TEMPLATE_TOKEN_PAIR_SUFFIX(openOracleReportDetails.token1Symbol, openOracleReportDetails.token2Symbol)} units={OPEN_ORACLE_PRICE_UNITS} copyable={false} />,
 						},
 						{
-							label: UI_STRINGS.openOracleSection.feeLabel,
-							value: <CurrencyValue value={openOracleReportDetails.fee} suffix={UI_STRINGS.common.ethSuffix} copyable={false} />,
+							label: UI_STRING_FEE,
+							value: <CurrencyValue value={openOracleReportDetails.fee} suffix={UI_STRING_ETH} copyable={false} />,
 						},
 						{
-							label: UI_STRINGS.openOracleSection.settlerRewardLabel,
-							value: <CurrencyValue value={openOracleReportDetails.settlerReward} suffix={UI_STRINGS.common.ethSuffix} copyable={false} />,
+							label: UI_STRING_SETTLER_REWARD,
+							value: <CurrencyValue value={openOracleReportDetails.settlerReward} suffix={UI_STRING_ETH} copyable={false} />,
 						},
 						{
-							label: UI_STRINGS.openOracleSection.escalationHaltLabel,
+							label: UI_STRING_ESCALATION_HALT,
 							value: <CurrencyValue value={openOracleReportDetails.escalationHalt} suffix={openOracleReportDetails.token1Symbol} units={openOracleReportDetails.token1Decimals} copyable={false} />,
 						},
 					])}
 				</ReadOnlyDetailAccordion>
 
-				<ReadOnlyDetailAccordion title={UI_STRINGS.openOracleSection.statusTitle}>
-					{renderReportSection(UI_STRINGS.openOracleSection.statusTitle, [
+				<ReadOnlyDetailAccordion title={UI_STRING_STATUS}>
+					{renderReportSection(UI_STRING_STATUS, [
 						{
-							label: UI_STRINGS.openOracleSection.reportTimestampLabel,
-							value: <TimestampValue currentTimestamp={openOracleReportDetails.currentTime} timestamp={openOracleReportDetails.reportTimestamp} zeroText={UI_STRINGS.openOracleSection.awaitingInitialReportLabel} />,
+							label: UI_STRING_REPORT_TIMESTAMP,
+							value: <TimestampValue currentTimestamp={openOracleReportDetails.currentTime} timestamp={openOracleReportDetails.reportTimestamp} zeroText={UI_STRING_AWAITING_INITIAL_REPORT_OPEN_ORACLE_SECTION_AWAITING_INITIAL_REPORT_LABEL} />,
 						},
 						{
-							label: UI_STRINGS.openOracleSection.disputeOccurredLabel,
-							value: openOracleReportDetails.disputeOccurred ? UI_STRINGS.openOracleSection.booleanYesLabel : UI_STRINGS.openOracleSection.booleanNoLabel,
+							label: UI_STRING_DISPUTE_OCCURRED,
+							value: openOracleReportDetails.disputeOccurred ? UI_STRING_YES : UI_STRING_NO,
 						},
 						{
-							label: UI_STRINGS.openOracleSection.settledLabel,
-							value: openOracleReportDetails.isDistributed ? UI_STRINGS.openOracleSection.booleanYesLabel : UI_STRINGS.openOracleSection.booleanNoLabel,
+							label: UI_STRING_SETTLED,
+							value: openOracleReportDetails.isDistributed ? UI_STRING_YES : UI_STRING_NO,
 						},
 						{
-							label: UI_STRINGS.openOracleSection.settlementTimestampLabel,
-							value: <TimestampValue currentTimestamp={openOracleReportDetails.currentTime} timestamp={openOracleReportDetails.settlementTimestamp} zeroText={UI_STRINGS.openOracleSection.notSettledLabel} />,
+							label: UI_STRING_SETTLEMENT_TIMESTAMP,
+							value: <TimestampValue currentTimestamp={openOracleReportDetails.currentTime} timestamp={openOracleReportDetails.settlementTimestamp} zeroText={UI_STRING_NOT_SETTLED} />,
 						},
 						{
-							label: UI_STRINGS.openOracleSection.lastReportOpportunityLabel,
-							value: openOracleReportDetails.lastReportOppoTime === 0n ? UI_STRINGS.common.noneLabel : `${openOracleReportDetails.lastReportOppoTime.toString()} ${openOracleReportDetails.timeType ? UI_STRINGS.openOracleSection.timeInSecondsSuffix : UI_STRINGS.openOracleSection.timeInBlocksSuffix}`,
+							label: UI_STRING_LAST_REPORT_OPPORTUNITY,
+							value: openOracleReportDetails.lastReportOppoTime === 0n ? UI_STRING_NONE : `${openOracleReportDetails.lastReportOppoTime.toString()} ${openOracleReportDetails.timeType ? UI_STRING_PLURAL_SUFFIX : UI_STRING_BLOCKS_OPEN_ORACLE_SECTION_TIME_IN_BLOCKS_SUFFIX}`,
 						},
 						{
-							label: UI_STRINGS.openOracleSection.stateHashLabel,
+							label: UI_STRING_STATE_HASH,
 							value: openOracleReportDetails.stateHash,
 						},
 					])}
 				</ReadOnlyDetailAccordion>
 
-				<ReadOnlyDetailAccordion title={UI_STRINGS.openOracleSection.settlementTitle}>
-					{renderReportSection(UI_STRINGS.openOracleSection.settlementTitle, [
+				<ReadOnlyDetailAccordion title={UI_STRING_SETTLEMENT}>
+					{renderReportSection(UI_STRING_SETTLEMENT, [
 						{
-							label: UI_STRINGS.openOracleSection.settlementTimeLabel,
-							value: `${openOracleReportDetails.settlementTime.toString()} ${openOracleReportDetails.timeType ? UI_STRINGS.openOracleSection.timeInSecondsSuffix : UI_STRINGS.openOracleSection.timeInBlocksSuffix}`,
+							label: UI_STRING_SETTLEMENT_TIME,
+							value: `${openOracleReportDetails.settlementTime.toString()} ${openOracleReportDetails.timeType ? UI_STRING_PLURAL_SUFFIX : UI_STRING_BLOCKS_OPEN_ORACLE_SECTION_TIME_IN_BLOCKS_SUFFIX}`,
 						},
 						{
-							label: UI_STRINGS.openOracleSection.disputeDelayLabel,
-							value: `${openOracleReportDetails.disputeDelay.toString()} ${openOracleReportDetails.timeType ? UI_STRINGS.openOracleSection.timeInSecondsSuffix : UI_STRINGS.openOracleSection.timeInBlocksSuffix}`,
+							label: UI_STRING_DISPUTE_DELAY,
+							value: `${openOracleReportDetails.disputeDelay.toString()} ${openOracleReportDetails.timeType ? UI_STRING_PLURAL_SUFFIX : UI_STRING_BLOCKS_OPEN_ORACLE_SECTION_TIME_IN_BLOCKS_SUFFIX}`,
 						},
 						{
-							label: UI_STRINGS.openOracleSection.feePercentageLabel,
+							label: UI_STRING_FEE_PERCENTAGE,
 							value: formatOpenOracleFeePercentage(openOracleReportDetails.feePercentage),
 						},
 						{
-							label: UI_STRINGS.openOracleSection.protocolFeeLabel,
+							label: UI_STRING_PROTOCOL_FEE,
 							value: formatOpenOracleFeePercentage(openOracleReportDetails.protocolFee),
 						},
 						{
-							label: UI_STRINGS.openOracleSection.multiplierLabel,
+							label: UI_STRING_MULTIPLIER,
 							value: formatOpenOracleMultiplier(openOracleReportDetails.multiplier),
 						},
 					])}
 				</ReadOnlyDetailAccordion>
 
-				<ReadOnlyDetailAccordion title={UI_STRINGS.openOracleSection.callbackExtraTitle}>
-					{renderReportSection(UI_STRINGS.openOracleSection.callbackExtraTitle, [
+				<ReadOnlyDetailAccordion title={UI_STRING_CALLBACK_EXTRA}>
+					{renderReportSection(UI_STRING_CALLBACK_EXTRA, [
 						{
-							label: UI_STRINGS.openOracleSection.callbackContractLabel,
-							value: openOracleReportDetails.callbackContract === zeroAddress ? UI_STRINGS.common.noneLabel : <AddressValue address={openOracleReportDetails.callbackContract} />,
+							label: UI_STRING_CALLBACK_CONTRACT,
+							value: openOracleReportDetails.callbackContract === zeroAddress ? UI_STRING_NONE : <AddressValue address={openOracleReportDetails.callbackContract} />,
 						},
 						{
-							label: UI_STRINGS.openOracleSection.callbackGasLimitLabel,
-							value: openOracleReportDetails.callbackGasLimit === 0 ? UI_STRINGS.common.noneLabel : openOracleReportDetails.callbackGasLimit.toString(),
+							label: UI_STRING_CALLBACK_GAS_LIMIT,
+							value: openOracleReportDetails.callbackGasLimit === 0 ? UI_STRING_NONE : openOracleReportDetails.callbackGasLimit.toString(),
 						},
 						{
-							label: UI_STRINGS.openOracleSection.protocolFeeRecipientLabel,
-							value: openOracleReportDetails.protocolFeeRecipient === zeroAddress ? UI_STRINGS.common.noneLabel : <AddressValue address={openOracleReportDetails.protocolFeeRecipient} />,
+							label: UI_STRING_PROTOCOL_FEE_RECIPIENT,
+							value: openOracleReportDetails.protocolFeeRecipient === zeroAddress ? UI_STRING_NONE : <AddressValue address={openOracleReportDetails.protocolFeeRecipient} />,
 						},
 						{
-							label: UI_STRINGS.openOracleSection.trackDisputesLabel,
-							value: openOracleReportDetails.trackDisputes ? UI_STRINGS.openOracleSection.booleanYesLabel : UI_STRINGS.openOracleSection.booleanNoLabel,
+							label: UI_STRING_TRACK_DISPUTES,
+							value: openOracleReportDetails.trackDisputes ? UI_STRING_YES : UI_STRING_NO,
 						},
 						{
-							label: UI_STRINGS.openOracleSection.numberOfReportsLabel,
+							label: UI_STRING_NUMBER_OF_REPORTS,
 							value: openOracleReportDetails.numReports.toString(),
 						},
 					])}
 				</ReadOnlyDetailAccordion>
 			</div>
 
-			<OperationModal isOpen={selectedReportModal === 'initial-report'} onClose={() => onSelectedReportModalChange(undefined)} title={UI_STRINGS.openOracleSection.initialReportModalTitle} description={UI_STRINGS.openOracleSection.initialReportModalDescription}>
+			<OperationModal isOpen={selectedReportModal === 'initial-report'} onClose={() => onSelectedReportModalChange(undefined)} title={UI_STRING_SUBMIT_INITIAL_REPORT} description={UI_STRING_REVIEW_PRICE_SOURCE_APPROVALS_AND_TOKEN_BALANCES_BEFORE_SUBMITTING_THE_INITIAL_REPORT}>
 				{renderSelectedReportActionSection({
 					actionMode: 'initial-report',
 					disputeSubmission: openOracleDisputeSubmission,
@@ -753,7 +897,7 @@ function renderReportDetailsCard(
 				})}
 			</OperationModal>
 
-			<OperationModal isOpen={selectedReportModal === 'dispute'} onClose={() => onSelectedReportModalChange(undefined)} title={UI_STRINGS.openOracleSection.disputeAndSwapModalTitle} description={UI_STRINGS.openOracleSection.disputeAndSwapModalDescription}>
+			<OperationModal isOpen={selectedReportModal === 'dispute'} onClose={() => onSelectedReportModalChange(undefined)} title={UI_STRING_DISPUTE_AND_SWAP} description={UI_STRING_PROVIDE_THE_REPLACEMENT_SWAP_AMOUNTS_FOR_THE_SELECTED_REPORT}>
 				{renderSelectedReportActionSection({
 					actionMode: 'dispute',
 					disputeSubmission: openOracleDisputeSubmission,
@@ -777,7 +921,7 @@ function renderReportDetailsCard(
 				})}
 			</OperationModal>
 
-			<OperationModal isOpen={selectedReportModal === 'settle'} onClose={() => onSelectedReportModalChange(undefined)} title={UI_STRINGS.openOracleSection.settleReportModalTitle} description={UI_STRINGS.openOracleSection.settleReportModalDescription}>
+			<OperationModal isOpen={selectedReportModal === 'settle'} onClose={() => onSelectedReportModalChange(undefined)} title={UI_STRING_SETTLE_REPORT} description={UI_STRING_CONFIRM_SETTLEMENT_ONCE_THE_SELECTED_REPORT_IS_READY}>
 				{renderSelectedReportActionSection({
 					actionMode: 'settle',
 					disputeSubmission: openOracleDisputeSubmission,
@@ -868,7 +1012,7 @@ export function OpenOracleSection({
 				},
 				onError: error => {
 					setBrowsePage(undefined)
-					setBrowseError(error instanceof Error ? error.message : UI_STRINGS.openOracleSection.loadOpenOracleReportsFailedMessage)
+					setBrowseError(error instanceof Error ? error.message : UI_STRING_FAILED_TO_LOAD_OPEN_ORACLE_REPORTS)
 				},
 			})
 		}
@@ -917,33 +1061,33 @@ export function OpenOracleSection({
 							/>
 						}
 						density='compact'
-						title={UI_STRINGS.openOracleSection.browseReportsTitle}
-						description={UI_STRINGS.openOracleSection.browseReportsDescription(BROWSE_PAGE_SIZE.toString())}
+						title={UI_STRING_BROWSE_REPORTS}
+						description={UI_TEMPLATE_BROWSE_REPORTS_DESCRIPTION(BROWSE_PAGE_SIZE.toString())}
 					>
 						<ErrorNotice message={browseError} />
 						<div className='filter-toolbar'>
 							<label className='field'>
-								<span>{UI_STRINGS.openOracleSection.searchReportsLabel}</span>
-								<FormInput value={browseSearchText} onInput={event => setBrowseSearchText(event.currentTarget.value)} placeholder={UI_STRINGS.openOracleSection.searchReportsPlaceholder} />
+								<span>{UI_STRING_SEARCH_REPORTS}</span>
+								<FormInput value={browseSearchText} onInput={event => setBrowseSearchText(event.currentTarget.value)} placeholder={UI_STRING_SEARCH_BY_REPORT_ID_TOKEN_SYMBOL_OR_TOKEN_ADDRESS} />
 							</label>
 							<label className='field'>
-								<span>{UI_STRINGS.openOracleSection.statusFieldLabel}</span>
+								<span>{UI_STRING_STATUS}</span>
 								<select value={browseStatusFilter} onChange={event => setBrowseStatusFilter(resolveBrowseStatusFilter(event.currentTarget.value))}>
-									<option value='all'>{UI_STRINGS.openOracleSection.statusFilterAllLabel}</option>
-									<option value='Awaiting Initial Report'>{UI_STRINGS.openOracleSection.statusFilterAwaitingInitialReportLabel}</option>
-									<option value='Pending'>{UI_STRINGS.openOracleSection.statusFilterPendingLabel}</option>
-									<option value='Disputed'>{UI_STRINGS.openOracleSection.statusFilterDisputedLabel}</option>
-									<option value='Settled'>{UI_STRINGS.openOracleSection.statusFilterSettledLabel}</option>
+									<option value='all'>{UI_STRING_ALL_STATUSES}</option>
+									<option value='Awaiting Initial Report'>{UI_STRING_AWAITING_INITIAL_REPORT}</option>
+									<option value='Pending'>{UI_STRING_PENDING}</option>
+									<option value='Disputed'>{UI_STRING_DISPUTED}</option>
+									<option value='Settled'>{UI_STRING_SETTLED}</option>
 								</select>
 							</label>
 						</div>
-						{browsePage === undefined ? undefined : <p className='detail'>{UI_STRINGS.openOracleSection.browseShownCountSummary(filteredBrowseReports.length.toString(), browsePage.reports.length.toString())}</p>}
+						{browsePage === undefined ? undefined : <p className='detail'>{UI_TEMPLATE_BROWSE_SHOWN_COUNT_SUMMARY(filteredBrowseReports.length.toString(), browsePage.reports.length.toString())}</p>}
 						{loadingBrowse ? (
-							<StateHint presentation={{ key: 'loading', badgeLabel: UI_STRINGS.common.loadingBadgeLabel, badgeTone: 'pending', detail: UI_STRINGS.openOracleSection.refreshingReportSummariesDetail }} />
+							<StateHint presentation={{ key: 'loading', badgeLabel: UI_STRING_LOADING, badgeTone: 'pending', detail: UI_STRING_REFRESHING_REPORT_SUMMARIES }} />
 						) : (
 							(() => {
-								if (browsePage === undefined || browsePage.reports.length === 0) return <StateHint presentation={{ key: 'empty', badgeLabel: UI_STRINGS.openOracleSection.noneYetBadgeLabel, badgeTone: 'muted', detail: UI_STRINGS.openOracleSection.noOpenOracleGamesDetail }} />
-								if (filteredBrowseReports.length === 0) return <StateHint presentation={{ key: 'empty', badgeLabel: UI_STRINGS.openOracleSection.noMatchesBadgeLabel, badgeTone: 'muted', detail: UI_STRINGS.openOracleSection.noReportsMatchFiltersDetail }} />
+								if (browsePage === undefined || browsePage.reports.length === 0) return <StateHint presentation={{ key: 'empty', badgeLabel: UI_STRING_NONE, badgeTone: 'muted', detail: UI_STRING_NO_OPEN_ORACLE_GAMES_FOUND }} />
+								if (filteredBrowseReports.length === 0) return <StateHint presentation={{ key: 'empty', badgeLabel: UI_STRING_NO_MATCHES, badgeTone: 'muted', detail: UI_STRING_NO_REPORTS_MATCH_THE_CURRENT_SEARCH_AND_STATUS_FILTERS }} />
 
 								return <div className='entity-card-list'>{filteredBrowseReports.map(report => renderReportSummaryCard(report, reportId => void openBrowseReport(reportId)))}</div>
 							})()
@@ -955,142 +1099,118 @@ export function OpenOracleSection({
 			{view === 'create' ? (
 				<div className='workflow-stack route-workflow-stack'>
 					{openOracleResult?.action !== 'createReportInstance' ? undefined : (
-						<SectionBlock title={UI_STRINGS.openOracleSection.createSuccessTitle} description={UI_STRINGS.openOracleSection.createSuccessDescription}>
+						<SectionBlock title={UI_STRING_CREATE_SUCCESS} description={UI_STRING_THE_REPORT_INSTANCE_WAS_CREATED_SUCCESSFULLY}>
 							<div className='actions'>
 								<button className='primary' type='button' onClick={() => onActiveViewChange('browse')}>
-									{UI_STRINGS.openOracleSection.returnToBrowseLabel}
+									{UI_STRING_RETURN_TO_BROWSE}
 								</button>
 								<button className='secondary' type='button' onClick={() => onActiveViewChange('create')}>
-									{UI_STRINGS.openOracleSection.createAnotherLabel}
+									{UI_STRING_CREATE_ANOTHER}
 								</button>
 							</div>
 						</SectionBlock>
 					)}
-					<SectionBlock title={UI_STRINGS.openOracleSection.advancedStandaloneOracleGameTitle} variant='plain' description={UI_STRINGS.openOracleSection.advancedStandaloneOracleGameDescription}>
-						<p className='notice warning'>{UI_STRINGS.openOracleSection.standaloneOracleWarning}</p>
+					<SectionBlock title={UI_STRING_OPEN_ORACLE_GAME} variant='plain' description={UI_STRING_DIRECT_OPEN_ORACLE_CREATION_FOR_PROTOCOL_TESTING_THIS_BYPASSES_POOL_MANAGED_ORACLE_MANAGER_STAGING_SO_CONFIRM_ADDRESSES_TOKEN_AMOUNTS_FEES_AND_TIMING_BEFORE_SUBMITTING}>
+						<p className='notice warning'>{UI_STRING_USE_THIS_ONLY_WHEN_YOU_INTEND_TO_CREATE_A_STANDALONE_ORACLE_GAME_DIRECTLY_FROM_THE_CONNECTED_WALLET_POOL_MANAGED_ORACLE_REQUESTS_SHOULD_BE_STARTED_FROM_A_SELECTED_SECURITY_POOL}</p>
 						<div className='form-grid'>
-							<SectionBlock headingLevel={4} title={UI_STRINGS.openOracleSection.tokenPairTitle} variant='embedded'>
+							<SectionBlock headingLevel={4} title={UI_STRING_TOKEN_PAIR} variant='embedded'>
 								<div className='field-row'>
 									<label className='field'>
-										<span>{UI_STRINGS.openOracleSection.token1AddressFieldLabel}</span>
-										<FormInput
-											value={openOracleCreateForm.token1Address}
-											onInput={event => onOpenOracleCreateFormChange({ token1Address: event.currentTarget.value })}
-											placeholder={UI_STRINGS.common.hexValuePlaceholder}
-											aria-label={UI_STRINGS.openOracleSection.token1AddressFieldLabel}
-											aria-describedby='open-oracle-token1-address-help'
-										/>
+										<span>{UI_STRING_TOKEN1_ADDRESS}</span>
+										<FormInput value={openOracleCreateForm.token1Address} onInput={event => onOpenOracleCreateFormChange({ token1Address: event.currentTarget.value })} placeholder={UI_STRING_HEX_VALUE_PLACEHOLDER} aria-label={UI_STRING_TOKEN1_ADDRESS} aria-describedby='open-oracle-token1-address-help' />
 										<p id='open-oracle-token1-address-help' className='field-help'>
-											{UI_STRINGS.openOracleSection.token1AddressFieldHelpText}
+											{UI_STRING_BASE_TOKEN_FOR_THE_REPORTED_PAIR}
 										</p>
 									</label>
 									<label className='field'>
-										<span>{UI_STRINGS.openOracleSection.token2AddressFieldLabel}</span>
-										<FormInput
-											value={openOracleCreateForm.token2Address}
-											onInput={event => onOpenOracleCreateFormChange({ token2Address: event.currentTarget.value })}
-											placeholder={UI_STRINGS.common.hexValuePlaceholder}
-											aria-label={UI_STRINGS.openOracleSection.token2AddressFieldLabel}
-											aria-describedby='open-oracle-token2-address-help'
-										/>
+										<span>{UI_STRING_TOKEN2_ADDRESS}</span>
+										<FormInput value={openOracleCreateForm.token2Address} onInput={event => onOpenOracleCreateFormChange({ token2Address: event.currentTarget.value })} placeholder={UI_STRING_HEX_VALUE_PLACEHOLDER} aria-label={UI_STRING_TOKEN2_ADDRESS} aria-describedby='open-oracle-token2-address-help' />
 										<p id='open-oracle-token2-address-help' className='field-help'>
-											{UI_STRINGS.openOracleSection.token2AddressFieldHelpText}
+											{UI_STRING_QUOTE_TOKEN_FOR_THE_REPORTED_PAIR}
 										</p>
 									</label>
 								</div>
 							</SectionBlock>
 
-							<SectionBlock headingLevel={4} title={UI_STRINGS.openOracleSection.initialEconomicsTitle} variant='embedded'>
+							<SectionBlock headingLevel={4} title={UI_STRING_INITIAL_ECONOMICS} variant='embedded'>
 								<div className='field-row'>
 									<label className='field'>
-										<span>{UI_STRINGS.openOracleSection.exactToken1ReportFieldLabel}</span>
-										<FormInput
-											value={openOracleCreateForm.exactToken1Report}
-											inputMode='decimal'
-											onInput={event => onOpenOracleCreateFormChange({ exactToken1Report: event.currentTarget.value })}
-											aria-label={UI_STRINGS.openOracleSection.exactToken1ReportFieldLabel}
-											aria-describedby='open-oracle-exact-token1-report-help'
-										/>
+										<span>{UI_STRING_EXACT_TOKEN1_REPORT}</span>
+										<FormInput value={openOracleCreateForm.exactToken1Report} inputMode='decimal' onInput={event => onOpenOracleCreateFormChange({ exactToken1Report: event.currentTarget.value })} aria-label={UI_STRING_EXACT_TOKEN1_REPORT} aria-describedby='open-oracle-exact-token1-report-help' />
 										<p id='open-oracle-exact-token1-report-help' className='field-help'>
-											{UI_STRINGS.openOracleSection.exactToken1ReportFieldHelpText}
+											{UI_STRING_TOKEN1_AMOUNT_TO_REPORT_ENTERED_AS_A_DECIMAL_VALUE_FOR_THE_TOKEN1_ADDRESS}
 										</p>
 									</label>
 									<label className='field'>
-										<span>{UI_STRINGS.openOracleSection.settlerRewardFieldLabel}</span>
-										<FormInput value={openOracleCreateForm.settlerReward} inputMode='decimal' onInput={event => onOpenOracleCreateFormChange({ settlerReward: event.currentTarget.value })} aria-label={UI_STRINGS.openOracleSection.settlerRewardFieldLabel} aria-describedby='open-oracle-settler-reward-help' />
+										<span>{UI_STRING_SETTLER_REWARD}</span>
+										<FormInput value={openOracleCreateForm.settlerReward} inputMode='decimal' onInput={event => onOpenOracleCreateFormChange({ settlerReward: event.currentTarget.value })} aria-label={UI_STRING_SETTLER_REWARD} aria-describedby='open-oracle-settler-reward-help' />
 										<p id='open-oracle-settler-reward-help' className='field-help'>
-											{UI_STRINGS.openOracleSection.settlerRewardFieldHelpText}
+											{UI_STRING_ETH_PAID_TO_THE_ACCOUNT_THAT_SETTLES_THE_REPORT}
 										</p>
 									</label>
 								</div>
 								<label className='field'>
-									<span>{UI_STRINGS.openOracleSection.ethValueToSendFieldLabel}</span>
-									<FormInput value={openOracleCreateForm.ethValue} inputMode='decimal' onInput={event => onOpenOracleCreateFormChange({ ethValue: event.currentTarget.value })} aria-label={UI_STRINGS.openOracleSection.ethValueToSendFieldLabel} aria-describedby='open-oracle-eth-value-help' />
+									<span>{UI_STRING_ETH_VALUE_TO_SEND}</span>
+									<FormInput value={openOracleCreateForm.ethValue} inputMode='decimal' onInput={event => onOpenOracleCreateFormChange({ ethValue: event.currentTarget.value })} aria-label={UI_STRING_ETH_VALUE_TO_SEND} aria-describedby='open-oracle-eth-value-help' />
 									<p id='open-oracle-eth-value-help' className='field-help'>
-										{UI_STRINGS.openOracleSection.ethValueToSendFieldHelpText}
+										{UI_STRING_ETH_SENT_WITH_CREATION_MUST_COVER_REQUIRED_FUNDING_AND_THE_SETTLER_REWARD}
 									</p>
 								</label>
 								<div className='field-row'>
 									<label className='field'>
-										<span>{UI_STRINGS.openOracleSection.feeFieldLabel}</span>
-										<FormInput value={openOracleCreateForm.feePercentage} inputMode='decimal' onInput={event => onOpenOracleCreateFormChange({ feePercentage: event.currentTarget.value })} aria-label={UI_STRINGS.openOracleSection.feeFieldLabel} aria-describedby='open-oracle-fee-percentage-help' />
+										<span>{UI_STRING_FEE_PERCENTAGE}</span>
+										<FormInput value={openOracleCreateForm.feePercentage} inputMode='decimal' onInput={event => onOpenOracleCreateFormChange({ feePercentage: event.currentTarget.value })} aria-label={UI_STRING_FEE_PERCENTAGE} aria-describedby='open-oracle-fee-percentage-help' />
 										<p id='open-oracle-fee-percentage-help' className='field-help'>
-											{UI_STRINGS.openOracleSection.feeFieldHelpText}
+											{UI_STRING_FEE_CHARGED_DURING_DISPUTE_ECONOMICS_ENTERED_AS_A_PERCENTAGE}
 										</p>
 									</label>
 									<label className='field'>
-										<span>{UI_STRINGS.openOracleSection.multiplierFieldLabel}</span>
-										<FormInput value={openOracleCreateForm.multiplier} inputMode='numeric' onInput={event => onOpenOracleCreateFormChange({ multiplier: event.currentTarget.value })} aria-label={UI_STRINGS.openOracleSection.multiplierFieldLabel} aria-describedby='open-oracle-multiplier-help' />
+										<span>{UI_STRING_MULTIPLIER}</span>
+										<FormInput value={openOracleCreateForm.multiplier} inputMode='numeric' onInput={event => onOpenOracleCreateFormChange({ multiplier: event.currentTarget.value })} aria-label={UI_STRING_MULTIPLIER} aria-describedby='open-oracle-multiplier-help' />
 										<p id='open-oracle-multiplier-help' className='field-help'>
-											{UI_STRINGS.openOracleSection.multiplierFieldHelpText}
+											{UI_STRING_ESCALATION_MULTIPLIER_FOR_DISPUTE_ECONOMICS}
 										</p>
 									</label>
 								</div>
 							</SectionBlock>
 
-							<SectionBlock headingLevel={4} title={UI_STRINGS.openOracleSection.timingTitle} variant='embedded'>
+							<SectionBlock headingLevel={4} title={UI_STRING_TIMING} variant='embedded'>
 								<div className='field-row'>
 									<label className='field'>
-										<span>{UI_STRINGS.openOracleSection.settlementTimeFieldLabel}</span>
-										<FormInput value={openOracleCreateForm.settlementTime} inputMode='numeric' onInput={event => onOpenOracleCreateFormChange({ settlementTime: event.currentTarget.value })} aria-label={UI_STRINGS.openOracleSection.settlementTimeFieldLabel} aria-describedby='open-oracle-settlement-time-help' />
+										<span>{UI_STRING_SETTLEMENT_TIME}</span>
+										<FormInput value={openOracleCreateForm.settlementTime} inputMode='numeric' onInput={event => onOpenOracleCreateFormChange({ settlementTime: event.currentTarget.value })} aria-label={UI_STRING_SETTLEMENT_TIME} aria-describedby='open-oracle-settlement-time-help' />
 										<p id='open-oracle-settlement-time-help' className='field-help'>
-											{UI_STRINGS.openOracleSection.settlementTimeFieldHelpText}
+											{UI_STRING_DELAY_IN_SECONDS_AFTER_THE_INITIAL_REPORT_BEFORE_SETTLEMENT_CAN_BEGIN}
 										</p>
 									</label>
 									<label className='field'>
-										<span>{UI_STRINGS.openOracleSection.escalationHaltFieldLabel}</span>
-										<FormInput value={openOracleCreateForm.escalationHalt} inputMode='decimal' onInput={event => onOpenOracleCreateFormChange({ escalationHalt: event.currentTarget.value })} aria-label={UI_STRINGS.openOracleSection.escalationHaltFieldLabel} aria-describedby='open-oracle-escalation-halt-help' />
+										<span>{UI_STRING_ESCALATION_HALT}</span>
+										<FormInput value={openOracleCreateForm.escalationHalt} inputMode='decimal' onInput={event => onOpenOracleCreateFormChange({ escalationHalt: event.currentTarget.value })} aria-label={UI_STRING_ESCALATION_HALT} aria-describedby='open-oracle-escalation-halt-help' />
 										<p id='open-oracle-escalation-halt-help' className='field-help'>
-											{UI_STRINGS.openOracleSection.escalationHaltFieldHelpText}
+											{UI_STRING_TOKEN1_AMOUNT_WHERE_DISPUTE_ESCALATION_STOPS_ENTERED_AS_A_DECIMAL_VALUE_FOR_THE_TOKEN1_ADDRESS}
 										</p>
 									</label>
 								</div>
 								<div className='field-row'>
 									<label className='field'>
-										<span>{UI_STRINGS.openOracleSection.disputeDelayFieldLabel}</span>
-										<FormInput value={openOracleCreateForm.disputeDelay} inputMode='numeric' onInput={event => onOpenOracleCreateFormChange({ disputeDelay: event.currentTarget.value })} aria-label={UI_STRINGS.openOracleSection.disputeDelayFieldLabel} aria-describedby='open-oracle-dispute-delay-help' />
+										<span>{UI_STRING_DISPUTE_DELAY}</span>
+										<FormInput value={openOracleCreateForm.disputeDelay} inputMode='numeric' onInput={event => onOpenOracleCreateFormChange({ disputeDelay: event.currentTarget.value })} aria-label={UI_STRING_DISPUTE_DELAY} aria-describedby='open-oracle-dispute-delay-help' />
 										<p id='open-oracle-dispute-delay-help' className='field-help'>
-											{UI_STRINGS.openOracleSection.disputeDelayFieldHelpText}
+											{UI_STRING_DELAY_IN_SECONDS_AFTER_THE_INITIAL_REPORT_BEFORE_DISPUTES_CAN_BEGIN}
 										</p>
 									</label>
 									<label className='field'>
-										<span>{UI_STRINGS.openOracleSection.protocolFeeFieldLabel}</span>
-										<FormInput value={openOracleCreateForm.protocolFee} inputMode='decimal' onInput={event => onOpenOracleCreateFormChange({ protocolFee: event.currentTarget.value })} aria-label={UI_STRINGS.openOracleSection.protocolFeeFieldLabel} aria-describedby='open-oracle-protocol-fee-help' />
+										<span>{UI_STRING_PROTOCOL_FEE}</span>
+										<FormInput value={openOracleCreateForm.protocolFee} inputMode='decimal' onInput={event => onOpenOracleCreateFormChange({ protocolFee: event.currentTarget.value })} aria-label={UI_STRING_PROTOCOL_FEE} aria-describedby='open-oracle-protocol-fee-help' />
 										<p id='open-oracle-protocol-fee-help' className='field-help'>
-											{UI_STRINGS.openOracleSection.protocolFeeFieldHelpText}
+											{UI_STRING_PROTOCOL_FEE_CHARGED_DURING_DISPUTES_ENTERED_AS_A_PERCENTAGE}
 										</p>
 									</label>
 								</div>
 							</SectionBlock>
 
 							<div className='actions'>
-								<TransactionActionButton
-									idleLabel={UI_STRINGS.openOracleSection.createStandaloneOracleGameButtonIdleLabel}
-									pendingLabel={UI_STRINGS.openOracleSection.createStandaloneOracleGameButtonPendingLabel}
-									onClick={onCreateOpenOracleGame}
-									pending={loadingOpenOracleCreate}
-									availability={{ disabled: !isMainnet || createAvailabilityMessage !== undefined, reason: createAvailabilityMessage }}
-								/>
+								<TransactionActionButton idleLabel={UI_STRING_CREATE_STANDALONE_ORACLE_GAME} pendingLabel={UI_STRING_CREATING} onClick={onCreateOpenOracleGame} pending={loadingOpenOracleCreate} availability={{ disabled: !isMainnet || createAvailabilityMessage !== undefined, reason: createAvailabilityMessage }} />
 							</div>
 						</div>
 					</SectionBlock>

--- a/ui/ts/components/OperationModal.tsx
+++ b/ui/ts/components/OperationModal.tsx
@@ -1,7 +1,7 @@
 import { useId, useRef } from 'preact/hooks'
 import { useModalFocusIsolation } from '../hooks/useModalFocusIsolation.js'
 import type { OperationModalProps } from '../types/components.js'
-import { UI_STRINGS } from '../lib/uiStrings.js'
+import { UI_STRING_CLOSE } from '../lib/uiStrings.js'
 
 export function OperationModal({ children, description, isOpen, onClose, title }: OperationModalProps) {
 	const dialogRef = useRef<HTMLElement | null>(null)
@@ -26,7 +26,7 @@ export function OperationModal({ children, description, isOpen, onClose, title }
 					<div className='modal-header-title'>
 						<h3 id={titleId}>{title}</h3>
 					</div>
-					<button ref={closeButtonRef} className='quiet modal-close-button' type='button' aria-label={UI_STRINGS.common.closeLabel} title={UI_STRINGS.common.closeLabel} onClick={onClose}>
+					<button ref={closeButtonRef} className='quiet modal-close-button' type='button' aria-label={UI_STRING_CLOSE} title={UI_STRING_CLOSE} onClick={onClose}>
 						×
 					</button>
 				</div>

--- a/ui/ts/components/OverviewPanels.tsx
+++ b/ui/ts/components/OverviewPanels.tsx
@@ -10,7 +10,33 @@ import { TimestampValue } from './TimestampValue.js'
 import { UniverseLink } from './UniverseLink.js'
 import { isMainnetChain } from '../lib/network.js'
 import { renderRepPriceSourceLabel } from '../lib/repPriceSource.js'
-import { UI_STRINGS } from '../lib/uiStrings.js'
+import {
+	UI_STRING_ADDRESS,
+	UI_STRING_AUGUR_PLACEHOLDER_OVERVIEW_PANELS_AUGUR_PLACEHOLDER_TITLE,
+	UI_STRING_CONNECT_WALLET,
+	UI_STRING_CONNECTED,
+	UI_STRING_CONNECTING,
+	UI_STRING_ETH,
+	UI_STRING_FORKED,
+	UI_STRING_GO_TO_GENESIS_UNIVERSE,
+	UI_STRING_NOT_CONNECTED,
+	UI_STRING_OPERATIONS,
+	UI_STRING_PARENT_UNIVERSE,
+	UI_STRING_READ_ONLY,
+	UI_STRING_REFRESH_REP_PRICES,
+	UI_STRING_REFRESHING_REP_PRICES,
+	UI_STRING_REP,
+	UI_STRING_REP_PER_ETH_COMPACT,
+	UI_STRING_REP_USDC,
+	UI_STRING_SIMULATION,
+	UI_STRING_SIMULATION_MODE_USES_BROWSER_LOCAL_CONTRACT_STATE_TRANSACTIONS_DO_NOT_AFFECT_A_PUBLIC_NETWORK,
+	UI_STRING_THIS_UNIVERSE_HAS_FORKED,
+	UI_STRING_UNIVERSE,
+	UI_STRING_USDC,
+	UI_STRING_WETH,
+	UI_STRING_WRONG_NETWORK_OVERVIEW_PANELS_WRONG_NETWORK_BADGE_LABEL,
+	UI_STRING_ZOLTAR_FORKED_ON,
+} from '../lib/uiStrings.js'
 import type { OverviewPanelsProps } from '../types/components.js'
 export function OverviewPanels({
 	activeUniverseId,
@@ -53,22 +79,22 @@ export function OverviewPanels({
 	const hasWrongWalletNetwork = accountState.address !== undefined && !walletOnMainnet && !isBrowserSimulationReadBackend
 	const showAccountBalances = walletBootstrapComplete && accountState.address !== undefined && !hasWrongWalletNetwork
 	const environmentBadge = (() => {
-		if (isBrowserSimulationReadBackend) return <Badge tone='warning'>{UI_STRINGS.overviewPanels.simulationBadgeLabel}</Badge>
-		if (hasWrongWalletNetwork) return <Badge tone='danger'>{UI_STRINGS.overviewPanels.wrongNetworkBadgeLabel}</Badge>
-		if (accountState.address === undefined) return <Badge tone='pending'>{UI_STRINGS.overviewPanels.readOnlyBadgeLabel}</Badge>
-		return <Badge tone='ok'>{UI_STRINGS.overviewPanels.connectedBadgeLabel}</Badge>
+		if (isBrowserSimulationReadBackend) return <Badge tone='warning'>{UI_STRING_SIMULATION}</Badge>
+		if (hasWrongWalletNetwork) return <Badge tone='danger'>{UI_STRING_WRONG_NETWORK_OVERVIEW_PANELS_WRONG_NETWORK_BADGE_LABEL}</Badge>
+		if (accountState.address === undefined) return <Badge tone='pending'>{UI_STRING_READ_ONLY}</Badge>
+		return <Badge tone='ok'>{UI_STRING_CONNECTED}</Badge>
 	})()
 	const environmentDescription = (() => {
-		if (isBrowserSimulationReadBackend) return UI_STRINGS.overviewPanels.simulationDescription
+		if (isBrowserSimulationReadBackend) return UI_STRING_SIMULATION_MODE_USES_BROWSER_LOCAL_CONTRACT_STATE_TRANSACTIONS_DO_NOT_AFFECT_A_PUBLIC_NETWORK
 		return undefined
 	})()
 	const operationsHeaderDescription = (() => {
 		const forkDescription = (() => {
 			if (!universeHasForked) return undefined
-			if (universeForkTime === undefined) return UI_STRINGS.overviewPanels.universeForkedDescription
+			if (universeForkTime === undefined) return UI_STRING_THIS_UNIVERSE_HAS_FORKED
 			return (
 				<>
-					{UI_STRINGS.overviewPanels.universeForkedOnDetailPrefix} <TimestampValue timestamp={universeForkTime} />.
+					{UI_STRING_ZOLTAR_FORKED_ON} <TimestampValue timestamp={universeForkTime} />.
 				</>
 			)
 		})()
@@ -87,45 +113,45 @@ export function OverviewPanels({
 					actions={
 						accountState.address === undefined ? (
 							<button className='secondary' type='button' onClick={onConnect} disabled={isConnectingWallet}>
-								{isConnectingWallet ? <LoadingText>{UI_STRINGS.overviewPanels.connectWalletPendingLabel}</LoadingText> : UI_STRINGS.overviewPanels.connectWalletIdleLabel}
+								{isConnectingWallet ? <LoadingText>{UI_STRING_CONNECTING}</LoadingText> : UI_STRING_CONNECT_WALLET}
 							</button>
 						) : undefined
 					}
 					badge={
 						<span className='environment-badge-row'>
 							{environmentBadge}
-							{universeHasForked ? <Badge tone='warning'>{UI_STRINGS.overviewPanels.forkedBadgeLabel}</Badge> : undefined}
+							{universeHasForked ? <Badge tone='warning'>{UI_STRING_FORKED}</Badge> : undefined}
 						</span>
 					}
 					description={operationsHeaderDescription}
-					eyebrow={UI_STRINGS.overviewPanels.operationsEyebrow}
-					title={UI_STRINGS.overviewPanels.augurPlaceholderTitle}
+					eyebrow={UI_STRING_OPERATIONS}
+					title={UI_STRING_AUGUR_PLACEHOLDER_OVERVIEW_PANELS_AUGUR_PLACEHOLDER_TITLE}
 				/>
 				<DataGrid className='overview-inline-metrics' columns='auto'>
-					<MetricField className='overview-address-metric' label={UI_STRINGS.overviewPanels.addressLabel}>
+					<MetricField className='overview-address-metric' label={UI_STRING_ADDRESS}>
 						{(() => {
 							if (isWalletAddressLoading)
 								return (
 									<span className='loading-value'>
 										<span className='spinner' aria-hidden='true' />
-										{UI_STRINGS.overviewPanels.connectingDetail}
+										{UI_STRING_CONNECTING}
 									</span>
 								)
-							if (accountState.address === undefined) return UI_STRINGS.overviewPanels.notConnectedLabel
+							if (accountState.address === undefined) return UI_STRING_NOT_CONNECTED
 
 							return <AddressValue address={accountState.address} />
 						})()}
 					</MetricField>
 					{showAccountBalances ? (
 						<>
-							<MetricField label={UI_STRINGS.overviewPanels.ethBalanceLabel}>
-								<CurrencyValue value={accountState.ethBalance} loading={isRefreshing && accountState.ethBalance === undefined} suffix={UI_STRINGS.common.ethSuffix} compactWhenOverflow />
+							<MetricField label={UI_STRING_ETH}>
+								<CurrencyValue value={accountState.ethBalance} loading={isRefreshing && accountState.ethBalance === undefined} suffix={UI_STRING_ETH} compactWhenOverflow />
 							</MetricField>
-							<MetricField label={UI_STRINGS.overviewPanels.wethBalanceLabel}>
-								<CurrencyValue value={accountState.wethBalance} loading={isRefreshing && accountState.wethBalance === undefined} suffix={UI_STRINGS.common.wethSuffix} compactWhenOverflow />
+							<MetricField label={UI_STRING_WETH}>
+								<CurrencyValue value={accountState.wethBalance} loading={isRefreshing && accountState.wethBalance === undefined} suffix={UI_STRING_WETH} compactWhenOverflow />
 							</MetricField>
-							<MetricField label={UI_STRINGS.overviewPanels.repBalanceLabel}>
-								<CurrencyValue value={universeRepBalance} loading={isLoadingUniverseRepBalance} suffix={UI_STRINGS.common.repLabel} compactWhenOverflow />
+							<MetricField label={UI_STRING_REP}>
+								<CurrencyValue value={universeRepBalance} loading={isLoadingUniverseRepBalance} suffix={UI_STRING_REP} compactWhenOverflow />
 							</MetricField>
 						</>
 					) : undefined}
@@ -133,16 +159,9 @@ export function OverviewPanels({
 						label={
 							<span className='metric-label-with-action'>
 								<span>
-									{UI_STRINGS.overviewPanels.repPerEthLabel} {renderRepPriceSourceLabel(repPerEthSource, repPerEthSourceUrl)}
+									{UI_STRING_REP_PER_ETH_COMPACT} {renderRepPriceSourceLabel(repPerEthSource, repPerEthSourceUrl)}
 								</span>
-								<button
-									type='button'
-									className='quiet metric-label-refresh'
-									onClick={onRefreshRepPrices}
-									disabled={isRefreshingRepPrices}
-									aria-label={UI_STRINGS.overviewPanels.refreshRepPricesAriaLabel}
-									title={isRefreshingRepPrices ? UI_STRINGS.overviewPanels.refreshRepPricesPendingTitle : UI_STRINGS.overviewPanels.refreshRepPricesIdleTitle}
-								>
+								<button type='button' className='quiet metric-label-refresh' onClick={onRefreshRepPrices} disabled={isRefreshingRepPrices} aria-label={UI_STRING_REFRESH_REP_PRICES} title={isRefreshingRepPrices ? UI_STRING_REFRESHING_REP_PRICES : UI_STRING_REFRESH_REP_PRICES}>
 									↻
 								</button>
 							</span>
@@ -153,15 +172,15 @@ export function OverviewPanels({
 					<MetricField
 						label={
 							<>
-								{UI_STRINGS.overviewPanels.repUsdcLabel} {renderRepPriceSourceLabel(repUsdcSource, repUsdcSourceUrl)}
+								{UI_STRING_REP_USDC} {renderRepPriceSourceLabel(repUsdcSource, repUsdcSourceUrl)}
 							</>
 						}
 					>
-						<CurrencyValue value={repUsdcPrice} loading={isLoadingRepPrices} suffix={UI_STRINGS.common.usdcSuffix} units={6} />
+						<CurrencyValue value={repUsdcPrice} loading={isLoadingRepPrices} suffix={UI_STRING_USDC} units={6} />
 					</MetricField>
-					<MetricField label={UI_STRINGS.overviewPanels.universeLabel}>{universeLabel}</MetricField>
+					<MetricField label={UI_STRING_UNIVERSE}>{universeLabel}</MetricField>
 					{shouldShowParentUniverse ? (
-						<MetricField label={UI_STRINGS.overviewPanels.parentUniverseLabel}>
+						<MetricField label={UI_STRING_PARENT_UNIVERSE}>
 							<UniverseLink universeId={parentUniverseId} />
 						</MetricField>
 					) : undefined}
@@ -172,7 +191,7 @@ export function OverviewPanels({
 						presentation={universePresentation}
 						actions={
 							<button className='secondary' onClick={onGoToGenesisUniverse}>
-								{UI_STRINGS.overviewPanels.goToGenesisUniverseLabel}
+								{UI_STRING_GO_TO_GENESIS_UNIVERSE}
 							</button>
 						}
 					/>

--- a/ui/ts/components/Question.tsx
+++ b/ui/ts/components/Question.tsx
@@ -5,7 +5,23 @@ import { OutcomeChipRow } from './OutcomeChipRow.js'
 import { TimestampValue } from './TimestampValue.js'
 import { assertNever } from '../lib/assert.js'
 import { appendInvalidOutcomeLabelIfMissing, isInvalidOutcomeLabel } from '../lib/outcomeLabels.js'
-import { UI_STRINGS } from '../lib/uiStrings.js'
+import {
+	UI_STRING_ANSWER_UNIT,
+	UI_STRING_BINARY,
+	UI_STRING_CATEGORICAL,
+	UI_STRING_CREATED,
+	UI_STRING_DISPLAY_RANGE,
+	UI_STRING_END_TIME,
+	UI_STRING_LOADING_QUESTION_DETAILS_QUESTION_LOADING_QUESTION_DETAILS_LABEL,
+	UI_STRING_NONE,
+	UI_STRING_OUTCOMES,
+	UI_STRING_QUESTION_ID,
+	UI_STRING_QUESTION_TIMELINE,
+	UI_STRING_QUESTION_TYPE,
+	UI_STRING_SCALAR,
+	UI_STRING_TICKS,
+	UI_STRING_UNTITLED_QUESTION,
+} from '../lib/uiStrings.js'
 import type { MarketDetails } from '../types/contracts.js'
 
 type QuestionProps = {
@@ -29,7 +45,7 @@ type QuestionSummaryField =
 	  }
 
 export function getQuestionTitle(question: MarketDetails) {
-	return question.title.trim() === '' ? UI_STRINGS.question.untitledQuestionLabel : question.title
+	return question.title.trim() === '' ? UI_STRING_UNTITLED_QUESTION : question.title
 }
 
 function getQuestionDescription(question: MarketDetails) {
@@ -41,18 +57,18 @@ function getQuestionDescription(question: MarketDetails) {
 function getQuestionTypeLabel(question: MarketDetails) {
 	switch (question.marketType) {
 		case 'binary':
-			return UI_STRINGS.marketCreateQuestionSection.marketTypeOptions.binaryLabel
+			return UI_STRING_BINARY
 		case 'categorical':
-			return UI_STRINGS.marketCreateQuestionSection.marketTypeOptions.categoricalLabel
+			return UI_STRING_CATEGORICAL
 		case 'scalar':
-			return UI_STRINGS.marketCreateQuestionSection.marketTypeOptions.scalarLabel
+			return UI_STRING_SCALAR
 		default:
 			return assertNever(question.marketType)
 	}
 }
 
 function getDisplayedOutcomes(question: MarketDetails) {
-	const outcomes = question.outcomeLabels.length === 0 ? [UI_STRINGS.question.scalarOutcomeLabel] : question.outcomeLabels
+	const outcomes = question.outcomeLabels.length === 0 ? [UI_STRING_SCALAR] : question.outcomeLabels
 	return appendInvalidOutcomeLabelIfMissing(outcomes)
 }
 
@@ -62,19 +78,15 @@ function getDisplayRange(question: MarketDetails) {
 
 export function getQuestionSummaryFields(question: MarketDetails): QuestionSummaryField[] {
 	const fields: QuestionSummaryField[] = [
-		{ kind: 'text', label: UI_STRINGS.marketCreateQuestionSection.questionTypeLabel, value: getQuestionTypeLabel(question) },
-		{ kind: 'text', label: UI_STRINGS.question.questionIdLabel, value: question.questionId },
-		{ kind: 'timestamp', label: UI_STRINGS.question.createdLabel, value: question.createdAt },
-		{ kind: 'timestamp', label: UI_STRINGS.question.endTimeLabel, value: question.endTime },
-		{ kind: 'text', label: UI_STRINGS.question.outcomesLabel, value: getDisplayedOutcomes(question).join(', ') },
+		{ kind: 'text', label: UI_STRING_QUESTION_TYPE, value: getQuestionTypeLabel(question) },
+		{ kind: 'text', label: UI_STRING_QUESTION_ID, value: question.questionId },
+		{ kind: 'timestamp', label: UI_STRING_CREATED, value: question.createdAt },
+		{ kind: 'timestamp', label: UI_STRING_END_TIME, value: question.endTime },
+		{ kind: 'text', label: UI_STRING_OUTCOMES, value: getDisplayedOutcomes(question).join(', ') },
 	]
 
 	if (question.marketType === 'scalar')
-		fields.push(
-			{ kind: 'text', label: UI_STRINGS.question.ticksLabel, value: question.numTicks.toString() },
-			{ kind: 'text', label: UI_STRINGS.question.displayRangeLabel, value: getDisplayRange(question) },
-			{ kind: 'text', label: UI_STRINGS.question.answerUnitLabel, value: question.answerUnit === '' ? UI_STRINGS.common.noneLabel : question.answerUnit },
-		)
+		fields.push({ kind: 'text', label: UI_STRING_TICKS, value: question.numTicks.toString() }, { kind: 'text', label: UI_STRING_DISPLAY_RANGE, value: getDisplayRange(question) }, { kind: 'text', label: UI_STRING_ANSWER_UNIT, value: question.answerUnit === '' ? UI_STRING_NONE : question.answerUnit })
 
 	return fields
 }
@@ -99,7 +111,7 @@ export function Question({ className = '', loading = false, question, showTitle 
 		return (
 			<div className={`question-summary ${className}`}>
 				<p className='detail'>
-					<LoadingText>{UI_STRINGS.question.loadingQuestionDetailsLabel}</LoadingText>
+					<LoadingText>{UI_STRING_LOADING_QUESTION_DETAILS_QUESTION_LOADING_QUESTION_DETAILS_LABEL}</LoadingText>
 				</p>
 			</div>
 		)
@@ -119,11 +131,11 @@ export function Question({ className = '', loading = false, question, showTitle 
 			? []
 			: [
 					{
-						label: UI_STRINGS.question.ticksLabel,
+						label: UI_STRING_TICKS,
 						value: question.numTicks.toString(),
 					},
 					{
-						label: UI_STRINGS.question.displayRangeLabel,
+						label: UI_STRING_DISPLAY_RANGE,
 						value: getDisplayRange(question),
 					},
 				]
@@ -138,15 +150,15 @@ export function Question({ className = '', loading = false, question, showTitle 
 					</div>
 				)}
 				<OutcomeChipRow items={outcomeItems} />
-				<div className='question-preview-timeline' role='list' aria-label={UI_STRINGS.question.questionTimelineAriaLabel}>
+				<div className='question-preview-timeline' role='list' aria-label={UI_STRING_QUESTION_TIMELINE}>
 					<div className='question-preview-timeline-item' role='listitem'>
-						<span className='question-preview-timeline-label'>{UI_STRINGS.question.createdLabel}</span>
+						<span className='question-preview-timeline-label'>{UI_STRING_CREATED}</span>
 						<strong className='question-preview-timeline-value'>
 							<TimestampValue timestamp={question.createdAt} />
 						</strong>
 					</div>
 					<div className='question-preview-timeline-item' role='listitem'>
-						<span className='question-preview-timeline-label'>{UI_STRINGS.question.endTimeLabel}</span>
+						<span className='question-preview-timeline-label'>{UI_STRING_END_TIME}</span>
 						<strong className='question-preview-timeline-value'>
 							<TimestampValue timestamp={question.endTime} />
 						</strong>
@@ -154,7 +166,7 @@ export function Question({ className = '', loading = false, question, showTitle 
 				</div>
 				<div className='question-preview-meta'>
 					<div className='question-preview-meta-item'>
-						<span className='question-preview-meta-label'>{UI_STRINGS.question.questionIdLabel}</span>
+						<span className='question-preview-meta-label'>{UI_STRING_QUESTION_ID}</span>
 						<strong>{question.questionId}</strong>
 					</div>
 					{scalarFields.map(field => (

--- a/ui/ts/components/ReportingSection.tsx
+++ b/ui/ts/components/ReportingSection.tsx
@@ -36,7 +36,113 @@ import {
 import { getReportingReportGuardMessage, getReportingWithdrawGuardMessage } from '../lib/reportingGuards.js'
 import { REPORTING_OUTCOME_DROPDOWN_OPTIONS, getReportingLockedUntilMessage, getReportingOutcomeLabel, hasReportingOpened } from '../lib/reporting.js'
 import { deriveSecurityPoolReportingStage, evaluateSecurityPoolState } from '../lib/securityPoolState.js'
-import { UI_STRINGS } from '../lib/uiStrings.js'
+import {
+	UI_STRING_1_OUTCOME,
+	UI_STRING_2_LOCK_REP,
+	UI_STRING_3_SETTLE,
+	UI_STRING_ACTIVE,
+	UI_STRING_AND_IF_NO_ONE_DISPUTES_AFTER_IT_THE_MARKET_WOULD_FINALIZE_IN,
+	UI_STRING_AVAILABLE_UNLOCKED_VAULT_REP_FOR_REPORTING,
+	UI_STRING_BASED_ON_THE_CURRENT_ESCALATION_STATE_THIS_ACTION_WOULD_LOCK,
+	UI_STRING_CHECK_BACK_NO_LATER_THAN,
+	UI_STRING_CHOOSE_DEPOSITS_TO_SETTLE,
+	UI_STRING_CONNECTED_WALLET_HAS_NO_UNSETTLED_ESCALATION_DEPOSITS,
+	UI_STRING_CONTINUE_IN_FORK_AND_MIGRATION_TO_MIGRATE_UNRESOLVED_ESCALATION_DEPOSITS_INTO_A_CHILD_UNIVERSE,
+	UI_STRING_CONTRIBUTION_AMOUNT_REP,
+	UI_STRING_CURRENT_CLAIM_TYPE,
+	UI_STRING_ENTER_A_VALID_REPORT_AMOUNT_TO_PREVIEW_PROFIT,
+	UI_STRING_ENTRY_DEPTH,
+	UI_STRING_ESCALATION_DEPOSITS_CANNOT_BE_SETTLED_UNTIL_THE_QUESTION_IS_FINALIZED,
+	UI_STRING_ESCALATION_DEPOSITS_REMAIN_LOCKED_AFTER_NON_DECISION_TRIGGER_ZOLTAR_FORK_HERE_IF_THIS_POOL_SHOULD_FORK_THE_UNIVERSE,
+	UI_STRING_ESCALATION_DEPOSITS_REMAIN_LOCKED_AFTER_NON_DECISION_ZOLTAR_FORK_HAS_ALREADY_BEEN_TRIGGERED_FOR_THIS_POOL_SO_CONTINUE_IN_FORK_AND_MIGRATION,
+	UI_STRING_ESCALATION_ENDED_BY_TIMEOUT_THE_WINNER_IS_COMPUTED,
+	UI_STRING_ESCALATION_HAS_ENDED_REFRESH_REPORTING_TO_VIEW_THE_FINALIZED_OUTCOME_BEFORE_SETTLING_DEPOSITS,
+	UI_STRING_ESCALATION_IS_LIVE_REVIEW_THE_BOND_SIDE_BALANCES_AND_TIME_REMAINING_BEFORE_CONTRIBUTING_OR_WITHDRAWING,
+	UI_STRING_ESCALATION_METRICS,
+	UI_STRING_ESCALATION_REACHED_NON_DECISION_AND_ZOLTAR_FORK_HAS_ALREADY_BEEN_TRIGGERED_FOR_THIS_POOL_CONTINUE_IN_FORK_AND_MIGRATION,
+	UI_STRING_ESCALATION_REACHED_NON_DECISION_TRIGGER_ZOLTAR_FORK_HERE_IF_THIS_POOL_SHOULD_FORK_THE_UNIVERSE,
+	UI_STRING_ESCALATION_STARTED,
+	UI_STRING_FORK_TRIGGERED,
+	UI_STRING_HEX_VALUE_PLACEHOLDER,
+	UI_STRING_IF,
+	UI_STRING_IF_NO_ONE_DISPUTES_AFTER_THIS_REPORT_THE_MARKET_WOULD_FINALIZE_IN,
+	UI_STRING_INITIALLY_DEPOSITED,
+	UI_STRING_INSTEAD_OF_THE_FULL_ENTERED_AMOUNT,
+	UI_STRING_IS_FILLED,
+	UI_STRING_IS_STILL_LEADING_IF_LATER_DISPUTES_KEEP_ESCALATION_OPEN,
+	UI_STRING_IS_THE_LEADING_OUTCOME_BEFORE_FINALIZATION,
+	UI_STRING_IS_THE_LEADING_OUTCOME_BEFORE_THE_REMAINING_REWARD_ELIGIBLE_REP_ON,
+	UI_STRING_LEAD_HOLDING_CAPITAL,
+	UI_STRING_LOAD_REPORTING_DETAILS_BEFORE_USING_PRESETS,
+	UI_STRING_LOAD_REPORTING_DETAILS_TO_VIEW_THE_ESCALATION_STATE_FOR_THIS_POOL,
+	UI_STRING_LOADING_AVAILABLE_VAULT_REP,
+	UI_STRING_LOADING_ESCALATION,
+	UI_STRING_LOADING_ESCALATION_DEPOSITS,
+	UI_STRING_LOADING_ESCALATION_DEPOSITS_REPORTING_SECTION_LOADING_ESCALATION_DEPOSITS_DETAIL,
+	UI_STRING_LOSING_DEPOSIT_SETTLEMENT,
+	UI_STRING_MAX,
+	UI_STRING_MAX_PROFIT,
+	UI_STRING_MAX_PROFIT_BECOMES_AVAILABLE_AFTER_THE_ESCALATION_GAME_STARTS,
+	UI_STRING_MAX_PROFIT_PRESET_UNAVAILABLE_BECAUSE_THE_REWARD_WINDOW_IS_ALREADY_FILLED_ON_THE_SELECTED_SIDE,
+	UI_STRING_METRIC_UNAVAILABLE_PLACEHOLDER,
+	UI_STRING_MIN_TO_TAKE_THE_LEAD,
+	UI_STRING_NO_REMAINING_CONTRIBUTION_CAPACITY_IS_AVAILABLE_ON_THE_SELECTED_SIDE,
+	UI_STRING_NO_UNLOCKED_VAULT_REP_AVAILABLE_FOR_REPORTING,
+	UI_STRING_NON_DECISION_THRESHOLD,
+	UI_STRING_OF_PROFIT,
+	UI_STRING_OPEN_FORK_AND_MIGRATION,
+	UI_STRING_PENDING_FINALIZATION,
+	UI_STRING_REFRESH_REPORTING,
+	UI_STRING_REMAINING_SELECTED_SIDE_CAPACITY_IS_BELOW_THE_MINIMUM_REPORT_BOND,
+	UI_STRING_REP,
+	UI_STRING_REPORT_ON_SELECTED_SIDE,
+	UI_STRING_REPORT_OUTCOME,
+	UI_STRING_REPORT_OUTCOME_REPORTING_SECTION_REPORT_OUTCOME_ARIA_LABEL,
+	UI_STRING_REPORTING_IS_OPEN,
+	UI_STRING_REPORTING_IS_OPEN_SELECT_AN_OUTCOME_SIDE_BELOW_TO_ENABLE_REPORTING,
+	UI_STRING_REPORTING_NOT_ENABLED,
+	UI_STRING_REPORTING_OPEN,
+	UI_STRING_REPORTING_SECTION_REPORTING_PROJECTION_NOT_STARTED_SIMPLE_SUFFIX,
+	UI_STRING_REPORTING_WORKFLOW,
+	UI_STRING_RESOLVED,
+	UI_STRING_SECURITY_POOL_ADDRESS,
+	UI_STRING_SELECT_AN_OUTCOME_SIDE_ABOVE_TO_ENABLE_REPORTING,
+	UI_STRING_SELECT_AN_OUTCOME_SIDE_BEFORE_USING_PRESETS,
+	UI_STRING_SELECT_AT_LEAST_ONE_DEPOSIT_TO_SETTLE_OR_USE_SETTLE_ALL_FOR_THIS_SIDE,
+	UI_STRING_SELECT_THE_ANSWER_YOU_BELIEVE_SHOULD_FINALIZE_LOCK,
+	UI_STRING_SELECTED_SIDE,
+	UI_STRING_SELECTED_SIDE_ALREADY_LEADS,
+	UI_STRING_SELECTED_SIDE_IS_UNAVAILABLE,
+	UI_STRING_SETTLE_ESCALATION_DEPOSITS,
+	UI_STRING_START_BOND,
+	UI_STRING_SUBMITTING_REPORT,
+	UI_STRING_THE_MIGRATION_WINDOW_FOR_THESE_UNRESOLVED_ESCALATION_DEPOSITS_HAS_CLOSED,
+	UI_STRING_THESE_ESCALATION_DEPOSITS_MUST_MIGRATE_IN_FORK_AND_MIGRATION,
+	UI_STRING_THIS_CONTRIBUTION_WOULD_END_THE_ESCALATION_AND_FINALIZE_THE_MARKET_IMMEDIATELY,
+	UI_STRING_THIS_CONTRIBUTION_WOULD_EXTEND_THE_TIMER_BY,
+	UI_STRING_THIS_CONTRIBUTION_WOULD_NOT_EXTEND_THE_TIMER_AND_IF_NO_ONE_DISPUTES_AFTER_IT_THE_MARKET_WOULD_FINALIZE_IN,
+	UI_STRING_THIS_IS_THE_REP_YOU_ARE_WILLING_TO_LOCK_ON_THE_SELECTED_SIDE_LARGER_AMOUNTS_CAN_CHANGE_THE_PROPOSED_OUTCOME_OR_EXTEND_THE_ESCALATION_TIMER,
+	UI_STRING_THIS_POOL_ALSO_HAS_FORK_CARRIED_ESCALATION_POSITIONS_SETTLE_THOSE_IN_FORK_AND_MIGRATION,
+	UI_STRING_THIS_POOL_IS_ALREADY_FINALIZED,
+	UI_STRING_TIME_LEFT,
+	UI_STRING_TIMED_OUT,
+	UI_STRING_TO_CONFIRM,
+	UI_STRING_TOTAL_SIDE_STAKE,
+	UI_STRING_TRIGGER_ZOLTAR_FORK,
+	UI_STRING_TRIGGERING_ZOLTAR_FORK,
+	UI_STRING_WINNING_PAYOUT,
+	UI_STRING_WINS_AND_NO_ONE_ELSE_CONTRIBUTES_AFTERWARD_THIS_AMOUNT_PROJECTS_ROUGHLY,
+	UI_STRING_WORTH_AFTER_FINALIZATION_PENDING_FINALIZATION,
+	UI_STRING_WORTH_NOW,
+	UI_STRING_YOUR_SIDE_STAKE,
+	UI_TEMPLATE_REPORT_SELECTED_OUTCOME_BUTTON_LABEL,
+	UI_TEMPLATE_REPORTING_LATEST_OUTCOME_REMINDER_IMMEDIATE,
+	UI_TEMPLATE_REPORTING_LATEST_OUTCOME_REMINDER_LATER,
+	UI_TEMPLATE_REPORTING_RESOLVED_DETAIL_LABEL,
+	UI_TEMPLATE_SETTLE_ALL_DEPOSITS_LABEL,
+	UI_TEMPLATE_SETTLE_SELECTED_DEPOSITS_LABEL,
+	UI_TEMPLATE_SETTLING_DEPOSITS_PENDING_LABEL,
+} from '../lib/uiStrings.js'
 import type { LifecycleStagePresentation, ReportingSectionProps } from '../types/components.js'
 import type { EscalationDeposit, ReportingDetails, ReportingOutcomeKey } from '../types/contracts.js'
 type ReportingStatus = 'active' | 'missing' | 'not-started'
@@ -47,18 +153,18 @@ type EscalationSideDisplay = {
 	userDeposits: EscalationDeposit[] | undefined
 	userStake: bigint | undefined
 }
-const MAX_PROFIT_NOT_STARTED_REASON = UI_STRINGS.reportingSection.maxProfitNotStartedReason
-const LOAD_REPORTING_PRESETS_REASON = UI_STRINGS.reportingSection.loadReportingDetailsReason
-const SELECT_OUTCOME_PRESET_REASON = UI_STRINGS.reportingSection.selectOutcomePresetReason
-const SELECTED_SIDE_ALREADY_LEADS_REASON = UI_STRINGS.reportingSection.selectedSideAlreadyLeadsReason
-const MAX_PROFIT_WINDOW_FILLED_REASON = UI_STRINGS.reportingSection.maxProfitWindowFilledReason
-const SELECT_OUTCOME_TO_ENABLE_REPORTING_MESSAGE = UI_STRINGS.reportingSection.selectOutcomeAboveToEnableReportingMessage
-const NO_SELECTED_SIDE_CAPACITY_REASON = UI_STRINGS.reportingSection.noSelectedSideCapacityReason
-const BELOW_MINIMUM_SELECTED_SIDE_CAPACITY_REASON = UI_STRINGS.reportingSection.belowMinimumSelectedSideCapacityReason
-const FORK_TRIGGERED_REPORT_REASON = UI_STRINGS.reportingSection.forkTriggeredReportReason
-const FORK_TRIGGERED_SETTLEMENT_REASON = UI_STRINGS.reportingSection.forkTriggeredSettlementReason
-const FORK_ALREADY_TRIGGERED_REPORT_REASON = UI_STRINGS.reportingSection.forkAlreadyTriggeredReportReason
-const FORK_ALREADY_TRIGGERED_SETTLEMENT_REASON = UI_STRINGS.reportingSection.forkAlreadyTriggeredSettlementReason
+const MAX_PROFIT_NOT_STARTED_REASON = UI_STRING_MAX_PROFIT_BECOMES_AVAILABLE_AFTER_THE_ESCALATION_GAME_STARTS
+const LOAD_REPORTING_PRESETS_REASON = UI_STRING_LOAD_REPORTING_DETAILS_BEFORE_USING_PRESETS
+const SELECT_OUTCOME_PRESET_REASON = UI_STRING_SELECT_AN_OUTCOME_SIDE_BEFORE_USING_PRESETS
+const SELECTED_SIDE_ALREADY_LEADS_REASON = UI_STRING_SELECTED_SIDE_ALREADY_LEADS
+const MAX_PROFIT_WINDOW_FILLED_REASON = UI_STRING_MAX_PROFIT_PRESET_UNAVAILABLE_BECAUSE_THE_REWARD_WINDOW_IS_ALREADY_FILLED_ON_THE_SELECTED_SIDE
+const SELECT_OUTCOME_TO_ENABLE_REPORTING_MESSAGE = UI_STRING_SELECT_AN_OUTCOME_SIDE_ABOVE_TO_ENABLE_REPORTING
+const NO_SELECTED_SIDE_CAPACITY_REASON = UI_STRING_NO_REMAINING_CONTRIBUTION_CAPACITY_IS_AVAILABLE_ON_THE_SELECTED_SIDE
+const BELOW_MINIMUM_SELECTED_SIDE_CAPACITY_REASON = UI_STRING_REMAINING_SELECTED_SIDE_CAPACITY_IS_BELOW_THE_MINIMUM_REPORT_BOND
+const FORK_TRIGGERED_REPORT_REASON = UI_STRING_ESCALATION_REACHED_NON_DECISION_TRIGGER_ZOLTAR_FORK_HERE_IF_THIS_POOL_SHOULD_FORK_THE_UNIVERSE
+const FORK_TRIGGERED_SETTLEMENT_REASON = UI_STRING_ESCALATION_DEPOSITS_REMAIN_LOCKED_AFTER_NON_DECISION_TRIGGER_ZOLTAR_FORK_HERE_IF_THIS_POOL_SHOULD_FORK_THE_UNIVERSE
+const FORK_ALREADY_TRIGGERED_REPORT_REASON = UI_STRING_ESCALATION_REACHED_NON_DECISION_AND_ZOLTAR_FORK_HAS_ALREADY_BEEN_TRIGGERED_FOR_THIS_POOL_CONTINUE_IN_FORK_AND_MIGRATION
+const FORK_ALREADY_TRIGGERED_SETTLEMENT_REASON = UI_STRING_ESCALATION_DEPOSITS_REMAIN_LOCKED_AFTER_NON_DECISION_ZOLTAR_FORK_HAS_ALREADY_BEEN_TRIGGERED_FOR_THIS_POOL_SO_CONTINUE_IN_FORK_AND_MIGRATION
 function getOutcomeSides(reportingDetails: ReportingDetails | undefined) {
 	if (reportingDetails?.status === 'active')
 		return reportingDetails.sides.map<EscalationSideDisplay>(side => ({
@@ -88,12 +194,12 @@ function isHiddenPresetReason(reason: string | undefined) {
 	return reason === LOAD_REPORTING_PRESETS_REASON || reason === MAX_PROFIT_NOT_STARTED_REASON || reason === SELECT_OUTCOME_PRESET_REASON || reason === SELECTED_SIDE_ALREADY_LEADS_REASON || reason === MAX_PROFIT_WINDOW_FILLED_REASON
 }
 function getResolvedReportingOutcomeLabel(reportingDetails: ReportingDetails) {
-	return reportingDetails.questionOutcome === 'none' ? UI_STRINGS.reportingSection.pendingFinalizationLabel : getReportingOutcomeLabel(reportingDetails.questionOutcome)
+	return reportingDetails.questionOutcome === 'none' ? UI_STRING_PENDING_FINALIZATION : getReportingOutcomeLabel(reportingDetails.questionOutcome)
 }
 function getWithdrawDepositClaimLabel(details: ReportingDetails | undefined, selectedOutcome: ReportingOutcomeKey) {
 	if (details === undefined || details.status !== 'active') return undefined
 	if (!isPoolQuestionFinalized(details)) return undefined
-	return details.questionOutcome === selectedOutcome ? UI_STRINGS.reportingSection.claimTypeWinningPayoutLabel : UI_STRINGS.reportingSection.claimTypeLosingDepositSettlementLabel
+	return details.questionOutcome === selectedOutcome ? UI_STRING_WINNING_PAYOUT : UI_STRING_LOSING_DEPOSIT_SETTLEMENT
 }
 
 function getReportingStagePresentation({
@@ -114,25 +220,25 @@ function getReportingStagePresentation({
 			blockedActions: [],
 			detail: getReportingLockedUntilMessage(marketDetails.endTime, effectiveCurrentTimestamp),
 			key: 'reporting-not-enabled',
-			label: UI_STRINGS.reportingSection.reportingNotEnabledTitle,
+			label: UI_STRING_REPORTING_NOT_ENABLED,
 			tone: 'warning',
 		}
 	if (reportingDetails === undefined)
 		return {
 			availableActions: [],
 			blockedActions: [],
-			detail: UI_STRINGS.reportingSection.reportingOpenDetail,
+			detail: UI_STRING_LOAD_REPORTING_DETAILS_TO_VIEW_THE_ESCALATION_STATE_FOR_THIS_POOL,
 			key: 'reporting-open',
-			label: UI_STRINGS.reportingSection.reportingOpenTitle,
+			label: UI_STRING_REPORTING_OPEN,
 			tone: 'default',
 		}
 	if (isPoolQuestionFinalized(reportingDetails))
 		return {
 			availableActions: [],
 			blockedActions: [],
-			detail: UI_STRINGS.reportingSection.reportingResolvedDetailLabel(getResolvedReportingOutcomeLabel(reportingDetails)),
+			detail: UI_TEMPLATE_REPORTING_RESOLVED_DETAIL_LABEL(getResolvedReportingOutcomeLabel(reportingDetails)),
 			key: 'escalation-resolved',
-			label: UI_STRINGS.reportingSection.resolvedTitle,
+			label: UI_STRING_RESOLVED,
 			tone: 'success',
 		}
 	if (reportingDetails.status === 'not-started') return undefined
@@ -144,9 +250,9 @@ function getReportingStagePresentation({
 			return {
 				availableActions: [],
 				blockedActions: [],
-				detail: UI_STRINGS.reportingSection.reportingActiveDetail,
+				detail: UI_STRING_ESCALATION_IS_LIVE_REVIEW_THE_BOND_SIDE_BALANCES_AND_TIME_REMAINING_BEFORE_CONTRIBUTING_OR_WITHDRAWING,
 				key: 'escalation-active',
-				label: UI_STRINGS.reportingSection.activeTitle,
+				label: UI_STRING_ACTIVE,
 				tone: 'default',
 			}
 		case 'Fork Triggered':
@@ -155,25 +261,25 @@ function getReportingStagePresentation({
 				blockedActions: [],
 				detail: forkAlreadyTriggered ? FORK_ALREADY_TRIGGERED_REPORT_REASON : FORK_TRIGGERED_REPORT_REASON,
 				key: 'escalation-fork-triggered',
-				label: UI_STRINGS.reportingSection.forkTriggeredTitle,
+				label: UI_STRING_FORK_TRIGGERED,
 				tone: 'default',
 			}
 		case 'Timed Out':
 			return {
 				availableActions: [],
 				blockedActions: [],
-				detail: UI_STRINGS.reportingSection.reportingTimedOutDetail,
+				detail: UI_STRING_ESCALATION_ENDED_BY_TIMEOUT_THE_WINNER_IS_COMPUTED,
 				key: 'escalation-timed-out',
-				label: UI_STRINGS.reportingSection.timedOutTitle,
+				label: UI_STRING_TIMED_OUT,
 				tone: 'default',
 			}
 		case 'Resolved':
 			return {
 				availableActions: [],
 				blockedActions: [],
-				detail: UI_STRINGS.reportingSection.reportingResolvedDetailLabel(getResolvedReportingOutcomeLabel(reportingDetails)),
+				detail: UI_TEMPLATE_REPORTING_RESOLVED_DETAIL_LABEL(getResolvedReportingOutcomeLabel(reportingDetails)),
 				key: 'escalation-resolved',
-				label: UI_STRINGS.reportingSection.resolvedTitle,
+				label: UI_STRING_RESOLVED,
 				tone: 'success',
 			}
 		default:
@@ -185,30 +291,30 @@ function getEscalationGameStartTimestamp(activationTime: bigint | undefined) {
 	return activationTime > ESCALATION_GAME_ACTIVATION_DELAY ? activationTime - ESCALATION_GAME_ACTIVATION_DELAY : 0n
 }
 function getLatestOutcomeReminder({ currentTimestamp, projectedFinalizationTimestamp, rewardWindowFillTimestamp, selectedOutcomeLabel }: { currentTimestamp: bigint | undefined; projectedFinalizationTimestamp: bigint | undefined; rewardWindowFillTimestamp: bigint | undefined; selectedOutcomeLabel: string }) {
-	if (projectedFinalizationTimestamp !== undefined && currentTimestamp !== undefined && projectedFinalizationTimestamp <= currentTimestamp) return <>{UI_STRINGS.reportingSection.reportingLatestOutcomeReminderImmediate(selectedOutcomeLabel)}</>
+	if (projectedFinalizationTimestamp !== undefined && currentTimestamp !== undefined && projectedFinalizationTimestamp <= currentTimestamp) return <>{UI_TEMPLATE_REPORTING_LATEST_OUTCOME_REMINDER_IMMEDIATE(selectedOutcomeLabel)}</>
 	if (rewardWindowFillTimestamp !== undefined && currentTimestamp !== undefined && rewardWindowFillTimestamp > currentTimestamp)
 		return (
 			<>
-				{UI_STRINGS.reportingSection.reportingLatestOutcomeReminderBeforeRewardWindowPrefix}
+				{UI_STRING_CHECK_BACK_NO_LATER_THAN}
 				<TimestampValue {...(currentTimestamp === undefined ? {} : { currentTimestamp })} timestamp={rewardWindowFillTimestamp} />
-				{UI_STRINGS.reportingSection.reportingLatestOutcomeReminderBeforeRewardWindowMiddle}
+				{UI_STRING_TO_CONFIRM}
 				{selectedOutcomeLabel}
-				{UI_STRINGS.reportingSection.reportingLatestOutcomeReminderBeforeRewardWindowSuffix}
+				{UI_STRING_IS_THE_LEADING_OUTCOME_BEFORE_THE_REMAINING_REWARD_ELIGIBLE_REP_ON}
 				{selectedOutcomeLabel}
-				{UI_STRINGS.reportingSection.reportingLatestOutcomeReminderBeforeRewardWindowTail}
+				{UI_STRING_IS_FILLED}
 			</>
 		)
 	if (projectedFinalizationTimestamp !== undefined)
 		return (
 			<>
-				{UI_STRINGS.reportingSection.reportingLatestOutcomeReminderBeforeFinalizationPrefix}
+				{UI_STRING_CHECK_BACK_NO_LATER_THAN}
 				<TimestampValue {...(currentTimestamp === undefined ? {} : { currentTimestamp })} timestamp={projectedFinalizationTimestamp} />
-				{UI_STRINGS.reportingSection.reportingLatestOutcomeReminderBeforeFinalizationMiddle}
+				{UI_STRING_TO_CONFIRM}
 				{selectedOutcomeLabel}
-				{UI_STRINGS.reportingSection.reportingLatestOutcomeReminderBeforeFinalizationSuffix}
+				{UI_STRING_IS_THE_LEADING_OUTCOME_BEFORE_FINALIZATION}
 			</>
 		)
-	return <>{UI_STRINGS.reportingSection.reportingLatestOutcomeReminderLater(selectedOutcomeLabel)}</>
+	return <>{UI_TEMPLATE_REPORTING_LATEST_OUTCOME_REMINDER_LATER(selectedOutcomeLabel)}</>
 }
 function getEffectiveReportingDetails(reportingDetails: ReportingDetails | undefined, currentTimestamp: bigint | undefined) {
 	if (reportingDetails === undefined || currentTimestamp === undefined || reportingDetails.currentTime === currentTimestamp) return reportingDetails
@@ -270,9 +376,9 @@ export function ReportingSection({
 	if (reportingStageKey === 'forkTriggered') {
 		reportLifecycleReason = forkAlreadyTriggered ? FORK_ALREADY_TRIGGERED_REPORT_REASON : FORK_TRIGGERED_REPORT_REASON
 	} else if (reportingStageKey === 'timedOut') {
-		reportLifecycleReason = UI_STRINGS.reportingSection.reportingHasEndedRefreshReason
+		reportLifecycleReason = UI_STRING_ESCALATION_HAS_ENDED_REFRESH_REPORTING_TO_VIEW_THE_FINALIZED_OUTCOME_BEFORE_SETTLING_DEPOSITS
 	} else if (reportingStageKey === 'resolved') {
-		reportLifecycleReason = UI_STRINGS.reportingSection.reportingPoolAlreadyFinalizedReason
+		reportLifecycleReason = UI_STRING_THIS_POOL_IS_ALREADY_FINALIZED
 	}
 	const reportControlsLockedReason = showFullReporting ? pickFirstReason(lockedReason, reportingState.reportingStage === 'preOpen' ? preOpenLockedReason : undefined, reportLifecycleReason) : preOpenLockedReason
 	const reportControlsLocked = !reportOutcomeEnabled || reportControlsLockedReason !== undefined
@@ -280,13 +386,13 @@ export function ReportingSection({
 	if (reportingStageKey === 'forkTriggered') {
 		settlementLifecycleReason = forkAlreadyTriggered ? FORK_ALREADY_TRIGGERED_SETTLEMENT_REASON : FORK_TRIGGERED_SETTLEMENT_REASON
 	} else if (activeReportingDetails?.settlementState === 'migration-required') {
-		settlementLifecycleReason = forkAlreadyTriggered ? UI_STRINGS.reportingSection.continueInForkAndMigrationReason : UI_STRINGS.reportingSection.migrationRequiredReason
+		settlementLifecycleReason = forkAlreadyTriggered ? UI_STRING_CONTINUE_IN_FORK_AND_MIGRATION_TO_MIGRATE_UNRESOLVED_ESCALATION_DEPOSITS_INTO_A_CHILD_UNIVERSE : UI_STRING_THESE_ESCALATION_DEPOSITS_MUST_MIGRATE_IN_FORK_AND_MIGRATION
 	} else if (activeReportingDetails?.settlementState === 'migration-expired') {
-		settlementLifecycleReason = UI_STRINGS.reportingSection.migrationExpiredReason
+		settlementLifecycleReason = UI_STRING_THE_MIGRATION_WINDOW_FOR_THESE_UNRESOLVED_ESCALATION_DEPOSITS_HAS_CLOSED
 	} else if (reportingStageKey === 'activeLocked') {
-		settlementLifecycleReason = UI_STRINGS.reportingSection.settlementLockedUntilFinalizedReason
+		settlementLifecycleReason = UI_STRING_ESCALATION_DEPOSITS_CANNOT_BE_SETTLED_UNTIL_THE_QUESTION_IS_FINALIZED
 	}
-	const withdrawControlsLockedReason = showSettlementSection && loadingReportingDetails ? UI_STRINGS.reportingSection.loadingEscalationDepositsReason : pickFirstReason(lockedReason, reportingState.reportingStage === 'preOpen' ? preOpenLockedReason : undefined, settlementLifecycleReason)
+	const withdrawControlsLockedReason = showSettlementSection && loadingReportingDetails ? UI_STRING_LOADING_ESCALATION_DEPOSITS : pickFirstReason(lockedReason, reportingState.reportingStage === 'preOpen' ? preOpenLockedReason : undefined, settlementLifecycleReason)
 	const withdrawControlsLocked = !withdrawEscalationEnabled || withdrawControlsLockedReason !== undefined
 	const selectedAmount = parseOptionalRepAmountInput(reportingForm.reportAmount)
 	const selectedOutcome = reportingForm.selectedOutcome
@@ -309,7 +415,7 @@ export function ReportingSection({
 	const actualReportDepositAmount = reportContributionPreview?.actualDepositAmount
 	const selectedEstimate = activeReportingDetails === undefined || selectedAmount === undefined || selectedOutcome === undefined ? undefined : calculateEstimatedEscalationReturn(activeReportingDetails, selectedOutcome, selectedAmount)
 	const timerPreview = effectiveReportingDetails === undefined || selectedAmount === undefined || selectedOutcome === undefined ? undefined : getReportingTimerPreview(effectiveReportingDetails, selectedOutcome, selectedAmount)
-	const selectedOutcomeLabel = selectedOutcome === undefined ? UI_STRINGS.reportingSection.selectedSideLabel : (outcomeSides.find(side => side.key === selectedOutcome)?.label ?? getReportingOutcomeLabel(selectedOutcome))
+	const selectedOutcomeLabel = selectedOutcome === undefined ? UI_STRING_SELECTED_SIDE : (outcomeSides.find(side => side.key === selectedOutcome)?.label ?? getReportingOutcomeLabel(selectedOutcome))
 	let projectedFinalizationTimestamp: bigint | undefined
 	if (timerPreview !== undefined && effectiveCurrentTimestamp !== undefined) {
 		if (timerPreview.kind === 'not-started') {
@@ -333,11 +439,11 @@ export function ReportingSection({
 			if (selectedEstimate === undefined) return undefined
 			return (
 				<>
-					{UI_STRINGS.reportingSection.reportingProjectionProfitPrefix}
+					{UI_STRING_IF}
 					{selectedOutcomeLabel}
-					{UI_STRINGS.reportingSection.reportingProjectionProfitMiddle}
-					<CurrencyValue value={selectedEstimate.profit} suffix={UI_STRINGS.common.repLabel} />
-					{UI_STRINGS.reportingSection.reportingProjectionProfitSuffix}
+					{UI_STRING_WINS_AND_NO_ONE_ELSE_CONTRIBUTES_AFTERWARD_THIS_AMOUNT_PROJECTS_ROUGHLY}
+					<CurrencyValue value={selectedEstimate.profit} suffix={UI_STRING_REP} />
+					{UI_STRING_OF_PROFIT}
 					{finalizationReminder}
 				</>
 			)
@@ -346,21 +452,21 @@ export function ReportingSection({
 			if (timerPreview.hypotheticalDuration > 0n)
 				return (
 					<>
-						{UI_STRINGS.reportingSection.reportingProjectionNotStartedPrefix}
+						{UI_STRING_IF_NO_ONE_DISPUTES_AFTER_THIS_REPORT_THE_MARKET_WOULD_FINALIZE_IN}
 						{formatDuration(timerPreview.timeUntilStart)}
-						{UI_STRINGS.reportingSection.reportingProjectionNotStartedSimpleSuffix}
-						{UI_STRINGS.reportingSection.reportingProjectionNotStartedCheckBackPrefix}
+						{UI_STRING_REPORTING_SECTION_REPORTING_PROJECTION_NOT_STARTED_SIMPLE_SUFFIX}
+						{UI_STRING_CHECK_BACK_NO_LATER_THAN}
 						<TimestampValue {...(effectiveCurrentTimestamp === undefined ? {} : { currentTimestamp: effectiveCurrentTimestamp })} timestamp={projectedFinalizationTimestamp} />
-						{UI_STRINGS.reportingSection.reportingProjectionNotStartedCheckBackMiddle}
+						{UI_STRING_TO_CONFIRM}
 						{selectedOutcomeLabel}
-						{UI_STRINGS.reportingSection.reportingProjectionNotStartedCheckBackSuffix}
+						{UI_STRING_IS_STILL_LEADING_IF_LATER_DISPUTES_KEEP_ESCALATION_OPEN}
 					</>
 				)
 			return (
 				<>
-					{UI_STRINGS.reportingSection.reportingProjectionNotStartedPrefix}
+					{UI_STRING_IF_NO_ONE_DISPUTES_AFTER_THIS_REPORT_THE_MARKET_WOULD_FINALIZE_IN}
 					{formatDuration(timerPreview.timeUntilStart)}
-					{UI_STRINGS.reportingSection.reportingProjectionNotStartedSimpleSuffix}
+					{UI_STRING_REPORTING_SECTION_REPORTING_PROJECTION_NOT_STARTED_SIMPLE_SUFFIX}
 					{finalizationReminder}
 				</>
 			)
@@ -369,12 +475,12 @@ export function ReportingSection({
 		if (timerPreview.actualState === 'ends-immediately')
 			return (
 				<>
-					{UI_STRINGS.reportingSection.reportingProjectionProfitPrefix}
+					{UI_STRING_IF}
 					{selectedOutcomeLabel}
-					{UI_STRINGS.reportingSection.reportingProjectionProfitMiddle}
-					<CurrencyValue value={selectedEstimate.profit} suffix={UI_STRINGS.common.repLabel} />
-					{UI_STRINGS.reportingSection.reportingProjectionProfitSuffix}
-					{UI_STRINGS.reportingSection.reportingProjectionEndsImmediatelyText}
+					{UI_STRING_WINS_AND_NO_ONE_ELSE_CONTRIBUTES_AFTERWARD_THIS_AMOUNT_PROJECTS_ROUGHLY}
+					<CurrencyValue value={selectedEstimate.profit} suffix={UI_STRING_REP} />
+					{UI_STRING_OF_PROFIT}
+					{UI_STRING_THIS_CONTRIBUTION_WOULD_END_THE_ESCALATION_AND_FINALIZE_THE_MARKET_IMMEDIATELY}
 					{finalizationReminder}
 				</>
 			)
@@ -382,43 +488,43 @@ export function ReportingSection({
 		if (timerPreview.actualState === 'extends')
 			return (
 				<>
-					{UI_STRINGS.reportingSection.reportingProjectionProfitPrefix}
+					{UI_STRING_IF}
 					{selectedOutcomeLabel}
-					{UI_STRINGS.reportingSection.reportingProjectionProfitMiddle}
-					<CurrencyValue value={selectedEstimate.profit} suffix={UI_STRINGS.common.repLabel} />
-					{UI_STRINGS.reportingSection.reportingProjectionProfitSuffix}
-					{UI_STRINGS.reportingSection.reportingProjectionExtendsPrefix}
+					{UI_STRING_WINS_AND_NO_ONE_ELSE_CONTRIBUTES_AFTERWARD_THIS_AMOUNT_PROJECTS_ROUGHLY}
+					<CurrencyValue value={selectedEstimate.profit} suffix={UI_STRING_REP} />
+					{UI_STRING_OF_PROFIT}
+					{UI_STRING_THIS_CONTRIBUTION_WOULD_EXTEND_THE_TIMER_BY}
 					{formatDuration(timerPreview.timerIncrease ?? 0n)}
-					{UI_STRINGS.reportingSection.reportingProjectionExtendsMiddle}
+					{UI_STRING_AND_IF_NO_ONE_DISPUTES_AFTER_IT_THE_MARKET_WOULD_FINALIZE_IN}
 					{projectedFinalizationDuration}
-					{UI_STRINGS.reportingSection.reportingProjectionNotStartedSimpleSuffix}
+					{UI_STRING_REPORTING_SECTION_REPORTING_PROJECTION_NOT_STARTED_SIMPLE_SUFFIX}
 					{finalizationReminder}
 				</>
 			)
 		return (
 			<>
-				{UI_STRINGS.reportingSection.reportingProjectionProfitPrefix}
+				{UI_STRING_IF}
 				{selectedOutcomeLabel}
-				{UI_STRINGS.reportingSection.reportingProjectionProfitMiddle}
-				<CurrencyValue value={selectedEstimate.profit} suffix={UI_STRINGS.common.repLabel} />
-				{UI_STRINGS.reportingSection.reportingProjectionProfitSuffix}
-				{UI_STRINGS.reportingSection.reportingProjectionDoesNotExtendPrefix}
+				{UI_STRING_WINS_AND_NO_ONE_ELSE_CONTRIBUTES_AFTERWARD_THIS_AMOUNT_PROJECTS_ROUGHLY}
+				<CurrencyValue value={selectedEstimate.profit} suffix={UI_STRING_REP} />
+				{UI_STRING_OF_PROFIT}
+				{UI_STRING_THIS_CONTRIBUTION_WOULD_NOT_EXTEND_THE_TIMER_AND_IF_NO_ONE_DISPUTES_AFTER_IT_THE_MARKET_WOULD_FINALIZE_IN}
 				{projectedFinalizationDuration}
-				{UI_STRINGS.reportingSection.reportingProjectionNotStartedSimpleSuffix}
+				{UI_STRING_REPORTING_SECTION_REPORTING_PROJECTION_NOT_STARTED_SIMPLE_SUFFIX}
 				{finalizationReminder}
 			</>
 		)
 	}
 	const projectedReportingPreview = getProjectedReportingPreview()
-	const reportButtonLabel = selectedOutcome === undefined ? UI_STRINGS.reportingSection.reportOnSelectedSideLabel : UI_STRINGS.reportingSection.reportSelectedOutcomeButtonLabel(selectedOutcomeLabel)
+	const reportButtonLabel = selectedOutcome === undefined ? UI_STRING_REPORT_ON_SELECTED_SIDE : UI_TEMPLATE_REPORT_SELECTED_OUTCOME_BUTTON_LABEL(selectedOutcomeLabel)
 	const minimumOutcomeChangeContribution = selectedOutcome === undefined ? { amount: undefined, reason: SELECT_OUTCOME_PRESET_REASON } : getReportingMinimumOutcomeChangeContribution(effectiveReportingDetails, selectedOutcome)
 	const maxProfitContribution = selectedOutcome === undefined ? { amount: undefined, reason: SELECT_OUTCOME_PRESET_REASON } : getReportingMaxProfitContribution(effectiveReportingDetails, selectedOutcome)
 	const remainingSelectedOutcomeCapacity = effectiveReportingDetails === undefined || selectedOutcome === undefined ? undefined : getRemainingSelectedOutcomeContributionCapacity(effectiveReportingDetails, selectedOutcome)
 	const maxContributionAmount = (() => {
 		if (selectedOutcome === undefined) return { amount: undefined, reason: SELECT_OUTCOME_PRESET_REASON }
 		if (effectiveReportingDetails === undefined) return { amount: undefined, reason: LOAD_REPORTING_PRESETS_REASON }
-		if (effectiveReportingDetails.viewerVaultAvailableEscalationRep === undefined) return { amount: undefined, reason: UI_STRINGS.reportingSection.loadingAvailableVaultRepReason }
-		if (effectiveReportingDetails.viewerVaultAvailableEscalationRep <= 0n) return { amount: undefined, reason: UI_STRINGS.reportingSection.noUnlockedVaultRepReason }
+		if (effectiveReportingDetails.viewerVaultAvailableEscalationRep === undefined) return { amount: undefined, reason: UI_STRING_LOADING_AVAILABLE_VAULT_REP }
+		if (effectiveReportingDetails.viewerVaultAvailableEscalationRep <= 0n) return { amount: undefined, reason: UI_STRING_NO_UNLOCKED_VAULT_REP_AVAILABLE_FOR_REPORTING }
 		if (remainingSelectedOutcomeCapacity !== undefined && remainingSelectedOutcomeCapacity <= 0n) return { amount: undefined, reason: NO_SELECTED_SIDE_CAPACITY_REASON }
 		if (effectiveReportingDetails.status === 'not-started') {
 			const cappedAmount = remainingSelectedOutcomeCapacity === undefined || effectiveReportingDetails.viewerVaultAvailableEscalationRep < remainingSelectedOutcomeCapacity ? effectiveReportingDetails.viewerVaultAvailableEscalationRep : remainingSelectedOutcomeCapacity
@@ -429,7 +535,7 @@ export function ReportingSection({
 			}
 		}
 		const selectedSide = effectiveReportingDetails.sides.find(side => side.key === selectedOutcome)
-		if (selectedSide === undefined) return { amount: undefined, reason: UI_STRINGS.reportingSection.selectedSideUnavailableReason }
+		if (selectedSide === undefined) return { amount: undefined, reason: UI_STRING_SELECTED_SIDE_IS_UNAVAILABLE }
 		const maxContributionPreview = previewReportingContribution(effectiveReportingDetails, selectedOutcome, effectiveReportingDetails.nonDecisionThreshold - selectedSide.balance)
 		if (maxContributionPreview.actualDepositAmount === undefined) return { amount: undefined, reason: maxContributionPreview.reason }
 		let cappedAmount = maxContributionPreview.actualDepositAmount
@@ -442,7 +548,7 @@ export function ReportingSection({
 		}
 	})()
 	const presetReasons = reportControlsLocked ? [] : [minimumOutcomeChangeContribution.reason, maxProfitContribution.reason].filter((reason, index, reasons): reason is string => reason !== undefined && !isHiddenPresetReason(reason) && reasons.indexOf(reason) === index)
-	const reportAmountError = selectedAmount === undefined && reportingForm.reportAmount.trim() !== '' ? UI_STRINGS.reportingSection.enterValidReportAmountReason : undefined
+	const reportAmountError = selectedAmount === undefined && reportingForm.reportAmount.trim() !== '' ? UI_STRING_ENTER_A_VALID_REPORT_AMOUNT_TO_PREVIEW_PROFIT : undefined
 	const reportGuardMessage =
 		reportControlsLockedReason ??
 		getReportingReportGuardMessage({
@@ -468,7 +574,7 @@ export function ReportingSection({
 	const reportOutcomeSelectionMessage = showFullReporting && reportingStatus !== 'missing' && selectedOutcome === undefined && !reportControlsLocked ? SELECT_OUTCOME_TO_ENABLE_REPORTING_MESSAGE : undefined
 	let reportingOpenNotice: string | undefined
 	if (showFullReporting && reportingStatus === 'not-started' && effectiveReportingDetails?.questionOutcome === 'none') {
-		reportingOpenNotice = selectedOutcome === undefined ? UI_STRINGS.reportingSection.reportingOpenSelectOutcomeMessage : UI_STRINGS.reportingSection.reportingOpenMessage
+		reportingOpenNotice = selectedOutcome === undefined ? UI_STRING_REPORTING_IS_OPEN_SELECT_AN_OUTCOME_SIDE_BELOW_TO_ENABLE_REPORTING : UI_STRING_REPORTING_IS_OPEN
 	}
 	const withdrawActionPending = reportingActiveAction === 'withdrawEscalation'
 	const shouldShowWithdrawEmptyState = !loadingReportingDetails && reportingStatus !== 'missing' && withdrawableSides.length === 0
@@ -479,12 +585,10 @@ export function ReportingSection({
 	const forkTriggeredActions =
 		reportingStageKey !== 'forkTriggered' || (!showForkWorkflowAction && !showTriggerZoltarForkAction) ? undefined : (
 			<div className='actions'>
-				{showTriggerZoltarForkAction ? (
-					<TransactionActionButton idleLabel={UI_STRINGS.reportingSection.triggerZoltarForkIdleLabel} pendingLabel={UI_STRINGS.reportingSection.triggeringZoltarForkLabel} onClick={onTriggerZoltarFork} pending={triggerZoltarForkPending} tone='primary' availability={resolvedTriggerZoltarForkAvailability} />
-				) : undefined}
+				{showTriggerZoltarForkAction ? <TransactionActionButton idleLabel={UI_STRING_TRIGGER_ZOLTAR_FORK} pendingLabel={UI_STRING_TRIGGERING_ZOLTAR_FORK} onClick={onTriggerZoltarFork} pending={triggerZoltarForkPending} tone='primary' availability={resolvedTriggerZoltarForkAvailability} /> : undefined}
 				{showForkWorkflowAction ? (
 					<button className='secondary' type='button' onClick={onOpenForkWorkflow}>
-						{UI_STRINGS.reportingSection.openForkAndMigrationLabel}
+						{UI_STRING_OPEN_FORK_AND_MIGRATION}
 					</button>
 				) : undefined}
 			</div>
@@ -518,20 +622,20 @@ export function ReportingSection({
 			})
 		: undefined
 	const reportingStageBanner = reportingStage?.key === 'escalation-active' ? undefined : reportingStage
-	const reportingWorkflowSummary = reportingStage?.detail ?? UI_STRINGS.reportingSection.reportingWorkflowSummary
+	const reportingWorkflowSummary = reportingStage?.detail ?? UI_STRING_SELECT_THE_ANSWER_YOU_BELIEVE_SHOULD_FINALIZE_LOCK
 	const showReportingHeaderStack = showFullReporting && (showSecurityPoolAddressInput || reportingStageBanner !== undefined || reportingOpenNotice !== undefined)
 	const sections = (
 		<>
 			{showFullReporting ? (
-				<SectionBlock className='reporting-workflow-section' title={UI_STRINGS.reportingSection.reportingWorkflowTitle} density='compact' variant='plain'>
+				<SectionBlock className='reporting-workflow-section' title={UI_STRING_REPORTING_WORKFLOW} density='compact' variant='plain'>
 					<div className='workflow-summary-strip workflow-guide workflow-guide-compact'>
 						<div className='workflow-guide-intro'>
 							<p className='detail'>{reportingWorkflowSummary}</p>
 						</div>
 						<div className='workflow-summary-strip-steps'>
-							<span className='current'>{UI_STRINGS.reportingSection.reportingWorkflowStepOutcomeLabel}</span>
-							<span>{UI_STRINGS.reportingSection.reportingWorkflowStepLockRepLabel}</span>
-							<span>{UI_STRINGS.reportingSection.reportingWorkflowStepSettleLabel}</span>
+							<span className='current'>{UI_STRING_1_OUTCOME}</span>
+							<span>{UI_STRING_2_LOCK_REP}</span>
+							<span>{UI_STRING_3_SETTLE}</span>
 						</div>
 					</div>
 				</SectionBlock>
@@ -541,13 +645,13 @@ export function ReportingSection({
 				<div className='reporting-header-stack'>
 					{showSecurityPoolAddressInput ? (
 						<LookupFieldRow
-							label={UI_STRINGS.reportingSection.securityPoolAddressLabel}
+							label={UI_STRING_SECURITY_POOL_ADDRESS}
 							value={reportingForm.securityPoolAddress}
 							onInput={securityPoolAddress => onReportingFormChange({ securityPoolAddress })}
-							placeholder={UI_STRINGS.common.hexValuePlaceholder}
+							placeholder={UI_STRING_HEX_VALUE_PLACEHOLDER}
 							action={
 								<button className='secondary' onClick={onLoadReporting} disabled={loadingReportingDetails || preOpenLockedReason !== undefined} title={preOpenLockedReason}>
-									{loadingReportingDetails ? <LoadingText>{UI_STRINGS.reportingSection.loadingEscalationLabel}</LoadingText> : UI_STRINGS.reportingSection.loadingReportingLabel}
+									{loadingReportingDetails ? <LoadingText>{UI_STRING_LOADING_ESCALATION}</LoadingText> : UI_STRING_REFRESH_REPORTING}
 								</button>
 							}
 						/>
@@ -557,41 +661,41 @@ export function ReportingSection({
 			) : undefined}
 
 			{showFullReporting ? (
-				<SectionBlock className='reporting-metrics-section' title={UI_STRINGS.reportingSection.reportingMetricsTitle} variant='embedded'>
+				<SectionBlock className='reporting-metrics-section' title={UI_STRING_ESCALATION_METRICS} variant='embedded'>
 					<div className='escalation-metrics'>
-						<MetricField label={UI_STRINGS.reportingSection.nonDecisionThresholdLabel}>
-							<CurrencyValue value={effectiveReportingDetails?.nonDecisionThreshold} suffix={UI_STRINGS.common.repLabel} />
+						<MetricField label={UI_STRING_NON_DECISION_THRESHOLD}>
+							<CurrencyValue value={effectiveReportingDetails?.nonDecisionThreshold} suffix={UI_STRING_REP} />
 						</MetricField>
-						<MetricField label={UI_STRINGS.reportingSection.timeLeftLabel}>{activeReportingDetails === undefined ? UI_STRINGS.common.metricUnavailablePlaceholder : formatDuration(getEscalationTimeRemaining(activeReportingDetails))}</MetricField>
-						<MetricField label={UI_STRINGS.reportingSection.escalationStartedLabel}>
+						<MetricField label={UI_STRING_TIME_LEFT}>{activeReportingDetails === undefined ? UI_STRING_METRIC_UNAVAILABLE_PLACEHOLDER : formatDuration(getEscalationTimeRemaining(activeReportingDetails))}</MetricField>
+						<MetricField label={UI_STRING_ESCALATION_STARTED}>
 							<TimestampValue {...(effectiveCurrentTimestamp === undefined ? {} : { currentTimestamp: effectiveCurrentTimestamp })} timestamp={escalationGameStartTimestamp} />
 						</MetricField>
-						<MetricField label={UI_STRINGS.reportingSection.startBondLabel}>
-							<CurrencyValue value={effectiveReportingDetails?.startBond} suffix={UI_STRINGS.common.repLabel} />
+						<MetricField label={UI_STRING_START_BOND}>
+							<CurrencyValue value={effectiveReportingDetails?.startBond} suffix={UI_STRING_REP} />
 						</MetricField>
 					</div>
 				</SectionBlock>
 			) : undefined}
 
 			{showFullReporting ? (
-				<SectionBlock className='reporting-outcome-section' title={UI_STRINGS.reportingSection.reportingOutcomeTitle} variant='embedded'>
+				<SectionBlock className='reporting-outcome-section' title={UI_STRING_REPORT_OUTCOME} variant='embedded'>
 					<div className='escalation-sides-shell'>
 						<div className='escalation-sides-legend'>
 							<div className='escalation-sides-legend-item'>
 								<span aria-hidden='true' className='escalation-sides-legend-swatch escalation-sides-legend-swatch-total' />
-								<span className='panel-label'>{UI_STRINGS.reportingSection.totalSideStakeLabel}</span>
+								<span className='panel-label'>{UI_STRING_TOTAL_SIDE_STAKE}</span>
 							</div>
 							<div className='escalation-sides-legend-item'>
 								<span aria-hidden='true' className='escalation-sides-legend-swatch escalation-sides-legend-swatch-user' />
-								<span className='panel-label'>{UI_STRINGS.reportingSection.selectedSideStakeLabel}</span>
+								<span className='panel-label'>{UI_STRING_YOUR_SIDE_STAKE}</span>
 							</div>
 							<div className='escalation-sides-legend-item escalation-sides-legend-item-binding'>
 								<span aria-hidden='true' className='escalation-sides-legend-marker' />
-								<span className='panel-label'>{UI_STRINGS.reportingSection.leadHoldingCapitalLabel}</span>
-								<CurrencyValue copyable={false} value={displayBindingCapital} suffix={UI_STRINGS.common.repLabel} />
+								<span className='panel-label'>{UI_STRING_LEAD_HOLDING_CAPITAL}</span>
+								<CurrencyValue copyable={false} value={displayBindingCapital} suffix={UI_STRING_REP} />
 							</div>
 						</div>
-						<div className='escalation-sides' role='radiogroup' aria-label={UI_STRINGS.reportingSection.reportOutcomeAriaLabel}>
+						<div className='escalation-sides' role='radiogroup' aria-label={UI_STRING_REPORT_OUTCOME_REPORTING_SECTION_REPORT_OUTCOME_ARIA_LABEL}>
 							{outcomeSides.map((side, index) => (
 								<EscalationSide
 									key={side.key}
@@ -610,12 +714,12 @@ export function ReportingSection({
 					{reportOutcomeSelectionMessage === undefined ? undefined : <p className='detail'>{reportOutcomeSelectionMessage}</p>}
 					{effectiveReportingDetails?.viewerVaultAvailableEscalationRep === undefined ? undefined : (
 						<p className='detail'>
-							{UI_STRINGS.reportingSection.availableUnlockedVaultRepPrefix} <CurrencyValue value={effectiveReportingDetails.viewerVaultAvailableEscalationRep} suffix={UI_STRINGS.common.repLabel} />.
+							{UI_STRING_AVAILABLE_UNLOCKED_VAULT_REP_FOR_REPORTING} <CurrencyValue value={effectiveReportingDetails.viewerVaultAvailableEscalationRep} suffix={UI_STRING_REP} />.
 						</p>
 					)}
 					<div className='field'>
 						<label htmlFor='reporting-contribution-amount'>
-							<span>{UI_STRINGS.reportingSection.contributionAmountLabel}</span>
+							<span>{UI_STRING_CONTRIBUTION_AMOUNT_REP}</span>
 						</label>
 						<div className='field-inline'>
 							<FormInput id='reporting-contribution-amount' className='field-inline-input' value={reportingForm.reportAmount} onInput={event => onReportingFormChange({ reportAmount: event.currentTarget.value })} disabled={reportControlsLocked} />
@@ -629,10 +733,10 @@ export function ReportingSection({
 								disabled={reportControlsLocked || maxContributionAmount.amount === undefined}
 								title={reportControlsLocked ? reportControlsLockedReason : maxContributionAmount.reason}
 							>
-								{UI_STRINGS.common.maxLabel}
+								{UI_STRING_MAX}
 							</button>
 						</div>
-						<p className='field-help'>{UI_STRINGS.reportingSection.contributionAmountHelpText}</p>
+						<p className='field-help'>{UI_STRING_THIS_IS_THE_REP_YOU_ARE_WILLING_TO_LOCK_ON_THE_SELECTED_SIDE_LARGER_AMOUNTS_CAN_CHANGE_THE_PROPOSED_OUTCOME_OR_EXTEND_THE_ESCALATION_TIMER}</p>
 					</div>
 
 					<div className='actions'>
@@ -646,7 +750,7 @@ export function ReportingSection({
 							disabled={reportControlsLocked || minimumOutcomeChangeContribution.amount === undefined}
 							title={reportControlsLocked ? reportControlsLockedReason : minimumOutcomeChangeContribution.reason}
 						>
-							{UI_STRINGS.reportingSection.minToTakeTheLeadLabel}
+							{UI_STRING_MIN_TO_TAKE_THE_LEAD}
 						</button>
 						<button
 							className='secondary'
@@ -658,7 +762,7 @@ export function ReportingSection({
 							disabled={reportControlsLocked || maxProfitContribution.amount === undefined}
 							title={reportControlsLocked ? reportControlsLockedReason : maxProfitContribution.reason}
 						>
-							{UI_STRINGS.reportingSection.maxProfitLabel}
+							{UI_STRING_MAX_PROFIT}
 						</button>
 					</div>
 
@@ -670,49 +774,43 @@ export function ReportingSection({
 					{reportAmountError === undefined ? undefined : <p className='detail'>{reportAmountError}</p>}
 					{actualReportDepositAmount === undefined || selectedAmount === undefined || actualReportDepositAmount === selectedAmount ? undefined : (
 						<p className='detail'>
-							{UI_STRINGS.reportingSection.reportingContributionLockPrefix}
-							<CurrencyValue value={actualReportDepositAmount} suffix={UI_STRINGS.common.repLabel} />
-							{UI_STRINGS.reportingSection.reportingContributionLockSuffix}
+							{UI_STRING_BASED_ON_THE_CURRENT_ESCALATION_STATE_THIS_ACTION_WOULD_LOCK}
+							<CurrencyValue value={actualReportDepositAmount} suffix={UI_STRING_REP} />
+							{UI_STRING_INSTEAD_OF_THE_FULL_ENTERED_AMOUNT}
 						</p>
 					)}
 					<div className='actions'>
-						<TransactionActionButton
-							idleLabel={reportButtonLabel}
-							pendingLabel={UI_STRINGS.reportingSection.submitReportPendingLabel}
-							onClick={onReportOutcome}
-							pending={reportingActiveAction === 'reportOutcome'}
-							availability={{ disabled: !isMainnet || !reportOutcomeEnabled || reportGuardMessage !== undefined, reason: reportGuardMessage }}
-						/>
+						<TransactionActionButton idleLabel={reportButtonLabel} pendingLabel={UI_STRING_SUBMITTING_REPORT} onClick={onReportOutcome} pending={reportingActiveAction === 'reportOutcome'} availability={{ disabled: !isMainnet || !reportOutcomeEnabled || reportGuardMessage !== undefined, reason: reportGuardMessage }} />
 					</div>
 					{projectedReportingPreview === undefined ? undefined : <p className='detail'>{projectedReportingPreview}</p>}
 				</SectionBlock>
 			) : undefined}
 
 			{showSettlementSection ? (
-				<SectionBlock className='reporting-settlement-section' title={UI_STRINGS.reportingSection.reportingSettlementTitle} variant='embedded'>
+				<SectionBlock className='reporting-settlement-section' title={UI_STRING_SETTLE_ESCALATION_DEPOSITS} variant='embedded'>
 					{reportingStageKey === 'forkTriggered' ? <p className='detail'>{forkAlreadyTriggered ? FORK_ALREADY_TRIGGERED_SETTLEMENT_REASON : FORK_TRIGGERED_SETTLEMENT_REASON}</p> : undefined}
-					{activeReportingDetails?.settlementState === 'migration-required' ? <p className='detail'>{forkAlreadyTriggered ? UI_STRINGS.reportingSection.continueInForkAndMigrationReason : UI_STRINGS.reportingSection.migrationRequiredReason}</p> : undefined}
-					{activeReportingDetails?.settlementState === 'migration-expired' ? <p className='detail'>{UI_STRINGS.reportingSection.migrationExpiredReason}</p> : undefined}
-					{hasImportedForkedDeposits ? <p className='detail'>{UI_STRINGS.reportingSection.thisPoolAlsoHasForkCarriedEscalationPositionsDetail}</p> : undefined}
+					{activeReportingDetails?.settlementState === 'migration-required' ? <p className='detail'>{forkAlreadyTriggered ? UI_STRING_CONTINUE_IN_FORK_AND_MIGRATION_TO_MIGRATE_UNRESOLVED_ESCALATION_DEPOSITS_INTO_A_CHILD_UNIVERSE : UI_STRING_THESE_ESCALATION_DEPOSITS_MUST_MIGRATE_IN_FORK_AND_MIGRATION}</p> : undefined}
+					{activeReportingDetails?.settlementState === 'migration-expired' ? <p className='detail'>{UI_STRING_THE_MIGRATION_WINDOW_FOR_THESE_UNRESOLVED_ESCALATION_DEPOSITS_HAS_CLOSED}</p> : undefined}
+					{hasImportedForkedDeposits ? <p className='detail'>{UI_STRING_THIS_POOL_ALSO_HAS_FORK_CARRIED_ESCALATION_POSITIONS_SETTLE_THOSE_IN_FORK_AND_MIGRATION}</p> : undefined}
 					{loadingReportingDetails ? (
 						<p className='detail'>
-							<LoadingText>{UI_STRINGS.reportingSection.loadingEscalationDepositsDetail}</LoadingText>
+							<LoadingText>{UI_STRING_LOADING_ESCALATION_DEPOSITS_REPORTING_SECTION_LOADING_ESCALATION_DEPOSITS_DETAIL}</LoadingText>
 						</p>
 					) : undefined}
-					{shouldShowWithdrawEmptyState && activeReportingDetails?.settlementState !== 'migration-required' && activeReportingDetails?.settlementState !== 'migration-expired' ? <p className='detail'>{UI_STRINGS.reportingSection.withdrawEmptyStateDetail}</p> : undefined}
+					{shouldShowWithdrawEmptyState && activeReportingDetails?.settlementState !== 'migration-required' && activeReportingDetails?.settlementState !== 'migration-expired' ? <p className='detail'>{UI_STRING_CONNECTED_WALLET_HAS_NO_UNSETTLED_ESCALATION_DEPOSITS}</p> : undefined}
 					{activeReportingDetails?.settlementState === 'migration-required' || activeReportingDetails?.settlementState === 'migration-expired'
 						? undefined
 						: withdrawableSides.map(side => {
 								const selectedWithdrawDepositIndexes = selectedWithdrawDepositIndexesByOutcome[side.key]
 								const allWithdrawDepositIndexes = side.userDeposits.map(deposit => deposit.depositIndex)
 								const claimLabel = getWithdrawDepositClaimLabel(effectiveReportingDetails, side.key)
-								const withdrawSelectedGuardMessage = withdrawGuardMessage ?? (!withdrawEscalationEnabled || selectedWithdrawDepositIndexes.length > 0 ? undefined : UI_STRINGS.reportingSection.settleAllForThisSideReason)
+								const withdrawSelectedGuardMessage = withdrawGuardMessage ?? (!withdrawEscalationEnabled || selectedWithdrawDepositIndexes.length > 0 ? undefined : UI_STRING_SELECT_AT_LEAST_ONE_DEPOSIT_TO_SETTLE_OR_USE_SETTLE_ALL_FOR_THIS_SIDE)
 								const isPendingSide = withdrawActionPending && pendingWithdrawOutcome === side.key
 
 								return (
 									<SectionBlock key={side.key} density='compact' headingLevel={4} title={side.label} variant='embedded'>
 										<div className='field'>
-											<span>{UI_STRINGS.reportingSection.chooseDepositsToSettleLabel}</span>
+											<span>{UI_STRING_CHOOSE_DEPOSITS_TO_SETTLE}</span>
 											<EscalationDepositSelectionList
 												disabled={withdrawControlsLocked || withdrawActionPending}
 												items={side.userDeposits.map(deposit => {
@@ -721,18 +819,18 @@ export function ReportingSection({
 														deposit,
 														details: [
 															<>
-																{UI_STRINGS.reportingSection.initiallyDepositedLabel} <CurrencyValue value={deposit.amount} suffix={UI_STRINGS.common.repLabel} />
+																{UI_STRING_INITIALLY_DEPOSITED} <CurrencyValue value={deposit.amount} suffix={UI_STRING_REP} />
 															</>,
 															claimAmount === undefined ? (
-																UI_STRINGS.reportingSection.worthAfterFinalizationPendingLabel
+																UI_STRING_WORTH_AFTER_FINALIZATION_PENDING_FINALIZATION
 															) : (
 																<>
-																	{UI_STRINGS.reportingSection.worthNowLabel} <CurrencyValue value={claimAmount} suffix={UI_STRINGS.common.repLabel} />
+																	{UI_STRING_WORTH_NOW} <CurrencyValue value={claimAmount} suffix={UI_STRING_REP} />
 																</>
 															),
-															`${UI_STRINGS.reportingSection.currentClaimTypePrefix} ${claimLabel ?? UI_STRINGS.reportingSection.pendingFinalizationLabel}`,
+															`${UI_STRING_CURRENT_CLAIM_TYPE} ${claimLabel ?? UI_STRING_PENDING_FINALIZATION}`,
 															<>
-																{UI_STRINGS.reportingSection.entryDepthLabel} <CurrencyValue value={deposit.cumulativeAmount} suffix={UI_STRINGS.common.repLabel} />
+																{UI_STRING_ENTRY_DEPTH} <CurrencyValue value={deposit.cumulativeAmount} suffix={UI_STRING_REP} />
 															</>,
 														],
 													}
@@ -751,8 +849,8 @@ export function ReportingSection({
 
 										<div className='actions'>
 											<TransactionActionButton
-												idleLabel={UI_STRINGS.reportingSection.settleSelectedDepositsLabel(side.label)}
-												pendingLabel={UI_STRINGS.reportingSection.settlingDepositsPendingLabel(side.label)}
+												idleLabel={UI_TEMPLATE_SETTLE_SELECTED_DEPOSITS_LABEL(side.label)}
+												pendingLabel={UI_TEMPLATE_SETTLING_DEPOSITS_PENDING_LABEL(side.label)}
 												onClick={() => handleWithdrawEscalation(side.key, selectedWithdrawDepositIndexes)}
 												pending={isPendingSide}
 												disabled={withdrawActionPending && pendingWithdrawOutcome !== side.key}
@@ -760,8 +858,8 @@ export function ReportingSection({
 												availability={{ disabled: !isMainnet || !withdrawEscalationEnabled || withdrawSelectedGuardMessage !== undefined, reason: withdrawSelectedGuardMessage }}
 											/>
 											<TransactionActionButton
-												idleLabel={UI_STRINGS.reportingSection.settleAllDepositsLabel(side.label)}
-												pendingLabel={UI_STRINGS.reportingSection.settlingDepositsPendingLabel(side.label)}
+												idleLabel={UI_TEMPLATE_SETTLE_ALL_DEPOSITS_LABEL(side.label)}
+												pendingLabel={UI_TEMPLATE_SETTLING_DEPOSITS_PENDING_LABEL(side.label)}
 												onClick={() => handleWithdrawEscalation(side.key, allWithdrawDepositIndexes)}
 												pending={isPendingSide}
 												disabled={withdrawActionPending && pendingWithdrawOutcome !== side.key}
@@ -781,7 +879,7 @@ export function ReportingSection({
 	)
 	if (embedInCard) return sections
 	return (
-		<RouteWorkflowPanel showHeader={showHeader} title={UI_STRINGS.reportingSection.reportingWorkflowCardTitle}>
+		<RouteWorkflowPanel showHeader={showHeader} title={UI_STRING_REPORTING_WORKFLOW}>
 			{sections}
 		</RouteWorkflowPanel>
 	)

--- a/ui/ts/components/ScalarDeploymentSection.tsx
+++ b/ui/ts/components/ScalarDeploymentSection.tsx
@@ -9,7 +9,34 @@ import { LoadingText } from './LoadingText.js'
 import { ScalarOutcomePicker } from './ScalarOutcomePicker.js'
 import { WorkflowSubsection } from './WorkflowSubsection.js'
 import { clampScalarTickIndex, formatScalarOutcomeLabel, getScalarOutcomeIndex } from '../lib/scalarOutcome.js'
-import { UI_STRINGS } from '../lib/uiStrings.js'
+import {
+	UI_STRING_CHILD_UNIVERSE_ALREADY_DEPLOYED,
+	UI_STRING_CHILD_UNIVERSE_NOT_ALREADY_DEPLOYED,
+	UI_STRING_CHILD_UNIVERSES,
+	UI_STRING_CHILD_UNIVERSES_UNAVAILABLE_BECAUSE_UNIVERSE_HAS_NOT_FORKED,
+	UI_STRING_CONFIRM_THE_SELECTED_SCALAR_OUTCOME_AND_DEPLOY_ITS_CHILD_UNIVERSE_IN_ONE_BOUNDED_EXECUTION_FLOW,
+	UI_STRING_CONNECT_A_WALLET_BEFORE_DEPLOYING_A_CHILD_UNIVERSE,
+	UI_STRING_CREATE_CHILD_UNIVERSE,
+	UI_STRING_CREATE_CHILD_UNIVERSE_TITLE,
+	UI_STRING_CREATE_INVALID_UNIVERSE,
+	UI_STRING_DEPLOY_INVALID_UNIVERSE,
+	UI_STRING_DEPLOY_UNIVERSE,
+	UI_STRING_DEPLOYED,
+	UI_STRING_DEPLOYING_UNIVERSE,
+	UI_STRING_EXISTING_CHILD_UNIVERSES,
+	UI_STRING_INVALID,
+	UI_STRING_LOADING_SCALAR_RANGE,
+	UI_STRING_NO_CHILD_UNIVERSE_SELECTED,
+	UI_STRING_NO_DEPLOYED_CHILD_UNIVERSES,
+	UI_STRING_OPENING,
+	UI_STRING_SCALAR_FORKS_CAN_DEPLOY_ONE_OUTCOME_UNIVERSE_AT_A_TIME,
+	UI_STRING_SELECT_CHILD_UNIVERSE,
+	UI_STRING_SELECTED_CHILD_UNIVERSE,
+	UI_STRING_SELECTED_TICK_IS_INVALID,
+	UI_STRING_UNIVERSE_IS_FORKED,
+	UI_STRING_WALLET_CONNECTED,
+	UI_TEMPLATE_SELECTED_TICK_LABEL,
+} from '../lib/uiStrings.js'
 import type { MarketDetails, ZoltarChildUniverseSummary } from '../types/contracts.js'
 type ScalarDeploymentSectionProps = {
 	accountAddress: Address | undefined
@@ -28,36 +55,36 @@ export function ScalarDeploymentSection({ accountAddress, childUniverses, hasFor
 	const [deployModalOpen, setDeployModalOpen] = useState(false)
 	if (questionDetails === undefined)
 		return (
-			<WorkflowSubsection title={UI_STRINGS.scalarDeploymentSection.childUniversesTitle}>
+			<WorkflowSubsection title={UI_STRING_CHILD_UNIVERSES}>
 				<p className='detail'>
-					<LoadingText>{UI_STRINGS.scalarDeploymentSection.loadingScalarRangeDetail}</LoadingText>
+					<LoadingText>{UI_STRING_LOADING_SCALAR_RANGE}</LoadingText>
 				</p>
 			</WorkflowSubsection>
 		)
 	const selectedScalarTick = BigInt(scalarOutcomeTick)
 	const clampedSelectedScalarTick = clampScalarTickIndex(selectedScalarTick, questionDetails.numTicks)
 	const clampedScalarOutcomeTick = clampedSelectedScalarTick.toString()
-	const selectedScalarOutcomeLabel = scalarOutcomeInvalid ? UI_STRINGS.scalarDeploymentSection.selectedTickInvalidLabel : formatScalarOutcomeLabel(questionDetails, clampedSelectedScalarTick)
+	const selectedScalarOutcomeLabel = scalarOutcomeInvalid ? UI_STRING_INVALID : formatScalarOutcomeLabel(questionDetails, clampedSelectedScalarTick)
 	const selectedScalarOutcomeIndex = scalarOutcomeInvalid ? 0n : getScalarOutcomeIndex(questionDetails, clampedSelectedScalarTick)
 	const selectedScalarChild = childUniverses.find(child => child.outcomeIndex === selectedScalarOutcomeIndex)
 	const selectedScalarChildExists = selectedScalarChild?.exists === true
 	const canDeployScalarChild = accountAddress !== undefined && isMainnet && hasForked && !selectedScalarChildExists
 	const deployReason = (() => {
-		if (accountAddress === undefined) return UI_STRINGS.scalarDeploymentSection.connectWalletBeforeDeployingChildUniverseReason
+		if (accountAddress === undefined) return UI_STRING_CONNECT_A_WALLET_BEFORE_DEPLOYING_A_CHILD_UNIVERSE
 		if (!isMainnet) return undefined
 
 		return (() => {
-			if (!hasForked) return UI_STRINGS.scalarDeploymentSection.forkBeforeDeployingChildUniversesReason
-			if (selectedScalarChildExists) return UI_STRINGS.scalarDeploymentSection.childUniverseAlreadyDeployedReason
+			if (!hasForked) return UI_STRING_CHILD_UNIVERSES_UNAVAILABLE_BECAUSE_UNIVERSE_HAS_NOT_FORKED
+			if (selectedScalarChildExists) return UI_STRING_CHILD_UNIVERSE_ALREADY_DEPLOYED
 
 			return scalarDeployError
 		})()
 	})()
 	const scalarDeployPending = zoltarChildUniversePendingOutcomeIndex === selectedScalarOutcomeIndex
 	const scalarDeployRequirements = [
-		{ key: 'forked', label: UI_STRINGS.scalarDeploymentSection.universeIsForkedLabel, resolved: hasForked, ...(hasForked ? {} : { detail: UI_STRINGS.scalarDeploymentSection.forkBeforeDeployingChildUniversesReason }) },
-		{ key: 'wallet', label: UI_STRINGS.scalarDeploymentSection.walletConnectedLabel, resolved: accountAddress !== undefined, ...(accountAddress !== undefined ? {} : { detail: UI_STRINGS.scalarDeploymentSection.connectWalletBeforeDeployingChildUniverseReason }) },
-		{ key: 'exists', label: UI_STRINGS.scalarDeploymentSection.childUniverseNotAlreadyDeployedLabel, resolved: !selectedScalarChildExists, ...(selectedScalarChildExists ? { detail: UI_STRINGS.scalarDeploymentSection.childUniverseAlreadyDeployedDetail } : {}) },
+		{ key: 'forked', label: UI_STRING_UNIVERSE_IS_FORKED, resolved: hasForked, ...(hasForked ? {} : { detail: UI_STRING_CHILD_UNIVERSES_UNAVAILABLE_BECAUSE_UNIVERSE_HAS_NOT_FORKED }) },
+		{ key: 'wallet', label: UI_STRING_WALLET_CONNECTED, resolved: accountAddress !== undefined, ...(accountAddress !== undefined ? {} : { detail: UI_STRING_CONNECT_A_WALLET_BEFORE_DEPLOYING_A_CHILD_UNIVERSE }) },
+		{ key: 'exists', label: UI_STRING_CHILD_UNIVERSE_NOT_ALREADY_DEPLOYED, resolved: !selectedScalarChildExists, ...(selectedScalarChildExists ? { detail: UI_STRING_CHILD_UNIVERSE_ALREADY_DEPLOYED } : {}) },
 	]
 	useEffect(() => {
 		const nextTick = clampScalarTickIndex(selectedScalarTick, questionDetails.numTicks).toString()
@@ -65,30 +92,24 @@ export function ScalarDeploymentSection({ accountAddress, childUniverses, hasFor
 		setScalarOutcomeTick(nextTick)
 	}, [questionDetails.numTicks, scalarOutcomeTick, selectedScalarTick])
 	return (
-		<WorkflowSubsection badge={<span className='detail'>{UI_STRINGS.scalarDeploymentSection.scalarForksCanDeployOneOutcomeUniverseAtATimeDetail}</span>} title={UI_STRINGS.scalarDeploymentSection.childUniversesTitle}>
-			<ChildUniversesSection
-				childUniverses={childUniverses}
-				emptyMessage={UI_STRINGS.scalarDeploymentSection.noDeployedChildUniversesMessage}
-				headerTitle={UI_STRINGS.scalarDeploymentSection.existingChildUniversesTitle}
-				renderBadge={child => <ChildUniverseStatusBadge child={child} />}
-				renderBody={child => <ChildUniverseDetails child={child} />}
-			/>
+		<WorkflowSubsection badge={<span className='detail'>{UI_STRING_SCALAR_FORKS_CAN_DEPLOY_ONE_OUTCOME_UNIVERSE_AT_A_TIME}</span>} title={UI_STRING_CHILD_UNIVERSES}>
+			<ChildUniversesSection childUniverses={childUniverses} emptyMessage={UI_STRING_NO_DEPLOYED_CHILD_UNIVERSES} headerTitle={UI_STRING_EXISTING_CHILD_UNIVERSES} renderBadge={child => <ChildUniverseStatusBadge child={child} />} renderBody={child => <ChildUniverseDetails child={child} />} />
 			<ScalarOutcomePicker
 				action={
 					<ActionLauncherButton
 						idleLabel={(() => {
-							if (selectedScalarChildExists) return UI_STRINGS.scalarDeploymentSection.deployedLabel
-							if (scalarOutcomeInvalid) return UI_STRINGS.scalarDeploymentSection.createInvalidUniverseLabel
+							if (selectedScalarChildExists) return UI_STRING_DEPLOYED
+							if (scalarOutcomeInvalid) return UI_STRING_CREATE_INVALID_UNIVERSE
 
-							return UI_STRINGS.scalarDeploymentSection.createChildUniverseLabel
+							return UI_STRING_CREATE_CHILD_UNIVERSE
 						})()}
-						pendingLabel={UI_STRINGS.scalarDeploymentSection.openingChildUniversePendingLabel}
+						pendingLabel={UI_STRING_OPENING}
 						onClick={() => {
 							try {
 								setScalarDeployError(undefined)
 								setDeployModalOpen(true)
 							} catch (error) {
-								setScalarDeployError(error instanceof Error ? error.message : UI_STRINGS.scalarDeploymentSection.selectedTickInvalidReason)
+								setScalarDeployError(error instanceof Error ? error.message : UI_STRING_SELECTED_TICK_IS_INVALID)
 							}
 						}}
 						pending={false}
@@ -103,7 +124,7 @@ export function ScalarDeploymentSection({ accountAddress, childUniverses, hasFor
 					numTicks: questionDetails.numTicks,
 				}}
 				isInvalid={scalarOutcomeInvalid}
-				label={UI_STRINGS.scalarDeploymentSection.selectChildUniverseLabel}
+				label={UI_STRING_SELECT_CHILD_UNIVERSE}
 				onInvalidChange={invalid => {
 					setScalarDeployError(undefined)
 					setScalarOutcomeInvalid(invalid)
@@ -114,28 +135,22 @@ export function ScalarDeploymentSection({ accountAddress, childUniverses, hasFor
 				}}
 				selectedOutcomeLabel={selectedScalarOutcomeLabel}
 				selectedTick={clampedScalarOutcomeTick}
-				selectedTickLabel={scalarOutcomeInvalid ? UI_STRINGS.scalarDeploymentSection.selectedTickInvalidLabel : UI_STRINGS.shareMigrationTargetsSection.selectedTickLabel(clampedScalarOutcomeTick, questionDetails.numTicks.toString())}
+				selectedTickLabel={scalarOutcomeInvalid ? UI_STRING_INVALID : UI_TEMPLATE_SELECTED_TICK_LABEL(clampedScalarOutcomeTick, questionDetails.numTicks.toString())}
 			/>
 			<ChildUniverseDeploymentModal
 				actionAvailability={{ disabled: !canDeployScalarChild || scalarDeployError !== undefined, reason: deployReason }}
-				description={UI_STRINGS.scalarDeploymentSection.executeChildUniverseDeploymentDescription}
-				idleLabel={scalarOutcomeInvalid ? UI_STRINGS.scalarDeploymentSection.deployInvalidUniverseLabel : UI_STRINGS.scalarDeploymentSection.deployUniverseLabel}
+				description={UI_STRING_CONFIRM_THE_SELECTED_SCALAR_OUTCOME_AND_DEPLOY_ITS_CHILD_UNIVERSE_IN_ONE_BOUNDED_EXECUTION_FLOW}
+				idleLabel={scalarOutcomeInvalid ? UI_STRING_DEPLOY_INVALID_UNIVERSE : UI_STRING_DEPLOY_UNIVERSE}
 				isOpen={deployModalOpen}
 				onClose={() => setDeployModalOpen(false)}
 				onConfirm={() => onCreateChildUniverseForOutcomeIndex(selectedScalarOutcomeIndex)}
 				pending={scalarDeployPending}
-				pendingLabel={UI_STRINGS.scalarDeploymentSection.deployingUniversePendingLabel}
+				pendingLabel={UI_STRING_DEPLOYING_UNIVERSE}
 				requirements={scalarDeployRequirements}
-				title={UI_STRINGS.scalarDeploymentSection.createChildUniverseTitle}
+				title={UI_STRING_CREATE_CHILD_UNIVERSE_TITLE}
 			>
 				{selectedScalarChild === undefined ? undefined : (
-					<ChildUniversesSection
-						childUniverses={[selectedScalarChild]}
-						emptyMessage={UI_STRINGS.scalarDeploymentSection.noChildUniverseSelectedMessage}
-						headerTitle={UI_STRINGS.scalarDeploymentSection.childUniverseSelectedTitle}
-						renderBadge={child => <ChildUniverseStatusBadge child={child} />}
-						renderBody={child => <ChildUniverseDetails child={child} />}
-					/>
+					<ChildUniversesSection childUniverses={[selectedScalarChild]} emptyMessage={UI_STRING_NO_CHILD_UNIVERSE_SELECTED} headerTitle={UI_STRING_SELECTED_CHILD_UNIVERSE} renderBadge={child => <ChildUniverseStatusBadge child={child} />} renderBody={child => <ChildUniverseDetails child={child} />} />
 				)}
 			</ChildUniverseDeploymentModal>
 			<ErrorNotice message={scalarDeployError} />

--- a/ui/ts/components/ScalarOutcomePicker.tsx
+++ b/ui/ts/components/ScalarOutcomePicker.tsx
@@ -1,6 +1,6 @@
 import { DataGrid } from './DataGrid.js'
 import { MetricField } from './MetricField.js'
-import { UI_STRINGS } from '../lib/uiStrings.js'
+import { UI_STRING_CURRENT_VALUE, UI_STRING_INVALID, UI_STRING_MAX_VALUE, UI_STRING_MIN_VALUE, UI_STRING_OR, UI_STRING_SELECTED_OUTCOME, UI_STRING_SELECTED_TICK } from '../lib/uiStrings.js'
 import { tryParseBigIntInput } from '../lib/marketForm.js'
 import type { ScalarOutcomePickerProps } from '../types/components.js'
 import { clampScalarTickIndex, getScalarSliderFillWidth } from '../lib/scalarOutcome.js'
@@ -25,18 +25,18 @@ export function ScalarOutcomePicker({ action, details, disabled = false, isInval
 							<input disabled={disabled || isInvalid} type='range' min='0' max={details.numTicks.toString()} step='1' value={resolvedSelectedTick} aria-valuetext={typeof selectedOutcomeLabel === 'string' ? selectedOutcomeLabel : undefined} onInput={event => onSelectedTickChange(event.currentTarget.value)} />
 						</div>
 					</div>
-					<span className='scalar-or-divider'>{UI_STRINGS.scalarOutcomePicker.orLabel}</span>
+					<span className='scalar-or-divider'>{UI_STRING_OR}</span>
 					<label className='scalar-invalid-toggle'>
 						<input type='checkbox' disabled={disabled} checked={isInvalid} onChange={event => onInvalidChange(event.currentTarget.checked)} />
-						<span>{UI_STRINGS.scalarOutcomePicker.invalidLabel}</span>
+						<span>{UI_STRING_INVALID}</span>
 					</label>
 				</div>
 			</div>
 			<DataGrid className='scalar-slider-stats'>
-				{showMinMax ? <MetricField label={UI_STRINGS.scalarOutcomePicker.minValueLabel}>{details.minValueLabel}</MetricField> : undefined}
-				<MetricField label={UI_STRINGS.scalarOutcomePicker.selectedTickLabel}>{selectedTickLabel}</MetricField>
-				<MetricField label={showMinMax ? UI_STRINGS.scalarOutcomePicker.selectedOutcomeLabel : UI_STRINGS.scalarOutcomePicker.currentValueLabel}>{selectedOutcomeLabel}</MetricField>
-				{showMinMax ? <MetricField label={UI_STRINGS.scalarOutcomePicker.maxValueLabel}>{details.maxValueLabel}</MetricField> : undefined}
+				{showMinMax ? <MetricField label={UI_STRING_MIN_VALUE}>{details.minValueLabel}</MetricField> : undefined}
+				<MetricField label={UI_STRING_SELECTED_TICK}>{selectedTickLabel}</MetricField>
+				<MetricField label={showMinMax ? UI_STRING_SELECTED_OUTCOME : UI_STRING_CURRENT_VALUE}>{selectedOutcomeLabel}</MetricField>
+				{showMinMax ? <MetricField label={UI_STRING_MAX_VALUE}>{details.maxValueLabel}</MetricField> : undefined}
 			</DataGrid>
 			{action === undefined ? undefined : <div className='actions'>{action}</div>}
 		</div>

--- a/ui/ts/components/SecurityPoolSection.tsx
+++ b/ui/ts/components/SecurityPoolSection.tsx
@@ -14,7 +14,31 @@ import { UniverseLink } from './UniverseLink.js'
 import { isMainnetChain } from '../lib/network.js'
 import { formatOpenInterestFeePerYearPercent, ORIGIN_POOL_INITIAL_RETENTION_RATE } from '../lib/retentionRate.js'
 import { getSecurityPoolCreateDisabledReason } from '../lib/securityPoolCreationGuards.js'
-import { UI_STRINGS } from '../lib/uiStrings.js'
+import {
+	UI_STRING_A_POOL_FOR_THIS_QUESTION_AND_SECURITY_MULTIPLIER_ALREADY_EXISTS_ORIGIN_POOL_DEPLOYMENT_IS_DETERMINISTIC_FOR_THAT_PAIR_SO_CHANGE_THE_SECURITY_MULTIPLIER_TO_CREATE_A_DIFFERENT_POOL,
+	UI_STRING_CHECKING_DUPLICATE,
+	UI_STRING_CREATE_ANOTHER_POOL,
+	UI_STRING_CREATE_POOL,
+	UI_STRING_CREATING_POOL,
+	UI_STRING_DEPLOYMENT_TRANSACTION_HASH,
+	UI_STRING_HEX_VALUE_PLACEHOLDER,
+	UI_STRING_INITIAL_OPEN_INTEREST_FEE_YEAR,
+	UI_STRING_INITIAL_OPEN_INTEREST_FEE_YEAR_IS_THE_STARTING_ANNUALIZED_FEE_CHARGED_AGAINST_OPEN_INTEREST_THE_RATE_FOLLOWS_POOL_UTILIZATION_AFTER_DEPLOYMENT,
+	UI_STRING_LOADING_QUESTION,
+	UI_STRING_OPEN_POOL,
+	UI_STRING_PASTE_AN_EXACT_BINARY_YES_NO_ZOLTAR_QUESTION_ID,
+	UI_STRING_POOL_ADDRESS_SECURITY_POOL_SECTION_POOL_ADDRESS_LABEL,
+	UI_STRING_POOL_ALREADY_EXISTS,
+	UI_STRING_POOL_CREATED,
+	UI_STRING_POOL_CREATION_LOCKED,
+	UI_STRING_QUESTION_ID,
+	UI_STRING_RETURN_TO_BROWSE,
+	UI_STRING_SECURITY_MULTIPLIER,
+	UI_STRING_SECURITY_MULTIPLIER_SETS_THE_REP_COLLATERAL_TARGET_RELATIVE_TO_OPEN_INTEREST_HIGHER_VALUES_REQUIRE_MORE_REP_BACKING_AND_CREATE_A_THICKER_SAFETY_BUFFER,
+	UI_STRING_SECURITY_POOLS_CAN_ONLY_BE_CREATED_FOR_EXACT_BINARY_YES_NO_QUESTIONS_ENTER_AN_ELIGIBLE_QUESTION_TO_PROCEED,
+	UI_STRING_SECURITY_POOLS_CANNOT_BE_CREATED_AFTER_ZOLTAR_HAS_FORKED,
+	UI_STRING_UNIVERSE,
+} from '../lib/uiStrings.js'
 import type { SecurityPoolSectionProps } from '../types/components.js'
 
 export function SecurityPoolSection({
@@ -56,32 +80,32 @@ export function SecurityPoolSection({
 			createdQuestionDetails = carriedPoolCreationMarketDetails
 		}
 
-	let createButtonLabel: ComponentChildren = UI_STRINGS.securityPoolSection.createPoolButtonIdleLabel
+	let createButtonLabel: ComponentChildren = UI_STRING_CREATE_POOL
 	if (securityPoolCreating) {
-		createButtonLabel = <LoadingText>{UI_STRINGS.securityPoolSection.createPoolButtonPendingLabel}</LoadingText>
+		createButtonLabel = <LoadingText>{UI_STRING_CREATING_POOL}</LoadingText>
 	} else if (checkingDuplicateOriginPool) {
-		createButtonLabel = <LoadingText>{UI_STRINGS.securityPoolSection.duplicateCheckPendingLabel}</LoadingText>
+		createButtonLabel = <LoadingText>{UI_STRING_CHECKING_DUPLICATE}</LoadingText>
 	} else if (duplicateOriginPoolExists) {
-		createButtonLabel = UI_STRINGS.securityPoolSection.poolAlreadyExistsLabel
-	} else if (zoltarUniverseHasForked) createButtonLabel = UI_STRINGS.securityPoolSection.createPoolLockedLabel
+		createButtonLabel = UI_STRING_POOL_ALREADY_EXISTS
+	} else if (zoltarUniverseHasForked) createButtonLabel = UI_STRING_POOL_CREATION_LOCKED
 
 	const createdPoolResult =
 		securityPoolResult === undefined ? undefined : (
 			<EntityCard
-				title={UI_STRINGS.securityPoolSection.createdPoolCardTitle}
+				title={UI_STRING_POOL_CREATED}
 				variant='record'
 				actions={
 					<div className='actions'>
 						<button className='primary' onClick={() => onOpenCreatedPool?.(securityPoolResult.securityPoolAddress)}>
-							{UI_STRINGS.securityPoolSection.openPoolLabel}
+							{UI_STRING_OPEN_POOL}
 						</button>
 						{onReturnToBrowse === undefined ? undefined : (
 							<button className='secondary' onClick={onReturnToBrowse}>
-								{UI_STRINGS.securityPoolSection.returnToBrowseLabel}
+								{UI_STRING_RETURN_TO_BROWSE}
 							</button>
 						)}
 						<button className='secondary' onClick={onResetSecurityPoolCreation}>
-							{UI_STRINGS.securityPoolSection.createAnotherPoolLabel}
+							{UI_STRING_CREATE_ANOTHER_POOL}
 						</button>
 					</div>
 				}
@@ -89,23 +113,23 @@ export function SecurityPoolSection({
 				<Question question={createdQuestionDetails} loading={createdQuestionDetails === undefined} />
 				<ul className='status-list hashes'>
 					<li>
-						<span>{UI_STRINGS.securityPoolSection.poolAddressLabel}</span>
+						<span>{UI_STRING_POOL_ADDRESS_SECURITY_POOL_SECTION_POOL_ADDRESS_LABEL}</span>
 						<strong>
 							<AddressValue address={securityPoolResult.securityPoolAddress} />
 						</strong>
 					</li>
 					<li>
-						<span>{UI_STRINGS.securityPoolSection.securityMultiplierLabel}</span>
+						<span>{UI_STRING_SECURITY_MULTIPLIER}</span>
 						<strong>{securityPoolResult.securityMultiplier.toString()}</strong>
 					</li>
 					<li>
-						<span>{UI_STRINGS.securityPoolSection.universeLabel}</span>
+						<span>{UI_STRING_UNIVERSE}</span>
 						<strong>
 							<UniverseLink universeId={securityPoolResult.universeId} />
 						</strong>
 					</li>
 					<li>
-						<span>{UI_STRINGS.securityPoolSection.deploymentTransactionHashLabel}</span>
+						<span>{UI_STRING_DEPLOYMENT_TRANSACTION_HASH}</span>
 						<strong>
 							<TransactionHashLink hash={securityPoolResult.deployPoolHash} />
 						</strong>
@@ -115,7 +139,7 @@ export function SecurityPoolSection({
 		)
 
 	return (
-		<RouteWorkflowPanel showHeader={showHeader} title={UI_STRINGS.securityPoolSection.createPoolPanelTitle}>
+		<RouteWorkflowPanel showHeader={showHeader} title={UI_STRING_CREATE_POOL}>
 			{hasSecurityPoolResult ? (
 				<>
 					{createdPoolResult}
@@ -123,15 +147,15 @@ export function SecurityPoolSection({
 				</>
 			) : (
 				<>
-					<SectionBlock title={UI_STRINGS.securityPoolSection.createPoolPanelTitle} variant='plain'>
+					<SectionBlock title={UI_STRING_CREATE_POOL} variant='plain'>
 						<div className='form-grid'>
 							<div className='field'>
-								<LookupFieldRow label={UI_STRINGS.securityPoolSection.questionIdLabel} value={securityPoolForm.marketId} onInput={marketId => onSecurityPoolFormChange({ marketId })} placeholder={UI_STRINGS.securityPoolSection.questionIdPlaceholder} />
-								<p className='field-help'>{UI_STRINGS.securityPoolSection.questionHelpText}</p>
+								<LookupFieldRow label={UI_STRING_QUESTION_ID} value={securityPoolForm.marketId} onInput={marketId => onSecurityPoolFormChange({ marketId })} placeholder={UI_STRING_HEX_VALUE_PLACEHOLDER} />
+								<p className='field-help'>{UI_STRING_PASTE_AN_EXACT_BINARY_YES_NO_ZOLTAR_QUESTION_ID}</p>
 							</div>
 							{loadingMarketDetails ? (
 								<p className='detail'>
-									<LoadingText>{UI_STRINGS.securityPoolSection.loadingQuestionLabel}</LoadingText>
+									<LoadingText>{UI_STRING_LOADING_QUESTION}</LoadingText>
 								</p>
 							) : undefined}
 							{marketDetails === undefined ? undefined : (
@@ -142,27 +166,27 @@ export function SecurityPoolSection({
 
 							<div className='field'>
 								<label htmlFor='security-pool-security-multiplier'>
-									<span>{UI_STRINGS.securityPoolSection.securityMultiplierLabel}</span>
+									<span>{UI_STRING_SECURITY_MULTIPLIER}</span>
 								</label>
 								<FormInput id='security-pool-security-multiplier' aria-describedby='security-pool-security-multiplier-help' value={securityPoolForm.securityMultiplier} onInput={event => onSecurityPoolFormChange({ securityMultiplier: event.currentTarget.value })} />
 								<p className='field-help' id='security-pool-security-multiplier-help'>
-									{UI_STRINGS.securityPoolSection.securityMultiplierHelpText}
+									{UI_STRING_SECURITY_MULTIPLIER_SETS_THE_REP_COLLATERAL_TARGET_RELATIVE_TO_OPEN_INTEREST_HIGHER_VALUES_REQUIRE_MORE_REP_BACKING_AND_CREATE_A_THICKER_SAFETY_BUFFER}
 								</p>
 							</div>
 
 							<div className='field'>
-								<span>{UI_STRINGS.securityPoolSection.initialOpenInterestFeeLabel}</span>
+								<span>{UI_STRING_INITIAL_OPEN_INTEREST_FEE_YEAR}</span>
 								<strong>{formatOpenInterestFeePerYearPercent(ORIGIN_POOL_INITIAL_RETENTION_RATE)}</strong>
-								<p className='field-help'>{UI_STRINGS.securityPoolSection.initialOpenInterestFeeHelpText}</p>
+								<p className='field-help'>{UI_STRING_INITIAL_OPEN_INTEREST_FEE_YEAR_IS_THE_STARTING_ANNUALIZED_FEE_CHARGED_AGAINST_OPEN_INTEREST_THE_RATE_FOLLOWS_POOL_UTILIZATION_AFTER_DEPLOYMENT}</p>
 							</div>
 
 							<div className='actions'>
-								<TransactionActionButton idleLabel={createButtonLabel} pendingLabel={UI_STRINGS.securityPoolSection.createPoolButtonPendingLabel} onClick={onCreateSecurityPool} pending={securityPoolCreating} availability={{ disabled: isCreateDisabled, reason: createDisabledReason }} />
+								<TransactionActionButton idleLabel={createButtonLabel} pendingLabel={UI_STRING_CREATING_POOL} onClick={onCreateSecurityPool} pending={securityPoolCreating} availability={{ disabled: isCreateDisabled, reason: createDisabledReason }} />
 							</div>
 						</div>
-						{!duplicateOriginPoolExists ? undefined : <p className='detail'>{UI_STRINGS.securityPoolSection.duplicatePoolError}</p>}
-						{marketDetails !== undefined && marketDetails.marketType !== 'binary' ? <p className='notice error'>{UI_STRINGS.securityPoolSection.ineligibleQuestionError}</p> : undefined}
-						{zoltarUniverseHasForked ? <p className='notice error'>{UI_STRINGS.securityPoolSection.creationLockedError}</p> : undefined}
+						{!duplicateOriginPoolExists ? undefined : <p className='detail'>{UI_STRING_A_POOL_FOR_THIS_QUESTION_AND_SECURITY_MULTIPLIER_ALREADY_EXISTS_ORIGIN_POOL_DEPLOYMENT_IS_DETERMINISTIC_FOR_THAT_PAIR_SO_CHANGE_THE_SECURITY_MULTIPLIER_TO_CREATE_A_DIFFERENT_POOL}</p>}
+						{marketDetails !== undefined && marketDetails.marketType !== 'binary' ? <p className='notice error'>{UI_STRING_SECURITY_POOLS_CAN_ONLY_BE_CREATED_FOR_EXACT_BINARY_YES_NO_QUESTIONS_ENTER_AN_ELIGIBLE_QUESTION_TO_PROCEED}</p> : undefined}
+						{zoltarUniverseHasForked ? <p className='notice error'>{UI_STRING_SECURITY_POOLS_CANNOT_BE_CREATED_AFTER_ZOLTAR_HAS_FORKED}</p> : undefined}
 					</SectionBlock>
 
 					<ErrorNotice message={securityPoolError} />

--- a/ui/ts/components/SecurityPoolWorkflowSection.tsx
+++ b/ui/ts/components/SecurityPoolWorkflowSection.tsx
@@ -72,7 +72,80 @@ import { useForkWorkflowSelectionState } from '../hooks/useForkWorkflowSelection
 import { useSelectedVaultWorkflowState, type SelectedVaultView } from '../hooks/useSelectedVaultWorkflowState.js'
 import type { SecurityPoolWorkflowRouteContentProps, ViewTabOption } from '../types/components.js'
 import type { ForkAuctionDetails, ListedSecurityPool } from '../types/contracts.js'
-import { UI_STRINGS } from '../lib/uiStrings.js'
+import {
+	UI_STRING_0,
+	UI_STRING_ADDITIONAL_POOL_ACTIONS,
+	UI_STRING_AMOUNT,
+	UI_STRING_AUTO_EXEC_PENDING,
+	UI_STRING_BUT_THE_APP_IS_CURRENTLY_SET_TO,
+	UI_STRING_DIRECTORY,
+	UI_STRING_ETH,
+	UI_STRING_EXECUTE_STAGED_OPERATION,
+	UI_STRING_EXECUTING_STAGED_OPERATION_SECURITY_POOL_WORKFLOW_SECTION_EXECUTING_STAGED_OPERATION_LABEL,
+	UI_STRING_HEX_VALUE_PLACEHOLDER,
+	UI_STRING_INITIATOR,
+	UI_STRING_INSPECT_THE_LIQUIDATION_QUOTE_TIMEOUT_AND_EXECUTION_PATH_BEFORE_QUEUEING_LIQUIDATION,
+	UI_STRING_LIQUIDATION,
+	UI_STRING_LOAD_STAGED_OPERATIONS,
+	UI_STRING_LOADING_VAULT,
+	UI_STRING_MANAGE_POOL,
+	UI_STRING_MANUAL_EXECUTION,
+	UI_STRING_NO_STAGED_OPERATIONS_ARE_CURRENTLY_QUEUED_FOR_THIS_POOL,
+	UI_STRING_NO_VAULTS_IN_THIS_POOL,
+	UI_STRING_NONE,
+	UI_STRING_NONE_QUEUED,
+	UI_STRING_NOT_FOUND,
+	UI_STRING_OPEN_ORACLE,
+	UI_STRING_OPEN_ORACLE_PRICE,
+	UI_STRING_OPERATION_ID,
+	UI_STRING_PARENT_POOL,
+	UI_STRING_PENDING_REQUEST,
+	UI_STRING_POOL_NOT_FOUND,
+	UI_STRING_PRIMARY_POOL_ACTIONS,
+	UI_STRING_QUESTION,
+	UI_STRING_REFRESH,
+	UI_STRING_REFRESH_ORACLE,
+	UI_STRING_REFRESH_POOL,
+	UI_STRING_REFRESH_STAGED_OPERATIONS,
+	UI_STRING_REFRESHING,
+	UI_STRING_REFRESHING_OPERATIONS,
+	UI_STRING_REFRESHING_ORACLE,
+	UI_STRING_REFRESHING_POOL,
+	UI_STRING_REPORTING_OPENS_AFTER_MARKET_END,
+	UI_STRING_REQUEST_COST,
+	UI_STRING_REQUEST_NEW_PRICE,
+	UI_STRING_REQUESTING_NEW_PRICE,
+	UI_STRING_REVIEW_LIQUIDATION,
+	UI_STRING_SECURITY_POOL_ADDRESS,
+	UI_STRING_SELECT_VAULT,
+	UI_STRING_SELECTED,
+	UI_STRING_SELECTED_POOL,
+	UI_STRING_SELECTED_POOL_VAULT_VIEWS,
+	UI_STRING_SELECTED_POOL_VIEWS,
+	UI_STRING_SELECTED_VAULT_ADDRESS,
+	UI_STRING_SET_BOND_ALLOWANCE,
+	UI_STRING_STAGED_OPERATION_ID,
+	UI_STRING_STAGED_OPERATIONS,
+	UI_STRING_STAGED_OPERATIONS_LIST,
+	UI_STRING_TARGET_VAULT,
+	UI_STRING_THIS_PARENT_POOL_IS_FORKED_CONTINUE_IN_FORK_AND_MIGRATION_FOR_MIGRATION_AND_SETTLEMENT,
+	UI_STRING_THIS_POOL_BELONGS_TO,
+	UI_STRING_THIS_POOL_DOES_NOT_EXIST,
+	UI_STRING_THIS_POOL_HAS_ALREADY_ENTERED_FORK_AND_MIGRATION,
+	UI_STRING_THIS_POOL_IS_CURRENTLY_OPERATIONAL_SO_FORK_AND_TRUTH_AUCTION_ACTIONS_ARE_READ_ONLY,
+	UI_STRING_THIS_POOL_IS_IN_FORK_MIGRATION_REPORTING_ACTIONS_UNLOCK_ONCE_THE_POOL_BECOMES_OPERATIONAL,
+	UI_STRING_THIS_POOL_IS_IN_TRUTH_AUCTION_REPORTING_ACTIONS_UNLOCK_ONCE_THE_POOL_BECOMES_OPERATIONAL,
+	UI_STRING_THIS_VAULT_DOES_NOT_EXIST,
+	UI_STRING_TRIGGERING_A_ZOLTAR_FORK_IS_NOT_AVAILABLE_IN_THE_CURRENT_POOL_STATE,
+	UI_STRING_TRY_ANOTHER_VAULT_ADDRESS,
+	UI_STRING_UNIVERSE_MISMATCH,
+	UI_STRING_VAULT_DIRECTORY,
+	UI_STRING_VAULT_OPERATIONS,
+	UI_STRING_WITHDRAW_REP,
+	UI_STRING_ZOLTAR_FORK_HAS_ALREADY_BEEN_TRIGGERED_FOR_THIS_POOL_CONTINUE_IN_FORK_AND_MIGRATION,
+	UI_TEMPLATE_PENDING_REPORT_LABEL,
+	UI_TEMPLATE_SHOWING_ACTIVE_STAGED_OPERATIONS_LABEL,
+} from '../lib/uiStrings.js'
 
 function buildSelectedPoolSummaryPool({ forkAuctionDetails, selectedPool }: { forkAuctionDetails: ForkAuctionDetails | undefined; selectedPool: ListedSecurityPool | undefined }) {
 	if (selectedPool === undefined) return undefined
@@ -97,17 +170,17 @@ function buildSelectedPoolSummaryPool({ forkAuctionDetails, selectedPool }: { fo
 function getPendingOperationLabel(operation: 'liquidation' | 'setSecurityBondsAllowance' | 'withdrawRep') {
 	switch (operation) {
 		case 'liquidation':
-			return UI_STRINGS.securityPoolWorkflowSection.pendingOperationLiquidationLabel
+			return UI_STRING_LIQUIDATION
 		case 'withdrawRep':
-			return UI_STRINGS.securityPoolWorkflowSection.pendingOperationWithdrawRepLabel
+			return UI_STRING_WITHDRAW_REP
 		case 'setSecurityBondsAllowance':
-			return UI_STRINGS.securityPoolWorkflowSection.pendingOperationSetBondAllowanceLabel
+			return UI_STRING_SET_BOND_ALLOWANCE
 		default:
 			return assertNever(operation)
 	}
 }
 function getStagedOperationExecutionModeLabel(operationId: bigint, pendingSettlementOperationIds: bigint[]) {
-	return pendingSettlementOperationIds.includes(operationId) ? UI_STRINGS.securityPoolWorkflowSection.autoExecPendingLabel : UI_STRINGS.securityPoolWorkflowSection.manualExecutionLabel
+	return pendingSettlementOperationIds.includes(operationId) ? UI_STRING_AUTO_EXEC_PENDING : UI_STRING_MANUAL_EXECUTION
 }
 function getSecurityPoolStatusBadgeTone(systemState: SecurityPoolLifecycleState | undefined) {
 	if (systemState === 'operational') return 'ok'
@@ -222,12 +295,12 @@ export function SecurityPoolWorkflowSection({
 	})
 	const triggerZoltarForkReason = (() => {
 		if (selectedPoolReportingStage === 'forkTriggered' && selectedPoolHasActualForkActivity) {
-			return UI_STRINGS.securityPoolWorkflowSection.triggerZoltarForkAlreadyTriggeredReason
+			return UI_STRING_ZOLTAR_FORK_HAS_ALREADY_BEEN_TRIGGERED_FOR_THIS_POOL_CONTINUE_IN_FORK_AND_MIGRATION
 		}
 		if (selectedPoolReportingStage === 'forkTriggered' && selectedPoolState !== 'operational') {
-			return UI_STRINGS.securityPoolWorkflowSection.triggerZoltarForkEnteredForkWorkflowReason
+			return UI_STRING_THIS_POOL_HAS_ALREADY_ENTERED_FORK_AND_MIGRATION
 		}
-		return UI_STRINGS.securityPoolWorkflowSection.triggerZoltarForkUnavailableReason
+		return UI_STRING_TRIGGERING_A_ZOLTAR_FORK_IS_NOT_AVAILABLE_IN_THE_CURRENT_POOL_STATE
 	})()
 	const triggerZoltarForkAvailability = {
 		disabled: !(selectedPoolReportingStage === 'forkTriggered' && !selectedPoolHasActualForkActivity && selectedPoolState === 'operational' && selectedPoolQuestionOutcome === 'none'),
@@ -239,11 +312,11 @@ export function SecurityPoolWorkflowSection({
 	})()
 	const selectedPoolForkWorkflowSystemState = selectedPoolLifecycleState === undefined || selectedPoolLifecycleState === 'ended' ? selectedPoolState : selectedPoolLifecycleState
 	const reportingLockedReason = (() => {
-		if (selectedPoolState === 'poolForked') return UI_STRINGS.securityPoolWorkflowSection.reportingLockedForkedReason
-		if (selectedPoolState === 'forkMigration') return UI_STRINGS.securityPoolWorkflowSection.reportingLockedForkMigrationReason
-		if (selectedPoolState === 'forkTruthAuction') return UI_STRINGS.securityPoolWorkflowSection.reportingLockedTruthAuctionReason
+		if (selectedPoolState === 'poolForked') return UI_STRING_THIS_PARENT_POOL_IS_FORKED_CONTINUE_IN_FORK_AND_MIGRATION_FOR_MIGRATION_AND_SETTLEMENT
+		if (selectedPoolState === 'forkMigration') return UI_STRING_THIS_POOL_IS_IN_FORK_MIGRATION_REPORTING_ACTIONS_UNLOCK_ONCE_THE_POOL_BECOMES_OPERATIONAL
+		if (selectedPoolState === 'forkTruthAuction') return UI_STRING_THIS_POOL_IS_IN_TRUTH_AUCTION_REPORTING_ACTIONS_UNLOCK_ONCE_THE_POOL_BECOMES_OPERATIONAL
 		if (reportingReady) return undefined
-		if (marketDetails === undefined) return UI_STRINGS.securityPoolWorkflowSection.reportingOpensAfterMarketEndReason
+		if (marketDetails === undefined) return UI_STRING_REPORTING_OPENS_AFTER_MARKET_END
 
 		return getReportingLockedUntilMessage(marketDetails.endTime, currentTimestamp)
 	})()
@@ -297,8 +370,8 @@ export function SecurityPoolWorkflowSection({
 				selectedPoolUniverseMismatch,
 			})
 	const selectedVaultViewOptions: ViewTabOption<SelectedVaultView>[] = [
-		{ label: UI_STRINGS.securityPoolWorkflowSection.directoryViewLabel, value: 'browse-vaults' },
-		{ label: UI_STRINGS.securityPoolWorkflowSection.selectedViewLabel, value: 'selected-vault' },
+		{ label: UI_STRING_DIRECTORY, value: 'browse-vaults' },
+		{ label: UI_STRING_SELECTED, value: 'selected-vault' },
 	]
 	const selectedPoolManagerAddress = selectedPool?.managerAddress
 	const currentPoolOracleManagerDetails = getCurrentPoolOracleManagerDetails({
@@ -396,10 +469,10 @@ export function SecurityPoolWorkflowSection({
 		if (securityVault.loadingSecurityVault)
 			return (
 				<p className='detail'>
-					<LoadingText>{UI_STRINGS.securityPoolWorkflowSection.loadingVaultDetail}</LoadingText>
+					<LoadingText>{UI_STRING_LOADING_VAULT}</LoadingText>
 				</p>
 			)
-		if (securityVault.securityVaultMissing) return <StateHint presentation={{ key: 'not_found', badgeLabel: UI_STRINGS.securityPoolWorkflowSection.notFoundBadgeLabel, badgeTone: 'blocked', detail: UI_STRINGS.securityPoolWorkflowSection.tryAnotherVaultAddressDetail }} />
+		if (securityVault.securityVaultMissing) return <StateHint presentation={{ key: 'not_found', badgeLabel: UI_STRING_NOT_FOUND, badgeTone: 'blocked', detail: UI_STRING_TRY_ANOTHER_VAULT_ADDRESS }} />
 
 		return undefined
 	})()
@@ -438,14 +511,14 @@ export function SecurityPoolWorkflowSection({
 						variant='hero'
 					>
 						{selectedPoolSummaryPool.parent === zeroAddress ? undefined : (
-							<MetricField label={UI_STRINGS.securityPoolWorkflowSection.parentPoolLabel}>
+							<MetricField label={UI_STRING_PARENT_POOL}>
 								<SecurityPoolLink securityPoolAddress={selectedPoolSummaryPool.parent} selectedPoolView={selectedPoolView} universeId={selectedPoolParentPool?.universeId} />
 							</MetricField>
 						)}
 						{currentPoolOracleManagerDetails?.pendingReportId === undefined || currentPoolOracleManagerDetails.pendingReportId === 0n ? undefined : (
-							<MetricField label={UI_STRINGS.securityPoolWorkflowSection.pendingRequestLabel}>
+							<MetricField label={UI_STRING_PENDING_REQUEST}>
 								<button className='link' type='button' onClick={() => onViewPendingReport(currentPoolOracleManagerDetails.pendingReportId)}>
-									{UI_STRINGS.securityPoolWorkflowSection.pendingReportLabel(currentPoolOracleManagerDetails.pendingReportId.toString())}
+									{UI_TEMPLATE_PENDING_REPORT_LABEL(currentPoolOracleManagerDetails.pendingReportId.toString())}
 								</button>
 							</MetricField>
 						)}
@@ -459,24 +532,24 @@ export function SecurityPoolWorkflowSection({
 				<div className='selected-pool-context-overview'>
 					<SecurityPoolSummaryMetrics metricVariant='context' pool={selectedPoolSummaryPool} repPerEthPrice={repPerEthPrice} repPerEthSource={repPerEthSource} repPerEthSourceUrl={repPerEthSourceUrl} showTotalBacking>
 						{selectedPoolSummaryPool.parent === zeroAddress ? undefined : (
-							<MetricField label={UI_STRINGS.securityPoolWorkflowSection.parentPoolLabel}>
+							<MetricField label={UI_STRING_PARENT_POOL}>
 								<SecurityPoolLink securityPoolAddress={selectedPoolSummaryPool.parent} selectedPoolView={selectedPoolView} universeId={selectedPoolParentPool?.universeId} />
 							</MetricField>
 						)}
-						<MetricField label={UI_STRINGS.securityPoolWorkflowSection.openOraclePriceLabel} valueTagName='span'>
+						<MetricField label={UI_STRING_OPEN_ORACLE_PRICE} valueTagName='span'>
 							<OpenOraclePriceValue currentTimestamp={currentTimestamp} lastPrice={currentPoolOraclePrice} lastSettlementTimestamp={currentPoolOracleSettlementTimestamp ?? 0n} priceValidUntilTimestamp={currentPoolOracleManagerDetails?.priceValidUntilTimestamp} />
 						</MetricField>
 						{currentPoolOracleManagerDetails?.pendingReportId === undefined || currentPoolOracleManagerDetails.pendingReportId === 0n ? undefined : (
-							<MetricField label={UI_STRINGS.securityPoolWorkflowSection.pendingRequestLabel}>
+							<MetricField label={UI_STRING_PENDING_REQUEST}>
 								<button className='link' type='button' onClick={() => onViewPendingReport(currentPoolOracleManagerDetails.pendingReportId)}>
-									{UI_STRINGS.securityPoolWorkflowSection.pendingReportLabel(currentPoolOracleManagerDetails.pendingReportId.toString())}
+									{UI_TEMPLATE_PENDING_REPORT_LABEL(currentPoolOracleManagerDetails.pendingReportId.toString())}
 								</button>
 							</MetricField>
 						)}
 					</SecurityPoolSummaryMetrics>
 				</div>
 				{marketDetails === undefined ? undefined : (
-					<SectionBlock headingLevel={3} title={UI_STRINGS.securityPoolWorkflowSection.questionTitle} variant='embedded'>
+					<SectionBlock headingLevel={3} title={UI_STRING_QUESTION} variant='embedded'>
 						<Question question={marketDetails} />
 					</SectionBlock>
 				)}
@@ -670,7 +743,7 @@ export function SecurityPoolWorkflowSection({
 		value: selectedPoolUiView,
 	}))
 	return (
-		<RouteWorkflowPanel showHeader={showHeader} title={UI_STRINGS.securityPoolWorkflowSection.selectedPoolTitle}>
+		<RouteWorkflowPanel showHeader={showHeader} title={UI_STRING_SELECTED_POOL}>
 			<StickyObjectContext
 				{...(loadedSelectedPool === undefined || selectedPoolSummaryPool === undefined
 					? {}
@@ -693,13 +766,13 @@ export function SecurityPoolWorkflowSection({
 				<div className='selected-pool-context-controls'>
 					<div className='selected-pool-context-lookup'>
 						<LookupFieldRow
-							label={UI_STRINGS.securityPoolWorkflowSection.securityPoolAddressLabel}
+							label={UI_STRING_SECURITY_POOL_ADDRESS}
 							value={securityPoolAddress}
 							onInput={onSecurityPoolAddressChange}
-							placeholder={UI_STRINGS.common.hexValuePlaceholder}
+							placeholder={UI_STRING_HEX_VALUE_PLACEHOLDER}
 							action={
 								<button className='secondary' onClick={() => onRefreshSelectedPoolData()} disabled={!hasSelectedPoolAddress || loadingSecurityPools}>
-									{loadingSecurityPools ? <LoadingText>{UI_STRINGS.securityPoolWorkflowSection.refreshingPoolLabel}</LoadingText> : UI_STRINGS.securityPoolWorkflowSection.refreshPoolLabel}
+									{loadingSecurityPools ? <LoadingText>{UI_STRING_REFRESHING_POOL}</LoadingText> : UI_STRING_REFRESH_POOL}
 								</button>
 							}
 						/>
@@ -710,10 +783,9 @@ export function SecurityPoolWorkflowSection({
 			<ErrorNotice message={securityPoolOverviewError} />
 
 			{selectedPool === undefined || !selectedPoolUniverseMismatch ? undefined : (
-				<SectionBlock title={UI_STRINGS.securityPoolWorkflowSection.universeMismatchTitle} tone='critical'>
+				<SectionBlock title={UI_STRING_UNIVERSE_MISMATCH} tone='critical'>
 					<p className='detail'>
-						<span>{UI_STRINGS.securityPoolWorkflowSection.universeMismatchDetailPrefix}</span> <UniverseLink format='hex' universeId={selectedPool.universeId} /> <span>{UI_STRINGS.securityPoolWorkflowSection.universeMismatchDetailMiddle}</span> <span>{formatUniverseIdHex(activeUniverseId)}</span>.{' '}
-						<span>{UI_STRINGS.securityPoolWorkflowSection.universeMismatchDetailSuffix}</span>
+						<span>{UI_STRING_THIS_POOL_BELONGS_TO}</span> <UniverseLink format='hex' universeId={selectedPool.universeId} /> <span>{UI_STRING_BUT_THE_APP_IS_CURRENTLY_SET_TO}</span> <span>{formatUniverseIdHex(activeUniverseId)}</span>. <span>{UI_STRING_THIS_POOL_DOES_NOT_EXIST}</span>
 					</p>
 				</SectionBlock>
 			)}
@@ -722,11 +794,11 @@ export function SecurityPoolWorkflowSection({
 				<div className='selected-pool-workspace-grid'>
 					<div className='selected-pool-workflow-rail'>
 						<ViewTabs
-							ariaLabel={UI_STRINGS.securityPoolWorkflowSection.selectedPoolViewsAriaLabel}
+							ariaLabel={UI_STRING_SELECTED_POOL_VIEWS}
 							className='selected-pool-workflow-nav'
 							groups={[
-								{ ariaLabel: UI_STRINGS.securityPoolWorkflowSection.primaryPoolActionsAriaLabel, className: 'selected-pool-workflow-group', values: SELECTED_POOL_PRIMARY_VIEWS },
-								{ ariaLabel: UI_STRINGS.securityPoolWorkflowSection.additionalPoolActionsAriaLabel, className: 'selected-pool-workflow-group selected-pool-workflow-group-secondary', values: SELECTED_POOL_SECONDARY_VIEWS },
+								{ ariaLabel: UI_STRING_PRIMARY_POOL_ACTIONS, className: 'selected-pool-workflow-group', values: SELECTED_POOL_PRIMARY_VIEWS },
+								{ ariaLabel: UI_STRING_ADDITIONAL_POOL_ACTIONS, className: 'selected-pool-workflow-group selected-pool-workflow-group-secondary', values: SELECTED_POOL_SECONDARY_VIEWS },
 							]}
 							orientation='vertical'
 							size='compact'
@@ -738,7 +810,7 @@ export function SecurityPoolWorkflowSection({
 
 					<div className='selected-pool-workflow-content'>
 						{!showSelectedPoolWorkflowDetails ? (
-							<SectionBlock title={selectedPoolLookupState === 'missing' ? UI_STRINGS.securityPoolWorkflowSection.poolNotFoundTitle : UI_STRINGS.securityPoolWorkflowSection.managePoolTitle} variant='plain'>
+							<SectionBlock title={selectedPoolLookupState === 'missing' ? UI_STRING_POOL_NOT_FOUND : UI_STRING_MANAGE_POOL} variant='plain'>
 								{selectedPoolUniverseMismatch || selectedPoolWorkflowLockedPresentation === undefined ? undefined : <StateHint presentation={selectedPoolWorkflowLockedPresentation} />}
 							</SectionBlock>
 						) : (
@@ -747,23 +819,23 @@ export function SecurityPoolWorkflowSection({
 									<div className='workflow-stack vault-workspace'>
 										<SectionBlock
 											density='compact'
-											title={UI_STRINGS.securityPoolWorkflowSection.vaultOperationsTitle}
+											title={UI_STRING_VAULT_OPERATIONS}
 											variant='plain'
 											actions={
 												<div className='actions'>
-													<ViewTabs ariaLabel={UI_STRINGS.securityPoolWorkflowSection.selectedPoolVaultViewsAriaLabel} className='vault-content-switch' size='compact' value={vaultView} onChange={setVaultView} options={selectedVaultViewOptions} />
+													<ViewTabs ariaLabel={UI_STRING_SELECTED_POOL_VAULT_VIEWS} className='vault-content-switch' size='compact' value={vaultView} onChange={setVaultView} options={selectedVaultViewOptions} />
 												</div>
 											}
 										>
 											{selectedVaultLoadNotice}
 											<LookupFieldRow
-												label={UI_STRINGS.securityPoolWorkflowSection.selectedVaultAddressLabel}
+												label={UI_STRING_SELECTED_VAULT_ADDRESS}
 												value={selectedVaultAddressInput}
 												onInput={selectedVaultAddress => securityVault.onSecurityVaultFormChange({ selectedVaultAddress })}
-												placeholder={UI_STRINGS.common.hexValuePlaceholder}
+												placeholder={UI_STRING_HEX_VALUE_PLACEHOLDER}
 												action={
 													<button className='secondary' onClick={() => securityVault.onLoadSecurityVault()} disabled={securityVault.loadingSecurityVault}>
-														{securityVault.loadingSecurityVault ? <LoadingText>{UI_STRINGS.securityPoolWorkflowSection.refreshingVaultLabel}</LoadingText> : UI_STRINGS.common.refreshLabel}
+														{securityVault.loadingSecurityVault ? <LoadingText>{UI_STRING_REFRESHING}</LoadingText> : UI_STRING_REFRESH}
 													</button>
 												}
 											/>
@@ -782,7 +854,7 @@ export function SecurityPoolWorkflowSection({
 										</SectionBlock>
 
 										{vaultView === 'browse-vaults' ? (
-											<SectionBlock title={UI_STRINGS.securityPoolWorkflowSection.vaultDirectoryTitle} variant='embedded'>
+											<SectionBlock title={UI_STRING_VAULT_DIRECTORY} variant='embedded'>
 												<SecurityPoolVaultDirectory
 													emptyState={(() => {
 														if (selectedPool === undefined) {
@@ -791,7 +863,7 @@ export function SecurityPoolWorkflowSection({
 															return <StateHint presentation={selectedPoolBrowsePresentation} />
 														}
 
-														return <StateHint presentation={{ key: 'empty', badgeLabel: UI_STRINGS.securityPoolWorkflowSection.noneYetBadgeLabel, badgeTone: 'muted', detail: UI_STRINGS.securityPoolWorkflowSection.noVaultsInThisPoolDetail }} />
+														return <StateHint presentation={{ key: 'empty', badgeLabel: UI_STRING_NONE, badgeTone: 'muted', detail: UI_STRING_NO_VAULTS_IN_THIS_POOL }} />
 													})()}
 													pool={selectedPool}
 													renderActions={vault => {
@@ -806,20 +878,20 @@ export function SecurityPoolWorkflowSection({
 																		void securityVault.onLoadSecurityVault(vault.vaultAddress.toString())
 																	}}
 																>
-																	{UI_STRINGS.securityPoolWorkflowSection.selectVaultActionLabel}
+																	{UI_STRING_SELECT_VAULT}
 																</button>
 																<button
 																	className='secondary'
 																	onClick={() => onOpenLiquidationModal(selectedPool.managerAddress, selectedPool.securityPoolAddress, vault.vaultAddress, vault.securityBondAllowance)}
 																	disabled={accountState.address === undefined || !isMainnet || currentPoolOracleManagerDetails?.isPriceValid === false || !liquidationEnabled}
-																	title={UI_STRINGS.securityPoolWorkflowSection.reviewLiquidationTitle}
+																	title={UI_STRING_REVIEW_LIQUIDATION}
 																>
-																	{UI_STRINGS.securityPoolWorkflowSection.reviewLiquidationActionLabel}
+																	{UI_STRING_REVIEW_LIQUIDATION}
 																</button>
 															</div>
 														)
 													}}
-													renderBadge={vault => (selectedVaultAddress !== '' && sameCaseInsensitiveText(selectedVaultAddress, vault.vaultAddress) ? <Badge tone='ok'>{UI_STRINGS.securityPoolWorkflowSection.selectedBadgeLabel}</Badge> : undefined)}
+													renderBadge={vault => (selectedVaultAddress !== '' && sameCaseInsensitiveText(selectedVaultAddress, vault.vaultAddress) ? <Badge tone='ok'>{UI_STRING_SELECTED}</Badge> : undefined)}
 													repPerEthPrice={repPerEthPrice}
 													repPerEthSource={repPerEthSource}
 													repPerEthSourceUrl={repPerEthSourceUrl}
@@ -834,17 +906,17 @@ export function SecurityPoolWorkflowSection({
 														const canUseSelectedVaultActions = accountState.address !== undefined && selectedVaultIsOwnedByAccount && selectedVaultDetails !== undefined && isMainnet
 														const loadedVaultMissing = selectedVaultDetails !== undefined && !selectedVaultExistsOnchain
 														const liquidationBlocker = (() => {
-															if (loadedVaultMissing) return UI_STRINGS.securityPoolWorkflowSection.vaultMissingDetail
+															if (loadedVaultMissing) return UI_STRING_THIS_VAULT_DOES_NOT_EXIST
 															return undefined
 														})()
 
 														return {
-															actionLabel: UI_STRINGS.securityPoolWorkflowSection.reviewLiquidationActionLabel,
+															actionLabel: UI_STRING_REVIEW_LIQUIDATION,
 															...(liquidationBlocker === undefined ? {} : { blocker: liquidationBlocker }),
-															description: UI_STRINGS.securityPoolWorkflowSection.reviewLiquidationDescription,
+															description: UI_STRING_INSPECT_THE_LIQUIDATION_QUOTE_TIMEOUT_AND_EXECUTION_PATH_BEFORE_QUEUEING_LIQUIDATION,
 															key: 'liquidate-vault',
 															readiness: liquidationBlocker === undefined && liquidationEnabled && canUseSelectedVaultActions ? 'ready' : 'blocked',
-															title: UI_STRINGS.securityPoolWorkflowSection.reviewLiquidationTitle,
+															title: UI_STRING_REVIEW_LIQUIDATION,
 															...(selectedPool === undefined || selectedVaultDetails === undefined || selectedVaultAddress === '' || !liquidationEnabled || !selectedVaultExistsOnchain || !canUseSelectedVaultActions
 																? {}
 																: {
@@ -896,7 +968,7 @@ export function SecurityPoolWorkflowSection({
 										currentStageView={currentForkStage}
 										currentTimestamp={currentTimestamp}
 										disabled={forkWorkflowDisabled}
-										disabledMessage={forkWorkflowDisabled ? UI_STRINGS.securityPoolWorkflowSection.forkAndTruthReadOnlyReason : undefined}
+										disabledMessage={forkWorkflowDisabled ? UI_STRING_THIS_POOL_IS_CURRENTLY_OPERATIONAL_SO_FORK_AND_TRUTH_AUCTION_ACTIONS_ARE_READ_ONLY : undefined}
 										embedInCard
 										forkAuctionDetails={currentForkAuctionDetails}
 										lifecycleStateOverride={selectedPoolLifecycleState}
@@ -916,9 +988,9 @@ export function SecurityPoolWorkflowSection({
 								) : undefined}
 
 								{view === 'staged-operations' && loadedSelectedPool !== undefined ? (
-									<SectionBlock density='compact' title={UI_STRINGS.securityPoolWorkflowSection.stagedOperationsLabel} variant='plain'>
+									<SectionBlock density='compact' title={UI_STRING_STAGED_OPERATIONS} variant='plain'>
 										<ErrorNotice message={poolOracleManagerError} />
-										<SectionBlock density='compact' headingLevel={4} title={UI_STRINGS.securityPoolWorkflowSection.stagedOperationsListLabel} variant='embedded'>
+										<SectionBlock density='compact' headingLevel={4} title={UI_STRING_STAGED_OPERATIONS_LIST} variant='embedded'>
 											{stagedOperations.map(operation => (
 												<WarningSurface key={operation.operationId.toString()} as='article' className='warning-entity-card' variant='compact'>
 													<div className='entity-card-header'>
@@ -928,43 +1000,41 @@ export function SecurityPoolWorkflowSection({
 														</div>
 													</div>
 													<MetricGrid className='entity-card-body'>
-														<MetricField label={UI_STRINGS.securityPoolWorkflowSection.operationIdLabel}>{operation.operationId.toString()}</MetricField>
-														<MetricField label={UI_STRINGS.securityPoolWorkflowSection.initiatorLabel}>
+														<MetricField label={UI_STRING_OPERATION_ID}>{operation.operationId.toString()}</MetricField>
+														<MetricField label={UI_STRING_INITIATOR}>
 															<AddressValue address={operation.initiatorVault} />
 														</MetricField>
-														<MetricField label={UI_STRINGS.securityPoolWorkflowSection.targetVaultLabel}>
+														<MetricField label={UI_STRING_TARGET_VAULT}>
 															<AddressValue address={operation.targetVault} />
 														</MetricField>
-														<MetricField label={UI_STRINGS.securityPoolWorkflowSection.amountLabel}>
+														<MetricField label={UI_STRING_AMOUNT}>
 															<CurrencyValue value={operation.amount} />
 														</MetricField>
 													</MetricGrid>
 												</WarningSurface>
 											))}
-											{activeStagedOperationCount > BigInt(stagedOperations.length) ? <p className='detail'>{UI_STRINGS.securityPoolWorkflowSection.showingActiveStagedOperationsLabel(stagedOperations.length.toString(), activeStagedOperationCount.toString())}</p> : null}
-											{currentPoolOracleManagerDetails === undefined || stagedOperations.length > 0 ? null : (
-												<StateHint presentation={{ key: 'empty', badgeLabel: UI_STRINGS.securityPoolWorkflowSection.noneQueuedBadgeLabel, badgeTone: 'muted', detail: UI_STRINGS.securityPoolWorkflowSection.noStagedOperationsQueuedDetail }} />
-											)}
+											{activeStagedOperationCount > BigInt(stagedOperations.length) ? <p className='detail'>{UI_TEMPLATE_SHOWING_ACTIVE_STAGED_OPERATIONS_LABEL(stagedOperations.length.toString(), activeStagedOperationCount.toString())}</p> : null}
+											{currentPoolOracleManagerDetails === undefined || stagedOperations.length > 0 ? null : <StateHint presentation={{ key: 'empty', badgeLabel: UI_STRING_NONE_QUEUED, badgeTone: 'muted', detail: UI_STRING_NO_STAGED_OPERATIONS_ARE_CURRENTLY_QUEUED_FOR_THIS_POOL }} />}
 										</SectionBlock>
 										{currentPoolOracleManagerDetails === undefined ? undefined : (
 											<label className='field'>
-												<span>{UI_STRINGS.securityPoolWorkflowSection.stagedOperationIdLabel}</span>
-												<FormInput value={manualPendingOperationId} onInput={event => setManualPendingOperationId(event.currentTarget.value)} placeholder={selectedPendingOperationId > 0n ? selectedPendingOperationId.toString() : UI_STRINGS.securityPoolWorkflowSection.stagedOperationIdPlaceholder} />
+												<span>{UI_STRING_STAGED_OPERATION_ID}</span>
+												<FormInput value={manualPendingOperationId} onInput={event => setManualPendingOperationId(event.currentTarget.value)} placeholder={selectedPendingOperationId > 0n ? selectedPendingOperationId.toString() : UI_STRING_0} />
 											</label>
 										)}
 										<div className='actions'>
 											<button className='secondary' onClick={() => onLoadPoolOracleManager(loadedSelectedPool.managerAddress)} disabled={loadingPoolOracleManager}>
 												{(() => {
-													if (loadingPoolOracleManager) return <LoadingText>{UI_STRINGS.securityPoolWorkflowSection.refreshingOperationsLabel}</LoadingText>
-													if (currentPoolOracleManagerDetails === undefined) return UI_STRINGS.securityPoolWorkflowSection.loadStagedOperationsLabel
+													if (loadingPoolOracleManager) return <LoadingText>{UI_STRING_REFRESHING_OPERATIONS}</LoadingText>
+													if (currentPoolOracleManagerDetails === undefined) return UI_STRING_LOAD_STAGED_OPERATIONS
 
-													return UI_STRINGS.securityPoolWorkflowSection.refreshStagedOperationsLabel
+													return UI_STRING_REFRESH_STAGED_OPERATIONS
 												})()}
 											</button>
 											{currentPoolOracleManagerDetails === undefined ? undefined : (
 												<TransactionActionButton
-													idleLabel={UI_STRINGS.securityPoolWorkflowSection.executeStagedOperationLabel}
-													pendingLabel={UI_STRINGS.securityPoolWorkflowSection.executingStagedOperationLabel}
+													idleLabel={UI_STRING_EXECUTE_STAGED_OPERATION}
+													pendingLabel={UI_STRING_EXECUTING_STAGED_OPERATION_SECURITY_POOL_WORKFLOW_SECTION_EXECUTING_STAGED_OPERATION_LABEL}
 													onClick={() => {
 														if (resolvedPendingOperationId === undefined) return
 														onExecutePendingPoolOperation(loadedSelectedPool.managerAddress, resolvedPendingOperationId)
@@ -982,9 +1052,9 @@ export function SecurityPoolWorkflowSection({
 								) : undefined}
 
 								{view === 'price-oracle' && loadedSelectedPool !== undefined ? (
-									<SectionBlock density='compact' title={UI_STRINGS.securityPoolWorkflowSection.openOracleTitle} variant='plain'>
+									<SectionBlock density='compact' title={UI_STRING_OPEN_ORACLE} variant='plain'>
 										<MetricGrid>
-											<MetricField label={UI_STRINGS.securityPoolWorkflowSection.openOraclePriceLabel} valueTagName='span'>
+											<MetricField label={UI_STRING_OPEN_ORACLE_PRICE} valueTagName='span'>
 												<OpenOraclePriceValue
 													currentTimestamp={currentTimestamp}
 													lastPrice={(currentPoolOracleManagerDetails ?? selectedPoolOracleMetricValues)?.lastPrice}
@@ -993,14 +1063,14 @@ export function SecurityPoolWorkflowSection({
 												/>
 											</MetricField>
 											{currentPoolOracleManagerDetails === undefined ? undefined : (
-												<MetricField label={UI_STRINGS.securityPoolWorkflowSection.requestCostLabel}>
-													<CurrencyValue value={currentPoolOracleManagerDetails.requestPriceEthCost} suffix={UI_STRINGS.common.ethSuffix} />
+												<MetricField label={UI_STRING_REQUEST_COST}>
+													<CurrencyValue value={currentPoolOracleManagerDetails.requestPriceEthCost} suffix={UI_STRING_ETH} />
 												</MetricField>
 											)}
 											{currentPoolOracleManagerDetails?.pendingReportId === undefined || currentPoolOracleManagerDetails.pendingReportId === 0n ? undefined : (
-												<MetricField label={UI_STRINGS.securityPoolWorkflowSection.pendingRequestLabel}>
+												<MetricField label={UI_STRING_PENDING_REQUEST}>
 													<button className='link' type='button' onClick={() => onViewPendingReport(currentPoolOracleManagerDetails.pendingReportId)}>
-														{UI_STRINGS.securityPoolWorkflowSection.pendingReportLabel(currentPoolOracleManagerDetails.pendingReportId.toString())}
+														{UI_TEMPLATE_PENDING_REPORT_LABEL(currentPoolOracleManagerDetails.pendingReportId.toString())}
 													</button>
 												</MetricField>
 											)}
@@ -1008,11 +1078,11 @@ export function SecurityPoolWorkflowSection({
 										<ErrorNotice message={poolOracleManagerError} />
 										<div className='actions'>
 											<button className='secondary' onClick={() => onLoadPoolOracleManager(loadedSelectedPool.managerAddress)} disabled={loadingPoolOracleManager}>
-												{loadingPoolOracleManager ? <LoadingText>{UI_STRINGS.securityPoolWorkflowSection.refreshingOracleLabel}</LoadingText> : UI_STRINGS.securityPoolWorkflowSection.refreshOracleLabel}
+												{loadingPoolOracleManager ? <LoadingText>{UI_STRING_REFRESHING_ORACLE}</LoadingText> : UI_STRING_REFRESH_ORACLE}
 											</button>
 											<TransactionActionButton
-												idleLabel={UI_STRINGS.securityPoolWorkflowSection.requestNewPriceLabel}
-												pendingLabel={UI_STRINGS.securityPoolWorkflowSection.requestingNewPriceLabel}
+												idleLabel={UI_STRING_REQUEST_NEW_PRICE}
+												pendingLabel={UI_STRING_REQUESTING_NEW_PRICE}
 												onClick={() => onRequestPoolPrice(loadedSelectedPool.managerAddress)}
 												pending={poolOracleActiveAction === 'requestPrice'}
 												tone='secondary'

--- a/ui/ts/components/SecurityVaultSection.tsx
+++ b/ui/ts/components/SecurityVaultSection.tsx
@@ -30,7 +30,117 @@ import { isMainnetChain } from '../lib/network.js'
 import { resolveOracleOperationEthFunding } from '../lib/oracleRequestEth.js'
 import { getWalletMainnetGuardState } from '../lib/actionGuards.js'
 import { getSecurityPoolVaultReadinessActions } from '../lib/securityPoolReadiness.js'
-import { UI_STRINGS } from '../lib/uiStrings.js'
+import {
+	UI_STRING_A_VALID_ORACLE_PRICE_IS_AVAILABLE,
+	UI_STRING_A_VALID_ORACLE_PRICE_WAS_ALREADY_AVAILABLE_SO_THE_NEW_BOND_ALLOWANCE_EXECUTED_IMMEDIATELY_AND_NO_STAGED_OPERATION_WAS_CREATED,
+	UI_STRING_A_VALID_ORACLE_PRICE_WAS_ALREADY_AVAILABLE_SO_THE_WITHDRAWAL_EXECUTED_IMMEDIATELY_AND_NO_STAGED_OPERATION_WAS_CREATED,
+	UI_STRING_ADD_REP_TO_THE_SELECTED_VAULT,
+	UI_STRING_AMOUNT,
+	UI_STRING_APPROVING_REP,
+	UI_STRING_BOND_ALLOWANCE_EXECUTED,
+	UI_STRING_BOND_ALLOWANCE_FAILED,
+	UI_STRING_BOND_ALLOWANCE_QUEUED,
+	UI_STRING_BOND_ALLOWANCE_SUBMITTED,
+	UI_STRING_CANCEL,
+	UI_STRING_CLAIM_FEES,
+	UI_STRING_CLAIMABLE_FEES,
+	UI_STRING_CLAIMABLE_FEES_ARE_AVAILABLE,
+	UI_STRING_CLAIMING_FEES,
+	UI_STRING_CONFIRM_THE_CLAIMABLE_FEE_BALANCE_BEFORE_SUBMITTING_THE_FEE_REDEMPTION_FOR_THIS_VAULT,
+	UI_STRING_CURRENT_BOND_ALLOWANCE,
+	UI_STRING_CURRENT_SECURITY_BOND_ALLOWANCE,
+	UI_STRING_DEPOSIT_REP,
+	UI_STRING_DEPOSITING_REP,
+	UI_STRING_DEPOSITING_REP_SECURITY_VAULT_SECTION_DEPOSIT_REP_PENDING_LABEL,
+	UI_STRING_ENTER_WHOLE_MINUTES_QUEUED_SELF_SERVICE_OPERATIONS_MUST_STAY_EXECUTABLE_FOR_AT_LEAST_1_MINUTE_AFTER_THE_ORACLE_SETTLEMENT_WINDOW_COMPLETES,
+	UI_STRING_ESCROWED_REP,
+	UI_STRING_ETH,
+	UI_STRING_EXECUTED,
+	UI_STRING_FAILED,
+	UI_STRING_FIRST_DEPOSIT_MEETS_THE_VAULT_MINIMUM,
+	UI_STRING_HEX_VALUE_PLACEHOLDER,
+	UI_STRING_IN_THE_FIRST_DEPOSIT,
+	UI_STRING_LOADING_VAULT,
+	UI_STRING_MANUAL_EXECUTION_TIMEOUT,
+	UI_STRING_MANUAL_EXECUTION_TIMEOUT_IS_AT_LEAST_1_MINUTE,
+	UI_STRING_MANUAL_QUEUED_OPERATION,
+	UI_STRING_MAX,
+	UI_STRING_METRIC_UNAVAILABLE_PLACEHOLDER,
+	UI_STRING_MINUTES,
+	UI_STRING_NEW_VAULTS_REQUIRE_AT_LEAST,
+	UI_STRING_NO_REP_REMAINS_LOCKED_IN_THE_ESCALATION_GAME,
+	UI_STRING_NONE_SELECTED,
+	UI_STRING_NOT_FOUND,
+	UI_STRING_ORACLE_EXECUTION_CAN_BE_FUNDED_UNTIL_A_FRESH_PRICE_ARRIVES,
+	UI_STRING_OWNED,
+	UI_STRING_PRICE_VALID_UNTIL,
+	UI_STRING_QUEUE_A_NEW_BOND_ALLOWANCE_USING_THE_LATEST_VALID_ORACLE_PRICE_FOR_THE_SELECTED_VAULT,
+	UI_STRING_QUEUE_A_NEW_SECURITY_BOND_ALLOWANCE_USING_THE_CURRENT_ORACLE_PRICE_CONTEXT,
+	UI_STRING_QUEUE_A_REP_WITHDRAWAL_AFTER_REVIEWING_THE_CURRENT_VAULT_COLLATERAL_AND_ORACLE_STATUS,
+	UI_STRING_QUEUE_A_REP_WITHDRAWAL_NOW_OR_LET_IT_EXECUTE_IMMEDIATELY_WHEN_A_VALID_ORACLE_PRICE_IS_ALREADY_AVAILABLE,
+	UI_STRING_QUEUEING_ALLOWANCE_UPDATE,
+	UI_STRING_QUEUEING_REP_WITHDRAWAL,
+	UI_STRING_READ_ONLY_SECURITY_VAULT_SECTION_READ_ONLY_BADGE_LABEL,
+	UI_STRING_REDEEM_REP,
+	UI_STRING_REDEEM_THE_REMAINING_REP_COLLATERAL_FROM_THIS_ENDED_POOL_AFTER_ESCALATION_DEPOSITS_ARE_SETTLED,
+	UI_STRING_REDEEMABLE_REP,
+	UI_STRING_REDEEMING_REP,
+	UI_STRING_REFRESH,
+	UI_STRING_REFRESHING,
+	UI_STRING_REFRESHING_BOND_ALLOWANCE_STATE,
+	UI_STRING_REFRESHING_THE_ORACLE_MANAGER_TO_DETERMINE_WHETHER_THE_BOND_ALLOWANCE_WAS_QUEUED_OR_EXECUTED_IMMEDIATELY,
+	UI_STRING_REFRESHING_THE_ORACLE_MANAGER_TO_DETERMINE_WHETHER_THE_WITHDRAWAL_WAS_QUEUED_OR_EXECUTED_IMMEDIATELY,
+	UI_STRING_REFRESHING_WITHDRAWAL_STATE,
+	UI_STRING_REFRESHING_WITHOUT_ELLIPSIS,
+	UI_STRING_REP,
+	UI_STRING_REP_AVAILABLE_TO_QUEUE,
+	UI_STRING_REP_COLLATERAL,
+	UI_STRING_REP_COLLATERAL_AMOUNT,
+	UI_STRING_REP_WITHDRAW_AMOUNT,
+	UI_STRING_REP_WITHDRAWAL_EXECUTED,
+	UI_STRING_REP_WITHDRAWAL_FAILED,
+	UI_STRING_REP_WITHDRAWAL_QUEUED,
+	UI_STRING_REP_WITHDRAWAL_SUBMITTED,
+	UI_STRING_REVIEW_CLAIMABLE_FEES_AND_CONFIRM_THE_FEE_REDEMPTION_FOR_THE_SELECTED_VAULT,
+	UI_STRING_SECURITY_BOND_ALLOWANCE_AMOUNT,
+	UI_STRING_SECURITY_POOL_ADDRESS,
+	UI_STRING_SECURITY_VAULT,
+	UI_STRING_SELECTED_VAULT,
+	UI_STRING_SELECTED_VAULT_ADDRESS,
+	UI_STRING_SELECTED_VAULT_DETAILS_ARE_UNAVAILABLE,
+	UI_STRING_SELECTED_VAULT_IS_OWNED_BY_THE_CONNECTED_ACCOUNT,
+	UI_STRING_SET_BOND_ALLOWANCE,
+	UI_STRING_SET_SECURITY_BOND_ALLOWANCE,
+	UI_STRING_STAGED_OPERATION,
+	UI_STRING_STAGED_OPERATION_RETRY,
+	UI_STRING_THE_ORACLE_MANAGER_ATTEMPTED_THE_ALLOWANCE_UPDATE_IMMEDIATELY_BUT_THE_SECURITY_POOL_REJECTED_IT,
+	UI_STRING_THE_ORACLE_MANAGER_ATTEMPTED_THE_WITHDRAWAL_IMMEDIATELY_BUT_THE_SECURITY_POOL_REJECTED_IT,
+	UI_STRING_THE_SECURITY_POOL_REJECTED_THE_ACTION,
+	UI_STRING_THE_VAULT_HAS_REDEEMABLE_REP,
+	UI_STRING_THE_VAULT_STILL_HOLDS_REP_COLLATERAL_TO_QUEUE,
+	UI_STRING_THIS_VAULT_DOES_NOT_EXIST,
+	UI_STRING_THIS_VAULT_DOES_NOT_EXIST_DEPOSIT_REP_TO_CREATE_IT,
+	UI_STRING_TRANSACTION_STATE_UNAVAILABLE,
+	UI_STRING_TRY_ANOTHER_POOL_ADDRESS,
+	UI_STRING_UNAVAILABLE,
+	UI_STRING_VAULT,
+	UI_STRING_VAULT_ACTIONS,
+	UI_STRING_VAULT_LOOKUP,
+	UI_STRING_VAULT_MISSING,
+	UI_STRING_VAULT_SUMMARY,
+	UI_STRING_VIEW_IN_STAGED_OPERATIONS,
+	UI_STRING_WALLET_REP,
+	UI_STRING_WALLET_REP_BALANCE_COVERS_THE_DEPOSIT_AMOUNT,
+	UI_STRING_WITHDRAW_ESCALATION_DEPOSITS,
+	UI_STRING_WITHDRAW_REP,
+	UI_STRING_WITHDRAWABLE_REP,
+	UI_TEMPLATE_ALLOWANCE_CHECKLIST_LABEL,
+	UI_TEMPLATE_FIRST_DEPOSIT_MINIMUM_CHECKLIST_DETAIL,
+	UI_TEMPLATE_INSUFFICIENT_REP_BALANCE_DETAIL,
+	UI_TEMPLATE_MANUAL_EXECUTION_TIMEOUT_RESOLVED_DETAIL,
+	UI_TEMPLATE_REP_BALANCE_SHORTAGE_DETAIL,
+	UI_TEMPLATE_VAULT_LAUNCHER_BLOCKER_REASON,
+} from '../lib/uiStrings.js'
 import { getVaultDepositGuardMessage, getVaultRedeemRepGuardMessage, getVaultSetSecurityBondAllowanceGuardMessage, getVaultWithdrawGuardMessage } from '../lib/securityVaultGuards.js'
 import { deriveTokenApprovalRequirement } from '../lib/tokenApproval.js'
 import {
@@ -63,16 +173,16 @@ type QueuedVaultOperationView = {
 	operationId: bigint
 }
 function getVaultLauncherWalletReason(action: 'claim-fees' | 'deposit-rep' | 'rep-exit' | 'set-bond-allowance', repExitMode: 'redeem' | 'withdraw') {
-	if (action === 'claim-fees') return UI_STRINGS.securityVaultSection.vaultLauncherBlockerReason('claim-fees', 'connect-wallet')
-	if (action === 'deposit-rep') return UI_STRINGS.securityVaultSection.vaultLauncherBlockerReason('deposit-rep', 'connect-wallet')
-	if (action === 'rep-exit') return repExitMode === 'redeem' ? UI_STRINGS.securityVaultSection.vaultLauncherBlockerReason('rep-exit-redeem', 'connect-wallet') : UI_STRINGS.securityVaultSection.vaultLauncherBlockerReason('rep-exit-withdraw', 'connect-wallet')
-	return UI_STRINGS.securityVaultSection.vaultLauncherBlockerReason('set-bond-allowance', 'connect-wallet')
+	if (action === 'claim-fees') return UI_TEMPLATE_VAULT_LAUNCHER_BLOCKER_REASON('claim-fees', 'connect-wallet')
+	if (action === 'deposit-rep') return UI_TEMPLATE_VAULT_LAUNCHER_BLOCKER_REASON('deposit-rep', 'connect-wallet')
+	if (action === 'rep-exit') return repExitMode === 'redeem' ? UI_TEMPLATE_VAULT_LAUNCHER_BLOCKER_REASON('rep-exit-redeem', 'connect-wallet') : UI_TEMPLATE_VAULT_LAUNCHER_BLOCKER_REASON('rep-exit-withdraw', 'connect-wallet')
+	return UI_TEMPLATE_VAULT_LAUNCHER_BLOCKER_REASON('set-bond-allowance', 'connect-wallet')
 }
 export function SelectedVaultSummarySection({ repPerEthPrice, repPerEthSource, repPerEthSourceUrl, securityBondAllowance, securityVaultDetails, selectedPoolSecurityMultiplier, selectedVaultIsOwnedByAccount, variant = 'record' }: SelectedVaultSummarySectionProps) {
 	const collateralizationPercent = getVaultCollateralizationPercent(securityVaultDetails.repDepositShare, securityBondAllowance, repPerEthPrice)
 	const collateralizationTarget = selectedPoolSecurityMultiplier === undefined ? undefined : selectedPoolSecurityMultiplier * 100n * 10n ** 18n
 
-	const summaryTitle = <span>{UI_STRINGS.securityVaultSection.vaultSummaryTitle}</span>
+	const summaryTitle = <span>{UI_STRING_VAULT_SUMMARY}</span>
 
 	const embeddedContent = (
 		<div className='security-pool-selected-vault-summary security-pool-browse-vault-list'>
@@ -87,15 +197,15 @@ export function SelectedVaultSummarySection({ repPerEthPrice, repPerEthSource, r
 						</div>
 					</div>
 					<div className='security-pool-browse-vault-row-kpi'>
-						<span>{UI_STRINGS.securityVaultSection.currentSecurityBondAllowanceLabel}</span>
+						<span>{UI_STRING_CURRENT_SECURITY_BOND_ALLOWANCE}</span>
 						<strong>
-							<CurrencyValue value={securityBondAllowance} suffix={UI_STRINGS.common.ethSuffix} />
+							<CurrencyValue value={securityBondAllowance} suffix={UI_STRING_ETH} />
 						</strong>
 					</div>
 					<div className='security-pool-browse-vault-row-kpi'>
-						<span>{UI_STRINGS.securityVaultSection.repCollateralLabel}</span>
+						<span>{UI_STRING_REP_COLLATERAL}</span>
 						<strong>
-							<CurrencyValue value={securityVaultDetails.repDepositShare} suffix={UI_STRINGS.common.repLabel} />
+							<CurrencyValue value={securityVaultDetails.repDepositShare} suffix={UI_STRING_REP} />
 						</strong>
 					</div>
 				</div>
@@ -122,7 +232,7 @@ export function SelectedVaultSummarySection({ repPerEthPrice, repPerEthSource, r
 			</SectionBlock>
 		)
 	return (
-		<EntityCard badge={<Badge tone={selectedVaultIsOwnedByAccount ? 'ok' : 'muted'}>{selectedVaultIsOwnedByAccount ? UI_STRINGS.securityVaultSection.ownedBadgeLabel : UI_STRINGS.securityVaultSection.readOnlyBadgeLabel}</Badge>} title={UI_STRINGS.securityVaultSection.selectedVaultTitle} variant='record'>
+		<EntityCard badge={<Badge tone={selectedVaultIsOwnedByAccount ? 'ok' : 'muted'}>{selectedVaultIsOwnedByAccount ? UI_STRING_OWNED : UI_STRING_READ_ONLY_SECURITY_VAULT_SECTION_READ_ONLY_BADGE_LABEL}</Badge>} title={UI_STRING_SELECTED_VAULT} variant='record'>
 			{gridContent}
 		</EntityCard>
 	)
@@ -195,10 +305,10 @@ function VaultQueuedOperationStatusCard({
 					</div>
 				</div>
 				<MetricGrid>
-					<MetricField label={UI_STRINGS.securityVaultSection.stagedOperationLabel}>{queuedVaultOperation === undefined ? UI_STRINGS.securityVaultSection.refreshButtonPendingLabel : `#${queuedVaultOperation.operationId.toString()}`}</MetricField>
+					<MetricField label={UI_STRING_STAGED_OPERATION}>{queuedVaultOperation === undefined ? UI_STRING_REFRESHING : `#${queuedVaultOperation.operationId.toString()}`}</MetricField>
 					{queuedVaultOperation?.amount === undefined ? null : (
-						<MetricField label={UI_STRINGS.securityVaultSection.repAmountLabel}>
-							<CurrencyValue value={queuedVaultOperation.amount} suffix={UI_STRINGS.common.repLabel} />
+						<MetricField label={UI_STRING_AMOUNT}>
+							<CurrencyValue value={queuedVaultOperation.amount} suffix={UI_STRING_REP} />
 						</MetricField>
 					)}
 				</MetricGrid>
@@ -206,7 +316,7 @@ function VaultQueuedOperationStatusCard({
 				{onViewStagedOperations === undefined ? undefined : (
 					<div className='actions'>
 						<button className='secondary' type='button' onClick={onViewStagedOperations}>
-							{UI_STRINGS.securityVaultSection.viewInStagedOperationsLabel}
+							{UI_STRING_VIEW_IN_STAGED_OPERATIONS}
 						</button>
 					</div>
 				)}
@@ -219,10 +329,10 @@ function VaultQueuedOperationStatusCard({
 					<div>
 						<h4>{failedTitle}</h4>
 					</div>
-					<Badge tone='blocked'>{UI_STRINGS.common.failedBadgeLabel}</Badge>
+					<Badge tone='blocked'>{UI_STRING_FAILED}</Badge>
 				</div>
-				<p className='detail'>{errorMessage ?? UI_STRINGS.securityVaultSection.securityPoolRejectedActionDetail}</p>
-				<p className='detail'>{UI_STRINGS.securityVaultSection.stagedOperationRetryDetail}</p>
+				<p className='detail'>{errorMessage ?? UI_STRING_THE_SECURITY_POOL_REJECTED_THE_ACTION}</p>
+				<p className='detail'>{UI_STRING_STAGED_OPERATION_RETRY}</p>
 			</section>
 		)
 	if (status === 'executed')
@@ -232,7 +342,7 @@ function VaultQueuedOperationStatusCard({
 					<div>
 						<h4>{executedTitle}</h4>
 					</div>
-					<Badge tone='ok'>{UI_STRINGS.securityVaultSection.operationExecutedBadgeLabel}</Badge>
+					<Badge tone='ok'>{UI_STRING_EXECUTED}</Badge>
 				</div>
 				<p className='detail'>{successDescription}</p>
 			</section>
@@ -254,7 +364,7 @@ function VaultQueuedOperationStatusCard({
 				<div>
 					<h4>{refreshingTitle}</h4>
 				</div>
-				<Badge tone='muted'>{UI_STRINGS.securityVaultSection.refreshingBadgeLabel}</Badge>
+				<Badge tone='muted'>{UI_STRING_REFRESHING_WITHOUT_ELLIPSIS}</Badge>
 			</div>
 			<p className='detail'>{refreshingDescription}</p>
 		</section>
@@ -361,11 +471,11 @@ export function SecurityVaultSection({
 	const poolCollateralActionsEnabled = depositRepEnabled
 	const effectiveRepExitMode = redeemRepEnabled ? 'redeem' : 'withdraw'
 	const repExitEnabled = effectiveRepExitMode === 'redeem' ? redeemRepEnabled : queueWithdrawRepEnabled
-	const repExitActionLabel = effectiveRepExitMode === 'redeem' ? UI_STRINGS.securityVaultSection.redeemRepIdleLabel : UI_STRINGS.securityVaultSection.withdrawRepIdleLabel
+	const repExitActionLabel = effectiveRepExitMode === 'redeem' ? UI_STRING_REDEEM_REP : UI_STRING_WITHDRAW_REP
 	const repExitAmountLabel = (() => {
-		if (effectiveRepExitMode === 'redeem') return UI_STRINGS.securityVaultSection.redeemableRepLabel
-		if (hasValidOraclePrice) return UI_STRINGS.securityVaultSection.withdrawableRepLabel
-		return UI_STRINGS.securityVaultSection.repAvailableToQueueLabel
+		if (effectiveRepExitMode === 'redeem') return UI_STRING_REDEEMABLE_REP
+		if (hasValidOraclePrice) return UI_STRING_WITHDRAWABLE_REP
+		return UI_STRING_REP_AVAILABLE_TO_QUEUE
 	})()
 	const setSecurityBondAllowanceFunding = resolveOracleOperationEthFunding({
 		managerDetails: oracleManagerDetails,
@@ -419,11 +529,12 @@ export function SecurityVaultSection({
 		queuedVaultOperation,
 		securityVaultResult,
 	})
-	const stagedOperationTimeoutHelpText = stagedOperationTimeoutSeconds === undefined ? UI_STRINGS.securityVaultSection.manualExecutionTimeoutInvalidDetail : UI_STRINGS.securityVaultSection.manualExecutionTimeoutResolvedDetail(formatDuration(stagedOperationTimeoutSeconds))
+	const stagedOperationTimeoutHelpText =
+		stagedOperationTimeoutSeconds === undefined ? UI_STRING_ENTER_WHOLE_MINUTES_QUEUED_SELF_SERVICE_OPERATIONS_MUST_STAY_EXECUTABLE_FOR_AT_LEAST_1_MINUTE_AFTER_THE_ORACLE_SETTLEMENT_WINDOW_COMPLETES : UI_TEMPLATE_MANUAL_EXECUTION_TIMEOUT_RESOLVED_DETAIL(formatDuration(stagedOperationTimeoutSeconds))
 	const renderStagedOperationTimeoutField = () => (
 		<>
 			<label className='field'>
-				<span>{UI_STRINGS.securityVaultSection.manualExecutionTimeoutLabel}</span>
+				<span>{UI_STRING_MANUAL_EXECUTION_TIMEOUT}</span>
 				<div className='field-inline'>
 					<FormInput
 						className='field-inline-input'
@@ -435,7 +546,7 @@ export function SecurityVaultSection({
 						onInput={event => onSecurityVaultFormChange({ stagedOperationTimeoutMinutes: event.currentTarget.value })}
 						disabled={!poolCollateralActionsEnabled}
 					/>
-					<span className='field-inline-action'>{UI_STRINGS.common.minutesLabel}</span>
+					<span className='field-inline-action'>{UI_STRING_MINUTES}</span>
 				</div>
 			</label>
 			<p className='detail'>{stagedOperationTimeoutHelpText}</p>
@@ -445,14 +556,14 @@ export function SecurityVaultSection({
 		if (loadingSecurityVault)
 			return (
 				<p className='detail'>
-					<LoadingText>{UI_STRINGS.securityVaultSection.loadingVaultDetail}</LoadingText>
+					<LoadingText>{UI_STRING_LOADING_VAULT}</LoadingText>
 				</p>
 			)
-		if (securityVaultMissing) return <StateHint presentation={{ key: 'not_found', badgeLabel: UI_STRINGS.common.notFoundBadgeLabel, badgeTone: 'blocked', detail: UI_STRINGS.securityVaultSection.tryAnotherPoolAddressDetail }} />
+		if (securityVaultMissing) return <StateHint presentation={{ key: 'not_found', badgeLabel: UI_STRING_NOT_FOUND, badgeTone: 'blocked', detail: UI_STRING_TRY_ANOTHER_POOL_ADDRESS }} />
 
 		return undefined
 	})()
-	const loadedVaultMissingBlocker = currentSelectedVaultDetails !== undefined && !vaultExistsOnchain ? UI_STRINGS.securityVaultSection.missingVaultBlockerDetail : undefined
+	const loadedVaultMissingBlocker = currentSelectedVaultDetails !== undefined && !vaultExistsOnchain ? UI_STRING_THIS_VAULT_DOES_NOT_EXIST : undefined
 	const getVaultLauncherBlocker = (action: 'claim-fees' | 'deposit-rep' | 'rep-exit' | 'set-bond-allowance') => {
 		const walletGuardState = getWalletMainnetGuardState({
 			accountAddress: accountState.address,
@@ -461,16 +572,16 @@ export function SecurityVaultSection({
 		})
 		if (walletGuardState.blocked) return walletGuardState.reason
 		if (!selectedVaultIsOwnedByAccount) {
-			if (action === 'claim-fees') return UI_STRINGS.securityVaultSection.vaultLauncherBlockerReason('claim-fees', 'select-own-vault')
-			if (action === 'deposit-rep') return UI_STRINGS.securityVaultSection.vaultLauncherBlockerReason('deposit-rep', 'select-own-vault')
-			if (action === 'rep-exit') return effectiveRepExitMode === 'redeem' ? UI_STRINGS.securityVaultSection.vaultLauncherBlockerReason('rep-exit-redeem', 'select-own-vault') : UI_STRINGS.securityVaultSection.vaultLauncherBlockerReason('rep-exit-withdraw', 'select-own-vault')
-			return UI_STRINGS.securityVaultSection.vaultLauncherBlockerReason('set-bond-allowance', 'select-own-vault')
+			if (action === 'claim-fees') return UI_TEMPLATE_VAULT_LAUNCHER_BLOCKER_REASON('claim-fees', 'select-own-vault')
+			if (action === 'deposit-rep') return UI_TEMPLATE_VAULT_LAUNCHER_BLOCKER_REASON('deposit-rep', 'select-own-vault')
+			if (action === 'rep-exit') return effectiveRepExitMode === 'redeem' ? UI_TEMPLATE_VAULT_LAUNCHER_BLOCKER_REASON('rep-exit-redeem', 'select-own-vault') : UI_TEMPLATE_VAULT_LAUNCHER_BLOCKER_REASON('rep-exit-withdraw', 'select-own-vault')
+			return UI_TEMPLATE_VAULT_LAUNCHER_BLOCKER_REASON('set-bond-allowance', 'select-own-vault')
 		}
 		if (!hasLoadedSelectedVaultDetails) {
-			if (action === 'claim-fees') return UI_STRINGS.securityVaultSection.vaultLauncherBlockerReason('claim-fees', 'refresh-vault')
-			if (action === 'deposit-rep') return UI_STRINGS.securityVaultSection.vaultLauncherBlockerReason('deposit-rep', 'refresh-vault')
-			if (action === 'rep-exit') return effectiveRepExitMode === 'redeem' ? UI_STRINGS.securityVaultSection.vaultLauncherBlockerReason('rep-exit-redeem', 'refresh-vault') : UI_STRINGS.securityVaultSection.vaultLauncherBlockerReason('rep-exit-withdraw', 'refresh-vault')
-			return UI_STRINGS.securityVaultSection.vaultLauncherBlockerReason('set-bond-allowance', 'refresh-vault')
+			if (action === 'claim-fees') return UI_TEMPLATE_VAULT_LAUNCHER_BLOCKER_REASON('claim-fees', 'refresh-vault')
+			if (action === 'deposit-rep') return UI_TEMPLATE_VAULT_LAUNCHER_BLOCKER_REASON('deposit-rep', 'refresh-vault')
+			if (action === 'rep-exit') return effectiveRepExitMode === 'redeem' ? UI_TEMPLATE_VAULT_LAUNCHER_BLOCKER_REASON('rep-exit-redeem', 'refresh-vault') : UI_TEMPLATE_VAULT_LAUNCHER_BLOCKER_REASON('rep-exit-withdraw', 'refresh-vault')
+			return UI_TEMPLATE_VAULT_LAUNCHER_BLOCKER_REASON('set-bond-allowance', 'refresh-vault')
 		}
 		if (action === 'deposit-rep') return undefined
 		return loadedVaultMissingBlocker
@@ -490,17 +601,17 @@ export function SecurityVaultSection({
 	}, [autoLoadKey, autoLoadVault, hasLoadedCurrentVault, loadingSecurityVault, normalizedSecurityVaultForm.securityPoolAddress, onLoadSecurityVault, selectedVaultAddress])
 	const vaultReadinessActions = getSecurityPoolVaultReadinessActions([
 		{
-			actionLabel: UI_STRINGS.securityVaultSection.depositRepIdleLabel,
-			description: UI_STRINGS.securityVaultSection.depositRepActionDescription,
+			actionLabel: UI_STRING_DEPOSIT_REP,
+			description: UI_STRING_ADD_REP_TO_THE_SELECTED_VAULT,
 			key: 'deposit-rep',
 			...(depositRepEnabled && canUseLoadedVaultActions ? { onAction: () => setVaultActionModal('deposit-rep') } : {}),
 			readiness: depositRepEnabled && canUseLoadedVaultActions ? 'ready' : 'blocked',
 			...(depositLauncherBlocker === undefined ? {} : { blocker: depositLauncherBlocker }),
-			title: UI_STRINGS.securityVaultSection.depositRepTitle,
+			title: UI_STRING_DEPOSIT_REP,
 		},
 		{
 			actionLabel: repExitActionLabel,
-			description: effectiveRepExitMode === 'redeem' ? UI_STRINGS.securityVaultSection.repExitRedeemDescription : UI_STRINGS.securityVaultSection.repWithdrawQueueDescription,
+			description: effectiveRepExitMode === 'redeem' ? UI_STRING_REDEEM_THE_REMAINING_REP_COLLATERAL_FROM_THIS_ENDED_POOL_AFTER_ESCALATION_DEPOSITS_ARE_SETTLED : UI_STRING_QUEUE_A_REP_WITHDRAWAL_NOW_OR_LET_IT_EXECUTE_IMMEDIATELY_WHEN_A_VALID_ORACLE_PRICE_IS_ALREADY_AVAILABLE,
 			key: 'rep-exit',
 			...(repExitEnabled && vaultExistsOnchain && canUseLoadedVaultActions ? { onAction: () => setVaultActionModal('withdraw-rep') } : {}),
 			readiness: repExitEnabled && vaultExistsOnchain && canUseLoadedVaultActions ? 'ready' : 'blocked',
@@ -508,29 +619,29 @@ export function SecurityVaultSection({
 			title: repExitActionLabel,
 		},
 		{
-			actionLabel: UI_STRINGS.securityVaultSection.setBondAllowanceIdleLabel,
-			description: UI_STRINGS.securityVaultSection.setBondAllowanceActionDescription,
+			actionLabel: UI_STRING_SET_BOND_ALLOWANCE,
+			description: UI_STRING_QUEUE_A_NEW_SECURITY_BOND_ALLOWANCE_USING_THE_CURRENT_ORACLE_PRICE_CONTEXT,
 			key: 'set-bond-allowance',
 			...(bondAllowanceEnabled && vaultExistsOnchain && canUseLoadedVaultActions ? { onAction: () => setVaultActionModal('set-bond-allowance') } : {}),
 			readiness: bondAllowanceEnabled && vaultExistsOnchain && canUseLoadedVaultActions ? 'ready' : 'blocked',
 			...(bondAllowanceLauncherBlocker === undefined ? {} : { blocker: bondAllowanceLauncherBlocker }),
-			title: UI_STRINGS.securityVaultSection.setSecurityBondAllowanceTitle,
+			title: UI_STRING_SET_SECURITY_BOND_ALLOWANCE,
 		},
 		{
-			actionLabel: UI_STRINGS.securityVaultSection.claimFeesIdleLabel,
-			description: UI_STRINGS.securityVaultSection.claimFeesActionDescription,
+			actionLabel: UI_STRING_CLAIM_FEES,
+			description: UI_STRING_REVIEW_CLAIMABLE_FEES_AND_CONFIRM_THE_FEE_REDEMPTION_FOR_THE_SELECTED_VAULT,
 			key: 'claim-fees',
 			...(claimFeesEnabled && hasClaimableFees && claimFeesLauncherBlocker === undefined && vaultExistsOnchain && canUseLoadedVaultActions ? { onAction: () => setVaultActionModal('claim-fees') } : {}),
 			readiness: claimFeesEnabled && hasClaimableFees && claimFeesLauncherBlocker === undefined && vaultExistsOnchain && canUseLoadedVaultActions ? 'ready' : 'blocked',
 			...(claimFeesLauncherBlocker === undefined ? {} : { blocker: claimFeesLauncherBlocker }),
-			title: UI_STRINGS.securityVaultSection.claimFeesTitle,
+			title: UI_STRING_CLAIM_FEES,
 		},
 		...extraReadinessActions,
 	] satisfies ReadinessAction[])
 	const actionSections = modalFirst ? (
 		<>
-			<SectionBlock title={UI_STRINGS.securityVaultSection.vaultActionsTitle}>
-				{showMissingVaultNotice ? <StateHint presentation={{ key: 'not_found', badgeLabel: UI_STRINGS.securityVaultSection.vaultMissingBadgeLabel, badgeTone: 'muted', detail: UI_STRINGS.securityVaultSection.createVaultByDepositingRepDetail }} /> : undefined}
+			<SectionBlock title={UI_STRING_VAULT_ACTIONS}>
+				{showMissingVaultNotice ? <StateHint presentation={{ key: 'not_found', badgeLabel: UI_STRING_VAULT_MISSING, badgeTone: 'muted', detail: UI_STRING_THIS_VAULT_DOES_NOT_EXIST_DEPOSIT_REP_TO_CREATE_IT }} /> : undefined}
 				<div className='vault-action-launcher-grid'>
 					{vaultReadinessActions.map(action => (
 						<ActionLauncherCard key={action.key} action={action} />
@@ -538,8 +649,8 @@ export function SecurityVaultSection({
 				</div>
 			</SectionBlock>
 			<ErrorNotice message={securityVaultError} />
-			<OperationModal isOpen={vaultActionModal === 'deposit-rep'} onClose={() => setVaultActionModal(undefined)} title={UI_STRINGS.securityVaultSection.depositRepTitle}>
-				{currentSelectedVaultDetails === undefined ? <p className='detail'>{UI_STRINGS.securityVaultSection.selectedVaultDetailsUnavailableDetail}</p> : null}
+			<OperationModal isOpen={vaultActionModal === 'deposit-rep'} onClose={() => setVaultActionModal(undefined)} title={UI_STRING_DEPOSIT_REP}>
+				{currentSelectedVaultDetails === undefined ? <p className='detail'>{UI_STRING_SELECTED_VAULT_DETAILS_ARE_UNAVAILABLE}</p> : null}
 				{currentSelectedVaultDetails === undefined ? null : (
 					<>
 						{vaultExistsOnchain ? (
@@ -554,10 +665,10 @@ export function SecurityVaultSection({
 								variant='embedded'
 							/>
 						) : (
-							<StateHint presentation={{ key: 'not_found', badgeLabel: UI_STRINGS.securityVaultSection.vaultMissingBadgeLabel, badgeTone: 'muted', detail: UI_STRINGS.securityVaultSection.createVaultByDepositingRepDetail }} />
+							<StateHint presentation={{ key: 'not_found', badgeLabel: UI_STRING_VAULT_MISSING, badgeTone: 'muted', detail: UI_STRING_THIS_VAULT_DOES_NOT_EXIST_DEPOSIT_REP_TO_CREATE_IT }} />
 						)}
 						<label className='field'>
-							<span>{UI_STRINGS.securityVaultSection.depositRepAmountLabel}</span>
+							<span>{UI_STRING_REP_COLLATERAL_AMOUNT}</span>
 							<div className='field-inline'>
 								<FormInput className='field-inline-input' value={normalizedSecurityVaultForm.depositAmount} onInput={event => onSecurityVaultFormChange({ depositAmount: event.currentTarget.value })} disabled={!poolCollateralActionsEnabled} />
 								<button
@@ -569,24 +680,24 @@ export function SecurityVaultSection({
 									}}
 									disabled={securityVaultRepBalance === undefined || !poolCollateralActionsEnabled}
 								>
-									{UI_STRINGS.common.maxLabel}
+									{UI_STRING_MAX}
 								</button>
 							</div>
 						</label>
 						<MetricGrid>
-							<MetricField label={UI_STRINGS.securityVaultSection.walletRepLabel}>
-								<CurrencyValue value={securityVaultRepBalance} suffix={UI_STRINGS.common.repLabel} />
+							<MetricField label={UI_STRING_WALLET_REP}>
+								<CurrencyValue value={securityVaultRepBalance} suffix={UI_STRING_REP} />
 							</MetricField>
 						</MetricGrid>
 						<TokenApprovalControl
-							actionLabel={UI_STRINGS.securityVaultSection.approveRepActionLabel}
+							actionLabel={UI_STRING_DEPOSITING_REP}
 							allowanceError={securityVaultRepApproval.error}
 							allowanceLoading={securityVaultRepApproval.loading}
 							approvedAmount={securityVaultRepApproval.value}
 							guardMessage={undefined}
 							onApprove={amount => onApproveRep(amount)}
 							pending={securityVaultActiveAction === 'approveRep'}
-							pendingLabel={UI_STRINGS.securityVaultSection.approvingRepPendingLabel}
+							pendingLabel={UI_STRING_APPROVING_REP}
 							requiredAmount={depositAmount}
 							resetKey={`${currentSelectedVaultDetails.repToken}:${currentSelectedVaultDetails.securityPoolAddress}:${depositAmount?.toString() ?? ''}`}
 							tokenSymbol='REP'
@@ -595,23 +706,23 @@ export function SecurityVaultSection({
 						/>
 						<RequirementsChecklist
 							items={[
-								{ key: 'owned', label: UI_STRINGS.securityVaultSection.ownedChecklistLabel, resolved: selectedVaultIsOwnedByAccount },
+								{ key: 'owned', label: UI_STRING_SELECTED_VAULT_IS_OWNED_BY_THE_CONNECTED_ACCOUNT, resolved: selectedVaultIsOwnedByAccount },
 								{
 									key: 'balance',
-									label: UI_STRINGS.securityVaultSection.repBalanceChecklistLabel,
+									label: UI_STRING_WALLET_REP_BALANCE_COVERS_THE_DEPOSIT_AMOUNT,
 									resolved: repBalanceGap === undefined || repBalanceGap <= 0n,
-									...(repBalanceGap !== undefined && repBalanceGap > 0n ? { detail: UI_STRINGS.securityVaultSection.repBalanceShortageDetail(formatCurrencyBalance(repBalanceGap)) } : {}),
+									...(repBalanceGap !== undefined && repBalanceGap > 0n ? { detail: UI_TEMPLATE_REP_BALANCE_SHORTAGE_DETAIL(formatCurrencyBalance(repBalanceGap)) } : {}),
 								},
-								{ key: 'minimum', label: UI_STRINGS.securityVaultSection.firstDepositMinimumChecklistLabel, resolved: !isDepositBelowMinimum, ...(isDepositBelowMinimum ? { detail: UI_STRINGS.securityVaultSection.firstDepositMinimumChecklistDetail(formatCurrencyBalance(MIN_SECURITY_VAULT_REP_DEPOSIT)) } : {}) },
+								{ key: 'minimum', label: UI_STRING_FIRST_DEPOSIT_MEETS_THE_VAULT_MINIMUM, resolved: !isDepositBelowMinimum, ...(isDepositBelowMinimum ? { detail: UI_TEMPLATE_FIRST_DEPOSIT_MINIMUM_CHECKLIST_DETAIL(formatCurrencyBalance(MIN_SECURITY_VAULT_REP_DEPOSIT)) } : {}) },
 							]}
 						/>
 						<div className='actions'>
 							<button className='secondary' type='button' onClick={() => setVaultActionModal(undefined)}>
-								{UI_STRINGS.common.cancelLabel}
+								{UI_STRING_CANCEL}
 							</button>
 							<TransactionActionButton
-								idleLabel={UI_STRINGS.securityVaultSection.depositRepIdleLabel}
-								pendingLabel={UI_STRINGS.securityVaultSection.depositRepPendingLabel}
+								idleLabel={UI_STRING_DEPOSIT_REP}
+								pendingLabel={UI_STRING_DEPOSITING_REP_SECURITY_VAULT_SECTION_DEPOSIT_REP_PENDING_LABEL}
 								onClick={onDepositRep}
 								pending={securityVaultActiveAction === 'depositRep'}
 								availability={{ disabled: !depositRepEnabled || !canUseLoadedVaultActions || !hasPositiveDepositAmount || depositGuardMessage !== undefined, reason: canUseLoadedVaultActions ? depositGuardMessage : undefined }}
@@ -621,25 +732,30 @@ export function SecurityVaultSection({
 				)}
 			</OperationModal>
 
-			<OperationModal isOpen={vaultActionModal === 'withdraw-rep'} onClose={() => setVaultActionModal(undefined)} title={repExitActionLabel} description={effectiveRepExitMode === 'redeem' ? UI_STRINGS.securityVaultSection.repExitRedeemDescription : UI_STRINGS.securityVaultSection.repExitWithdrawDescription}>
-				{currentSelectedVaultDetails === undefined ? <p className='detail'>{UI_STRINGS.securityVaultSection.selectedVaultDetailsUnavailableDetail}</p> : null}
+			<OperationModal
+				isOpen={vaultActionModal === 'withdraw-rep'}
+				onClose={() => setVaultActionModal(undefined)}
+				title={repExitActionLabel}
+				description={effectiveRepExitMode === 'redeem' ? UI_STRING_REDEEM_THE_REMAINING_REP_COLLATERAL_FROM_THIS_ENDED_POOL_AFTER_ESCALATION_DEPOSITS_ARE_SETTLED : UI_STRING_QUEUE_A_REP_WITHDRAWAL_AFTER_REVIEWING_THE_CURRENT_VAULT_COLLATERAL_AND_ORACLE_STATUS}
+			>
+				{currentSelectedVaultDetails === undefined ? <p className='detail'>{UI_STRING_SELECTED_VAULT_DETAILS_ARE_UNAVAILABLE}</p> : null}
 				{currentSelectedVaultDetails === undefined ? null : (
 					<>
 						{effectiveRepExitMode === 'redeem' ? null : (
 							<VaultQueuedOperationStatusCard
-								errorMessage={securityVaultResult?.stagedExecution?.errorMessage ?? UI_STRINGS.securityVaultSection.repWithdrawalRejectedDetail}
-								executedTitle={UI_STRINGS.securityVaultSection.repWithdrawalExecutedTitle}
-								failedTitle={UI_STRINGS.securityVaultSection.repWithdrawalFailedTitle}
-								manualQueuedDescription={UI_STRINGS.securityVaultSection.oracleManagerAutoExecuteQueueFullDetail}
-								missingDescription={UI_STRINGS.securityVaultSection.operationStatusUnavailableDetail}
-								missingTitle={UI_STRINGS.securityVaultSection.repWithdrawalSubmittedTitle}
+								errorMessage={securityVaultResult?.stagedExecution?.errorMessage ?? UI_STRING_THE_ORACLE_MANAGER_ATTEMPTED_THE_WITHDRAWAL_IMMEDIATELY_BUT_THE_SECURITY_POOL_REJECTED_IT}
+								executedTitle={UI_STRING_REP_WITHDRAWAL_EXECUTED}
+								failedTitle={UI_STRING_REP_WITHDRAWAL_FAILED}
+								manualQueuedDescription={UI_STRING_MANUAL_QUEUED_OPERATION}
+								missingDescription={UI_STRING_TRANSACTION_STATE_UNAVAILABLE}
+								missingTitle={UI_STRING_REP_WITHDRAWAL_SUBMITTED}
 								onViewStagedOperations={onViewStagedOperations}
-								queuedTitle={UI_STRINGS.securityVaultSection.repWithdrawalQueuedTitle}
+								queuedTitle={UI_STRING_REP_WITHDRAWAL_QUEUED}
 								queuedVaultOperation={queuedVaultOperation}
-								refreshingDescription={UI_STRINGS.securityVaultSection.refreshingWithdrawalStateDetail}
-								refreshingTitle={UI_STRINGS.securityVaultSection.refreshingWithdrawalStateTitle}
+								refreshingDescription={UI_STRING_REFRESHING_THE_ORACLE_MANAGER_TO_DETERMINE_WHETHER_THE_WITHDRAWAL_WAS_QUEUED_OR_EXECUTED_IMMEDIATELY}
+								refreshingTitle={UI_STRING_REFRESHING_WITHDRAWAL_STATE}
 								status={securityVaultResult?.action === 'queueWithdrawRep' ? queuedVaultOperationStatus : undefined}
-								successDescription={UI_STRINGS.securityVaultSection.successfulImmediateWithdrawalDetail}
+								successDescription={UI_STRING_A_VALID_ORACLE_PRICE_WAS_ALREADY_AVAILABLE_SO_THE_WITHDRAWAL_EXECUTED_IMMEDIATELY_AND_NO_STAGED_OPERATION_WAS_CREATED}
 							/>
 						)}
 						<SelectedVaultSummarySection
@@ -658,24 +774,24 @@ export function SecurityVaultSection({
 									if (effectiveRepExitMode === 'redeem') {
 										if (redeemableRepAmount === undefined) return '—'
 
-										return <CurrencyValue value={redeemableRepAmount} suffix={UI_STRINGS.common.repLabel} />
+										return <CurrencyValue value={redeemableRepAmount} suffix={UI_STRING_REP} />
 									}
 									if (queuedWithdrawRepLimit === undefined) return '—'
 
-									return <CurrencyValue value={queuedWithdrawRepLimit} suffix={UI_STRINGS.common.repLabel} />
+									return <CurrencyValue value={queuedWithdrawRepLimit} suffix={UI_STRING_REP} />
 								})()}
 							</MetricField>
 							{effectiveRepExitMode === 'redeem' ? (
-								<MetricField label={UI_STRINGS.securityVaultSection.escalationEscrowedRepLabel}>
-									<CurrencyValue value={currentSelectedVaultDetails.escalationEscrowedRep} suffix={UI_STRINGS.common.repLabel} />
+								<MetricField label={UI_STRING_ESCROWED_REP}>
+									<CurrencyValue value={currentSelectedVaultDetails.escalationEscrowedRep} suffix={UI_STRING_REP} />
 								</MetricField>
 							) : (
-								<MetricField label={UI_STRINGS.securityVaultSection.priceValidUntilLabel}>{oraclePriceValidUntilTimestamp === undefined ? UI_STRINGS.common.unavailableLabel : <TimestampValue timestamp={oraclePriceValidUntilTimestamp} />}</MetricField>
+								<MetricField label={UI_STRING_PRICE_VALID_UNTIL}>{oraclePriceValidUntilTimestamp === undefined ? UI_STRING_UNAVAILABLE : <TimestampValue timestamp={oraclePriceValidUntilTimestamp} />}</MetricField>
 							)}
 						</MetricGrid>
 						{effectiveRepExitMode === 'redeem' ? null : (
 							<label className='field'>
-								<span>{UI_STRINGS.securityVaultSection.repWithdrawAmountLabel}</span>
+								<span>{UI_STRING_REP_WITHDRAW_AMOUNT}</span>
 								<div className='field-inline'>
 									<FormInput className='field-inline-input' value={normalizedSecurityVaultForm.repWithdrawAmount} onInput={event => onSecurityVaultFormChange({ repWithdrawAmount: event.currentTarget.value })} disabled={!poolCollateralActionsEnabled} />
 									<button
@@ -687,7 +803,7 @@ export function SecurityVaultSection({
 										}}
 										disabled={queuedWithdrawRepLimit === undefined || !poolCollateralActionsEnabled}
 									>
-										{UI_STRINGS.common.maxLabel}
+										{UI_STRING_MAX}
 									</button>
 								</div>
 							</label>
@@ -697,38 +813,38 @@ export function SecurityVaultSection({
 							items={
 								effectiveRepExitMode === 'redeem'
 									? [
-											{ key: 'owned', label: UI_STRINGS.securityVaultSection.ownedChecklistLabel, resolved: selectedVaultIsOwnedByAccount },
+											{ key: 'owned', label: UI_STRING_SELECTED_VAULT_IS_OWNED_BY_THE_CONNECTED_ACCOUNT, resolved: selectedVaultIsOwnedByAccount },
 											{
 												key: 'locked',
-												label: UI_STRINGS.securityVaultSection.noRepLockedChecklistLabel,
+												label: UI_STRING_NO_REP_REMAINS_LOCKED_IN_THE_ESCALATION_GAME,
 												resolved: currentSelectedVaultDetails.escalationEscrowedRep === 0n,
-												...(currentSelectedVaultDetails.escalationEscrowedRep > 0n ? { detail: UI_STRINGS.securityVaultSection.noRepLockedChecklistDetail } : {}),
+												...(currentSelectedVaultDetails.escalationEscrowedRep > 0n ? { detail: UI_STRING_WITHDRAW_ESCALATION_DEPOSITS } : {}),
 											},
-											{ key: 'redeemable', label: UI_STRINGS.securityVaultSection.redeemableRepChecklistLabel, resolved: redeemableRepAmount !== undefined && redeemableRepAmount > 0n },
+											{ key: 'redeemable', label: UI_STRING_THE_VAULT_HAS_REDEEMABLE_REP, resolved: redeemableRepAmount !== undefined && redeemableRepAmount > 0n },
 										]
 									: [
-											{ key: 'owned', label: UI_STRINGS.securityVaultSection.ownedChecklistLabel, resolved: selectedVaultIsOwnedByAccount },
+											{ key: 'owned', label: UI_STRING_SELECTED_VAULT_IS_OWNED_BY_THE_CONNECTED_ACCOUNT, resolved: selectedVaultIsOwnedByAccount },
 											{
 												key: 'oracle',
-												label: hasValidOraclePrice ? UI_STRINGS.securityVaultSection.validOraclePriceChecklistLabel : UI_STRINGS.securityVaultSection.oracleExecutionFundingChecklistLabel,
+												label: hasValidOraclePrice ? UI_STRING_A_VALID_ORACLE_PRICE_IS_AVAILABLE : UI_STRING_ORACLE_EXECUTION_CAN_BE_FUNDED_UNTIL_A_FRESH_PRICE_ARRIVES,
 												resolved: hasValidOraclePrice || withdrawRepFunding !== undefined,
 											},
 											{
 												key: 'withdrawable',
-												label: hasValidOraclePrice ? UI_STRINGS.securityVaultSection.withdrawableRepLabel : UI_STRINGS.securityVaultSection.withdrawFundingChecklistLabel,
+												label: hasValidOraclePrice ? UI_STRING_WITHDRAWABLE_REP : UI_STRING_THE_VAULT_STILL_HOLDS_REP_COLLATERAL_TO_QUEUE,
 												resolved: queuedWithdrawRepLimit !== undefined && queuedWithdrawRepLimit > 0n,
 											},
-											{ key: 'timeout', label: UI_STRINGS.securityVaultSection.timeoutChecklistLabel, resolved: stagedOperationTimeoutSeconds !== undefined },
+											{ key: 'timeout', label: UI_STRING_MANUAL_EXECUTION_TIMEOUT_IS_AT_LEAST_1_MINUTE, resolved: stagedOperationTimeoutSeconds !== undefined },
 										]
 							}
 						/>
 						<div className='actions'>
 							<button className='secondary' type='button' onClick={() => setVaultActionModal(undefined)}>
-								{UI_STRINGS.common.cancelLabel}
+								{UI_STRING_CANCEL}
 							</button>
 							<TransactionActionButton
 								idleLabel={repExitActionLabel}
-								pendingLabel={effectiveRepExitMode === 'redeem' ? UI_STRINGS.securityVaultSection.redeemRepPendingLabel : UI_STRINGS.securityVaultSection.withdrawRepPendingLabel}
+								pendingLabel={effectiveRepExitMode === 'redeem' ? UI_STRING_REDEEMING_REP : UI_STRING_QUEUEING_REP_WITHDRAWAL}
 								onClick={effectiveRepExitMode === 'redeem' ? onRedeemRep : onWithdrawRep}
 								pending={effectiveRepExitMode === 'redeem' ? securityVaultActiveAction === 'redeemRep' : securityVaultActiveAction === 'queueWithdrawRep'}
 								tone='secondary'
@@ -742,56 +858,56 @@ export function SecurityVaultSection({
 				)}
 			</OperationModal>
 
-			<OperationModal isOpen={vaultActionModal === 'set-bond-allowance'} onClose={() => setVaultActionModal(undefined)} title={UI_STRINGS.securityVaultSection.setBondAllowanceModalTitle} description={UI_STRINGS.securityVaultSection.setSecurityBondAllowanceModalDescription}>
-				{currentSelectedVaultDetails === undefined ? <p className='detail'>{UI_STRINGS.securityVaultSection.selectedVaultDetailsUnavailableDetail}</p> : null}
+			<OperationModal isOpen={vaultActionModal === 'set-bond-allowance'} onClose={() => setVaultActionModal(undefined)} title={UI_STRING_SET_BOND_ALLOWANCE} description={UI_STRING_QUEUE_A_NEW_BOND_ALLOWANCE_USING_THE_LATEST_VALID_ORACLE_PRICE_FOR_THE_SELECTED_VAULT}>
+				{currentSelectedVaultDetails === undefined ? <p className='detail'>{UI_STRING_SELECTED_VAULT_DETAILS_ARE_UNAVAILABLE}</p> : null}
 				{currentSelectedVaultDetails === undefined ? null : (
 					<>
 						<VaultQueuedOperationStatusCard
-							errorMessage={securityVaultResult?.stagedExecution?.errorMessage ?? UI_STRINGS.securityVaultSection.bondAllowanceRejectedDetail}
-							executedTitle={UI_STRINGS.securityVaultSection.bondAllowanceExecutedTitle}
-							failedTitle={UI_STRINGS.securityVaultSection.bondAllowanceFailedTitle}
-							manualQueuedDescription={UI_STRINGS.securityVaultSection.oracleManagerAutoExecuteQueueFullDetail}
-							missingDescription={UI_STRINGS.securityVaultSection.operationStatusUnavailableDetail}
-							missingTitle={UI_STRINGS.securityVaultSection.bondAllowanceSubmittedTitle}
+							errorMessage={securityVaultResult?.stagedExecution?.errorMessage ?? UI_STRING_THE_ORACLE_MANAGER_ATTEMPTED_THE_ALLOWANCE_UPDATE_IMMEDIATELY_BUT_THE_SECURITY_POOL_REJECTED_IT}
+							executedTitle={UI_STRING_BOND_ALLOWANCE_EXECUTED}
+							failedTitle={UI_STRING_BOND_ALLOWANCE_FAILED}
+							manualQueuedDescription={UI_STRING_MANUAL_QUEUED_OPERATION}
+							missingDescription={UI_STRING_TRANSACTION_STATE_UNAVAILABLE}
+							missingTitle={UI_STRING_BOND_ALLOWANCE_SUBMITTED}
 							onViewStagedOperations={onViewStagedOperations}
-							queuedTitle={UI_STRINGS.securityVaultSection.bondAllowanceQueuedTitle}
+							queuedTitle={UI_STRING_BOND_ALLOWANCE_QUEUED}
 							queuedVaultOperation={queuedVaultOperation}
-							refreshingDescription={UI_STRINGS.securityVaultSection.refreshingBondAllowanceStateDetail}
-							refreshingTitle={UI_STRINGS.securityVaultSection.refreshingBondAllowanceStateTitle}
+							refreshingDescription={UI_STRING_REFRESHING_THE_ORACLE_MANAGER_TO_DETERMINE_WHETHER_THE_BOND_ALLOWANCE_WAS_QUEUED_OR_EXECUTED_IMMEDIATELY}
+							refreshingTitle={UI_STRING_REFRESHING_BOND_ALLOWANCE_STATE}
 							status={securityVaultResult?.action === 'queueSetSecurityBondAllowance' ? queuedVaultOperationStatus : undefined}
-							successDescription={UI_STRINGS.securityVaultSection.successfulImmediateBondAllowanceDetail}
+							successDescription={UI_STRING_A_VALID_ORACLE_PRICE_WAS_ALREADY_AVAILABLE_SO_THE_NEW_BOND_ALLOWANCE_EXECUTED_IMMEDIATELY_AND_NO_STAGED_OPERATION_WAS_CREATED}
 						/>
 						<MetricGrid>
-							<MetricField label={UI_STRINGS.securityVaultSection.currentBondAllowanceLabel}>
-								<CurrencyValue value={currentSelectedVaultDetails.securityBondAllowance} suffix={UI_STRINGS.common.ethSuffix} />
+							<MetricField label={UI_STRING_CURRENT_BOND_ALLOWANCE}>
+								<CurrencyValue value={currentSelectedVaultDetails.securityBondAllowance} suffix={UI_STRING_ETH} />
 							</MetricField>
-							<MetricField label={UI_STRINGS.securityVaultSection.priceValidUntilLabel}>{oraclePriceValidUntilTimestamp === undefined ? UI_STRINGS.common.unavailableLabel : <TimestampValue timestamp={oraclePriceValidUntilTimestamp} />}</MetricField>
+							<MetricField label={UI_STRING_PRICE_VALID_UNTIL}>{oraclePriceValidUntilTimestamp === undefined ? UI_STRING_UNAVAILABLE : <TimestampValue timestamp={oraclePriceValidUntilTimestamp} />}</MetricField>
 						</MetricGrid>
 						<label className='field'>
-							<span>{UI_STRINGS.securityVaultSection.securityBondAllowanceAmountLabel}</span>
+							<span>{UI_STRING_SECURITY_BOND_ALLOWANCE_AMOUNT}</span>
 							<div className='field-inline'>
 								<FormInput className='field-inline-input' value={normalizedSecurityVaultForm.securityBondAllowanceAmount} onInput={event => onSecurityVaultFormChange({ securityBondAllowanceAmount: event.currentTarget.value })} disabled={!poolCollateralActionsEnabled} />
 								<button className='quiet field-inline-action' type='button' onClick={() => onSecurityVaultFormChange({ securityBondAllowanceAmount: formatCurrencyInputBalance(maxSecurityBondAllowanceAmount) })} disabled={maxSecurityBondAllowanceAmount <= 0n || !poolCollateralActionsEnabled}>
-									{UI_STRINGS.common.maxLabel}
+									{UI_STRING_MAX}
 								</button>
 							</div>
 						</label>
 						{renderStagedOperationTimeoutField()}
 						<RequirementsChecklist
 							items={[
-								{ key: 'owned', label: UI_STRINGS.securityVaultSection.ownedChecklistLabel, resolved: selectedVaultIsOwnedByAccount },
-								{ key: 'oracle', label: UI_STRINGS.securityVaultSection.validOraclePriceChecklistLabel, resolved: hasValidOraclePrice },
-								{ key: 'allowance', label: UI_STRINGS.securityVaultSection.allowanceChecklistLabel(formatCurrencyBalance(MIN_SECURITY_BOND_ALLOWANCE)), resolved: hasValidSecurityBondAllowanceAmount },
-								{ key: 'timeout', label: UI_STRINGS.securityVaultSection.timeoutChecklistLabel, resolved: stagedOperationTimeoutSeconds !== undefined },
+								{ key: 'owned', label: UI_STRING_SELECTED_VAULT_IS_OWNED_BY_THE_CONNECTED_ACCOUNT, resolved: selectedVaultIsOwnedByAccount },
+								{ key: 'oracle', label: UI_STRING_A_VALID_ORACLE_PRICE_IS_AVAILABLE, resolved: hasValidOraclePrice },
+								{ key: 'allowance', label: UI_TEMPLATE_ALLOWANCE_CHECKLIST_LABEL(formatCurrencyBalance(MIN_SECURITY_BOND_ALLOWANCE)), resolved: hasValidSecurityBondAllowanceAmount },
+								{ key: 'timeout', label: UI_STRING_MANUAL_EXECUTION_TIMEOUT_IS_AT_LEAST_1_MINUTE, resolved: stagedOperationTimeoutSeconds !== undefined },
 							]}
 						/>
 						<div className='actions'>
 							<button className='secondary' type='button' onClick={() => setVaultActionModal(undefined)}>
-								{UI_STRINGS.common.cancelLabel}
+								{UI_STRING_CANCEL}
 							</button>
 							<TransactionActionButton
-								idleLabel={UI_STRINGS.securityVaultSection.setSecurityBondAllowanceIdleLabel}
-								pendingLabel={UI_STRINGS.securityVaultSection.setSecurityBondAllowancePendingLabel}
+								idleLabel={UI_STRING_SET_SECURITY_BOND_ALLOWANCE}
+								pendingLabel={UI_STRING_QUEUEING_ALLOWANCE_UPDATE}
 								onClick={onSetSecurityBondAllowance}
 								pending={securityVaultActiveAction === 'queueSetSecurityBondAllowance'}
 								tone='secondary'
@@ -802,57 +918,45 @@ export function SecurityVaultSection({
 				)}
 			</OperationModal>
 
-			<OperationModal isOpen={vaultActionModal === 'claim-fees'} onClose={() => setVaultActionModal(undefined)} title={UI_STRINGS.securityVaultSection.claimFeesTitle} description={UI_STRINGS.securityVaultSection.claimFeesModalDescription}>
+			<OperationModal isOpen={vaultActionModal === 'claim-fees'} onClose={() => setVaultActionModal(undefined)} title={UI_STRING_CLAIM_FEES} description={UI_STRING_CONFIRM_THE_CLAIMABLE_FEE_BALANCE_BEFORE_SUBMITTING_THE_FEE_REDEMPTION_FOR_THIS_VAULT}>
 				<MetricGrid>
-					<MetricField label={UI_STRINGS.securityVaultSection.claimFeesAmountLabel}>{currentSelectedVaultDetails === undefined ? UI_STRINGS.common.metricUnavailablePlaceholder : <CurrencyValue value={currentSelectedVaultDetails.unpaidEthFees} suffix={UI_STRINGS.common.ethSuffix} />}</MetricField>
-					<MetricField label={UI_STRINGS.securityVaultSection.vaultLabel}>{selectedVaultAddress === undefined ? UI_STRINGS.common.noneSelectedLabel : <AddressValue address={selectedVaultAddress} />}</MetricField>
+					<MetricField label={UI_STRING_CLAIMABLE_FEES}>{currentSelectedVaultDetails === undefined ? UI_STRING_METRIC_UNAVAILABLE_PLACEHOLDER : <CurrencyValue value={currentSelectedVaultDetails.unpaidEthFees} suffix={UI_STRING_ETH} />}</MetricField>
+					<MetricField label={UI_STRING_VAULT}>{selectedVaultAddress === undefined ? UI_STRING_NONE_SELECTED : <AddressValue address={selectedVaultAddress} />}</MetricField>
 				</MetricGrid>
 				<RequirementsChecklist
 					items={[
-						{ key: 'owned', label: UI_STRINGS.securityVaultSection.ownedChecklistLabel, resolved: selectedVaultIsOwnedByAccount },
-						{ key: 'fees', label: UI_STRINGS.securityVaultSection.hasClaimableFeesChecklistLabel, resolved: hasClaimableFees },
+						{ key: 'owned', label: UI_STRING_SELECTED_VAULT_IS_OWNED_BY_THE_CONNECTED_ACCOUNT, resolved: selectedVaultIsOwnedByAccount },
+						{ key: 'fees', label: UI_STRING_CLAIMABLE_FEES_ARE_AVAILABLE, resolved: hasClaimableFees },
 					]}
 				/>
 				<div className='actions'>
 					<button className='secondary' type='button' onClick={() => setVaultActionModal(undefined)}>
-						{UI_STRINGS.common.cancelLabel}
+						{UI_STRING_CANCEL}
 					</button>
-					<TransactionActionButton
-						idleLabel={UI_STRINGS.securityVaultSection.claimFeesIdleLabel}
-						pendingLabel={UI_STRINGS.securityVaultSection.claimFeesPendingLabel}
-						onClick={onRedeemFees}
-						pending={securityVaultActiveAction === 'redeemFees'}
-						availability={{ disabled: !claimFeesEnabled || !canUseLoadedVaultActions || !hasClaimableFees, reason: undefined }}
-					/>
+					<TransactionActionButton idleLabel={UI_STRING_CLAIM_FEES} pendingLabel={UI_STRING_CLAIMING_FEES} onClick={onRedeemFees} pending={securityVaultActiveAction === 'redeemFees'} availability={{ disabled: !claimFeesEnabled || !canUseLoadedVaultActions || !hasClaimableFees, reason: undefined }} />
 				</div>
 			</OperationModal>
 		</>
 	) : (
 		<>
-			<SectionBlock title={UI_STRINGS.securityVaultSection.claimFeesTitle}>
+			<SectionBlock title={UI_STRING_CLAIM_FEES}>
 				{currentSelectedVaultDetails === undefined ? (
-					<p className='detail'>{UI_STRINGS.securityVaultSection.selectedVaultDetailsUnavailableDetail}</p>
+					<p className='detail'>{UI_STRING_SELECTED_VAULT_DETAILS_ARE_UNAVAILABLE}</p>
 				) : (
 					<div className='entity-metric-grid'>
-						<MetricField className='entity-metric' label={UI_STRINGS.securityVaultSection.claimFeesAmountLabel}>
-							<CurrencyValue value={currentSelectedVaultDetails.unpaidEthFees} suffix={UI_STRINGS.common.ethSuffix} />
+						<MetricField className='entity-metric' label={UI_STRING_CLAIMABLE_FEES}>
+							<CurrencyValue value={currentSelectedVaultDetails.unpaidEthFees} suffix={UI_STRING_ETH} />
 						</MetricField>
 					</div>
 				)}
 				<div className='actions'>
-					<TransactionActionButton
-						idleLabel={UI_STRINGS.securityVaultSection.claimFeesIdleLabel}
-						pendingLabel={UI_STRINGS.securityVaultSection.claimFeesPendingLabel}
-						onClick={onRedeemFees}
-						pending={securityVaultActiveAction === 'redeemFees'}
-						availability={{ disabled: !claimFeesEnabled || !canUseLoadedVaultActions || !hasClaimableFees, reason: undefined }}
-					/>
+					<TransactionActionButton idleLabel={UI_STRING_CLAIM_FEES} pendingLabel={UI_STRING_CLAIMING_FEES} onClick={onRedeemFees} pending={securityVaultActiveAction === 'redeemFees'} availability={{ disabled: !claimFeesEnabled || !canUseLoadedVaultActions || !hasClaimableFees, reason: undefined }} />
 				</div>
 			</SectionBlock>
 
-			<SectionBlock title={UI_STRINGS.securityVaultSection.depositRepTitle}>
+			<SectionBlock title={UI_STRING_DEPOSIT_REP}>
 				<label className='field'>
-					<span>{UI_STRINGS.securityVaultSection.depositRepAmountLabel}</span>
+					<span>{UI_STRING_REP_COLLATERAL_AMOUNT}</span>
 					<div className='field-inline'>
 						<FormInput className='field-inline-input' value={normalizedSecurityVaultForm.depositAmount} onInput={event => onSecurityVaultFormChange({ depositAmount: event.currentTarget.value })} disabled={!poolCollateralActionsEnabled} />
 						<button
@@ -864,19 +968,19 @@ export function SecurityVaultSection({
 							}}
 							disabled={securityVaultRepBalance === undefined || !poolCollateralActionsEnabled}
 						>
-							{UI_STRINGS.common.maxLabel}
+							{UI_STRING_MAX}
 						</button>
 					</div>
 				</label>
 				<TokenApprovalControl
-					actionLabel={UI_STRINGS.securityVaultSection.approveRepActionLabel}
+					actionLabel={UI_STRING_DEPOSITING_REP}
 					allowanceError={securityVaultRepApproval.error}
 					allowanceLoading={securityVaultRepApproval.loading}
 					approvedAmount={securityVaultRepApproval.value}
 					guardMessage={undefined}
 					onApprove={amount => onApproveRep(amount)}
 					pending={securityVaultActiveAction === 'approveRep'}
-					pendingLabel={UI_STRINGS.securityVaultSection.approvingRepPendingLabel}
+					pendingLabel={UI_STRING_APPROVING_REP}
 					requiredAmount={depositAmount}
 					resetKey={`${currentSelectedVaultDetails?.repToken ?? ''}:${currentSelectedVaultDetails?.securityPoolAddress ?? ''}:${depositAmount?.toString() ?? ''}`}
 					tokenSymbol='REP'
@@ -885,19 +989,19 @@ export function SecurityVaultSection({
 				/>
 				<div className='actions'>
 					<TransactionActionButton
-						idleLabel={UI_STRINGS.securityVaultSection.depositRepIdleLabel}
-						pendingLabel={UI_STRINGS.securityVaultSection.depositRepPendingLabel}
+						idleLabel={UI_STRING_DEPOSIT_REP}
+						pendingLabel={UI_STRING_DEPOSITING_REP_SECURITY_VAULT_SECTION_DEPOSIT_REP_PENDING_LABEL}
 						onClick={onDepositRep}
 						pending={securityVaultActiveAction === 'depositRep'}
 						availability={{ disabled: !depositRepEnabled || !canUseLoadedVaultActions || !hasPositiveDepositAmount || depositGuardMessage !== undefined, reason: canUseLoadedVaultActions ? depositGuardMessage : undefined }}
 					/>
 				</div>
 				{(() => {
-					if (repBalanceGap !== undefined && repBalanceGap > 0n) return <ErrorNotice message={UI_STRINGS.securityVaultSection.insufficientRepBalanceDetail(formatCurrencyBalance(repBalanceGap))} />
+					if (repBalanceGap !== undefined && repBalanceGap > 0n) return <ErrorNotice message={UI_TEMPLATE_INSUFFICIENT_REP_BALANCE_DETAIL(formatCurrencyBalance(repBalanceGap))} />
 					if (isDepositBelowMinimum)
 						return (
 							<p className='detail'>
-								{UI_STRINGS.securityVaultSection.firstDepositMinimumDetailPrefix} <CurrencyValue value={MIN_SECURITY_VAULT_REP_DEPOSIT} suffix={UI_STRINGS.common.repLabel} copyable={false} /> {UI_STRINGS.securityVaultSection.firstDepositMinimumInlineDetailSuffix}
+								{UI_STRING_NEW_VAULTS_REQUIRE_AT_LEAST} <CurrencyValue value={MIN_SECURITY_VAULT_REP_DEPOSIT} suffix={UI_STRING_REP} copyable={false} /> {UI_STRING_IN_THE_FIRST_DEPOSIT}
 							</p>
 						)
 
@@ -905,35 +1009,35 @@ export function SecurityVaultSection({
 				})()}
 			</SectionBlock>
 
-			<SectionBlock title={UI_STRINGS.securityVaultSection.setSecurityBondAllowanceTitle}>
+			<SectionBlock title={UI_STRING_SET_SECURITY_BOND_ALLOWANCE}>
 				{currentSelectedVaultDetails === undefined ? (
-					<p className='detail'>{UI_STRINGS.securityVaultSection.selectedVaultDetailsUnavailableDetail}</p>
+					<p className='detail'>{UI_STRING_SELECTED_VAULT_DETAILS_ARE_UNAVAILABLE}</p>
 				) : (
 					<>
 						<div className='entity-metric-grid'>
-							<MetricField className='entity-metric' label={UI_STRINGS.securityVaultSection.currentSecurityBondAllowanceLabel}>
-								<CurrencyValue value={securityBondAllowance} suffix={UI_STRINGS.common.ethSuffix} />
+							<MetricField className='entity-metric' label={UI_STRING_CURRENT_SECURITY_BOND_ALLOWANCE}>
+								<CurrencyValue value={securityBondAllowance} suffix={UI_STRING_ETH} />
 							</MetricField>
 							{oraclePriceValidUntilTimestamp === undefined ? undefined : (
-								<MetricField className='entity-metric' label={UI_STRINGS.securityVaultSection.priceValidUntilLabel}>
+								<MetricField className='entity-metric' label={UI_STRING_PRICE_VALID_UNTIL}>
 									<TimestampValue timestamp={oraclePriceValidUntilTimestamp} />
 								</MetricField>
 							)}
 						</div>
 						<label className='field'>
-							<span>{UI_STRINGS.securityVaultSection.securityBondAllowanceAmountLabel}</span>
+							<span>{UI_STRING_SECURITY_BOND_ALLOWANCE_AMOUNT}</span>
 							<div className='field-inline'>
 								<FormInput className='field-inline-input' value={normalizedSecurityVaultForm.securityBondAllowanceAmount} onInput={event => onSecurityVaultFormChange({ securityBondAllowanceAmount: event.currentTarget.value })} disabled={!poolCollateralActionsEnabled} />
 								<button className='quiet field-inline-action' type='button' onClick={() => onSecurityVaultFormChange({ securityBondAllowanceAmount: formatCurrencyInputBalance(maxSecurityBondAllowanceAmount) })} disabled={maxSecurityBondAllowanceAmount <= 0n || !poolCollateralActionsEnabled}>
-									{UI_STRINGS.common.maxLabel}
+									{UI_STRING_MAX}
 								</button>
 							</div>
 						</label>
 						{renderStagedOperationTimeoutField()}
 						<div className='actions'>
 							<TransactionActionButton
-								idleLabel={UI_STRINGS.securityVaultSection.setSecurityBondAllowanceIdleLabel}
-								pendingLabel={UI_STRINGS.securityVaultSection.setSecurityBondAllowancePendingLabel}
+								idleLabel={UI_STRING_SET_SECURITY_BOND_ALLOWANCE}
+								pendingLabel={UI_STRING_QUEUEING_ALLOWANCE_UPDATE}
 								onClick={onSetSecurityBondAllowance}
 								pending={securityVaultActiveAction === 'queueSetSecurityBondAllowance'}
 								tone='secondary'
@@ -946,23 +1050,23 @@ export function SecurityVaultSection({
 
 			<SectionBlock title={repExitActionLabel}>
 				{(effectiveRepExitMode === 'redeem' ? redeemableRepAmount : queuedWithdrawRepLimit) === undefined ? (
-					<p className='detail'>{UI_STRINGS.securityVaultSection.selectedVaultDetailsUnavailableDetail}</p>
+					<p className='detail'>{UI_STRING_SELECTED_VAULT_DETAILS_ARE_UNAVAILABLE}</p>
 				) : (
 					<div className='entity-metric-grid'>
 						<MetricField className='entity-metric' label={repExitAmountLabel}>
-							<CurrencyValue value={effectiveRepExitMode === 'redeem' ? redeemableRepAmount : queuedWithdrawRepLimit} suffix={UI_STRINGS.common.repLabel} />
+							<CurrencyValue value={effectiveRepExitMode === 'redeem' ? redeemableRepAmount : queuedWithdrawRepLimit} suffix={UI_STRING_REP} />
 						</MetricField>
 						{(() => {
 							if (effectiveRepExitMode === 'redeem')
 								return (
-									<MetricField className='entity-metric' label={UI_STRINGS.securityVaultSection.escalationEscrowedRepLabel}>
-										<CurrencyValue value={currentSelectedVaultDetails?.escalationEscrowedRep} suffix={UI_STRINGS.common.repLabel} />
+									<MetricField className='entity-metric' label={UI_STRING_ESCROWED_REP}>
+										<CurrencyValue value={currentSelectedVaultDetails?.escalationEscrowedRep} suffix={UI_STRING_REP} />
 									</MetricField>
 								)
 							if (oraclePriceValidUntilTimestamp === undefined) return undefined
 
 							return (
-								<MetricField className='entity-metric' label={UI_STRINGS.securityVaultSection.priceValidUntilLabel}>
+								<MetricField className='entity-metric' label={UI_STRING_PRICE_VALID_UNTIL}>
 									<TimestampValue timestamp={oraclePriceValidUntilTimestamp} />
 								</MetricField>
 							)
@@ -971,7 +1075,7 @@ export function SecurityVaultSection({
 				)}
 				{effectiveRepExitMode === 'redeem' ? null : (
 					<label className='field'>
-						<span>{UI_STRINGS.securityVaultSection.repWithdrawAmountLabel}</span>
+						<span>{UI_STRING_REP_WITHDRAW_AMOUNT}</span>
 						<div className='field-inline'>
 							<FormInput className='field-inline-input' value={normalizedSecurityVaultForm.repWithdrawAmount} onInput={event => onSecurityVaultFormChange({ repWithdrawAmount: event.currentTarget.value })} disabled={!poolCollateralActionsEnabled} />
 							<button
@@ -983,7 +1087,7 @@ export function SecurityVaultSection({
 								}}
 								disabled={queuedWithdrawRepLimit === undefined || !poolCollateralActionsEnabled}
 							>
-								{UI_STRINGS.common.maxLabel}
+								{UI_STRING_MAX}
 							</button>
 						</div>
 					</label>
@@ -992,7 +1096,7 @@ export function SecurityVaultSection({
 				<div className='actions'>
 					<TransactionActionButton
 						idleLabel={repExitActionLabel}
-						pendingLabel={effectiveRepExitMode === 'redeem' ? UI_STRINGS.securityVaultSection.redeemRepPendingLabel : UI_STRINGS.securityVaultSection.withdrawRepPendingLabel}
+						pendingLabel={effectiveRepExitMode === 'redeem' ? UI_STRING_REDEEMING_REP : UI_STRING_QUEUEING_REP_WITHDRAWAL}
 						onClick={effectiveRepExitMode === 'redeem' ? onRedeemRep : onWithdrawRep}
 						pending={effectiveRepExitMode === 'redeem' ? securityVaultActiveAction === 'redeemRep' : securityVaultActiveAction === 'queueWithdrawRep'}
 						tone='secondary'
@@ -1002,7 +1106,7 @@ export function SecurityVaultSection({
 						}}
 					/>
 				</div>
-				{effectiveRepExitMode === 'redeem' && currentSelectedVaultDetails?.escalationEscrowedRep !== undefined && currentSelectedVaultDetails.escalationEscrowedRep > 0n ? <p className='detail'>{UI_STRINGS.securityVaultSection.withdrawEscalationDepositsDetail}</p> : undefined}
+				{effectiveRepExitMode === 'redeem' && currentSelectedVaultDetails?.escalationEscrowedRep !== undefined && currentSelectedVaultDetails.escalationEscrowedRep > 0n ? <p className='detail'>{UI_STRING_WITHDRAW_ESCALATION_DEPOSITS}</p> : undefined}
 			</SectionBlock>
 
 			<ErrorNotice message={securityVaultError} />
@@ -1011,23 +1115,23 @@ export function SecurityVaultSection({
 	const sections = (
 		<>
 			{showLookupSection ? (
-				<SectionBlock title={UI_STRINGS.securityVaultSection.vaultLookupTitle}>
+				<SectionBlock title={UI_STRING_VAULT_LOOKUP}>
 					{vaultLoadNotice}
 					<LookupFieldRow
-						label={UI_STRINGS.securityVaultSection.selectedVaultAddressLabel}
+						label={UI_STRING_SELECTED_VAULT_ADDRESS}
 						value={normalizedSecurityVaultForm.selectedVaultAddress}
 						onInput={selectedVaultAddressInput => onSecurityVaultFormChange({ selectedVaultAddress: selectedVaultAddressInput })}
-						placeholder={UI_STRINGS.securityVaultSection.vaultLookupPlaceholder}
+						placeholder={UI_STRING_HEX_VALUE_PLACEHOLDER}
 						action={
 							<button className='secondary' onClick={() => onLoadSecurityVault()} disabled={loadingSecurityVault}>
-								{loadingSecurityVault ? <LoadingText>{UI_STRINGS.securityVaultSection.refreshButtonPendingLabel}</LoadingText> : UI_STRINGS.securityVaultSection.refreshButtonIdleLabel}
+								{loadingSecurityVault ? <LoadingText>{UI_STRING_REFRESHING}</LoadingText> : UI_STRING_REFRESH}
 							</button>
 						}
 					/>
 					{showSecurityPoolAddressInput ? (
 						<label className='field'>
-							<span>{UI_STRINGS.securityVaultSection.securityPoolAddressLabel}</span>
-							<FormInput value={normalizedSecurityVaultForm.securityPoolAddress} onInput={event => onSecurityVaultFormChange({ securityPoolAddress: event.currentTarget.value })} placeholder={UI_STRINGS.securityVaultSection.securityPoolAddressPlaceholder} />
+							<span>{UI_STRING_SECURITY_POOL_ADDRESS}</span>
+							<FormInput value={normalizedSecurityVaultForm.securityPoolAddress} onInput={event => onSecurityVaultFormChange({ securityPoolAddress: event.currentTarget.value })} placeholder={UI_STRING_HEX_VALUE_PLACEHOLDER} />
 						</label>
 					) : undefined}
 				</SectionBlock>
@@ -1050,7 +1154,7 @@ export function SecurityVaultSection({
 	)
 	if (compactLayout) return sections
 	return (
-		<RouteWorkflowPanel showHeader={showHeader} title={UI_STRINGS.securityVaultSection.securityVaultTitle}>
+		<RouteWorkflowPanel showHeader={showHeader} title={UI_STRING_SECURITY_VAULT}>
 			{sections}
 		</RouteWorkflowPanel>
 	)

--- a/ui/ts/components/ShareMigrationTargetsSection.tsx
+++ b/ui/ts/components/ShareMigrationTargetsSection.tsx
@@ -4,7 +4,27 @@ import { OutcomeSelectionList } from './OutcomeSelectionList.js'
 import { ScalarOutcomePicker } from './ScalarOutcomePicker.js'
 import { WorkflowSubsection } from './WorkflowSubsection.js'
 import { clampScalarTickIndex, formatScalarOutcomeIndexLabel, formatScalarOutcomeLabel, getScalarOutcomeIndex, getScalarOutcomeIndexDescriptor } from '../lib/scalarOutcome.js'
-import { UI_STRINGS } from '../lib/uiStrings.js'
+import {
+	UI_STRING_ADD_TARGET,
+	UI_STRING_CHILD_DEPLOYED,
+	UI_STRING_CHILD_NOT_DEPLOYED,
+	UI_STRING_CHILD_UNIVERSE_TARGETS_UNLOCK_AFTER_THIS_UNIVERSE_FORKS,
+	UI_STRING_CLEAR,
+	UI_STRING_INVALID,
+	UI_STRING_LOADING_FORK_QUESTION_DETAILS,
+	UI_STRING_LOADING_FORK_TARGET_UNIVERSES,
+	UI_STRING_LOADING_SCALAR_FORK_DETAILS,
+	UI_STRING_NO_TARGET_CHILD_UNIVERSES_AVAILABLE,
+	UI_STRING_NOT_SELECTED,
+	UI_STRING_REMOVE_TARGET,
+	UI_STRING_SELECT_ALL,
+	UI_STRING_SELECT_AT_LEAST_ONE_SCALAR_TARGET_UNIVERSE,
+	UI_STRING_SELECT_SCALAR_TARGET,
+	UI_STRING_SELECTED,
+	UI_STRING_TARGET_CHILD_UNIVERSES,
+	UI_TEMPLATE_MALFORMED_OUTCOME_LABEL,
+	UI_TEMPLATE_SELECTED_TICK_LABEL,
+} from '../lib/uiStrings.js'
 import type { MarketDetails, ZoltarChildUniverseSummary, ZoltarUniverseSummary } from '../types/contracts.js'
 
 type ShareMigrationTargetsSectionProps = {
@@ -24,7 +44,7 @@ type TargetOutcomePresentation = {
 }
 
 function getTargetOutcomeBadgeLabel(target: TargetOutcomePresentation) {
-	return target.exists ? UI_STRINGS.shareMigrationTargetsSection.childDeployedLabel : UI_STRINGS.shareMigrationTargetsSection.childNotDeployedLabel
+	return target.exists ? UI_STRING_CHILD_DEPLOYED : UI_STRING_CHILD_NOT_DEPLOYED
 }
 
 function renderTargetOutcomeRow(target: TargetOutcomePresentation, selected: boolean, disabled: boolean, onToggleOutcomeIndex: (outcomeIndex: bigint) => void) {
@@ -32,7 +52,7 @@ function renderTargetOutcomeRow(target: TargetOutcomePresentation, selected: boo
 		details: (
 			<>
 				<span>
-					<strong>{selected ? UI_STRINGS.shareMigrationTargetsSection.selectedLabel : UI_STRINGS.shareMigrationTargetsSection.notSelectedLabel}</strong>
+					<strong>{selected ? UI_STRING_SELECTED : UI_STRING_NOT_SELECTED}</strong>
 				</span>
 				<span>
 					<strong>{getTargetOutcomeBadgeLabel(target)}</strong>
@@ -51,7 +71,7 @@ function getScalarSelectedTargetOutcomes(childUniverseByOutcomeIndex: Map<string
 	return selectedOutcomeIndexes.map(outcomeIndex => {
 		const childUniverse = childUniverseByOutcomeIndex.get(outcomeIndex.toString())
 		const descriptor = getScalarOutcomeIndexDescriptor(scalarQuestion, outcomeIndex)
-		const label = childUniverse?.outcomeLabel ?? (descriptor.kind === 'malformed' ? UI_STRINGS.shareMigrationTargetsSection.malformedOutcomeLabel(outcomeIndex.toString()) : formatScalarOutcomeIndexLabel(scalarQuestion, outcomeIndex))
+		const label = childUniverse?.outcomeLabel ?? (descriptor.kind === 'malformed' ? UI_TEMPLATE_MALFORMED_OUTCOME_LABEL(outcomeIndex.toString()) : formatScalarOutcomeIndexLabel(scalarQuestion, outcomeIndex))
 		return {
 			exists: childUniverse?.exists === true,
 			label,
@@ -82,11 +102,11 @@ export function ShareMigrationTargetsSection({ disabled, forkUniverse, onClearOu
 		setScalarOutcomeTick(nextTick)
 	}, [scalarOutcomeTick, scalarQuestion, selectedScalarTick])
 
-	if (forkUniverse === undefined) return renderTargetSection(UI_STRINGS.shareMigrationTargetsSection.targetChildUniversesTitle, <p className='detail'>{UI_STRINGS.shareMigrationTargetsSection.loadingForkTargetUniversesDetail}</p>)
+	if (forkUniverse === undefined) return renderTargetSection(UI_STRING_TARGET_CHILD_UNIVERSES, <p className='detail'>{UI_STRING_LOADING_FORK_TARGET_UNIVERSES}</p>)
 
-	if (!forkUniverse.hasForked) return renderTargetSection(UI_STRINGS.shareMigrationTargetsSection.targetChildUniversesTitle, <p className='detail'>{UI_STRINGS.shareMigrationTargetsSection.targetsUnlockAfterForkDetail}</p>)
+	if (!forkUniverse.hasForked) return renderTargetSection(UI_STRING_TARGET_CHILD_UNIVERSES, <p className='detail'>{UI_STRING_CHILD_UNIVERSE_TARGETS_UNLOCK_AFTER_THIS_UNIVERSE_FORKS}</p>)
 
-	if (forkUniverse.forkQuestionDetails === undefined) return renderTargetSection(UI_STRINGS.shareMigrationTargetsSection.targetChildUniversesTitle, <p className='detail'>{UI_STRINGS.shareMigrationTargetsSection.loadingForkQuestionDetailsDetail}</p>)
+	if (forkUniverse.forkQuestionDetails === undefined) return renderTargetSection(UI_STRING_TARGET_CHILD_UNIVERSES, <p className='detail'>{UI_STRING_LOADING_FORK_QUESTION_DETAILS}</p>)
 
 	if (forkUniverse.forkQuestionDetails.marketType !== 'scalar') {
 		const childUniverses = forkUniverse.childUniverses.map(child => ({
@@ -97,36 +117,36 @@ export function ShareMigrationTargetsSection({ disabled, forkUniverse, onClearOu
 		const hasSelectableTargets = childUniverses.length > 0
 
 		return renderTargetSection(
-			UI_STRINGS.shareMigrationTargetsSection.targetChildUniversesTitle,
-			<OutcomeSelectionList emptyMessage={UI_STRINGS.shareMigrationTargetsSection.noTargetChildUniversesDetail} items={childUniverses.map(target => renderTargetOutcomeRow(target, selectedOutcomeIndexSet.has(target.outcomeIndex.toString()), disabled, onToggleOutcomeIndex))} />,
+			UI_STRING_TARGET_CHILD_UNIVERSES,
+			<OutcomeSelectionList emptyMessage={UI_STRING_NO_TARGET_CHILD_UNIVERSES_AVAILABLE} items={childUniverses.map(target => renderTargetOutcomeRow(target, selectedOutcomeIndexSet.has(target.outcomeIndex.toString()), disabled, onToggleOutcomeIndex))} />,
 			<div className='actions'>
 				<button className='quiet' type='button' onClick={onSelectAllOutcomeIndexes} disabled={disabled || !hasSelectableTargets}>
-					{UI_STRINGS.shareMigrationTargetsSection.selectAllLabel}
+					{UI_STRING_SELECT_ALL}
 				</button>
 				<button className='quiet' type='button' onClick={onClearOutcomeIndexes} disabled={disabled || selectedOutcomeIndexes.length === 0}>
-					{UI_STRINGS.shareMigrationTargetsSection.clearLabel}
+					{UI_STRING_CLEAR}
 				</button>
 			</div>,
 		)
 	}
 
-	if (scalarQuestion === undefined) return renderTargetSection(UI_STRINGS.shareMigrationTargetsSection.targetChildUniversesTitle, <p className='detail'>{UI_STRINGS.shareMigrationTargetsSection.loadingScalarForkDetailsDetail}</p>)
+	if (scalarQuestion === undefined) return renderTargetSection(UI_STRING_TARGET_CHILD_UNIVERSES, <p className='detail'>{UI_STRING_LOADING_SCALAR_FORK_DETAILS}</p>)
 
 	const clampedSelectedScalarTick = clampScalarTickIndex(selectedScalarTick, scalarQuestion.numTicks)
 	const clampedScalarOutcomeTick = clampedSelectedScalarTick.toString()
 	const candidateOutcomeIndex = scalarOutcomeInvalid ? 0n : getScalarOutcomeIndex(scalarQuestion, clampedSelectedScalarTick)
-	const candidateOutcomeLabel = scalarOutcomeInvalid ? UI_STRINGS.question.invalidOutcomeLabel : formatScalarOutcomeLabel(scalarQuestion, clampedSelectedScalarTick)
+	const candidateOutcomeLabel = scalarOutcomeInvalid ? UI_STRING_INVALID : formatScalarOutcomeLabel(scalarQuestion, clampedSelectedScalarTick)
 	const candidateSelected = selectedOutcomeIndexSet.has(candidateOutcomeIndex.toString())
 	const selectedTargetOutcomes = getScalarSelectedTargetOutcomes(childUniverseByOutcomeIndex, scalarQuestion, selectedOutcomeIndexes)
 
 	return renderTargetSection(
-		UI_STRINGS.shareMigrationTargetsSection.targetChildUniversesTitle,
+		UI_STRING_TARGET_CHILD_UNIVERSES,
 		<>
-			<OutcomeSelectionList emptyMessage={UI_STRINGS.shareMigrationTargetsSection.selectScalarTargetUniverseDetail} items={selectedTargetOutcomes.map(target => renderTargetOutcomeRow(target, true, disabled, onToggleOutcomeIndex))} />
+			<OutcomeSelectionList emptyMessage={UI_STRING_SELECT_AT_LEAST_ONE_SCALAR_TARGET_UNIVERSE} items={selectedTargetOutcomes.map(target => renderTargetOutcomeRow(target, true, disabled, onToggleOutcomeIndex))} />
 			<ScalarOutcomePicker
 				action={
 					<button className='secondary' type='button' onClick={() => onToggleOutcomeIndex(candidateOutcomeIndex)} disabled={disabled}>
-						{candidateSelected ? UI_STRINGS.shareMigrationTargetsSection.removeTargetLabel : UI_STRINGS.shareMigrationTargetsSection.addTargetLabel}
+						{candidateSelected ? UI_STRING_REMOVE_TARGET : UI_STRING_ADD_TARGET}
 					</button>
 				}
 				details={{
@@ -136,16 +156,16 @@ export function ShareMigrationTargetsSection({ disabled, forkUniverse, onClearOu
 				}}
 				disabled={disabled}
 				isInvalid={scalarOutcomeInvalid}
-				label={UI_STRINGS.shareMigrationTargetsSection.selectScalarTargetLabel}
+				label={UI_STRING_SELECT_SCALAR_TARGET}
 				onInvalidChange={setScalarOutcomeInvalid}
 				onSelectedTickChange={setScalarOutcomeTick}
 				selectedOutcomeLabel={candidateOutcomeLabel}
 				selectedTick={clampedScalarOutcomeTick}
-				selectedTickLabel={scalarOutcomeInvalid ? UI_STRINGS.question.invalidOutcomeLabel : UI_STRINGS.shareMigrationTargetsSection.selectedTickLabel(clampedScalarOutcomeTick, scalarQuestion.numTicks.toString())}
+				selectedTickLabel={scalarOutcomeInvalid ? UI_STRING_INVALID : UI_TEMPLATE_SELECTED_TICK_LABEL(clampedScalarOutcomeTick, scalarQuestion.numTicks.toString())}
 			/>
 		</>,
 		<button className='quiet' type='button' onClick={onClearOutcomeIndexes} disabled={disabled || selectedOutcomeIndexes.length === 0}>
-			{UI_STRINGS.shareMigrationTargetsSection.clearLabel}
+			{UI_STRING_CLEAR}
 		</button>,
 	)
 }

--- a/ui/ts/components/TabNavigation.tsx
+++ b/ui/ts/components/TabNavigation.tsx
@@ -1,38 +1,38 @@
 import { ViewTabs } from './ViewTabs.js'
 import { buildRouteHref, getRouteHashSearch } from '../lib/routing.js'
-import { UI_STRINGS } from '../lib/uiStrings.js'
+import { UI_STRING_APPLICATION_SECTIONS, UI_STRING_DEPLOY, UI_STRING_DEPLOY_THE_APPLICATION_CONTRACTS_BEFORE_USING_THIS_SECTION, UI_STRING_MARKETS, UI_STRING_ORACLE_REPORTS, UI_STRING_SECURITY_POOLS } from '../lib/uiStrings.js'
 import type { TabNavigationProps } from '../types/components.js'
 
 export function TabNavigation({ route, showDeployTab = true, augurPlaceHolderDeployed, deployRoute, marketRoute, openOracleRoute, securityPoolsRoute, onRouteChange }: TabNavigationProps) {
-	const disabledTabReason = UI_STRINGS.tabNavigation.deployContractsFirstReason
+	const disabledTabReason = UI_STRING_DEPLOY_THE_APPLICATION_CONTRACTS_BEFORE_USING_THIS_SECTION
 	const options: Array<{ disabled?: boolean; href: string; label: string; reason?: string; value: Exclude<TabNavigationProps['route'], 'not-found'> }> = []
 	const currentRouteSearch = getRouteHashSearch()
-	if (showDeployTab) options.push({ value: 'deploy', label: UI_STRINGS.tabNavigation.deployTabLabel, href: buildRouteHref(deployRoute, currentRouteSearch) })
+	if (showDeployTab) options.push({ value: 'deploy', label: UI_STRING_DEPLOY, href: buildRouteHref(deployRoute, currentRouteSearch) })
 	options.push({
 		value: 'zoltar',
-		label: UI_STRINGS.tabNavigation.marketsTabLabel,
+		label: UI_STRING_MARKETS,
 		href: buildRouteHref(marketRoute, currentRouteSearch),
 		disabled: !augurPlaceHolderDeployed,
 		...(!augurPlaceHolderDeployed ? { reason: disabledTabReason } : {}),
 	})
 	options.push({
 		value: 'security-pools',
-		label: UI_STRINGS.tabNavigation.securityPoolsTabLabel,
+		label: UI_STRING_SECURITY_POOLS,
 		href: buildRouteHref(securityPoolsRoute, currentRouteSearch),
 		disabled: !augurPlaceHolderDeployed,
 		...(!augurPlaceHolderDeployed ? { reason: disabledTabReason } : {}),
 	})
 	options.push({
 		value: 'open-oracle',
-		label: UI_STRINGS.tabNavigation.oracleReportsTabLabel,
+		label: UI_STRING_ORACLE_REPORTS,
 		href: buildRouteHref(openOracleRoute, currentRouteSearch),
 		disabled: !augurPlaceHolderDeployed,
 		...(!augurPlaceHolderDeployed ? { reason: disabledTabReason } : {}),
 	})
 
 	return (
-		<nav className='tab-nav' aria-label={UI_STRINGS.tabNavigation.applicationSectionsAriaLabel}>
-			<ViewTabs ariaLabel={UI_STRINGS.tabNavigation.applicationSectionsAriaLabel} value={route === 'not-found' ? 'deploy' : route} variant='route' onChange={value => onRouteChange(value as Exclude<TabNavigationProps['route'], 'not-found'>)} options={options} />
+		<nav className='tab-nav' aria-label={UI_STRING_APPLICATION_SECTIONS}>
+			<ViewTabs ariaLabel={UI_STRING_APPLICATION_SECTIONS} value={route === 'not-found' ? 'deploy' : route} variant='route' onChange={value => onRouteChange(value as Exclude<TabNavigationProps['route'], 'not-found'>)} options={options} />
 		</nav>
 	)
 }

--- a/ui/ts/components/TradingSection.tsx
+++ b/ui/ts/components/TradingSection.tsx
@@ -18,7 +18,66 @@ import { tryParseBigIntListInput } from '../lib/inputs.js'
 import { isMainnetChain } from '../lib/network.js'
 import { getReportingOutcomeLabel, REPORTING_OUTCOME_DROPDOWN_OPTIONS } from '../lib/reporting.js'
 import { deriveSecurityPoolLifecycleState, evaluateSecurityPoolState } from '../lib/securityPoolState.js'
-import { UI_STRINGS } from '../lib/uiStrings.js'
+import {
+	UI_STRING_BOND_ALLOWANCE_IN_USE,
+	UI_STRING_BURN_MATCHING_YES_NO_AND_INVALID_SHARES_TO_RECOVER_COLLATERAL_FROM_THE_CURRENT_POOL,
+	UI_STRING_BURN_PARENT_POOL_SHARES_FOR_ONE_OUTCOME_AND_RECREATE_THEM_ACROSS_SELECTED_CHILD_UNIVERSES,
+	UI_STRING_CONNECT_A_WALLET_BEFORE_MIGRATING_SHARES,
+	UI_STRING_CONNECT_A_WALLET_BEFORE_MINTING_COMPLETE_SETS,
+	UI_STRING_CONNECT_A_WALLET_BEFORE_REDEEMING_COMPLETE_SETS,
+	UI_STRING_CONNECT_A_WALLET_BEFORE_REDEEMING_SHARES,
+	UI_STRING_ETH,
+	UI_STRING_HEX_VALUE_PLACEHOLDER,
+	UI_STRING_INVALID,
+	UI_STRING_LIMITED_BY_YOUR_SMALLEST_YES_NO_OR_INVALID_BALANCE,
+	UI_STRING_LOAD_A_POOL_BEFORE_MIGRATING_SHARES,
+	UI_STRING_LOAD_A_POOL_BEFORE_MINTING_COMPLETE_SETS,
+	UI_STRING_LOAD_A_POOL_BEFORE_REDEEMING_COMPLETE_SETS,
+	UI_STRING_LOAD_A_POOL_BEFORE_REDEEMING_SHARES,
+	UI_STRING_LOADING_FORK_TARGET_UNIVERSES_TRADING_SECTION_LOADING_FORK_TARGET_UNIVERSES_REASON,
+	UI_STRING_LOADING_MINT_CAPACITY,
+	UI_STRING_LOADING_WALLET_SHARE_BALANCES,
+	UI_STRING_LOCK_COLLATERAL_TO_MINT_A_FRESH_YES_NO_AND_INVALID_SHARE_SET_FOR_THIS_POOL,
+	UI_STRING_MAX,
+	UI_STRING_MIGRATE_FORKED_SHARES,
+	UI_STRING_MIGRATE_FORKED_SHARES_TRADING_SECTION_MIGRATE_FORKED_SHARES_TITLE,
+	UI_STRING_MIGRATE_SHARES,
+	UI_STRING_MIGRATING_BURNS_THE_SELECTED_PARENT_POOL_SHARE_BALANCE_AND_RECREATES_IT_ACROSS_THE_CHOSEN_CHILD_UNIVERSES_REVIEW_THE_SOURCE_OUTCOME_AND_TARGET_UNIVERSES_CAREFULLY_BEFORE_SUBMITTING,
+	UI_STRING_MIGRATING_SHARES,
+	UI_STRING_MINT_COMPLETE_SETS,
+	UI_STRING_MINT_COMPLETE_SETS_AMOUNT,
+	UI_STRING_MINT_COMPLETE_SETS_TRADING_SECTION_MINT_COMPLETE_SETS_ACTION_LABEL,
+	UI_STRING_MINTING_COMPLETE_SETS,
+	UI_STRING_NO,
+	UI_STRING_NO_MINT_CAPACITY_REMAINING,
+	UI_STRING_REDEEM_COMPLETE_SETS,
+	UI_STRING_REDEEM_COMPLETE_SETS_AMOUNT,
+	UI_STRING_REDEEM_COMPLETE_SETS_TRADING_SECTION_REDEEM_COMPLETE_SETS_ACTION_LABEL,
+	UI_STRING_REDEEM_FINAL_WINNING_SHARES_AFTER_THE_SELECTED_POOL_FULLY_RESOLVES,
+	UI_STRING_REDEEM_FINALIZED_WINNING_SHARES_ONCE_THE_SELECTED_POOL_HAS_RESOLVED,
+	UI_STRING_REDEEM_RESOLVED_SHARES,
+	UI_STRING_REDEEM_RESOLVED_SHARES_TRADING_SECTION_REDEEM_SHARES_ACTION_LABEL,
+	UI_STRING_REDEEM_SHARES,
+	UI_STRING_REDEEMABLE_COMPLETE_SETS,
+	UI_STRING_REDEEMING_COMPLETE_SETS,
+	UI_STRING_REDEEMING_COMPLETE_SETS_REQUIRES_MATCHING_YES_NO_AND_INVALID_SHARES_USE_THE_REDEEMABLE_COMPLETE_SETS_AMOUNT_AS_THE_CEILING,
+	UI_STRING_REDEEMING_SHARES,
+	UI_STRING_REFRESH_THE_FORK_TARGET_UNIVERSES,
+	UI_STRING_REP,
+	UI_STRING_REP_BACKING,
+	UI_STRING_REVIEW_AVAILABLE_CAPACITY_AND_CONFIRM_THE_COMPLETE_SET_MINT_AMOUNT_BEFORE_SUBMITTING,
+	UI_STRING_SECURITY_POOL_ADDRESS,
+	UI_STRING_SHARE_OUTCOME_TO_MIGRATE,
+	UI_STRING_SHARES,
+	UI_STRING_THIS_MARKET_HAS_ALREADY_FINALIZED,
+	UI_STRING_TOTAL_ACROSS_OUTCOMES,
+	UI_STRING_WAIT_FOR_THE_SELECTED_POOL_TO_RESOLVE_BEFORE_REDEEMING_SHARES,
+	UI_STRING_WALLET_BALANCES_ARE_NOT_LOADED,
+	UI_STRING_YES,
+	UI_STRING_YOUR_HOLDINGS,
+	UI_TEMPLATE_ACTION_UNAVAILABLE_REASON,
+	UI_TEMPLATE_NO_SHARES_AVAILABLE_TO_MIGRATE_REASON,
+} from '../lib/uiStrings.js'
 import {
 	getDefaultShareMigrationTargetOutcomeIndexes,
 	getRemainingMintCapacity,
@@ -133,20 +192,20 @@ export function TradingSection({
 	const remainingMintCapacity = getRemainingMintCapacity(selectedPool?.totalSecurityBondAllowance, selectedPool?.completeSetCollateralAmount, selectedPool?.shareTokenSupply)
 	const selectedOutcomeBalance = getSelectedOutcomeShareBalance(shareBalances, tradingForm.selectedShareOutcome)
 	const mintLauncherBlocker = (() => {
-		if (!hasSelectedPool) return UI_STRINGS.tradingSection.loadPoolToMintReason
-		if (accountState.address === undefined) return UI_STRINGS.tradingSection.connectWalletToMintReason
+		if (!hasSelectedPool) return UI_STRING_LOAD_A_POOL_BEFORE_MINTING_COMPLETE_SETS
+		if (accountState.address === undefined) return UI_STRING_CONNECT_A_WALLET_BEFORE_MINTING_COMPLETE_SETS
 
 		return (() => {
 			if (!isMainnet) return undefined
-			if (selectedPool?.questionOutcome !== 'none') return UI_STRINGS.tradingSection.marketAlreadyFinalizedReason
-			if (remainingMintCapacity === undefined) return UI_STRINGS.tradingSection.loadingMintCapacityReason
+			if (selectedPool?.questionOutcome !== 'none') return UI_STRING_THIS_MARKET_HAS_ALREADY_FINALIZED
+			if (remainingMintCapacity === undefined) return UI_STRING_LOADING_MINT_CAPACITY
 			if (hasUndefinedCompleteSetExchangeRate(selectedPool?.completeSetCollateralAmount, selectedPool?.shareTokenSupply) === true) return UNDEFINED_COMPLETE_SET_EXCHANGE_RATE_MESSAGE
 
 			return (() => {
 				if (remainingMintCapacity === 0n) {
 					if (hasRepBackedPoolWithNoActiveAllowance(selectedPool?.totalRepDeposit, selectedPool?.totalSecurityBondAllowance)) return NO_MINT_CAPACITY_NO_ACTIVE_ALLOWANCE_MESSAGE
 
-					return UI_STRINGS.tradingSection.noMintCapacityRemainingReason
+					return UI_STRING_NO_MINT_CAPACITY_REMAINING
 				}
 
 				return undefined
@@ -154,15 +213,15 @@ export function TradingSection({
 		})()
 	})()
 	const redeemCompleteSetsLauncherBlocker = (() => {
-		if (!hasSelectedPool) return UI_STRINGS.tradingSection.loadPoolToRedeemCompleteSetsReason
-		if (accountState.address === undefined) return UI_STRINGS.tradingSection.connectWalletToRedeemCompleteSetsReason
+		if (!hasSelectedPool) return UI_STRING_LOAD_A_POOL_BEFORE_REDEEMING_COMPLETE_SETS
+		if (accountState.address === undefined) return UI_STRING_CONNECT_A_WALLET_BEFORE_REDEEMING_COMPLETE_SETS
 
 		return (() => {
 			if (!isMainnet) return undefined
-			if (loadingTradingDetails) return UI_STRINGS.tradingSection.loadWalletShareBalancesReason
+			if (loadingTradingDetails) return UI_STRING_LOADING_WALLET_SHARE_BALANCES
 
 			return (() => {
-				if (maxRedeemableCompleteSets === undefined) return UI_STRINGS.tradingSection.loadWalletShareBalancesReason
+				if (maxRedeemableCompleteSets === undefined) return UI_STRING_LOADING_WALLET_SHARE_BALANCES
 				if (maxRedeemableCompleteSets === 0n) return NEED_MATCHING_COMPLETE_SET_SHARES_MESSAGE
 
 				return undefined
@@ -170,20 +229,20 @@ export function TradingSection({
 		})()
 	})()
 	const migrateSharesLauncherBlocker = (() => {
-		if (!hasSelectedPool) return UI_STRINGS.tradingSection.loadPoolToMigrateSharesReason
-		if (accountState.address === undefined) return UI_STRINGS.tradingSection.connectWalletToMigrateSharesReason
+		if (!hasSelectedPool) return UI_STRING_LOAD_A_POOL_BEFORE_MIGRATING_SHARES
+		if (accountState.address === undefined) return UI_STRING_CONNECT_A_WALLET_BEFORE_MIGRATING_SHARES
 
 		return (() => {
 			if (!isMainnet) return undefined
-			if (loadingTradingForkUniverse) return UI_STRINGS.tradingSection.loadingForkTargetUniversesReason
+			if (loadingTradingForkUniverse) return UI_STRING_LOADING_FORK_TARGET_UNIVERSES_TRADING_SECTION_LOADING_FORK_TARGET_UNIVERSES_REASON
 
 			return (() => {
-				if (tradingForkUniverse === undefined || !tradingForkUniverse.hasForked) return UI_STRINGS.tradingSection.refreshForkTargetUniversesReason
-				if (loadingTradingDetails) return UI_STRINGS.tradingSection.loadWalletShareBalancesReason
+				if (tradingForkUniverse === undefined || !tradingForkUniverse.hasForked) return UI_STRING_REFRESH_THE_FORK_TARGET_UNIVERSES
+				if (loadingTradingDetails) return UI_STRING_LOADING_WALLET_SHARE_BALANCES
 
 				return (() => {
-					if (selectedOutcomeBalance === undefined) return UI_STRINGS.tradingSection.loadWalletShareBalancesReason
-					if (selectedOutcomeBalance === 0n) return UI_STRINGS.tradingSection.noSharesAvailableToMigrateReason(getReportingOutcomeLabel(tradingForm.selectedShareOutcome))
+					if (selectedOutcomeBalance === undefined) return UI_STRING_LOADING_WALLET_SHARE_BALANCES
+					if (selectedOutcomeBalance === 0n) return UI_TEMPLATE_NO_SHARES_AVAILABLE_TO_MIGRATE_REASON(getReportingOutcomeLabel(tradingForm.selectedShareOutcome))
 
 					return undefined
 				})()
@@ -191,18 +250,18 @@ export function TradingSection({
 		})()
 	})()
 	const redeemSharesLauncherBlocker = !hasSelectedPool
-		? UI_STRINGS.tradingSection.loadPoolToRedeemSharesReason
+		? UI_STRING_LOAD_A_POOL_BEFORE_REDEEMING_SHARES
 		: (() => {
-				if (accountState.address === undefined) return UI_STRINGS.tradingSection.connectWalletToRedeemSharesReason
+				if (accountState.address === undefined) return UI_STRING_CONNECT_A_WALLET_BEFORE_REDEEMING_SHARES
 				if (!isMainnet) return undefined
-				if (selectedPool?.questionOutcome === 'none') return UI_STRINGS.tradingSection.waitForPoolToResolveReason
+				if (selectedPool?.questionOutcome === 'none') return UI_STRING_WAIT_FOR_THE_SELECTED_POOL_TO_RESOLVE_BEFORE_REDEEMING_SHARES
 
 				return undefined
 			})()
-	const effectiveMintLauncherBlocker = mintLauncherBlocker ?? (mintEnabled ? undefined : UI_STRINGS.tradingSection.actionUnavailableReason(UI_STRINGS.tradingSection.mintCompleteSetsActionLabel))
-	const effectiveRedeemCompleteSetsLauncherBlocker = redeemCompleteSetsLauncherBlocker ?? (redeemCompleteSetsEnabled ? undefined : UI_STRINGS.tradingSection.actionUnavailableReason(UI_STRINGS.tradingSection.redeemCompleteSetsActionLabel))
-	const effectiveMigrateSharesLauncherBlocker = migrateSharesLauncherBlocker ?? (migrateSharesEnabled ? undefined : UI_STRINGS.tradingSection.actionUnavailableReason(UI_STRINGS.tradingSection.migrateForkedSharesActionLabel))
-	const effectiveRedeemSharesLauncherBlocker = redeemSharesLauncherBlocker ?? (redeemSharesEnabled ? undefined : UI_STRINGS.tradingSection.actionUnavailableReason(UI_STRINGS.tradingSection.redeemSharesActionLabel))
+	const effectiveMintLauncherBlocker = mintLauncherBlocker ?? (mintEnabled ? undefined : UI_TEMPLATE_ACTION_UNAVAILABLE_REASON(UI_STRING_MINT_COMPLETE_SETS_TRADING_SECTION_MINT_COMPLETE_SETS_ACTION_LABEL))
+	const effectiveRedeemCompleteSetsLauncherBlocker = redeemCompleteSetsLauncherBlocker ?? (redeemCompleteSetsEnabled ? undefined : UI_TEMPLATE_ACTION_UNAVAILABLE_REASON(UI_STRING_REDEEM_COMPLETE_SETS_TRADING_SECTION_REDEEM_COMPLETE_SETS_ACTION_LABEL))
+	const effectiveMigrateSharesLauncherBlocker = migrateSharesLauncherBlocker ?? (migrateSharesEnabled ? undefined : UI_TEMPLATE_ACTION_UNAVAILABLE_REASON(UI_STRING_MIGRATE_FORKED_SHARES))
+	const effectiveRedeemSharesLauncherBlocker = redeemSharesLauncherBlocker ?? (redeemSharesEnabled ? undefined : UI_TEMPLATE_ACTION_UNAVAILABLE_REASON(UI_STRING_REDEEM_RESOLVED_SHARES_TRADING_SECTION_REDEEM_SHARES_ACTION_LABEL))
 	const shareMigrationSelectionDisabled = poolUniverseHasForked !== true
 	const setAllTargetOutcomeIndexes = () => {
 		onTradingFormChange({ targetOutcomeIndexes: getDefaultShareMigrationTargetOutcomeIndexes(tradingForkUniverse) })
@@ -237,38 +296,38 @@ export function TradingSection({
 	const renderShareMetricValue = (value: bigint | undefined) => <CurrencyValue loading={loadingTradingDetails} value={value} />
 	const tradingLaunchers: ReadinessAction[] = [
 		{
-			actionLabel: UI_STRINGS.tradingSection.mintCompleteSetsActionLabel,
-			description: UI_STRINGS.tradingSection.mintCompleteSetsDescription,
+			actionLabel: UI_STRING_MINT_COMPLETE_SETS_TRADING_SECTION_MINT_COMPLETE_SETS_ACTION_LABEL,
+			description: UI_STRING_LOCK_COLLATERAL_TO_MINT_A_FRESH_YES_NO_AND_INVALID_SHARE_SET_FOR_THIS_POOL,
 			key: 'mint-complete-sets',
 			readiness: !walletOnWrongNetwork && mintEnabled && effectiveMintLauncherBlocker === undefined ? 'ready' : 'blocked',
-			title: UI_STRINGS.tradingSection.mintCompleteSetsTitle,
+			title: UI_STRING_MINT_COMPLETE_SETS,
 			...(!walletOnWrongNetwork && mintEnabled && effectiveMintLauncherBlocker === undefined ? { onAction: () => setActiveModal('mint') } : {}),
 			...(effectiveMintLauncherBlocker === undefined ? {} : { blocker: effectiveMintLauncherBlocker }),
 		},
 		{
-			actionLabel: UI_STRINGS.tradingSection.redeemCompleteSetsActionLabel,
-			description: UI_STRINGS.tradingSection.redeemCompleteSetsDescription,
+			actionLabel: UI_STRING_REDEEM_COMPLETE_SETS_TRADING_SECTION_REDEEM_COMPLETE_SETS_ACTION_LABEL,
+			description: UI_STRING_BURN_MATCHING_YES_NO_AND_INVALID_SHARES_TO_RECOVER_COLLATERAL_FROM_THE_CURRENT_POOL,
 			key: 'redeem-complete-sets',
 			readiness: !walletOnWrongNetwork && redeemCompleteSetsEnabled && effectiveRedeemCompleteSetsLauncherBlocker === undefined ? 'ready' : 'blocked',
-			title: UI_STRINGS.tradingSection.redeemCompleteSetsTitle,
+			title: UI_STRING_REDEEM_COMPLETE_SETS,
 			...(!walletOnWrongNetwork && redeemCompleteSetsEnabled && effectiveRedeemCompleteSetsLauncherBlocker === undefined ? { onAction: () => setActiveModal('redeem-complete-sets') } : {}),
 			...(effectiveRedeemCompleteSetsLauncherBlocker === undefined ? {} : { blocker: effectiveRedeemCompleteSetsLauncherBlocker }),
 		},
 		{
-			actionLabel: UI_STRINGS.tradingSection.migrateForkedSharesActionLabel,
-			description: UI_STRINGS.tradingSection.migrateForkedSharesDescription,
+			actionLabel: UI_STRING_MIGRATE_FORKED_SHARES,
+			description: UI_STRING_BURN_PARENT_POOL_SHARES_FOR_ONE_OUTCOME_AND_RECREATE_THEM_ACROSS_SELECTED_CHILD_UNIVERSES,
 			key: 'migrate-shares',
 			readiness: !walletOnWrongNetwork && migrateSharesEnabled && effectiveMigrateSharesLauncherBlocker === undefined ? 'ready' : 'blocked',
-			title: UI_STRINGS.tradingSection.migrateForkedSharesTitle,
+			title: UI_STRING_MIGRATE_FORKED_SHARES_TRADING_SECTION_MIGRATE_FORKED_SHARES_TITLE,
 			...(!walletOnWrongNetwork && migrateSharesEnabled && effectiveMigrateSharesLauncherBlocker === undefined ? { onAction: () => setActiveModal('migrate-shares') } : {}),
 			...(effectiveMigrateSharesLauncherBlocker === undefined ? {} : { blocker: effectiveMigrateSharesLauncherBlocker }),
 		},
 		{
-			actionLabel: UI_STRINGS.tradingSection.redeemSharesActionLabel,
-			description: UI_STRINGS.tradingSection.redeemSharesDescription,
+			actionLabel: UI_STRING_REDEEM_RESOLVED_SHARES_TRADING_SECTION_REDEEM_SHARES_ACTION_LABEL,
+			description: UI_STRING_REDEEM_FINAL_WINNING_SHARES_AFTER_THE_SELECTED_POOL_FULLY_RESOLVES,
 			key: 'redeem-shares',
 			readiness: !walletOnWrongNetwork && redeemSharesEnabled && effectiveRedeemSharesLauncherBlocker === undefined ? 'ready' : 'blocked',
-			title: UI_STRINGS.tradingSection.redeemSharesTitle,
+			title: UI_STRING_REDEEM_RESOLVED_SHARES,
 			...(!walletOnWrongNetwork && redeemSharesEnabled && effectiveRedeemSharesLauncherBlocker === undefined ? { onAction: () => setActiveModal('redeem-shares') } : {}),
 			...(effectiveRedeemSharesLauncherBlocker === undefined ? {} : { blocker: effectiveRedeemSharesLauncherBlocker }),
 		},
@@ -278,40 +337,40 @@ export function TradingSection({
 			{!showSecurityPoolAddressInput ? undefined : (
 				<SectionBlock density='compact'>
 					<label className='field'>
-						<span>{UI_STRINGS.tradingSection.securityPoolAddressLabel}</span>
-						<FormInput value={tradingForm.securityPoolAddress} onInput={event => onTradingFormChange({ securityPoolAddress: event.currentTarget.value })} placeholder={UI_STRINGS.common.hexValuePlaceholder} />
+						<span>{UI_STRING_SECURITY_POOL_ADDRESS}</span>
+						<FormInput value={tradingForm.securityPoolAddress} onInput={event => onTradingFormChange({ securityPoolAddress: event.currentTarget.value })} placeholder={UI_STRING_HEX_VALUE_PLACEHOLDER} />
 					</label>
 				</SectionBlock>
 			)}
 
 			{selectedPool === undefined ? undefined : (
-				<SectionBlock title={UI_STRINGS.tradingSection.yourHoldingsTitle}>
+				<SectionBlock title={UI_STRING_YOUR_HOLDINGS}>
 					<div className='trading-holdings-stage'>
 						<div className='trading-holdings-hero'>
-							<span>{UI_STRINGS.tradingSection.redeemableCompleteSetsLabel}</span>
+							<span>{UI_STRING_REDEEMABLE_COMPLETE_SETS}</span>
 							<strong>{renderShareMetricValue(displayMaxRedeemableCompleteSets)}</strong>
-							<p className='detail'>{UI_STRINGS.tradingSection.redeemableCompleteSetsDetail}</p>
+							<p className='detail'>{UI_STRING_LIMITED_BY_YOUR_SMALLEST_YES_NO_OR_INVALID_BALANCE}</p>
 						</div>
 						<div className='trading-holdings-layout'>
 							<RankedBarList
 								className='trading-share-distribution'
-								emptyMessage={UI_STRINGS.tradingSection.shareBalancesNotLoadedMessage}
+								emptyMessage={UI_STRING_WALLET_BALANCES_ARE_NOT_LOADED}
 								items={[
 									{
 										key: 'yes',
-										label: UI_STRINGS.tradingSection.shareOutcomeYesLabel,
+										label: UI_STRING_YES,
 										valueText: renderShareMetricValue(displayShareBalances?.yes),
 										...(displayShareBalances?.yes === undefined ? {} : { value: displayShareBalances.yes }),
 									},
 									{
 										key: 'no',
-										label: UI_STRINGS.tradingSection.shareOutcomeNoLabel,
+										label: UI_STRING_NO,
 										valueText: renderShareMetricValue(displayShareBalances?.no),
 										...(displayShareBalances?.no === undefined ? {} : { value: displayShareBalances.no }),
 									},
 									{
 										key: 'invalid',
-										label: UI_STRINGS.question.invalidOutcomeLabel,
+										label: UI_STRING_INVALID,
 										valueText: renderShareMetricValue(displayShareBalances?.invalid),
 										...(displayShareBalances?.invalid === undefined ? {} : { value: displayShareBalances.invalid }),
 									},
@@ -319,19 +378,19 @@ export function TradingSection({
 							/>
 							<div className='trading-share-callouts'>
 								<div>
-									<span>{UI_STRINGS.tradingSection.shareOutcomeYesLabel}</span>
+									<span>{UI_STRING_YES}</span>
 									<strong>{renderShareMetricValue(displayShareBalances?.yes)}</strong>
 								</div>
 								<div>
-									<span>{UI_STRINGS.tradingSection.shareOutcomeNoLabel}</span>
+									<span>{UI_STRING_NO}</span>
 									<strong>{renderShareMetricValue(displayShareBalances?.no)}</strong>
 								</div>
 								<div>
-									<span>{UI_STRINGS.question.invalidOutcomeLabel}</span>
+									<span>{UI_STRING_INVALID}</span>
 									<strong>{renderShareMetricValue(displayShareBalances?.invalid)}</strong>
 								</div>
 								<div className='trading-share-callouts-total'>
-									<span>{UI_STRINGS.tradingSection.totalAcrossOutcomesLabel}</span>
+									<span>{UI_STRING_TOTAL_ACROSS_OUTCOMES}</span>
 									<strong>{renderShareMetricValue(totalShareCount)}</strong>
 								</div>
 							</div>
@@ -340,7 +399,7 @@ export function TradingSection({
 				</SectionBlock>
 			)}
 
-			<SectionBlock title={UI_STRINGS.tradingSection.sharesSectionTitle}>
+			<SectionBlock title={UI_STRING_SHARES}>
 				<div className='vault-action-launcher-grid'>
 					{tradingLaunchers.map(action => (
 						<ActionLauncherCard key={action.key} action={action} />
@@ -350,26 +409,26 @@ export function TradingSection({
 
 			<ErrorNotice message={tradingError} />
 
-			<OperationModal description={UI_STRINGS.tradingSection.mintCompleteSetsModalDescription} isOpen={activeModal === 'mint'} onClose={() => setActiveModal(undefined)} title={UI_STRINGS.tradingSection.mintCompleteSetsTitle}>
+			<OperationModal description={UI_STRING_REVIEW_AVAILABLE_CAPACITY_AND_CONFIRM_THE_COMPLETE_SET_MINT_AMOUNT_BEFORE_SUBMITTING} isOpen={activeModal === 'mint'} onClose={() => setActiveModal(undefined)} title={UI_STRING_MINT_COMPLETE_SETS}>
 				{selectedPool === undefined ? undefined : (
 					<MetricGrid>
-						<MetricField label={UI_STRINGS.tradingSection.bondAllowanceInUseLabel}>
-							<CurrencyValue value={selectedPool.totalSecurityBondAllowance} suffix={UI_STRINGS.common.ethSuffix} />
+						<MetricField label={UI_STRING_BOND_ALLOWANCE_IN_USE}>
+							<CurrencyValue value={selectedPool.totalSecurityBondAllowance} suffix={UI_STRING_ETH} />
 						</MetricField>
-						<MetricField label={UI_STRINGS.tradingSection.repBackingLabel}>
-							<CurrencyValue value={selectedPool.totalRepDeposit} suffix={UI_STRINGS.common.repLabel} />
+						<MetricField label={UI_STRING_REP_BACKING}>
+							<CurrencyValue value={selectedPool.totalRepDeposit} suffix={UI_STRING_REP} />
 						</MetricField>
 					</MetricGrid>
 				)}
 				<label className='field'>
-					<span>{UI_STRINGS.tradingSection.mintCompleteSetsAmountLabel}</span>
+					<span>{UI_STRING_MINT_COMPLETE_SETS_AMOUNT}</span>
 					<FormInput value={tradingForm.completeSetAmount} inputMode='decimal' onInput={event => onTradingFormChange({ completeSetAmount: event.currentTarget.value })} />
 				</label>
 				{mintGuardMessage === undefined ? undefined : <p className='detail'>{mintGuardMessage}</p>}
 				<div className='actions'>
 					<TransactionActionButton
-						idleLabel={UI_STRINGS.tradingSection.mintCompleteSetsTitle}
-						pendingLabel={UI_STRINGS.tradingSection.mintCompleteSetsPendingLabel}
+						idleLabel={UI_STRING_MINT_COMPLETE_SETS}
+						pendingLabel={UI_STRING_MINTING_COMPLETE_SETS}
 						onClick={onCreateCompleteSet}
 						pending={tradingActiveAction === 'createCompleteSet'}
 						availability={{ disabled: !isMainnet || !mintEnabled || mintGuardMessage !== undefined, reason: mintEnabled ? mintGuardMessage : undefined }}
@@ -377,9 +436,9 @@ export function TradingSection({
 				</div>
 			</OperationModal>
 
-			<OperationModal description={UI_STRINGS.tradingSection.redeemCompleteSetsModalDescription} isOpen={activeModal === 'redeem-complete-sets'} onClose={() => setActiveModal(undefined)} title={UI_STRINGS.tradingSection.redeemCompleteSetsTitle}>
+			<OperationModal description={UI_STRING_REDEEMING_COMPLETE_SETS_REQUIRES_MATCHING_YES_NO_AND_INVALID_SHARES_USE_THE_REDEEMABLE_COMPLETE_SETS_AMOUNT_AS_THE_CEILING} isOpen={activeModal === 'redeem-complete-sets'} onClose={() => setActiveModal(undefined)} title={UI_STRING_REDEEM_COMPLETE_SETS}>
 				<label className='field'>
-					<span>{UI_STRINGS.tradingSection.completeSetRedeemAmountLabel}</span>
+					<span>{UI_STRING_REDEEM_COMPLETE_SETS_AMOUNT}</span>
 					<div className='field-inline'>
 						<FormInput className='field-inline-input' value={tradingForm.redeemAmount} inputMode='decimal' onInput={event => onTradingFormChange({ redeemAmount: event.currentTarget.value })} />
 						<button
@@ -391,15 +450,15 @@ export function TradingSection({
 							}}
 							disabled={displayMaxRedeemableCompleteSets === undefined || displayMaxRedeemableCompleteSets <= 0n}
 						>
-							{UI_STRINGS.common.maxLabel}
+							{UI_STRING_MAX}
 						</button>
 					</div>
 				</label>
 				{redeemCompleteSetGuardMessage === undefined ? undefined : <p className='detail'>{redeemCompleteSetGuardMessage}</p>}
 				<div className='actions'>
 					<TransactionActionButton
-						idleLabel={UI_STRINGS.tradingSection.redeemCompleteSetsTitle}
-						pendingLabel={UI_STRINGS.tradingSection.redeemCompleteSetsPendingLabel}
+						idleLabel={UI_STRING_REDEEM_COMPLETE_SETS}
+						pendingLabel={UI_STRING_REDEEMING_COMPLETE_SETS}
 						onClick={onRedeemCompleteSet}
 						pending={tradingActiveAction === 'redeemCompleteSet'}
 						tone='secondary'
@@ -408,9 +467,14 @@ export function TradingSection({
 				</div>
 			</OperationModal>
 
-			<OperationModal description={UI_STRINGS.tradingSection.migrateForkedSharesModalDescription} isOpen={activeModal === 'migrate-shares'} onClose={() => setActiveModal(undefined)} title={UI_STRINGS.tradingSection.migrateForkedSharesTitle}>
+			<OperationModal
+				description={UI_STRING_MIGRATING_BURNS_THE_SELECTED_PARENT_POOL_SHARE_BALANCE_AND_RECREATES_IT_ACROSS_THE_CHOSEN_CHILD_UNIVERSES_REVIEW_THE_SOURCE_OUTCOME_AND_TARGET_UNIVERSES_CAREFULLY_BEFORE_SUBMITTING}
+				isOpen={activeModal === 'migrate-shares'}
+				onClose={() => setActiveModal(undefined)}
+				title={UI_STRING_MIGRATE_FORKED_SHARES_TRADING_SECTION_MIGRATE_FORKED_SHARES_TITLE}
+			>
 				<label className='field'>
-					<span>{UI_STRINGS.tradingSection.shareOutcomeToMigrateLabel}</span>
+					<span>{UI_STRING_SHARE_OUTCOME_TO_MIGRATE}</span>
 					<EnumDropdown options={REPORTING_OUTCOME_DROPDOWN_OPTIONS} value={tradingForm.selectedShareOutcome} onChange={selectedShareOutcome => onTradingFormChange({ selectedShareOutcome })} disabled={shareMigrationSelectionDisabled} />
 				</label>
 				<ShareMigrationTargetsSection
@@ -425,8 +489,8 @@ export function TradingSection({
 				{migrateSharesGuardMessage === undefined ? undefined : <p className='detail'>{migrateSharesGuardMessage}</p>}
 				<div className='actions'>
 					<TransactionActionButton
-						idleLabel={UI_STRINGS.tradingSection.migrateSharesIdleLabel}
-						pendingLabel={UI_STRINGS.tradingSection.migrateSharesPendingLabel}
+						idleLabel={UI_STRING_MIGRATE_SHARES}
+						pendingLabel={UI_STRING_MIGRATING_SHARES}
 						onClick={onMigrateShares}
 						pending={tradingActiveAction === 'migrateShares'}
 						tone='secondary'
@@ -435,12 +499,12 @@ export function TradingSection({
 				</div>
 			</OperationModal>
 
-			<OperationModal description={UI_STRINGS.tradingSection.redeemResolvedSharesModalDescription} isOpen={activeModal === 'redeem-shares'} onClose={() => setActiveModal(undefined)} title={UI_STRINGS.tradingSection.redeemSharesTitle}>
+			<OperationModal description={UI_STRING_REDEEM_FINALIZED_WINNING_SHARES_ONCE_THE_SELECTED_POOL_HAS_RESOLVED} isOpen={activeModal === 'redeem-shares'} onClose={() => setActiveModal(undefined)} title={UI_STRING_REDEEM_RESOLVED_SHARES}>
 				{redeemSharesGuardMessage === undefined ? undefined : <p className='detail'>{redeemSharesGuardMessage}</p>}
 				<div className='actions'>
 					<TransactionActionButton
-						idleLabel={UI_STRINGS.tradingSection.redeemSharesIdleLabel}
-						pendingLabel={UI_STRINGS.tradingSection.redeemSharesPendingLabel}
+						idleLabel={UI_STRING_REDEEM_SHARES}
+						pendingLabel={UI_STRING_REDEEMING_SHARES}
 						onClick={onRedeemShares}
 						pending={tradingActiveAction === 'redeemShares'}
 						tone='secondary'
@@ -452,7 +516,7 @@ export function TradingSection({
 	)
 	if (embedInCard) return sections
 	return (
-		<RouteWorkflowPanel showHeader={showHeader} title={UI_STRINGS.tradingSection.sharesSectionTitle}>
+		<RouteWorkflowPanel showHeader={showHeader} title={UI_STRING_SHARES}>
 			{sections}
 		</RouteWorkflowPanel>
 	)

--- a/ui/ts/components/TruthAuctionMarketViewSection.tsx
+++ b/ui/ts/components/TruthAuctionMarketViewSection.tsx
@@ -5,7 +5,23 @@ import { SectionBlock } from './SectionBlock.js'
 import { TruthAuctionDepthChart } from './TruthAuctionDepthChart.js'
 import { getTruthAuctionDispositionClassName, type TruthAuctionDepthPoint } from '../lib/truthAuctionBook.js'
 import { getVisualRatio } from '../lib/visualMetrics.js'
-import { UI_STRINGS } from '../lib/uiStrings.js'
+import {
+	UI_STRING_CLEARING_LEVEL,
+	UI_STRING_CURRENT_FORM_PRICE,
+	UI_STRING_CURRENT_SIZE,
+	UI_STRING_ETH,
+	UI_STRING_LOAD_MORE_PRICE_LEVELS,
+	UI_STRING_LOADED_DEPTH,
+	UI_STRING_LOADING_ORDER_BOOK,
+	UI_STRING_LOADING_PRICE_LEVELS,
+	UI_STRING_MARKET_VIEW,
+	UI_STRING_NO_ACTIVE_LEVELS_ARE_VISIBLE,
+	UI_STRING_NO_LIVE_PRICE_LEVELS_ARE_CURRENTLY_ACTIVE_FOR_THIS_AUCTION,
+	UI_STRING_PRICE_LADDER,
+	UI_STRING_PRICE_LEVEL,
+	UI_STRING_VISIBLE_DEPTH,
+	UI_TEMPLATE_SUBMISSIONS_LABEL,
+} from '../lib/uiStrings.js'
 
 type TruthAuctionMarketViewSectionProps = {
 	clearingTick: bigint | undefined
@@ -26,29 +42,29 @@ function clampPercentage(value: bigint, maxValue: bigint) {
 
 export function TruthAuctionMarketViewSection({ clearingTick, hasMoreTickSummaries, loadingTruthAuctionBook, maxTickEth, onLoadNextTickPage, onSelectTick, renderPriceValue, showDepthClearingTick, truthAuctionBookError, truthAuctionDepthPoints }: TruthAuctionMarketViewSectionProps) {
 	return (
-		<SectionBlock title={UI_STRINGS.truthAuctionMarketViewSection.marketViewTitle}>
+		<SectionBlock title={UI_STRING_MARKET_VIEW}>
 			{truthAuctionBookError === undefined ? undefined : <p className='detail truth-auction-book-error'>{truthAuctionBookError}</p>}
 			<div className='truth-auction-market-board'>
 				<div className='truth-auction-market-section truth-auction-depth-panel'>
 					<div className='truth-auction-depth-header'>
 						<div>
-							<h4>{UI_STRINGS.truthAuctionMarketViewSection.visibleDepthTitle}</h4>
+							<h4>{UI_STRING_VISIBLE_DEPTH}</h4>
 						</div>
 					</div>
-					{loadingTruthAuctionBook ? <p className='detail'>{UI_STRINGS.truthAuctionMarketViewSection.loadingOrderBookDetail}</p> : undefined}
-					{!loadingTruthAuctionBook && truthAuctionDepthPoints.length === 0 ? <p className='detail'>{UI_STRINGS.truthAuctionMarketViewSection.noLivePriceLevelsDetail}</p> : undefined}
+					{loadingTruthAuctionBook ? <p className='detail'>{UI_STRING_LOADING_ORDER_BOOK}</p> : undefined}
+					{!loadingTruthAuctionBook && truthAuctionDepthPoints.length === 0 ? <p className='detail'>{UI_STRING_NO_LIVE_PRICE_LEVELS_ARE_CURRENTLY_ACTIVE_FOR_THIS_AUCTION}</p> : undefined}
 					{truthAuctionDepthPoints.length === 0 ? undefined : <TruthAuctionDepthChart onSelectTick={onSelectTick} points={truthAuctionDepthPoints} {...(showDepthClearingTick && clearingTick !== undefined ? { clearingTick } : {})} />}
 				</div>
 				<div className='truth-auction-market-detail-grid'>
 					<div className='truth-auction-market-section'>
 						<div className='truth-auction-panel-header'>
 							<div>
-								<h4>{UI_STRINGS.truthAuctionMarketViewSection.priceLadderTitle}</h4>
+								<h4>{UI_STRING_PRICE_LADDER}</h4>
 							</div>
 						</div>
 						<div className='truth-auction-ladder'>
-							{loadingTruthAuctionBook ? <p className='detail'>{UI_STRINGS.truthAuctionMarketViewSection.loadingPriceLevelsDetail}</p> : undefined}
-							{!loadingTruthAuctionBook && truthAuctionDepthPoints.length === 0 ? <p className='detail'>{UI_STRINGS.truthAuctionMarketViewSection.noActiveLevelsDetail}</p> : undefined}
+							{loadingTruthAuctionBook ? <p className='detail'>{UI_STRING_LOADING_PRICE_LEVELS}</p> : undefined}
+							{!loadingTruthAuctionBook && truthAuctionDepthPoints.length === 0 ? <p className='detail'>{UI_STRING_NO_ACTIVE_LEVELS_ARE_VISIBLE}</p> : undefined}
 							{truthAuctionDepthPoints.map(point => (
 								<button
 									aria-pressed={point.isSelected}
@@ -62,27 +78,27 @@ export function TruthAuctionMarketViewSection({ clearingTick, hasMoreTickSummari
 										<div className='truth-auction-price-row-main'>
 											<div>
 												<strong>{renderPriceValue(point.price)}</strong>
-												<span className='truth-auction-price-row-price'>{UI_STRINGS.truthAuctionMarketViewSection.priceLevelLabel}</span>
+												<span className='truth-auction-price-row-price'>{UI_STRING_PRICE_LEVEL}</span>
 											</div>
 											<div className='truth-auction-price-row-badges'>
-												{clearingTick === point.tick ? <span className='truth-auction-ladder-helper'>{UI_STRINGS.truthAuctionMarketViewSection.clearingLevelBadgeLabel}</span> : undefined}
-												{point.isPreviewTick ? <span className='truth-auction-ladder-helper'>{UI_STRINGS.truthAuctionMarketViewSection.currentFormPriceBadgeLabel}</span> : undefined}
+												{clearingTick === point.tick ? <span className='truth-auction-ladder-helper'>{UI_STRING_CLEARING_LEVEL}</span> : undefined}
+												{point.isPreviewTick ? <span className='truth-auction-ladder-helper'>{UI_STRING_CURRENT_FORM_PRICE}</span> : undefined}
 												<span className={`truth-auction-status-pill ${getTruthAuctionDispositionClassName(point.disposition.tone)}`}>{point.disposition.label}</span>
 											</div>
 										</div>
 										<div className='truth-auction-price-row-meta'>
 											<span>
-												{UI_STRINGS.truthAuctionMarketViewSection.currentSizeLabel} <CurrencyValue value={point.currentTotalEth} suffix={UI_STRINGS.common.ethSuffix} />
+												{UI_STRING_CURRENT_SIZE} <CurrencyValue value={point.currentTotalEth} suffix={UI_STRING_ETH} />
 											</span>
 											<span className='truth-auction-ladder-row-cumulative'>
-												{UI_STRINGS.truthAuctionMarketViewSection.loadedDepthLabel} <CurrencyValue value={point.cumulativeEth} suffix={UI_STRINGS.common.ethSuffix} />
+												{UI_STRING_LOADED_DEPTH} <CurrencyValue value={point.cumulativeEth} suffix={UI_STRING_ETH} />
 											</span>
-											<span>{UI_STRINGS.truthAuctionMarketViewSection.submissionsLabel(point.submissionCount.toString())}</span>
+											<span>{UI_TEMPLATE_SUBMISSIONS_LABEL(point.submissionCount.toString())}</span>
 										</div>
 									</div>
 								</button>
 							))}
-							{hasMoreTickSummaries ? <PaginationControls hasNextPage={hasMoreTickSummaries} onLoadMore={onLoadNextTickPage} loadMoreLabel={UI_STRINGS.truthAuctionMarketViewSection.loadMorePriceLevelsLabel} /> : undefined}
+							{hasMoreTickSummaries ? <PaginationControls hasNextPage={hasMoreTickSummaries} onLoadMore={onLoadNextTickPage} loadMoreLabel={UI_STRING_LOAD_MORE_PRICE_LEVELS} /> : undefined}
 						</div>
 					</div>
 				</div>

--- a/ui/ts/lib/actionGuards.ts
+++ b/ui/ts/lib/actionGuards.ts
@@ -1,6 +1,6 @@
 import type { Address } from '@zoltar/shared/ethereum'
 import type { ActionAvailability } from '../types/components.js'
-import { UI_STRINGS } from './uiStrings.js'
+import { UI_STRING_CONNECT_WALLET_TO_CONTINUE } from './uiStrings.js'
 
 type WalletMainnetGuardParameters = {
 	accountAddress: Address | string | undefined
@@ -20,7 +20,7 @@ type WalletMainnetGuardState = {
 }
 
 function getWalletRequiredReason(walletRequiredReason: string | undefined) {
-	return walletRequiredReason ?? UI_STRINGS.common.connectWalletToContinueDetail
+	return walletRequiredReason ?? UI_STRING_CONNECT_WALLET_TO_CONTINUE
 }
 
 export function getWalletMainnetGuardState({ accountAddress, isMainnet, walletRequiredReason }: WalletMainnetGuardParameters): WalletMainnetGuardState {

--- a/ui/ts/lib/appPageTitle.ts
+++ b/ui/ts/lib/appPageTitle.ts
@@ -1,6 +1,20 @@
 import type { Route } from '../types/app.js'
 import type { OpenOracleView, SecurityPoolsView, ZoltarView } from '../types/components.js'
-import { UI_STRINGS } from './uiStrings.js'
+import {
+	UI_STRING_APP_DOCUMENT_TITLE_SUFFIX,
+	UI_STRING_CREATE_ORACLE_REPORT,
+	UI_STRING_CREATE_QUESTION,
+	UI_STRING_CREATE_SECURITY_POOL,
+	UI_STRING_DEPLOY_CONTRACTS,
+	UI_STRING_FORK_ZOLTAR,
+	UI_STRING_MANAGE_SECURITY_POOL,
+	UI_STRING_MIGRATE_REP,
+	UI_STRING_ORACLE_REPORT_DETAILS,
+	UI_STRING_ORACLE_REPORTS,
+	UI_STRING_PAGE_NOT_FOUND_APP_PAGE_TITLE_PAGE_NOT_FOUND_PAGE_TITLE,
+	UI_STRING_QUESTIONS_AND_MARKETS,
+	UI_STRING_SECURITY_POOLS,
+} from './uiStrings.js'
 
 export type AppPageTitleInput = {
 	activeOpenOracleView: OpenOracleView
@@ -10,26 +24,26 @@ export type AppPageTitleInput = {
 }
 
 export function getAppPageTitle({ activeOpenOracleView, activeSecurityPoolsView, activeZoltarView, route }: AppPageTitleInput) {
-	if (route === 'deploy') return UI_STRINGS.appPageTitle.deployContractsPageTitle
+	if (route === 'deploy') return UI_STRING_DEPLOY_CONTRACTS
 	if (route === 'zoltar') {
-		if (activeZoltarView === 'create') return UI_STRINGS.appPageTitle.createQuestionPageTitle
-		if (activeZoltarView === 'fork') return UI_STRINGS.appPageTitle.forkOraclePageTitle
-		if (activeZoltarView === 'migrate') return UI_STRINGS.appPageTitle.migrateRepPageTitle
-		return UI_STRINGS.appPageTitle.questionsAndMarketsPageTitle
+		if (activeZoltarView === 'create') return UI_STRING_CREATE_QUESTION
+		if (activeZoltarView === 'fork') return UI_STRING_FORK_ZOLTAR
+		if (activeZoltarView === 'migrate') return UI_STRING_MIGRATE_REP
+		return UI_STRING_QUESTIONS_AND_MARKETS
 	}
 	if (route === 'security-pools') {
-		if (activeSecurityPoolsView === 'create') return UI_STRINGS.appPageTitle.createSecurityPoolPageTitle
-		if (activeSecurityPoolsView === 'operate') return UI_STRINGS.appPageTitle.manageSecurityPoolPageTitle
-		return UI_STRINGS.appPageTitle.securityPoolsPageTitle
+		if (activeSecurityPoolsView === 'create') return UI_STRING_CREATE_SECURITY_POOL
+		if (activeSecurityPoolsView === 'operate') return UI_STRING_MANAGE_SECURITY_POOL
+		return UI_STRING_SECURITY_POOLS
 	}
 	if (route === 'open-oracle') {
-		if (activeOpenOracleView === 'create') return UI_STRINGS.appPageTitle.createOracleReportPageTitle
-		if (activeOpenOracleView === 'selected-report') return UI_STRINGS.appPageTitle.openOracleReportDetailsPageTitle
-		return UI_STRINGS.appPageTitle.openOracleReportsPageTitle
+		if (activeOpenOracleView === 'create') return UI_STRING_CREATE_ORACLE_REPORT
+		if (activeOpenOracleView === 'selected-report') return UI_STRING_ORACLE_REPORT_DETAILS
+		return UI_STRING_ORACLE_REPORTS
 	}
-	return UI_STRINGS.appPageTitle.pageNotFoundPageTitle
+	return UI_STRING_PAGE_NOT_FOUND_APP_PAGE_TITLE_PAGE_NOT_FOUND_PAGE_TITLE
 }
 
 export function formatAppDocumentTitle(pageTitle: string) {
-	return `${pageTitle} | ${UI_STRINGS.appPageTitle.documentTitleSuffix}`
+	return `${pageTitle} | ${UI_STRING_APP_DOCUMENT_TITLE_SUFFIX}`
 }

--- a/ui/ts/lib/liquidation.ts
+++ b/ui/ts/lib/liquidation.ts
@@ -1,6 +1,15 @@
 import { LIQUIDATION_BPS_DENOMINATOR, LIQUIDATION_PRICE_PRECISION, LIQUIDATION_REP_BONUS_BPS, getLiquidationRepToMove } from '@zoltar/shared/liquidation'
 import { getVaultCollateralizationPercent } from './trading.js'
-import { UI_STRINGS } from './uiStrings.js'
+import {
+	UI_STRING_NO_DEBT_IS_EXECUTABLE_FOR_LIQUIDATION_AT_THE_CURRENT_TARGET_SIDE_BOUNDS,
+	UI_STRING_THE_CALLER_VAULT_WOULD_BECOME_UNDERCOLLATERALIZED_AFTER_THIS_LIQUIDATION_OR_THE_LIQUIDATOR_VAULT_IS_THE_TARGET_VAULT,
+	UI_STRING_THE_CALLER_VAULT_WOULD_REMAIN_BELOW_THE_MINIMUM_REP_COLLATERAL_AFTER_LIQUIDATION,
+	UI_STRING_THE_CALLER_VAULT_WOULD_REMAIN_BELOW_THE_MINIMUM_SECURITY_BOND_ALLOWANCE_AFTER_LIQUIDATION,
+	UI_STRING_THE_TARGET_VAULT_IS_NOT_LIQUIDATABLE_AT_THE_CURRENT_PRICE,
+	UI_STRING_THE_TARGET_VAULT_WOULD_FALL_BELOW_THE_MINIMUM_REP_COLLATERAL_AFTER_LIQUIDATION,
+	UI_STRING_THE_TARGET_VAULT_WOULD_FALL_BELOW_THE_MINIMUM_SECURITY_BOND_ALLOWANCE_AFTER_LIQUIDATION,
+	UI_STRING_THIS_LIQUIDATION_AMOUNT_IS_TOO_SMALL_TO_IMPROVE_THE_TARGET_VAULT_HEALTH_AFTER_ROUNDING,
+} from './uiStrings.js'
 import type { SecurityPoolVaultSummary } from '../types/contracts.js'
 
 const MIN_SECURITY_BOND_DEBT = 1n * 10n ** 18n
@@ -23,21 +32,21 @@ function getRepToMoveForLiquidation(debtToMove: bigint, repPerEthPrice: bigint, 
 export function getLiquidationExecutionFailureDetail(errorMessage: string | undefined) {
 	switch (errorMessage) {
 		case 'Target safe':
-			return UI_STRINGS.liquidationModal.liquidationFailureTargetSafeDetail
+			return UI_STRING_THE_TARGET_VAULT_IS_NOT_LIQUIDATABLE_AT_THE_CURRENT_PRICE
 		case 'No liq':
-			return UI_STRINGS.liquidationModal.liquidationFailureNoExecutableDebtDetail
+			return UI_STRING_NO_DEBT_IS_EXECUTABLE_FOR_LIQUIDATION_AT_THE_CURRENT_TARGET_SIDE_BOUNDS
 		case 'No gain':
-			return UI_STRINGS.liquidationModal.liquidationFailureNoHealthGainDetail
+			return UI_STRING_THIS_LIQUIDATION_AMOUNT_IS_TOO_SMALL_TO_IMPROVE_THE_TARGET_VAULT_HEALTH_AFTER_ROUNDING
 		case 'Caller bad':
-			return UI_STRINGS.liquidationModal.liquidationFailureUndercollateralizedCallerDetail
+			return UI_STRING_THE_CALLER_VAULT_WOULD_BECOME_UNDERCOLLATERALIZED_AFTER_THIS_LIQUIDATION_OR_THE_LIQUIDATOR_VAULT_IS_THE_TARGET_VAULT
 		case 'Target REP':
-			return UI_STRINGS.liquidationModal.liquidationFailureTargetRepDetail
+			return UI_STRING_THE_TARGET_VAULT_WOULD_FALL_BELOW_THE_MINIMUM_REP_COLLATERAL_AFTER_LIQUIDATION
 		case 'Target debt':
-			return UI_STRINGS.liquidationModal.liquidationFailureTargetDebtDetail
+			return UI_STRING_THE_TARGET_VAULT_WOULD_FALL_BELOW_THE_MINIMUM_SECURITY_BOND_ALLOWANCE_AFTER_LIQUIDATION
 		case 'Caller REP':
-			return UI_STRINGS.liquidationModal.liquidationFailureCallerRepDetail
+			return UI_STRING_THE_CALLER_VAULT_WOULD_REMAIN_BELOW_THE_MINIMUM_REP_COLLATERAL_AFTER_LIQUIDATION
 		case 'Caller debt':
-			return UI_STRINGS.liquidationModal.liquidationFailureCallerDebtDetail
+			return UI_STRING_THE_CALLER_VAULT_WOULD_REMAIN_BELOW_THE_MINIMUM_SECURITY_BOND_ALLOWANCE_AFTER_LIQUIDATION
 		default:
 			return errorMessage
 	}
@@ -163,7 +172,7 @@ export function getDeterministicLiquidationFailureReason({
 	}
 	const targetMaxDebtToMove = maxDebtToMove === undefined || maxDebtToMove > targetVaultSummary.securityBondAllowance ? targetVaultSummary.securityBondAllowance : maxDebtToMove
 	const debtToMove = liquidationAmount < targetMaxDebtToMove ? liquidationAmount : targetMaxDebtToMove
-	if (debtToMove <= 0n) return UI_STRINGS.liquidationModal.liquidationFailureNoExecutableDebtDetail
+	if (debtToMove <= 0n) return UI_STRING_NO_DEBT_IS_EXECUTABLE_FOR_LIQUIDATION_AT_THE_CURRENT_TARGET_SIDE_BOUNDS
 	const repToMove = repPerEthPrice === undefined ? undefined : getRepToMoveForLiquidation(debtToMove, repPerEthPrice, targetVaultSummary.securityBondAllowance, targetVaultSummary.repDepositShare)
 	const targetAfterAllowance = targetVaultSummary.securityBondAllowance - debtToMove
 	const targetAfterRepDeposit = repToMove === undefined ? undefined : targetVaultSummary.repDepositShare - repToMove

--- a/ui/ts/lib/network.ts
+++ b/ui/ts/lib/network.ts
@@ -1,6 +1,6 @@
 import type { Address } from '@zoltar/shared/ethereum'
 import { getActiveNetworkProfile } from './activeEnvironment.js'
-import { UI_STRINGS } from './uiStrings.js'
+import { UI_STRING_SWITCH_TO_ETHEREUM_MAINNET } from './uiStrings.js'
 
 export function isSupportedAppChain(chainId: string | undefined) {
 	const profile = getActiveNetworkProfile()
@@ -19,5 +19,5 @@ export function getWalletScopedAccountAddress(accountAddress: Address | undefine
 export function getWrongNetworkMessage() {
 	const profile = getActiveNetworkProfile()
 	if (profile.id === 'simulation') return undefined
-	return UI_STRINGS.userCopy.wallet.switchToMainnetDetail
+	return UI_STRING_SWITCH_TO_ETHEREUM_MAINNET
 }

--- a/ui/ts/lib/uiStrings.ts
+++ b/ui/ts/lib/uiStrings.ts
@@ -6,8 +6,8 @@ export const UI_STRING_AMOUNT = 'Amount'
 export const UI_STRING_ANNUAL_FEE = 'Annual Fee'
 export const UI_STRING_APPROVING_REP = 'Approving REP...'
 export const UI_STRING_BID_AMOUNT_ETH = 'Bid Amount (ETH)'
-const UI_STRING_CANCEL = 'Cancel'
-const UI_STRING_CHECK_BACK_NO_LATER_THAN = 'Check back no later than '
+export const UI_STRING_CANCEL = 'Cancel'
+export const UI_STRING_CHECK_BACK_NO_LATER_THAN = 'Check back no later than '
 export const UI_STRING_CHECKING_WHETHER_POOL_REP_IS_ALREADY_READY_FOR_SELECTED_CHILD_UNIVERSE = 'Checking whether pool REP is already ready for the selected child universe.'
 export const UI_STRING_CHILD_UNIVERSE_ALREADY_DEPLOYED = 'Child universe already deployed.'
 export const UI_STRING_CHILD_UNIVERSE_NOT_ALREADY_DEPLOYED = 'Child universe not already deployed'
@@ -16,26 +16,26 @@ export const UI_STRING_CHILD_UNIVERSES_UNAVAILABLE_BECAUSE_UNIVERSE_HAS_NOT_FORK
 export const UI_STRING_CLEARING_PRICE = 'Clearing Price'
 export const UI_STRING_CLOSED = 'Closed'
 export const UI_STRING_CONNECT_A_WALLET_BEFORE_DEPLOYING_A_CHILD_UNIVERSE = 'Connect a wallet before deploying a child universe.'
-const UI_STRING_CONNECT_WALLET_TO_CONTINUE = 'Connect wallet to continue.'
+export const UI_STRING_CONNECT_WALLET_TO_CONTINUE = 'Connect wallet to continue.'
 export const UI_STRING_COPIED = 'Copied'
 export const UI_STRING_CREATE_CHILD_UNIVERSE = 'Create child universe'
 export const UI_STRING_CREATE_CHILD_UNIVERSE_TITLE = 'Create Child Universe'
-const UI_STRING_CREATE_QUESTION = 'Create Question'
+export const UI_STRING_CREATE_QUESTION = 'Create Question'
 export const UI_STRING_CREATE_SECURITY_POOL = 'Create Security Pool'
 export const UI_STRING_DELETE_SAVE = 'Delete save'
 export const UI_STRING_DEPLOYED = 'Deployed'
-const UI_STRING_DEPLOYING = 'Deploying...'
+export const UI_STRING_DEPLOYING = 'Deploying...'
 export const UI_STRING_DEPLOYING_UNIVERSE = 'Deploying universe...'
 export const UI_STRING_DEPLOY_UNIVERSE = 'Deploy Universe'
-const UI_STRING_DEPOSIT_REP = 'Deposit REP'
-const UI_STRING_DISPUTE_REPORT = 'Dispute Report'
+export const UI_STRING_DEPOSIT_REP = 'Deposit REP'
+export const UI_STRING_DISPUTE_REPORT = 'Dispute Report'
 export const UI_STRING_ENDS = 'Ends'
 export const UI_STRING_ENTER_AN_AMOUNT_GREATER_THAN_ZERO = 'Enter an amount greater than zero.'
 export const UI_STRING_ENTRY_DEPTH_PREFIX = 'Entry depth: '
 export const UI_STRING_ERROR = 'Error'
 export const UI_STRING_ESCALATION_DEPOSIT_DETAILS_ARE_UNAVAILABLE_FOR_THIS_POOL = 'Escalation deposit details are unavailable for this pool right now.'
-const UI_STRING_ESCALATION_ENDED_BY_TIMEOUT_THE_WINNER_IS_COMPUTED = 'Escalation ended by timeout. The winner is computed from the current stakes.'
-const UI_STRING_ESCALATION_METRICS = 'Escalation Metrics'
+export const UI_STRING_ESCALATION_ENDED_BY_TIMEOUT_THE_WINNER_IS_COMPUTED = 'Escalation ended by timeout. The winner is computed from the current stakes.'
+export const UI_STRING_ESCALATION_METRICS = 'Escalation Metrics'
 export const UI_STRING_ESCROWED_REP = 'Escrowed REP'
 export const UI_STRING_ETH = 'ETH'
 export const UI_STRING_ETH_RAISED_PER_CAP = 'ETH Raised / Cap'
@@ -57,25 +57,25 @@ export const UI_STRING_LOADED_DEPTH_ETH = 'Loaded Depth (ETH)'
 export const UI_STRING_LOADING = 'Loading'
 export const UI_STRING_LOADING_WITH_ELLIPSIS = 'Loading...'
 export const UI_STRING_LOADING_CURRENT_CHAIN_TIME = 'Loading current chain time.'
-const UI_STRING_LOADING_ESCALATION_DEPOSITS = 'Loading escalation deposits.'
+export const UI_STRING_LOADING_ESCALATION_DEPOSITS = 'Loading escalation deposits.'
 export const UI_STRING_LOADING_UNIVERSE_DETAILS = 'Loading universe details.'
-const UI_STRING_LOADING_VAULT = 'Loading vault...'
-const UI_STRING_MANAGE_POOL = 'Manage Pool'
+export const UI_STRING_LOADING_VAULT = 'Loading vault...'
+export const UI_STRING_MANAGE_POOL = 'Manage Pool'
 export const UI_STRING_MAX = 'Max'
 export const UI_STRING_MAX_PREFIX = 'Max '
 export const UI_STRING_MIGRATE_REP = 'Migrate REP'
-const UI_STRING_MIGRATE_SHARES = 'Migrate Shares'
+export const UI_STRING_MIGRATE_SHARES = 'Migrate Shares'
 export const UI_STRING_MIGRATE_VAULT = 'Migrate Vault'
 export const UI_STRING_MIGRATING_VAULT = 'Migrating vault...'
 export const UI_STRING_MIGRATION_TIMING_IS_UNAVAILABLE = 'Migration timing is unavailable.'
-const UI_STRING_MINT_COMPLETE_SETS = 'Mint Complete Sets'
+export const UI_STRING_MINT_COMPLETE_SETS = 'Mint Complete Sets'
 export const UI_STRING_MULTIPLIER = 'Multiplier'
 export const UI_STRING_NO = 'No'
 export const UI_STRING_NO_MATCHES = 'No matches'
 export const UI_STRING_NO_PREFIX = 'No '
-const UI_STRING_NO_QUESTIONS = 'No questions'
+export const UI_STRING_NO_QUESTIONS = 'No questions'
 export const UI_STRING_NO_REP_COLLATERAL_OR_SECURITY_BOND_ALLOWANCE_REMAINS = 'No REP collateral or security bond allowance remains to migrate for the connected wallet.'
-const UI_STRING_NOT_FOUND = 'Not found'
+export const UI_STRING_NOT_FOUND = 'Not found'
 export const UI_STRING_NOT_STARTED = 'Not started'
 export const UI_STRING_NO_UNRESOLVED_PARENT_ESCALATION_DEPOSITS_REMAIN_FOR_CONNECTED_WALLET = 'No unresolved parent escalation deposits remain for the connected wallet.'
 export const UI_STRING_OF_PREFIX = 'of '
@@ -90,7 +90,7 @@ export const UI_STRING_OUTCOME_INDEX = 'Outcome Index'
 export const UI_STRING_PAGE_NOT_FOUND = 'Page not found'
 export const UI_STRING_PENDING = 'Pending'
 export const UI_STRING_PERCENT = '%'
-const UI_STRING_PLURAL_SUFFIX = 's'
+export const UI_STRING_PLURAL_SUFFIX = 's'
 export const UI_STRING_POOL = 'Pool'
 export const UI_STRING_POOL_ADDRESS = 'Pool Address'
 export const UI_STRING_POOL_COLLATERALIZATION = 'Pool collateralization'
@@ -99,16 +99,16 @@ export const UI_STRING_PRICE_ETH_PER_REP = 'Price (ETH / REP)'
 export const UI_STRING_PRICE_VALID_UNTIL = 'Price Valid Until'
 export const UI_STRING_QUESTION = 'Question'
 export const UI_STRING_QUESTION_ID = 'Question ID'
-const UI_STRING_QUEUE_LIQUIDATION = 'Queue Liquidation'
-const UI_STRING_REDEEM_COMPLETE_SETS = 'Redeem Complete Sets'
-const UI_STRING_REDEEM_RESOLVED_SHARES = 'Redeem Resolved Shares'
-const UI_STRING_REFRESHING = 'Refreshing...'
+export const UI_STRING_QUEUE_LIQUIDATION = 'Queue Liquidation'
+export const UI_STRING_REDEEM_COMPLETE_SETS = 'Redeem Complete Sets'
+export const UI_STRING_REDEEM_RESOLVED_SHARES = 'Redeem Resolved Shares'
+export const UI_STRING_REFRESHING = 'Refreshing...'
 export const UI_STRING_REMOVE_CORRUPTED_SAVES = 'Remove corrupted saves'
 export const UI_STRING_REP = 'REP'
 export const UI_STRING_REP_COLLATERAL = 'REP Collateral'
 export const UI_STRING_REP_MIGRATION_UNAVAILABLE_BECAUSE_UNIVERSE_HAS_NOT_FORKED = 'REP migration is unavailable because this universe has not forked.'
-const UI_STRING_REPORTING_WORKFLOW = 'Reporting Workflow'
-const UI_STRING_REPORT_OUTCOME = 'Report Outcome'
+export const UI_STRING_REPORTING_WORKFLOW = 'Reporting Workflow'
+export const UI_STRING_REPORT_OUTCOME = 'Report Outcome'
 export const UI_STRING_REP_PER_ETH = 'REP / ETH'
 export const UI_STRING_REP_PURCHASED = 'REP Purchased'
 export const UI_STRING_REPUTATION_TOKEN = 'Reputation Token'
@@ -118,18 +118,18 @@ export const UI_STRING_SECURITY_MULTIPLIER = 'Security Multiplier'
 export const UI_STRING_SECURITY_POOL_ADDRESS = 'Security Pool Address'
 export const UI_STRING_SECURITY_POOLS = 'Security Pools'
 export const UI_STRING_SELECT_A_CHILD_UNIVERSE_TO_DEPLOY = 'Select a child universe to deploy.'
-const UI_STRING_SELECT_AN_OUTCOME_SIDE_ABOVE_TO_ENABLE_REPORTING = 'Select an outcome side above to enable reporting.'
-const UI_STRING_SELECT_AT_LEAST_ONE_DEPOSIT_TO_SETTLE_OR_USE_SETTLE_ALL_FOR_THIS_SIDE = 'Select at least one deposit to settle or use Settle all for this side.'
+export const UI_STRING_SELECT_AN_OUTCOME_SIDE_ABOVE_TO_ENABLE_REPORTING = 'Select an outcome side above to enable reporting.'
+export const UI_STRING_SELECT_AT_LEAST_ONE_DEPOSIT_TO_SETTLE_OR_USE_SETTLE_ALL_FOR_THIS_SIDE = 'Select at least one deposit to settle or use Settle all for this side.'
 export const UI_STRING_SELECTED = 'Selected'
 export const UI_STRING_SELECTED_CHILD_UNIVERSE = 'Selected Child Universe'
-const UI_STRING_SELECTED_VAULT_ADDRESS = 'Selected Vault Address'
-const UI_STRING_SELECT_THE_ANSWER_YOU_BELIEVE_SHOULD_FINALIZE_LOCK = 'Select the answer you believe should finalize, lock REP behind it, and return after finalization to settle deposits.'
-const UI_STRING_SET_BOND_ALLOWANCE = 'Set Bond Allowance'
+export const UI_STRING_SELECTED_VAULT_ADDRESS = 'Selected Vault Address'
+export const UI_STRING_SELECT_THE_ANSWER_YOU_BELIEVE_SHOULD_FINALIZE_LOCK = 'Select the answer you believe should finalize, lock REP behind it, and return after finalization to settle deposits.'
+export const UI_STRING_SET_BOND_ALLOWANCE = 'Set Bond Allowance'
 export const UI_STRING_SETTLED = 'Settled'
-const UI_STRING_SETTLE_ESCALATION_DEPOSITS = 'Settle Escalation Deposits'
+export const UI_STRING_SETTLE_ESCALATION_DEPOSITS = 'Settle Escalation Deposits'
 export const UI_STRING_SETTLE_FINALIZED_REFUNDS = 'Settle Finalized Refunds'
 export const UI_STRING_SETTLEMENT = 'Settlement'
-const UI_STRING_SETTLE_REPORT = 'Settle Report'
+export const UI_STRING_SETTLE_REPORT = 'Settle Report'
 export const UI_STRING_SHOWING_PREFIX = 'Showing '
 export const UI_STRING_SPLIT_REP = 'Split REP'
 export const UI_STRING_STAGED_OPERATION = 'Staged Operation'
@@ -138,13 +138,13 @@ export const UI_STRING_STARTS = 'Starts'
 export const UI_STRING_START_TRUTH_AUCTION = 'Start Truth Auction'
 export const UI_STRING_STATUS = 'Status'
 export const UI_STRING_SUBMIT_BID = 'Submit Bid'
-const UI_STRING_SUBMIT_INITIAL_REPORT = 'Submit Initial Report'
+export const UI_STRING_SUBMIT_INITIAL_REPORT = 'Submit Initial Report'
 export const UI_STRING_SUBMITTING_A_BID_LOCKS_ETH_UNTIL_SETTLEMENT_LOSING = 'Submitting a bid locks ETH until settlement. Losing bids are refunded during settlement.'
-const UI_STRING_TARGET_VAULT = 'Target Vault'
+export const UI_STRING_TARGET_VAULT = 'Target Vault'
 export const UI_STRING_MIGRATION_AMOUNT_ALREADY_SPLIT_DETAIL = 'This amount is already fully split across the selected universes.'
-const UI_STRING_THIS_VAULT_DOES_NOT_EXIST = 'This vault does not exist.'
-const UI_STRING_TO_CONFIRM = ' to confirm '
-const UI_STRING_TRIGGER_ZOLTAR_FORK = 'Trigger Zoltar Fork'
+export const UI_STRING_THIS_VAULT_DOES_NOT_EXIST = 'This vault does not exist.'
+export const UI_STRING_TO_CONFIRM = ' to confirm '
+export const UI_STRING_TRIGGER_ZOLTAR_FORK = 'Trigger Zoltar Fork'
 export const UI_STRING_TRUTH_AUCTION = 'Truth Auction'
 export const UI_STRING_UNAVAILABLE = 'Unavailable'
 export const UI_STRING_UNFORKED = 'Unforked'
@@ -153,59 +153,59 @@ export const UI_STRING_UNIVERSE_IS_FORKED = 'Universe is forked'
 export const UI_STRING_UNRESOLVED_ESCALATION_DEPOSIT_DETAILS_ARE_UNAVAILABLE_FOR_THIS_POOL_RIGHT_NOW = 'Unresolved escalation deposit details are unavailable for this pool right now.'
 export const UI_STRING_VAULTS = 'Vaults'
 export const UI_STRING_WALLET_CONNECTED = 'Wallet connected'
-const UI_STRING_WETH = 'WETH'
-const UI_STRING_WITHDRAW_REP = 'Withdraw REP'
+export const UI_STRING_WETH = 'WETH'
+export const UI_STRING_WITHDRAW_REP = 'Withdraw REP'
 export const UI_STRING_WORTH_NOW_PREFIX = 'Worth now: '
 export const UI_STRING_YES = 'Yes'
 export const UI_STRING_ZERO_DECIMAL_PLACEHOLDER = '0.0'
 export const UI_STRING_ZOLTAR_IS_ALREADY_FORKED = 'Zoltar is already forked.'
-const UI_STRING_APP_DOCUMENT_TITLE_SUFFIX = 'Zoltar + Augur Placeholder'
-const UI_STRING_ANSWER_UNIT = 'Answer Unit'
-const UI_STRING_ALREADY_FORKED = 'Already Forked'
-const UI_STRING_CLAIM_FEES = 'Claim Fees'
-const UI_STRING_CONNECT_WALLET = 'Connect wallet'
-const UI_STRING_CONNECTING = 'Connecting...'
-const UI_STRING_CREATE_POOL = 'Create Pool'
-const UI_STRING_CLOSE = 'Close'
-const UI_STRING_MANUAL_EXECUTION_TIMEOUT = 'Manual Execution Timeout'
-const UI_STRING_DEPLOY = 'Deploy'
-const UI_STRING_DISPUTE_AND_SWAP = 'Dispute & Swap'
-const UI_STRING_DISPUTE_DELAY = 'Dispute Delay'
-const UI_STRING_END_TIME = 'End Time'
-const UI_STRING_ESCALATION_HALT = 'Escalation Halt'
-const UI_STRING_FEE_PERCENTAGE = 'Fee Percentage'
-const UI_STRING_GO_TO_GENESIS_UNIVERSE = 'Go to Genesis universe'
-const UI_STRING_LIQUIDATE_VAULT = 'Liquidate Vault'
-const UI_STRING_MARKETS = 'Markets'
-const UI_STRING_MULTIPLIER_SUFFIX = 'x'
-const UI_STRING_OUTCOMES = 'Outcomes'
+export const UI_STRING_APP_DOCUMENT_TITLE_SUFFIX = 'Zoltar + Augur Placeholder'
+export const UI_STRING_ANSWER_UNIT = 'Answer Unit'
+export const UI_STRING_ALREADY_FORKED = 'Already Forked'
+export const UI_STRING_CLAIM_FEES = 'Claim Fees'
+export const UI_STRING_CONNECT_WALLET = 'Connect wallet'
+export const UI_STRING_CONNECTING = 'Connecting...'
+export const UI_STRING_CREATE_POOL = 'Create Pool'
+export const UI_STRING_CLOSE = 'Close'
+export const UI_STRING_MANUAL_EXECUTION_TIMEOUT = 'Manual Execution Timeout'
+export const UI_STRING_DEPLOY = 'Deploy'
+export const UI_STRING_DISPUTE_AND_SWAP = 'Dispute & Swap'
+export const UI_STRING_DISPUTE_DELAY = 'Dispute Delay'
+export const UI_STRING_END_TIME = 'End Time'
+export const UI_STRING_ESCALATION_HALT = 'Escalation Halt'
+export const UI_STRING_FEE_PERCENTAGE = 'Fee Percentage'
+export const UI_STRING_GO_TO_GENESIS_UNIVERSE = 'Go to Genesis universe'
+export const UI_STRING_LIQUIDATE_VAULT = 'Liquidate Vault'
+export const UI_STRING_MARKETS = 'Markets'
+export const UI_STRING_MULTIPLIER_SUFFIX = 'x'
+export const UI_STRING_OUTCOMES = 'Outcomes'
 export const UI_STRING_NONE = 'None'
-const UI_STRING_NOT_CHECKED = 'Not checked'
-const UI_STRING_ORACLE_REPORTS = 'Oracle Reports'
-const UI_STRING_PRICE = 'Price'
-const UI_STRING_PROTOCOL_FEE = 'Protocol Fee'
-const UI_STRING_QUESTION_TYPE = 'Question Type'
-const UI_STRING_QUESTIONS_AND_MARKETS = 'Questions & Markets'
-const UI_STRING_REFRESH = 'Refresh'
-const UI_STRING_REFRESH_REP_PRICES = 'Refresh REP prices'
-const UI_STRING_REFRESHING_WITHOUT_ELLIPSIS = 'Refreshing'
-const UI_STRING_REPORT_DETAILS = 'Report Details'
-const UI_STRING_REPORT_ID = 'Report ID'
-const UI_STRING_REP_PER_ETH_COMPACT = 'REP/ETH'
-const UI_STRING_RETURN_TO_BROWSE = 'Return to Browse'
-const UI_STRING_SCALAR = 'Scalar'
-const UI_STRING_SETTLEMENT_TIME = 'Settlement Time'
-const UI_STRING_SETTLER_REWARD = 'Settler Reward'
-const UI_STRING_SET_SECURITY_BOND_ALLOWANCE = 'Set Security Bond Allowance'
-const UI_STRING_TOKEN_PAIR = 'Token Pair'
-const UI_STRING_VIEW_IN_STAGED_OPERATIONS = 'View In Staged Operations'
-const UI_STRING_WALLET_REP = 'Wallet REP'
-const UI_STRING_WRONG_NETWORK = 'Wrong network'
-const UI_STRING_EXECUTED = 'Executed'
-const UI_STRING_STAGED_OPERATION_RETRY = 'Submit a new staged operation if you want to try again.'
-const UI_STRING_TRANSACTION_STATE_UNAVAILABLE = 'The transaction succeeded, but the latest manager state is not available.'
-const UI_STRING_WITHDRAW_ESCALATION_DEPOSITS = 'Withdraw escalation deposits before redeeming REP.'
-const UI_STRING_MANUAL_QUEUED_OPERATION = 'The settlement auto-execute list is full. Execute this staged operation manually with its id after a valid oracle price is available.'
+export const UI_STRING_NOT_CHECKED = 'Not checked'
+export const UI_STRING_ORACLE_REPORTS = 'Oracle Reports'
+export const UI_STRING_PRICE = 'Price'
+export const UI_STRING_PROTOCOL_FEE = 'Protocol Fee'
+export const UI_STRING_QUESTION_TYPE = 'Question Type'
+export const UI_STRING_QUESTIONS_AND_MARKETS = 'Questions & Markets'
+export const UI_STRING_REFRESH = 'Refresh'
+export const UI_STRING_REFRESH_REP_PRICES = 'Refresh REP prices'
+export const UI_STRING_REFRESHING_WITHOUT_ELLIPSIS = 'Refreshing'
+export const UI_STRING_REPORT_DETAILS = 'Report Details'
+export const UI_STRING_REPORT_ID = 'Report ID'
+export const UI_STRING_REP_PER_ETH_COMPACT = 'REP/ETH'
+export const UI_STRING_RETURN_TO_BROWSE = 'Return to Browse'
+export const UI_STRING_SCALAR = 'Scalar'
+export const UI_STRING_SETTLEMENT_TIME = 'Settlement Time'
+export const UI_STRING_SETTLER_REWARD = 'Settler Reward'
+export const UI_STRING_SET_SECURITY_BOND_ALLOWANCE = 'Set Security Bond Allowance'
+export const UI_STRING_TOKEN_PAIR = 'Token Pair'
+export const UI_STRING_VIEW_IN_STAGED_OPERATIONS = 'View In Staged Operations'
+export const UI_STRING_WALLET_REP = 'Wallet REP'
+export const UI_STRING_WRONG_NETWORK = 'Wrong network'
+export const UI_STRING_EXECUTED = 'Executed'
+export const UI_STRING_STAGED_OPERATION_RETRY = 'Submit a new staged operation if you want to try again.'
+export const UI_STRING_TRANSACTION_STATE_UNAVAILABLE = 'The transaction succeeded, but the latest manager state is not available.'
+export const UI_STRING_WITHDRAW_ESCALATION_DEPOSITS = 'Withdraw escalation deposits before redeeming REP.'
+export const UI_STRING_MANUAL_QUEUED_OPERATION = 'The settlement auto-execute list is full. Execute this staged operation manually with its id after a valid oracle price is available.'
 
 export const UI_TEMPLATE_ADD_REP_TO_MIGRATION_BALANCE_DETAIL = (value0: UiStringTemplateValue) => `Add ${value0} REP to your migration balance from this universe, then split it across the selected universes.`
 export const UI_TEMPLATE_CHECKING_POOL_REP_MIGRATED_TO_CHILD_UNIVERSE = (value0: UiStringTemplateValue) => `Checking whether pool REP has already been migrated for the ${value0} child universe.`
@@ -679,1069 +679,678 @@ export const UI_STRING_REMOVE_CORRUPTED_SAVED_STATES = 'Remove Corrupted Saved S
 export const UI_STRING_REMOVE_SAVED_SIMULATION_STATE_ENTRIES_THAT_ARE_NO_LONGER_READABLE_FROM_BROWSER = 'Remove saved simulation state entries that are no longer readable from browser storage. Valid saved states will be kept.'
 export const UI_STRING_UNLIMITED_APPROVAL = 'Unlimited approval'
 
-export const UI_STRINGS = {
-	appPageTitle: {
-		createOracleReportPageTitle: 'Create Oracle Report',
-		createQuestionPageTitle: UI_STRING_CREATE_QUESTION,
-		createSecurityPoolPageTitle: UI_STRING_CREATE_SECURITY_POOL,
-		deployContractsPageTitle: 'Deploy Contracts',
-		documentTitleSuffix: UI_STRING_APP_DOCUMENT_TITLE_SUFFIX,
-		forkOraclePageTitle: UI_STRING_FORK_ZOLTAR,
-		manageSecurityPoolPageTitle: 'Manage Security Pool',
-		migrateRepPageTitle: UI_STRING_MIGRATE_REP,
-		openOracleReportDetailsPageTitle: 'Oracle Report Details',
-		openOracleReportsPageTitle: UI_STRING_ORACLE_REPORTS,
-		pageNotFoundPageTitle: 'Page Not Found',
-		questionsAndMarketsPageTitle: UI_STRING_QUESTIONS_AND_MARKETS,
-		securityPoolsPageTitle: UI_STRING_SECURITY_POOLS,
-	},
-	app: {
-		openOracle: {
-			browseLabel: 'Browse',
-			createReportLabel: 'Create Report',
-			reportDetailsLabel: UI_STRING_REPORT_DETAILS,
-			subNavigationAriaLabel: 'Oracle report views',
-		},
-		securityPools: {
-			browsePoolsLabel: 'Browse Pools',
-			createPoolLabel: UI_STRING_CREATE_POOL,
-			managePoolLabel: UI_STRING_MANAGE_POOL,
-			subNavigationAriaLabel: 'Security Pools views',
-		},
-		zoltar: {
-			createQuestionLabel: UI_STRING_CREATE_QUESTION,
-			forkOracleLabel: UI_STRING_FORK_ZOLTAR,
-			forkOracleRequiredForRepMigrationReason: UI_STRING_REP_MIGRATION_UNAVAILABLE_BECAUSE_UNIVERSE_HAS_NOT_FORKED,
-			migrateRepLabel: UI_STRING_MIGRATE_REP,
-			questionsAndMarketsLabel: UI_STRING_QUESTIONS_AND_MARKETS,
-			subNavigationAriaLabel: 'Market views',
-		},
-	},
-	common: {
-		cancelLabel: UI_STRING_CANCEL,
-		closeLabel: UI_STRING_CLOSE,
-		connectWalletToContinueDetail: UI_STRING_CONNECT_WALLET_TO_CONTINUE,
-		hexValuePlaceholder: UI_STRING_HEX_VALUE_PLACEHOLDER,
-		failedBadgeLabel: UI_STRING_FAILED,
-		loadingBadgeLabel: UI_STRING_LOADING,
-		loadingLabel: UI_STRING_LOADING_WITH_ELLIPSIS,
-		maxLabel: UI_STRING_MAX,
-		metricUnavailablePlaceholder: UI_STRING_METRIC_UNAVAILABLE_PLACEHOLDER,
-		minutesLabel: 'minutes',
-		multiplierSuffix: UI_STRING_MULTIPLIER_SUFFIX,
-		noLabel: UI_STRING_NO,
-		notChosenLabel: UI_STRING_NOT_CHOSEN,
-		noneLabel: UI_STRING_NONE,
-		noneSelectedLabel: 'None selected',
-		notCheckedBadgeLabel: UI_STRING_NOT_CHECKED,
-		notFoundBadgeLabel: UI_STRING_NOT_FOUND,
-		noneYetBadgeLabel: UI_STRING_NONE,
-		ethSuffix: UI_STRING_ETH,
-		repPerEthSuffix: UI_STRING_REP_PER_ETH,
-		usdcSuffix: 'USDC',
-		wethSuffix: UI_STRING_WETH,
-		repLabel: UI_STRING_REP,
-		refreshLabel: UI_STRING_REFRESH,
-		unavailableLabel: UI_STRING_UNAVAILABLE,
-		yesLabel: UI_STRING_YES,
-	},
-	childUniversesSection: {
-		existsLabel: 'Exists',
-		notDeployedLabel: 'Not deployed',
-		workingLabel: 'Working...',
-	},
-	appStatusNotices: {
-		activeReadRpcLabel: 'Active read RPC',
-		appErrorTitle: UI_STRING_ERROR,
-		configuredFallbackReadRpcLabel: 'Configured fallback read RPC',
-		defaultRpcSourceLabel: 'default',
-		environmentRpcSourceLabel: 'environment',
-		explicitOverrideRpcSourceLabel: 'explicit override',
-		finishSetupBeforeUsingAppDetail: 'Required application contracts are not deployed.',
-		globalRuntimeRpcSourceLabel: 'global runtime',
-		ignoredReadRpcOverrideTitle: 'Read RPC override ignored',
-		localStorageRpcSourceLabel: 'local storage',
-		pageUrlRpcSourceLabel: 'page URL',
-		readRpcOverrideIgnoredDetail: (sourceLabel: string, url: string, reason: string, configuredRpcLabel: string, activeRpcUrl: string) => `Ignored ${sourceLabel} RPC override (${url}): ${reason} ${configuredRpcLabel} is ${activeRpcUrl}.`,
-		readRpcOverrideFromUrlDetail: (configuredRpcLabel: string, rpcUrl: string) => `${configuredRpcLabel} came from the page URL: ${rpcUrl}. Verify this endpoint before relying on displayed onchain state.`,
-		readRpcOverrideActiveDetail: (configuredRpcLabel: string, sourceLabel: string, rpcUrl: string) => `${configuredRpcLabel} came from ${sourceLabel}: ${rpcUrl}. Verify this endpoint before relying on displayed onchain state.`,
-		readBackendMismatchSuffix: 'Displayed onchain state may not match the network this interface writes to.',
-		readRpcMismatchTitle: 'Read RPC mismatch',
-		readRpcOverrideActiveTitle: 'Read RPC override active',
-		setupIncompleteTitle: 'Setup incomplete',
-		simulationBootstrapFailedTitle: 'Simulation bootstrap failed',
-		staleReadBackendSuffix: 'Displayed onchain state may be behind the latest chain state. Refresh or switch RPC before acting on balances, settlement, or liquidation.',
-		universeForkedOnDetailSuffix: 'has forked on',
-		universeForkedTitle: 'Universe forked',
-		urlProvidedReadRpcTitle: 'URL-provided read RPC',
-	},
-	truthAuctionMarketViewSection: {
-		currentFormPriceBadgeLabel: 'Current form price',
-		currentSizeLabel: 'Current size',
-		clearingLevelBadgeLabel: 'Clearing level',
-		loadedDepthLabel: 'Loaded depth',
-		loadMorePriceLevelsLabel: 'Load More Price Levels',
-		loadingOrderBookDetail: 'Loading order book…',
-		loadingPriceLevelsDetail: 'Loading price levels…',
-		marketViewTitle: 'Market View',
-		noActiveLevelsDetail: 'No active levels are visible.',
-		noLivePriceLevelsDetail: 'No live price levels are currently active for this auction.',
-		priceLadderTitle: 'Price Ladder',
-		priceLevelLabel: 'Price level',
-		submissionsLabel: (count: string) => `${count} submissions`,
-		visibleDepthTitle: 'Visible Depth',
-	},
-	deploymentSection: {
-		canDeployNowDetail: 'Can deploy now.',
-		codeFoundAtExpectedAddressDetail: 'Code found at expected address.',
-		connectWalletToContinueDetail: UI_STRING_CONNECT_WALLET_TO_CONTINUE,
-		deployedBadgeLabel: UI_STRING_DEPLOYED,
-		deployButtonLabel: UI_STRING_DEPLOY,
-		deployingBadgeLabel: UI_STRING_DEPLOYING,
-		deployingDetail: 'Deployment in progress.',
-		deployingPendingLabel: UI_STRING_DEPLOYING,
-		notDeployedBadgeLabel: 'Not Deployed',
-		waitingBadgeLabel: 'Waiting',
-		waitingForPrerequisiteDetail: (prerequisiteLabel: string) => `Waiting for ${prerequisiteLabel}.`,
-	},
-	securityPoolWorkflowSection: {
-		autoExecPendingLabel: 'Auto-exec pending',
-		additionalPoolActionsAriaLabel: 'Additional pool actions',
-		amountLabel: UI_STRING_AMOUNT,
-		directoryViewLabel: 'Directory',
-		executeStagedOperationLabel: 'Execute Staged Operation',
-		executingStagedOperationLabel: 'Executing staged operation...',
-		forkAndTruthReadOnlyReason: 'This pool is currently operational, so fork and truth auction actions are read only.',
-		initiatorLabel: 'Initiator',
-		loadingVaultDetail: UI_STRING_LOADING_VAULT,
-		loadStagedOperationsLabel: 'Load Staged Operations',
-		manualExecutionLabel: 'Manual execution',
-		noStagedOperationsQueuedDetail: 'No staged operations are currently queued for this pool.',
-		noVaultsInThisPoolDetail: UI_STRING_NO_VAULTS_IN_THIS_POOL,
-		noneQueuedBadgeLabel: 'None queued',
-		noneYetBadgeLabel: UI_STRING_NONE,
-		pendingOperationLiquidationLabel: 'Liquidation',
-		pendingOperationSetBondAllowanceLabel: UI_STRING_SET_BOND_ALLOWANCE,
-		pendingOperationWithdrawRepLabel: UI_STRING_WITHDRAW_REP,
-		pendingReportLabel: (reportId: string) => UI_TEMPLATE_REPORT_NUMBER_LABEL(reportId),
-		primaryPoolActionsAriaLabel: 'Primary pool actions',
-		poolNotFoundTitle: 'Pool not found',
-		managePoolTitle: UI_STRING_MANAGE_POOL,
-		refreshOracleLabel: 'Refresh Oracle',
-		refreshPoolLabel: 'Refresh pool',
-		refreshStagedOperationsLabel: 'Refresh Staged Operations',
-		refreshingOracleLabel: 'Refreshing oracle...',
-		refreshingOperationsLabel: 'Refreshing operations...',
-		refreshingPoolLabel: 'Refreshing pool...',
-		refreshingVaultLabel: UI_STRING_REFRESHING,
-		requestCostLabel: 'Request Cost',
-		requestNewPriceLabel: 'Request New Price',
-		requestingNewPriceLabel: 'Requesting new price...',
-		reviewLiquidationActionLabel: UI_STRING_REVIEW_LIQUIDATION,
-		reviewLiquidationDescription: 'Inspect the liquidation quote, timeout, and execution path before queueing liquidation.',
-		reviewLiquidationTitle: UI_STRING_REVIEW_LIQUIDATION,
-		selectedBadgeLabel: UI_STRING_SELECTED,
-		selectedPoolTitle: 'Selected Pool',
-		selectedPoolVaultViewsAriaLabel: 'Selected pool vault views',
-		selectedPoolViewsAriaLabel: 'Selected pool views',
-		notFoundBadgeLabel: UI_STRING_NOT_FOUND,
-		openOraclePriceLabel: UI_STRING_OPEN_ORACLE_PRICE,
-		openOracleTitle: 'Open Oracle',
-		parentPoolLabel: 'Parent Pool',
-		pendingRequestLabel: 'Pending Request',
-		questionTitle: UI_STRING_QUESTION,
-		selectVaultActionLabel: 'Select Vault',
-		selectedViewLabel: UI_STRING_SELECTED,
-		showingActiveStagedOperationsLabel: (loadedCount: string, activeCount: string) => `Showing ${loadedCount} of ${activeCount} active staged operations, newest first.`,
-		stagedOperationIdLabel: 'Staged Operation Id',
-		stagedOperationIdPlaceholder: '0',
-		stagedOperationsLabel: 'Staged Operations',
-		stagedOperationsListLabel: 'Staged Operations List',
-		targetVaultLabel: UI_STRING_TARGET_VAULT,
-		universeMismatchTitle: 'Universe Mismatch',
-		universeMismatchDetailPrefix: 'This pool belongs to',
-		universeMismatchDetailMiddle: 'but the app is currently set to',
-		universeMismatchDetailSuffix: 'This pool does not exist.',
-		vaultDirectoryTitle: 'Vault Directory',
-		vaultMissingDetail: UI_STRING_THIS_VAULT_DOES_NOT_EXIST,
-		vaultOperationsTitle: 'Vault Operations',
-		selectedVaultAddressLabel: UI_STRING_SELECTED_VAULT_ADDRESS,
-		securityPoolAddressLabel: UI_STRING_SECURITY_POOL_ADDRESS,
-		tryAnotherVaultAddressDetail: 'Try another vault address.',
-		triggerZoltarForkAlreadyTriggeredReason: 'Zoltar fork has already been triggered for this pool. Continue in Fork & Migration.',
-		triggerZoltarForkEnteredForkWorkflowReason: 'This pool has already entered Fork & Migration.',
-		triggerZoltarForkUnavailableReason: 'Triggering a Zoltar fork is not available in the current pool state.',
-		reportingLockedForkMigrationReason: 'This pool is in fork migration. Reporting actions unlock once the pool becomes operational.',
-		reportingLockedForkedReason: 'This parent pool is forked. Continue in Fork & Migration for migration and settlement.',
-		reportingLockedTruthAuctionReason: 'This pool is in truth auction. Reporting actions unlock once the pool becomes operational.',
-		reportingOpensAfterMarketEndReason: 'Reporting opens after market end.',
-		operationIdLabel: 'Operation Id',
-	},
-	forkAuctionSection: {
-		childUniverseNotCreatedForOutcomeDetail: UI_TEMPLATE_CHILD_UNIVERSE_NOT_CREATED_FOR_OUTCOME_DETAIL,
-	},
-	liquidationModal: {
-		callerCollateralizationAtOpenOracleLabel: 'Caller Collateralization @ Open Oracle',
-		collateralizationAtOpenOracleLabel: 'Collateralization @ Open Oracle',
-		callerVaultAfterLiquidationTitle: 'Caller Vault After Liquidation',
-		callerVaultLabel: 'Caller Vault',
-		checkStateBadgeLabel: 'Check State',
-		closeButtonAriaLabel: UI_STRING_CLOSE,
-		enterLiquidationAmountReason: 'Enter a liquidation amount.',
-		enterLiquidationTimeoutReason: 'Enter a liquidation timeout of at least 1 minute.',
-		executeLiquidationPendingLabel: 'Executing liquidation...',
-		executeVaultLiquidationTitle: 'Execute Vault Liquidation',
-		failedBadgeLabel: UI_STRING_FAILED,
-		invalidLiquidationPairTitle: 'Invalid Liquidation Pair',
-		liquidateVaultIdleLabel: UI_STRING_LIQUIDATE_VAULT,
-		liquidateVaultPendingLabel: 'Submitting liquidation...',
-		liquidateVaultTitle: UI_STRING_LIQUIDATE_VAULT,
-		liquidationAmountLabel: 'Liquidation Amount (ETH)',
-		liquidationAmountPlaceholder: UI_STRING_ZERO_DECIMAL_PLACEHOLDER,
-		liquidationExecutedTitle: UI_STRING_LIQUIDATION_EXECUTED,
-		liquidationFailedDetail: 'The oracle manager attempted the liquidation immediately, but the security pool rejected it.',
-		liquidationFailedTitle: UI_STRING_LIQUIDATION_FAILED,
-		liquidationFailureCallerDebtDetail: 'The caller vault would remain below the minimum security bond allowance after liquidation.',
-		liquidationFailureCallerRepDetail: 'The caller vault would remain below the minimum REP collateral after liquidation.',
-		liquidationFailureNoHealthGainDetail: 'This liquidation amount is too small to improve the target vault health after rounding.',
-		liquidationFailureNoExecutableDebtDetail: 'No debt is executable for liquidation at the current target-side bounds.',
-		liquidationFailureTargetSafeDetail: 'The target vault is not liquidatable at the current price.',
-		liquidationFailureTargetDebtDetail: 'The target vault would fall below the minimum security bond allowance after liquidation.',
-		liquidationFailureTargetRepDetail: 'The target vault would fall below the minimum REP collateral after liquidation.',
-		liquidationFailureUndercollateralizedCallerDetail: 'The caller vault would become undercollateralized after this liquidation, or the liquidator vault is the target vault.',
-		liquidationQueuedTitle: 'Liquidation Queued',
-		liquidationSubmittedTitle: UI_STRING_LIQUIDATION_SUBMITTED,
-		manualExecutionTimeoutLabel: UI_STRING_MANUAL_EXECUTION_TIMEOUT,
-		manualQueuedLiquidationDetail: UI_STRING_MANUAL_QUEUED_OPERATION,
-		metricAmountLabel: UI_STRING_AMOUNT,
-		openOraclePriceLabel: UI_STRING_OPEN_ORACLE_PRICE,
-		operationExecutedBadgeLabel: UI_STRING_EXECUTED,
-		queueLiquidationActionLabel: 'queue liquidation',
-		queueLiquidationIdleLabel: UI_STRING_QUEUE_LIQUIDATION,
-		queueLiquidationPendingLabel: 'Queueing liquidation...',
-		queueVaultLiquidationTitle: 'Queue Vault Liquidation',
-		queuedBadgeLabel: 'Queued',
-		refreshingBadgeLabel: UI_STRING_REFRESHING_WITHOUT_ELLIPSIS,
-		refreshingLiquidationStateDetail: 'Refreshing liquidation state.',
-		refreshingLiquidationStateTitle: 'Refreshing Liquidation State',
-		refreshingOpenOracleValidityReason: 'Refreshing price validity.',
-		reloadPoolBeforeExecutingReason: 'Reload the selected pool before executing liquidation.',
-		reloadPoolBeforeLiquidatingReason: 'Reload the selected pool before liquidating.',
-		repCollateralLabel: UI_STRING_REP_COLLATERAL,
-		repMovedLabel: 'Rep Moved',
-		securityBondAllowanceLabel: UI_STRING_SECURITY_BOND_ALLOWANCE,
-		securityMultiplierLabel: UI_STRING_SECURITY_MULTIPLIER,
-		securityPoolLabel: 'Security Pool',
-		selectDifferentTargetVaultReason: 'Select a target vault that is different from the caller vault.',
-		selectTargetVaultReason: 'Select a target vault first.',
-		submitNewStagedOperationDetail: UI_STRING_STAGED_OPERATION_RETRY,
-		targetCollateralizationAtOpenOracleLabel: 'Target Collateralization @ Open Oracle',
-		targetVaultLabel: UI_STRING_TARGET_VAULT,
-		timeoutHelpTextInvalid: 'Enter whole minutes. Queued staged operations must stay executable for at least 1 minute after the oracle settlement window completes.',
-		timeoutHelpTextResolved: (duration: string) => `This queued staged operation will expire ${duration} after the oracle settlement window completes.`,
-		transactionStateUnavailableDetail: UI_STRING_TRANSACTION_STATE_UNAVAILABLE,
-		validOracleExecutedDetail: 'A valid oracle price was already available, so the liquidation executed immediately and no staged operation was created.',
-		viewInStagedOperationsLabel: UI_STRING_VIEW_IN_STAGED_OPERATIONS,
-	},
-	deploymentRouteContent: {
-		allDeployedLabel: 'All deployed',
-		completedSectionTitle: (sectionTitle: string) => `${sectionTitle} (Completed)`,
-		contractsDeployedLabel: 'Contracts deployed',
-		deployButtonIdleLabel: 'Deploy Next Missing',
-		deployButtonPendingLabel: UI_STRING_DEPLOYING,
-		deploymentGroupsDescription: 'All deterministic contracts are deployed in grouped sections.',
-		deploymentGroupsTitle: 'Deployment Groups',
-		deploymentInProgressLabel: 'Deployment In Progress',
-		deterministicContractDeploymentDescription: 'Deploy and verify the shared deterministic contracts that back the application.',
-		deterministicContractDeploymentTitle: 'Deterministic contract deployment',
-		deployRouteEyebrow: UI_STRING_DEPLOY,
-		loadingDeploymentStatusLabel: 'Loading deployment status...',
-		loadingLabel: UI_STRING_LOADING_WITH_ELLIPSIS,
-		nextDeployableLabel: 'Next deployable',
-		nextDeployablePrefix: 'Next deployable contract:',
-	},
-	marketSection: {
-		forkActionLabel: UI_STRING_FORK_ZOLTAR,
-		forkZoltarModalTitle: UI_STRING_FORK_ZOLTAR,
-		forkSectionTitle: 'Fork',
-		marketsSectionTitle: UI_STRING_MARKETS,
-		openRepMigrationLabel: 'Open REP Migration',
-		postForkActionsDescription: 'The universe is forked. Migration is now the primary follow-up action.',
-		postForkActionsTitle: 'Post-Fork Actions',
-		questionsLabel: 'Questions',
-		selectedForkQuestionPrefix: 'Selected fork question:',
-		statusForkedLabel: UI_STRING_FORKED,
-		statusLabel: UI_STRING_STATUS,
-		statusUnforkedLabel: UI_STRING_UNFORKED,
-		universeLabel: UI_STRING_UNIVERSE,
-	},
-	marketOverviewSection: {
-		childUniverseAlreadyDeployedReason: UI_STRING_CHILD_UNIVERSE_ALREADY_DEPLOYED,
-		childUniverseNotAlreadyDeployedLabel: UI_STRING_CHILD_UNIVERSE_NOT_ALREADY_DEPLOYED,
-		childUniversesUnavailableReason: UI_STRING_CHILD_UNIVERSES_UNAVAILABLE_BECAUSE_UNIVERSE_HAS_NOT_FORKED,
-		universeIsForkedLabel: UI_STRING_UNIVERSE_IS_FORKED,
-	},
-	marketCreateQuestionSection: {
-		alreadyForkedLabel: UI_STRING_ALREADY_FORKED,
-		answerUnitFieldLabel: UI_STRING_ANSWER_UNIT,
-		answerUnitFieldPlaceholder: 'USD',
-		createAnotherQuestionLabel: 'Create Another Question',
-		createPoolFromQuestionLabel: 'Create Pool From Question',
-		createQuestionButtonIdleLabel: UI_STRING_CREATE_QUESTION,
-		createQuestionButtonPendingLabel: 'Creating Question...',
-		createQuestionDescription: 'Define the market type, timing, and outcomes for a new Zoltar question.',
-		createQuestionTitle: UI_STRING_CREATE_QUESTION,
-		creationTransactionHashLabel: 'Creation transaction hash',
-		descriptionFieldHelpText: 'Include the resolution source, any edge cases, and what should make the question resolve as invalid.',
-		descriptionFieldLabel: 'Description',
-		descriptionFieldPlaceholder: 'Optional question context',
-		draftPreviewDescription: 'Draft Preview shows the level of clarity traders and reporters will see before trusting the question.',
-		draftPreviewTitle: 'Draft Preview',
-		draftQuestionStatusAriaLabel: 'Draft question status',
-		draftQuestionSummaryAriaLabel: 'Draft question summary',
-		chooseEndTimeLabel: 'Choose an end time',
-		contextPresentForReviewLabel: 'Context is present for review',
-		draftQuestionContextProvidedLabel: 'Context provided',
-		draftQuestionNeedsContextLabel: 'Needs context',
-		endTimeFieldLabel: UI_STRING_END_TIME,
-		immediatelyAfterCreationLabel: 'Immediately after creation',
-		lowTrustUntilContextAddedLabel: 'Low trust until context is added',
-		outcomeFieldLabelPrefix: UI_STRING_OUTCOME,
-		outcomesFieldLabel: UI_STRING_OUTCOMES,
-		addOutcomeLabel: 'Add Outcome',
-		addAtLeastTwoOutcomesLabel: 'Add at least 2 outcomes',
-		removeOutcomeLabel: 'Remove',
-		outcomesFieldHelpText: 'Use concise, mutually exclusive labels. Users should be able to tell at a glance which outcome would win.',
-		poolEligibilityBinaryQuestionText: 'Placeholder origin security pools support this exact Yes / No question shape.',
-		poolEligibilityCategoricalQuestionText: 'Categorical questions are valid in Zoltar, but Placeholder origin security pools currently require an exact binary Yes / No question.',
-		poolEligibilityScalarQuestionText: 'Scalar questions are valid in Zoltar, but Placeholder origin security pools currently require an exact binary Yes / No question.',
-		questionDefaultDescriptionText: 'Add resolution notes, evidence sources, and edge-case handling so other users know how this question will settle.',
-		questionDefaultTitleText: 'Add a clear question title',
-		questionFallbackTitle: UI_STRING_QUESTION,
-		questionTypeAriaLabel: UI_STRING_QUESTION_TYPE,
-		questionTypeGuidanceTitle: 'Question Type Guidance',
-		questionTypeLabel: UI_STRING_QUESTION_TYPE,
-		questionDetailsLoadingAriaLabel: 'Loading question details',
-		questionDetailsNotLoadedText: 'Question details are not available.',
-		riskCueFieldLabel: 'Risk cue',
-		scalarFieldHelpText: 'Scalar questions settle to a numeric result inside the range above. Use a unit that matches the public source you expect to cite.',
-		scalarIncrementFieldLabel: 'Scalar Increment',
-		scalarIncrementFieldPlaceholder: '0.1',
-		scalarMaxFieldLabel: 'Scalar Max',
-		scalarMaxFieldPlaceholder: '10',
-		scalarMinFieldLabel: 'Scalar Min',
-		scalarMinFieldPlaceholder: '1',
-		scalarPreviewPromptText: 'Enter scalar min, max, and increment to preview the tick slider.',
-		startTimeFieldLabel: 'Start Time',
-		startsLabel: UI_STRING_STARTS,
-		endsLabel: UI_STRING_ENDS,
-		timingFieldHelpText: 'Times use your browser timezone. Leave start time blank to allow activity immediately after creation.',
-		titleFieldHelpText: 'Keep the title self-contained so users can understand the exact question before opening details.',
-		titleFieldPlaceholder: 'Will event X happen?',
-		titleFieldLabel: 'Title',
-		useForForkLabel: 'Use For Fork',
-		walletRequiredReason: 'Connect a wallet before creating a question.',
-		workflowIntroTitle: 'Write the question the way a resolver will read it.',
-		workflowStepDefineEventLabel: '1. Define the event clearly',
-		workflowStepExplainResolutionLabel: '2. Explain how it resolves',
-		workflowStepSetTimingWindowLabel: '3. Set the timing window',
-		marketTypeOptions: {
-			binaryLabel: 'Binary',
-			categoricalLabel: 'Categorical',
-			scalarLabel: UI_STRING_SCALAR,
-		},
-		marketTypeGuidance: {
-			binary: {
-				description: 'Ask a yes-or-no question that can be resolved from one public source of truth.',
-				stepOne: 'Write the title so it can be answered with Yes, No, or Invalid.',
-				stepTwo: 'Name the event window clearly in the title or description.',
-				stepThree: 'Use the description for the exact resolution source and edge cases.',
-			},
-			categorical: {
-				description: 'List the mutually exclusive outcomes that could win this question.',
-				stepOne: 'Keep outcomes short and clearly distinct from each other.',
-				stepTwo: 'Use the description to explain how ties, cancellations, or exceptions resolve.',
-				stepThree: 'Only include outcomes that a resolver can verify from a public source.',
-			},
-			scalar: {
-				description: 'Ask for a measurable number with a unit, range, and increment that users can understand.',
-				stepOne: 'Pick a range that covers realistic answers without being overly broad.',
-				stepTwo: 'Set the answer unit so users know what the number represents.',
-				stepThree: 'Use the description to explain rounding, source data, and invalid conditions.',
-			},
-		},
-	},
-	marketQuestionsSection: {
-		alreadyForkedLabel: UI_STRING_ALREADY_FORKED,
-		loadingQuestionsLabel: 'Loading questions...',
-		marketsTitle: UI_STRING_MARKETS,
-		noQuestionsEmptyBadgeLabel: UI_STRING_NO_QUESTIONS,
-		noQuestionsBadgeLabel: UI_STRING_NO_QUESTIONS,
-		noQuestionsDetail: 'No questions.',
-		nonBinaryPoolRestrictionDetail: 'Non-binary questions are valid in Zoltar, but Placeholder origin pools currently require an exact binary Yes / No question.',
-		pageUnavailableDetail: 'Question page unavailable.',
-	},
-	openOracleSection: {
-		advancedStandaloneOracleGameDescription: 'Direct Open Oracle creation for protocol testing. This bypasses pool-managed oracle-manager staging, so confirm addresses, token amounts, fees, and timing before submitting.',
-		advancedStandaloneOracleGameTitle: 'Open Oracle Game',
-		approvingTokenPendingLabel: (tokenSymbol: string) => `Approving ${tokenSymbol}...`,
-		browseReportsTitle: 'Browse Reports',
-		browseReportsDescription: (pageSize: string) => `Browse every Open Oracle game and open a selected report view. Page size is fixed at ${pageSize} reports.`,
-		browseShownCountSummary: (shownCount: string, pageCount: string) => `${shownCount} of ${pageCount} reports shown on this page.`,
-		callbackContractLabel: 'Callback Contract',
-		callbackExtraTitle: 'Callback / Extra',
-		callbackGasLimitLabel: 'Callback Gas Limit',
-		currentAmount1Label: (tokenSymbol: string) => `Current Amount 1 (${tokenSymbol})`,
-		currentAmount2Label: (tokenSymbol: string) => `Current Amount 2 (${tokenSymbol})`,
-		tokenPairSuffix: (token1Symbol: string, token2Symbol: string) => UI_TEMPLATE_PAIR_SLASH(token1Symbol, token2Symbol),
-		createAnotherLabel: 'Create Another',
-		createStandaloneOracleGameButtonIdleLabel: 'Create Standalone Oracle Game',
-		createStandaloneOracleGameButtonPendingLabel: 'Creating...',
-		createSuccessDescription: 'The report instance was created successfully.',
-		createSuccessTitle: 'Create Success',
-		currentPriceLabel: 'Current Price',
-		currentReportStateTitle: 'Current Report State',
-		currentReporterLabel: 'Current Reporter',
-		currentReporterAwaitingInitialReportLabel: 'None (awaiting initial report)',
-		booleanNoLabel: UI_STRING_NO,
-		booleanYesLabel: UI_STRING_YES,
-		disputeAndSwapModalDescription: 'Provide the replacement swap amounts for the selected report.',
-		disputeAndSwapModalTitle: UI_STRING_DISPUTE_AND_SWAP,
-		disputeAndSwapPendingLabel: 'Submitting dispute...',
-		disputingReportActionLabel: 'disputing the report',
-		disputeDelayFieldHelpText: 'Delay in seconds after the initial report before disputes can begin.',
-		disputeDelayFieldLabel: UI_STRING_DISPUTE_DELAY,
-		disputeDelayLabel: UI_STRING_DISPUTE_DELAY,
-		disputeOccurredLabel: 'Dispute Occurred',
-		disputeReportActionLabel: UI_STRING_DISPUTE_AND_SWAP,
-		disconnectedWalletApprovalReason: (tokenSymbol: string) => `Connect a wallet before approving ${tokenSymbol}.`,
-		disconnectedWalletDisputeReason: 'Connect a wallet before disputing the report.',
-		disconnectedWalletSettleReason: 'Connect a wallet before settling the report.',
-		disconnectedWalletSubmitInitialReportReason: 'Connect a wallet before submitting the initial report.',
-		disconnectedWalletWrapEthReason: 'Connect a wallet before wrapping ETH.',
-		disputeReportTitle: UI_STRING_DISPUTE_REPORT,
-		economicsTitle: 'Economics',
-		enterValidDisputeAmountsBeforeApprovingReason: (tokenSymbol: string) => `Enter valid dispute amounts before approving ${tokenSymbol}.`,
-		enterValidPriceBeforeApprovingReason: (token1Symbol: string, token2Symbol: string) => `Enter a valid ${token1Symbol} / ${token2Symbol} price before approving ${token2Symbol}.`,
-		escalationHaltFieldHelpText: 'Token1 amount where dispute escalation stops, entered as a decimal value for the token1 address.',
-		escalationHaltFieldLabel: UI_STRING_ESCALATION_HALT,
-		escalationHaltLabel: UI_STRING_ESCALATION_HALT,
-		ethValueToSendFieldHelpText: 'ETH sent with creation; must cover required funding and the settler reward.',
-		ethValueToSendFieldLabel: 'ETH Value To Send',
-		exactTokenRequiredLabel: (tokenSymbol: string) => `Exact ${tokenSymbol} Required`,
-		exactToken1ReportFieldHelpText: 'Token1 amount to report, entered as a decimal value for the token1 address.',
-		exactToken1ReportFieldLabel: 'Exact Token1 Report',
-		feeFieldHelpText: 'Fee charged during dispute economics, entered as a percentage.',
-		feeFieldLabel: UI_STRING_FEE_PERCENTAGE,
-		feePercentageLabel: UI_STRING_FEE_PERCENTAGE,
-		feeLabel: 'Fee',
-		fetchPriceFromUniswapIdleLabel: 'Fetch price from Uniswap',
-		fetchPriceFromUniswapPendingLabel: 'Fetching...',
-		identityTitle: 'Identity',
-		initialEconomicsTitle: 'Initial Economics',
-		initialReportContextTitle: 'Report Context',
-		initialReportModalDescription: 'Review price source, approvals, and token balances before submitting the initial report.',
-		initialReportModalTitle: UI_STRING_SUBMIT_INITIAL_REPORT,
-		initialReportTitle: 'Initial Report',
-		initialReporterLabel: 'Initial Reporter',
-		initialReportTokenApprovalActionLabel: 'submitting the initial report',
-		lastReportOpportunityLabel: 'Last Report Opportunity',
-		loadOpenOracleReportsFailedMessage: 'Failed to load Open Oracle reports',
-		loadReportFirstReason: 'Load a report first.',
-		multiplierFieldHelpText: 'Escalation multiplier for dispute economics.',
-		multiplierFieldLabel: UI_STRING_MULTIPLIER,
-		multiplierLabel: UI_STRING_MULTIPLIER,
-		newAmountMustBeExactDetail: (tokenSymbol: string, amount: string) => `New ${tokenSymbol} amount must be exactly ${amount} for this dispute.`,
-		noWriteActionsAvailableDetail: 'This report is settled. No write actions are available.',
-		numberOfReportsLabel: 'Number of Reports',
-		openReportButtonLabel: 'Open report',
-		oracleAddressLabel: 'Oracle Address',
-		priceFieldPlaceholder: '1.00',
-		priceFieldLabel: (token1Symbol: string, token2Symbol: string) => `Price (${token1Symbol} / ${token2Symbol})`,
-		priceLabel: UI_STRING_PRICE,
-		priceSourceLabelPrefix: 'Price source:',
-		protocolFeeFieldHelpText: 'Protocol fee charged during disputes, entered as a percentage.',
-		protocolFeeFieldLabel: UI_STRING_PROTOCOL_FEE,
-		protocolFeeLabel: UI_STRING_PROTOCOL_FEE,
-		protocolFeeRecipientLabel: 'Protocol Fee Recipient',
-		reportDetailsTitle: UI_STRING_REPORT_DETAILS,
-		reportIdFieldLabel: UI_STRING_REPORT_ID,
-		reportIdLabel: UI_STRING_REPORT_ID,
-		reportLabel: 'Report',
-		reportNumberTitle: (reportId: string) => UI_TEMPLATE_REPORT_NUMBER_LABEL(reportId),
-		reportTimestampLabel: 'Report Timestamp',
-		reportActionsTitle: 'Report Actions',
-		reportActionsDescription: 'Open a focused action flow for the selected report when it is available.',
-		returnToBrowseLabel: UI_STRING_RETURN_TO_BROWSE,
-		searchReportsLabel: 'Search Reports',
-		settleConfirmationDetail: 'Settlement is confirmation-first. Review the current report state and confirm only when the dispute window is closed.',
-		settleReportIdleLabel: UI_STRING_SETTLE_REPORT,
-		settleReportModalDescription: 'Confirm settlement once the selected report is ready.',
-		settleReportModalTitle: UI_STRING_SETTLE_REPORT,
-		settleReportPendingLabel: 'Settling report...',
-		settleReportTitle: UI_STRING_SETTLE_REPORT,
-		settledLabel: UI_STRING_SETTLED,
-		settledReportTitle: 'Settled Report',
-		settlerRewardFieldHelpText: 'ETH paid to the account that settles the report.',
-		settlerRewardFieldLabel: UI_STRING_SETTLER_REWARD,
-		settlerRewardLabel: UI_STRING_SETTLER_REWARD,
-		settlementSummaryTitle: 'Settlement Summary',
-		settlementTimeFieldHelpText: 'Delay in seconds after the initial report before settlement can begin.',
-		settlementTimeFieldLabel: UI_STRING_SETTLEMENT_TIME,
-		settlementTimeLabel: UI_STRING_SETTLEMENT_TIME,
-		settlementTimestampLabel: 'Settlement Timestamp',
-		settlementTitle: UI_STRING_SETTLEMENT,
-		notSettledLabel: 'Not settled',
-		stateHashLabel: 'State Hash',
-		statusFieldLabel: UI_STRING_STATUS,
-		statusFilterAllLabel: 'All statuses',
-		statusFilterAwaitingInitialReportLabel: 'Awaiting initial report',
-		statusFilterPendingLabel: UI_STRING_PENDING,
-		statusFilterDisputedLabel: 'Disputed',
-		statusFilterSettledLabel: UI_STRING_SETTLED,
-		noneYetBadgeLabel: UI_STRING_NONE,
-		noMatchesBadgeLabel: UI_STRING_NO_MATCHES,
-		noOpenOracleGamesDetail: 'No Open Oracle games found.',
-		noReportsMatchFiltersDetail: 'No reports match the current search and status filters.',
-		refreshingReportSummariesDetail: 'Refreshing report summaries.',
-		refreshReportButtonLabel: 'Refresh report',
-		reportAmountsTitle: 'Report Amounts',
-		selectedReportEyebrow: 'Open Oracle Report Details',
-		searchReportsPlaceholder: 'Search by report ID, token symbol, or token address',
-		staleQuoteRefreshDetail: 'This quote is stale and will be refreshed before submission.',
-		standaloneOracleWarning: 'Use this only when you intend to create a standalone oracle game directly from the connected wallet. Pool-managed oracle requests should be started from a selected security pool.',
-		statusTitle: UI_STRING_STATUS,
-		submitInitialReportIdleLabel: UI_STRING_SUBMIT_INITIAL_REPORT,
-		submitInitialReportPendingLabel: 'Submitting...',
-		timeInBlocksSuffix: ' blocks',
-		timeInSecondsSuffix: UI_STRING_PLURAL_SUFFIX,
-		timingTitle: 'Timing',
-		quoteLoadedDetail: (quoteBlockNumberText: string | undefined, ageText: string) => (quoteBlockNumberText === undefined ? `Quote loaded ${ageText}.` : `Quote loaded at block ${quoteBlockNumberText} ${ageText}.`),
-		quoteAgeText: (quoteLoadedAtMs: number) => {
-			const elapsedSeconds = Math.max(0, Math.floor((Date.now() - quoteLoadedAtMs) / 1000))
-			if (elapsedSeconds < 60) return `${elapsedSeconds}s ago`
-			const elapsedMinutes = Math.floor(elapsedSeconds / 60)
-			if (elapsedMinutes < 60) return `${elapsedMinutes}m ago`
-			const elapsedHours = Math.floor(elapsedMinutes / 60)
-			return `${elapsedHours}h ago`
-		},
-		token1AddressFieldHelpText: 'Base token for the reported pair.',
-		token1AddressFieldLabel: 'Token1 Address',
-		tokenApprovalTitle: (tokenSymbol: string) => `${tokenSymbol} Approval`,
-		token2AddressFieldHelpText: 'Quote token for the reported pair.',
-		token2AddressFieldLabel: 'Token2 Address',
-		tokenPairLabel: UI_STRING_TOKEN_PAIR,
-		tokenPairTitle: UI_STRING_TOKEN_PAIR,
-		tokenSwapOutLabel: 'Token to Swap Out',
-		trackDisputesLabel: 'Track Disputes',
-		awaitingInitialReportLabel: 'Awaiting Initial Report',
-		newTokenAmountFieldLabel: (tokenSymbol: string) => `New ${tokenSymbol} Amount`,
-		requiredWethWrapDetailPrefix: 'Need',
-		requiredWethWrapDetailSuffix: 'more WETH for this report.',
-		wrapEthToWethIdleLabel: 'Wrap needed ETH to WETH',
-		wrapEthToWethPendingLabel: 'Wrapping ETH...',
-		stickyContextFields: {
-			priceLabel: UI_STRING_PRICE,
-			reporterLabel: 'Reporter',
-			stageLabel: 'Stage',
-			tokenPairLabel: UI_STRING_TOKEN_PAIR,
-		},
-	},
-	zoltarMigrationSection: {
-		prepareRepIdleLabel: UI_STRING_PREPARE_REP,
-		preparingRepPendingLabel: UI_STRING_PREPARING_REP_PENDING,
-		repMigrationUnavailableReason: UI_STRING_REP_MIGRATION_UNAVAILABLE_BECAUSE_UNIVERSE_HAS_NOT_FORKED,
-		repPreparationUnavailableReason: UI_STRING_REP_PREPARATION_UNAVAILABLE_BECAUSE_UNIVERSE_HAS_NOT_FORKED,
-		splitRepIdleLabel: UI_STRING_SPLIT_REP,
-		splittingRepPendingLabel: UI_STRING_SPLITTING_REP_PENDING,
-	},
-	overviewPanels: {
-		addressLabel: 'Address',
-		augurPlaceholderTitle: 'Augur Placeholder',
-		connectWalletIdleLabel: UI_STRING_CONNECT_WALLET,
-		connectWalletPendingLabel: UI_STRING_CONNECTING,
-		connectedBadgeLabel: 'Connected',
-		connectingDetail: UI_STRING_CONNECTING,
-		ethBalanceLabel: UI_STRING_ETH,
-		forkedBadgeLabel: UI_STRING_FORKED,
-		goToGenesisUniverseLabel: UI_STRING_GO_TO_GENESIS_UNIVERSE,
-		notConnectedLabel: 'Not connected',
-		operationsEyebrow: 'Operations',
-		parentUniverseLabel: 'Parent Universe',
-		readOnlyBadgeLabel: 'Read-only',
-		repBalanceLabel: UI_STRING_REP,
-		repPerEthLabel: UI_STRING_REP_PER_ETH_COMPACT,
-		repUsdcLabel: 'REP/USDC',
-		refreshRepPricesAriaLabel: UI_STRING_REFRESH_REP_PRICES,
-		refreshRepPricesIdleTitle: UI_STRING_REFRESH_REP_PRICES,
-		refreshRepPricesPendingTitle: 'Refreshing REP prices...',
-		simulationBadgeLabel: 'Simulation',
-		simulationDescription: 'Simulation mode uses browser-local contract state. Transactions do not affect a public network.',
-		universeForkedDescription: 'This universe has forked.',
-		universeForkedOnDetailPrefix: 'Zoltar forked on',
-		universeLabel: UI_STRING_UNIVERSE,
-		wethBalanceLabel: UI_STRING_WETH,
-		wrongNetworkBadgeLabel: 'Wrong Network',
-	},
-	question: {
-		answerUnitLabel: UI_STRING_ANSWER_UNIT,
-		createdLabel: 'Created',
-		displayRangeLabel: 'Display Range',
-		endTimeLabel: UI_STRING_END_TIME,
-		invalidOutcomeLabel: UI_STRING_INVALID,
-		loadingQuestionDetailsLabel: 'Loading question details...',
-		outcomesLabel: UI_STRING_OUTCOMES,
-		questionIdLabel: UI_STRING_QUESTION_ID,
-		questionTimelineAriaLabel: 'Question timeline',
-		scalarOutcomeLabel: UI_STRING_SCALAR,
-		ticksLabel: 'Ticks',
-		untitledQuestionLabel: 'Untitled question',
-	},
-	scalarDeploymentSection: {
-		childUniverseAlreadyDeployedDetail: UI_STRING_CHILD_UNIVERSE_ALREADY_DEPLOYED,
-		childUniverseAlreadyDeployedReason: UI_STRING_CHILD_UNIVERSE_ALREADY_DEPLOYED,
-		childUniverseNotAlreadyDeployedLabel: UI_STRING_CHILD_UNIVERSE_NOT_ALREADY_DEPLOYED,
-		childUniverseSelectedTitle: UI_STRING_SELECTED_CHILD_UNIVERSE,
-		childUniversesTitle: UI_STRING_CHILD_UNIVERSES,
-		connectWalletBeforeDeployingChildUniverseReason: UI_STRING_CONNECT_A_WALLET_BEFORE_DEPLOYING_A_CHILD_UNIVERSE,
-		createChildUniverseLabel: UI_STRING_CREATE_CHILD_UNIVERSE,
-		createChildUniverseTitle: UI_STRING_CREATE_CHILD_UNIVERSE_TITLE,
-		createInvalidUniverseLabel: 'Create invalid universe',
-		deployedLabel: UI_STRING_DEPLOYED,
-		deployInvalidUniverseLabel: 'Deploy Invalid Universe',
-		deployUniverseLabel: UI_STRING_DEPLOY_UNIVERSE,
-		deployingUniversePendingLabel: UI_STRING_DEPLOYING_UNIVERSE,
-		existingChildUniversesTitle: 'Existing Child Universes',
-		executeChildUniverseDeploymentDescription: 'Confirm the selected scalar outcome and deploy its child universe in one bounded execution flow.',
-		forkBeforeDeployingChildUniversesReason: UI_STRING_CHILD_UNIVERSES_UNAVAILABLE_BECAUSE_UNIVERSE_HAS_NOT_FORKED,
-		loadingScalarRangeDetail: 'Loading scalar range...',
-		noChildUniverseSelectedMessage: 'No child universe selected.',
-		noDeployedChildUniversesMessage: 'No deployed child universes.',
-		openingChildUniversePendingLabel: UI_STRING_OPENING,
-		scalarForksCanDeployOneOutcomeUniverseAtATimeDetail: 'Scalar forks can deploy one outcome universe at a time.',
-		selectChildUniverseLabel: 'Select Child Universe',
-		selectedTickInvalidLabel: UI_STRING_INVALID,
-		selectedTickInvalidReason: 'Selected tick is invalid',
-		universeIsForkedLabel: UI_STRING_UNIVERSE_IS_FORKED,
-		walletConnectedLabel: UI_STRING_WALLET_CONNECTED,
-	},
-	shareMigrationTargetsSection: {
-		addTargetLabel: 'Add Target',
-		childDeployedLabel: 'Child deployed',
-		childNotDeployedLabel: 'Child not deployed',
-		clearLabel: 'Clear',
-		loadingForkQuestionDetailsDetail: 'Loading fork question details...',
-		loadingForkTargetUniversesDetail: 'Loading fork target universes...',
-		malformedOutcomeLabel: (outcomeIndex: string) => `Malformed (${outcomeIndex})`,
-		loadingScalarForkDetailsDetail: 'Loading scalar fork details...',
-		noTargetChildUniversesDetail: 'No target child universes available.',
-		notSelectedLabel: 'Not selected',
-		removeTargetLabel: 'Remove Target',
-		selectAllLabel: 'Select all',
-		selectScalarTargetLabel: 'Select Scalar Target',
-		selectScalarTargetUniverseDetail: 'Select at least one scalar target universe.',
-		selectedLabel: UI_STRING_SELECTED,
-		selectedTickLabel: (selectedTick: string, totalTicks: string) => UI_TEMPLATE_PAIR_SLASH(selectedTick, totalTicks),
-		targetChildUniversesTitle: 'Target Child Universes',
-		targetsUnlockAfterForkDetail: 'Child-universe targets unlock after this universe forks.',
-	},
-	scalarOutcomePicker: {
-		currentValueLabel: 'Current Value',
-		invalidLabel: UI_STRING_INVALID,
-		maxValueLabel: 'Max Value',
-		minValueLabel: 'Min Value',
-		orLabel: 'or',
-		selectedOutcomeLabel: 'Selected Outcome',
-		selectedTickLabel: 'Selected Tick',
-	},
-	reportingSection: {
-		belowMinimumSelectedSideCapacityReason: 'Remaining selected-side capacity is below the minimum report bond.',
-		continueInForkAndMigrationReason: 'Continue in Fork & Migration to migrate unresolved escalation deposits into a child universe.',
-		continueInForkAndMigrationLabel: 'Continue in Fork & Migration',
-		contributionAmountHelpText: 'This is the REP you are willing to lock on the selected side. Larger amounts can change the proposed outcome or extend the escalation timer.',
-		contributionAmountLabel: 'Contribution Amount (REP)',
-		enterValidReportAmountReason: 'Enter a valid report amount to preview profit.',
-		escalationMetricsTitle: UI_STRING_ESCALATION_METRICS,
-		escalationStartedLabel: 'Escalation started',
-		escalationWorkflowSummary: UI_STRING_SELECT_THE_ANSWER_YOU_BELIEVE_SHOULD_FINALIZE_LOCK,
-		establishedReportOutcomeLabel: UI_STRING_REPORT_OUTCOME,
-		chooseDepositsToSettleLabel: 'Choose deposits to settle',
-		forkAlreadyTriggeredReportReason: 'Escalation reached non-decision and Zoltar fork has already been triggered for this pool. Continue in Fork & Migration.',
-		forkAlreadyTriggeredSettlementReason: 'Escalation deposits remain locked after non-decision. Zoltar fork has already been triggered for this pool, so continue in Fork & Migration.',
-		forkTriggeredReportReason: 'Escalation reached non-decision. Trigger Zoltar Fork here if this pool should fork the universe.',
-		forkTriggeredSettlementReason: 'Escalation deposits remain locked after non-decision. Trigger Zoltar Fork here if this pool should fork the universe.',
-		initiallyDepositedLabel: 'Initially deposited:',
-		leadHoldingCapitalLabel: 'Lead-holding capital',
-		loadingAvailableVaultRepReason: 'Loading available vault REP.',
-		loadingEscalationDepositsReason: UI_STRING_LOADING_ESCALATION_DEPOSITS,
-		loadReportingDetailsReason: 'Load reporting details before using presets.',
-		loadingEscalationLabel: 'Loading escalation...',
-		loadingReportingLabel: 'Refresh reporting',
-		maxProfitNotStartedReason: 'Max profit becomes available after the escalation game starts.',
-		maxProfitLabel: 'Max profit',
-		maxProfitWindowFilledReason: 'Max profit preset unavailable because the reward window is already filled on the selected side.',
-		minToTakeTheLeadLabel: 'Min to take the lead',
-		noSelectedSideCapacityReason: 'No remaining contribution capacity is available on the selected side.',
-		noUnlockedVaultRepReason: 'No unlocked vault REP available for reporting.',
-		nonDecisionThresholdLabel: 'Non-decision threshold',
-		reportOnSelectedSideLabel: 'Report On Selected Side',
-		reportOutcomeAriaLabel: 'Report outcome',
-		reportSelectedOutcomeButtonLabel: (selectedOutcomeLabel: string) => `Report ${selectedOutcomeLabel}`,
-		reportOutcomeSelectionMessage: UI_STRING_SELECT_AN_OUTCOME_SIDE_ABOVE_TO_ENABLE_REPORTING,
-		reportingActiveDetail: 'Escalation is live. Review the bond, side balances, and time remaining before contributing or withdrawing.',
-		reportingWorkflowTitle: UI_STRING_REPORTING_WORKFLOW,
-		reportingLatestOutcomeReminderImmediate: (selectedOutcomeLabel: string) => `Check back immediately to confirm the market finalized as ${selectedOutcomeLabel}.`,
-		reportingLatestOutcomeReminderLater: (selectedOutcomeLabel: string) => `Check back later to confirm ${selectedOutcomeLabel} is the leading outcome.`,
-		reportingLatestOutcomeReminderBeforeRewardWindowPrefix: UI_STRING_CHECK_BACK_NO_LATER_THAN,
-		reportingLatestOutcomeReminderBeforeRewardWindowMiddle: UI_STRING_TO_CONFIRM,
-		reportingLatestOutcomeReminderBeforeRewardWindowSuffix: ' is the leading outcome before the remaining reward-eligible REP on ',
-		reportingLatestOutcomeReminderBeforeRewardWindowTail: ' is filled.',
-		reportingLatestOutcomeReminderBeforeFinalizationPrefix: UI_STRING_CHECK_BACK_NO_LATER_THAN,
-		reportingLatestOutcomeReminderBeforeFinalizationMiddle: UI_STRING_TO_CONFIRM,
-		reportingLatestOutcomeReminderBeforeFinalizationSuffix: ' is the leading outcome before finalization.',
-		reportingProjectionProfitPrefix: 'If ',
-		reportingProjectionProfitMiddle: ' wins and no one else contributes afterward, this amount projects roughly ',
-		reportingProjectionProfitSuffix: ' of profit. ',
-		reportingProjectionNotStartedPrefix: 'If no one disputes after this report, the market would finalize in ',
-		reportingProjectionNotStartedCheckBackPrefix: UI_STRING_CHECK_BACK_NO_LATER_THAN,
-		reportingProjectionNotStartedCheckBackMiddle: UI_STRING_TO_CONFIRM,
-		reportingProjectionNotStartedCheckBackSuffix: ' is still leading if later disputes keep escalation open.',
-		reportingProjectionNotStartedSimpleSuffix: '. ',
-		reportingProjectionEndsImmediatelyText: 'This contribution would end the escalation and finalize the market immediately. ',
-		reportingProjectionExtendsPrefix: 'This contribution would extend the timer by ',
-		reportingProjectionExtendsMiddle: ', and if no one disputes after it, the market would finalize in ',
-		reportingProjectionDoesNotExtendPrefix: 'This contribution would not extend the timer, and if no one disputes after it, the market would finalize in ',
-		reportingContributionLockPrefix: 'Based on the current escalation state, this action would lock ',
-		reportingContributionLockSuffix: ' instead of the full entered amount.',
-		openForkAndMigrationLabel: 'Open Fork & Migration',
-		settleAllForThisSideReason: UI_STRING_SELECT_AT_LEAST_ONE_DEPOSIT_TO_SETTLE_OR_USE_SETTLE_ALL_FOR_THIS_SIDE,
-		migrationRequiredReason: 'These escalation deposits must migrate in Fork & Migration.',
-		reportingWorkflowStepOutcomeLabel: '1. Outcome',
-		reportingWorkflowStepLockRepLabel: '2. Lock REP',
-		reportingWorkflowStepSettleLabel: '3. Settle',
-		reportingWorkflowCardDescription: UI_STRING_SELECT_THE_ANSWER_YOU_BELIEVE_SHOULD_FINALIZE_LOCK,
-		reportingWorkflowCardTitle: UI_STRING_REPORTING_WORKFLOW,
-		reportingWorkflowSummary: UI_STRING_SELECT_THE_ANSWER_YOU_BELIEVE_SHOULD_FINALIZE_LOCK,
-		submitReportPendingLabel: 'Submitting report...',
-		reportingSettlementTitle: UI_STRING_SETTLE_ESCALATION_DEPOSITS,
-		reportingMetricsTitle: UI_STRING_ESCALATION_METRICS,
-		reportingOutcomeTitle: UI_STRING_REPORT_OUTCOME,
-		reportingNotEnabledTitle: 'Reporting Not Enabled',
-		reportingOpenTitle: 'Reporting Open',
-		resolvedTitle: 'Resolved',
-		activeTitle: UI_STRING_ACTIVE,
-		forkTriggeredTitle: UI_STRING_FORK_TRIGGERED,
-		timedOutTitle: 'Timed Out',
-		pendingFinalizationLabel: 'Pending finalization',
-		timeLeftLabel: 'Time Left',
-		claimTypeWinningPayoutLabel: 'Winning payout',
-		claimTypeLosingDepositSettlementLabel: 'Losing deposit settlement',
-		currentClaimTypePrefix: 'Current claim type:',
-		entryDepthLabel: 'Entry depth:',
-		reportingHasEndedRefreshReason: 'Escalation has ended. Refresh reporting to view the finalized outcome before settling deposits.',
-		reportingOpenDetail: 'Load reporting details to view the escalation state for this pool.',
-		reportingOpenMessage: 'Reporting is open.',
-		reportingOpenSelectOutcomeMessage: 'Reporting is open. Select an outcome side below to enable reporting.',
-		reportingPoolAlreadyFinalizedReason: 'This pool is already finalized.',
-		settlementLockedUntilFinalizedReason: 'Escalation deposits cannot be settled until the question is finalized.',
-		reportingResolvedDetail: 'Market finalized as',
-		reportingResolvedDetailLabel: (selectedOutcomeLabel: string) => `Market finalized as ${selectedOutcomeLabel}.`,
-		reportingTimedOutReason: UI_STRING_ESCALATION_ENDED_BY_TIMEOUT_THE_WINNER_IS_COMPUTED,
-		reportingTimedOutDetail: UI_STRING_ESCALATION_ENDED_BY_TIMEOUT_THE_WINNER_IS_COMPUTED,
-		migrationExpiredReason: 'The migration window for these unresolved escalation deposits has closed.',
-		worthAfterFinalizationPendingLabel: 'Worth after finalization: Pending finalization',
-		worthNowLabel: 'Worth now:',
-		selectOutcomeAboveToEnableReportingMessage: UI_STRING_SELECT_AN_OUTCOME_SIDE_ABOVE_TO_ENABLE_REPORTING,
-		selectOutcomePresetReason: 'Select an outcome side before using presets.',
-		selectedSideAlreadyLeadsReason: 'Selected side already leads.',
-		selectedSideUnavailableReason: 'Selected side is unavailable.',
-		selectedSideLabel: 'Selected Side',
-		securityPoolAddressLabel: UI_STRING_SECURITY_POOL_ADDRESS,
-		settleAllDepositsLabel: (sideLabel: string) => `Settle All ${sideLabel} Deposits`,
-		settleSelectedDepositsLabel: (sideLabel: string) => `Settle Selected ${sideLabel} Deposits`,
-		settlingDepositsPendingLabel: (sideLabel: string) => `Settling ${sideLabel} deposits...`,
-		startBondLabel: 'Start Bond',
-		totalSideStakeLabel: 'Total side stake',
-		selectedSideStakeLabel: 'Your side stake',
-		triggeringZoltarForkLabel: 'Triggering Zoltar fork...',
-		triggerZoltarForkIdleLabel: UI_STRING_TRIGGER_ZOLTAR_FORK,
-		triggerZoltarForkLabel: UI_STRING_TRIGGER_ZOLTAR_FORK,
-		loadingEscalationDepositReason: UI_STRING_LOADING_ESCALATION_DEPOSITS,
-		loadingEscalationDepositsDetail: 'Loading escalation deposits...',
-		availableUnlockedVaultRepPrefix: 'Available unlocked vault REP for reporting:',
-		withdrawSelectedAllReason: UI_STRING_SELECT_AT_LEAST_ONE_DEPOSIT_TO_SETTLE_OR_USE_SETTLE_ALL_FOR_THIS_SIDE,
-		withdrawEmptyStateDetail: 'Connected wallet has no unsettled escalation deposits.',
-		thisPoolAlsoHasForkCarriedEscalationPositionsDetail: 'This pool also has fork-carried escalation positions. Settle those in Fork & Migration.',
-	},
-	securityPoolSection: {
-		createAnotherPoolLabel: 'Create Another Pool',
-		createPoolButtonIdleLabel: UI_STRING_CREATE_POOL,
-		createPoolButtonPendingLabel: 'Creating Pool...',
-		createPoolLockedLabel: 'Pool Creation Locked',
-		createPoolPanelTitle: UI_STRING_CREATE_POOL,
-		createdPoolCardTitle: 'Pool Created',
-		creationLockedError: 'Security pools cannot be created after Zoltar has forked.',
-		deploymentTransactionHashLabel: 'Deployment transaction hash',
-		duplicateCheckPendingLabel: 'Checking Duplicate...',
-		duplicatePoolError: 'A pool for this question and security multiplier already exists. Origin pool deployment is deterministic for that pair, so change the security multiplier to create a different pool.',
-		initialOpenInterestFeeHelpText: 'Initial Open Interest Fee / Year is the starting annualized fee charged against open interest. The rate follows pool utilization after deployment.',
-		initialOpenInterestFeeLabel: 'Initial Open Interest Fee / Year',
-		ineligibleQuestionError: 'Security pools can only be created for exact binary Yes / No questions. Enter an eligible question to proceed.',
-		loadingQuestionLabel: 'Loading question...',
-		openPoolLabel: UI_STRING_OPEN_POOL,
-		poolAddressLabel: 'Pool address',
-		poolAlreadyExistsLabel: 'Pool Already Exists',
-		questionHelpText: 'Paste an exact binary Yes / No Zoltar question ID.',
-		questionIdLabel: UI_STRING_QUESTION_ID,
-		questionIdPlaceholder: UI_STRING_HEX_VALUE_PLACEHOLDER,
-		returnToBrowseLabel: UI_STRING_RETURN_TO_BROWSE,
-		securityMultiplierHelpText: 'Security Multiplier sets the REP collateral target relative to open interest. Higher values require more REP backing and create a thicker safety buffer.',
-		securityMultiplierLabel: UI_STRING_SECURITY_MULTIPLIER,
-		universeLabel: UI_STRING_UNIVERSE,
-	},
-	securityVaultSection: {
-		approveRepActionLabel: 'depositing REP',
-		approvingRepPendingLabel: UI_STRING_APPROVING_REP,
-		bondAllowanceRejectedDetail: 'The oracle manager attempted the allowance update immediately, but the security pool rejected it.',
-		bondAllowanceExecutedTitle: 'Bond Allowance Executed',
-		bondAllowanceFailedTitle: 'Bond Allowance Failed',
-		bondAllowanceQueuedTitle: 'Bond Allowance Queued',
-		bondAllowanceSubmittedTitle: 'Bond Allowance Submitted',
-		claimFeesActionDescription: 'Review claimable fees and confirm the fee redemption for the selected vault.',
-		claimFeesAmountLabel: 'Claimable Fees',
-		claimFeesIdleLabel: UI_STRING_CLAIM_FEES,
-		claimFeesModalDescription: 'Confirm the claimable fee balance before submitting the fee redemption for this vault.',
-		claimFeesPendingLabel: 'Claiming fees...',
-		claimFeesTitle: UI_STRING_CLAIM_FEES,
-		createVaultByDepositingRepDetail: 'This vault does not exist. Deposit REP to create it.',
-		currentBondAllowanceLabel: 'Current Bond Allowance',
-		currentSecurityBondAllowanceLabel: 'Current Security Bond Allowance',
-		depositRepActionDescription: 'Add REP to the selected vault.',
-		depositRepAmountLabel: 'REP Collateral Amount',
-		depositRepIdleLabel: UI_STRING_DEPOSIT_REP,
-		depositRepPendingLabel: 'Depositing REP...',
-		depositRepTitle: UI_STRING_DEPOSIT_REP,
-		firstDepositMinimumChecklistDetail: (amount: string) => `First deposits must be at least ${amount} REP.`,
-		firstDepositMinimumInlineDetailSuffix: 'in the first deposit.',
-		escalationEscrowedRepLabel: UI_STRING_ESCROWED_REP,
-		firstDepositMinimumChecklistLabel: 'First deposit meets the vault minimum',
-		firstDepositMinimumDetailPrefix: 'New vaults require at least',
-		hasClaimableFeesChecklistLabel: 'Claimable fees are available',
-		insufficientRepBalanceDetail: (amount: string) => `Insufficient REP balance. Deposit amount exceeds your wallet balance by ${amount} REP.`,
-		loadingVaultDetail: UI_STRING_LOADING_VAULT,
-		missingVaultBlockerDetail: UI_STRING_THIS_VAULT_DOES_NOT_EXIST,
-		vaultLauncherBlockerReason: (action: 'claim-fees' | 'deposit-rep' | 'rep-exit-redeem' | 'rep-exit-withdraw' | 'set-bond-allowance', blocker: 'connect-wallet' | 'missing-vault' | 'refresh-vault' | 'select-own-vault') => {
-			if (blocker === 'missing-vault') return UI_STRING_THIS_VAULT_DOES_NOT_EXIST
+export const UI_STRING_CREATE_ORACLE_REPORT = 'Create Oracle Report'
+export const UI_STRING_DEPLOY_CONTRACTS = 'Deploy Contracts'
+export const UI_STRING_MANAGE_SECURITY_POOL = 'Manage Security Pool'
+export const UI_STRING_ORACLE_REPORT_DETAILS = 'Oracle Report Details'
+export const UI_STRING_PAGE_NOT_FOUND_APP_PAGE_TITLE_PAGE_NOT_FOUND_PAGE_TITLE = 'Page Not Found'
+export const UI_STRING_BROWSE = 'Browse'
+export const UI_STRING_CREATE_REPORT = 'Create Report'
+export const UI_STRING_ORACLE_REPORT_VIEWS = 'Oracle report views'
+export const UI_STRING_BROWSE_POOLS = 'Browse Pools'
+export const UI_STRING_SECURITY_POOLS_VIEWS = 'Security Pools views'
+export const UI_STRING_MARKET_VIEWS = 'Market views'
+export const UI_STRING_MINUTES = 'minutes'
+export const UI_STRING_NONE_SELECTED = 'None selected'
+export const UI_STRING_USDC = 'USDC'
+export const UI_STRING_EXISTS = 'Exists'
+export const UI_STRING_NOT_DEPLOYED = 'Not deployed'
+export const UI_STRING_WORKING = 'Working...'
+export const UI_STRING_ACTIVE_READ_RPC = 'Active read RPC'
+export const UI_STRING_CONFIGURED_FALLBACK_READ_RPC = 'Configured fallback read RPC'
+export const UI_STRING_DEFAULT = 'default'
+export const UI_STRING_ENVIRONMENT = 'environment'
+export const UI_STRING_EXPLICIT_OVERRIDE = 'explicit override'
+export const UI_STRING_REQUIRED_APPLICATION_CONTRACTS_ARE_NOT_DEPLOYED = 'Required application contracts are not deployed.'
+export const UI_STRING_GLOBAL_RUNTIME = 'global runtime'
+export const UI_STRING_READ_RPC_OVERRIDE_IGNORED = 'Read RPC override ignored'
+export const UI_STRING_LOCAL_STORAGE = 'local storage'
+export const UI_STRING_PAGE_URL = 'page URL'
+export const UI_TEMPLATE_READ_RPC_OVERRIDE_IGNORED_DETAIL = (sourceLabel: string, url: string, reason: string, configuredRpcLabel: string, activeRpcUrl: string) => `Ignored ${sourceLabel} RPC override (${url}): ${reason} ${configuredRpcLabel} is ${activeRpcUrl}.`
+export const UI_TEMPLATE_READ_RPC_OVERRIDE_FROM_URL_DETAIL = (configuredRpcLabel: string, rpcUrl: string) => `${configuredRpcLabel} came from the page URL: ${rpcUrl}. Verify this endpoint before relying on displayed onchain state.`
+export const UI_TEMPLATE_READ_RPC_OVERRIDE_ACTIVE_DETAIL = (configuredRpcLabel: string, sourceLabel: string, rpcUrl: string) => `${configuredRpcLabel} came from ${sourceLabel}: ${rpcUrl}. Verify this endpoint before relying on displayed onchain state.`
+export const UI_STRING_DISPLAYED_ONCHAIN_STATE_MAY_NOT_MATCH_THE_NETWORK_THIS_INTERFACE_WRITES_TO = 'Displayed onchain state may not match the network this interface writes to.'
+export const UI_STRING_READ_RPC_MISMATCH = 'Read RPC mismatch'
+export const UI_STRING_READ_RPC_OVERRIDE_ACTIVE = 'Read RPC override active'
+export const UI_STRING_SETUP_INCOMPLETE = 'Setup incomplete'
+export const UI_STRING_SIMULATION_BOOTSTRAP_FAILED = 'Simulation bootstrap failed'
+export const UI_STRING_DISPLAYED_ONCHAIN_STATE_MAY_BE_BEHIND_THE_LATEST_CHAIN_STATE_REFRESH_OR_SWITCH_RPC_BEFORE_ACTING_ON_BALANCES_SETTLEMENT_OR_LIQUIDATION = 'Displayed onchain state may be behind the latest chain state. Refresh or switch RPC before acting on balances, settlement, or liquidation.'
+export const UI_STRING_HAS_FORKED_ON = 'has forked on'
+export const UI_STRING_UNIVERSE_FORKED = 'Universe forked'
+export const UI_STRING_URL_PROVIDED_READ_RPC = 'URL-provided read RPC'
+export const UI_STRING_CURRENT_FORM_PRICE = 'Current form price'
+export const UI_STRING_CURRENT_SIZE = 'Current size'
+export const UI_STRING_CLEARING_LEVEL = 'Clearing level'
+export const UI_STRING_LOADED_DEPTH = 'Loaded depth'
+export const UI_STRING_LOAD_MORE_PRICE_LEVELS = 'Load More Price Levels'
+export const UI_STRING_LOADING_ORDER_BOOK = 'Loading order book…'
+export const UI_STRING_LOADING_PRICE_LEVELS = 'Loading price levels…'
+export const UI_STRING_MARKET_VIEW = 'Market View'
+export const UI_STRING_NO_ACTIVE_LEVELS_ARE_VISIBLE = 'No active levels are visible.'
+export const UI_STRING_NO_LIVE_PRICE_LEVELS_ARE_CURRENTLY_ACTIVE_FOR_THIS_AUCTION = 'No live price levels are currently active for this auction.'
+export const UI_STRING_PRICE_LADDER = 'Price Ladder'
+export const UI_STRING_PRICE_LEVEL = 'Price level'
+export const UI_TEMPLATE_SUBMISSIONS_LABEL = (count: string) => `${count} submissions`
+export const UI_STRING_VISIBLE_DEPTH = 'Visible Depth'
+export const UI_STRING_CAN_DEPLOY_NOW = 'Can deploy now.'
+export const UI_STRING_CODE_FOUND_AT_EXPECTED_ADDRESS = 'Code found at expected address.'
+export const UI_STRING_DEPLOYMENT_IN_PROGRESS = 'Deployment in progress.'
+export const UI_STRING_NOT_DEPLOYED_DEPLOYMENT_SECTION_NOT_DEPLOYED_BADGE_LABEL = 'Not Deployed'
+export const UI_STRING_WAITING = 'Waiting'
+export const UI_TEMPLATE_WAITING_FOR_PREREQUISITE_DETAIL = (prerequisiteLabel: string) => `Waiting for ${prerequisiteLabel}.`
+export const UI_STRING_AUTO_EXEC_PENDING = 'Auto-exec pending'
+export const UI_STRING_ADDITIONAL_POOL_ACTIONS = 'Additional pool actions'
+export const UI_STRING_DIRECTORY = 'Directory'
+export const UI_STRING_EXECUTE_STAGED_OPERATION = 'Execute Staged Operation'
+export const UI_STRING_EXECUTING_STAGED_OPERATION_SECURITY_POOL_WORKFLOW_SECTION_EXECUTING_STAGED_OPERATION_LABEL = 'Executing staged operation...'
+export const UI_STRING_THIS_POOL_IS_CURRENTLY_OPERATIONAL_SO_FORK_AND_TRUTH_AUCTION_ACTIONS_ARE_READ_ONLY = 'This pool is currently operational, so fork and truth auction actions are read only.'
+export const UI_STRING_INITIATOR = 'Initiator'
+export const UI_STRING_LOAD_STAGED_OPERATIONS = 'Load Staged Operations'
+export const UI_STRING_MANUAL_EXECUTION = 'Manual execution'
+export const UI_STRING_NO_STAGED_OPERATIONS_ARE_CURRENTLY_QUEUED_FOR_THIS_POOL = 'No staged operations are currently queued for this pool.'
+export const UI_STRING_NONE_QUEUED = 'None queued'
+export const UI_STRING_LIQUIDATION = 'Liquidation'
+export const UI_TEMPLATE_PENDING_REPORT_LABEL = (reportId: string) => UI_TEMPLATE_REPORT_NUMBER_LABEL(reportId)
+export const UI_STRING_PRIMARY_POOL_ACTIONS = 'Primary pool actions'
+export const UI_STRING_POOL_NOT_FOUND = 'Pool not found'
+export const UI_STRING_REFRESH_ORACLE = 'Refresh Oracle'
+export const UI_STRING_REFRESH_POOL = 'Refresh pool'
+export const UI_STRING_REFRESH_STAGED_OPERATIONS = 'Refresh Staged Operations'
+export const UI_STRING_REFRESHING_ORACLE = 'Refreshing oracle...'
+export const UI_STRING_REFRESHING_OPERATIONS = 'Refreshing operations...'
+export const UI_STRING_REFRESHING_POOL = 'Refreshing pool...'
+export const UI_STRING_REQUEST_COST = 'Request Cost'
+export const UI_STRING_REQUEST_NEW_PRICE = 'Request New Price'
+export const UI_STRING_REQUESTING_NEW_PRICE = 'Requesting new price...'
+export const UI_STRING_INSPECT_THE_LIQUIDATION_QUOTE_TIMEOUT_AND_EXECUTION_PATH_BEFORE_QUEUEING_LIQUIDATION = 'Inspect the liquidation quote, timeout, and execution path before queueing liquidation.'
+export const UI_STRING_SELECTED_POOL = 'Selected Pool'
+export const UI_STRING_SELECTED_POOL_VAULT_VIEWS = 'Selected pool vault views'
+export const UI_STRING_SELECTED_POOL_VIEWS = 'Selected pool views'
+export const UI_STRING_OPEN_ORACLE = 'Open Oracle'
+export const UI_STRING_PARENT_POOL = 'Parent Pool'
+export const UI_STRING_PENDING_REQUEST = 'Pending Request'
+export const UI_STRING_SELECT_VAULT = 'Select Vault'
+export const UI_TEMPLATE_SHOWING_ACTIVE_STAGED_OPERATIONS_LABEL = (loadedCount: string, activeCount: string) => `Showing ${loadedCount} of ${activeCount} active staged operations, newest first.`
+export const UI_STRING_STAGED_OPERATION_ID = 'Staged Operation Id'
+export const UI_STRING_0 = '0'
+export const UI_STRING_STAGED_OPERATIONS = 'Staged Operations'
+export const UI_STRING_STAGED_OPERATIONS_LIST = 'Staged Operations List'
+export const UI_STRING_UNIVERSE_MISMATCH = 'Universe Mismatch'
+export const UI_STRING_THIS_POOL_BELONGS_TO = 'This pool belongs to'
+export const UI_STRING_BUT_THE_APP_IS_CURRENTLY_SET_TO = 'but the app is currently set to'
+export const UI_STRING_THIS_POOL_DOES_NOT_EXIST = 'This pool does not exist.'
+export const UI_STRING_VAULT_DIRECTORY = 'Vault Directory'
+export const UI_STRING_VAULT_OPERATIONS = 'Vault Operations'
+export const UI_STRING_TRY_ANOTHER_VAULT_ADDRESS = 'Try another vault address.'
+export const UI_STRING_ZOLTAR_FORK_HAS_ALREADY_BEEN_TRIGGERED_FOR_THIS_POOL_CONTINUE_IN_FORK_AND_MIGRATION = 'Zoltar fork has already been triggered for this pool. Continue in Fork & Migration.'
+export const UI_STRING_THIS_POOL_HAS_ALREADY_ENTERED_FORK_AND_MIGRATION = 'This pool has already entered Fork & Migration.'
+export const UI_STRING_TRIGGERING_A_ZOLTAR_FORK_IS_NOT_AVAILABLE_IN_THE_CURRENT_POOL_STATE = 'Triggering a Zoltar fork is not available in the current pool state.'
+export const UI_STRING_THIS_POOL_IS_IN_FORK_MIGRATION_REPORTING_ACTIONS_UNLOCK_ONCE_THE_POOL_BECOMES_OPERATIONAL = 'This pool is in fork migration. Reporting actions unlock once the pool becomes operational.'
+export const UI_STRING_THIS_PARENT_POOL_IS_FORKED_CONTINUE_IN_FORK_AND_MIGRATION_FOR_MIGRATION_AND_SETTLEMENT = 'This parent pool is forked. Continue in Fork & Migration for migration and settlement.'
+export const UI_STRING_THIS_POOL_IS_IN_TRUTH_AUCTION_REPORTING_ACTIONS_UNLOCK_ONCE_THE_POOL_BECOMES_OPERATIONAL = 'This pool is in truth auction. Reporting actions unlock once the pool becomes operational.'
+export const UI_STRING_REPORTING_OPENS_AFTER_MARKET_END = 'Reporting opens after market end.'
+export const UI_STRING_OPERATION_ID = 'Operation Id'
+export const UI_STRING_CALLER_COLLATERALIZATION_AT_OPEN_ORACLE = 'Caller Collateralization @ Open Oracle'
+export const UI_STRING_COLLATERALIZATION_AT_OPEN_ORACLE = 'Collateralization @ Open Oracle'
+export const UI_STRING_CALLER_VAULT_AFTER_LIQUIDATION = 'Caller Vault After Liquidation'
+export const UI_STRING_CALLER_VAULT = 'Caller Vault'
+export const UI_STRING_CHECK_STATE = 'Check State'
+export const UI_STRING_ENTER_A_LIQUIDATION_AMOUNT = 'Enter a liquidation amount.'
+export const UI_STRING_ENTER_A_LIQUIDATION_TIMEOUT_OF_AT_LEAST_1_MINUTE = 'Enter a liquidation timeout of at least 1 minute.'
+export const UI_STRING_EXECUTING_LIQUIDATION = 'Executing liquidation...'
+export const UI_STRING_EXECUTE_VAULT_LIQUIDATION = 'Execute Vault Liquidation'
+export const UI_STRING_INVALID_LIQUIDATION_PAIR = 'Invalid Liquidation Pair'
+export const UI_STRING_SUBMITTING_LIQUIDATION_LIQUIDATION_MODAL_LIQUIDATE_VAULT_PENDING_LABEL = 'Submitting liquidation...'
+export const UI_STRING_LIQUIDATION_AMOUNT_ETH = 'Liquidation Amount (ETH)'
+export const UI_STRING_THE_ORACLE_MANAGER_ATTEMPTED_THE_LIQUIDATION_IMMEDIATELY_BUT_THE_SECURITY_POOL_REJECTED_IT = 'The oracle manager attempted the liquidation immediately, but the security pool rejected it.'
+export const UI_STRING_THE_CALLER_VAULT_WOULD_REMAIN_BELOW_THE_MINIMUM_SECURITY_BOND_ALLOWANCE_AFTER_LIQUIDATION = 'The caller vault would remain below the minimum security bond allowance after liquidation.'
+export const UI_STRING_THE_CALLER_VAULT_WOULD_REMAIN_BELOW_THE_MINIMUM_REP_COLLATERAL_AFTER_LIQUIDATION = 'The caller vault would remain below the minimum REP collateral after liquidation.'
+export const UI_STRING_THIS_LIQUIDATION_AMOUNT_IS_TOO_SMALL_TO_IMPROVE_THE_TARGET_VAULT_HEALTH_AFTER_ROUNDING = 'This liquidation amount is too small to improve the target vault health after rounding.'
+export const UI_STRING_NO_DEBT_IS_EXECUTABLE_FOR_LIQUIDATION_AT_THE_CURRENT_TARGET_SIDE_BOUNDS = 'No debt is executable for liquidation at the current target-side bounds.'
+export const UI_STRING_THE_TARGET_VAULT_IS_NOT_LIQUIDATABLE_AT_THE_CURRENT_PRICE = 'The target vault is not liquidatable at the current price.'
+export const UI_STRING_THE_TARGET_VAULT_WOULD_FALL_BELOW_THE_MINIMUM_SECURITY_BOND_ALLOWANCE_AFTER_LIQUIDATION = 'The target vault would fall below the minimum security bond allowance after liquidation.'
+export const UI_STRING_THE_TARGET_VAULT_WOULD_FALL_BELOW_THE_MINIMUM_REP_COLLATERAL_AFTER_LIQUIDATION = 'The target vault would fall below the minimum REP collateral after liquidation.'
+export const UI_STRING_THE_CALLER_VAULT_WOULD_BECOME_UNDERCOLLATERALIZED_AFTER_THIS_LIQUIDATION_OR_THE_LIQUIDATOR_VAULT_IS_THE_TARGET_VAULT = 'The caller vault would become undercollateralized after this liquidation, or the liquidator vault is the target vault.'
+export const UI_STRING_LIQUIDATION_QUEUED = 'Liquidation Queued'
+export const UI_STRING_QUEUE_LIQUIDATION_LIQUIDATION_MODAL_QUEUE_LIQUIDATION_ACTION_LABEL = 'queue liquidation'
+export const UI_STRING_QUEUEING_LIQUIDATION = 'Queueing liquidation...'
+export const UI_STRING_QUEUE_VAULT_LIQUIDATION = 'Queue Vault Liquidation'
+export const UI_STRING_QUEUED = 'Queued'
+export const UI_STRING_REFRESHING_LIQUIDATION_STATE = 'Refreshing liquidation state.'
+export const UI_STRING_REFRESHING_LIQUIDATION_STATE_LIQUIDATION_MODAL_REFRESHING_LIQUIDATION_STATE_TITLE = 'Refreshing Liquidation State'
+export const UI_STRING_REFRESHING_PRICE_VALIDITY = 'Refreshing price validity.'
+export const UI_STRING_RELOAD_THE_SELECTED_POOL_BEFORE_EXECUTING_LIQUIDATION = 'Reload the selected pool before executing liquidation.'
+export const UI_STRING_RELOAD_THE_SELECTED_POOL_BEFORE_LIQUIDATING = 'Reload the selected pool before liquidating.'
+export const UI_STRING_REP_MOVED = 'Rep Moved'
+export const UI_STRING_SECURITY_POOL = 'Security Pool'
+export const UI_STRING_SELECT_A_TARGET_VAULT_THAT_IS_DIFFERENT_FROM_THE_CALLER_VAULT = 'Select a target vault that is different from the caller vault.'
+export const UI_STRING_SELECT_A_TARGET_VAULT_FIRST = 'Select a target vault first.'
+export const UI_STRING_TARGET_COLLATERALIZATION_AT_OPEN_ORACLE = 'Target Collateralization @ Open Oracle'
+export const UI_STRING_ENTER_WHOLE_MINUTES_QUEUED_STAGED_OPERATIONS_MUST_STAY_EXECUTABLE_FOR_AT_LEAST_1_MINUTE_AFTER_THE_ORACLE_SETTLEMENT_WINDOW_COMPLETES = 'Enter whole minutes. Queued staged operations must stay executable for at least 1 minute after the oracle settlement window completes.'
+export const UI_TEMPLATE_TIMEOUT_HELP_TEXT_RESOLVED = (duration: string) => `This queued staged operation will expire ${duration} after the oracle settlement window completes.`
+export const UI_STRING_A_VALID_ORACLE_PRICE_WAS_ALREADY_AVAILABLE_SO_THE_LIQUIDATION_EXECUTED_IMMEDIATELY_AND_NO_STAGED_OPERATION_WAS_CREATED = 'A valid oracle price was already available, so the liquidation executed immediately and no staged operation was created.'
+export const UI_STRING_ALL_DEPLOYED = 'All deployed'
+export const UI_TEMPLATE_COMPLETED_SECTION_TITLE = (sectionTitle: string) => `${sectionTitle} (Completed)`
+export const UI_STRING_CONTRACTS_DEPLOYED = 'Contracts deployed'
+export const UI_STRING_DEPLOY_NEXT_MISSING = 'Deploy Next Missing'
+export const UI_STRING_ALL_DETERMINISTIC_CONTRACTS_ARE_DEPLOYED_IN_GROUPED_SECTIONS = 'All deterministic contracts are deployed in grouped sections.'
+export const UI_STRING_DEPLOYMENT_GROUPS = 'Deployment Groups'
+export const UI_STRING_DEPLOYMENT_IN_PROGRESS_DEPLOYMENT_ROUTE_CONTENT_DEPLOYMENT_IN_PROGRESS_LABEL = 'Deployment In Progress'
+export const UI_STRING_DEPLOY_AND_VERIFY_THE_SHARED_DETERMINISTIC_CONTRACTS_THAT_BACK_THE_APPLICATION = 'Deploy and verify the shared deterministic contracts that back the application.'
+export const UI_STRING_DETERMINISTIC_CONTRACT_DEPLOYMENT = 'Deterministic contract deployment'
+export const UI_STRING_LOADING_DEPLOYMENT_STATUS = 'Loading deployment status...'
+export const UI_STRING_NEXT_DEPLOYABLE = 'Next deployable'
+export const UI_STRING_NEXT_DEPLOYABLE_CONTRACT = 'Next deployable contract:'
+export const UI_STRING_FORK = 'Fork'
+export const UI_STRING_OPEN_REP_MIGRATION = 'Open REP Migration'
+export const UI_STRING_THE_UNIVERSE_IS_FORKED_MIGRATION_IS_NOW_THE_PRIMARY_FOLLOW_UP_ACTION = 'The universe is forked. Migration is now the primary follow-up action.'
+export const UI_STRING_POST_FORK_ACTIONS = 'Post-Fork Actions'
+export const UI_STRING_QUESTIONS = 'Questions'
+export const UI_STRING_SELECTED_FORK_QUESTION_MARKET_SECTION_SELECTED_FORK_QUESTION_PREFIX = 'Selected fork question:'
+export const UI_STRING_USD = 'USD'
+export const UI_STRING_CREATE_ANOTHER_QUESTION = 'Create Another Question'
+export const UI_STRING_CREATE_POOL_FROM_QUESTION = 'Create Pool From Question'
+export const UI_STRING_CREATING_QUESTION_MARKET_CREATE_QUESTION_SECTION_CREATE_QUESTION_BUTTON_PENDING_LABEL = 'Creating Question...'
+export const UI_STRING_DEFINE_THE_MARKET_TYPE_TIMING_AND_OUTCOMES_FOR_A_NEW_ZOLTAR_QUESTION = 'Define the market type, timing, and outcomes for a new Zoltar question.'
+export const UI_STRING_CREATION_TRANSACTION_HASH = 'Creation transaction hash'
+export const UI_STRING_INCLUDE_THE_RESOLUTION_SOURCE_ANY_EDGE_CASES_AND_WHAT_SHOULD_MAKE_THE_QUESTION_RESOLVE_AS_INVALID = 'Include the resolution source, any edge cases, and what should make the question resolve as invalid.'
+export const UI_STRING_DESCRIPTION = 'Description'
+export const UI_STRING_OPTIONAL_QUESTION_CONTEXT = 'Optional question context'
+export const UI_STRING_DRAFT_PREVIEW_SHOWS_THE_LEVEL_OF_CLARITY_TRADERS_AND_REPORTERS_WILL_SEE_BEFORE_TRUSTING_THE_QUESTION = 'Draft Preview shows the level of clarity traders and reporters will see before trusting the question.'
+export const UI_STRING_DRAFT_PREVIEW = 'Draft Preview'
+export const UI_STRING_DRAFT_QUESTION_STATUS = 'Draft question status'
+export const UI_STRING_DRAFT_QUESTION_SUMMARY = 'Draft question summary'
+export const UI_STRING_CHOOSE_AN_END_TIME = 'Choose an end time'
+export const UI_STRING_CONTEXT_IS_PRESENT_FOR_REVIEW = 'Context is present for review'
+export const UI_STRING_CONTEXT_PROVIDED = 'Context provided'
+export const UI_STRING_NEEDS_CONTEXT = 'Needs context'
+export const UI_STRING_IMMEDIATELY_AFTER_CREATION = 'Immediately after creation'
+export const UI_STRING_LOW_TRUST_UNTIL_CONTEXT_IS_ADDED = 'Low trust until context is added'
+export const UI_STRING_ADD_OUTCOME = 'Add Outcome'
+export const UI_STRING_ADD_AT_LEAST_2_OUTCOMES = 'Add at least 2 outcomes'
+export const UI_STRING_REMOVE = 'Remove'
+export const UI_STRING_USE_CONCISE_MUTUALLY_EXCLUSIVE_LABELS_USERS_SHOULD_BE_ABLE_TO_TELL_AT_A_GLANCE_WHICH_OUTCOME_WOULD_WIN = 'Use concise, mutually exclusive labels. Users should be able to tell at a glance which outcome would win.'
+export const UI_STRING_PLACEHOLDER_ORIGIN_SECURITY_POOLS_SUPPORT_THIS_EXACT_YES_NO_QUESTION_SHAPE = 'Placeholder origin security pools support this exact Yes / No question shape.'
+export const UI_STRING_CATEGORICAL_QUESTIONS_ARE_VALID_IN_ZOLTAR_BUT_PLACEHOLDER_ORIGIN_SECURITY_POOLS_CURRENTLY_REQUIRE_AN_EXACT_BINARY_YES_NO_QUESTION = 'Categorical questions are valid in Zoltar, but Placeholder origin security pools currently require an exact binary Yes / No question.'
+export const UI_STRING_SCALAR_QUESTIONS_ARE_VALID_IN_ZOLTAR_BUT_PLACEHOLDER_ORIGIN_SECURITY_POOLS_CURRENTLY_REQUIRE_AN_EXACT_BINARY_YES_NO_QUESTION = 'Scalar questions are valid in Zoltar, but Placeholder origin security pools currently require an exact binary Yes / No question.'
+export const UI_STRING_ADD_RESOLUTION_NOTES_EVIDENCE_SOURCES_AND_EDGE_CASE_HANDLING_SO_OTHER_USERS_KNOW_HOW_THIS_QUESTION_WILL_SETTLE = 'Add resolution notes, evidence sources, and edge-case handling so other users know how this question will settle.'
+export const UI_STRING_ADD_A_CLEAR_QUESTION_TITLE = 'Add a clear question title'
+export const UI_STRING_QUESTION_TYPE_GUIDANCE = 'Question Type Guidance'
+export const UI_STRING_LOADING_QUESTION_DETAILS = 'Loading question details'
+export const UI_STRING_QUESTION_DETAILS_ARE_NOT_AVAILABLE = 'Question details are not available.'
+export const UI_STRING_RISK_CUE = 'Risk cue'
+export const UI_STRING_SCALAR_QUESTIONS_SETTLE_TO_A_NUMERIC_RESULT_INSIDE_THE_RANGE_ABOVE_USE_A_UNIT_THAT_MATCHES_THE_PUBLIC_SOURCE_YOU_EXPECT_TO_CITE = 'Scalar questions settle to a numeric result inside the range above. Use a unit that matches the public source you expect to cite.'
+export const UI_STRING_SCALAR_INCREMENT = 'Scalar Increment'
+export const UI_STRING_0_1 = '0.1'
+export const UI_STRING_SCALAR_MAX = 'Scalar Max'
+export const UI_STRING_10 = '10'
+export const UI_STRING_SCALAR_MIN = 'Scalar Min'
+export const UI_STRING_1 = '1'
+export const UI_STRING_ENTER_SCALAR_MIN_MAX_AND_INCREMENT_TO_PREVIEW_THE_TICK_SLIDER = 'Enter scalar min, max, and increment to preview the tick slider.'
+export const UI_STRING_START_TIME = 'Start Time'
+export const UI_STRING_TIMES_USE_YOUR_BROWSER_TIMEZONE_LEAVE_START_TIME_BLANK_TO_ALLOW_ACTIVITY_IMMEDIATELY_AFTER_CREATION = 'Times use your browser timezone. Leave start time blank to allow activity immediately after creation.'
+export const UI_STRING_KEEP_THE_TITLE_SELF_CONTAINED_SO_USERS_CAN_UNDERSTAND_THE_EXACT_QUESTION_BEFORE_OPENING_DETAILS = 'Keep the title self-contained so users can understand the exact question before opening details.'
+export const UI_STRING_WILL_EVENT_X_HAPPEN = 'Will event X happen?'
+export const UI_STRING_TITLE = 'Title'
+export const UI_STRING_USE_FOR_FORK = 'Use For Fork'
+export const UI_STRING_CONNECT_A_WALLET_BEFORE_CREATING_A_QUESTION = 'Connect a wallet before creating a question.'
+export const UI_STRING_WRITE_THE_QUESTION_THE_WAY_A_RESOLVER_WILL_READ_IT = 'Write the question the way a resolver will read it.'
+export const UI_STRING_1_DEFINE_THE_EVENT_CLEARLY = '1. Define the event clearly'
+export const UI_STRING_2_EXPLAIN_HOW_IT_RESOLVES = '2. Explain how it resolves'
+export const UI_STRING_3_SET_THE_TIMING_WINDOW = '3. Set the timing window'
+export const UI_STRING_BINARY = 'Binary'
+export const UI_STRING_CATEGORICAL = 'Categorical'
+export const UI_STRING_ASK_A_YES_OR_NO_QUESTION_THAT_CAN_BE_RESOLVED_FROM_ONE_PUBLIC_SOURCE_OF_TRUTH = 'Ask a yes-or-no question that can be resolved from one public source of truth.'
+export const UI_STRING_WRITE_THE_TITLE_SO_IT_CAN_BE_ANSWERED_WITH_YES_NO_OR_INVALID = 'Write the title so it can be answered with Yes, No, or Invalid.'
+export const UI_STRING_NAME_THE_EVENT_WINDOW_CLEARLY_IN_THE_TITLE_OR_DESCRIPTION = 'Name the event window clearly in the title or description.'
+export const UI_STRING_USE_THE_DESCRIPTION_FOR_THE_EXACT_RESOLUTION_SOURCE_AND_EDGE_CASES = 'Use the description for the exact resolution source and edge cases.'
+export const UI_STRING_LIST_THE_MUTUALLY_EXCLUSIVE_OUTCOMES_THAT_COULD_WIN_THIS_QUESTION = 'List the mutually exclusive outcomes that could win this question.'
+export const UI_STRING_KEEP_OUTCOMES_SHORT_AND_CLEARLY_DISTINCT_FROM_EACH_OTHER = 'Keep outcomes short and clearly distinct from each other.'
+export const UI_STRING_USE_THE_DESCRIPTION_TO_EXPLAIN_HOW_TIES_CANCELLATIONS_OR_EXCEPTIONS_RESOLVE = 'Use the description to explain how ties, cancellations, or exceptions resolve.'
+export const UI_STRING_ONLY_INCLUDE_OUTCOMES_THAT_A_RESOLVER_CAN_VERIFY_FROM_A_PUBLIC_SOURCE = 'Only include outcomes that a resolver can verify from a public source.'
+export const UI_STRING_ASK_FOR_A_MEASURABLE_NUMBER_WITH_A_UNIT_RANGE_AND_INCREMENT_THAT_USERS_CAN_UNDERSTAND = 'Ask for a measurable number with a unit, range, and increment that users can understand.'
+export const UI_STRING_PICK_A_RANGE_THAT_COVERS_REALISTIC_ANSWERS_WITHOUT_BEING_OVERLY_BROAD = 'Pick a range that covers realistic answers without being overly broad.'
+export const UI_STRING_SET_THE_ANSWER_UNIT_SO_USERS_KNOW_WHAT_THE_NUMBER_REPRESENTS = 'Set the answer unit so users know what the number represents.'
+export const UI_STRING_USE_THE_DESCRIPTION_TO_EXPLAIN_ROUNDING_SOURCE_DATA_AND_INVALID_CONDITIONS = 'Use the description to explain rounding, source data, and invalid conditions.'
+export const UI_STRING_LOADING_QUESTIONS = 'Loading questions...'
+export const UI_STRING_NO_QUESTIONS_MARKET_QUESTIONS_SECTION_NO_QUESTIONS_DETAIL = 'No questions.'
+export const UI_STRING_NON_BINARY_QUESTIONS_ARE_VALID_IN_ZOLTAR_BUT_PLACEHOLDER_ORIGIN_POOLS_CURRENTLY_REQUIRE_AN_EXACT_BINARY_YES_NO_QUESTION = 'Non-binary questions are valid in Zoltar, but Placeholder origin pools currently require an exact binary Yes / No question.'
+export const UI_STRING_QUESTION_PAGE_UNAVAILABLE = 'Question page unavailable.'
+export const UI_STRING_DIRECT_OPEN_ORACLE_CREATION_FOR_PROTOCOL_TESTING_THIS_BYPASSES_POOL_MANAGED_ORACLE_MANAGER_STAGING_SO_CONFIRM_ADDRESSES_TOKEN_AMOUNTS_FEES_AND_TIMING_BEFORE_SUBMITTING =
+	'Direct Open Oracle creation for protocol testing. This bypasses pool-managed oracle-manager staging, so confirm addresses, token amounts, fees, and timing before submitting.'
+export const UI_STRING_OPEN_ORACLE_GAME = 'Open Oracle Game'
+export const UI_TEMPLATE_APPROVING_TOKEN_PENDING_LABEL = (tokenSymbol: string) => `Approving ${tokenSymbol}...`
+export const UI_STRING_BROWSE_REPORTS = 'Browse Reports'
+export const UI_TEMPLATE_BROWSE_REPORTS_DESCRIPTION = (pageSize: string) => `Browse every Open Oracle game and open a selected report view. Page size is fixed at ${pageSize} reports.`
+export const UI_TEMPLATE_BROWSE_SHOWN_COUNT_SUMMARY = (shownCount: string, pageCount: string) => `${shownCount} of ${pageCount} reports shown on this page.`
+export const UI_STRING_CALLBACK_CONTRACT = 'Callback Contract'
+export const UI_STRING_CALLBACK_EXTRA = 'Callback / Extra'
+export const UI_STRING_CALLBACK_GAS_LIMIT = 'Callback Gas Limit'
+export const UI_TEMPLATE_CURRENT_AMOUNT1_LABEL = (tokenSymbol: string) => `Current Amount 1 (${tokenSymbol})`
+export const UI_TEMPLATE_CURRENT_AMOUNT2_LABEL = (tokenSymbol: string) => `Current Amount 2 (${tokenSymbol})`
+export const UI_TEMPLATE_TOKEN_PAIR_SUFFIX = (token1Symbol: string, token2Symbol: string) => UI_TEMPLATE_PAIR_SLASH(token1Symbol, token2Symbol)
+export const UI_STRING_CREATE_ANOTHER = 'Create Another'
+export const UI_STRING_CREATE_STANDALONE_ORACLE_GAME = 'Create Standalone Oracle Game'
+export const UI_STRING_CREATING = 'Creating...'
+export const UI_STRING_THE_REPORT_INSTANCE_WAS_CREATED_SUCCESSFULLY = 'The report instance was created successfully.'
+export const UI_STRING_CREATE_SUCCESS = 'Create Success'
+export const UI_STRING_CURRENT_PRICE = 'Current Price'
+export const UI_STRING_CURRENT_REPORT_STATE = 'Current Report State'
+export const UI_STRING_CURRENT_REPORTER = 'Current Reporter'
+export const UI_STRING_NONE_AWAITING_INITIAL_REPORT = 'None (awaiting initial report)'
+export const UI_STRING_PROVIDE_THE_REPLACEMENT_SWAP_AMOUNTS_FOR_THE_SELECTED_REPORT = 'Provide the replacement swap amounts for the selected report.'
+export const UI_STRING_SUBMITTING_DISPUTE = 'Submitting dispute...'
+export const UI_STRING_DISPUTING_THE_REPORT = 'disputing the report'
+export const UI_STRING_DELAY_IN_SECONDS_AFTER_THE_INITIAL_REPORT_BEFORE_DISPUTES_CAN_BEGIN = 'Delay in seconds after the initial report before disputes can begin.'
+export const UI_STRING_DISPUTE_OCCURRED = 'Dispute Occurred'
+export const UI_TEMPLATE_DISCONNECTED_WALLET_APPROVAL_REASON = (tokenSymbol: string) => `Connect a wallet before approving ${tokenSymbol}.`
+export const UI_STRING_CONNECT_A_WALLET_BEFORE_DISPUTING_THE_REPORT = 'Connect a wallet before disputing the report.'
+export const UI_STRING_CONNECT_A_WALLET_BEFORE_SETTLING_THE_REPORT = 'Connect a wallet before settling the report.'
+export const UI_STRING_CONNECT_A_WALLET_BEFORE_SUBMITTING_THE_INITIAL_REPORT = 'Connect a wallet before submitting the initial report.'
+export const UI_STRING_CONNECT_A_WALLET_BEFORE_WRAPPING_ETH = 'Connect a wallet before wrapping ETH.'
+export const UI_STRING_ECONOMICS = 'Economics'
+export const UI_TEMPLATE_ENTER_VALID_DISPUTE_AMOUNTS_BEFORE_APPROVING_REASON = (tokenSymbol: string) => `Enter valid dispute amounts before approving ${tokenSymbol}.`
+export const UI_TEMPLATE_ENTER_VALID_PRICE_BEFORE_APPROVING_REASON = (token1Symbol: string, token2Symbol: string) => `Enter a valid ${token1Symbol} / ${token2Symbol} price before approving ${token2Symbol}.`
+export const UI_STRING_TOKEN1_AMOUNT_WHERE_DISPUTE_ESCALATION_STOPS_ENTERED_AS_A_DECIMAL_VALUE_FOR_THE_TOKEN1_ADDRESS = 'Token1 amount where dispute escalation stops, entered as a decimal value for the token1 address.'
+export const UI_STRING_ETH_SENT_WITH_CREATION_MUST_COVER_REQUIRED_FUNDING_AND_THE_SETTLER_REWARD = 'ETH sent with creation; must cover required funding and the settler reward.'
+export const UI_STRING_ETH_VALUE_TO_SEND = 'ETH Value To Send'
+export const UI_TEMPLATE_EXACT_TOKEN_REQUIRED_LABEL = (tokenSymbol: string) => `Exact ${tokenSymbol} Required`
+export const UI_STRING_TOKEN1_AMOUNT_TO_REPORT_ENTERED_AS_A_DECIMAL_VALUE_FOR_THE_TOKEN1_ADDRESS = 'Token1 amount to report, entered as a decimal value for the token1 address.'
+export const UI_STRING_EXACT_TOKEN1_REPORT = 'Exact Token1 Report'
+export const UI_STRING_FEE_CHARGED_DURING_DISPUTE_ECONOMICS_ENTERED_AS_A_PERCENTAGE = 'Fee charged during dispute economics, entered as a percentage.'
+export const UI_STRING_FEE = 'Fee'
+export const UI_STRING_FETCH_PRICE_FROM_UNISWAP = 'Fetch price from Uniswap'
+export const UI_STRING_FETCHING = 'Fetching...'
+export const UI_STRING_IDENTITY = 'Identity'
+export const UI_STRING_INITIAL_ECONOMICS = 'Initial Economics'
+export const UI_STRING_REPORT_CONTEXT = 'Report Context'
+export const UI_STRING_REVIEW_PRICE_SOURCE_APPROVALS_AND_TOKEN_BALANCES_BEFORE_SUBMITTING_THE_INITIAL_REPORT = 'Review price source, approvals, and token balances before submitting the initial report.'
+export const UI_STRING_INITIAL_REPORT = 'Initial Report'
+export const UI_STRING_INITIAL_REPORTER = 'Initial Reporter'
+export const UI_STRING_SUBMITTING_THE_INITIAL_REPORT = 'submitting the initial report'
+export const UI_STRING_LAST_REPORT_OPPORTUNITY = 'Last Report Opportunity'
+export const UI_STRING_FAILED_TO_LOAD_OPEN_ORACLE_REPORTS = 'Failed to load Open Oracle reports'
+export const UI_STRING_LOAD_A_REPORT_FIRST = 'Load a report first.'
+export const UI_STRING_ESCALATION_MULTIPLIER_FOR_DISPUTE_ECONOMICS = 'Escalation multiplier for dispute economics.'
+export const UI_TEMPLATE_NEW_AMOUNT_MUST_BE_EXACT_DETAIL = (tokenSymbol: string, amount: string) => `New ${tokenSymbol} amount must be exactly ${amount} for this dispute.`
+export const UI_STRING_THIS_REPORT_IS_SETTLED_NO_WRITE_ACTIONS_ARE_AVAILABLE = 'This report is settled. No write actions are available.'
+export const UI_STRING_NUMBER_OF_REPORTS = 'Number of Reports'
+export const UI_STRING_OPEN_REPORT = 'Open report'
+export const UI_STRING_ORACLE_ADDRESS = 'Oracle Address'
+export const UI_STRING_1_00 = '1.00'
+export const UI_TEMPLATE_PRICE_FIELD_LABEL = (token1Symbol: string, token2Symbol: string) => `Price (${token1Symbol} / ${token2Symbol})`
+export const UI_STRING_PRICE_SOURCE = 'Price source:'
+export const UI_STRING_PROTOCOL_FEE_CHARGED_DURING_DISPUTES_ENTERED_AS_A_PERCENTAGE = 'Protocol fee charged during disputes, entered as a percentage.'
+export const UI_STRING_PROTOCOL_FEE_RECIPIENT = 'Protocol Fee Recipient'
+export const UI_STRING_REPORT = 'Report'
+export const UI_TEMPLATE_REPORT_NUMBER_TITLE = (reportId: string) => UI_TEMPLATE_REPORT_NUMBER_LABEL(reportId)
+export const UI_STRING_REPORT_TIMESTAMP = 'Report Timestamp'
+export const UI_STRING_REPORT_ACTIONS = 'Report Actions'
+export const UI_STRING_OPEN_A_FOCUSED_ACTION_FLOW_FOR_THE_SELECTED_REPORT_WHEN_IT_IS_AVAILABLE = 'Open a focused action flow for the selected report when it is available.'
+export const UI_STRING_SEARCH_REPORTS = 'Search Reports'
+export const UI_STRING_SETTLEMENT_IS_CONFIRMATION_FIRST_REVIEW_THE_CURRENT_REPORT_STATE_AND_CONFIRM_ONLY_WHEN_THE_DISPUTE_WINDOW_IS_CLOSED = 'Settlement is confirmation-first. Review the current report state and confirm only when the dispute window is closed.'
+export const UI_STRING_CONFIRM_SETTLEMENT_ONCE_THE_SELECTED_REPORT_IS_READY = 'Confirm settlement once the selected report is ready.'
+export const UI_STRING_SETTLING_REPORT = 'Settling report...'
+export const UI_STRING_SETTLED_REPORT = 'Settled Report'
+export const UI_STRING_ETH_PAID_TO_THE_ACCOUNT_THAT_SETTLES_THE_REPORT = 'ETH paid to the account that settles the report.'
+export const UI_STRING_SETTLEMENT_SUMMARY = 'Settlement Summary'
+export const UI_STRING_DELAY_IN_SECONDS_AFTER_THE_INITIAL_REPORT_BEFORE_SETTLEMENT_CAN_BEGIN = 'Delay in seconds after the initial report before settlement can begin.'
+export const UI_STRING_SETTLEMENT_TIMESTAMP = 'Settlement Timestamp'
+export const UI_STRING_NOT_SETTLED = 'Not settled'
+export const UI_STRING_STATE_HASH = 'State Hash'
+export const UI_STRING_ALL_STATUSES = 'All statuses'
+export const UI_STRING_AWAITING_INITIAL_REPORT = 'Awaiting initial report'
+export const UI_STRING_DISPUTED = 'Disputed'
+export const UI_STRING_NO_OPEN_ORACLE_GAMES_FOUND = 'No Open Oracle games found.'
+export const UI_STRING_NO_REPORTS_MATCH_THE_CURRENT_SEARCH_AND_STATUS_FILTERS = 'No reports match the current search and status filters.'
+export const UI_STRING_REFRESHING_REPORT_SUMMARIES = 'Refreshing report summaries.'
+export const UI_STRING_REFRESH_REPORT = 'Refresh report'
+export const UI_STRING_REPORT_AMOUNTS = 'Report Amounts'
+export const UI_STRING_OPEN_ORACLE_REPORT_DETAILS = 'Open Oracle Report Details'
+export const UI_STRING_SEARCH_BY_REPORT_ID_TOKEN_SYMBOL_OR_TOKEN_ADDRESS = 'Search by report ID, token symbol, or token address'
+export const UI_STRING_THIS_QUOTE_IS_STALE_AND_WILL_BE_REFRESHED_BEFORE_SUBMISSION = 'This quote is stale and will be refreshed before submission.'
+export const UI_STRING_USE_THIS_ONLY_WHEN_YOU_INTEND_TO_CREATE_A_STANDALONE_ORACLE_GAME_DIRECTLY_FROM_THE_CONNECTED_WALLET_POOL_MANAGED_ORACLE_REQUESTS_SHOULD_BE_STARTED_FROM_A_SELECTED_SECURITY_POOL =
+	'Use this only when you intend to create a standalone oracle game directly from the connected wallet. Pool-managed oracle requests should be started from a selected security pool.'
+export const UI_STRING_SUBMITTING = 'Submitting...'
+export const UI_STRING_BLOCKS_OPEN_ORACLE_SECTION_TIME_IN_BLOCKS_SUFFIX = ' blocks'
+export const UI_STRING_TIMING = 'Timing'
+export const UI_TEMPLATE_QUOTE_LOADED_DETAIL = (quoteBlockNumberText: string | undefined, ageText: string) => (quoteBlockNumberText === undefined ? `Quote loaded ${ageText}.` : `Quote loaded at block ${quoteBlockNumberText} ${ageText}.`)
+export const UI_TEMPLATE_QUOTE_AGE_TEXT = (quoteLoadedAtMs: number) => {
+	const elapsedSeconds = Math.max(0, Math.floor((Date.now() - quoteLoadedAtMs) / 1000))
+	if (elapsedSeconds < 60) return `${elapsedSeconds}s ago`
+	const elapsedMinutes = Math.floor(elapsedSeconds / 60)
+	if (elapsedMinutes < 60) return `${elapsedMinutes}m ago`
+	const elapsedHours = Math.floor(elapsedMinutes / 60)
+	return `${elapsedHours}h ago`
+}
+export const UI_STRING_BASE_TOKEN_FOR_THE_REPORTED_PAIR = 'Base token for the reported pair.'
+export const UI_STRING_TOKEN1_ADDRESS = 'Token1 Address'
+export const UI_TEMPLATE_TOKEN_APPROVAL_TITLE = (tokenSymbol: string) => `${tokenSymbol} Approval`
+export const UI_STRING_QUOTE_TOKEN_FOR_THE_REPORTED_PAIR = 'Quote token for the reported pair.'
+export const UI_STRING_TOKEN2_ADDRESS = 'Token2 Address'
+export const UI_STRING_TOKEN_TO_SWAP_OUT = 'Token to Swap Out'
+export const UI_STRING_TRACK_DISPUTES = 'Track Disputes'
+export const UI_STRING_AWAITING_INITIAL_REPORT_OPEN_ORACLE_SECTION_AWAITING_INITIAL_REPORT_LABEL = 'Awaiting Initial Report'
+export const UI_TEMPLATE_NEW_TOKEN_AMOUNT_FIELD_LABEL = (tokenSymbol: string) => `New ${tokenSymbol} Amount`
+export const UI_STRING_NEED = 'Need'
+export const UI_STRING_MORE_WETH_FOR_THIS_REPORT = 'more WETH for this report.'
+export const UI_STRING_WRAP_NEEDED_ETH_TO_WETH = 'Wrap needed ETH to WETH'
+export const UI_STRING_WRAPPING_ETH = 'Wrapping ETH...'
+export const UI_STRING_REPORTER = 'Reporter'
+export const UI_STRING_STAGE = 'Stage'
+export const UI_STRING_ADDRESS = 'Address'
+export const UI_STRING_AUGUR_PLACEHOLDER_OVERVIEW_PANELS_AUGUR_PLACEHOLDER_TITLE = 'Augur Placeholder'
+export const UI_STRING_CONNECTED = 'Connected'
+export const UI_STRING_NOT_CONNECTED = 'Not connected'
+export const UI_STRING_OPERATIONS = 'Operations'
+export const UI_STRING_PARENT_UNIVERSE = 'Parent Universe'
+export const UI_STRING_READ_ONLY = 'Read-only'
+export const UI_STRING_REP_USDC = 'REP/USDC'
+export const UI_STRING_REFRESHING_REP_PRICES = 'Refreshing REP prices...'
+export const UI_STRING_SIMULATION = 'Simulation'
+export const UI_STRING_SIMULATION_MODE_USES_BROWSER_LOCAL_CONTRACT_STATE_TRANSACTIONS_DO_NOT_AFFECT_A_PUBLIC_NETWORK = 'Simulation mode uses browser-local contract state. Transactions do not affect a public network.'
+export const UI_STRING_THIS_UNIVERSE_HAS_FORKED = 'This universe has forked.'
+export const UI_STRING_ZOLTAR_FORKED_ON = 'Zoltar forked on'
+export const UI_STRING_WRONG_NETWORK_OVERVIEW_PANELS_WRONG_NETWORK_BADGE_LABEL = 'Wrong Network'
+export const UI_STRING_CREATED = 'Created'
+export const UI_STRING_DISPLAY_RANGE = 'Display Range'
+export const UI_STRING_LOADING_QUESTION_DETAILS_QUESTION_LOADING_QUESTION_DETAILS_LABEL = 'Loading question details...'
+export const UI_STRING_QUESTION_TIMELINE = 'Question timeline'
+export const UI_STRING_TICKS = 'Ticks'
+export const UI_STRING_UNTITLED_QUESTION = 'Untitled question'
+export const UI_STRING_CREATE_INVALID_UNIVERSE = 'Create invalid universe'
+export const UI_STRING_DEPLOY_INVALID_UNIVERSE = 'Deploy Invalid Universe'
+export const UI_STRING_EXISTING_CHILD_UNIVERSES = 'Existing Child Universes'
+export const UI_STRING_CONFIRM_THE_SELECTED_SCALAR_OUTCOME_AND_DEPLOY_ITS_CHILD_UNIVERSE_IN_ONE_BOUNDED_EXECUTION_FLOW = 'Confirm the selected scalar outcome and deploy its child universe in one bounded execution flow.'
+export const UI_STRING_LOADING_SCALAR_RANGE = 'Loading scalar range...'
+export const UI_STRING_NO_CHILD_UNIVERSE_SELECTED = 'No child universe selected.'
+export const UI_STRING_NO_DEPLOYED_CHILD_UNIVERSES = 'No deployed child universes.'
+export const UI_STRING_SCALAR_FORKS_CAN_DEPLOY_ONE_OUTCOME_UNIVERSE_AT_A_TIME = 'Scalar forks can deploy one outcome universe at a time.'
+export const UI_STRING_SELECT_CHILD_UNIVERSE = 'Select Child Universe'
+export const UI_STRING_SELECTED_TICK_IS_INVALID = 'Selected tick is invalid'
+export const UI_STRING_ADD_TARGET = 'Add Target'
+export const UI_STRING_CHILD_DEPLOYED = 'Child deployed'
+export const UI_STRING_CHILD_NOT_DEPLOYED = 'Child not deployed'
+export const UI_STRING_CLEAR = 'Clear'
+export const UI_STRING_LOADING_FORK_QUESTION_DETAILS = 'Loading fork question details...'
+export const UI_STRING_LOADING_FORK_TARGET_UNIVERSES = 'Loading fork target universes...'
+export const UI_TEMPLATE_MALFORMED_OUTCOME_LABEL = (outcomeIndex: string) => `Malformed (${outcomeIndex})`
+export const UI_STRING_LOADING_SCALAR_FORK_DETAILS = 'Loading scalar fork details...'
+export const UI_STRING_NO_TARGET_CHILD_UNIVERSES_AVAILABLE = 'No target child universes available.'
+export const UI_STRING_NOT_SELECTED = 'Not selected'
+export const UI_STRING_REMOVE_TARGET = 'Remove Target'
+export const UI_STRING_SELECT_ALL = 'Select all'
+export const UI_STRING_SELECT_SCALAR_TARGET = 'Select Scalar Target'
+export const UI_STRING_SELECT_AT_LEAST_ONE_SCALAR_TARGET_UNIVERSE = 'Select at least one scalar target universe.'
+export const UI_TEMPLATE_SELECTED_TICK_LABEL = (selectedTick: string, totalTicks: string) => UI_TEMPLATE_PAIR_SLASH(selectedTick, totalTicks)
+export const UI_STRING_TARGET_CHILD_UNIVERSES = 'Target Child Universes'
+export const UI_STRING_CHILD_UNIVERSE_TARGETS_UNLOCK_AFTER_THIS_UNIVERSE_FORKS = 'Child-universe targets unlock after this universe forks.'
+export const UI_STRING_CURRENT_VALUE = 'Current Value'
+export const UI_STRING_MAX_VALUE = 'Max Value'
+export const UI_STRING_MIN_VALUE = 'Min Value'
+export const UI_STRING_OR = 'or'
+export const UI_STRING_SELECTED_OUTCOME = 'Selected Outcome'
+export const UI_STRING_SELECTED_TICK = 'Selected Tick'
+export const UI_STRING_REMAINING_SELECTED_SIDE_CAPACITY_IS_BELOW_THE_MINIMUM_REPORT_BOND = 'Remaining selected-side capacity is below the minimum report bond.'
+export const UI_STRING_CONTINUE_IN_FORK_AND_MIGRATION_TO_MIGRATE_UNRESOLVED_ESCALATION_DEPOSITS_INTO_A_CHILD_UNIVERSE = 'Continue in Fork & Migration to migrate unresolved escalation deposits into a child universe.'
+export const UI_STRING_THIS_IS_THE_REP_YOU_ARE_WILLING_TO_LOCK_ON_THE_SELECTED_SIDE_LARGER_AMOUNTS_CAN_CHANGE_THE_PROPOSED_OUTCOME_OR_EXTEND_THE_ESCALATION_TIMER = 'This is the REP you are willing to lock on the selected side. Larger amounts can change the proposed outcome or extend the escalation timer.'
+export const UI_STRING_CONTRIBUTION_AMOUNT_REP = 'Contribution Amount (REP)'
+export const UI_STRING_ENTER_A_VALID_REPORT_AMOUNT_TO_PREVIEW_PROFIT = 'Enter a valid report amount to preview profit.'
+export const UI_STRING_ESCALATION_STARTED = 'Escalation started'
+export const UI_STRING_CHOOSE_DEPOSITS_TO_SETTLE = 'Choose deposits to settle'
+export const UI_STRING_ESCALATION_REACHED_NON_DECISION_AND_ZOLTAR_FORK_HAS_ALREADY_BEEN_TRIGGERED_FOR_THIS_POOL_CONTINUE_IN_FORK_AND_MIGRATION = 'Escalation reached non-decision and Zoltar fork has already been triggered for this pool. Continue in Fork & Migration.'
+export const UI_STRING_ESCALATION_DEPOSITS_REMAIN_LOCKED_AFTER_NON_DECISION_ZOLTAR_FORK_HAS_ALREADY_BEEN_TRIGGERED_FOR_THIS_POOL_SO_CONTINUE_IN_FORK_AND_MIGRATION = 'Escalation deposits remain locked after non-decision. Zoltar fork has already been triggered for this pool, so continue in Fork & Migration.'
+export const UI_STRING_ESCALATION_REACHED_NON_DECISION_TRIGGER_ZOLTAR_FORK_HERE_IF_THIS_POOL_SHOULD_FORK_THE_UNIVERSE = 'Escalation reached non-decision. Trigger Zoltar Fork here if this pool should fork the universe.'
+export const UI_STRING_ESCALATION_DEPOSITS_REMAIN_LOCKED_AFTER_NON_DECISION_TRIGGER_ZOLTAR_FORK_HERE_IF_THIS_POOL_SHOULD_FORK_THE_UNIVERSE = 'Escalation deposits remain locked after non-decision. Trigger Zoltar Fork here if this pool should fork the universe.'
+export const UI_STRING_INITIALLY_DEPOSITED = 'Initially deposited:'
+export const UI_STRING_LEAD_HOLDING_CAPITAL = 'Lead-holding capital'
+export const UI_STRING_LOADING_AVAILABLE_VAULT_REP = 'Loading available vault REP.'
+export const UI_STRING_LOAD_REPORTING_DETAILS_BEFORE_USING_PRESETS = 'Load reporting details before using presets.'
+export const UI_STRING_LOADING_ESCALATION = 'Loading escalation...'
+export const UI_STRING_REFRESH_REPORTING = 'Refresh reporting'
+export const UI_STRING_MAX_PROFIT_BECOMES_AVAILABLE_AFTER_THE_ESCALATION_GAME_STARTS = 'Max profit becomes available after the escalation game starts.'
+export const UI_STRING_MAX_PROFIT = 'Max profit'
+export const UI_STRING_MAX_PROFIT_PRESET_UNAVAILABLE_BECAUSE_THE_REWARD_WINDOW_IS_ALREADY_FILLED_ON_THE_SELECTED_SIDE = 'Max profit preset unavailable because the reward window is already filled on the selected side.'
+export const UI_STRING_MIN_TO_TAKE_THE_LEAD = 'Min to take the lead'
+export const UI_STRING_NO_REMAINING_CONTRIBUTION_CAPACITY_IS_AVAILABLE_ON_THE_SELECTED_SIDE = 'No remaining contribution capacity is available on the selected side.'
+export const UI_STRING_NO_UNLOCKED_VAULT_REP_AVAILABLE_FOR_REPORTING = 'No unlocked vault REP available for reporting.'
+export const UI_STRING_NON_DECISION_THRESHOLD = 'Non-decision threshold'
+export const UI_STRING_REPORT_ON_SELECTED_SIDE = 'Report On Selected Side'
+export const UI_STRING_REPORT_OUTCOME_REPORTING_SECTION_REPORT_OUTCOME_ARIA_LABEL = 'Report outcome'
+export const UI_TEMPLATE_REPORT_SELECTED_OUTCOME_BUTTON_LABEL = (selectedOutcomeLabel: string) => `Report ${selectedOutcomeLabel}`
+export const UI_STRING_ESCALATION_IS_LIVE_REVIEW_THE_BOND_SIDE_BALANCES_AND_TIME_REMAINING_BEFORE_CONTRIBUTING_OR_WITHDRAWING = 'Escalation is live. Review the bond, side balances, and time remaining before contributing or withdrawing.'
+export const UI_TEMPLATE_REPORTING_LATEST_OUTCOME_REMINDER_IMMEDIATE = (selectedOutcomeLabel: string) => `Check back immediately to confirm the market finalized as ${selectedOutcomeLabel}.`
+export const UI_TEMPLATE_REPORTING_LATEST_OUTCOME_REMINDER_LATER = (selectedOutcomeLabel: string) => `Check back later to confirm ${selectedOutcomeLabel} is the leading outcome.`
+export const UI_STRING_IS_THE_LEADING_OUTCOME_BEFORE_THE_REMAINING_REWARD_ELIGIBLE_REP_ON = ' is the leading outcome before the remaining reward-eligible REP on '
+export const UI_STRING_IS_FILLED = ' is filled.'
+export const UI_STRING_IS_THE_LEADING_OUTCOME_BEFORE_FINALIZATION = ' is the leading outcome before finalization.'
+export const UI_STRING_IF = 'If '
+export const UI_STRING_WINS_AND_NO_ONE_ELSE_CONTRIBUTES_AFTERWARD_THIS_AMOUNT_PROJECTS_ROUGHLY = ' wins and no one else contributes afterward, this amount projects roughly '
+export const UI_STRING_OF_PROFIT = ' of profit. '
+export const UI_STRING_IF_NO_ONE_DISPUTES_AFTER_THIS_REPORT_THE_MARKET_WOULD_FINALIZE_IN = 'If no one disputes after this report, the market would finalize in '
+export const UI_STRING_IS_STILL_LEADING_IF_LATER_DISPUTES_KEEP_ESCALATION_OPEN = ' is still leading if later disputes keep escalation open.'
+export const UI_STRING_REPORTING_SECTION_REPORTING_PROJECTION_NOT_STARTED_SIMPLE_SUFFIX = '. '
+export const UI_STRING_THIS_CONTRIBUTION_WOULD_END_THE_ESCALATION_AND_FINALIZE_THE_MARKET_IMMEDIATELY = 'This contribution would end the escalation and finalize the market immediately. '
+export const UI_STRING_THIS_CONTRIBUTION_WOULD_EXTEND_THE_TIMER_BY = 'This contribution would extend the timer by '
+export const UI_STRING_AND_IF_NO_ONE_DISPUTES_AFTER_IT_THE_MARKET_WOULD_FINALIZE_IN = ', and if no one disputes after it, the market would finalize in '
+export const UI_STRING_THIS_CONTRIBUTION_WOULD_NOT_EXTEND_THE_TIMER_AND_IF_NO_ONE_DISPUTES_AFTER_IT_THE_MARKET_WOULD_FINALIZE_IN = 'This contribution would not extend the timer, and if no one disputes after it, the market would finalize in '
+export const UI_STRING_BASED_ON_THE_CURRENT_ESCALATION_STATE_THIS_ACTION_WOULD_LOCK = 'Based on the current escalation state, this action would lock '
+export const UI_STRING_INSTEAD_OF_THE_FULL_ENTERED_AMOUNT = ' instead of the full entered amount.'
+export const UI_STRING_OPEN_FORK_AND_MIGRATION = 'Open Fork & Migration'
+export const UI_STRING_THESE_ESCALATION_DEPOSITS_MUST_MIGRATE_IN_FORK_AND_MIGRATION = 'These escalation deposits must migrate in Fork & Migration.'
+export const UI_STRING_1_OUTCOME = '1. Outcome'
+export const UI_STRING_2_LOCK_REP = '2. Lock REP'
+export const UI_STRING_3_SETTLE = '3. Settle'
+export const UI_STRING_SUBMITTING_REPORT = 'Submitting report...'
+export const UI_STRING_REPORTING_NOT_ENABLED = 'Reporting Not Enabled'
+export const UI_STRING_REPORTING_OPEN = 'Reporting Open'
+export const UI_STRING_RESOLVED = 'Resolved'
+export const UI_STRING_TIMED_OUT = 'Timed Out'
+export const UI_STRING_PENDING_FINALIZATION = 'Pending finalization'
+export const UI_STRING_TIME_LEFT = 'Time Left'
+export const UI_STRING_WINNING_PAYOUT = 'Winning payout'
+export const UI_STRING_LOSING_DEPOSIT_SETTLEMENT = 'Losing deposit settlement'
+export const UI_STRING_CURRENT_CLAIM_TYPE = 'Current claim type:'
+export const UI_STRING_ENTRY_DEPTH = 'Entry depth:'
+export const UI_STRING_ESCALATION_HAS_ENDED_REFRESH_REPORTING_TO_VIEW_THE_FINALIZED_OUTCOME_BEFORE_SETTLING_DEPOSITS = 'Escalation has ended. Refresh reporting to view the finalized outcome before settling deposits.'
+export const UI_STRING_LOAD_REPORTING_DETAILS_TO_VIEW_THE_ESCALATION_STATE_FOR_THIS_POOL = 'Load reporting details to view the escalation state for this pool.'
+export const UI_STRING_REPORTING_IS_OPEN = 'Reporting is open.'
+export const UI_STRING_REPORTING_IS_OPEN_SELECT_AN_OUTCOME_SIDE_BELOW_TO_ENABLE_REPORTING = 'Reporting is open. Select an outcome side below to enable reporting.'
+export const UI_STRING_THIS_POOL_IS_ALREADY_FINALIZED = 'This pool is already finalized.'
+export const UI_STRING_ESCALATION_DEPOSITS_CANNOT_BE_SETTLED_UNTIL_THE_QUESTION_IS_FINALIZED = 'Escalation deposits cannot be settled until the question is finalized.'
+export const UI_TEMPLATE_REPORTING_RESOLVED_DETAIL_LABEL = (selectedOutcomeLabel: string) => `Market finalized as ${selectedOutcomeLabel}.`
+export const UI_STRING_THE_MIGRATION_WINDOW_FOR_THESE_UNRESOLVED_ESCALATION_DEPOSITS_HAS_CLOSED = 'The migration window for these unresolved escalation deposits has closed.'
+export const UI_STRING_WORTH_AFTER_FINALIZATION_PENDING_FINALIZATION = 'Worth after finalization: Pending finalization'
+export const UI_STRING_WORTH_NOW = 'Worth now:'
+export const UI_STRING_SELECT_AN_OUTCOME_SIDE_BEFORE_USING_PRESETS = 'Select an outcome side before using presets.'
+export const UI_STRING_SELECTED_SIDE_ALREADY_LEADS = 'Selected side already leads.'
+export const UI_STRING_SELECTED_SIDE_IS_UNAVAILABLE = 'Selected side is unavailable.'
+export const UI_STRING_SELECTED_SIDE = 'Selected Side'
+export const UI_TEMPLATE_SETTLE_ALL_DEPOSITS_LABEL = (sideLabel: string) => `Settle All ${sideLabel} Deposits`
+export const UI_TEMPLATE_SETTLE_SELECTED_DEPOSITS_LABEL = (sideLabel: string) => `Settle Selected ${sideLabel} Deposits`
+export const UI_TEMPLATE_SETTLING_DEPOSITS_PENDING_LABEL = (sideLabel: string) => `Settling ${sideLabel} deposits...`
+export const UI_STRING_START_BOND = 'Start Bond'
+export const UI_STRING_TOTAL_SIDE_STAKE = 'Total side stake'
+export const UI_STRING_YOUR_SIDE_STAKE = 'Your side stake'
+export const UI_STRING_TRIGGERING_ZOLTAR_FORK = 'Triggering Zoltar fork...'
+export const UI_STRING_LOADING_ESCALATION_DEPOSITS_REPORTING_SECTION_LOADING_ESCALATION_DEPOSITS_DETAIL = 'Loading escalation deposits...'
+export const UI_STRING_AVAILABLE_UNLOCKED_VAULT_REP_FOR_REPORTING = 'Available unlocked vault REP for reporting:'
+export const UI_STRING_CONNECTED_WALLET_HAS_NO_UNSETTLED_ESCALATION_DEPOSITS = 'Connected wallet has no unsettled escalation deposits.'
+export const UI_STRING_THIS_POOL_ALSO_HAS_FORK_CARRIED_ESCALATION_POSITIONS_SETTLE_THOSE_IN_FORK_AND_MIGRATION = 'This pool also has fork-carried escalation positions. Settle those in Fork & Migration.'
+export const UI_STRING_CREATE_ANOTHER_POOL = 'Create Another Pool'
+export const UI_STRING_CREATING_POOL = 'Creating Pool...'
+export const UI_STRING_POOL_CREATION_LOCKED = 'Pool Creation Locked'
+export const UI_STRING_POOL_CREATED = 'Pool Created'
+export const UI_STRING_SECURITY_POOLS_CANNOT_BE_CREATED_AFTER_ZOLTAR_HAS_FORKED = 'Security pools cannot be created after Zoltar has forked.'
+export const UI_STRING_DEPLOYMENT_TRANSACTION_HASH = 'Deployment transaction hash'
+export const UI_STRING_CHECKING_DUPLICATE = 'Checking Duplicate...'
+export const UI_STRING_A_POOL_FOR_THIS_QUESTION_AND_SECURITY_MULTIPLIER_ALREADY_EXISTS_ORIGIN_POOL_DEPLOYMENT_IS_DETERMINISTIC_FOR_THAT_PAIR_SO_CHANGE_THE_SECURITY_MULTIPLIER_TO_CREATE_A_DIFFERENT_POOL =
+	'A pool for this question and security multiplier already exists. Origin pool deployment is deterministic for that pair, so change the security multiplier to create a different pool.'
+export const UI_STRING_INITIAL_OPEN_INTEREST_FEE_YEAR_IS_THE_STARTING_ANNUALIZED_FEE_CHARGED_AGAINST_OPEN_INTEREST_THE_RATE_FOLLOWS_POOL_UTILIZATION_AFTER_DEPLOYMENT = 'Initial Open Interest Fee / Year is the starting annualized fee charged against open interest. The rate follows pool utilization after deployment.'
+export const UI_STRING_INITIAL_OPEN_INTEREST_FEE_YEAR = 'Initial Open Interest Fee / Year'
+export const UI_STRING_SECURITY_POOLS_CAN_ONLY_BE_CREATED_FOR_EXACT_BINARY_YES_NO_QUESTIONS_ENTER_AN_ELIGIBLE_QUESTION_TO_PROCEED = 'Security pools can only be created for exact binary Yes / No questions. Enter an eligible question to proceed.'
+export const UI_STRING_LOADING_QUESTION = 'Loading question...'
+export const UI_STRING_POOL_ADDRESS_SECURITY_POOL_SECTION_POOL_ADDRESS_LABEL = 'Pool address'
+export const UI_STRING_POOL_ALREADY_EXISTS = 'Pool Already Exists'
+export const UI_STRING_PASTE_AN_EXACT_BINARY_YES_NO_ZOLTAR_QUESTION_ID = 'Paste an exact binary Yes / No Zoltar question ID.'
+export const UI_STRING_SECURITY_MULTIPLIER_SETS_THE_REP_COLLATERAL_TARGET_RELATIVE_TO_OPEN_INTEREST_HIGHER_VALUES_REQUIRE_MORE_REP_BACKING_AND_CREATE_A_THICKER_SAFETY_BUFFER =
+	'Security Multiplier sets the REP collateral target relative to open interest. Higher values require more REP backing and create a thicker safety buffer.'
+export const UI_STRING_DEPOSITING_REP = 'depositing REP'
+export const UI_STRING_THE_ORACLE_MANAGER_ATTEMPTED_THE_ALLOWANCE_UPDATE_IMMEDIATELY_BUT_THE_SECURITY_POOL_REJECTED_IT = 'The oracle manager attempted the allowance update immediately, but the security pool rejected it.'
+export const UI_STRING_BOND_ALLOWANCE_EXECUTED = 'Bond Allowance Executed'
+export const UI_STRING_BOND_ALLOWANCE_FAILED = 'Bond Allowance Failed'
+export const UI_STRING_BOND_ALLOWANCE_QUEUED = 'Bond Allowance Queued'
+export const UI_STRING_BOND_ALLOWANCE_SUBMITTED = 'Bond Allowance Submitted'
+export const UI_STRING_REVIEW_CLAIMABLE_FEES_AND_CONFIRM_THE_FEE_REDEMPTION_FOR_THE_SELECTED_VAULT = 'Review claimable fees and confirm the fee redemption for the selected vault.'
+export const UI_STRING_CLAIMABLE_FEES = 'Claimable Fees'
+export const UI_STRING_CONFIRM_THE_CLAIMABLE_FEE_BALANCE_BEFORE_SUBMITTING_THE_FEE_REDEMPTION_FOR_THIS_VAULT = 'Confirm the claimable fee balance before submitting the fee redemption for this vault.'
+export const UI_STRING_CLAIMING_FEES = 'Claiming fees...'
+export const UI_STRING_THIS_VAULT_DOES_NOT_EXIST_DEPOSIT_REP_TO_CREATE_IT = 'This vault does not exist. Deposit REP to create it.'
+export const UI_STRING_CURRENT_BOND_ALLOWANCE = 'Current Bond Allowance'
+export const UI_STRING_CURRENT_SECURITY_BOND_ALLOWANCE = 'Current Security Bond Allowance'
+export const UI_STRING_ADD_REP_TO_THE_SELECTED_VAULT = 'Add REP to the selected vault.'
+export const UI_STRING_REP_COLLATERAL_AMOUNT = 'REP Collateral Amount'
+export const UI_STRING_DEPOSITING_REP_SECURITY_VAULT_SECTION_DEPOSIT_REP_PENDING_LABEL = 'Depositing REP...'
+export const UI_TEMPLATE_FIRST_DEPOSIT_MINIMUM_CHECKLIST_DETAIL = (amount: string) => `First deposits must be at least ${amount} REP.`
+export const UI_STRING_IN_THE_FIRST_DEPOSIT = 'in the first deposit.'
+export const UI_STRING_FIRST_DEPOSIT_MEETS_THE_VAULT_MINIMUM = 'First deposit meets the vault minimum'
+export const UI_STRING_NEW_VAULTS_REQUIRE_AT_LEAST = 'New vaults require at least'
+export const UI_STRING_CLAIMABLE_FEES_ARE_AVAILABLE = 'Claimable fees are available'
+export const UI_TEMPLATE_INSUFFICIENT_REP_BALANCE_DETAIL = (amount: string) => `Insufficient REP balance. Deposit amount exceeds your wallet balance by ${amount} REP.`
+export const UI_TEMPLATE_VAULT_LAUNCHER_BLOCKER_REASON = (action: 'claim-fees' | 'deposit-rep' | 'rep-exit-redeem' | 'rep-exit-withdraw' | 'set-bond-allowance', blocker: 'connect-wallet' | 'missing-vault' | 'refresh-vault' | 'select-own-vault') => {
+	if (blocker === 'missing-vault') return UI_STRING_THIS_VAULT_DOES_NOT_EXIST
 
-			if (blocker === 'connect-wallet') {
-				if (action === 'claim-fees') return 'Connect a wallet before claiming fees.'
-				if (action === 'deposit-rep') return 'Connect a wallet before depositing REP.'
-				if (action === 'rep-exit-redeem') return 'Connect a wallet before redeeming REP.'
-				if (action === 'rep-exit-withdraw') return 'Connect a wallet before withdrawing REP.'
-				return 'Connect a wallet before setting the security bond allowance.'
-			}
+	if (blocker === 'connect-wallet') {
+		if (action === 'claim-fees') return 'Connect a wallet before claiming fees.'
+		if (action === 'deposit-rep') return 'Connect a wallet before depositing REP.'
+		if (action === 'rep-exit-redeem') return 'Connect a wallet before redeeming REP.'
+		if (action === 'rep-exit-withdraw') return 'Connect a wallet before withdrawing REP.'
+		return 'Connect a wallet before setting the security bond allowance.'
+	}
 
-			if (blocker === 'select-own-vault') {
-				if (action === 'claim-fees') return 'Select your own vault to claim fees.'
-				if (action === 'deposit-rep') return 'Select your own vault to deposit REP.'
-				if (action === 'rep-exit-redeem') return 'Select your own vault to redeem REP.'
-				if (action === 'rep-exit-withdraw') return 'Select your own vault to withdraw REP.'
-				return 'Select your own vault to set the security bond allowance.'
-			}
+	if (blocker === 'select-own-vault') {
+		if (action === 'claim-fees') return 'Select your own vault to claim fees.'
+		if (action === 'deposit-rep') return 'Select your own vault to deposit REP.'
+		if (action === 'rep-exit-redeem') return 'Select your own vault to redeem REP.'
+		if (action === 'rep-exit-withdraw') return 'Select your own vault to withdraw REP.'
+		return 'Select your own vault to set the security bond allowance.'
+	}
 
-			if (action === 'claim-fees') return 'Refresh the vault before claiming fees.'
-			if (action === 'deposit-rep') return 'Refresh the vault before depositing REP.'
-			if (action === 'rep-exit-redeem') return 'Refresh the vault before redeeming REP.'
-			if (action === 'rep-exit-withdraw') return 'Refresh the vault before withdrawing REP.'
-			return 'Refresh the vault before setting the security bond allowance.'
-		},
-		noRepLockedChecklistDetail: UI_STRING_WITHDRAW_ESCALATION_DEPOSITS,
-		oracleExecutionFundingChecklistLabel: 'Oracle execution can be funded until a fresh price arrives',
-		manualExecutionTimeoutInvalidDetail: 'Enter whole minutes. Queued self-service operations must stay executable for at least 1 minute after the oracle settlement window completes.',
-		manualExecutionTimeoutLabel: UI_STRING_MANUAL_EXECUTION_TIMEOUT,
-		manualExecutionTimeoutResolvedDetail: (duration: string) => `This queued self-service operation will expire ${duration} after the oracle settlement window completes.`,
-		noRepLockedChecklistLabel: 'No REP remains locked in the escalation game',
-		ownedBadgeLabel: 'Owned',
-		ownedChecklistLabel: 'Selected vault is owned by the connected account',
-		operationExecutedBadgeLabel: UI_STRING_EXECUTED,
-		operationStatusUnavailableDetail: UI_STRING_TRANSACTION_STATE_UNAVAILABLE,
-		oracleManagerAutoExecuteQueueFullDetail: UI_STRING_MANUAL_QUEUED_OPERATION,
-		priceValidUntilLabel: UI_STRING_PRICE_VALID_UNTIL,
-		readOnlyBadgeLabel: 'Read only',
-		refreshButtonIdleLabel: UI_STRING_REFRESH,
-		refreshButtonPendingLabel: UI_STRING_REFRESHING,
-		refreshingBadgeLabel: UI_STRING_REFRESHING_WITHOUT_ELLIPSIS,
-		refreshingBondAllowanceStateDetail: 'Refreshing the oracle manager to determine whether the bond allowance was queued or executed immediately.',
-		refreshingBondAllowanceStateTitle: 'Refreshing Bond Allowance State',
-		refreshingWithdrawalStateDetail: 'Refreshing the oracle manager to determine whether the withdrawal was queued or executed immediately.',
-		refreshingWithdrawalStateTitle: 'Refreshing Withdrawal State',
-		repAvailableToQueueLabel: 'REP Available To Queue',
-		repAmountLabel: UI_STRING_AMOUNT,
-		repBalanceChecklistLabel: 'Wallet REP balance covers the deposit amount',
-		repBalanceShortageDetail: (amount: string) => `Need ${amount} more REP.`,
-		repCollateralLabel: UI_STRING_REP_COLLATERAL,
-		securityPoolRejectedActionDetail: 'The security pool rejected the action.',
-		stagedOperationRetryDetail: UI_STRING_STAGED_OPERATION_RETRY,
-		tryAnotherPoolAddressDetail: 'Try another pool address.',
-		repWithdrawalExecutedTitle: 'REP Withdrawal Executed',
-		repWithdrawalFailedTitle: 'REP Withdrawal Failed',
-		repWithdrawalRejectedDetail: 'The oracle manager attempted the withdrawal immediately, but the security pool rejected it.',
-		repWithdrawalQueuedTitle: 'REP Withdrawal Queued',
-		repWithdrawalSubmittedTitle: 'REP Withdrawal Submitted',
-		redeemRepIdleLabel: 'Redeem REP',
-		redeemRepPendingLabel: 'Redeeming REP...',
-		redeemableRepChecklistLabel: 'The vault has redeemable REP',
-		redeemableRepLabel: 'Redeemable REP',
-		repExitRedeemDescription: 'Redeem the remaining REP collateral from this ended pool after escalation deposits are settled.',
-		repExitWithdrawDescription: 'Queue a REP withdrawal after reviewing the current vault collateral and oracle status.',
-		repWithdrawAmountLabel: 'REP Withdraw Amount',
-		repWithdrawQueueDescription: 'Queue a REP withdrawal now, or let it execute immediately when a valid oracle price is already available.',
-		selectedVaultDetailsUnavailableDetail: 'Selected vault details are unavailable.',
-		securityPoolAddressLabel: UI_STRING_SECURITY_POOL_ADDRESS,
-		securityPoolAddressPlaceholder: UI_STRING_HEX_VALUE_PLACEHOLDER,
-		securityBondAllowanceAmountLabel: 'Security Bond Allowance Amount',
-		securityVaultTitle: 'Security Vault',
-		setBondAllowanceActionDescription: 'Queue a new security bond allowance using the current oracle price context.',
-		setBondAllowanceModalTitle: UI_STRING_SET_BOND_ALLOWANCE,
-		setBondAllowanceIdleLabel: UI_STRING_SET_BOND_ALLOWANCE,
-		setSecurityBondAllowanceIdleLabel: UI_STRING_SET_SECURITY_BOND_ALLOWANCE,
-		setSecurityBondAllowanceModalDescription: 'Queue a new bond allowance using the latest valid oracle price for the selected vault.',
-		setSecurityBondAllowancePendingLabel: 'Queueing allowance update...',
-		setSecurityBondAllowanceTitle: UI_STRING_SET_SECURITY_BOND_ALLOWANCE,
-		selectedVaultAddressLabel: UI_STRING_SELECTED_VAULT_ADDRESS,
-		selectedVaultTitle: 'Selected Vault',
-		stagedOperationLabel: UI_STRING_STAGED_OPERATION,
-		successfulImmediateBondAllowanceDetail: 'A valid oracle price was already available, so the new bond allowance executed immediately and no staged operation was created.',
-		successfulImmediateWithdrawalDetail: 'A valid oracle price was already available, so the withdrawal executed immediately and no staged operation was created.',
-		timeoutChecklistLabel: 'Manual execution timeout is at least 1 minute',
-		allowanceChecklistLabel: (amount: string) => `Allowance amount is zero or at least ${amount} ETH`,
-		validOraclePriceChecklistLabel: 'A valid oracle price is available',
-		vaultLabel: 'Vault',
-		vaultActionsTitle: 'Vault Actions',
-		vaultLookupTitle: 'Vault Lookup',
-		vaultLookupPlaceholder: UI_STRING_HEX_VALUE_PLACEHOLDER,
-		vaultMissingBadgeLabel: 'Vault missing',
-		vaultSummaryTitle: 'Vault Summary',
-		viewInStagedOperationsLabel: UI_STRING_VIEW_IN_STAGED_OPERATIONS,
-		walletRepLabel: UI_STRING_WALLET_REP,
-		withdrawEscalationDepositsDetail: UI_STRING_WITHDRAW_ESCALATION_DEPOSITS,
-		withdrawFundingChecklistLabel: 'The vault still holds REP collateral to queue',
-		withdrawableRepLabel: 'Withdrawable REP',
-		withdrawRepIdleLabel: UI_STRING_WITHDRAW_REP,
-		withdrawRepPendingLabel: 'Queueing REP withdrawal...',
-	},
-	tradingSection: {
-		actionUnavailableReason: (actionLabel: string) => `${actionLabel} is not available right now.`,
-		completeSetRedeemAmountLabel: 'Redeem Complete Sets Amount',
-		connectWalletToMigrateSharesReason: 'Connect a wallet before migrating shares.',
-		connectWalletToMintReason: 'Connect a wallet before minting complete sets.',
-		connectWalletToRedeemCompleteSetsReason: 'Connect a wallet before redeeming complete sets.',
-		connectWalletToRedeemSharesReason: 'Connect a wallet before redeeming shares.',
-		loadWalletShareBalancesReason: 'Loading wallet share balances.',
-		loadPoolToMigrateSharesReason: 'Load a pool before migrating shares.',
-		loadPoolToMintReason: 'Load a pool before minting complete sets.',
-		loadPoolToRedeemCompleteSetsReason: 'Load a pool before redeeming complete sets.',
-		loadPoolToRedeemSharesReason: 'Load a pool before redeeming shares.',
-		loadingForkTargetUniversesReason: 'Loading fork target universes.',
-		refreshForkTargetUniversesReason: 'Refresh the fork target universes.',
-		loadingMintCapacityReason: 'Loading mint capacity.',
-		migrateForkedSharesActionLabel: 'Migrate forked shares',
-		migrateForkedSharesDescription: 'Burn parent-pool shares for one outcome and recreate them across selected child universes.',
-		migrateForkedSharesModalDescription: 'Migrating burns the selected parent-pool share balance and recreates it across the chosen child universes. Review the source outcome and target universes carefully before submitting.',
-		migrateForkedSharesTitle: 'Migrate Forked Shares',
-		migrateSharesIdleLabel: UI_STRING_MIGRATE_SHARES,
-		migrateSharesPendingLabel: 'Migrating shares...',
-		marketAlreadyFinalizedReason: 'This market has already finalized.',
-		mintCompleteSetsAmountLabel: 'Mint Complete Sets Amount',
-		mintCompleteSetsActionLabel: 'Mint complete sets',
-		mintCompleteSetsDescription: 'Lock collateral to mint a fresh Yes, No, and Invalid share set for this pool.',
-		mintCompleteSetsModalDescription: 'Review available capacity and confirm the complete-set mint amount before submitting.',
-		mintCompleteSetsPendingLabel: 'Minting complete sets...',
-		mintCompleteSetsTitle: UI_STRING_MINT_COMPLETE_SETS,
-		noMintCapacityRemainingReason: 'No mint capacity remaining.',
-		noSharesAvailableToMigrateReason: (outcomeLabel: string) => `No ${outcomeLabel} shares available to migrate.`,
-		redeemResolvedSharesModalDescription: 'Redeem finalized winning shares once the selected pool has resolved.',
-		repBackingLabel: 'REP Backing',
-		redeemCompleteSetsActionLabel: 'Redeem complete sets',
-		redeemCompleteSetsDescription: 'Burn matching Yes, No, and Invalid shares to recover collateral from the current pool.',
-		redeemCompleteSetsModalDescription: 'Redeeming complete sets requires matching yes, no, and invalid shares. Use the redeemable complete sets amount as the ceiling.',
-		redeemCompleteSetsPendingLabel: 'Redeeming complete sets...',
-		redeemCompleteSetsTitle: UI_STRING_REDEEM_COMPLETE_SETS,
-		redeemSharesActionLabel: 'Redeem resolved shares',
-		redeemSharesDescription: 'Redeem final winning shares after the selected pool fully resolves.',
-		redeemSharesIdleLabel: 'Redeem Shares',
-		redeemSharesPendingLabel: 'Redeeming shares...',
-		redeemSharesTitle: UI_STRING_REDEEM_RESOLVED_SHARES,
-		redeemableCompleteSetsDetail: 'Limited by your smallest Yes, No, or Invalid balance.',
-		redeemableCompleteSetsLabel: 'Redeemable Complete Sets',
-		bondAllowanceInUseLabel: 'Bond Allowance In Use',
-		securityPoolAddressLabel: UI_STRING_SECURITY_POOL_ADDRESS,
-		shareBalancesNotLoadedMessage: 'Wallet balances are not loaded.',
-		shareOutcomeInvalidLabel: UI_STRING_INVALID,
-		shareOutcomeNoLabel: UI_STRING_NO,
-		shareOutcomeYesLabel: UI_STRING_YES,
-		shareOutcomeToMigrateLabel: 'Share Outcome To Migrate',
-		sharesSectionTitle: 'Shares',
-		totalAcrossOutcomesLabel: 'Total Across Outcomes',
-		waitForPoolToResolveReason: 'Wait for the selected pool to resolve before redeeming shares.',
-		yourHoldingsTitle: 'Your Holdings',
-		tradingRouteTitle: 'Trading',
-	},
-	tabNavigation: {
-		applicationSectionsAriaLabel: 'Application sections',
-		deployContractsFirstReason: 'Deploy the application contracts before using this section.',
-		deployTabLabel: UI_STRING_DEPLOY,
-		marketsTabLabel: UI_STRING_MARKETS,
-		oracleReportsTabLabel: UI_STRING_ORACLE_REPORTS,
-		securityPoolsTabLabel: UI_STRING_SECURITY_POOLS,
-	},
-	userCopy: {
-		pageNotFound: {
-			actionHint: 'Open one of the sections below.',
-			badgeLabel: UI_STRING_PAGE_NOT_FOUND,
-		},
-		poolRegistry: {
-			collection: {
-				emptyActionHint: 'Create a pool from an exact Yes / No question to enable shares, reporting, and vault workflows.',
-				emptyBadgeLabel: UI_STRING_NONE,
-				emptyDetail: 'No security pools are available in this universe.',
-				loadingBadgeLabel: UI_STRING_LOADING,
-				loadingDetail: 'Refreshing pools.',
-				notCheckedBadgeLabel: UI_STRING_NOT_CHECKED,
-				notCheckedDetail: 'Load security pools to check what is available in this universe.',
-			},
-			selection: {
-				loadingBadgeLabel: UI_STRING_LOADING,
-				loadingDetail: UI_STRING_LOADING_WITH_ELLIPSIS,
-				notCheckedBadgeLabel: UI_STRING_NOT_CHECKED,
-				notFoundBadgeLabel: UI_STRING_NOT_FOUND,
-			},
-		},
-		report: {
-			loadingDetail: 'retrieving...',
-			notCheckedBadgeLabel: UI_STRING_NOT_CHECKED,
-			notFoundBadgeLabel: UI_STRING_NOT_FOUND,
-			questionNoun: 'questions',
-			refreshActionHintPrefix: UI_STRING_REFRESH,
-			refreshOrTryAnotherIdSuffix: 'or try another ID.',
-			refreshToCheckIdSuffix: 'to check this ID.',
-			reportNoun: 'reports',
-		},
-		universe: {
-			goToGenesisUniverseActionHint: UI_STRING_GO_TO_GENESIS_UNIVERSE,
-			loadingBadgeLabel: UI_STRING_LOADING,
-			loadingDetail: UI_STRING_LOADING_UNIVERSE_DETAILS,
-			notCheckedBadgeLabel: UI_STRING_NOT_CHECKED,
-			notCheckedDetail: 'Choose a universe to continue.',
-			notFoundBadgeLabel: UI_STRING_NOT_FOUND,
-			notFoundDetail: 'Choose another universe.',
-		},
-		wallet: {
-			connectWalletBadgeLabel: UI_STRING_CONNECT_WALLET,
-			connectWalletDetail: UI_STRING_CONNECT_WALLET_TO_CONTINUE,
-			installWalletDetail: 'Install or enable a wallet to continue.',
-			switchToMainnetDetail: 'Switch to Ethereum mainnet.',
-			wrongNetworkBadgeLabel: UI_STRING_WRONG_NETWORK,
-		},
-	},
-} as const
+	if (action === 'claim-fees') return 'Refresh the vault before claiming fees.'
+	if (action === 'deposit-rep') return 'Refresh the vault before depositing REP.'
+	if (action === 'rep-exit-redeem') return 'Refresh the vault before redeeming REP.'
+	if (action === 'rep-exit-withdraw') return 'Refresh the vault before withdrawing REP.'
+	return 'Refresh the vault before setting the security bond allowance.'
+}
+export const UI_STRING_ORACLE_EXECUTION_CAN_BE_FUNDED_UNTIL_A_FRESH_PRICE_ARRIVES = 'Oracle execution can be funded until a fresh price arrives'
+export const UI_STRING_ENTER_WHOLE_MINUTES_QUEUED_SELF_SERVICE_OPERATIONS_MUST_STAY_EXECUTABLE_FOR_AT_LEAST_1_MINUTE_AFTER_THE_ORACLE_SETTLEMENT_WINDOW_COMPLETES = 'Enter whole minutes. Queued self-service operations must stay executable for at least 1 minute after the oracle settlement window completes.'
+export const UI_TEMPLATE_MANUAL_EXECUTION_TIMEOUT_RESOLVED_DETAIL = (duration: string) => `This queued self-service operation will expire ${duration} after the oracle settlement window completes.`
+export const UI_STRING_NO_REP_REMAINS_LOCKED_IN_THE_ESCALATION_GAME = 'No REP remains locked in the escalation game'
+export const UI_STRING_OWNED = 'Owned'
+export const UI_STRING_SELECTED_VAULT_IS_OWNED_BY_THE_CONNECTED_ACCOUNT = 'Selected vault is owned by the connected account'
+export const UI_STRING_READ_ONLY_SECURITY_VAULT_SECTION_READ_ONLY_BADGE_LABEL = 'Read only'
+export const UI_STRING_REFRESHING_THE_ORACLE_MANAGER_TO_DETERMINE_WHETHER_THE_BOND_ALLOWANCE_WAS_QUEUED_OR_EXECUTED_IMMEDIATELY = 'Refreshing the oracle manager to determine whether the bond allowance was queued or executed immediately.'
+export const UI_STRING_REFRESHING_BOND_ALLOWANCE_STATE = 'Refreshing Bond Allowance State'
+export const UI_STRING_REFRESHING_THE_ORACLE_MANAGER_TO_DETERMINE_WHETHER_THE_WITHDRAWAL_WAS_QUEUED_OR_EXECUTED_IMMEDIATELY = 'Refreshing the oracle manager to determine whether the withdrawal was queued or executed immediately.'
+export const UI_STRING_REFRESHING_WITHDRAWAL_STATE = 'Refreshing Withdrawal State'
+export const UI_STRING_REP_AVAILABLE_TO_QUEUE = 'REP Available To Queue'
+export const UI_STRING_WALLET_REP_BALANCE_COVERS_THE_DEPOSIT_AMOUNT = 'Wallet REP balance covers the deposit amount'
+export const UI_TEMPLATE_REP_BALANCE_SHORTAGE_DETAIL = (amount: string) => `Need ${amount} more REP.`
+export const UI_STRING_THE_SECURITY_POOL_REJECTED_THE_ACTION = 'The security pool rejected the action.'
+export const UI_STRING_TRY_ANOTHER_POOL_ADDRESS = 'Try another pool address.'
+export const UI_STRING_REP_WITHDRAWAL_EXECUTED = 'REP Withdrawal Executed'
+export const UI_STRING_REP_WITHDRAWAL_FAILED = 'REP Withdrawal Failed'
+export const UI_STRING_THE_ORACLE_MANAGER_ATTEMPTED_THE_WITHDRAWAL_IMMEDIATELY_BUT_THE_SECURITY_POOL_REJECTED_IT = 'The oracle manager attempted the withdrawal immediately, but the security pool rejected it.'
+export const UI_STRING_REP_WITHDRAWAL_QUEUED = 'REP Withdrawal Queued'
+export const UI_STRING_REP_WITHDRAWAL_SUBMITTED = 'REP Withdrawal Submitted'
+export const UI_STRING_REDEEM_REP = 'Redeem REP'
+export const UI_STRING_REDEEMING_REP = 'Redeeming REP...'
+export const UI_STRING_THE_VAULT_HAS_REDEEMABLE_REP = 'The vault has redeemable REP'
+export const UI_STRING_REDEEMABLE_REP = 'Redeemable REP'
+export const UI_STRING_REDEEM_THE_REMAINING_REP_COLLATERAL_FROM_THIS_ENDED_POOL_AFTER_ESCALATION_DEPOSITS_ARE_SETTLED = 'Redeem the remaining REP collateral from this ended pool after escalation deposits are settled.'
+export const UI_STRING_QUEUE_A_REP_WITHDRAWAL_AFTER_REVIEWING_THE_CURRENT_VAULT_COLLATERAL_AND_ORACLE_STATUS = 'Queue a REP withdrawal after reviewing the current vault collateral and oracle status.'
+export const UI_STRING_REP_WITHDRAW_AMOUNT = 'REP Withdraw Amount'
+export const UI_STRING_QUEUE_A_REP_WITHDRAWAL_NOW_OR_LET_IT_EXECUTE_IMMEDIATELY_WHEN_A_VALID_ORACLE_PRICE_IS_ALREADY_AVAILABLE = 'Queue a REP withdrawal now, or let it execute immediately when a valid oracle price is already available.'
+export const UI_STRING_SELECTED_VAULT_DETAILS_ARE_UNAVAILABLE = 'Selected vault details are unavailable.'
+export const UI_STRING_SECURITY_BOND_ALLOWANCE_AMOUNT = 'Security Bond Allowance Amount'
+export const UI_STRING_SECURITY_VAULT = 'Security Vault'
+export const UI_STRING_QUEUE_A_NEW_SECURITY_BOND_ALLOWANCE_USING_THE_CURRENT_ORACLE_PRICE_CONTEXT = 'Queue a new security bond allowance using the current oracle price context.'
+export const UI_STRING_QUEUE_A_NEW_BOND_ALLOWANCE_USING_THE_LATEST_VALID_ORACLE_PRICE_FOR_THE_SELECTED_VAULT = 'Queue a new bond allowance using the latest valid oracle price for the selected vault.'
+export const UI_STRING_QUEUEING_ALLOWANCE_UPDATE = 'Queueing allowance update...'
+export const UI_STRING_SELECTED_VAULT = 'Selected Vault'
+export const UI_STRING_A_VALID_ORACLE_PRICE_WAS_ALREADY_AVAILABLE_SO_THE_NEW_BOND_ALLOWANCE_EXECUTED_IMMEDIATELY_AND_NO_STAGED_OPERATION_WAS_CREATED = 'A valid oracle price was already available, so the new bond allowance executed immediately and no staged operation was created.'
+export const UI_STRING_A_VALID_ORACLE_PRICE_WAS_ALREADY_AVAILABLE_SO_THE_WITHDRAWAL_EXECUTED_IMMEDIATELY_AND_NO_STAGED_OPERATION_WAS_CREATED = 'A valid oracle price was already available, so the withdrawal executed immediately and no staged operation was created.'
+export const UI_STRING_MANUAL_EXECUTION_TIMEOUT_IS_AT_LEAST_1_MINUTE = 'Manual execution timeout is at least 1 minute'
+export const UI_TEMPLATE_ALLOWANCE_CHECKLIST_LABEL = (amount: string) => `Allowance amount is zero or at least ${amount} ETH`
+export const UI_STRING_A_VALID_ORACLE_PRICE_IS_AVAILABLE = 'A valid oracle price is available'
+export const UI_STRING_VAULT = 'Vault'
+export const UI_STRING_VAULT_ACTIONS = 'Vault Actions'
+export const UI_STRING_VAULT_LOOKUP = 'Vault Lookup'
+export const UI_STRING_VAULT_MISSING = 'Vault missing'
+export const UI_STRING_VAULT_SUMMARY = 'Vault Summary'
+export const UI_STRING_THE_VAULT_STILL_HOLDS_REP_COLLATERAL_TO_QUEUE = 'The vault still holds REP collateral to queue'
+export const UI_STRING_WITHDRAWABLE_REP = 'Withdrawable REP'
+export const UI_STRING_QUEUEING_REP_WITHDRAWAL = 'Queueing REP withdrawal...'
+export const UI_TEMPLATE_ACTION_UNAVAILABLE_REASON = (actionLabel: string) => `${actionLabel} is not available right now.`
+export const UI_STRING_REDEEM_COMPLETE_SETS_AMOUNT = 'Redeem Complete Sets Amount'
+export const UI_STRING_CONNECT_A_WALLET_BEFORE_MIGRATING_SHARES = 'Connect a wallet before migrating shares.'
+export const UI_STRING_CONNECT_A_WALLET_BEFORE_MINTING_COMPLETE_SETS = 'Connect a wallet before minting complete sets.'
+export const UI_STRING_CONNECT_A_WALLET_BEFORE_REDEEMING_COMPLETE_SETS = 'Connect a wallet before redeeming complete sets.'
+export const UI_STRING_CONNECT_A_WALLET_BEFORE_REDEEMING_SHARES = 'Connect a wallet before redeeming shares.'
+export const UI_STRING_LOADING_WALLET_SHARE_BALANCES = 'Loading wallet share balances.'
+export const UI_STRING_LOAD_A_POOL_BEFORE_MIGRATING_SHARES = 'Load a pool before migrating shares.'
+export const UI_STRING_LOAD_A_POOL_BEFORE_MINTING_COMPLETE_SETS = 'Load a pool before minting complete sets.'
+export const UI_STRING_LOAD_A_POOL_BEFORE_REDEEMING_COMPLETE_SETS = 'Load a pool before redeeming complete sets.'
+export const UI_STRING_LOAD_A_POOL_BEFORE_REDEEMING_SHARES = 'Load a pool before redeeming shares.'
+export const UI_STRING_LOADING_FORK_TARGET_UNIVERSES_TRADING_SECTION_LOADING_FORK_TARGET_UNIVERSES_REASON = 'Loading fork target universes.'
+export const UI_STRING_REFRESH_THE_FORK_TARGET_UNIVERSES = 'Refresh the fork target universes.'
+export const UI_STRING_LOADING_MINT_CAPACITY = 'Loading mint capacity.'
+export const UI_STRING_MIGRATE_FORKED_SHARES = 'Migrate forked shares'
+export const UI_STRING_BURN_PARENT_POOL_SHARES_FOR_ONE_OUTCOME_AND_RECREATE_THEM_ACROSS_SELECTED_CHILD_UNIVERSES = 'Burn parent-pool shares for one outcome and recreate them across selected child universes.'
+export const UI_STRING_MIGRATING_BURNS_THE_SELECTED_PARENT_POOL_SHARE_BALANCE_AND_RECREATES_IT_ACROSS_THE_CHOSEN_CHILD_UNIVERSES_REVIEW_THE_SOURCE_OUTCOME_AND_TARGET_UNIVERSES_CAREFULLY_BEFORE_SUBMITTING =
+	'Migrating burns the selected parent-pool share balance and recreates it across the chosen child universes. Review the source outcome and target universes carefully before submitting.'
+export const UI_STRING_MIGRATE_FORKED_SHARES_TRADING_SECTION_MIGRATE_FORKED_SHARES_TITLE = 'Migrate Forked Shares'
+export const UI_STRING_MIGRATING_SHARES = 'Migrating shares...'
+export const UI_STRING_THIS_MARKET_HAS_ALREADY_FINALIZED = 'This market has already finalized.'
+export const UI_STRING_MINT_COMPLETE_SETS_AMOUNT = 'Mint Complete Sets Amount'
+export const UI_STRING_MINT_COMPLETE_SETS_TRADING_SECTION_MINT_COMPLETE_SETS_ACTION_LABEL = 'Mint complete sets'
+export const UI_STRING_LOCK_COLLATERAL_TO_MINT_A_FRESH_YES_NO_AND_INVALID_SHARE_SET_FOR_THIS_POOL = 'Lock collateral to mint a fresh Yes, No, and Invalid share set for this pool.'
+export const UI_STRING_REVIEW_AVAILABLE_CAPACITY_AND_CONFIRM_THE_COMPLETE_SET_MINT_AMOUNT_BEFORE_SUBMITTING = 'Review available capacity and confirm the complete-set mint amount before submitting.'
+export const UI_STRING_MINTING_COMPLETE_SETS = 'Minting complete sets...'
+export const UI_STRING_NO_MINT_CAPACITY_REMAINING = 'No mint capacity remaining.'
+export const UI_TEMPLATE_NO_SHARES_AVAILABLE_TO_MIGRATE_REASON = (outcomeLabel: string) => `No ${outcomeLabel} shares available to migrate.`
+export const UI_STRING_REDEEM_FINALIZED_WINNING_SHARES_ONCE_THE_SELECTED_POOL_HAS_RESOLVED = 'Redeem finalized winning shares once the selected pool has resolved.'
+export const UI_STRING_REP_BACKING = 'REP Backing'
+export const UI_STRING_REDEEM_COMPLETE_SETS_TRADING_SECTION_REDEEM_COMPLETE_SETS_ACTION_LABEL = 'Redeem complete sets'
+export const UI_STRING_BURN_MATCHING_YES_NO_AND_INVALID_SHARES_TO_RECOVER_COLLATERAL_FROM_THE_CURRENT_POOL = 'Burn matching Yes, No, and Invalid shares to recover collateral from the current pool.'
+export const UI_STRING_REDEEMING_COMPLETE_SETS_REQUIRES_MATCHING_YES_NO_AND_INVALID_SHARES_USE_THE_REDEEMABLE_COMPLETE_SETS_AMOUNT_AS_THE_CEILING = 'Redeeming complete sets requires matching yes, no, and invalid shares. Use the redeemable complete sets amount as the ceiling.'
+export const UI_STRING_REDEEMING_COMPLETE_SETS = 'Redeeming complete sets...'
+export const UI_STRING_REDEEM_RESOLVED_SHARES_TRADING_SECTION_REDEEM_SHARES_ACTION_LABEL = 'Redeem resolved shares'
+export const UI_STRING_REDEEM_FINAL_WINNING_SHARES_AFTER_THE_SELECTED_POOL_FULLY_RESOLVES = 'Redeem final winning shares after the selected pool fully resolves.'
+export const UI_STRING_REDEEM_SHARES = 'Redeem Shares'
+export const UI_STRING_REDEEMING_SHARES = 'Redeeming shares...'
+export const UI_STRING_LIMITED_BY_YOUR_SMALLEST_YES_NO_OR_INVALID_BALANCE = 'Limited by your smallest Yes, No, or Invalid balance.'
+export const UI_STRING_REDEEMABLE_COMPLETE_SETS = 'Redeemable Complete Sets'
+export const UI_STRING_BOND_ALLOWANCE_IN_USE = 'Bond Allowance In Use'
+export const UI_STRING_WALLET_BALANCES_ARE_NOT_LOADED = 'Wallet balances are not loaded.'
+export const UI_STRING_SHARE_OUTCOME_TO_MIGRATE = 'Share Outcome To Migrate'
+export const UI_STRING_SHARES = 'Shares'
+export const UI_STRING_TOTAL_ACROSS_OUTCOMES = 'Total Across Outcomes'
+export const UI_STRING_WAIT_FOR_THE_SELECTED_POOL_TO_RESOLVE_BEFORE_REDEEMING_SHARES = 'Wait for the selected pool to resolve before redeeming shares.'
+export const UI_STRING_YOUR_HOLDINGS = 'Your Holdings'
+export const UI_STRING_APPLICATION_SECTIONS = 'Application sections'
+export const UI_STRING_DEPLOY_THE_APPLICATION_CONTRACTS_BEFORE_USING_THIS_SECTION = 'Deploy the application contracts before using this section.'
+export const UI_STRING_OPEN_ONE_OF_THE_SECTIONS_BELOW = 'Open one of the sections below.'
+export const UI_STRING_CREATE_A_POOL_FROM_AN_EXACT_YES_NO_QUESTION_TO_ENABLE_SHARES_REPORTING_AND_VAULT_WORKFLOWS = 'Create a pool from an exact Yes / No question to enable shares, reporting, and vault workflows.'
+export const UI_STRING_NO_SECURITY_POOLS_ARE_AVAILABLE_IN_THIS_UNIVERSE = 'No security pools are available in this universe.'
+export const UI_STRING_REFRESHING_POOLS = 'Refreshing pools.'
+export const UI_STRING_LOAD_SECURITY_POOLS_TO_CHECK_WHAT_IS_AVAILABLE_IN_THIS_UNIVERSE = 'Load security pools to check what is available in this universe.'
+export const UI_STRING_RETRIEVING = 'retrieving...'
+export const UI_STRING_QUESTIONS_USER_COPY_REPORT_QUESTION_NOUN = 'questions'
+export const UI_STRING_OR_TRY_ANOTHER_ID = 'or try another ID.'
+export const UI_STRING_TO_CHECK_THIS_ID = 'to check this ID.'
+export const UI_STRING_REPORTS = 'reports'
+export const UI_STRING_CHOOSE_A_UNIVERSE_TO_CONTINUE = 'Choose a universe to continue.'
+export const UI_STRING_CHOOSE_ANOTHER_UNIVERSE = 'Choose another universe.'
+export const UI_STRING_INSTALL_OR_ENABLE_A_WALLET_TO_CONTINUE = 'Install or enable a wallet to continue.'
+export const UI_STRING_SWITCH_TO_ETHEREUM_MAINNET = 'Switch to Ethereum mainnet.'

--- a/ui/ts/lib/userCopy.ts
+++ b/ui/ts/lib/userCopy.ts
@@ -2,7 +2,35 @@ import type { Address } from '@zoltar/shared/ethereum'
 import { assertNever } from './assert.js'
 import { getWrongNetworkMessage } from './network.js'
 import type { LoadableValueState } from './loadState.js'
-import { UI_STRINGS } from './uiStrings.js'
+import {
+	UI_STRING_CHOOSE_A_UNIVERSE_TO_CONTINUE,
+	UI_STRING_CHOOSE_ANOTHER_UNIVERSE,
+	UI_STRING_CONNECT_WALLET,
+	UI_STRING_CONNECT_WALLET_TO_CONTINUE,
+	UI_STRING_CREATE_A_POOL_FROM_AN_EXACT_YES_NO_QUESTION_TO_ENABLE_SHARES_REPORTING_AND_VAULT_WORKFLOWS,
+	UI_STRING_GO_TO_GENESIS_UNIVERSE,
+	UI_STRING_INSTALL_OR_ENABLE_A_WALLET_TO_CONTINUE,
+	UI_STRING_LOAD_SECURITY_POOLS_TO_CHECK_WHAT_IS_AVAILABLE_IN_THIS_UNIVERSE,
+	UI_STRING_LOADING,
+	UI_STRING_LOADING_UNIVERSE_DETAILS,
+	UI_STRING_LOADING_WITH_ELLIPSIS,
+	UI_STRING_METRIC_UNAVAILABLE_PLACEHOLDER,
+	UI_STRING_NO_SECURITY_POOLS_ARE_AVAILABLE_IN_THIS_UNIVERSE,
+	UI_STRING_NONE,
+	UI_STRING_NOT_CHECKED,
+	UI_STRING_NOT_FOUND,
+	UI_STRING_OPEN_ONE_OF_THE_SECTIONS_BELOW,
+	UI_STRING_OR_TRY_ANOTHER_ID,
+	UI_STRING_PAGE_NOT_FOUND,
+	UI_STRING_QUESTIONS_USER_COPY_REPORT_QUESTION_NOUN,
+	UI_STRING_REFRESH,
+	UI_STRING_REFRESHING_POOLS,
+	UI_STRING_REPORTS,
+	UI_STRING_RETRIEVING,
+	UI_STRING_SWITCH_TO_ETHEREUM_MAINNET,
+	UI_STRING_TO_CHECK_THIS_ID,
+	UI_STRING_WRONG_NETWORK,
+} from './uiStrings.js'
 
 export type UserMessageKey = 'not_checked' | 'loading' | 'not_found' | 'empty' | 'action_needed' | 'wrong_network' | 'wallet_disconnected' | 'unavailable' | 'page_not_found' | 'load_failed'
 
@@ -18,7 +46,7 @@ export type UserMessagePresentation = {
 	placeholder?: string
 }
 
-const METRIC_PLACEHOLDER = UI_STRINGS.common.metricUnavailablePlaceholder
+const METRIC_PLACEHOLDER = UI_STRING_METRIC_UNAVAILABLE_PLACEHOLDER
 
 function createPresentation(key: UserMessageKey, presentation: Omit<UserMessagePresentation, 'key'>): UserMessagePresentation {
 	return { key, ...presentation }
@@ -28,9 +56,9 @@ export function getMetricPlaceholderPresentation(value: unknown, options?: { loa
 	if (value !== undefined) return undefined
 	if (options?.loading === true)
 		return createPresentation('loading', {
-			badgeLabel: UI_STRINGS.userCopy.poolRegistry.collection.loadingBadgeLabel,
+			badgeLabel: UI_STRING_LOADING,
 			badgeTone: 'pending',
-			placeholder: UI_STRINGS.userCopy.poolRegistry.selection.loadingDetail,
+			placeholder: UI_STRING_LOADING_WITH_ELLIPSIS,
 		})
 	return createPresentation('unavailable', {
 		placeholder: METRIC_PLACEHOLDER,
@@ -54,40 +82,40 @@ export function getPoolRegistryPresentation(
 		if (input.poolCount > 0) return undefined
 		if (input.isLoading)
 			return createPresentation('loading', {
-				badgeLabel: UI_STRINGS.userCopy.poolRegistry.collection.loadingBadgeLabel,
+				badgeLabel: UI_STRING_LOADING,
 				badgeTone: 'pending',
-				detail: UI_STRINGS.userCopy.poolRegistry.collection.loadingDetail,
+				detail: UI_STRING_REFRESHING_POOLS,
 			})
 		if (!input.hasLoaded)
 			return createPresentation('not_checked', {
-				badgeLabel: UI_STRINGS.userCopy.poolRegistry.collection.notCheckedBadgeLabel,
+				badgeLabel: UI_STRING_NOT_CHECKED,
 				badgeTone: 'muted',
-				detail: UI_STRINGS.userCopy.poolRegistry.collection.notCheckedDetail,
+				detail: UI_STRING_LOAD_SECURITY_POOLS_TO_CHECK_WHAT_IS_AVAILABLE_IN_THIS_UNIVERSE,
 			})
 		return createPresentation('empty', {
-			actionHint: UI_STRINGS.userCopy.poolRegistry.collection.emptyActionHint,
-			badgeLabel: UI_STRINGS.userCopy.poolRegistry.collection.emptyBadgeLabel,
+			actionHint: UI_STRING_CREATE_A_POOL_FROM_AN_EXACT_YES_NO_QUESTION_TO_ENABLE_SHARES_REPORTING_AND_VAULT_WORKFLOWS,
+			badgeLabel: UI_STRING_NONE,
 			badgeTone: 'muted',
-			detail: UI_STRINGS.userCopy.poolRegistry.collection.emptyDetail,
+			detail: UI_STRING_NO_SECURITY_POOLS_ARE_AVAILABLE_IN_THIS_UNIVERSE,
 		})
 	}
 
 	switch (input.state) {
 		case 'loading':
 			return createPresentation('loading', {
-				badgeLabel: UI_STRINGS.userCopy.poolRegistry.selection.loadingBadgeLabel,
+				badgeLabel: UI_STRING_LOADING,
 				badgeTone: 'pending',
-				detail: UI_STRINGS.userCopy.poolRegistry.selection.loadingDetail,
+				detail: UI_STRING_LOADING_WITH_ELLIPSIS,
 				detailIsLoading: true,
 			})
 		case 'unknown':
 			return createPresentation('not_checked', {
-				badgeLabel: UI_STRINGS.userCopy.poolRegistry.selection.notCheckedBadgeLabel,
+				badgeLabel: UI_STRING_NOT_CHECKED,
 				badgeTone: 'muted',
 			})
 		case 'missing':
 			return createPresentation('not_found', {
-				badgeLabel: UI_STRINGS.userCopy.poolRegistry.selection.notFoundBadgeLabel,
+				badgeLabel: UI_STRING_NOT_FOUND,
 				badgeTone: 'blocked',
 			})
 		case 'ready':
@@ -101,22 +129,22 @@ export function getUniversePresentation(state: LoadableValueState) {
 	switch (state) {
 		case 'loading':
 			return createPresentation('loading', {
-				badgeLabel: UI_STRINGS.userCopy.universe.loadingBadgeLabel,
+				badgeLabel: UI_STRING_LOADING,
 				badgeTone: 'pending',
-				detail: UI_STRINGS.userCopy.universe.loadingDetail,
+				detail: UI_STRING_LOADING_UNIVERSE_DETAILS,
 			})
 		case 'unknown':
 			return createPresentation('not_checked', {
-				badgeLabel: UI_STRINGS.userCopy.universe.notCheckedBadgeLabel,
+				badgeLabel: UI_STRING_NOT_CHECKED,
 				badgeTone: 'muted',
-				detail: UI_STRINGS.userCopy.universe.notCheckedDetail,
+				detail: UI_STRING_CHOOSE_A_UNIVERSE_TO_CONTINUE,
 			})
 		case 'missing':
 			return createPresentation('not_found', {
-				actionHint: UI_STRINGS.userCopy.universe.goToGenesisUniverseActionHint,
-				badgeLabel: UI_STRINGS.userCopy.universe.notFoundBadgeLabel,
+				actionHint: UI_STRING_GO_TO_GENESIS_UNIVERSE,
+				badgeLabel: UI_STRING_NOT_FOUND,
 				badgeTone: 'blocked',
-				detail: UI_STRINGS.userCopy.universe.notFoundDetail,
+				detail: UI_STRING_CHOOSE_ANOTHER_UNIVERSE,
 			})
 		case 'ready':
 			return undefined
@@ -131,45 +159,45 @@ export function getWalletPresentation({ accountAddress, hasInjectedWallet, hasWa
 
 	if (!walletAvailable)
 		return createPresentation('wallet_disconnected', {
-			badgeLabel: UI_STRINGS.userCopy.wallet.connectWalletBadgeLabel,
+			badgeLabel: UI_STRING_CONNECT_WALLET,
 			badgeTone: 'blocked',
-			detail: UI_STRINGS.userCopy.wallet.installWalletDetail,
+			detail: UI_STRING_INSTALL_OR_ENABLE_A_WALLET_TO_CONTINUE,
 		})
 	if (accountAddress === undefined)
 		return createPresentation('wallet_disconnected', {
-			badgeLabel: UI_STRINGS.userCopy.wallet.connectWalletBadgeLabel,
+			badgeLabel: UI_STRING_CONNECT_WALLET,
 			badgeTone: 'blocked',
-			detail: UI_STRINGS.userCopy.wallet.connectWalletDetail,
+			detail: UI_STRING_CONNECT_WALLET_TO_CONTINUE,
 		})
 	if (!supportedChain)
 		return createPresentation('wrong_network', {
-			badgeLabel: UI_STRINGS.userCopy.wallet.wrongNetworkBadgeLabel,
+			badgeLabel: UI_STRING_WRONG_NETWORK,
 			badgeTone: 'blocked',
-			detail: getWrongNetworkMessage() ?? UI_STRINGS.userCopy.wallet.switchToMainnetDetail,
+			detail: getWrongNetworkMessage() ?? UI_STRING_SWITCH_TO_ETHEREUM_MAINNET,
 		})
 	return undefined
 }
 
 export function getReportPresentation({ kind, state }: { kind: 'question' | 'report'; state: LoadableValueState }) {
-	const noun = kind === 'question' ? UI_STRINGS.userCopy.report.questionNoun : UI_STRINGS.userCopy.report.reportNoun
+	const noun = kind === 'question' ? UI_STRING_QUESTIONS_USER_COPY_REPORT_QUESTION_NOUN : UI_STRING_REPORTS
 	switch (state) {
 		case 'loading':
 			return createPresentation('loading', {
-				detail: UI_STRINGS.userCopy.report.loadingDetail,
+				detail: UI_STRING_RETRIEVING,
 				detailIsLoading: true,
 			})
 		case 'unknown':
 			return createPresentation('not_checked', {
-				actionHint: `${UI_STRINGS.userCopy.report.refreshActionHintPrefix} ${noun}`,
-				badgeLabel: UI_STRINGS.userCopy.report.notCheckedBadgeLabel,
+				actionHint: `${UI_STRING_REFRESH} ${noun}`,
+				badgeLabel: UI_STRING_NOT_CHECKED,
 				badgeTone: 'muted',
-				detail: `${UI_STRINGS.userCopy.report.refreshActionHintPrefix} ${noun} ${UI_STRINGS.userCopy.report.refreshToCheckIdSuffix}`,
+				detail: `${UI_STRING_REFRESH} ${noun} ${UI_STRING_TO_CHECK_THIS_ID}`,
 			})
 		case 'missing':
 			return createPresentation('not_found', {
-				badgeLabel: UI_STRINGS.userCopy.report.notFoundBadgeLabel,
+				badgeLabel: UI_STRING_NOT_FOUND,
 				badgeTone: 'blocked',
-				detail: `${UI_STRINGS.userCopy.report.refreshActionHintPrefix} ${noun} ${UI_STRINGS.userCopy.report.refreshOrTryAnotherIdSuffix}`,
+				detail: `${UI_STRING_REFRESH} ${noun} ${UI_STRING_OR_TRY_ANOTHER_ID}`,
 			})
 		case 'ready':
 			return undefined
@@ -180,8 +208,8 @@ export function getReportPresentation({ kind, state }: { kind: 'question' | 'rep
 
 export function getPageNotFoundPresentation() {
 	return createPresentation('page_not_found', {
-		actionHint: UI_STRINGS.userCopy.pageNotFound.actionHint,
-		badgeLabel: UI_STRINGS.userCopy.pageNotFound.badgeLabel,
+		actionHint: UI_STRING_OPEN_ONE_OF_THE_SECTIONS_BELOW,
+		badgeLabel: UI_STRING_PAGE_NOT_FOUND,
 		badgeTone: 'blocked',
 	})
 }

--- a/ui/ts/tests/openOracleRouteSection.test.tsx
+++ b/ui/ts/tests/openOracleRouteSection.test.tsx
@@ -14,7 +14,7 @@ import type { OpenOracleReportDetails } from '../types/contracts.js'
 import { installDomEnvironment } from './testUtils/domEnvironment.js'
 import { renderIntoDocument } from './testUtils/renderIntoDocument.js'
 import { expectTransactionButtonDisabled, expectTransactionButtonEnabled } from './testUtils/transactionActionButton.js'
-import { UI_STRINGS } from '../lib/uiStrings.js'
+import { UI_TEMPLATE_BROWSE_REPORTS_DESCRIPTION } from '../lib/uiStrings.js'
 
 const ETH = 10n ** 18n
 
@@ -323,7 +323,7 @@ describe('OpenOracleSection route create view', () => {
 	})
 
 	test('formats browse description with the shared page size', () => {
-		expect(UI_STRINGS.openOracleSection.browseReportsDescription('10')).toContain('10 reports')
+		expect(UI_TEMPLATE_BROWSE_REPORTS_DESCRIPTION('10')).toContain('10 reports')
 	})
 
 	test('does not disable create before token decimals are loaded for large but valid token1 amounts', async () => {

--- a/ui/ts/tests/reportingSection.test.tsx
+++ b/ui/ts/tests/reportingSection.test.tsx
@@ -9,7 +9,7 @@ import { zeroAddress } from '@zoltar/shared/ethereum'
 import { ReportingSection } from '../components/ReportingSection.js'
 import { formatDuration, formatTimestamp } from '../lib/formatters.js'
 import { getReportingLockedUntilMessage } from '../lib/reporting.js'
-import { UI_STRINGS } from '../lib/uiStrings.js'
+import { UI_STRING_IF_NO_ONE_DISPUTES_AFTER_THIS_REPORT_THE_MARKET_WOULD_FINALIZE_IN } from '../lib/uiStrings.js'
 import { computeEscalationTimeSinceStartFromAttritionCost, ESCALATION_GAME_ACTIVATION_DELAY, getEscalationBalanceTuple, getEscalationBindingCapital, getSelectedOutcomeRewardWindowFillTimestamp } from '../lib/reportingDomain.js'
 import type { AccountState, ReportingFormState } from '../types/app.js'
 import type { ActiveReportingDetails, EscalationDeposit, MarketDetails, ReportingDetails } from '../types/contracts.js'
@@ -1020,7 +1020,7 @@ describe('ReportingSection', () => {
 		expect(reportOutcomeSection.querySelectorAll('.currency-value.unavailable')).toHaveLength(0)
 		expect(document.body.textContent?.includes('Load reporting details to populate live stakes')).toBe(false)
 		expectTransactionButtonEnabled(document.body, 'Report Yes')
-		expect(document.body.textContent?.includes(UI_STRINGS.reportingSection.reportingProjectionNotStartedPrefix)).toBe(true)
+		expect(document.body.textContent?.includes(UI_STRING_IF_NO_ONE_DISPUTES_AFTER_THIS_REPORT_THE_MARKET_WOULD_FINALIZE_IN)).toBe(true)
 		expect(document.body.textContent?.includes(`Check back no later than ${formatTimestamp(150n + ESCALATION_GAME_ACTIVATION_DELAY)} (in 3d 0h 0m) to confirm Yes is the leading outcome before finalization.`)).toBe(true)
 	})
 
@@ -1041,7 +1041,7 @@ describe('ReportingSection', () => {
 		)
 		cleanupRenderedComponent = renderedComponent.cleanup
 
-		expect(document.body.textContent?.includes(UI_STRINGS.reportingSection.reportingProjectionNotStartedPrefix)).toBe(true)
+		expect(document.body.textContent?.includes(UI_STRING_IF_NO_ONE_DISPUTES_AFTER_THIS_REPORT_THE_MARKET_WOULD_FINALIZE_IN)).toBe(true)
 		expect(document.body.textContent?.includes(`If no one disputes after this report, the market would finalize in ${formatDuration(ESCALATION_GAME_ACTIVATION_DELAY)}.`)).toBe(true)
 		expect(document.body.textContent?.includes(`Check back no later than ${formatTimestamp(latestCheckBackTimestamp)} (in ${formatDuration(ESCALATION_GAME_ACTIVATION_DELAY + hypotheticalDuration)}) to confirm Invalid is still leading if later disputes keep escalation open.`)).toBe(true)
 	})


### PR DESCRIPTION
## Summary
- Replaced the shared `UI_STRINGS` object usage with named `uiStrings` exports across the UI components and helpers.
- Updated copy-heavy sections, modals, and route navigation to import the specific strings they use.
- Aligned the UI string lint rule and tests with the new named-export convention.

## Testing
- Not run: changes were reviewed from the provided diff only.
- Not run: no local validation commands were executed in this context.