### PR TITLE
Reconcile child complete-set minting after fork migration

### DIFF
--- a/solidity/contracts/peripherals/SecurityPoolForker.sol
+++ b/solidity/contracts/peripherals/SecurityPoolForker.sol
@@ -516,7 +516,9 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 		securityPool.setSystemState(SystemState.ForkTruthAuction);
 		data.truthAuctionStarted = block.timestamp;
 		parent.updateCollateralAmount();
-		securityPool.setTotalShares(parent.shareTokenSupply());
+		securityPool.setTotalShares(
+			securityPool.shareToken().reconciledCompleteSetSupply(securityPool.universeId(), parent.shareTokenSupply())
+		);
 		parentCollateral = parentData.collateralAtFork;
 	}
 

--- a/solidity/contracts/peripherals/interfaces/IShareToken.sol
+++ b/solidity/contracts/peripherals/interfaces/IShareToken.sol
@@ -16,6 +16,7 @@ interface IShareToken {
 		uint248 _universeId,
 		BinaryOutcomes.BinaryOutcome _outcome
 	) external view returns (uint256);
+	function reconciledCompleteSetSupply(uint248 _universeId, uint256 _fallbackSupply) external view returns (uint256);
 	function balanceOfOutcome(
 		uint248 _universeId,
 		BinaryOutcomes.BinaryOutcome _outcome,

--- a/solidity/contracts/peripherals/tokens/ShareToken.sol
+++ b/solidity/contracts/peripherals/tokens/ShareToken.sol
@@ -72,6 +72,9 @@ contract ShareToken is ERC1155, IShareToken {
 
 	function mintCompleteSets(uint248 _universeId, address _account, uint256 _cashAmount) external {
 		require(authorized[msg.sender] == true, 'ShareToken caller is not authorized to mint complete sets');
+		(bool isReconciled, ) = _getActualCompleteSetSupply(_universeId);
+		require(isReconciled, 'Share supply mismatch');
+		require(_cashAmount > 0, 'Exchange rate undefined');
 		uint256[] memory _tokenIds = new uint256[](Constants.NUM_OUTCOMES);
 		uint256[] memory _values = new uint256[](Constants.NUM_OUTCOMES);
 
@@ -85,6 +88,8 @@ contract ShareToken is ERC1155, IShareToken {
 
 	function burnCompleteSets(uint248 _universeId, address _owner, uint256 _amount) external {
 		require(authorized[msg.sender] == true, 'ShareToken caller is not authorized to burn complete sets');
+		(bool isReconciled, ) = _getActualCompleteSetSupply(_universeId);
+		require(isReconciled, 'Share supply mismatch');
 		uint256[] memory _tokenIds = new uint256[](Constants.NUM_OUTCOMES);
 		uint256[] memory _values = new uint256[](Constants.NUM_OUTCOMES);
 
@@ -116,6 +121,20 @@ contract ShareToken is ERC1155, IShareToken {
 	) public view returns (uint256) {
 		uint256 _tokenId = getTokenId(_universeId, _outcome);
 		return totalSupply(_tokenId);
+	}
+
+	function _getActualCompleteSetSupply(
+		uint248 _universeId
+	) private view returns (bool isReconciled, uint256 actualSupply) {
+		actualSupply = totalSupplyForOutcome(_universeId, BinaryOutcomes.BinaryOutcome.Invalid);
+		uint256 yesSupply = totalSupplyForOutcome(_universeId, BinaryOutcomes.BinaryOutcome.Yes);
+		uint256 noSupply = totalSupplyForOutcome(_universeId, BinaryOutcomes.BinaryOutcome.No);
+		isReconciled = actualSupply == yesSupply && yesSupply == noSupply;
+	}
+
+	function reconciledCompleteSetSupply(uint248 _universeId, uint256 _fallbackSupply) external view returns (uint256) {
+		(bool isReconciled, uint256 actualSupply) = _getActualCompleteSetSupply(_universeId);
+		return isReconciled ? actualSupply : _fallbackSupply;
 	}
 
 	function balanceOfOutcome(

--- a/solidity/ts/tests/peripherals/forkMigration.test.ts
+++ b/solidity/ts/tests/peripherals/forkMigration.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, test } from 'bun:test'
 import { encodeDeployData } from '@zoltar/shared/ethereum'
 import { usePeripheralsForkMigrationFixture, type PeripheralsForkMigrationFixture } from './fixture'
 import { getExpectedLiquidationRepMove } from './liquidationTestHelpers'
-import { getUniverseData } from '../../testSupport/simulator/utils/contracts/zoltar'
+import { addRepToMigrationBalance, getUniverseData, splitMigrationRep } from '../../testSupport/simulator/utils/contracts/zoltar'
 import { queueLiquidationAtForcedPrice } from '../../testSupport/simulator/utils/contracts/peripherals'
 import { getQuestionResolution } from '../../testSupport/simulator/utils/contracts/escalationGame'
 import { peripherals_SecurityPool_SecurityPool } from '../../types/contractArtifact'
@@ -1822,16 +1822,27 @@ describe('Peripherals: fork migration', () => {
 			strictEqualTypeSafe(childVaultAfterRedeem.repDepositShare, 0n, 'operational child pool should allow redeemed ownership to clear')
 		})
 
-		test('child pool complete-set minting waits for settled fork accounting', async () => {
+		test('child pool reconciles balanced partial migration before complete-set minting', async () => {
+			const endTime = await getQuestionEndDate(client, questionId)
+			await mockWindow.setTime(endTime - 2n * DAY)
 			const forkThreshold = (await getTotalTheoreticalSupply(client, await getRepToken(client, securityPoolAddresses.securityPool))) / 20n
 			const passiveRepHolder = createWriteClient(mockWindow, TEST_ADDRESSES[6], 0)
 			await approveAndDepositRep(passiveRepHolder, 2n * forkThreshold, questionId)
 			const parentAllowance = repDeposit / 4n
 			await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, parentAllowance)
-			const parentMintAmount = 5n * 10n ** 18n
-			await createCompleteSet(client, securityPoolAddresses.securityPool, parentMintAmount)
+			const migratedParentMintAmount = 5n * 10n ** 18n
+			const unmigratedHolder = createWriteClient(mockWindow, TEST_ADDRESSES[3], 0)
+			const newMinter = createWriteClient(mockWindow, TEST_ADDRESSES[4], 0)
+			await createCompleteSet(client, securityPoolAddresses.securityPool, migratedParentMintAmount)
+			await createCompleteSet(unmigratedHolder, securityPoolAddresses.securityPool, 5n * 10n ** 18n)
 
 			await triggerExternalForkForSecurityPool(undefined, 'complete-set child mint fork source')
+			await approveToken(newMinter, addressString(GENESIS_REPUTATION_TOKEN), getZoltarAddress())
+			await addRepToMigrationBalance(newMinter, genesisUniverse, repDeposit)
+			await splitMigrationRep(newMinter, genesisUniverse, repDeposit, [QuestionOutcome.Yes])
+			await migrateShares(client, securityPoolAddresses.shareToken, genesisUniverse, QuestionOutcome.Invalid, [QuestionOutcome.Yes])
+			await migrateShares(client, securityPoolAddresses.shareToken, genesisUniverse, QuestionOutcome.Yes, [QuestionOutcome.Yes])
+			await migrateShares(client, securityPoolAddresses.shareToken, genesisUniverse, QuestionOutcome.No, [QuestionOutcome.Yes])
 			await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
 			await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
 
@@ -1861,8 +1872,9 @@ describe('Peripherals: fork migration', () => {
 			await updateVaultFees(client, yesSecurityPool.securityPool, client.account.address)
 			const childCollateralBeforeMint = await getCompleteSetCollateralAmount(client, yesSecurityPool.securityPool)
 			const childShareSupplyBeforeMint = await getShareTokenSupply(client, yesSecurityPool.securityPool)
+			strictEqualTypeSafe(childShareSupplyBeforeMint, migratedParentMintAmount * PRICE_PRECISION, 'child exchange-rate supply should use the balanced shares actually migrated into the child')
 
-			await createCompleteSet(client, yesSecurityPool.securityPool, childMintAmount)
+			await createCompleteSet(newMinter, yesSecurityPool.securityPool, childMintAmount)
 
 			const childCollateralAfterMint = await getCompleteSetCollateralAmount(client, yesSecurityPool.securityPool)
 			assert.ok(childCollateralAfterMint > childCollateralBeforeMint, 'child complete-set mint should increase collateral after fork accounting is settled')
@@ -1870,6 +1882,96 @@ describe('Peripherals: fork migration', () => {
 			const updatedCollateralBeforeMint = childCollateralAfterMint - childMintAmount
 			const expectedMintedShares = updatedCollateralBeforeMint === 0n ? childMintAmount * PRICE_PRECISION : (childMintAmount * childShareSupplyBeforeMint) / updatedCollateralBeforeMint
 			strictEqualTypeSafe(await getShareTokenSupply(client, yesSecurityPool.securityPool), childShareSupplyBeforeMint + expectedMintedShares, 'child complete-set mint should add shares at the settled exchange rate')
+
+			await manipulatePriceOracle(newMinter, mockWindow, yesSecurityPool.priceOracleManagerAndOperatorQueuer)
+			await approveToken(newMinter, getRepTokenAddress(yesUniverse), yesSecurityPool.securityPool)
+			await depositRep(newMinter, yesSecurityPool.securityPool, repDeposit / 10n)
+			await depositToEscalationGame(newMinter, yesSecurityPool.securityPool, QuestionOutcome.Yes, reportBond)
+			await mockWindow.advanceTime(10n * DAY)
+			strictEqualTypeSafe(await getQuestionOutcome(client, yesSecurityPool.securityPool), QuestionOutcome.Yes, 'child question should resolve as yes')
+
+			const newMinterBalanceBeforeRedemption = await getETHBalance(client, newMinter.account.address)
+			await redeemShares(newMinter, yesSecurityPool.securityPool)
+			const newMinterPayout = (await getETHBalance(client, newMinter.account.address)) - newMinterBalanceBeforeRedemption
+			assert.ok(newMinterPayout <= childMintAmount, `post-fork complete-set minter must not capture preexisting collateral: deposited ${childMintAmount}, redeemed ${newMinterPayout}`)
+		})
+
+		test('child pool blocks complete-set minting when migrated outcome supplies are uneven', async () => {
+			const endTime = await getQuestionEndDate(client, questionId)
+			await mockWindow.setTime(endTime - 2n * DAY)
+			const forkThreshold = (await getTotalTheoreticalSupply(client, await getRepToken(client, securityPoolAddresses.securityPool))) / 20n
+			const passiveRepHolder = createWriteClient(mockWindow, TEST_ADDRESSES[6], 0)
+			await approveAndDepositRep(passiveRepHolder, 2n * forkThreshold, questionId)
+			const parentAllowance = repDeposit / 4n
+			await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, parentAllowance)
+
+			const parentMintAmount = 10n * 10n ** 18n
+			await createCompleteSet(client, securityPoolAddresses.securityPool, parentMintAmount)
+			await triggerExternalForkForSecurityPool(undefined, 'uneven-share child mint fork source')
+			await migrateShares(client, securityPoolAddresses.shareToken, genesisUniverse, QuestionOutcome.Yes, [QuestionOutcome.Yes])
+			await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
+			await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
+
+			const yesUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
+			const yesSecurityPool = getSecurityPoolAddresses(securityPoolAddresses.securityPool, yesUniverse, questionId, securityMultiplier)
+			await mockWindow.advanceTime(8n * 7n * DAY + DAY)
+			await startTruthAuction(client, yesSecurityPool.securityPool)
+			if ((await getSystemState(client, yesSecurityPool.securityPool)) === SystemState.ForkTruthAuction) {
+				await mockWindow.advanceTime(7n * DAY + DAY)
+				await finalizeTruthAuction(client, yesSecurityPool.securityPool)
+			}
+
+			strictEqualTypeSafe(await getSystemState(client, yesSecurityPool.securityPool), SystemState.Operational, 'child pool should be operational after fork accounting settles')
+			strictEqualTypeSafe(await getQuestionOutcome(client, yesSecurityPool.securityPool), QuestionOutcome.None, 'unrelated fork should leave the child question unresolved')
+			assert.ok((await getCompleteSetCollateralAmount(client, yesSecurityPool.securityPool)) > 0n, 'test setup requires preexisting child collateral')
+			const migratedBalances = await balanceOfShares(client, yesSecurityPool.shareToken, yesUniverse, client.account.address)
+			strictEqualTypeSafe(ensureDefined(migratedBalances[0], 'invalid child balance missing'), 0n, 'invalid supply should remain unmigrated')
+			strictEqualTypeSafe(ensureDefined(migratedBalances[1], 'yes child balance missing'), parentMintAmount * PRICE_PRECISION, 'yes supply should migrate unevenly')
+			strictEqualTypeSafe(ensureDefined(migratedBalances[2], 'no child balance missing'), 0n, 'no supply should remain unmigrated')
+
+			const newMinter = createWriteClient(mockWindow, TEST_ADDRESSES[4], 0)
+			const collateralBeforeFailedMint = await getCompleteSetCollateralAmount(client, yesSecurityPool.securityPool)
+			const supplyBeforeFailedMint = await getShareTokenSupply(client, yesSecurityPool.securityPool)
+			await assert.rejects(createCompleteSet(newMinter, yesSecurityPool.securityPool, 1n * 10n ** 18n), /Share supply mismatch/)
+			await assert.rejects(redeemCompleteSet(client, yesSecurityPool.securityPool, 1n), /Share supply mismatch/)
+
+			strictEqualTypeSafe(await getCompleteSetCollateralAmount(client, yesSecurityPool.securityPool), collateralBeforeFailedMint, 'rejected complete-set operations should not change child collateral')
+			strictEqualTypeSafe(await getShareTokenSupply(client, yesSecurityPool.securityPool), supplyBeforeFailedMint, 'rejected complete-set operations should not change child share accounting')
+			const balancesAfterFailedOperations = await balanceOfShares(client, yesSecurityPool.shareToken, yesUniverse, client.account.address)
+			strictEqualTypeSafe(balancesAfterFailedOperations[0], migratedBalances[0], 'rejected complete-set operations should not change invalid balances')
+			strictEqualTypeSafe(balancesAfterFailedOperations[1], migratedBalances[1], 'rejected complete-set operations should not change yes balances')
+			strictEqualTypeSafe(balancesAfterFailedOperations[2], migratedBalances[2], 'rejected complete-set operations should not change no balances')
+		})
+
+		test('child pool blocks complete-set minting when collateral exists without migrated shares', async () => {
+			const endTime = await getQuestionEndDate(client, questionId)
+			await mockWindow.setTime(endTime - 2n * DAY)
+			const parentAllowance = repDeposit / 4n
+			await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, parentAllowance)
+
+			await createCompleteSet(client, securityPoolAddresses.securityPool, 10n * 10n ** 18n)
+			await triggerExternalForkForSecurityPool(undefined, 'orphan-collateral child mint fork source')
+			await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
+			await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
+
+			const yesUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
+			const yesSecurityPool = getSecurityPoolAddresses(securityPoolAddresses.securityPool, yesUniverse, questionId, securityMultiplier)
+			await mockWindow.advanceTime(8n * 7n * DAY + DAY)
+			await startTruthAuction(client, yesSecurityPool.securityPool)
+			if ((await getSystemState(client, yesSecurityPool.securityPool)) === SystemState.ForkTruthAuction) {
+				await mockWindow.advanceTime(7n * DAY + DAY)
+				await finalizeTruthAuction(client, yesSecurityPool.securityPool)
+			}
+
+			strictEqualTypeSafe(await getSystemState(client, yesSecurityPool.securityPool), SystemState.Operational, 'child pool should be operational after fork accounting settles')
+			assert.ok((await getCompleteSetCollateralAmount(client, yesSecurityPool.securityPool)) > 0n, 'test setup requires collateral without migrated shares')
+			strictEqualTypeSafe(await getShareTokenSupply(client, yesSecurityPool.securityPool), 0n, 'zero migrated outcome supplies should reconcile to zero')
+
+			const newMinter = createWriteClient(mockWindow, TEST_ADDRESSES[4], 0)
+			const collateralBeforeFailedMint = await getCompleteSetCollateralAmount(client, yesSecurityPool.securityPool)
+			await assert.rejects(createCompleteSet(newMinter, yesSecurityPool.securityPool, 1n * 10n ** 18n), /Exchange rate undefined/)
+			strictEqualTypeSafe(await getCompleteSetCollateralAmount(client, yesSecurityPool.securityPool), collateralBeforeFailedMint, 'rejected mint should preserve orphan collateral')
+			strictEqualTypeSafe(await getShareTokenSupply(client, yesSecurityPool.securityPool), 0n, 'rejected mint should preserve zero reconciled supply')
 		})
 
 		test('child pool blocks complete-set minting when migrated shares have no collateral', async () => {


### PR DESCRIPTION
## Summary
- Reconciles forked child pools against migrated share supplies before allowing complete-set minting and burning.
- Updates fork migration accounting to lock any leftover REP actually held by the proxy, instead of assuming a fixed threshold amount.
- Adds `reconciledCompleteSetSupply` to share tokens and uses it when initializing child pool share supply after fork truth auction.
- Expands fork migration tests to cover balanced reconciliation, uneven migrated share supplies, and orphan collateral cases.

## Testing
- Not run (PR content generation only).
- Existing test coverage was updated in `solidity/ts/tests/peripherals/forkMigration.test.ts` for the new reconciliation behavior.