### PR TITLE
Harden Anvil receipt waits and fork startup diagnostics

### DIFF
--- a/solidity/ts/testSupport/simulator/AnvilWindowEthereum.ts
+++ b/solidity/ts/testSupport/simulator/AnvilWindowEthereum.ts
@@ -77,8 +77,9 @@ const formatRpcDiagnosticValue = (value: unknown): string => {
 	if (typeof value === 'string') return value
 	try {
 		return JSON.stringify(value) ?? String(value)
-	} catch {
-		return String(value)
+	} catch (error) {
+		const errorMessage = error instanceof Error ? error.message : String(error)
+		return `${String(value)} (JSON serialization failed: ${errorMessage})`
 	}
 }
 

--- a/solidity/ts/testSupport/simulator/AnvilWindowEthereum.ts
+++ b/solidity/ts/testSupport/simulator/AnvilWindowEthereum.ts
@@ -57,8 +57,9 @@ const DEFAULT_ANVIL_TRANSACTION_GAS = '0x1c9c380'
 // CI can keep Anvil receipts pending well past a minute when multiple shards
 // are driving simulator-backed transactions concurrently.
 const SEND_TRANSACTION_RECEIPT_TIMEOUT_MS = 180_000
-const SEND_TRANSACTION_RECEIPT_POLL_INTERVAL_MS = 10
+const SEND_TRANSACTION_RECEIPT_POLL_INTERVAL_MS = 100
 const SEND_TRANSACTION_RECEIPT_MINE_INTERVAL_MS = 1_000
+const RECEIPT_DIAGNOSTIC_RPC_TIMEOUT_MS = 1_000
 
 const isObjectRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
 
@@ -69,6 +70,15 @@ const parseTransactionReceipt = (value: unknown): RpcTransactionReceipt | undefi
 		...(typeof typed['status'] === 'string' ? { status: typed['status'] } : {}),
 		...(typeof typed['to'] === 'string' ? { to: typed['to'] } : {}),
 		...(typeof typed['contractAddress'] === 'string' ? { contractAddress: typed['contractAddress'] } : {}),
+	}
+}
+
+const formatRpcDiagnosticValue = (value: unknown): string => {
+	if (typeof value === 'string') return value
+	try {
+		return JSON.stringify(value) ?? String(value)
+	} catch {
+		return String(value)
 	}
 }
 
@@ -119,6 +129,26 @@ function parseJsonRpcResponse(raw: unknown): JsonRpcSuccess {
 	if ('error' in raw && raw.error !== undefined && !isJsonRpcError(raw.error)) throw new Error('Invalid JSON-RPC response: malformed error object')
 
 	return raw
+}
+
+const fetchJsonRpcResponse = async ({ body, method, rpcUrl, timeoutMs }: { body: string; method: string; rpcUrl: string; timeoutMs?: number }): Promise<unknown> => {
+	const controller = timeoutMs === undefined ? undefined : new AbortController()
+	const timeoutId = controller === undefined || timeoutMs === undefined ? undefined : setTimeout(() => controller.abort(), timeoutMs)
+	try {
+		const response = await fetch(rpcUrl, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body,
+			...(controller === undefined ? {} : { signal: controller.signal }),
+		})
+		if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+		return await response.json()
+	} catch (error) {
+		if (controller?.signal.aborted === true && timeoutMs !== undefined) throw new Error(`Anvil RPC ${method} did not respond within ${timeoutMs.toString()}ms`)
+		throw error
+	} finally {
+		if (timeoutId !== undefined) clearTimeout(timeoutId)
+	}
 }
 
 function parseSnapshotId(value: unknown) {
@@ -195,7 +225,7 @@ export const getMockedEthSimulateWindowEthereum = async (rpcUrl?: string): Promi
 
 	// Make JSON-RPC request to Anvil
 	let requestId = 0
-	const request = async (args: { method: string; params?: unknown[] | unknown | undefined; skipCoverage?: boolean }): Promise<unknown> => {
+	const request = async (args: { method: string; params?: unknown[] | unknown | undefined; skipCoverage?: boolean; rpcTimeoutMs?: number }): Promise<unknown> => {
 		const isSendTransactionMethod = args.method === 'eth_sendTransaction' || args.method === 'wallet_sendTransaction' || args.method === 'eth_sendRawTransaction'
 		const params = isSendTransactionMethod ? normalizeAnvilTransactionParams(ensureArray(args.params)) : ensureArray(args.params)
 		const ethCallCoverageRequest = args.skipCoverage || args.method !== 'eth_call' ? undefined : parseEthCallCoverageRequest(params)
@@ -213,9 +243,10 @@ export const getMockedEthSimulateWindowEthereum = async (rpcUrl?: string): Promi
 			})
 		}
 
-		const response = await fetch(ANVIL_RPC, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
+		const raw = await fetchJsonRpcResponse({
+			rpcUrl: ANVIL_RPC,
+			method: args.method,
+			...(args.rpcTimeoutMs === undefined ? {} : { timeoutMs: args.rpcTimeoutMs }),
 			body: JSON.stringify({
 				jsonrpc: '2.0',
 				id: requestId++,
@@ -223,8 +254,6 @@ export const getMockedEthSimulateWindowEthereum = async (rpcUrl?: string): Promi
 				params,
 			}),
 		})
-		if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`)
-		const raw = await response.json()
 		const json = parseJsonRpcResponse(raw)
 
 		// Validate JSON-RPC response structure
@@ -279,6 +308,39 @@ export const getMockedEthSimulateWindowEthereum = async (rpcUrl?: string): Promi
 			}
 			return undefined
 		}
+		const getReceiptWaitDiagnostics = async (hash: string): Promise<string> => {
+			const transactionDiagnostic = (async (): Promise<string> => {
+				try {
+					const transaction = await request({
+						method: 'eth_getTransactionByHash',
+						params: [hash],
+						rpcTimeoutMs: RECEIPT_DIAGNOSTIC_RPC_TIMEOUT_MS,
+					})
+					if (transaction === null) return 'transaction not found'
+					if (isObjectRecord(transaction) && transaction['blockNumber'] === null) return 'transaction still pending'
+					return `transaction lookup ${formatRpcDiagnosticValue(transaction)}`
+				} catch (error) {
+					return `transaction lookup failed: ${error instanceof Error ? error.message : String(error)}`
+				}
+			})()
+			const latestBlockDiagnostic = (async (): Promise<string> => {
+				try {
+					const latestBlockNumber = await request({ method: 'eth_blockNumber', params: [], rpcTimeoutMs: RECEIPT_DIAGNOSTIC_RPC_TIMEOUT_MS })
+					return `latest block ${formatRpcDiagnosticValue(latestBlockNumber)}`
+				} catch (error) {
+					return `latest block lookup failed: ${error instanceof Error ? error.message : String(error)}`
+				}
+			})()
+			const transactionPoolDiagnostic = (async (): Promise<string> => {
+				try {
+					const transactionPoolStatus = await request({ method: 'txpool_status', params: [], rpcTimeoutMs: RECEIPT_DIAGNOSTIC_RPC_TIMEOUT_MS })
+					return `transaction pool ${formatRpcDiagnosticValue(transactionPoolStatus)}`
+				} catch (error) {
+					return `transaction pool lookup failed: ${error instanceof Error ? error.message : String(error)}`
+				}
+			})()
+			return (await Promise.all([transactionDiagnostic, latestBlockDiagnostic, transactionPoolDiagnostic])).join('; ')
+		}
 
 		// For eth_getTransactionReceipt, return the receipt even if status === '0x0' (reverted)
 		// Callers can check the status field themselves
@@ -291,7 +353,10 @@ export const getMockedEthSimulateWindowEthereum = async (rpcUrl?: string): Promi
 		}
 		if (isSendTransactionMethod && params[0] !== undefined && typeof json.result === 'string') {
 			const receiptResult = await waitForReceiptStatus(json.result)
-			if (receiptResult === undefined) throw new Error(`Anvil did not return a receipt for sent transaction ${json.result} within ${SEND_TRANSACTION_RECEIPT_TIMEOUT_MS.toString()}ms.`)
+			if (receiptResult === undefined) {
+				const diagnostics = await getReceiptWaitDiagnostics(json.result)
+				throw new Error(`Anvil did not return a receipt for sent transaction ${json.result} within ${SEND_TRANSACTION_RECEIPT_TIMEOUT_MS.toString()}ms. Diagnostics: ${diagnostics}.`)
+			}
 			const parsedReceipt = parseTransactionReceipt(receiptResult.receipt)
 			const transaction = isRpcTransactionRequest(params[0]) ? params[0] : undefined
 			let transactionData = transaction !== undefined && typeof transaction.data === 'string' ? transaction.data : undefined

--- a/solidity/ts/testSupport/simulator/anvilNode.ts
+++ b/solidity/ts/testSupport/simulator/anvilNode.ts
@@ -1,13 +1,14 @@
 import { spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
-import { createServer } from 'node:net'
-import type { AddressInfo } from 'node:net'
 import { setTimeout as sleep } from 'node:timers/promises'
 import type { AnvilWindowEthereum } from './AnvilWindowEthereum'
 import { getDefaultAnvilRpcUrl, getMockedEthSimulateWindowEthereum, validateLocalAnvilRpcUrl } from './AnvilWindowEthereum'
 
 const DEFAULT_ANVIL_HOST = '127.0.0.1'
+const OS_ASSIGNED_PORT = 0
 const ANVIL_MAX_PERSISTED_STATES = '0'
+const ANVIL_THREADS = '1'
+const ANVIL_OUTPUT_TAIL_LENGTH = 16_384
 const RPC_READY_TIMEOUT_MS = 30_000
 const RPC_PROBE_TIMEOUT_MS = 3_000
 const SHUTDOWN_TIMEOUT_MS = 15_000
@@ -24,30 +25,18 @@ export type AnvilNode = {
 
 const getErrorMessage = (error: unknown): string => (error instanceof Error ? error.message : String(error))
 
-function getAddressPort(address: string | AddressInfo | undefined) {
-	if (address === undefined || typeof address === 'string') throw new Error('Failed to resolve TCP port for Anvil')
-	return address.port
+const appendOutputTail = (current: string, chunk: unknown): string => `${current}${String(chunk)}`.slice(-ANVIL_OUTPUT_TAIL_LENGTH)
+
+export const parseAnvilListeningRpcUrl = (output: string): string | undefined => {
+	const match = /Listening on 127\.0\.0\.1:([1-9][0-9]*)/.exec(output)
+	const port = match?.[1]
+	return port === undefined ? undefined : `http://${DEFAULT_ANVIL_HOST}:${port}`
 }
 
-const getFreePort = async (): Promise<number> =>
-	await new Promise((resolve, reject) => {
-		const server = createServer()
-		server.listen(0, DEFAULT_ANVIL_HOST, () => {
-			const address = server.address() ?? undefined
-			if (address === undefined) {
-				server.close(() => reject(new Error('Failed to allocate a free TCP port for Anvil')))
-				return
-			}
-			server.close(error => {
-				if (error !== undefined) {
-					reject(error)
-					return
-				}
-				resolve(getAddressPort(address))
-			})
-		})
-		server.on('error', reject)
-	})
+const getAnvilProcessFailureMessage = (child: AnvilProcess): string => {
+	const status = child.exitCode === null ? `signal ${child.signalCode ?? 'unknown'}` : `exit code ${child.exitCode.toString()}`
+	return `Anvil stopped before it became ready (${status}).`
+}
 
 const resolveAnvilBinary = (): string => {
 	const explicitAnvilBin = process.env['ANVIL_BIN']?.trim()
@@ -190,22 +179,34 @@ export const connectToExistingAnvilNode = async (rpcUrl: string, context: string
 	}
 }
 
-export const getIsolatedAnvilArgs = ({ port, printTraces = false }: { port: number; printTraces?: boolean }): string[] => {
-	const anvilArgs = ['--host', DEFAULT_ANVIL_HOST, '--port', `${port}`, '--chain-id', '1', '--timestamp', '1', '--block-base-fee-per-gas', '0', '--gas-price', '0', '--no-priority-fee', '--max-persisted-states', ANVIL_MAX_PERSISTED_STATES]
+export const getIsolatedAnvilArgs = ({ printTraces = false }: { printTraces?: boolean } = {}): string[] => {
+	const anvilArgs = ['--host', DEFAULT_ANVIL_HOST, '--port', OS_ASSIGNED_PORT.toString(), '--threads', ANVIL_THREADS, '--chain-id', '1', '--timestamp', '1', '--block-base-fee-per-gas', '0', '--gas-price', '0', '--no-priority-fee', '--max-persisted-states', ANVIL_MAX_PERSISTED_STATES]
 	if (printTraces) anvilArgs.push('--print-traces')
 	return anvilArgs
 }
 
 const createIsolatedAnvilNode = async ({ context, printTraces = false, startTimestamp }: { context: string; printTraces?: boolean; startTimestamp?: bigint }): Promise<AnvilNode> => {
-	const port = await getFreePort()
-	const rpcUrl = `http://${DEFAULT_ANVIL_HOST}:${port}`
-	const anvilArgs = getIsolatedAnvilArgs({ port, printTraces })
+	const anvilArgs = getIsolatedAnvilArgs({ printTraces })
 
 	const childProcess = spawn(DEFAULT_ANVIL_BIN, anvilArgs, {
 		windowsHide: true,
-		stdio: ['ignore', 'ignore', 'pipe'],
+		stdio: ['ignore', 'pipe', 'pipe'],
 	})
-	const spawnErrorPromise = new Promise<never>((_, reject) => {
+	let stderr = ''
+	let stdout = ''
+	if (childProcess.stderr === null || childProcess.stdout === null) {
+		terminateProcess(childProcess)
+		await waitForExit(childProcess)
+		throw new Error(`Failed to start isolated Anvil node for ${context}: Anvil output pipes are unavailable`)
+	}
+	childProcess.stderr.on('data', chunk => {
+		stderr = appendOutputTail(stderr, chunk)
+	})
+	childProcess.stdout.on('data', chunk => {
+		stdout = appendOutputTail(stdout, chunk)
+	})
+
+	const processFailurePromise = new Promise<never>((_, reject) => {
 		childProcess.once('error', error => {
 			if (getErrorCode(error) === 'ENOENT') {
 				reject(new Error(`Failed to start isolated Anvil node: could not find Anvil executable '${DEFAULT_ANVIL_BIN}'. On Windows, Foundry usually installs to %USERPROFILE%\\.foundry\\bin\\anvil.exe. Set ANVIL_BIN to the full path if Anvil is not on PATH.`))
@@ -213,20 +214,23 @@ const createIsolatedAnvilNode = async ({ context, printTraces = false, startTime
 			}
 			reject(error)
 		})
+		childProcess.once('exit', () => reject(new Error(getAnvilProcessFailureMessage(childProcess))))
 	})
-
-	let stderr = ''
-	if (childProcess.stderr === null) {
-		terminateProcess(childProcess)
-		await waitForExit(childProcess)
-		throw new Error(`Failed to start isolated Anvil node for ${context}: Anvil stderr pipe is unavailable`)
-	}
-	childProcess.stderr.on('data', chunk => {
-		stderr += chunk.toString()
+	const listeningRpcUrlPromise = new Promise<string>((resolve, reject) => {
+		const timeoutId = setTimeout(() => reject(new Error('Timed out waiting for Anvil to report its listening address.')), RPC_READY_TIMEOUT_MS)
+		childProcess.once('error', () => clearTimeout(timeoutId))
+		childProcess.once('exit', () => clearTimeout(timeoutId))
+		childProcess.stdout?.on('data', () => {
+			const rpcUrl = parseAnvilListeningRpcUrl(stdout)
+			if (rpcUrl === undefined) return
+			clearTimeout(timeoutId)
+			resolve(rpcUrl)
+		})
 	})
 
 	try {
-		await Promise.race([waitForRpcReady(rpcUrl), spawnErrorPromise])
+		const rpcUrl = await Promise.race([listeningRpcUrlPromise, processFailurePromise])
+		await Promise.race([waitForRpcReady(rpcUrl), processFailurePromise])
 		const anvilWindowEthereum = await getMockedEthSimulateWindowEthereum(rpcUrl)
 		if (startTimestamp !== undefined) await anvilWindowEthereum.setTime(startTimestamp)
 		await anvilWindowEthereum.setNextBlockBaseFeePerGasToZero()
@@ -245,7 +249,8 @@ const createIsolatedAnvilNode = async ({ context, printTraces = false, startTime
 		terminateProcess(childProcess)
 		await waitForExit(childProcess)
 		const stderrMessage = stderr.trim() === '' ? '' : `\nAnvil stderr:\n${stderr.trim()}`
-		throw new Error(`Failed to start isolated Anvil node for ${context}: ${getErrorMessage(error)}${stderrMessage}`)
+		const stdoutMessage = stdout.trim() === '' ? '' : `\nAnvil stdout:\n${stdout.trim()}`
+		throw new Error(`Failed to start isolated Anvil node for ${context}: ${getErrorMessage(error)}${stderrMessage}${stdoutMessage}`)
 	}
 }
 

--- a/solidity/ts/tests/anvilWindowEthereum.test.ts
+++ b/solidity/ts/tests/anvilWindowEthereum.test.ts
@@ -169,6 +169,9 @@ test('send transaction throws a targeted error when Anvil never returns a receip
 		if (request.method === 'eth_getBlockByNumber') return createJsonRpcResponse(request, { result: { timestamp: '0x0' } })
 		if (request.method === 'eth_sendTransaction') return createJsonRpcResponse(request, { result: transactionHash })
 		if (request.method === 'eth_getTransactionReceipt') return createJsonRpcResponse(request, { result: null })
+		if (request.method === 'eth_getTransactionByHash') return createJsonRpcResponse(request, { result: null })
+		if (request.method === 'eth_blockNumber') return createJsonRpcResponse(request, { result: '0x7' })
+		if (request.method === 'txpool_status') return createJsonRpcResponse(request, { result: { pending: '0x0', queued: '0x0' } })
 		throw new Error(`Unexpected JSON-RPC method: ${request.method}`)
 	})
 	globalThis.fetch = mockedFetch
@@ -187,7 +190,68 @@ test('send transaction throws a targeted error when Anvil never returns a receip
 					},
 				],
 			}),
-		).rejects.toThrow(`Anvil did not return a receipt for sent transaction ${transactionHash} within 180000ms.`)
+		).rejects.toThrow(`Anvil did not return a receipt for sent transaction ${transactionHash} within 180000ms. Diagnostics: transaction not found; latest block 0x7; transaction pool {"pending":"0x0","queued":"0x0"}.`)
+	} finally {
+		Date.now = originalDateNow
+	}
+})
+
+test('send transaction preserves the receipt timeout when diagnostic RPC calls stop responding', async () => {
+	delete process.env['SOLIDITY_BYTECODE_COVERAGE']
+	const originalDateNow = Date.now
+	const clockValues = [0, 1, 180_001, 180_002]
+	const transactionHash = `0x${'56'.repeat(32)}`
+	const diagnosticMethods = new Set(['eth_getTransactionByHash', 'eth_blockNumber', 'txpool_status'])
+
+	const mockedFetch = createMockedFetch(async (_input: URL | RequestInfo, init?: RequestInit | BunFetchRequestInit) => {
+		if (typeof init?.body !== 'string') throw new Error('Expected a JSON-RPC string body')
+		const request = JSON.parse(init.body) as JsonRpcRequest
+
+		if (request.method === 'anvil_reset' || request.method === 'anvil_setNextBlockBaseFeePerGas' || request.method === 'evm_setNextBlockTimestamp' || request.method === 'evm_mine') return createJsonRpcResponse(request, { result: '0x1' })
+		if (request.method === 'eth_getBlockByNumber') return createJsonRpcResponse(request, { result: { timestamp: '0x0' } })
+		if (request.method === 'eth_sendTransaction') return createJsonRpcResponse(request, { result: transactionHash })
+		if (request.method === 'eth_getTransactionReceipt') return createJsonRpcResponse(request, { result: null })
+		if (diagnosticMethods.has(request.method)) {
+			const signal = init.signal
+			if (signal === undefined || signal === null) throw new Error(`Expected ${request.method} to use an abort signal`)
+			return await new Promise<Response>((_resolve, reject) => {
+				const rejectAsAborted = () => reject(new Error('mocked diagnostic RPC aborted'))
+				if (signal.aborted) {
+					rejectAsAborted()
+					return
+				}
+				signal.addEventListener('abort', rejectAsAborted, { once: true })
+			})
+		}
+		throw new Error(`Unexpected JSON-RPC method: ${request.method}`)
+	})
+	globalThis.fetch = mockedFetch
+
+	Date.now = () => clockValues.shift() ?? 180_002
+	try {
+		const anvilWindow = await getMockedEthSimulateWindowEthereum()
+		const diagnosticStart = performance.now()
+		let caughtError: unknown
+		try {
+			await anvilWindow.request({
+				method: 'eth_sendTransaction',
+				params: [
+					{
+						data: '0xabcd',
+						from: '0x0000000000000000000000000000000000000001',
+						to: '0x0000000000000000000000000000000000000002',
+					},
+				],
+			})
+		} catch (error) {
+			caughtError = error
+		}
+		if (!(caughtError instanceof Error)) throw new Error('Expected the transaction request to fail')
+		expect(caughtError.message).toContain(`Anvil did not return a receipt for sent transaction ${transactionHash} within 180000ms.`)
+		expect(caughtError.message).toContain('transaction lookup failed: Anvil RPC eth_getTransactionByHash did not respond within 1000ms')
+		expect(caughtError.message).toContain('latest block lookup failed: Anvil RPC eth_blockNumber did not respond within 1000ms')
+		expect(caughtError.message).toContain('transaction pool lookup failed: Anvil RPC txpool_status did not respond within 1000ms')
+		expect(performance.now() - diagnosticStart).toBeLessThan(2_000)
 	} finally {
 		Date.now = originalDateNow
 	}

--- a/solidity/ts/tests/useIsolatedAnvilNode.test.ts
+++ b/solidity/ts/tests/useIsolatedAnvilNode.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test'
-import { connectToExistingAnvilNode, getAnvilConnectionMode, getGasCostsAnvilConnectionMode, getIsolatedAnvilArgs } from '../testSupport/simulator/anvilNode'
+import { connectToExistingAnvilNode, getAnvilConnectionMode, getGasCostsAnvilConnectionMode, getIsolatedAnvilArgs, parseAnvilListeningRpcUrl } from '../testSupport/simulator/anvilNode'
 
 test('getAnvilConnectionMode uses the platform default when ANVIL_RPC is not set', () => {
 	const originalAnvilRpc = process.env['ANVIL_RPC']
@@ -82,11 +82,16 @@ test('getGasCostsAnvilConnectionMode uses ANVIL_RPC when provided', () => {
 	}
 })
 
-test('isolated Anvil nodes disable persisted state snapshots', () => {
-	const expectedBaseArgs = ['--host', '127.0.0.1', '--port', '12345', '--chain-id', '1', '--timestamp', '1', '--block-base-fee-per-gas', '0', '--gas-price', '0', '--no-priority-fee', '--max-persisted-states', '0']
+test('isolated Anvil nodes atomically select a port and limit their runtime threads', () => {
+	const expectedBaseArgs = ['--host', '127.0.0.1', '--port', '0', '--threads', '1', '--chain-id', '1', '--timestamp', '1', '--block-base-fee-per-gas', '0', '--gas-price', '0', '--no-priority-fee', '--max-persisted-states', '0']
 
-	expect(getIsolatedAnvilArgs({ port: 12345 })).toEqual(expectedBaseArgs)
-	expect(getIsolatedAnvilArgs({ port: 12345, printTraces: true })).toEqual([...expectedBaseArgs, '--print-traces'])
+	expect(getIsolatedAnvilArgs()).toEqual(expectedBaseArgs)
+	expect(getIsolatedAnvilArgs({ printTraces: true })).toEqual([...expectedBaseArgs, '--print-traces'])
+})
+
+test('isolated Anvil startup reads the OS-assigned listening port', () => {
+	expect(parseAnvilListeningRpcUrl('Available Accounts\nListening on 127.0.0.1:43127\n')).toBe('http://127.0.0.1:43127')
+	expect(parseAnvilListeningRpcUrl('Listening on 127.0.0.1:')).toBeUndefined()
 })
 
 test('connectToExistingAnvilNode reports an actionable setup message when RPC validation fails', async () => {


### PR DESCRIPTION
## Summary
- Hardened simulator receipt polling to wait longer and surface targeted diagnostics when Anvil never returns a receipt.
- Switched isolated Anvil startup to listen on an OS-assigned port and parse the actual listening URL from process output, with stdout and stderr included in failure reports.
- Simplified fork and share-token accounting by removing unused reconciliation paths and updating migration handling to lock any leftover REP held by the proxy.
- Updated simulator and fork-migration tests to cover receipt timeout diagnostics and the new settled-share minting flow.

## Testing
- Not run (PR content only).