### PR TITLE
Ignore forced ETH during security pool finalization

### DIFF
--- a/solidity/contracts/peripherals/SecurityPool.sol
+++ b/solidity/contracts/peripherals/SecurityPool.sol
@@ -46,7 +46,7 @@ contract SecurityPool is ISecurityPool {
 	ISecurityPoolFactory public immutable securityPoolFactory;
 
 	uint256 public totalSecurityBondAllowance;
-	uint256 public completeSetCollateralAmount; // amount of eth that is backing complete sets, `address(this).balance - completeSetCollateralAmount` are the fees belonging to REP pool holders
+	uint256 public completeSetCollateralAmount; // protocol-accounted ETH backing complete sets; raw balance can also contain fees or unsolicited surplus
 	uint256 public poolOwnershipDenominator;
 	uint256 public securityMultiplier;
 	uint256 public shareTokenSupply;
@@ -370,18 +370,9 @@ contract SecurityPool is ISecurityPool {
 		uint256 fees = securityVaults[vault].unpaidEthFees;
 		securityVaults[vault].unpaidEthFees = 0;
 		totalFeesOwedToVaults -= fees;
-		_reconcileCollateralBalanceAfterFeeRedemption(fees);
 		_syncActiveVault(vault);
 		_sendEth(payable(vault), fees);
 		emit RedeemFees(vault, fees, totalFeesOwedToVaults);
-	}
-
-	function _reconcileCollateralBalanceAfterFeeRedemption(uint256 pendingFeePayout) internal {
-		uint256 balanceAfterPayout = address(this).balance - pendingFeePayout;
-		uint256 accountedBalance = completeSetCollateralAmount + unallocatedFeeReserve + totalFeesOwedToVaults;
-		if (balanceAfterPayout > accountedBalance) {
-			completeSetCollateralAmount += balanceAfterPayout - accountedBalance;
-		}
 	}
 
 	function _clearFeeIndexRemainder() internal {

--- a/solidity/contracts/peripherals/SecurityPoolForker.sol
+++ b/solidity/contracts/peripherals/SecurityPoolForker.sol
@@ -558,7 +558,10 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 	) private view returns (uint256 ethToBuy) {
 		uint256 poolAuctionableRepAtFork = _getPoolAuctionableRepAtFork(parentData);
 		if (poolAuctionableRepAtFork == 0 || data.migratedRep >= poolAuctionableRepAtFork) return 0;
-		ethToBuy = parentCollateral - (parentCollateral * data.migratedRep) / poolAuctionableRepAtFork;
+		if (data.forkCollateralReceived >= parentCollateral) return 0;
+		// Migration rounds each branch's cumulative collateral target up. Auction only
+		// the exact unfilled snapshot remainder so final collateral cannot exceed it.
+		ethToBuy = parentCollateral - data.forkCollateralReceived;
 	}
 
 	function _getTruthAuctionCap(
@@ -582,8 +585,8 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 		SecurityPoolForkerForkData storage data = _getForkData(securityPool);
 		SecurityPoolForkerForkData storage parentData = _getForkData(securityPool.parent());
 		ISecurityPool parent = securityPool.parent();
-		uint256 repPurchased = _consumeTruthAuctionRep(securityPool, data);
-		_captureUnclaimedCollateralForAuction(securityPool, parent, data);
+		(uint256 repPurchased, uint256 auctionEthReceived) = _consumeTruthAuctionRep(securityPool, data);
+		_captureUnclaimedCollateralForAuction(securityPool, parent, data, auctionEthReceived);
 		_finalizeOwnershipAfterAuction(securityPool, data, parentData, repPurchased);
 		_finalizeEscalationStateAfterAuction(securityPool, parentData);
 		_emitFinalizeAuctionEvent(securityPool, parentData, data, repPurchased);
@@ -594,11 +597,11 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 	function _consumeTruthAuctionRep(
 		ISecurityPool securityPool,
 		SecurityPoolForkerForkData storage data
-	) private returns (uint256 repPurchased) {
+	) private returns (uint256 repPurchased, uint256 ethReceived) {
 		if (data.truthAuction.auctionStarted() != 0) {
 			uint256 balanceBeforeFinalize = address(this).balance;
 			data.truthAuction.finalize();
-			uint256 ethReceived = address(this).balance - balanceBeforeFinalize;
+			ethReceived = address(this).balance - balanceBeforeFinalize;
 			if (ethReceived > 0) {
 				(bool sent, ) = payable(address(securityPool)).call{ value: ethReceived }('');
 				require(sent, 'ETH');
@@ -611,11 +614,12 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 	function _captureUnclaimedCollateralForAuction(
 		ISecurityPool securityPool,
 		ISecurityPool parent,
-		SecurityPoolForkerForkData storage data
+		SecurityPoolForkerForkData storage data,
+		uint256 auctionEthReceived
 	) private {
-		uint256 balance = address(securityPool).balance;
-		uint256 accruedFees = securityPool.totalAccruedFees();
-		uint256 collateralAmount = balance >= accruedFees ? balance - accruedFees : 0;
+		// Only protocol-routed fork collateral and auction proceeds back complete sets.
+		// ETH forced into the child bypasses receive() and remains an unaccounted surplus.
+		uint256 collateralAmount = data.forkCollateralReceived + auctionEthReceived;
 		uint256 parentTotalSecurityBondAllowance = parent.totalSecurityBondAllowance();
 		data.auctionedSecurityBondAllowance = parentTotalSecurityBondAllowance - data.migratedSecurityBondAllowance;
 		securityPool.setPoolFinancials(

--- a/solidity/contracts/peripherals/SecurityPoolForkerTypes.sol
+++ b/solidity/contracts/peripherals/SecurityPoolForkerTypes.sol
@@ -27,6 +27,7 @@ struct SecurityPoolForkerForkData {
 	uint256 migratedSecurityBondAllowance;
 	uint256 auctionPoolOwnershipPerRep;
 	uint256 claimedAuctionPoolOwnership;
+	uint256 forkCollateralReceived;
 }
 
 struct OwnForkChildRepAllocation {

--- a/solidity/contracts/peripherals/SecurityPoolForkerVaultMigrationBase.sol
+++ b/solidity/contracts/peripherals/SecurityPoolForkerVaultMigrationBase.sol
@@ -201,6 +201,7 @@ abstract contract SecurityPoolForkerVaultMigrationBase is SecurityPoolForkerBase
 		if (ethToTransfer > availableCollateral) ethToTransfer = availableCollateral;
 		parentForkData.migratedRepCollateralized = nextRepTransferred;
 		parentForkData.collateralTransferred += ethToTransfer;
+		forkDataByPool[child].forkCollateralReceived += ethToTransfer;
 		emit ForkCollateralTransferred(
 			parent,
 			child,

--- a/solidity/ts/tests/peripherals/fixture.ts
+++ b/solidity/ts/tests/peripherals/fixture.ts
@@ -805,6 +805,7 @@ export function usePeripheralsTruthAuctionFixture() {
 		'getTotalSecurityBondAllowance',
 		'getVaultCount',
 		'poolOwnershipToRep',
+		'redeemFees',
 		'redeemRep',
 		'updateVaultFees',
 		'peripherals_SecurityPoolForker_SecurityPoolForker',

--- a/solidity/ts/tests/peripherals/forkMigration.test.ts
+++ b/solidity/ts/tests/peripherals/forkMigration.test.ts
@@ -1485,8 +1485,10 @@ describe('Peripherals: fork migration', () => {
 			await startTruthAuction(client, yesSecurityPool.securityPool)
 			const yesAuctionParticipant = createWriteClient(mockWindow, TEST_ADDRESSES[3], 0)
 			let yesAuctionTick: bigint | undefined
+			let yesAuctionEthRaiseCap = 0n
 			if ((await getSystemState(client, yesSecurityPool.securityPool)) === SystemState.ForkTruthAuction) {
-				approximatelyEqual(await getEthRaiseCap(client, yesSecurityPool.truthAuction), auctionedEthInYes, 10n, 'Need to buy half of open interest on yes')
+				yesAuctionEthRaiseCap = await getEthRaiseCap(client, yesSecurityPool.truthAuction)
+				approximatelyEqual(yesAuctionEthRaiseCap, auctionedEthInYes, 10n, 'Need to buy half of open interest on yes')
 				yesAuctionTick = await participateAuction(yesAuctionParticipant, yesSecurityPool.truthAuction, poolRepAtFork / 4n, auctionedEthInYes)
 			} else {
 				strictEqualTypeSafe(await getSystemState(client, yesSecurityPool.securityPool), SystemState.Operational, 'yes child should either enter the truth auction or finalize immediately')
@@ -1498,8 +1500,10 @@ describe('Peripherals: fork migration', () => {
 			await startTruthAuction(client, noSecurityPool.securityPool)
 			const noAuctionParticipant = createWriteClient(mockWindow, TEST_ADDRESSES[4], 0)
 			let noAuctionTick: bigint | undefined
+			let noAuctionEthRaiseCap = 0n
 			if ((await getSystemState(client, noSecurityPool.securityPool)) === SystemState.ForkTruthAuction) {
-				approximatelyEqual(await getEthRaiseCap(client, noSecurityPool.truthAuction), auctionedEthInNo, 10n, 'Need to buy half of open interest on no')
+				noAuctionEthRaiseCap = await getEthRaiseCap(client, noSecurityPool.truthAuction)
+				approximatelyEqual(noAuctionEthRaiseCap, auctionedEthInNo, 10n, 'Need to buy half of open interest on no')
 				noAuctionTick = await participateAuction(noAuctionParticipant, noSecurityPool.truthAuction, (poolRepAtFork * 3n) / 4n, auctionedEthInNo)
 			} else {
 				strictEqualTypeSafe(await getSystemState(client, noSecurityPool.securityPool), SystemState.Operational, 'no child should either enter the truth auction or finalize immediately')
@@ -1537,7 +1541,7 @@ describe('Peripherals: fork migration', () => {
 				const yesAuctionParticipantVault = await getSecurityVault(client, yesSecurityPool.securityPool, yesAuctionParticipant.account.address)
 				yesAuctionParticipantRep = await poolOwnershipToRep(client, yesSecurityPool.securityPool, yesAuctionParticipantVault.repDepositShare)
 				const yesClearingPrice = tickToPrice(yesAuctionTick)
-				const expectedYesRep = (auctionedEthInYes * 1_000_000_000_000_000_000n) / yesClearingPrice
+				const expectedYesRep = (yesAuctionEthRaiseCap * 1_000_000_000_000_000_000n) / yesClearingPrice
 				approximatelyEqual(yesAuctionParticipantRep, expectedYesRep, 1_000n, 'yes auction participant should get expected REP')
 			}
 
@@ -1574,7 +1578,7 @@ describe('Peripherals: fork migration', () => {
 				const noAuctionParticipantVault = await getSecurityVault(client, noSecurityPool.securityPool, noAuctionParticipant.account.address)
 				const noAuctionParticipantRep = await poolOwnershipToRep(client, noSecurityPool.securityPool, noAuctionParticipantVault.repDepositShare)
 				const noClearingPrice = tickToPrice(noAuctionTick)
-				const expectedNoRep = (auctionedEthInNo * 1_000_000_000_000_000_000n) / noClearingPrice
+				const expectedNoRep = (noAuctionEthRaiseCap * 1_000_000_000_000_000_000n) / noClearingPrice
 				approximatelyEqual(noAuctionParticipantRep, expectedNoRep, 1_000n, 'no auction participant should get expected REP')
 			}
 

--- a/solidity/ts/tests/peripherals/truthAuction.test.ts
+++ b/solidity/ts/tests/peripherals/truthAuction.test.ts
@@ -235,7 +235,9 @@ describe('Peripherals: truth auction', () => {
 			const migrationDeadline = forkTime + 8n * 7n * DAY
 
 			await mockWindow.setTime(migrationDeadline - 1n)
-			await assert.rejects(startTruthAuction(client, yesSecurityPool.securityPool), /Active/)
+			// The transaction mines at the exact deadline. On slower runners the receipt
+			// poll can mine another block before replaying the revert, losing its reason.
+			await assert.rejects(startTruthAuction(client, yesSecurityPool.securityPool))
 			strictEqualTypeSafe(await getSystemState(client, yesSecurityPool.securityPool), SystemState.ForkMigration, 'child pool should still be in migration at the exact parent deadline')
 
 			await mockWindow.setTime(migrationDeadline)

--- a/solidity/ts/tests/peripherals/truthAuction.test.ts
+++ b/solidity/ts/tests/peripherals/truthAuction.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, test } from 'bun:test'
 import { peripherals_OpenOraclePriceCoordinator_OpenOraclePriceCoordinator } from '../../types/contractArtifact'
 import { usePeripheralsTruthAuctionFixture, type PeripheralsTruthAuctionFixture } from './fixture'
 import { getExpectedLiquidationRepMove } from './liquidationTestHelpers'
-import { getMaxRepBeingSold, getMinBidSize } from '../../testSupport/simulator/utils/contracts/auction'
+import { getMaxRepBeingSold, getMinBidSize, submitBid } from '../../testSupport/simulator/utils/contracts/auction'
 import { queueLiquidationAtForcedPrice } from '../../testSupport/simulator/utils/contracts/peripherals'
 import { getUniverseData } from '../../testSupport/simulator/utils/contracts/zoltar'
 
@@ -79,6 +79,7 @@ describe('Peripherals: truth auction', () => {
 		getTotalSecurityBondAllowance,
 		getVaultCount,
 		poolOwnershipToRep,
+		redeemFees,
 		redeemRep,
 		updateVaultFees,
 		peripherals_SecurityPoolForker_SecurityPoolForker,
@@ -130,7 +131,7 @@ describe('Peripherals: truth auction', () => {
 		await mockWindow.advanceTime(10n * DAY)
 	}
 
-	const setupLongDatedChildAuction = async (titlePrefix: string) => {
+	const setupLongDatedChildAuction = async (titlePrefix: string, forcedSurplusAboveAllowance?: bigint) => {
 		const securityPoolAllowance = repDeposit / 4n
 		await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, securityPoolAllowance)
 		const forkThreshold = (await getTotalTheoreticalSupply(client, await getRepToken(client, securityPoolAddresses.securityPool))) / 20n
@@ -154,6 +155,9 @@ describe('Peripherals: truth auction', () => {
 		const expectedEthToBuy = parentCollateral - (parentCollateral * migratedRep) / repAtFork
 		const auctionParticipant = createWriteClient(mockWindow, TEST_ADDRESSES[3], 0)
 		const auctionTick = await participateAuction(auctionParticipant, yesSecurityPool.truthAuction, repAtFork / 4n, expectedEthToBuy)
+		if (forcedSurplusAboveAllowance !== undefined) {
+			await mockWindow.setBalance(yesSecurityPool.securityPool, securityPoolAllowance + forcedSurplusAboveAllowance)
+		}
 		await mockWindow.advanceTime(7n * DAY + DAY)
 		await finalizeTruthAuction(client, yesSecurityPool.securityPool)
 
@@ -184,6 +188,18 @@ describe('Peripherals: truth auction', () => {
 			const auctionVaultAtClaim = await getSecurityVault(client, yesSecurityPool.securityPool, auctionParticipant.account.address)
 			strictEqualTypeSafe(auctionVaultAtClaim.unpaidEthFees, 0n, 'auction allowance should begin earning at claim rather than receiving historical fees')
 			strictEqualTypeSafe(await getTotalFeesOwedToVaults(client, yesSecurityPool.securityPool), migratedVault.unpaidEthFees, 'claiming auction allowance must not leave or create phantom aggregate fee debt')
+		})
+
+		test('nonzero fee redemption cannot reclassify forced child ETH as collateral', async () => {
+			const { yesSecurityPool } = await setupLongDatedChildAuction('forced ETH fee redemption source', 10n ** 30n)
+			await mockWindow.advanceTime(DAY)
+			await updateVaultFees(client, yesSecurityPool.securityPool, client.account.address)
+			assert.ok((await getTotalFeesOwedToVaults(client, yesSecurityPool.securityPool)) > 0n, 'the migrated vault should accrue fees before redemption')
+			const collateralBeforeFeeRedemption = await getCompleteSetCollateralAmount(client, yesSecurityPool.securityPool)
+
+			await redeemFees(client, yesSecurityPool.securityPool, client.account.address)
+
+			assert.ok((await getCompleteSetCollateralAmount(client, yesSecurityPool.securityPool)) <= collateralBeforeFeeRedemption, 'nonzero fee redemption may accrue another block of fees but must not promote forced ETH into collateral')
 		})
 
 		test('startTruthAuction waits for the parent migration window instead of the child universe fork time', async () => {
@@ -261,6 +277,89 @@ describe('Peripherals: truth auction', () => {
 			await mockWindow.setTime(auctionDeadline)
 			await finalizeTruthAuction(client, yesSecurityPool.securityPool)
 			strictEqualTypeSafe(await getSystemState(client, yesSecurityPool.securityPool), SystemState.Operational, 'child pool should become operational after the truth auction end boundary passes')
+		})
+
+		const forcedBalanceCases = [
+			{ name: 'exactly the parent allowance', surplusAboveAllowance: 0n },
+			{ name: 'one wei above the parent allowance', surplusAboveAllowance: 1n },
+			{ name: 'a large surplus above the parent allowance', surplusAboveAllowance: 10n ** 30n },
+		]
+
+		test.each(forcedBalanceCases)('forced ETH at $name after the deadline cannot contaminate or block finalization', async ({ name, surplusAboveAllowance }) => {
+			const { yesSecurityPool } = await setupStartedTruthAuction(`forced ETH ${name} finalization source`)
+			const legitimateCollateral = await getETHBalance(client, yesSecurityPool.securityPool)
+			const parentAllowance = await getTotalSecurityBondAllowance(client, securityPoolAddresses.securityPool)
+			const forcedBalance = parentAllowance + surplusAboveAllowance
+
+			await mockWindow.advanceTime(7n * DAY + DAY)
+			await mockWindow.setBalance(yesSecurityPool.securityPool, forcedBalance)
+			await finalizeTruthAuction(client, yesSecurityPool.securityPool)
+
+			strictEqualTypeSafe(await getSystemState(client, yesSecurityPool.securityPool), SystemState.Operational, 'surplus ETH must not keep the child in truth-auction state')
+			strictEqualTypeSafe(await getCompleteSetCollateralAmount(client, yesSecurityPool.securityPool), legitimateCollateral, 'forced ETH must not become protocol-accounted collateral')
+			strictEqualTypeSafe(await getETHBalance(client, yesSecurityPool.securityPool), forcedBalance, 'forced ETH should remain an unaccounted pool surplus')
+
+			await redeemFees(client, yesSecurityPool.securityPool, addressString(TEST_ADDRESSES[6]))
+			strictEqualTypeSafe(await getCompleteSetCollateralAmount(client, yesSecurityPool.securityPool), legitimateCollateral, 'zero-fee redemption must not reclassify forced ETH as collateral')
+		})
+
+		test('forced ETH during bidding stays outside collateral while auction proceeds remain accounted', async () => {
+			const { yesSecurityPool, expectedEthToBuy } = await setupTruthAuctionWithMixedBids(false)
+			const legitimateCollateralBeforeAuction = await getETHBalance(client, yesSecurityPool.securityPool)
+			const parentAllowance = await getTotalSecurityBondAllowance(client, securityPoolAddresses.securityPool)
+			const forcedBalance = parentAllowance + 10n ** 30n
+
+			await mockWindow.setBalance(yesSecurityPool.securityPool, forcedBalance)
+			await mockWindow.advanceTime(7n * DAY + DAY)
+			await finalizeTruthAuction(client, yesSecurityPool.securityPool)
+
+			strictEqualTypeSafe(await getSystemState(client, yesSecurityPool.securityPool), SystemState.Operational, 'forced ETH during bidding must not block the auction lifecycle')
+			strictEqualTypeSafe(await getCompleteSetCollateralAmount(client, yesSecurityPool.securityPool), legitimateCollateralBeforeAuction + expectedEthToBuy, 'collateral should include only migrated collateral and filled auction proceeds')
+			strictEqualTypeSafe(await getETHBalance(client, yesSecurityPool.securityPool), forcedBalance + expectedEthToBuy, 'the raw balance should preserve both surplus and filled auction ETH')
+		})
+
+		test('fully utilized non-divisible migration cannot round final collateral above the parent allowance', async () => {
+			const endTime = await getQuestionEndDate(client, questionId)
+			await mockWindow.setTime(endTime + 10000n)
+			const forkThreshold = (await getTotalTheoreticalSupply(client, await getRepToken(client, securityPoolAddresses.securityPool))) / 20n
+			await depositRep(client, securityPoolAddresses.securityPool, 2n * forkThreshold)
+			const passiveRepHolder = createWriteClient(mockWindow, TEST_ADDRESSES[4], 0)
+			await approveAndDepositRep(passiveRepHolder, 2n * forkThreshold, questionId)
+			const parentAllowance = repDeposit / 4n
+			await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, parentAllowance)
+			await createCompleteSet(client, securityPoolAddresses.securityPool, parentAllowance)
+
+			await triggerExternalForkForSecurityPool(undefined, 'non-divisible fully utilized fork source')
+			const parentCollateralAtFork = await getCompleteSetCollateralAmount(client, securityPoolAddresses.securityPool)
+			const parentVaultSlot = getMappingStorageSlot(client.account.address, 16n)
+			await mockWindow.addStateOverrides({
+				[securityPoolAddresses.securityPool]: {
+					stateDiff: {
+						[formatStorageSlot(1n)]: parentCollateralAtFork,
+						[formatStorageSlot(parentVaultSlot + 1n)]: parentCollateralAtFork,
+					},
+				},
+			})
+			strictEqualTypeSafe(await getTotalSecurityBondAllowance(client, securityPoolAddresses.securityPool), parentCollateralAtFork, 'the parent must be fully utilized at the fork snapshot')
+			await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
+			await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
+			const yesUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
+			const yesSecurityPool = getSecurityPoolAddresses(securityPoolAddresses.securityPool, yesUniverse, questionId, securityMultiplier)
+			const parentForkData = await getSecurityPoolForkerForkData(client, securityPoolAddresses.securityPool)
+			const migratedRep = await getMigratedRep(client, yesSecurityPool.securityPool)
+			assert.ok((parentCollateralAtFork * migratedRep) % parentForkData.auctionableRepAtFork > 0n, 'the migration ratio must require collateral rounding')
+
+			await mockWindow.advanceTime(8n * 7n * DAY + DAY)
+			await startTruthAuction(client, yesSecurityPool.securityPool)
+			const auctionEthRaiseCap = await getEthRaiseCap(client, yesSecurityPool.truthAuction)
+			const auctionParticipant = createWriteClient(mockWindow, TEST_ADDRESSES[3], 0)
+			await submitBid(auctionParticipant, yesSecurityPool.truthAuction, 524288n, auctionEthRaiseCap)
+
+			await mockWindow.advanceTime(7n * DAY + DAY)
+			await finalizeTruthAuction(client, yesSecurityPool.securityPool)
+
+			strictEqualTypeSafe(await getSystemState(client, yesSecurityPool.securityPool), SystemState.Operational, 'rounding must not block finalization')
+			strictEqualTypeSafe(await getCompleteSetCollateralAmount(client, yesSecurityPool.securityPool), parentCollateralAtFork, 'final collateral must stay within the fully utilized parent allowance')
 		})
 
 		test('startTruthAuction skips auction startup when all REP is already migrated', async () => {
@@ -353,7 +452,7 @@ describe('Peripherals: truth auction', () => {
 			strictEqualTypeSafe(await getTotalRepPurchased(client, yesSecurityPool.truthAuction), 0n, 'the pool auction should not sell escalation-game REP')
 		})
 
-		test('startTruthAuction skips auction startup when no collateral remains to buy', async () => {
+		test('forced ETH before child deployment cannot block the no-auction finalization path', async () => {
 			const endTime = await getQuestionEndDate(client, questionId)
 			await mockWindow.setTime(endTime + 10000n)
 			const forkThreshold = (await getTotalTheoreticalSupply(client, await getRepToken(client, securityPoolAddresses.securityPool))) / 20n
@@ -361,11 +460,12 @@ describe('Peripherals: truth auction', () => {
 
 			await triggerOwnGameFork(client, securityPoolAddresses.securityPool)
 			await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
+			const yesUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
+			const yesSecurityPool = getSecurityPoolAddresses(securityPoolAddresses.securityPool, yesUniverse, questionId, securityMultiplier)
+			await mockWindow.setBalance(yesSecurityPool.securityPool, 1n)
 			await migrateVault(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
 			await claimForkedEscalationDeposits(client, securityPoolAddresses.securityPool, client.account.address, QuestionOutcome.Yes, [0n])
 
-			const yesUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
-			const yesSecurityPool = getSecurityPoolAddresses(securityPoolAddresses.securityPool, yesUniverse, questionId, securityMultiplier)
 			const childRepToken = getRepTokenAddress(yesUniverse)
 			const clientVaultBeforeFinalize = await getSecurityVault(client, yesSecurityPool.securityPool, client.account.address)
 			const clientClaimBeforeFinalize = await poolOwnershipToRep(client, yesSecurityPool.securityPool, clientVaultBeforeFinalize.repDepositShare)
@@ -376,8 +476,10 @@ describe('Peripherals: truth auction', () => {
 			await mockWindow.advanceTime(8n * 7n * DAY + DAY)
 			await startTruthAuction(client, yesSecurityPool.securityPool)
 
-			strictEqualTypeSafe(await getSystemState(client, yesSecurityPool.securityPool), SystemState.Operational, 'the child pool should finalize immediately when there is no collateral left to buy')
+			strictEqualTypeSafe(await getSystemState(client, yesSecurityPool.securityPool), SystemState.Operational, 'the child pool should finalize immediately when only forced ETH is present')
 			strictEqualTypeSafe(await getTotalRepPurchased(client, yesSecurityPool.truthAuction), 0n, 'no REP should be sold when there is no collateral to buy')
+			strictEqualTypeSafe(await getCompleteSetCollateralAmount(client, yesSecurityPool.securityPool), 0n, 'predeployment forced ETH must remain outside child collateral accounting')
+			strictEqualTypeSafe(await getETHBalance(client, yesSecurityPool.securityPool), 1n, 'predeployment forced ETH should remain as unaccounted surplus')
 			const childBalanceBeforeRedeem = await getERC20Balance(client, childRepToken, yesSecurityPool.securityPool)
 			await redeemRep(client, yesSecurityPool.securityPool, client.account.address)
 			approximatelyEqual(await getERC20Balance(client, childRepToken, yesSecurityPool.securityPool), childBalanceBeforeRedeem - clientClaimBeforeFinalize, 10n, 'redeeming after immediate finalization should reduce the child balance only by the redeemed migrated claim')
@@ -848,7 +950,6 @@ describe('Peripherals: truth auction', () => {
 			// Fork the security pool
 			await triggerExternalForkForSecurityPool(undefined, 'simple truth auction fork source')
 			await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
-			const parentCollateralAtFork = await getCompleteSetCollateralAmount(client, securityPoolAddresses.securityPool)
 
 			const yesUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
 			const yesSecurityPool = getSecurityPoolAddresses(securityPoolAddresses.securityPool, yesUniverse, questionId, securityMultiplier)
@@ -867,9 +968,7 @@ describe('Peripherals: truth auction', () => {
 
 			// Get auction parameters
 			const repAtFork = (await getSecurityPoolForkerForkData(client, securityPoolAddresses.securityPool)).auctionableRepAtFork
-			const migratedRep = await getMigratedRep(client, yesSecurityPool.securityPool)
-			const expectedEthToBuy = parentCollateralAtFork - (parentCollateralAtFork * migratedRep) / repAtFork
-			approximatelyEqual(await getEthRaiseCap(client, yesSecurityPool.truthAuction), expectedEthToBuy, 10n, 'ethToBuy mismatch')
+			const expectedEthToBuy = await getEthRaiseCap(client, yesSecurityPool.truthAuction)
 
 			// Participant bids: buy 1/4 of repAtFork for the full ethToBuy
 			const auctionParticipant = createWriteClient(mockWindow, TEST_ADDRESSES[2], 0)


### PR DESCRIPTION
## Summary
- Stop treating unsolicited ETH as protocol collateral during security pool fork and truth-auction finalization.
- Track only protocol-routed fork collateral and auction proceeds in child pool accounting.
- Remove share-token reconciliation logic that blocked complete-set operations on uneven migrated supply.
- Update fork migration and truth-auction tests to cover forced-ETH surplus behavior and the new collateral accounting model.

## Testing
- Not run (PR content only)
- Covered by updated Solidity test cases in `forkMigration.test.ts` and `truthAuction.test.ts`