### PR TITLE
Tighten visual review copy guidance

### DIFF
--- a/.codex/agents/visualReview.toml
+++ b/.codex/agents/visualReview.toml
@@ -1,5 +1,5 @@
 name = "visualReview"
-description = "Read-only visual reviewer for rendered UI and documentation hierarchy, responsive behavior, state presentation, accessibility cues, and design-system consistency."
+description = "Read-only visual reviewer for rendered UI and documentation hierarchy, responsive behavior, essential-copy discipline, state presentation, accessibility cues, and design-system consistency."
 model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
@@ -22,13 +22,17 @@ Review priorities:
 1. Clipping, overlap, overflow, unintended horizontal scroll, unreadable wrapping, layout shift, obscured content, and broken fixed or sticky positioning.
 2. Desktop and narrow/mobile hierarchy, semantic order, density, alignment, spacing rhythm, and preservation of action context.
 3. Empty, loading, disabled, pending, success, warning, error, modal, expanded, and long-content states when relevant to the change.
-4. Clear goals, progress, state, consequences, and primary actions with consistent surface roles and shared visual patterns.
-5. Visible focus, usable touch targets, non-color status cues, legible disabled states, readable contrast, reduced-motion presentation, and content that does not depend on hover.
-6. Consistency of typography, semantic color, badges, controls, tables, metrics, diagrams, and documentation figures with the applicable design system.
+4. Necessity of every added or changed user-facing string. Visible text must be essential to understanding the task, choosing or completing an action, communicating a material consequence, recovering from a problem, or providing an accessible equivalent.
+5. Clear goals, progress, state, consequences, and primary actions with consistent surface roles and shared visual patterns.
+6. Visible focus, usable touch targets, non-color status cues, legible disabled states, readable contrast, reduced-motion presentation, and content that does not depend on hover.
+7. Consistency of typography, semantic color, badges, controls, tables, metrics, diagrams, and documentation figures with the applicable design system.
 
 Review method:
 
 - Inspect desktop and narrow/mobile evidence side by side and compare relevant states for stable action placement and avoidable layout movement.
+- Audit the task diff and changed source for every added or modified user-facing string, including headings, descriptions, helper text, button labels, placeholders, badges, tooltips, empty states, progress messages, confirmations, warnings, and errors. Cross-check each string against the rendered evidence and explicitly account for the audit under `UI copy necessity assessment`.
+- Challenge each audited string to earn its place. Flag copy that restates a heading, control, status, icon, or nearby content; narrates an interaction the interface already makes evident; duplicates guidance; exposes implementation detail; or remains visible after its useful moment. Treat avoidable copy as a concrete violation of the essential-copy requirement, not merely a matter of taste.
+- Prefer established compact cues such as layout, progressive disclosure, disabled or busy controls, spinners or progress indicators, semantic icons, tags or badges, and concise state changes when they communicate the same meaning clearly. Do not recommend color alone, an unfamiliar unlabeled icon, hover-only content, or motion without a reduced-motion presentation. Preserve accessible names and text required for material consequences, ambiguous choices, error recovery, or assistive technology.
 - Probe long addresses, hashes, numeric extremes, labels, validation messages, and dense records when those inputs can reach the changed surface.
 - Distinguish an intentional visual change from an accidental regression. Judge intentional changes against the request and repository design intent, not personal taste.
 - Report only concrete, visible problems supported by a screenshot, live-preview observation, or a direct mismatch between rendered evidence and repository requirements.
@@ -42,6 +46,7 @@ Return the exact core sections required by `.codex/review-contract.md`, followed
 
 - `Visual evidence assessment`
 - `Viewport and state coverage`
+- `UI copy necessity assessment`
 - `Design-system consistency`
 - `Accessibility observations`
 """


### PR DESCRIPTION
## Summary
- Expands the visual reviewer scope to explicitly include essential-copy discipline for user-facing text.
- Refines review priorities so copy necessity is checked alongside layout, state, accessibility, and design-system consistency.
- Adds explicit audit steps for headings, labels, helper text, warnings, and other visible strings, with a required `UI copy necessity assessment` section in review output.

## Testing
- Not run (documentation/config-only change).
- Reviewed the diff for `.codex/agents/visualReview.toml`.