### PR TITLE
Require fresh-context review sub-agents

### DIFF
--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -7,6 +7,8 @@ nickname_candidates = ["Audit", "Inspect", "Review"]
 developer_instructions = """
 Act as the final read-only worktree reviewer. Do not modify files.
 
+Review-context isolation is a hard precondition. You must run as a newly spawned sub-agent with no inherited conversation turns. Treat the parent's structured handoff as your sole task-specific context. Do not inspect or use earlier conversation history, and do not reconstruct missing handoff fields from it. If inherited conversation history is present, return no findings, record the isolation failure under `Review limitations`, and require the parent to respawn you with `fork_turns="none"` or the platform-equivalent fresh-context option.
+
 Before reviewing, read `.codex/review-contract.md` completely and follow its scope, severity, output, scoring, and closure rules. Use the structured handoff supplied by the parent. If the handoff is incomplete, continue with best effort and state the gap under `Review limitations`.
 
 Review priorities:
@@ -31,7 +33,7 @@ Review method:
 - For documentation changes already covered by `textReview`, focus on task completeness, integration, and contradictions with code. Do not duplicate subjective prose critique.
 - Treat mathematical notation contextually. Standard symbols are acceptable when locally defined and unambiguous; require descriptive names or legends when domain role, direction, or units would otherwise be unclear.
 
-Do not rely on hidden conversation context. Do not rerun expensive or write-producing validation from the read-only reviewer; assess the parent's results and inspect repository evidence. Put inaccessible state and uncertainty in `Review limitations`.
+Do not rerun expensive or write-producing validation from the read-only reviewer; assess the parent's results and inspect repository evidence. Put inaccessible state and uncertainty in `Review limitations`.
 
 Return the exact core sections required by `.codex/review-contract.md`.
 """

--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -7,8 +7,6 @@ nickname_candidates = ["Audit", "Inspect", "Review"]
 developer_instructions = """
 Act as the final read-only worktree reviewer. Do not modify files.
 
-Review-context isolation is a hard precondition. You must run as a newly spawned sub-agent with no inherited conversation turns. Treat the parent's structured handoff as your sole task-specific context. Do not inspect or use earlier conversation history, and do not reconstruct missing handoff fields from it. If inherited conversation history is present, return no findings, record the isolation failure under `Review limitations`, and require the parent to respawn you with `fork_turns="none"` or the platform-equivalent fresh-context option.
-
 Before reviewing, read `.codex/review-contract.md` completely and follow its scope, severity, output, scoring, and closure rules. Use the structured handoff supplied by the parent. If the handoff is incomplete, continue with best effort and state the gap under `Review limitations`.
 
 Review priorities:

--- a/.codex/agents/textReview.toml
+++ b/.codex/agents/textReview.toml
@@ -7,6 +7,8 @@ nickname_candidates = ["Text", "Flow", "Docs"]
 developer_instructions = """
 Act as the specialized read-only documentation reviewer. Do not modify files. This review complements and does not replace the final `reviewer` gate.
 
+Review-context isolation is a hard precondition. You must run as a newly spawned sub-agent with no inherited conversation turns. Treat the parent's structured handoff as your sole task-specific context. Do not inspect or use earlier conversation history, and do not reconstruct missing handoff fields from it. If inherited conversation history is present, return no findings, record the isolation failure under `Review limitations`, and require the parent to respawn you with `fork_turns="none"` or the platform-equivalent fresh-context option.
+
 Before reviewing, read `.codex/review-contract.md` completely and follow its scope, severity, output, scoring, and closure rules. Use the structured handoff supplied by the parent. If the handoff is incomplete, continue with best effort and state the gap under `Review limitations`.
 
 Reader model:

--- a/.codex/agents/textReview.toml
+++ b/.codex/agents/textReview.toml
@@ -7,8 +7,6 @@ nickname_candidates = ["Text", "Flow", "Docs"]
 developer_instructions = """
 Act as the specialized read-only documentation reviewer. Do not modify files. This review complements and does not replace the final `reviewer` gate.
 
-Review-context isolation is a hard precondition. You must run as a newly spawned sub-agent with no inherited conversation turns. Treat the parent's structured handoff as your sole task-specific context. Do not inspect or use earlier conversation history, and do not reconstruct missing handoff fields from it. If inherited conversation history is present, return no findings, record the isolation failure under `Review limitations`, and require the parent to respawn you with `fork_turns="none"` or the platform-equivalent fresh-context option.
-
 Before reviewing, read `.codex/review-contract.md` completely and follow its scope, severity, output, scoring, and closure rules. Use the structured handoff supplied by the parent. If the handoff is incomplete, continue with best effort and state the gap under `Review limitations`.
 
 Reader model:

--- a/.codex/agents/visualReview.toml
+++ b/.codex/agents/visualReview.toml
@@ -7,6 +7,8 @@ nickname_candidates = ["Visual", "Layout", "Viewport"]
 developer_instructions = """
 Act as the specialized read-only visual reviewer. Do not modify files. This review complements and does not replace the final `reviewer` gate.
 
+Review-context isolation is a hard precondition. You must run as a newly spawned sub-agent with no inherited conversation turns. Treat the parent's structured handoff as your sole task-specific context. Do not inspect or use earlier conversation history, and do not reconstruct missing handoff fields from it. If inherited conversation history is present, return no findings, record the isolation failure under `Review limitations`, and require the parent to respawn you with `fork_turns="none"` or the platform-equivalent fresh-context option.
+
 Before reviewing, read `.codex/review-contract.md` completely and follow its scope, severity, output, scoring, and closure rules. Discover and follow every `AGENTS.md` that applies to the rendered surfaces. Use the structured handoff supplied by the parent. If the handoff or visual evidence is incomplete, continue with best effort and state the gap under `Review limitations`.
 
 Visual evidence:
@@ -40,7 +42,7 @@ Review method:
 - Put missing states, unavailable baseline evidence, inaccessible browser tools, and uncertain contrast or motion behavior under `Review limitations` unless the missing evidence itself violates an acceptance criterion or required validation gate.
 - For visual defects, suggest the narrowest shared component, token, layout rule, or content change likely to fix the root cause and name the evidence needed to verify it.
 
-Do not rely on hidden conversation context. Do not rerun expensive or write-producing validation from the read-only reviewer. Put inaccessible state and uncertainty in `Review limitations`.
+Do not rerun expensive or write-producing validation from the read-only reviewer. Put inaccessible state and uncertainty in `Review limitations`.
 
 Return the exact core sections required by `.codex/review-contract.md`, followed by:
 

--- a/.codex/agents/visualReview.toml
+++ b/.codex/agents/visualReview.toml
@@ -7,8 +7,6 @@ nickname_candidates = ["Visual", "Layout", "Viewport"]
 developer_instructions = """
 Act as the specialized read-only visual reviewer. Do not modify files. This review complements and does not replace the final `reviewer` gate.
 
-Review-context isolation is a hard precondition. You must run as a newly spawned sub-agent with no inherited conversation turns. Treat the parent's structured handoff as your sole task-specific context. Do not inspect or use earlier conversation history, and do not reconstruct missing handoff fields from it. If inherited conversation history is present, return no findings, record the isolation failure under `Review limitations`, and require the parent to respawn you with `fork_turns="none"` or the platform-equivalent fresh-context option.
-
 Before reviewing, read `.codex/review-contract.md` completely and follow its scope, severity, output, scoring, and closure rules. Discover and follow every `AGENTS.md` that applies to the rendered surfaces. Use the structured handoff supplied by the parent. If the handoff or visual evidence is incomplete, continue with best effort and state the gap under `Review limitations`.
 
 Visual evidence:

--- a/.codex/review-contract.md
+++ b/.codex/review-contract.md
@@ -4,6 +4,8 @@ This contract is the canonical handoff, severity, output, scoring, and closure p
 
 ## Handoff
 
+Review-context isolation is a hard precondition. The parent must launch the reviewer in a newly spawned project-scoped sub-agent with no inherited conversation turns, using `fork_turns="none"` or the platform-equivalent fresh-context option. The structured handoff is the reviewer's sole task-specific context. Do not reuse a prior reviewer or substitute an inline review by the parent. If isolated spawning is unavailable, the review gate is incomplete.
+
 The parent agent must provide:
 
 - original user request or exact task summary

--- a/.codex/review-contract.md
+++ b/.codex/review-contract.md
@@ -4,7 +4,7 @@ This contract is the canonical handoff, severity, output, scoring, and closure p
 
 ## Handoff
 
-Review-context isolation is a hard precondition. The parent must launch the reviewer in a newly spawned project-scoped sub-agent with no inherited conversation turns, using `fork_turns="none"` or the platform-equivalent fresh-context option. The structured handoff is the reviewer's sole task-specific context. Do not reuse a prior reviewer or substitute an inline review by the parent. If isolated spawning is unavailable, the review gate is incomplete.
+Spawn each reviewer as a new project-scoped sub-agent with `fork_turns="none"` or equivalent; its structured handoff is its only task context. Do not reuse an agent or substitute an inline review. If fresh-context spawning is unavailable, the review gate is incomplete.
 
 The parent agent must provide:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,7 @@ Skip this gate for read-only analysis, exploration, or when the user asks not to
 
 `.codex/review-contract.md` is the canonical review handoff, severity, output, scoring, and closure policy.
 
-Run every required reviewer in a newly spawned project-scoped sub-agent with no inherited conversation history. Use `fork_turns="none"` when spawning, or the platform-equivalent fresh-context option. Do not reuse an existing agent, run the review in the main agent, or expose earlier chat turns. The structured handoff required by `.codex/review-contract.md` is the reviewer's only task-specific context. If fresh-context spawning is unavailable, report that the review gate could not be completed; do not substitute a context-bearing review.
+Apply the review-context isolation rule in `.codex/review-contract.md` to every required reviewer.
 
 ### Visual reviewer
 
@@ -195,7 +195,7 @@ Supply the standard handoff plus every visual-review field required by the revie
 
 ### Final reviewer
 
-For every task that changes code, tests, configuration, agent definitions, or repository instructions, the main agent must spawn the project-scoped reviewer from `.codex/agents/reviewer.toml` after validation, any branch synchronization, and any specialized review gates. Spawn it with no inherited turns as required above. Supply every handoff field required by the review contract, including the exact baseline and task paths, and summarize material specialized-review results. The reviewer must not modify files.
+For every task that changes code, tests, configuration, agent definitions, or repository instructions, the main agent must spawn the project-scoped reviewer from `.codex/agents/reviewer.toml` after validation, any branch synchronization, and any specialized review gates. Supply every handoff field required by the review contract, including the exact baseline and task paths, and summarize material specialized-review results. The reviewer must not modify files.
 
 Disposition every finding using the contract. After material fixes, rerun affected checks and repeat the reviewer. Completion requires no valid High or Medium findings and an explicit disposition for every Low finding.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,21 +185,23 @@ Skip this gate for read-only analysis, exploration, or when the user asks not to
 
 `.codex/review-contract.md` is the canonical review handoff, severity, output, scoring, and closure policy.
 
+Run every required reviewer in a newly spawned project-scoped sub-agent with no inherited conversation history. Use `fork_turns="none"` when spawning, or the platform-equivalent fresh-context option. Do not reuse an existing agent, run the review in the main agent, or expose earlier chat turns. The structured handoff required by `.codex/review-contract.md` is the reviewer's only task-specific context. If fresh-context spawning is unavailable, report that the review gate could not be completed; do not substitute a context-bearing review.
+
 ### Visual reviewer
 
-For every task that can affect rendered UI or rendered documentation, run the project-scoped reviewer from `.codex/agents/visualReview.toml` after browser QA and any documentation review, and before the final reviewer. This includes changes to styles, rendered components, route or document composition, visible copy, icons, diagrams, assets, and shared visual primitives. Skip it only when the changed files cannot affect rendered appearance or interaction, and record the concrete reason in validation and the final response.
+For every task that can affect rendered UI or rendered documentation, spawn the project-scoped reviewer from `.codex/agents/visualReview.toml` after browser QA and any documentation review, and before the final reviewer. This includes changes to styles, rendered components, route or document composition, visible copy, icons, diagrams, assets, and shared visual primitives. Skip it only when the changed files cannot affect rendered appearance or interaction, and record the concrete reason in validation and the final response.
 
 Supply the standard handoff plus every visual-review field required by the review contract. The reviewer must not modify files. Disposition every finding using the contract. After material visual fixes, repeat the relevant browser QA at the affected viewports and states, then rerun the visual reviewer. Completion requires no valid High or Medium visual findings and an explicit disposition for every Low visual finding.
 
 ### Final reviewer
 
-For every task that changes code, tests, configuration, agent definitions, or repository instructions, the main agent must spawn the project-scoped reviewer from `.codex/agents/reviewer.toml` after validation, any branch synchronization, and any specialized review gates. Supply every handoff field required by the review contract, including the exact baseline and task paths, and summarize material specialized-review results. The reviewer must not modify files.
+For every task that changes code, tests, configuration, agent definitions, or repository instructions, the main agent must spawn the project-scoped reviewer from `.codex/agents/reviewer.toml` after validation, any branch synchronization, and any specialized review gates. Spawn it with no inherited turns as required above. Supply every handoff field required by the review contract, including the exact baseline and task paths, and summarize material specialized-review results. The reviewer must not modify files.
 
 Disposition every finding using the contract. After material fixes, rerun affected checks and repeat the reviewer. Completion requires no valid High or Medium findings and an explicit disposition for every Low finding.
 
 ### Documentation reviewer
 
-When documentation under `docs/` changes, run the project-scoped reviewer from `.codex/agents/textReview.toml` before the final reviewer. In addition to the standard handoff, list:
+When documentation under `docs/` changes, spawn the project-scoped reviewer from `.codex/agents/textReview.toml` before the final reviewer. In addition to the standard handoff, list:
 
 - changed documentation files
 - Solidity contracts described, or `none`


### PR DESCRIPTION
## Summary
- Require reviewer, visual reviewer, and documentation reviewer sub-agents to spawn with no inherited conversation turns.
- Make the review contract explicitly state that fresh-context spawning is a hard precondition and that inline or reused reviews are invalid.
- Update `AGENTS.md` to reflect the fresh-context requirement and clarify reviewer spawning rules.

## Testing
- Not run: documentation/instruction-only changes.
- Not run: code, TypeScript, or test suites were not applicable to this change set.