### PR TITLE
Prevent fork share collisions with canonical pool tracking

### DIFF
--- a/scripts/check-docs-reference-values.mts
+++ b/scripts/check-docs-reference-values.mts
@@ -284,7 +284,7 @@ function assertContractInteractionDistinctions(): void {
 	assert.match(escalationGameForker, /'Claim window closed'/)
 	assert.match(securityPool, /event SystemStateSet\(SystemState systemState\)/)
 	assert.match(securityPool, /require\(zoltar\.getForkTime\(universeId\) == 0, 'Forked'\)/)
-	assert.match(securityPool, /function activateForkMode\(\) external onlyForker/)
+	assert.match(securityPool, /function activateForkMode\(bool forkQuestionMatchesPoolQuestion\) external onlyForker/)
 	assert.match(securityPool, /systemState = SystemState\.PoolForked/)
 	assert.match(securityPool, /shareToken\.authorize\(pool\)/)
 	assert.match(securityPoolFactory, /shareToken\.authorize\(securityPool\)/)

--- a/scripts/generate-contract-interaction-reference.mts
+++ b/scripts/generate-contract-interaction-reference.mts
@@ -120,7 +120,7 @@ const entrypointSignaturesBySource: Record<string, Record<string, string[]>> = {
 		setSecurityPool: ['public(ISecurityPool)'],
 	},
 	'solidity/contracts/peripherals/SecurityPool.sol': {
-		activateForkMode: ['external()'],
+		activateForkMode: ['external(bool)'],
 		addFeeEligibleSecurityBondAllowance: ['external(address,uint256)'],
 		authorizeChildPool: ['external(ISecurityPool)'],
 		configureVault: ['external(address,uint256,uint256,uint256)'],

--- a/solidity/contracts/peripherals/SecurityPool.sol
+++ b/solidity/contracts/peripherals/SecurityPool.sol
@@ -52,6 +52,7 @@ contract SecurityPool is ISecurityPool {
 	address public immutable securityPoolForker;
 	address public immutable truthAuction;
 	ISecurityPoolFactory public immutable securityPoolFactory;
+	bool private immutable hasInheritedForkOutcome;
 	SecurityPoolEventEmitter private immutable eventEmitter;
 
 	uint256 public totalSecurityBondAllowance;
@@ -179,6 +180,14 @@ contract SecurityPool is ISecurityPool {
 			systemState = SystemState.Operational;
 		} else {
 			systemState = SystemState.ForkMigration;
+			ISecurityPool ancestor = parent;
+			while (address(ancestor) != address(0x0)) {
+				if (zoltar.forkQuestionMatches(ancestor.universeId(), questionId)) {
+					hasInheritedForkOutcome = true;
+					break;
+				}
+				ancestor = ancestor.parent();
+			}
 		}
 		shareToken = _shareToken;
 		repToken = zoltar.getRepToken(universeId);
@@ -877,7 +886,8 @@ contract SecurityPool is ISecurityPool {
 		_syncActiveVault(beneficiaryVault);
 	}
 
-	function activateForkMode() external onlyForker {
+	function activateForkMode(bool forkQuestionMatchesPoolQuestion) external onlyForker {
+		require(!hasInheritedForkOutcome || forkQuestionMatchesPoolQuestion, 'Resolved');
 		systemState = SystemState.PoolForked;
 		updateCollateralAmount();
 		uint256 repTransferred = repToken.balanceOf(address(this));

--- a/solidity/contracts/peripherals/SecurityPoolForker.sol
+++ b/solidity/contracts/peripherals/SecurityPoolForker.sol
@@ -362,7 +362,7 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 		uint248 universe = securityPool.universeId();
 		data.forkQuestionMatchesPoolQuestion = zoltar.forkQuestionMatches(universe, securityPool.questionId());
 		uint256 repBalanceBefore = rep.balanceOf(address(this));
-		securityPool.activateForkMode();
+		securityPool.activateForkMode(data.forkQuestionMatchesPoolQuestion);
 		data.collateralAtFork = securityPool.completeSetCollateralAmount();
 		data.migratedRepCollateralized = 0;
 		data.collateralTransferred = 0;
@@ -698,7 +698,7 @@ contract SecurityPoolForker is SecurityPoolForkerBase {
 		ReputationToken rep = securityPool.repToken();
 		uint256 poolRepToFork = rep.balanceOf(address(securityPool));
 		uint256 repBalanceBefore = rep.balanceOf(address(this));
-		securityPool.activateForkMode();
+		securityPool.activateForkMode(true);
 		uint256 escalationRepToFork = escalationGame.drainAllRep(address(this));
 		SecurityPoolForkerForkData storage data = forkDataByPool[securityPool];
 		data.ownFork = true;

--- a/solidity/contracts/peripherals/factories/SecurityPoolFactory.sol
+++ b/solidity/contracts/peripherals/factories/SecurityPoolFactory.sol
@@ -29,6 +29,8 @@ contract SecurityPoolFactory is ISecurityPoolFactory {
 	SecurityPoolDeployer immutable securityPoolDeployer;
 	uint256 public immutable initialEscalationGameDeposit;
 	SecurityPoolDeployment[] private securityPoolDeployments;
+	mapping(bytes32 => ISecurityPool) private canonicalSecurityPools;
+	mapping(bytes32 => bool) private canonicalSecurityPoolClaims;
 
 	event DeploySecurityPool(
 		ISecurityPool indexed securityPool,
@@ -71,6 +73,14 @@ contract SecurityPoolFactory is ISecurityPoolFactory {
 		return securityPoolDeployments.length;
 	}
 
+	function getCanonicalSecurityPool(
+		uint248 universeId,
+		uint256 questionId,
+		uint256 securityMultiplier
+	) external view returns (ISecurityPool) {
+		return canonicalSecurityPools[_getCanonicalSecurityPoolKey(universeId, questionId, securityMultiplier)];
+	}
+
 	function securityPoolDeploymentsRange(
 		uint256 startIndex,
 		uint256 count
@@ -99,6 +109,16 @@ contract SecurityPoolFactory is ISecurityPoolFactory {
 		uint256 completeSetCollateralAmount
 	) external returns (ISecurityPool securityPool, UniformPriceDualCapBatchAuction truthAuction) {
 		require(msg.sender == address(securityPoolForker), 'Only the security pool forker can deploy child pools');
+		require(
+			address(
+				canonicalSecurityPools[
+					_getCanonicalSecurityPoolKey(parent.universeId(), questionId, securityMultiplier)
+				]
+			) == address(parent),
+			'Security pool parent must be canonical'
+		);
+		require(address(parent.shareToken()) == address(shareToken), 'Security pool child must use parent share token');
+		bytes32 canonicalPoolKey = _reserveCanonicalSecurityPool(universeId, questionId, securityMultiplier);
 		bytes32 securityPoolSalt = keccak256(abi.encode(parent, universeId, questionId, securityMultiplier));
 		ReputationToken reputationToken = zoltar.getRepToken(universeId);
 		OpenOraclePriceCoordinator priceOracleManagerAndOperatorQueuer = priceOracleManagerAndOperatorQueuerFactory
@@ -119,6 +139,7 @@ contract SecurityPoolFactory is ISecurityPoolFactory {
 			completeSetCollateralAmount,
 			address(truthAuction)
 		);
+		_setCanonicalSecurityPool(canonicalPoolKey, securityPool);
 		_recordSecurityPoolDeployment(
 			SecurityPoolDeployment(
 				securityPool,
@@ -160,6 +181,8 @@ contract SecurityPoolFactory is ISecurityPoolFactory {
 
 		ReputationToken reputationToken = zoltar.getRepToken(universeId);
 		require(address(reputationToken) != address(0x0), 'Security pool universe is missing a REP token');
+		_requireNoCanonicalSecurityPoolAncestor(universeId, questionId, securityMultiplier);
+		bytes32 canonicalPoolKey = _reserveCanonicalSecurityPool(universeId, questionId, securityMultiplier);
 		bytes32 securityPoolSalt = keccak256(abi.encode(address(0x0), universeId, questionId, securityMultiplier));
 		OpenOraclePriceCoordinator priceOracleManagerAndOperatorQueuer = priceOracleManagerAndOperatorQueuerFactory
 			.deployPriceOracleManagerAndOperatorQueuer(openOracle, reputationToken, securityPoolSalt);
@@ -180,6 +203,7 @@ contract SecurityPoolFactory is ISecurityPoolFactory {
 			address(0)
 		);
 
+		_setCanonicalSecurityPool(canonicalPoolKey, securityPool);
 		shareToken.authorize(securityPool);
 		_recordSecurityPoolDeployment(
 			SecurityPoolDeployment(
@@ -195,6 +219,46 @@ contract SecurityPoolFactory is ISecurityPoolFactory {
 				0
 			)
 		);
+	}
+
+	function _requireNoCanonicalSecurityPoolAncestor(
+		uint248 universeId,
+		uint256 questionId,
+		uint256 securityMultiplier
+	) private view {
+		while (universeId != 0) {
+			(, , , , universeId) = zoltar.universes(universeId);
+			require(
+				!canonicalSecurityPoolClaims[_getCanonicalSecurityPoolKey(universeId, questionId, securityMultiplier)],
+				'Security pool canonical ancestor requires child deployment'
+			);
+		}
+	}
+
+	function _getCanonicalSecurityPoolKey(
+		uint248 universeId,
+		uint256 questionId,
+		uint256 securityMultiplier
+	) private pure returns (bytes32) {
+		return keccak256(abi.encode(universeId, questionId, securityMultiplier));
+	}
+
+	function _reserveCanonicalSecurityPool(
+		uint248 universeId,
+		uint256 questionId,
+		uint256 securityMultiplier
+	) private returns (bytes32 canonicalPoolKey) {
+		canonicalPoolKey = _getCanonicalSecurityPoolKey(universeId, questionId, securityMultiplier);
+		require(!canonicalSecurityPoolClaims[canonicalPoolKey], 'Security pool canonical key already claimed');
+		canonicalSecurityPoolClaims[canonicalPoolKey] = true;
+	}
+
+	function _setCanonicalSecurityPool(bytes32 canonicalPoolKey, ISecurityPool securityPool) private {
+		require(
+			address(canonicalSecurityPools[canonicalPoolKey]) == address(0x0),
+			'Security pool canonical pool already set'
+		);
+		canonicalSecurityPools[canonicalPoolKey] = securityPool;
 	}
 
 	function _recordSecurityPoolDeployment(SecurityPoolDeployment memory deployment) private {

--- a/solidity/contracts/peripherals/interfaces/ISecurityPool.sol
+++ b/solidity/contracts/peripherals/interfaces/ISecurityPool.sol
@@ -215,7 +215,7 @@ interface ISecurityPool {
 	) external;
 	function resumeForkedEscalationGame() external;
 	function setAwaitingForkContinuation(bool shouldAwait) external;
-	function activateForkMode() external;
+	function activateForkMode(bool forkQuestionMatchesPoolQuestion) external;
 	function setSystemState(SystemState newState) external;
 	function configureVault(
 		address vault,
@@ -270,6 +270,11 @@ interface ISecurityPoolFactory {
 		uint256 questionId,
 		uint256 securityMultiplier
 	) external returns (ISecurityPool securityPool);
+	function getCanonicalSecurityPool(
+		uint248 universeId,
+		uint256 questionId,
+		uint256 securityMultiplier
+	) external view returns (ISecurityPool securityPool);
 	function securityPoolDeploymentCount() external view returns (uint256);
 	function securityPoolDeploymentsRange(
 		uint256 startIndex,

--- a/solidity/contracts/peripherals/interfaces/IShareToken.sol
+++ b/solidity/contracts/peripherals/interfaces/IShareToken.sol
@@ -11,6 +11,7 @@ interface IShareToken {
 
 	function authorize(ISecurityPool _securityPoolCandidate) external;
 	function isAuthorized(address account) external view returns (bool);
+	function canonicalPoolByUniverse(uint248 universeId) external view returns (ISecurityPool);
 	function mintCompleteSets(uint248 _universeId, address _account, uint256 _cashAmount) external;
 	function burnCompleteSets(uint248 _universeId, address _owner, uint256 _amount) external;
 	function burnTokenIdAndGetRemainingSupply(

--- a/solidity/contracts/peripherals/tokens/ShareToken.sol
+++ b/solidity/contracts/peripherals/tokens/ShareToken.sol
@@ -5,6 +5,7 @@ import '../../Constants.sol';
 import './TokenId.sol';
 import '../../Zoltar.sol';
 import '../interfaces/ISecurityPool.sol';
+import '../interfaces/ISecurityPoolForker.sol';
 import '../interfaces/IShareToken.sol';
 import '../BinaryOutcomes.sol';
 import '../SecurityPoolUtils.sol';
@@ -19,6 +20,7 @@ contract ShareToken is ERC1155, IShareToken {
 	string public symbol;
 	Zoltar public immutable zoltar;
 	mapping(address => bool) private authorized;
+	mapping(uint248 => ISecurityPool) public canonicalPoolByUniverse;
 	event Migrate(address indexed migrator, uint256 indexed fromId, uint256 indexed toId, uint256 fromIdBalance);
 
 	constructor(address owner, Zoltar _zoltar, uint256 questionId) {
@@ -51,7 +53,19 @@ contract ShareToken is ERC1155, IShareToken {
 
 	function authorize(ISecurityPool _securityPoolCandidate) external {
 		require(authorized[msg.sender], 'ShareToken caller is not authorized to add another authorized pool');
+		require(
+			address(_securityPoolCandidate.shareToken()) == address(this),
+			'ShareToken candidate must use this share token'
+		);
+		uint248 candidateUniverseId = _securityPoolCandidate.universeId();
+		ISecurityPool currentCanonicalPool = canonicalPoolByUniverse[candidateUniverseId];
+		require(
+			address(currentCanonicalPool) == address(0x0) ||
+				address(currentCanonicalPool) == address(_securityPoolCandidate),
+			'ShareToken universe already has a canonical pool'
+		);
 		if (authorized[address(_securityPoolCandidate)]) return;
+		canonicalPoolByUniverse[candidateUniverseId] = _securityPoolCandidate;
 		authorized[address(_securityPoolCandidate)] = true;
 		emit AuthorizationUpdated(address(_securityPoolCandidate), msg.sender, true);
 	}
@@ -188,9 +202,6 @@ contract ShareToken is ERC1155, IShareToken {
 		uint256 fromIdBalance = balanceOf(msg.sender, fromId);
 		require(fromIdBalance > 0, 'ShareToken holder has no balance to migrate from the source token id');
 
-		// Burn from the old token ID using the base ERC1155 _burn function
-		_burn(msg.sender, fromId, fromIdBalance);
-
 		(, uint256 questionId, , , ) = zoltar.universes(universeId);
 		uint256 targetOutcomeIndexesLength = targetOutcomeIndexes.length;
 		uint256 previousOutcomeIndex;
@@ -206,8 +217,36 @@ contract ShareToken is ERC1155, IShareToken {
 					'ShareToken target outcomes must be provided in strictly increasing order'
 				);
 			previousOutcomeIndex = outcomeIndex;
+		}
 
-			uint256 toId = getChildId(fromId, getChildUniverseId(universeId, outcomeIndex));
+		ISecurityPool sourcePool = canonicalPoolByUniverse[universeId];
+		require(address(sourcePool) != address(0x0), 'ShareToken source universe is missing a canonical pool');
+		ISecurityPoolForker forker = ISecurityPoolForker(sourcePool.securityPoolForker());
+		if (sourcePool.systemState() == SystemState.Operational) {
+			forker.initiateSecurityPoolFork(sourcePool);
+		}
+		require(sourcePool.systemState() == SystemState.PoolForked, 'ShareToken source pool cannot migrate');
+
+		uint248[] memory targetUniverseIds = new uint248[](targetOutcomeIndexesLength);
+		for (uint256 i = 0; i < targetOutcomeIndexesLength; i++) {
+			uint256 outcomeIndex = targetOutcomeIndexes[i];
+			uint248 targetUniverseId = getChildUniverseId(universeId, outcomeIndex);
+			ISecurityPool targetPool = canonicalPoolByUniverse[targetUniverseId];
+			if (address(targetPool) == address(0x0)) {
+				require(targetOutcomeIndexesLength == 1, 'ShareToken bulk migration requires canonical child pools');
+				forker.createChildUniverse(sourcePool, outcomeIndex);
+				targetPool = canonicalPoolByUniverse[targetUniverseId];
+			}
+			require(
+				address(targetPool) != address(0x0) && address(targetPool.parent()) == address(sourcePool),
+				'ShareToken destination is missing a canonical child pool'
+			);
+			targetUniverseIds[i] = targetUniverseId;
+		}
+
+		_burn(msg.sender, fromId, fromIdBalance);
+		for (uint256 i = 0; i < targetOutcomeIndexesLength; i++) {
+			uint256 toId = getChildId(fromId, targetUniverseIds[i]);
 			_mint(msg.sender, toId, fromIdBalance);
 			emit Migrate(msg.sender, fromId, toId, fromIdBalance);
 		}

--- a/solidity/contracts/test/peripherals/ERC1155ReceiverMock.sol
+++ b/solidity/contracts/test/peripherals/ERC1155ReceiverMock.sol
@@ -2,6 +2,8 @@
 pragma solidity 0.8.35;
 
 import '../../peripherals/interfaces/IERC1155Receiver.sol';
+import '../../peripherals/interfaces/ISecurityPool.sol';
+import '../../peripherals/interfaces/IShareToken.sol';
 
 contract ERC1155ReceiverMock is IERC1155Receiver {
 	bytes4 private constant ERC1155_RECEIVED_SELECTOR = 0xf23a6e61;
@@ -64,3 +66,17 @@ contract ERC1155ReceiverMock is IERC1155Receiver {
 }
 
 contract ERC1155NonReceiver {}
+
+contract ShareTokenAuthorizationPoolMock {
+	IShareToken public immutable shareToken;
+	uint248 public immutable universeId;
+
+	constructor(IShareToken _shareToken, uint248 _universeId) {
+		shareToken = _shareToken;
+		universeId = _universeId;
+	}
+
+	function authorizePool(ISecurityPool pool) external {
+		shareToken.authorize(pool);
+	}
+}

--- a/solidity/ts/tests/erc1155.test.ts
+++ b/solidity/ts/tests/erc1155.test.ts
@@ -8,8 +8,7 @@ import { ensureInfraDeployed } from '../testSupport/simulator/utils/contracts/de
 import { ensureZoltarDeployed, getZoltarAddress } from '../testSupport/simulator/utils/contracts/zoltar'
 import { setupTestAccounts } from '../testSupport/simulator/utils/utilities'
 import { createWriteClient, type WriteClient, writeContractAndWait } from '../testSupport/simulator/utils/clients'
-import { addressString } from '../testSupport/simulator/utils/bigint'
-import { peripherals_tokens_ShareToken_ShareToken, test_peripherals_ERC1155ReceiverMock_ERC1155NonReceiver, test_peripherals_ERC1155ReceiverMock_ERC1155ReceiverMock } from '../types/contractArtifact'
+import { peripherals_tokens_ShareToken_ShareToken, test_peripherals_ERC1155ReceiverMock_ERC1155NonReceiver, test_peripherals_ERC1155ReceiverMock_ERC1155ReceiverMock, test_peripherals_ERC1155ReceiverMock_ShareTokenAuthorizationPoolMock } from '../types/contractArtifact'
 
 setDefaultTimeout(TEST_TIMEOUT_MS)
 
@@ -139,22 +138,79 @@ describe('ERC1155 Compliance Test Suite', () => {
 		assert.strictEqual(constructorLog.args.actor, client.account.address)
 		assert.strictEqual(constructorLog.args.authorized, true)
 
+		const firstPool = await deployContract(
+			encodeDeployData({
+				abi: test_peripherals_ERC1155ReceiverMock_ShareTokenAuthorizationPoolMock.abi,
+				bytecode: `0x${test_peripherals_ERC1155ReceiverMock_ShareTokenAuthorizationPoolMock.evm.bytecode.object}`,
+				args: [shareTokenAddress, 0n],
+			}),
+		)
+		const chainedPool = await deployContract(
+			encodeDeployData({
+				abi: test_peripherals_ERC1155ReceiverMock_ShareTokenAuthorizationPoolMock.abi,
+				bytecode: `0x${test_peripherals_ERC1155ReceiverMock_ShareTokenAuthorizationPoolMock.evm.bytecode.object}`,
+				args: [shareTokenAddress, 1n],
+			}),
+		)
+		const collidingPool = await deployContract(
+			encodeDeployData({
+				abi: test_peripherals_ERC1155ReceiverMock_ShareTokenAuthorizationPoolMock.abi,
+				bytecode: `0x${test_peripherals_ERC1155ReceiverMock_ShareTokenAuthorizationPoolMock.evm.bytecode.object}`,
+				args: [shareTokenAddress, 0n],
+			}),
+		)
 		await writeContractAndWait(client, () =>
 			client.writeContract({
 				abi: peripherals_tokens_ShareToken_ShareToken.abi,
 				address: shareTokenAddress,
 				functionName: 'authorize',
-				args: [operatorClient.account.address],
+				args: [firstPool],
 			}),
 		)
-		const chainedAccount = TEST_ADDRESSES[2]
-		if (chainedAccount === undefined) throw new Error('chained authorization account missing')
-		const chainedHash = await writeContractAndWait(operatorClient, () =>
-			operatorClient.writeContract({
+		await assert.rejects(
+			writeContractAndWait(client, () =>
+				client.writeContract({
+					abi: peripherals_tokens_ShareToken_ShareToken.abi,
+					address: shareTokenAddress,
+					functionName: 'authorize',
+					args: [collidingPool],
+				}),
+			),
+			/ShareToken universe already has a canonical pool/,
+		)
+		assert.strictEqual(
+			await client.readContract({
 				abi: peripherals_tokens_ShareToken_ShareToken.abi,
 				address: shareTokenAddress,
-				functionName: 'authorize',
-				args: [addressString(chainedAccount)],
+				functionName: 'canonicalPoolByUniverse',
+				args: [0n],
+			}),
+			firstPool,
+		)
+		assert.strictEqual(
+			await client.readContract({
+				abi: peripherals_tokens_ShareToken_ShareToken.abi,
+				address: shareTokenAddress,
+				functionName: 'isAuthorized',
+				args: [firstPool],
+			}),
+			true,
+		)
+		assert.strictEqual(
+			await client.readContract({
+				abi: peripherals_tokens_ShareToken_ShareToken.abi,
+				address: shareTokenAddress,
+				functionName: 'isAuthorized',
+				args: [collidingPool],
+			}),
+			false,
+		)
+		const chainedHash = await writeContractAndWait(client, () =>
+			client.writeContract({
+				abi: test_peripherals_ERC1155ReceiverMock_ShareTokenAuthorizationPoolMock.abi,
+				address: firstPool,
+				functionName: 'authorizePool',
+				args: [chainedPool],
 			}),
 		)
 		const chainedReceipt = await client.waitForTransactionReceipt({ hash: chainedHash })
@@ -168,15 +224,15 @@ describe('ERC1155 Compliance Test Suite', () => {
 			)
 			.find(log => log.eventName === 'AuthorizationUpdated')
 		if (chainedLog === undefined) throw new Error('chained authorization log missing')
-		assert.strictEqual(chainedLog.args.account, addressString(chainedAccount))
-		assert.strictEqual(chainedLog.args.actor, operatorClient.account.address)
+		assert.strictEqual(chainedLog.args.account, chainedPool)
+		assert.strictEqual(chainedLog.args.actor, firstPool)
 		assert.strictEqual(chainedLog.args.authorized, true)
 		assert.strictEqual(
 			await client.readContract({
 				abi: peripherals_tokens_ShareToken_ShareToken.abi,
 				address: shareTokenAddress,
 				functionName: 'isAuthorized',
-				args: [addressString(chainedAccount)],
+				args: [chainedPool],
 			}),
 			true,
 		)

--- a/solidity/ts/tests/peripherals/deploymentAndOwnForkEscalation.test.ts
+++ b/solidity/ts/tests/peripherals/deploymentAndOwnForkEscalation.test.ts
@@ -4,8 +4,8 @@ import type { Abi, Address } from '@zoltar/shared/ethereum'
 import type { WriteClient } from '../../testSupport/simulator/utils/clients'
 import { peripherals_factories_SecurityPoolFactory_SecurityPoolFactory, peripherals_SecurityPool_SecurityPool, peripherals_tokens_ShareToken_ShareToken } from '../../types/contractArtifact'
 import { getQuestionResolution as readQuestionResolution } from '../../testSupport/simulator/utils/contracts/escalationGame'
-import { deployChild } from '../../testSupport/simulator/utils/contracts/zoltar'
-import { finalizeTruthAuction, startTruthAuction } from '../../testSupport/simulator/utils/contracts/securityPoolForker'
+import { deployChild, getZoltarForkThreshold } from '../../testSupport/simulator/utils/contracts/zoltar'
+import { finalizeTruthAuction, initiateSecurityPoolFork, startTruthAuction } from '../../testSupport/simulator/utils/contracts/securityPoolForker'
 import { createCarryProof, SparseNullifierTree } from '../carryProofHelpers'
 
 describe('Peripherals: deployment and own-fork escalation', () => {
@@ -159,7 +159,161 @@ describe('Peripherals: deployment and own-fork escalation', () => {
 		await assert.rejects(deployOriginSecurityPool(client, missingUniverseId, questionId, securityMultiplier), /universe is missing/)
 	})
 
+	test('rejects a parallel origin pool before deploying the canonical fork child', async () => {
+		const forkQuestionData = {
+			...questionData,
+			title: `parallel origin fork source ${await mockWindow.getTime()}`,
+			endTime: (await mockWindow.getTime()) + DAY,
+		}
+		const forkQuestionId = getQuestionId(forkQuestionData, outcomes)
+		await createQuestion(client, forkQuestionData, outcomes)
+		await mockWindow.setTime(forkQuestionData.endTime + 1n)
+		await approveToken(client, addressString(GENESIS_REPUTATION_TOKEN), getZoltarAddress())
+		await forkUniverse(client, genesisUniverse, forkQuestionId)
+		await deployChild(client, genesisUniverse, BigInt(QuestionOutcome.Yes))
+
+		const yesUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
+		await assert.rejects(deployOriginSecurityPool(client, yesUniverse, questionId, securityMultiplier), /canonical ancestor/i)
+
+		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
+		await createChildUniverse(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
+		const yesSecurityPool = getSecurityPoolAddresses(securityPoolAddresses.securityPool, yesUniverse, questionId, securityMultiplier)
+		assert.ok(await contractExists(client, yesSecurityPool.securityPool), 'canonical child pool should remain deployable after the rejected origin attempt')
+		strictEqualTypeSafe(
+			await client.readContract({
+				abi: peripherals_factories_SecurityPoolFactory_SecurityPoolFactory.abi,
+				functionName: 'getCanonicalSecurityPool',
+				address: getInfraContractAddresses().securityPoolFactory,
+				args: [yesUniverse, questionId, securityMultiplier],
+			}),
+			yesSecurityPool.securityPool,
+			'factory registry should point the child namespace to the canonical fork child',
+		)
+		strictEqualTypeSafe(
+			await client.readContract({
+				abi: peripherals_tokens_ShareToken_ShareToken.abi,
+				functionName: 'canonicalPoolByUniverse',
+				address: securityPoolAddresses.shareToken,
+				args: [yesUniverse],
+			}),
+			yesSecurityPool.securityPool,
+			'share token should authorize exactly the canonical fork child for the child universe',
+		)
+		await assert.rejects(deployOriginSecurityPool(client, yesUniverse, questionId, securityMultiplier), /canonical ancestor|canonical key/i)
+	})
+
+	test('rejects a parallel origin pool when only a higher canonical ancestor exists', async () => {
+		const firstForkQuestionData = {
+			...questionData,
+			title: `recursive origin first fork ${await mockWindow.getTime()}`,
+			endTime: (await mockWindow.getTime()) + DAY,
+		}
+		const firstForkQuestionId = getQuestionId(firstForkQuestionData, outcomes)
+		await createQuestion(client, firstForkQuestionData, outcomes)
+		await mockWindow.setTime(firstForkQuestionData.endTime + 1n)
+		await approveToken(client, addressString(GENESIS_REPUTATION_TOKEN), getZoltarAddress())
+		await forkUniverse(client, genesisUniverse, firstForkQuestionId)
+		await deployChild(client, genesisUniverse, BigInt(QuestionOutcome.Yes))
+
+		const firstChildUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
+		const firstChildRepToken = getRepTokenAddress(firstChildUniverse)
+		const firstChildForkThreshold = await getZoltarForkThreshold(client, firstChildUniverse)
+		const firstChildBalanceSlot = formatStorageSlot(getMappingStorageSlot(client.account.address, 0n))
+		await mockWindow.addStateOverrides({
+			[firstChildRepToken]: {
+				stateDiff: {
+					[firstChildBalanceSlot]: firstChildForkThreshold * 2n,
+				},
+			},
+		})
+
+		const secondForkQuestionData = {
+			...questionData,
+			title: `recursive origin second fork ${await mockWindow.getTime()}`,
+			endTime: (await mockWindow.getTime()) + DAY,
+		}
+		const secondForkQuestionId = getQuestionId(secondForkQuestionData, outcomes)
+		await createQuestion(client, secondForkQuestionData, outcomes)
+		await mockWindow.setTime(secondForkQuestionData.endTime + 1n)
+		await approveToken(client, firstChildRepToken, getZoltarAddress())
+		await forkUniverse(client, firstChildUniverse, secondForkQuestionId)
+		await deployChild(client, firstChildUniverse, BigInt(QuestionOutcome.No))
+
+		const grandchildUniverse = getChildUniverseId(firstChildUniverse, QuestionOutcome.No)
+		await assert.rejects(deployOriginSecurityPool(client, grandchildUniverse, questionId, securityMultiplier), /canonical ancestor/i)
+
+		const unrelatedQuestionData = {
+			...questionData,
+			title: `recursive origin unrelated market ${await mockWindow.getTime()}`,
+			endTime: (await mockWindow.getTime()) + DAY,
+		}
+		const unrelatedQuestionId = getQuestionId(unrelatedQuestionData, outcomes)
+		await createQuestion(client, unrelatedQuestionData, outcomes)
+		await deployOriginSecurityPool(client, grandchildUniverse, unrelatedQuestionId, securityMultiplier)
+		const unrelatedPool = getSecurityPoolAddresses(addressString(0n), grandchildUniverse, unrelatedQuestionId, securityMultiplier)
+		assert.ok(await contractExists(client, unrelatedPool.securityPool), 'a genuinely unrelated grandchild market should remain deployable')
+	})
+
+	test('stateful factory sequences keep one canonical collateral ledger per child token namespace', async () => {
+		const forkQuestionData = {
+			...questionData,
+			title: `stateful canonical pool fork ${await mockWindow.getTime()}`,
+			endTime: (await mockWindow.getTime()) + DAY,
+		}
+		const forkQuestionId = getQuestionId(forkQuestionData, outcomes)
+		await createQuestion(client, forkQuestionData, outcomes)
+		await mockWindow.setTime(forkQuestionData.endTime + 1n)
+		await approveToken(client, addressString(GENESIS_REPUTATION_TOKEN), getZoltarAddress())
+		await forkUniverse(client, genesisUniverse, forkQuestionId)
+
+		const branchOutcomes = [QuestionOutcome.Invalid, QuestionOutcome.Yes, QuestionOutcome.No]
+		for (const outcome of branchOutcomes) {
+			await deployChild(client, genesisUniverse, BigInt(outcome))
+		}
+		await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
+
+		let fuzzState = 0x5ec01n
+		const shuffledOutcomes = [...branchOutcomes]
+		for (let index = shuffledOutcomes.length - 1; index > 0; index--) {
+			fuzzState = (fuzzState * 6364136223846793005n + 1442695040888963407n) & ((1n << 64n) - 1n)
+			const swapIndex = Number(fuzzState % BigInt(index + 1))
+			const currentOutcome = shuffledOutcomes[index]
+			const swapOutcome = shuffledOutcomes[swapIndex]
+			if (currentOutcome === undefined || swapOutcome === undefined) throw new Error('stateful outcome shuffle failed')
+			shuffledOutcomes[index] = swapOutcome
+			shuffledOutcomes[swapIndex] = currentOutcome
+		}
+
+		for (const outcome of shuffledOutcomes) {
+			const childUniverse = getChildUniverseId(genesisUniverse, outcome)
+			await assert.rejects(deployOriginSecurityPool(client, childUniverse, questionId, securityMultiplier), /canonical ancestor/i)
+			await createChildUniverse(client, securityPoolAddresses.securityPool, outcome)
+			const childPool = getSecurityPoolAddresses(securityPoolAddresses.securityPool, childUniverse, questionId, securityMultiplier).securityPool
+			const factoryCanonicalPool = await client.readContract({
+				abi: peripherals_factories_SecurityPoolFactory_SecurityPoolFactory.abi,
+				functionName: 'getCanonicalSecurityPool',
+				address: getInfraContractAddresses().securityPoolFactory,
+				args: [childUniverse, questionId, securityMultiplier],
+			})
+			const tokenCanonicalPool = await client.readContract({
+				abi: peripherals_tokens_ShareToken_ShareToken.abi,
+				functionName: 'canonicalPoolByUniverse',
+				address: securityPoolAddresses.shareToken,
+				args: [childUniverse],
+			})
+			strictEqualTypeSafe(factoryCanonicalPool, childPool, 'factory should retain one canonical child collateral ledger')
+			strictEqualTypeSafe(tokenCanonicalPool, childPool, 'share token namespace should retain the same canonical child ledger')
+			await assert.rejects(deployOriginSecurityPool(client, childUniverse, questionId, securityMultiplier), /canonical ancestor|canonical key/i)
+		}
+	})
+
 	test('reuses and authorizes the share token when sibling universes deploy the same market', async () => {
+		const siblingMarketQuestionData = {
+			...questionData,
+			title: `sibling market ${await mockWindow.getTime()}`,
+		}
+		const siblingMarketQuestionId = getQuestionId(siblingMarketQuestionData, outcomes)
+		await createQuestion(client, siblingMarketQuestionData, outcomes)
 		const forkQuestionData = {
 			...questionData,
 			title: `sibling share token source ${await mockWindow.getTime()}`,
@@ -176,11 +330,11 @@ describe('Peripherals: deployment and own-fork escalation', () => {
 
 		const yesUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
 		const noUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.No)
-		await deployOriginSecurityPool(client, yesUniverse, questionId, securityMultiplier)
-		await deployOriginSecurityPool(client, noUniverse, questionId, securityMultiplier)
+		await deployOriginSecurityPool(client, yesUniverse, siblingMarketQuestionId, securityMultiplier)
+		await deployOriginSecurityPool(client, noUniverse, siblingMarketQuestionId, securityMultiplier)
 
-		const yesPoolAddresses = getSecurityPoolAddresses(addressString(0x0n), yesUniverse, questionId, securityMultiplier)
-		const noPoolAddresses = getSecurityPoolAddresses(addressString(0x0n), noUniverse, questionId, securityMultiplier)
+		const yesPoolAddresses = getSecurityPoolAddresses(addressString(0x0n), yesUniverse, siblingMarketQuestionId, securityMultiplier)
+		const noPoolAddresses = getSecurityPoolAddresses(addressString(0x0n), noUniverse, siblingMarketQuestionId, securityMultiplier)
 		strictEqualTypeSafe(yesPoolAddresses.shareToken, noPoolAddresses.shareToken, 'sibling markets should reuse their share token')
 		for (const [securityPool, universe] of [
 			[yesPoolAddresses.securityPool, yesUniverse],

--- a/solidity/ts/tests/peripherals/forkMigration.test.ts
+++ b/solidity/ts/tests/peripherals/forkMigration.test.ts
@@ -1549,6 +1549,12 @@ describe('Peripherals: fork migration', () => {
 
 			strictEqualTypeSafe(await getQuestionOutcome(client, securityPoolAddresses.securityPool), QuestionOutcome.Yes, 'late unrelated fork should not erase finalized market outcome')
 			strictEqualTypeSafe(await getSystemState(client, securityPoolAddresses.securityPool), SystemState.Operational, 'late unrelated Zoltar fork should not initiate this security pool fork')
+			const sourceBalancesBeforeRejectedMigration = await balanceOfShares(openInterestHolder, securityPoolAddresses.shareToken, genesisUniverse, openInterestHolder.account.address)
+			for (const sourceOutcome of [QuestionOutcome.Invalid, QuestionOutcome.Yes, QuestionOutcome.No]) {
+				await assert.rejects(migrateShares(openInterestHolder, securityPoolAddresses.shareToken, genesisUniverse, sourceOutcome, [QuestionOutcome.Yes]), /Resolved|resolved before fork/i)
+			}
+			await assert.rejects(migrateShares(openInterestHolder, securityPoolAddresses.shareToken, genesisUniverse, QuestionOutcome.Yes, [QuestionOutcome.Invalid, QuestionOutcome.Yes, QuestionOutcome.No]), /Resolved|resolved before fork/i)
+			assert.deepStrictEqual(await balanceOfShares(openInterestHolder, securityPoolAddresses.shareToken, genesisUniverse, openInterestHolder.account.address), sourceBalancesBeforeRejectedMigration, 'rejected migration must preserve every funded source outcome balance')
 			const walletRepBeforeClaims = await getERC20Balance(client, addressString(GENESIS_REPUTATION_TOKEN), client.account.address)
 			await redeemShares(openInterestHolder, securityPoolAddresses.securityPool)
 			strictEqualTypeSafe(await getShareTokenSupply(client, securityPoolAddresses.securityPool), 0n, 'winning redemption should still complete after the unrelated fork')
@@ -1827,6 +1833,10 @@ describe('Peripherals: fork migration', () => {
 			const lowScalarOutcome = getScalarOutcomeIndex(scalarForkQuestion, 3n)
 			const highScalarOutcome = getScalarOutcomeIndex(scalarForkQuestion, 7n)
 			const sortedScalarOutcomes = sortBigIntsAscending([lowScalarOutcome, highScalarOutcome])
+			await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
+			for (const outcome of sortedScalarOutcomes) {
+				await createChildUniverse(client, securityPoolAddresses.securityPool, outcome)
+			}
 			const holderAddress = addressString(TEST_ADDRESSES[2])
 			const parentBalancesBeforeMigration = await balanceOfShares(client, securityPoolAddresses.shareToken, genesisUniverse, holderAddress)
 			const parentYesBalance = ensureDefined(parentBalancesBeforeMigration[1], 'parent yes balance is undefined')
@@ -2182,11 +2192,11 @@ describe('Peripherals: fork migration', () => {
 			await createCompleteSet(openInterestHolder, securityPoolAddresses.securityPool, parentMintAmount)
 
 			await triggerExternalForkForSecurityPool(undefined, 'zero-collateral child complete-set fork source')
+			await createChildUniverse(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
 			await migrateShares(openInterestHolder, securityPoolAddresses.shareToken, genesisUniverse, QuestionOutcome.Invalid, [QuestionOutcome.Yes])
 			await migrateShares(openInterestHolder, securityPoolAddresses.shareToken, genesisUniverse, QuestionOutcome.Yes, [QuestionOutcome.Yes])
 			await migrateShares(openInterestHolder, securityPoolAddresses.shareToken, genesisUniverse, QuestionOutcome.No, [QuestionOutcome.Yes])
 			await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
-			await createChildUniverse(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
 
 			const yesUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
 			const yesSecurityPool = getSecurityPoolAddresses(securityPoolAddresses.securityPool, yesUniverse, questionId, securityMultiplier)
@@ -2627,13 +2637,88 @@ describe('Peripherals: fork migration', () => {
 			strictEqualTypeSafe(await getQuestionOutcome(client, yesSecurityPool.securityPool), QuestionOutcome.Yes, 'matching-question child should resolve to its branch outcome')
 		})
 
+		test('a fixed-outcome child rejects an unrelated recursive fork without burning funded shares', async () => {
+			const openInterestAmount = 5n * 10n ** 18n
+			const openInterestHolder = createWriteClient(mockWindow, TEST_ADDRESSES[2], 0)
+			await manipulatePriceOracleAndPerformOperation(client, mockWindow, securityPoolAddresses.priceOracleManagerAndOperatorQueuer, OperationType.SetSecurityBondsAllowance, client.account.address, repDeposit / 4n)
+			await createCompleteSet(openInterestHolder, securityPoolAddresses.securityPool, openInterestAmount)
+
+			const endTime = await getQuestionEndDate(client, questionId)
+			await mockWindow.setTime(endTime + 10000n)
+			await approveToken(client, addressString(GENESIS_REPUTATION_TOKEN), getZoltarAddress())
+			await forkUniverse(client, genesisUniverse, questionId)
+			await initiateSecurityPoolFork(client, securityPoolAddresses.securityPool)
+			await migrateRepToZoltar(client, securityPoolAddresses.securityPool, [QuestionOutcome.Yes])
+			await createChildUniverse(client, securityPoolAddresses.securityPool, QuestionOutcome.Yes)
+			await migrateShares(openInterestHolder, securityPoolAddresses.shareToken, genesisUniverse, QuestionOutcome.Yes, [QuestionOutcome.Yes])
+
+			const fixedChildUniverse = getChildUniverseId(genesisUniverse, QuestionOutcome.Yes)
+			const fixedChildPool = getSecurityPoolAddresses(securityPoolAddresses.securityPool, fixedChildUniverse, questionId, securityMultiplier)
+			await mockWindow.advanceTime(8n * 7n * DAY + DAY)
+			await startTruthAuction(client, fixedChildPool.securityPool)
+			if ((await getSystemState(client, fixedChildPool.securityPool)) === SystemState.ForkTruthAuction) {
+				const repairContribution = await getEthRaiseCap(client, fixedChildPool.truthAuction)
+				await mockWindow.advanceTime(7n * DAY + DAY)
+				await finalizeTruthAuction(client, fixedChildPool.securityPool, repairContribution)
+			}
+			strictEqualTypeSafe(await getSystemState(client, fixedChildPool.securityPool), SystemState.Operational, 'fixed child should be operational before the unrelated recursive fork')
+			strictEqualTypeSafe(await getQuestionOutcome(client, fixedChildPool.securityPool), QuestionOutcome.Yes, 'matching first fork should fix the child outcome to yes')
+			await client.simulateContract({
+				abi: peripherals_SecurityPool_SecurityPool.abi,
+				address: fixedChildPool.securityPool,
+				functionName: 'activateForkMode',
+				args: [true],
+				account: getInfraContractAddresses().securityPoolForker,
+			})
+			await assert.rejects(
+				client.simulateContract({
+					abi: peripherals_SecurityPool_SecurityPool.abi,
+					address: fixedChildPool.securityPool,
+					functionName: 'activateForkMode',
+					args: [false],
+					account: getInfraContractAddresses().securityPoolForker,
+				}),
+				/Resolved/,
+			)
+
+			const unrelatedForkQuestionData = {
+				...questionData,
+				title: 'unrelated recursive fork against a fixed child',
+				endTime: await mockWindow.getTime(),
+			}
+			const unrelatedForkQuestionId = getQuestionId(unrelatedForkQuestionData, outcomes)
+			await createQuestion(client, unrelatedForkQuestionData, outcomes)
+			const childRepToken = await getRepToken(client, fixedChildPool.securityPool)
+			const childForkThreshold = await getZoltarForkThreshold(client, fixedChildUniverse)
+			const childBalanceSlot = formatStorageSlot(getMappingStorageSlot(client.account.address, 0n))
+			await mockWindow.addStateOverrides({
+				[childRepToken]: {
+					stateDiff: {
+						[childBalanceSlot]: childForkThreshold * 2n,
+					},
+				},
+			})
+			await approveToken(client, childRepToken, getZoltarAddress())
+			await forkUniverse(client, fixedChildUniverse, unrelatedForkQuestionId)
+
+			const sourceBalancesBeforeRejectedMigration = await balanceOfShares(openInterestHolder, fixedChildPool.shareToken, fixedChildUniverse, openInterestHolder.account.address)
+			assert.ok(ensureDefined(sourceBalancesBeforeRejectedMigration[1], 'fixed child winning balance missing') > 0n, 'test setup should preserve funded winning shares in the fixed child')
+			await assert.rejects(initiateSecurityPoolFork(client, fixedChildPool.securityPool), /Resolved/)
+			await assert.rejects(migrateShares(openInterestHolder, fixedChildPool.shareToken, fixedChildUniverse, QuestionOutcome.Yes, [QuestionOutcome.Yes]), /Resolved/)
+			await assert.rejects(migrateShares(openInterestHolder, fixedChildPool.shareToken, fixedChildUniverse, QuestionOutcome.Yes, [QuestionOutcome.Invalid, QuestionOutcome.Yes, QuestionOutcome.No]), /Resolved/)
+			assert.deepStrictEqual(await balanceOfShares(openInterestHolder, fixedChildPool.shareToken, fixedChildUniverse, openInterestHolder.account.address), sourceBalancesBeforeRejectedMigration, 'rejected scalar and bulk migrations must preserve every funded source balance')
+			strictEqualTypeSafe(await getSystemState(client, fixedChildPool.securityPool), SystemState.Operational, 'rejected recursive fork attempts must leave the fixed child operational')
+
+			const collateralBeforeRedemption = await getCompleteSetCollateralAmount(client, fixedChildPool.securityPool)
+			const holderBalanceBeforeRedemption = await getETHBalance(client, openInterestHolder.account.address)
+			await redeemShares(openInterestHolder, fixedChildPool.securityPool)
+			assert.ok((await getETHBalance(client, openInterestHolder.account.address)) > holderBalanceBeforeRedemption, 'funded winning shares should remain redeemable after the rejected recursive fork')
+			assert.ok(collateralBeforeRedemption > 0n, 'fixed child should hold funded collateral before redemption')
+			strictEqualTypeSafe(await getCompleteSetCollateralAmount(client, fixedChildPool.securityPool), 0n, 'winning redemption should consume the fixed child collateral')
+			strictEqualTypeSafe(await getShareTokenSupply(client, fixedChildPool.securityPool), 0n, 'winning redemption should consume the fixed child supply')
+		})
+
 		test.each([
-			{
-				name: 'matching then unrelated inherits the first fixed outcome',
-				firstForkMatches: true,
-				secondForkMatches: false,
-				expectedOutcome: QuestionOutcome.Yes,
-			},
 			{
 				name: 'unrelated then matching installs the second branch outcome',
 				firstForkMatches: false,

--- a/solidity/ts/tests/peripheralsInvariant.test.ts
+++ b/solidity/ts/tests/peripheralsInvariant.test.ts
@@ -947,6 +947,7 @@ describe('Peripherals invariant harness', () => {
 			await triggerExternalForkForSecurityPool(undefined, 'stateful lifecycle fork source')
 		}
 		strictEqualTypeSafe(await getSystemState(client, context.securityPool), SystemState.PoolForked, 'forking should freeze the parent pool')
+		await createChildUniverse(client, context.securityPool, QuestionOutcome.Yes)
 
 		const migrationActions = shuffle(['invalid-shares', 'yes-shares', 'no-shares', 'rep', 'vault'] as const, seed)
 		for (const action of migrationActions) {


### PR DESCRIPTION
## Summary
- Add canonical pool tracking in the security pool factory so forked share tokens cannot collide across pools.
- Tighten fork and share-token logic to bind share accounting to the canonical pool identity.
- Expand ERC-1155, fork migration, and deployment coverage for the new collision-prevention behavior.
- Refresh invariant and protocol docs to reflect the updated fork/share model and terminology.

## Testing
- `bun run tsc`
- `bun run ensure-contract-artifacts && bun run check:shared-dependencies && bun run test:run -- --bail=1`
- `bun run format:check`
- `bun run check:changed`
- `bun run knip`
- `git diff --check`