### PR TITLE
Preserve solc type index in Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@ solidity/coverage
 solidity/js
 solidity/ts/**/*.d.ts
 solidity/ts/**/*.d.ts.map
+!solidity/ts/types/index.d.ts
 solidity/ts/**/*.js
 solidity/ts/**/*.js.map
 solidity/ts/types/contractArtifact.ts


### PR DESCRIPTION
## Summary
- Keep `solidity/ts/types/index.d.ts` included in the Docker build context.
- Ensure the generated Solc TypeScript type index is available to downstream build and packaging steps.

## Testing
- Not run (change is limited to `.dockerignore` only).