### PR TITLE
Fix maintenance workflows and refresh mainnet addresses

### DIFF
--- a/docs/mainnet-deployment-addresses.json
+++ b/docs/mainnet-deployment-addresses.json
@@ -13,7 +13,7 @@
 		{
 			"id": "deploymentStatusOracle",
 			"label": "Deployment Status Oracle",
-			"address": "0x1d3615F8acB26A117F1C5dBa2A1caF049B802c09"
+			"address": "0xA4650AF4AF9d7240DFc2Ca4995E58B5163AE1EaF"
 		},
 		{
 			"id": "multicall3",
@@ -23,7 +23,7 @@
 		{
 			"id": "uniformPriceDualCapBatchAuctionFactory",
 			"label": "UniformPriceDualCapBatchAuctionFactory",
-			"address": "0x330a2A568F875B5BC3fD8FA368050d4f414c05FA"
+			"address": "0x54E477cb424C9123d6869f0d89E404086bCD644D"
 		},
 		{
 			"id": "scalarOutcomes",
@@ -33,7 +33,7 @@
 		{
 			"id": "securityPoolUtils",
 			"label": "SecurityPoolUtils",
-			"address": "0x10293D04A06C49E2BFFD84c1A1739b2A59EB9A69"
+			"address": "0xfA24d690774E8Dc654E38372e7aD1d55D940aFd3"
 		},
 		{
 			"id": "openOracle",
@@ -53,34 +53,34 @@
 		{
 			"id": "shareTokenFactory",
 			"label": "ShareTokenFactory",
-			"address": "0x63425911EECa54423d57bE5D576c2e1a19ab3e55"
+			"address": "0xEA7C84334060d1E708cdd1f9C2AAa65f07d66555"
 		},
 		{
 			"id": "priceOracleManagerAndOperatorQueuerFactory",
 			"label": "OpenOracle Price Coordinator Factory",
-			"address": "0x214764d43841141dB60C84b59EAbdA877aC4f116"
+			"address": "0x0425CB20530d26C720FbB2713ff7eFefFEd9893B"
 		},
 		{
 			"id": "securityPoolForker",
 			"label": "Security Pool Forker",
-			"address": "0x7A81c01BA213FEFbD349E30a959fba74231E4149"
+			"address": "0x7eb818176CeDD11dC5063FB90cBc94AD4Bf00383"
 		},
 		{
 			"id": "escalationGameFactory",
 			"label": "Escalation Game Factory",
-			"address": "0xdF909711df244796C9e61F37aa4E183769378A90"
+			"address": "0x78B32B5C65C8c1275c9f087f53F9b73fBD9EA398"
 		},
 		{
 			"id": "securityPoolFactory",
 			"label": "Security Pool Factory",
-			"address": "0x1Aa25f25c47d7a881524FE513808a50a69BeD2b0"
+			"address": "0x3b1e9D4F06bBD4D76A1544aBaD0B66B81B7ce322"
 		}
 	],
 	"derivedContracts": [
 		{
 			"id": "escalationGameProofVerifier",
 			"label": "Escalation Game Proof Verifier",
-			"address": "0x47bDe81Be54B358E6C5CCd8637D25444beE7B8c3"
+			"address": "0xbef5755686C16793FbED23e27539Ad34807d915F"
 		}
 	]
 }

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
 		"update:escalation-game-abi-snapshot": "UPDATE_ESCALATION_GAME_ABI_SNAPSHOT=1 bun test solidity/ts/tests/escalationGameInterfaceRegression.test.ts",
 		"update:escalation-game-bytecode-snapshot": "UPDATE_ESCALATION_GAME_BYTECODE_SNAPSHOT=1 bun test solidity/ts/tests/escalationGameInterfaceRegression.test.ts",
 		"coverage:ui": "bun run ensure-shared-build && bun run check:shared-dependencies && bun test --preload ./bun-test-setup-ui.ts --isolate --coverage --coverage-reporter=lcov --coverage-reporter=text --coverage-dir=coverage/ui ui/ts/tests",
-		"coverage:contracts:ts": "bun run ensure-contract-artifacts && bun test --coverage --coverage-reporter=lcov --coverage-reporter=text --coverage-dir=coverage/contracts-ts solidity/ts/tests",
+		"coverage:contracts:ts": "bun run ensure-contract-artifacts && bun test --timeout 300000 --coverage --coverage-reporter=lcov --coverage-reporter=text --coverage-dir=coverage/contracts-ts solidity/ts/tests",
 		"coverage:contracts:bytecode": "bun run ensure-contract-artifacts && bun run check:shared-dependencies && bun ./scripts/run-solidity-bytecode-coverage.mts",
 		"coverage:contracts:bytecode:shard1": "bun run ensure-contract-artifacts && bun run check:shared-dependencies && bun ./scripts/run-solidity-bytecode-coverage.mts --shard 1",
 		"coverage:contracts:bytecode:shard2": "bun run ensure-contract-artifacts && bun run check:shared-dependencies && bun ./scripts/run-solidity-bytecode-coverage.mts --shard 2",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -13,7 +13,7 @@
 		"setup": "bun ../scripts/install-frozen.mjs . && bun run compile-contracts",
 		"generate:contract-artifacts": "bun run compile-contracts",
 		"compile-contracts": "bun run shared && bun run refresh:shared-dependency && bun tsc --project tsconfig-compile.json && bun ./js/compile.js && cd .. && bun run generate:ui-contract-artifact && bun ./scripts/ensure-contract-artifacts.mts --sync-contract-freshness",
-		"gas-costs": "cd .. && bun run ensure-shared-build && cd solidity && bun run check:shared-dependency && bun tsc && bun run ./js/gas-costs.js",
+		"gas-costs": "cd .. && bun run ensure-shared-build && cd solidity && bun run check:shared-dependency && bun run ./ts/gas-costs.ts",
 		"test": "bun run ensure-contract-artifacts && bun run check:shared-dependency && bun tsc && bun test --timeout 300000 ./js/tests/"
 	},
 	"keywords": [],

--- a/solidity/ts/gas-costs.ts
+++ b/solidity/ts/gas-costs.ts
@@ -175,6 +175,7 @@ const prepareEscalationFork = async (context: PoolContext) => {
 	const repToken = await getRepToken(alice, context.addresses.securityPool)
 	const forkThreshold = (await getTotalTheoreticalSupply(alice, repToken)) / 20n
 	await anvil.setTime(context.questionData.endTime + 10_000n)
+	await manipulatePriceOracle(alice, anvil, context.addresses.priceOracleManagerAndOperatorQueuer)
 	await confirmTx(alice, approveToken(alice, addressString(GENESIS_REPUTATION_TOKEN), context.addresses.securityPool))
 	await confirmTx(alice, depositRep(alice, context.addresses.securityPool, 2n * forkThreshold))
 	await confirmTx(alice, depositToEscalationGame(alice, context.addresses.securityPool, QuestionOutcome.Yes, forkThreshold))
@@ -196,7 +197,7 @@ const prepareExternalZoltarFork = async (context: PoolContext, titlePrefix: stri
 	await confirmTx(alice, forkUniverse(alice, genesisUniverse, forkQuestionId))
 }
 
-const prepareYesChildForAuction = async () => {
+const prepareYesChildForAuction = async (migrateOpenInterestShares = false) => {
 	const context = await setupPool('Gas auction question')
 	await confirmTx(alice, approveToken(alice, addressString(GENESIS_REPUTATION_TOKEN), context.addresses.securityPool))
 	await confirmTx(alice, depositRep(alice, context.addresses.securityPool, repDepositAmount))
@@ -213,12 +214,18 @@ const prepareYesChildForAuction = async () => {
 	const yesPool = getSecurityPoolAddresses(context.addresses.securityPool, yesUniverse, context.questionId, securityMultiplier)
 	const forkData = await getSecurityPoolForkerForkData(alice, context.addresses.securityPool)
 	const ethRaiseCap = openInterestAmount - (openInterestAmount * forkData.migratedRep) / forkData.auctionableRepAtFork
+	if (migrateOpenInterestShares) {
+		const winningChildTarget = [QuestionOutcome.Yes]
+		await confirmTx(carol, migrateShares(carol, context.addresses.shareToken, genesisUniverse, QuestionOutcome.Invalid, winningChildTarget))
+		await confirmTx(carol, migrateShares(carol, context.addresses.shareToken, genesisUniverse, QuestionOutcome.Yes, winningChildTarget))
+		await confirmTx(carol, migrateShares(carol, context.addresses.shareToken, genesisUniverse, QuestionOutcome.No, winningChildTarget))
+	}
 	await anvil.advanceTime(8n * 7n * DAY + DAY)
 	return { context, yesPool, ethRaiseCap }
 }
 
-const prepareYesChildFinalized = async () => {
-	const { context, yesPool, ethRaiseCap } = await prepareYesChildForAuction()
+const prepareYesChildFinalized = async (migrateOpenInterestShares = false) => {
+	const { context, yesPool, ethRaiseCap } = await prepareYesChildForAuction(migrateOpenInterestShares)
 	await confirmTx(alice, startTruthAuction(alice, yesPool.securityPool))
 	await confirmTx(dave, submitBid(dave, yesPool.truthAuction, 0n, ethRaiseCap))
 	await anvil.advanceTime(8n * DAY)
@@ -690,12 +697,8 @@ const scenarios: Scenario[] = [
 		section: '16. Migration',
 		label: 'redeem winning shares after migration to child',
 		run: async () => {
-			const prepared = await prepareYesChildFinalized()
+			const prepared = await prepareYesChildFinalized(true)
 			await confirmTx(alice, claimAuctionProceeds(alice, prepared.yesPool.securityPool, dave.account.address, [{ tick: 0n, bidIndex: 0n }]))
-			const binaryTargetOutcomes = [QuestionOutcome.Invalid, QuestionOutcome.Yes, QuestionOutcome.No]
-			await confirmTx(carol, migrateShares(carol, prepared.context.addresses.shareToken, genesisUniverse, QuestionOutcome.Invalid, binaryTargetOutcomes))
-			await confirmTx(carol, migrateShares(carol, prepared.context.addresses.shareToken, genesisUniverse, QuestionOutcome.Yes, binaryTargetOutcomes))
-			await confirmTx(carol, migrateShares(carol, prepared.context.addresses.shareToken, genesisUniverse, QuestionOutcome.No, binaryTargetOutcomes))
 			return await waitForGas(carol, redeemShares(carol, prepared.yesPool.securityPool))
 		},
 	},


### PR DESCRIPTION
## Summary

- run the gas-cost benchmark from its TypeScript source instead of the emitting Solidity TypeScript configuration that rejects shared source imports and leaves generated JavaScript beside source files
- repair stale benchmark setup by refreshing the oracle price and migrating shares to the canonical child before the migration deadline
- give contract TypeScript coverage the repository-standard 300-second per-test timeout so legitimate coverage overhead does not kill isolated Anvil and cascade into RPC failures
- refresh eight deterministic mainnet deployment-step addresses and the derived escalation-game verifier address
- explicitly retain `OpenOraclePriceCoordinator`; repository-wide scans confirm the stale `SecurityPoolOracleCoordinator` specification has no implementation, ABI, deployment, test, event, or documentation occurrence to rename

## Why

`bun run gas-costs` first failed during an emitting TypeScript compile because `solidity/tsconfig.json` constrains `rootDir` to `solidity/ts` while shared imports resolve to `shared/ts`. Once execution reached the benchmark, two scenarios also depended on outdated lifecycle timing: a price was stale after a year-long time jump, and share migration occurred after its eight-week window.

`bun run coverage:full` used Bun's five-second default for contract TypeScript coverage. A valid isolated-Anvil truth-auction test takes slightly more than five seconds under coverage, so Bun terminated the test and its Anvil process, producing follow-on `ECONNRESET` and connection-refused errors.

## Validation

- `bun run tsc`
- focused truth-auction coverage regression: 1 passed, 47 filtered
- `bun run gas-costs`
- `bun run coverage:contracts:ts`: 550 passed, 0 failed
- `bun run coverage:contracts:bytecode`: shard 1 255 passed; shard 2 299 passed
- `bun run coverage:full`: UI, contract TypeScript, both bytecode shards, and final merge completed; merged bytecode coverage is 3,338 / 3,345 lines across 43 files
- `bun run docs:check:current`
- `bun run format:check`
- `bun run check`
- `bun run knip`
- `git diff --check`

Documentation review and final code review both scored 99/100 with no High, Medium, or Low findings.

## Visual QA

Not applicable: the changed files do not affect rendered UI or rendered documentation surfaces.
