### PR TITLE
Center documentation equations

### DIFF
--- a/docs/shared-docs.css
+++ b/docs/shared-docs.css
@@ -497,7 +497,7 @@ body.doc-openoracle .term:focus-visible {
 body.doc-openoracle .equation math {
 	display: block;
 	width: max-content;
-	min-width: 100%;
+	margin-inline: auto;
 	padding: 0.25rem 0;
 	font-size: clamp(0.84rem, 1.6vw, 1.05rem);
 }
@@ -1207,7 +1207,8 @@ body.paper-statoblast .equation {
 }
 body.paper-statoblast .equation math {
 	display: block;
-	min-width: max-content;
+	width: max-content;
+	margin-inline: auto;
 	font-size: 1.02rem;
 }
 body.paper-statoblast .equation-caption {
@@ -2185,7 +2186,8 @@ body.paper-zoltar .equation {
 }
 body.paper-zoltar .equation math {
 	display: block;
-	min-width: max-content;
+	width: max-content;
+	margin-inline: auto;
 	font-size: 1.02rem;
 }
 body.paper-zoltar .equation-caption {


### PR DESCRIPTION
## Summary

- center native MathML display equations across the standard docs, Statoblast paper, and Zoltar paper themes
- preserve left-aligned captions and inline math
- keep oversized formulas start-anchored inside their existing horizontal scroll containers

## Why

Display MathML previously occupied the full equation container, so browser-native MathML layout placed formula content at the inline start. Using intrinsic-width MathML boxes with automatic inline margins centers formulas that fit without making long equations inaccessible.

## Validation

- bun run docs:check-html
- bun run format:check
- bun run check:changed
- git diff --check
- Chromium QA at 1440x900 across all three docs themes
- Chromium QA at 390x844 for ordinary and oversized equations

Text review: 96/100, no findings. Visual review: 96/100, no findings. Final review: 97/100, no findings.

## Visual evidence

### Standard documentation — desktop (1440x900)

![Centered complete-set equation on desktop](https://sharey.org/8iiPt4.png)

### Standard documentation — mobile (390x844)

![Centered complete-set equation on mobile](https://sharey.org/KoUMFC.png)

### Zoltar whitepaper (1440x900)

![Centered Zoltar whitepaper equations](https://sharey.org/4VJ5tR.png)

### Statoblast whitepaper (1440x900)

![Centered Statoblast whitepaper equations](https://sharey.org/rEN9QK.png)

Screenshots expire after 90 days.