### PR TITLE
Fix ten bot safety and reliability edge cases

### DIFF
--- a/bots/liquidator/src/cli/run.ts
+++ b/bots/liquidator/src/cli/run.ts
@@ -13,11 +13,12 @@ import { stagedOperationOutcome } from '#core/staged-outcome'
 import { dryRunCandidate, executeLiquidation, executeOriginPoolDeployment, executeVaultMigration, maintainVault, validateReceiptExpectation } from '#execution/liquidation-executor'
 import { scanPools } from '#monitoring/pool-monitor'
 import { assertIntentSender, clearMarketEvidenceForConfigurationChange, commitReconciledIntent, initialRuntimeState, loadDurableState, operatorSnapshot, recordActivity, recoveredIntentCanBeResubmitted, resolveRecoveredIntentJournal, saveDurableState, type PoolObservation } from '#state/operator-state'
-import { evaluateCandidate, liquidationExecutionAllowed, sortCandidates } from '#core/strategy'
+import { evaluateCandidate, liquidationExecutionAllowed, selectAllowedCandidate } from '#core/strategy'
 import { ambiguousRecoveryAction, PRIVATE_INTENT_FINALITY_BLOCKS, requireRecoveredTransactionSuccess, shouldStopAfterSuccessfulCycle } from '#core/cycle-control'
 import { inheritedChildPoolSelections, selectVaultMigration, validateApprovedUniverseSelection } from '#core/fork-migration'
 import { createConfigurationMutationGate } from '#core/configuration-gate'
 import { commitSignerMutation } from '#core/signer-mutation'
+import { acquireLiquidatorExecutionLocksForShutdown, createLiquidatorShutdownController, liquidatorDashboardLifecycle } from '#core/process-lock'
 import { parseTransactionReconciliation, validateReconciliationIntentChain, verifyFinalizedReplacement } from '#core/transaction-reconciliation'
 import { centralizedMarketConfigurationAllowsExecution, centralizedMarketConsensusObservations, centralizedPriceAllowsExecution, marketConsensusSettings, observeCentralizedMarkets, parseCentralizedMarketSettings } from '@zoltar/bot-shared/monitoring/centralized-markets'
 import { observeConstantProductMarkets } from '@zoltar/bot-shared/monitoring/constant-product-markets'
@@ -91,9 +92,12 @@ async function desiredPoolStatus(settings: OperatorSettings, desired: DesiredPoo
 	return { address, desired }
 }
 
-function selectedCandidate(pools: readonly PoolObservation[], settings: OperatorSettings) {
+function selectedCandidate(pools: readonly PoolObservation[], settings: OperatorSettings, allowed: (pool: PoolObservation) => boolean) {
 	const candidates = pools.flatMap(pool => pool.candidates)
-	const candidate = sortCandidates(candidates, settings.strategy.candidatePriority)[0]
+	const candidate = selectAllowedCandidate(candidates, settings.strategy.candidatePriority, candidate => {
+		const pool = pools.find(pool => pool.address.toLowerCase() === candidate.pool.address.toLowerCase())
+		return pool !== undefined && allowed(pool)
+	})
 	if (candidate === undefined) return undefined
 	const pool = pools.find(pool => pool.address.toLowerCase() === candidate.pool.address.toLowerCase())
 	if (pool === undefined) throw new Error('Selected candidate pool disappeared from the scan')
@@ -274,6 +278,15 @@ async function main() {
 	let settings = loaded.settings
 	let settingsRevision = loaded.revision
 	let activePrivateKey = settings.privateKey
+	let executionAccount: Account | undefined
+	if (settings.runtime.execute) {
+		if (activePrivateKey === undefined) throw new Error('Live execution requires a configured signer')
+		executionAccount = privateKeyToAccount(activePrivateKey)
+	}
+	using shutdown = createLiquidatorShutdownController()
+	const acquiredExecutionLocks = await acquireLiquidatorExecutionLocksForShutdown(settings.runtime.stateFile, settings.network.chainId, executionAccount?.address, shutdown)
+	if (acquiredExecutionLocks === undefined) return
+	await using executionLocks = acquiredExecutionLocks
 	let settingsQueue = Promise.resolve()
 	const chain = chainFor(settings)
 	let client = createPublicClient({
@@ -515,23 +528,26 @@ async function main() {
 							throw new Error('Signer request requires privateKey and rememberSigner')
 						}
 						const candidate = signerCandidate(rawPrivateKey.trim() === '' ? null : rawPrivateKey)
-						await commitSignerMutation(
-							candidate,
-							rememberSigner,
-							async signer => persistSettings(current => ({ ...current, privateKey: signer.privateKey })),
-							signer => {
-								activePrivateKey = signer.privateKey
-								wallet =
-									activePrivateKey === undefined
-										? undefined
-										: createWalletClient({
-												account: privateKeyToAccount(activePrivateKey),
-												chain,
-												transport: http(settings.connectivity.readRpcUrl),
-											})
-								state.wallet = wallet?.account.address
-							},
-						)
+						const commit = () =>
+							commitSignerMutation(
+								candidate,
+								rememberSigner,
+								async signer => persistSettings(current => ({ ...current, privateKey: signer.privateKey })),
+								signer => {
+									activePrivateKey = signer.privateKey
+									wallet =
+										activePrivateKey === undefined
+											? undefined
+											: createWalletClient({
+													account: privateKeyToAccount(activePrivateKey),
+													chain,
+													transport: http(settings.connectivity.readRpcUrl),
+												})
+									state.wallet = wallet?.account.address
+								},
+							)
+						if (settings.runtime.execute && candidate.address !== undefined && executionLocks !== undefined) await executionLocks.withSignerReservation(candidate.address, commit)
+						else await commit()
 						recordActivity(state, {
 							kind: 'configuration',
 							message: candidate.address === undefined ? 'Active signer cleared' : `Signer ${candidate.address} activated${rememberSigner ? ' and saved' : ''}`,
@@ -552,6 +568,7 @@ async function main() {
 					}),
 			})
 		: undefined
+	await using dashboardLifecycle = dashboard === undefined ? undefined : liquidatorDashboardLifecycle(dashboard)
 	if (dashboard !== undefined) {
 		console.log(`dashboard=${dashboard.url}`)
 	}
@@ -575,6 +592,7 @@ async function main() {
 	let lastDryRunKey: string | undefined
 	await pollUntilStopped(
 		async () => {
+			if (shutdown.isRequested()) return true
 			if (configurationMutationGate.isActive()) return false
 			state.scanning = true
 			state.error = undefined
@@ -716,29 +734,15 @@ async function main() {
 							return shouldStopAfterSuccessfulCycle(settings.runtime.once)
 						}
 					}
-					const selected = selectedCandidate(state.pools, settings)
+					const selected = selectedCandidate(state.pools, settings, pool => settings.selectedPools.some(selectedPool => selectedPool.toLowerCase() === pool.address.toLowerCase()) && liquidationExecutionAllowed(pool.lastPrice, marketPriceAllowsExecution(pool, settings, state)))
 					if (selected !== undefined) {
-						if (!settings.selectedPools.some(pool => pool.toLowerCase() === selected.pool.address.toLowerCase())) return shouldStopAfterSuccessfulCycle(settings.runtime.once)
-						const centralizedPriceAllowed = marketPriceAllowsExecution(selected.pool, settings, state)
-						if (!liquidationExecutionAllowed(selected.pool.lastPrice, centralizedPriceAllowed)) {
-							recordActivity(state, {
-								details: `pool=${selected.pool.address}`,
-								kind: 'scan',
-								message: selected.pool.lastPrice === 0n ? 'Candidate skipped because its pool has no coordinator REP price' : 'Candidate skipped because its REP price disagrees with the independent market reference',
-								status: 'info',
-							})
-							return shouldStopAfterSuccessfulCycle(settings.runtime.once)
-						}
 						const currentCandidate = evaluateCandidate(selected.candidate.pool, selected.candidate.target, selected.pool.botVault, settings.strategy)
 						if (currentCandidate === undefined) return shouldStopAfterSuccessfulCycle(settings.runtime.once)
 						await executeLiquidation(wallet, settings, state, selected.pool, currentCandidate, () => canonicalMarketPriceAllowsExecution(selected.pool, settings, state, blockNumber => canonicalBlockHash(settings, blockNumber)))
 					}
 				} else if (!state.paused) {
-					const selected = selectedCandidate(state.pools, settings)
+					const selected = selectedCandidate(state.pools, settings, pool => marketPriceAllowsExecution(pool, settings, state))
 					if (selected !== undefined) {
-						if (!marketPriceAllowsExecution(selected.pool, settings, state)) {
-							return shouldStopAfterSuccessfulCycle(settings.runtime.once)
-						}
 						const dryRunKey = `${selected.pool.address}:${selected.candidate.target.address}:${selected.candidate.debtToMove.toString()}:${selected.pool.lastPrice.toString()}`
 						if (dryRunKey !== lastDryRunKey) {
 							dryRunCandidate(state, selected.candidate)
@@ -769,11 +773,10 @@ async function main() {
 				state.scanning = false
 			}
 		},
-		() => new Promise(resolve => setTimeout(resolve, settings.runtime.pollMilliseconds)),
+		() => shutdown.wait(settings.runtime.pollMilliseconds),
 		settings.runtime.once,
 		error => console.error(`liquidator=${errorMessage(error)}`),
 	)
-	dashboard?.stop()
 }
 
 main().catch(error => {

--- a/bots/liquidator/src/core/process-lock.ts
+++ b/bots/liquidator/src/core/process-lock.ts
@@ -1,0 +1,159 @@
+import { mkdir, open, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { getAddress, type Address } from '@zoltar/bot-shared/ethereum'
+
+type ProcessLock = {
+	release: () => Promise<void>
+}
+
+async function acquireProcessLock(path: string, subject: string, metadata: Record<string, string | number>): Promise<ProcessLock> {
+	await mkdir(dirname(path), { mode: 0o700, recursive: true })
+	let handle: Awaited<ReturnType<typeof open>>
+	try {
+		handle = await open(path, 'wx', 0o600)
+	} catch (error) {
+		if (typeof error === 'object' && error !== null && 'code' in error && error.code === 'EEXIST') {
+			let owner = 'owner metadata unavailable'
+			try {
+				owner = (await readFile(path, 'utf8')).trim()
+			} catch (readError) {
+				void readError
+			}
+			throw new Error(`${subject} is already locked (${owner}). Stop the other process before removing ${path}.`)
+		}
+		throw error
+	}
+	const payload = `${JSON.stringify({ acquiredAt: new Date().toISOString(), ...metadata, pid: process.pid })}\n`
+	try {
+		await handle.writeFile(payload, { encoding: 'utf8' })
+		await handle.chmod(0o600)
+		await handle.sync()
+	} catch (error) {
+		await handle.close()
+		await rm(path, { force: true })
+		throw error
+	}
+	let released = false
+	return {
+		release: async () => {
+			if (released) return
+			released = true
+			await handle.close()
+			const current = await readFile(path, 'utf8').catch(error => {
+				throw new Error(`${subject} lock ${path} disappeared before release: ${error instanceof Error ? error.message : String(error)}`)
+			})
+			if (current !== payload) throw new Error(`${subject} lock ${path} changed ownership before release`)
+			await rm(path, { force: true })
+		},
+	}
+}
+
+export async function acquireLiquidatorExecutionLocks(stateFile: string, chainId: number, account?: Address) {
+	if (!Number.isSafeInteger(chainId) || chainId <= 0) throw new Error('Execution signer lock chain id is invalid')
+	const statePath = resolve(stateFile)
+	const stateLock = await acquireProcessLock(`${statePath}.lock`, `Liquidator state ${statePath}`, { stateFile: statePath })
+	const signerLocks: ProcessLock[] = []
+	const signerAddresses = new Set<string>()
+	if (account !== undefined) {
+		const signer = getAddress(account)
+		try {
+			signerLocks.push(await acquireLiquidatorSignerLock(chainId, signer))
+			signerAddresses.add(signer.toLowerCase())
+		} catch (error) {
+			await stateLock.release()
+			throw error
+		}
+	}
+	let released = false
+	const release = async () => {
+		if (released) return
+		released = true
+		let failure: unknown
+		for (const lock of [...signerLocks].reverse()) {
+			try {
+				await lock.release()
+			} catch (error) {
+				failure ??= error
+			}
+		}
+		try {
+			await stateLock.release()
+		} catch (error) {
+			failure ??= error
+		}
+		if (failure !== undefined) throw failure
+	}
+	return {
+		[Symbol.asyncDispose]: release,
+		release,
+		withSignerReservation: async <T>(nextAccount: Address, operation: () => Promise<T>) => {
+			const nextSigner = getAddress(nextAccount)
+			const key = nextSigner.toLowerCase()
+			if (signerAddresses.has(key)) return operation()
+			const lock = await acquireLiquidatorSignerLock(chainId, nextSigner)
+			try {
+				const result = await operation()
+				signerLocks.push(lock)
+				signerAddresses.add(key)
+				return result
+			} catch (error) {
+				await lock.release()
+				throw error
+			}
+		},
+	}
+}
+
+export async function acquireLiquidatorExecutionLocksForShutdown(stateFile: string, chainId: number, account: Address | undefined, shutdown: { isRequested: () => boolean }, acquire: typeof acquireLiquidatorExecutionLocks = acquireLiquidatorExecutionLocks) {
+	const locks = await acquire(stateFile, chainId, account)
+	if (!shutdown.isRequested()) return locks
+	await locks.release()
+	return undefined
+}
+
+export function liquidatorDashboardLifecycle(dashboard: { stop: () => Promise<void> }) {
+	return { [Symbol.asyncDispose]: () => dashboard.stop() }
+}
+
+export function createLiquidatorShutdownController() {
+	let requested = false
+	let disposed = false
+	const waiters = new Set<() => void>()
+	const requestShutdown = () => {
+		requested = true
+		for (const finish of [...waiters]) finish()
+	}
+	process.on('SIGINT', requestShutdown)
+	process.on('SIGTERM', requestShutdown)
+	return {
+		[Symbol.dispose]: () => {
+			if (disposed) return
+			disposed = true
+			process.off('SIGINT', requestShutdown)
+			process.off('SIGTERM', requestShutdown)
+			for (const finish of [...waiters]) finish()
+		},
+		isRequested: () => requested,
+		wait: (milliseconds: number) => {
+			if (!Number.isSafeInteger(milliseconds) || milliseconds < 0) throw new Error('Shutdown wait must be a non-negative integer')
+			if (requested) return Promise.resolve()
+			return new Promise<void>(resolve => {
+				let timer: ReturnType<typeof setTimeout>
+				const finish = () => {
+					clearTimeout(timer)
+					waiters.delete(finish)
+					resolve()
+				}
+				timer = setTimeout(finish, milliseconds)
+				waiters.add(finish)
+			})
+		},
+	}
+}
+
+export function acquireLiquidatorSignerLock(chainId: number, account: Address) {
+	if (!Number.isSafeInteger(chainId) || chainId <= 0) throw new Error('Execution signer lock chain id is invalid')
+	const signer = getAddress(account)
+	return acquireProcessLock(join(tmpdir(), 'zoltar-liquidator-locks', `${chainId.toString()}-${signer.toLowerCase()}.lock`), `Liquidator execution signer ${signer} on chain ${chainId.toString()}`, { chainId, signer })
+}

--- a/bots/liquidator/src/core/strategy.ts
+++ b/bots/liquidator/src/core/strategy.ts
@@ -160,6 +160,10 @@ export function sortCandidates(candidates: readonly LiquidationCandidate[], prio
 	})
 }
 
+export function selectAllowedCandidate(candidates: readonly LiquidationCandidate[], priority: CandidatePriority, allowed: (candidate: LiquidationCandidate) => boolean) {
+	return sortCandidates(candidates, priority).find(allowed)
+}
+
 export function surplusRepForWithdrawal(caller: VaultPosition, pool: Pick<PoolRiskContext, 'multiplierBps' | 'price'>, strategy: Pick<StrategySettings, 'minimumRepWithdrawal' | 'vaultTargetHealthBps' | 'vaultWithdrawHealthBps'>) {
 	if (caller.rep === 0n) return 0n
 	const retainedRep = requiredRepForAllowance(caller.allowance, pool.multiplierBps, pool.price, strategy.vaultTargetHealthBps)

--- a/bots/liquidator/src/dashboard/dashboard.ts
+++ b/bots/liquidator/src/dashboard/dashboard.ts
@@ -891,7 +891,28 @@ clearSignerButton.addEventListener('click', async () => {
 	}
 })
 
-async function refresh() {
+let refreshInFlight: Promise<void> | undefined
+let refreshQueued = false
+
+function refresh() {
+	if (refreshInFlight !== undefined) {
+		refreshQueued = true
+		return refreshInFlight
+	}
+	refreshInFlight = (async () => {
+		refreshQueued = false
+		await performRefresh()
+		while (refreshQueued) {
+			refreshQueued = false
+			await performRefresh()
+		}
+	})().finally(() => {
+		refreshInFlight = undefined
+	})
+	return refreshInFlight
+}
+
+async function performRefresh() {
 	try {
 		render(await api<Snapshot>('/api/state'))
 	} catch (error) {

--- a/bots/liquidator/tests/core/process-lock.test.ts
+++ b/bots/liquidator/tests/core/process-lock.test.ts
@@ -3,7 +3,6 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
-import type { Address } from '@zoltar/bot-shared/ethereum'
 import { acquireLiquidatorExecutionLocks, acquireLiquidatorExecutionLocksForShutdown, liquidatorDashboardLifecycle } from '../../src/core/process-lock.ts'
 
 const temporaryDirectories: string[] = []
@@ -17,7 +16,7 @@ afterEach(async () => {
 test('prevents duplicate state-file and signer execution processes', async () => {
 	const directory = await mkdtemp(join(tmpdir(), 'zoltar-liquidator-lock-'))
 	temporaryDirectories.push(directory)
-	const signer = '0x0000000000000000000000000000000000000001' as Address
+	const signer = '0x0000000000000000000000000000000000000001'
 	const first = await acquireLiquidatorExecutionLocks(join(directory, 'state.json'), 1, signer)
 	releases.push(first.release)
 	await expect(acquireLiquidatorExecutionLocks(join(directory, 'state.json'), 1, signer)).rejects.toThrow('already locked')
@@ -32,7 +31,7 @@ test('prevents a state-only process from overlapping a live process', async () =
 	const directory = await mkdtemp(join(tmpdir(), 'zoltar-liquidator-lock-'))
 	temporaryDirectories.push(directory)
 	const stateFile = join(directory, 'state.json')
-	const signer = '0x0000000000000000000000000000000000000001' as Address
+	const signer = '0x0000000000000000000000000000000000000001'
 	const live = await acquireLiquidatorExecutionLocks(stateFile, 1, signer)
 	releases.push(live.release)
 	await expect(acquireLiquidatorExecutionLocks(stateFile, 1, undefined)).rejects.toThrow('already locked')
@@ -45,8 +44,8 @@ test('prevents a state-only process from overlapping a live process', async () =
 test('reserves live signer replacements and releases failed reservations', async () => {
 	const directory = await mkdtemp(join(tmpdir(), 'zoltar-liquidator-lock-'))
 	temporaryDirectories.push(directory)
-	const originalSigner = '0x0000000000000000000000000000000000000001' as Address
-	const replacementSigner = '0x0000000000000000000000000000000000000002' as Address
+	const originalSigner = '0x0000000000000000000000000000000000000001'
+	const replacementSigner = '0x0000000000000000000000000000000000000002'
 	{
 		await using locks = await acquireLiquidatorExecutionLocks(join(directory, 'state.json'), 1, originalSigner)
 		await expect(
@@ -67,7 +66,7 @@ test('releases state and signer locks after graceful SIGTERM shutdown', async ()
 	const directory = await mkdtemp(join(tmpdir(), 'zoltar-liquidator-lock-'))
 	temporaryDirectories.push(directory)
 	const stateFile = join(directory, 'state.json')
-	const signer = '0x0000000000000000000000000000000000000003' as Address
+	const signer = '0x0000000000000000000000000000000000000003'
 	const moduleUrl = pathToFileURL(resolve(import.meta.dir, '../../src/core/process-lock.ts')).href
 	const script = `
 		import { acquireLiquidatorExecutionLocks, createLiquidatorShutdownController, liquidatorDashboardLifecycle } from ${JSON.stringify(moduleUrl)}
@@ -118,7 +117,7 @@ test('cleans up when SIGTERM arrives before asynchronous lock acquisition return
 	const directory = await mkdtemp(join(tmpdir(), 'zoltar-liquidator-lock-'))
 	temporaryDirectories.push(directory)
 	const stateFile = join(directory, 'state.json')
-	const signer = '0x0000000000000000000000000000000000000004' as Address
+	const signer = '0x0000000000000000000000000000000000000004'
 	const moduleUrl = pathToFileURL(resolve(import.meta.dir, '../../src/core/process-lock.ts')).href
 	const script = `
 		import { acquireLiquidatorExecutionLocks, acquireLiquidatorExecutionLocksForShutdown, createLiquidatorShutdownController } from ${JSON.stringify(moduleUrl)}

--- a/bots/liquidator/tests/core/process-lock.test.ts
+++ b/bots/liquidator/tests/core/process-lock.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import type { Address } from '@zoltar/bot-shared/ethereum'
+import { acquireLiquidatorExecutionLocks, acquireLiquidatorExecutionLocksForShutdown, liquidatorDashboardLifecycle } from '../../src/core/process-lock.ts'
+
+const temporaryDirectories: string[] = []
+const releases: Array<() => Promise<void>> = []
+
+afterEach(async () => {
+	await Promise.all(releases.splice(0).map(release => release()))
+	await Promise.all(temporaryDirectories.splice(0).map(directory => rm(directory, { force: true, recursive: true })))
+})
+
+test('prevents duplicate state-file and signer execution processes', async () => {
+	const directory = await mkdtemp(join(tmpdir(), 'zoltar-liquidator-lock-'))
+	temporaryDirectories.push(directory)
+	const signer = '0x0000000000000000000000000000000000000001' as Address
+	const first = await acquireLiquidatorExecutionLocks(join(directory, 'state.json'), 1, signer)
+	releases.push(first.release)
+	await expect(acquireLiquidatorExecutionLocks(join(directory, 'state.json'), 1, signer)).rejects.toThrow('already locked')
+	await expect(acquireLiquidatorExecutionLocks(join(directory, 'other-state.json'), 1, signer)).rejects.toThrow('already locked')
+	await first.release()
+	releases.splice(0)
+	const replacement = await acquireLiquidatorExecutionLocks(join(directory, 'state.json'), 1, signer)
+	releases.push(replacement.release)
+})
+
+test('prevents a state-only process from overlapping a live process', async () => {
+	const directory = await mkdtemp(join(tmpdir(), 'zoltar-liquidator-lock-'))
+	temporaryDirectories.push(directory)
+	const stateFile = join(directory, 'state.json')
+	const signer = '0x0000000000000000000000000000000000000001' as Address
+	const live = await acquireLiquidatorExecutionLocks(stateFile, 1, signer)
+	releases.push(live.release)
+	await expect(acquireLiquidatorExecutionLocks(stateFile, 1, undefined)).rejects.toThrow('already locked')
+	await live.release()
+	releases.splice(0)
+	const stateOnly = await acquireLiquidatorExecutionLocks(stateFile, 1, undefined)
+	releases.push(stateOnly.release)
+})
+
+test('reserves live signer replacements and releases failed reservations', async () => {
+	const directory = await mkdtemp(join(tmpdir(), 'zoltar-liquidator-lock-'))
+	temporaryDirectories.push(directory)
+	const originalSigner = '0x0000000000000000000000000000000000000001' as Address
+	const replacementSigner = '0x0000000000000000000000000000000000000002' as Address
+	{
+		await using locks = await acquireLiquidatorExecutionLocks(join(directory, 'state.json'), 1, originalSigner)
+		await expect(
+			locks.withSignerReservation(replacementSigner, async () => {
+				throw new Error('settings write failed')
+			}),
+		).rejects.toThrow('settings write failed')
+		const temporary = await acquireLiquidatorExecutionLocks(join(directory, 'other-state.json'), 1, replacementSigner)
+		await temporary.release()
+		await locks.withSignerReservation(replacementSigner, () => Promise.resolve())
+		await expect(acquireLiquidatorExecutionLocks(join(directory, 'other-state.json'), 1, replacementSigner)).rejects.toThrow('already locked')
+	}
+	const replacement = await acquireLiquidatorExecutionLocks(join(directory, 'state.json'), 1, originalSigner)
+	releases.push(replacement.release)
+})
+
+test('releases state and signer locks after graceful SIGTERM shutdown', async () => {
+	const directory = await mkdtemp(join(tmpdir(), 'zoltar-liquidator-lock-'))
+	temporaryDirectories.push(directory)
+	const stateFile = join(directory, 'state.json')
+	const signer = '0x0000000000000000000000000000000000000003' as Address
+	const moduleUrl = pathToFileURL(resolve(import.meta.dir, '../../src/core/process-lock.ts')).href
+	const script = `
+		import { acquireLiquidatorExecutionLocks, createLiquidatorShutdownController, liquidatorDashboardLifecycle } from ${JSON.stringify(moduleUrl)}
+		{
+			using shutdown = createLiquidatorShutdownController()
+			await using locks = await acquireLiquidatorExecutionLocks(${JSON.stringify(stateFile)}, 1, ${JSON.stringify(signer)})
+			await using dashboardLifecycle = liquidatorDashboardLifecycle({
+				stop: async () => {
+					console.log('draining')
+					await Bun.sleep(500)
+				},
+			})
+			console.log('ready')
+			while (!shutdown.isRequested()) await shutdown.wait(60_000)
+		}
+	`
+	const child = Bun.spawn([process.execPath, '--eval', script], {
+		cwd: resolve(import.meta.dir, '../..'),
+		stderr: 'pipe',
+		stdout: 'pipe',
+	})
+	try {
+		const reader = child.stdout.getReader()
+		const decoder = new TextDecoder()
+		let output = ''
+		const readUntil = async (target: string) => {
+			while (!output.includes(target)) {
+				const next = await reader.read()
+				if (next.done) throw new Error(`Lock subprocess stopped before reporting ${target}: ${await new Response(child.stderr).text()}`)
+				output += decoder.decode(next.value, { stream: true })
+			}
+		}
+		await readUntil('ready')
+		child.kill('SIGTERM')
+		await readUntil('draining')
+		await expect(acquireLiquidatorExecutionLocks(stateFile, 1, signer)).rejects.toThrow('already locked')
+		reader.releaseLock()
+		expect(await child.exited).toBe(0)
+	} finally {
+		if (child.exitCode === null) child.kill('SIGKILL')
+		await child.exited
+	}
+	const replacement = await acquireLiquidatorExecutionLocks(stateFile, 1, signer)
+	releases.push(replacement.release)
+})
+
+test('cleans up when SIGTERM arrives before asynchronous lock acquisition returns', async () => {
+	const directory = await mkdtemp(join(tmpdir(), 'zoltar-liquidator-lock-'))
+	temporaryDirectories.push(directory)
+	const stateFile = join(directory, 'state.json')
+	const signer = '0x0000000000000000000000000000000000000004' as Address
+	const moduleUrl = pathToFileURL(resolve(import.meta.dir, '../../src/core/process-lock.ts')).href
+	const script = `
+		import { acquireLiquidatorExecutionLocks, acquireLiquidatorExecutionLocksForShutdown, createLiquidatorShutdownController } from ${JSON.stringify(moduleUrl)}
+		using shutdown = createLiquidatorShutdownController()
+		const locks = await acquireLiquidatorExecutionLocksForShutdown(${JSON.stringify(stateFile)}, 1, ${JSON.stringify(signer)}, shutdown, async () => {
+			const acquired = await acquireLiquidatorExecutionLocks(${JSON.stringify(stateFile)}, 1, ${JSON.stringify(signer)})
+			console.log('locked-before-return')
+			await shutdown.wait(60_000)
+			return acquired
+		})
+		await locks?.release()
+	`
+	const child = Bun.spawn([process.execPath, '--eval', script], {
+		cwd: resolve(import.meta.dir, '../..'),
+		stderr: 'pipe',
+		stdout: 'pipe',
+	})
+	try {
+		const reader = child.stdout.getReader()
+		const next = await reader.read()
+		if (next.done || !new TextDecoder().decode(next.value).includes('locked-before-return')) throw new Error(`Lock subprocess stopped before acquisition pause: ${await new Response(child.stderr).text()}`)
+		reader.releaseLock()
+		child.kill('SIGTERM')
+		expect(await child.exited).toBe(0)
+	} finally {
+		if (child.exitCode === null) child.kill('SIGKILL')
+		await child.exited
+	}
+	const replacement = await acquireLiquidatorExecutionLocks(stateFile, 1, signer)
+	releases.push(replacement.release)
+})
+
+test('always drains the dashboard when polling fails', async () => {
+	let stopped = false
+	await expect(
+		(async () => {
+			await using dashboardLifecycle = liquidatorDashboardLifecycle({
+				stop: () => {
+					stopped = true
+					return Promise.resolve()
+				},
+			})
+			throw new Error('poll failed')
+		})(),
+	).rejects.toThrow('poll failed')
+	expect(stopped).toBe(true)
+})

--- a/bots/liquidator/tests/core/strategy.test.ts
+++ b/bots/liquidator/tests/core/strategy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { parseStrategy } from '../../src/config/settings.ts'
-import { BPS_DENOMINATOR, PRICE_PRECISION, calculateLiquidationTransfer, conservativeLiquidationRep, evaluateCandidate, liquidationExecutionAllowed, surplusRepForWithdrawal, vaultHealthBps, type PoolRiskContext, type VaultPosition } from '../../src/core/strategy.ts'
+import { BPS_DENOMINATOR, PRICE_PRECISION, calculateLiquidationTransfer, conservativeLiquidationRep, evaluateCandidate, liquidationExecutionAllowed, selectAllowedCandidate, surplusRepForWithdrawal, vaultHealthBps, type PoolRiskContext, type VaultPosition } from '../../src/core/strategy.ts'
 import { candidateScreeningPrice } from '../../src/monitoring/pool-monitor.ts'
 import { getAddress } from '../helpers/ethereum.ts'
 
@@ -89,6 +89,22 @@ describe('liquidation strategy', () => {
 		expect(liquidationExecutionAllowed(0n, true)).toBe(false)
 		expect(liquidationExecutionAllowed(10n * PRICE_PRECISION, false)).toBe(false)
 		expect(liquidationExecutionAllowed(10n * PRICE_PRECISION, true)).toBe(true)
+	})
+
+	test('selects the highest-priority candidate whose market permits execution', () => {
+		const pool: PoolRiskContext = {
+			address: poolAddress,
+			denominator: 1_000n * PRICE_PRECISION,
+			manager: managerAddress,
+			minLiquidationPriceDistanceBps: 0n,
+			multiplierBps: 20_000n,
+			price: 10n * PRICE_PRECISION,
+			totalRep: 1_000n * PRICE_PRECISION,
+		}
+		const lower = evaluateCandidate(pool, vault(targetAddress, 1_000n * PRICE_PRECISION, 75n * PRICE_PRECISION), vault(callerAddress, 0n, 0n), strategy())
+		if (lower === undefined) throw new Error('Expected a liquidation candidate')
+		const higher = { ...lower, bonusValueEth: lower.bonusValueEth + 1n, target: { ...lower.target, address: managerAddress } }
+		expect(selectAllowedCandidate([lower, higher], 'largest-bonus', candidate => candidate.target.address === lower.target.address)).toBe(lower)
 	})
 
 	test('caps stale exposure using the buffered acquisition ceiling', () => {

--- a/bots/liquidator/tests/dashboard/dashboard-refresh.test.ts
+++ b/bots/liquidator/tests/dashboard/dashboard-refresh.test.ts
@@ -105,6 +105,8 @@ async function dashboard() {
 	}
 	let snapshot = state('rpc secret at /api/internal')
 	let rejectPause = false
+	let stateRequestCount = 0
+	let releaseStateRequest: (() => void) | undefined
 	window.fetch = async input => {
 		const inputUrl = typeof input === 'string' ? input : input instanceof window.URL ? input.href : Reflect.get(input, 'url')
 		if (typeof inputUrl !== 'string') throw new Error('Unexpected request URL')
@@ -114,7 +116,11 @@ async function dashboard() {
 				headers: { 'content-type': 'application/json' },
 			})
 		}
-		if (url.pathname === '/api/state') return new window.Response(JSON.stringify(snapshot), { headers: { 'content-type': 'application/json' } })
+		if (url.pathname === '/api/state') {
+			stateRequestCount += 1
+			if (releaseStateRequest !== undefined) await new Promise<void>(resolve => (releaseStateRequest = resolve))
+			return new window.Response(JSON.stringify(snapshot), { headers: { 'content-type': 'application/json' } })
+		}
 		if (url.pathname === '/api/test-market-sources') {
 			return new window.Response(JSON.stringify({ assets: [{ assetId: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', sources: [{ id: 'uniswap-v2', kind: 'dex', market: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', status: 'observed' }] }], blockNumber: '42' }), { headers: { 'content-type': 'application/json' } })
 		}
@@ -138,12 +144,34 @@ async function dashboard() {
 		setSnapshot: (next: ReturnType<typeof state>) => {
 			snapshot = next
 		},
+		stateRequestCount: () => stateRequestCount,
+		suspendNextStateRequest: () => {
+			releaseStateRequest = () => undefined
+		},
+		releaseStateRequest: () => {
+			const release = releaseStateRequest
+			releaseStateRequest = undefined
+			release?.()
+		},
 		window,
 		waitUntilComplete: () => page.waitUntilComplete(),
 	}
 }
 
 describe('liquidator dashboard refresh behavior', () => {
+	test('serializes overlapping polling refreshes and preserves one trailing request', async () => {
+		const page = await dashboard()
+		const before = page.stateRequestCount()
+		page.suspendNextStateRequest()
+		const first = page.refresh()
+		const second = page.refresh()
+		await Bun.sleep(1)
+		expect(page.stateRequestCount()).toBe(before + 1)
+		page.releaseStateRequest()
+		await Promise.all([first, second])
+		expect(page.stateRequestCount()).toBe(before + 2)
+	})
+
 	test('preserves focused controls and expanded pool addresses across polling', async () => {
 		const page = await dashboard()
 		const checkbox = page.window.document.querySelector('[data-record-key^="pool:"]')

--- a/bots/open-oracle-arbitrager/src/cli/run.ts
+++ b/bots/open-oracle-arbitrager/src/cli/run.ts
@@ -38,11 +38,11 @@ import {
 } from '@zoltar/shared/openOracle'
 import { constantProductFactoryAbi, constantProductPairAbi, erc20Abi, factoryAbi, openOracleAbi, openOracleArbitrageExecutorAbi, openOraclePriceCoordinatorAbi, poolAbi, quoterAbi, v4QuoterAbi } from '#contracts/abi'
 import { advanceCursorAfterSuccessfulHead, assertFinalityAnchor, cursorForHeadScan, initialCursor, operatorStatusAfterPause, scanRanges, withFinalityAnchor, type SyncCursor } from '#monitoring/block-sync'
-import { checkConnectivity, checkSubmissionEndpoints, endpointLabel, updateConnectivityEndpointChecks, updateSubmissionEndpointChecks, validateConnectivitySettings, type ConnectivitySettings } from '#monitoring/connectivity'
+import { checkConnectivity, checkSubmissionEndpoints, endpointLabel, updateConnectivityEndpointChecks, updateSubmissionEndpointChecks, validateConnectivitySettingsForQuorum, validateIndependentReadRpcUrls, type ConnectivitySettings } from '#monitoring/connectivity'
 import { applyStrategy, loadConfiguration, mutableStrategy, type Configuration } from '#config/configuration'
 import { startDashboardServer } from '#dashboard/dashboard-server'
 import { authenticateDeploymentManifest, type DeploymentRole } from '#config/deployment-auth'
-import { prepareDeploymentTokenTransition, replacePrimaryRepToken, validateDeploymentSettings, type DeploymentSettings } from '#config/deployment-settings'
+import { assertFocusedDeploymentCompatible, prepareDeploymentTokenTransition, replacePrimaryRepToken, validateDeploymentSettings, type DeploymentSettings } from '#config/deployment-settings'
 import { deployExecutorCreate2, executorDeploymentPlan } from '#execution/create2-executor'
 import { createSignerOperationGate } from '#execution/signer-operation-gate'
 import {
@@ -119,7 +119,7 @@ import { quorumValue } from '#monitoring/read-quorum'
 import { bestSuccessful, compactFinalityWindow, pollUntilStopped, replaceOverlap } from '#monitoring/resilience'
 import { adjustedNetProfitWeth, positionConsumesRisk, positionRiskLimitMismatch, projectedLifecycleGasReserveWeth, type RiskLimits } from '#core/safety-controls'
 import type { NetworkConfiguration } from '#config/network'
-import { configurationRevisionConflict, loadOperatorSettingsWithRevision, parseOperatorSettings, saveOperatorSettings, serializeOperatorSettings, type PersistedOperatorSettings } from '#config/settings-store'
+import { configurationRevisionConflict, loadOperatorSettingsWithRevision, parseOperatorSettings, saveOperatorSettings, serializeOperatorSettings, validateSubmissionForConnectivity, type PersistedOperatorSettings } from '#config/settings-store'
 import { signerCandidate } from '#config/signer'
 import {
 	calculateFee,
@@ -1257,6 +1257,7 @@ async function executeDispute(
 							() =>
 								submitSignedBundle({
 									address: account.address,
+									minimumSuccessfulRelays: config.submission.minimumRelaySuccesses,
 									relayUrls: relaySimulations.successful.map(result => result.relayUrl),
 									signMessage,
 									targetBlockNumber,
@@ -2050,6 +2051,7 @@ export async function processPositionLifecycle(client: ReadClient, readClients: 
 				() =>
 					submitSignedBundle({
 						address: account.address,
+						minimumSuccessfulRelays: config.submission.minimumRelaySuccesses,
 						relayUrls: relaySimulations.successful.map(result => result.relayUrl),
 						signMessage,
 						targetBlockNumber,
@@ -2384,10 +2386,15 @@ async function runOperator(config: Configuration, lockManager: ExecutionLockMana
 						recordOperation(state, { category: 'configuration', details: undefined, level: 'info', message: paused ? 'Operator paused' : 'Operator resumed', reason: 'Dashboard command saved for restart', reportId: undefined })
 					}),
 				updateConnectivity: async value => {
-					const next = validateConnectivitySettings(value)
+					const next = validateConnectivitySettingsForQuorum(value, (pendingDeployment ?? fixedState.deployment).quorumRpcUrls)
+					validateSubmissionForConnectivity(pendingSubmission ?? config.submission, next)
 					await updateConnectivityEndpointChecks(state, () => checkConnectivity(next, config.network.chain.id))
 					return queueSettingsUpdate(async () => {
-						await persistFocusedSettings(settings => ({ ...settings, connectivity: next }))
+						await persistFocusedSettings(settings => {
+							validateIndependentReadRpcUrls(next.readRpcUrl, settings.deployment.quorumRpcUrls)
+							validateSubmissionForConnectivity(settings.submission, next)
+							return { ...settings, connectivity: next }
+						})
 						pendingConnectivity = next
 						recordOperation(state, { category: 'configuration', details: next.publicRpcUrls.map(endpointLabel).join(', '), level: 'info', message: 'RPC configuration verified and saved', reason: `Read RPC ${endpointLabel(next.readRpcUrl)}`, reportId: undefined })
 						return next
@@ -2395,10 +2402,15 @@ async function runOperator(config: Configuration, lockManager: ExecutionLockMana
 				},
 				updateDeployment: value => {
 					const next = validateDeploymentSettings(value)
+					validateIndependentReadRpcUrls((pendingConnectivity ?? config.connectivity).readRpcUrl, next.quorumRpcUrls)
 					return queueSettingsUpdate(async () => {
 						const previous = pendingDeployment ?? fixedState.deployment
 						const tokens = prepareDeploymentTokenTransition(pendingTokenAddresses ?? config.tokenAddresses, restartTokenAddresses, previous.rep, next.rep)
-						await persistFocusedSettings(settings => ({ ...settings, deployment: next, tokenAddresses: tokens.restart }))
+						await persistFocusedSettings(settings => {
+							assertFocusedDeploymentCompatible(next.rep, settings.centralizedMarkets)
+							validateIndependentReadRpcUrls(settings.connectivity.readRpcUrl, next.quorumRpcUrls)
+							return { ...settings, deployment: next, tokenAddresses: tokens.restart }
+						})
 						pendingDeployment = next
 						pendingTokenAddresses = tokens.active
 						restartTokenAddresses = tokens.restart
@@ -2519,10 +2531,10 @@ async function runOperator(config: Configuration, lockManager: ExecutionLockMana
 					})
 				},
 				updateSubmission: async value => {
-					const next = validateSubmissionSettings(value)
+					const next = validateSubmissionForConnectivity(validateSubmissionSettings(value), pendingConnectivity ?? config.connectivity)
 					await updateSubmissionEndpointChecks(state, () => checkSubmissionEndpoints(next, config.network.chain.id))
 					return queueSettingsUpdate(async () => {
-						await persistFocusedSettings(settings => ({ ...settings, submission: next }))
+						await persistFocusedSettings(settings => ({ ...settings, submission: validateSubmissionForConnectivity(next, settings.connectivity) }))
 						pendingSubmission = next
 						recordOperation(state, { category: 'configuration', details: next.relayUrls.map(endpointLabel).join(', ') || undefined, level: 'info', message: `Submission mode ${next.mode} verified and saved`, reason: 'Applied at the next scan boundary', reportId: undefined })
 						return pendingSubmission

--- a/bots/open-oracle-arbitrager/src/config/deployment-settings.ts
+++ b/bots/open-oracle-arbitrager/src/config/deployment-settings.ts
@@ -1,5 +1,6 @@
 import { getAddress, type Address } from '#ethereum'
 import { parseDeploymentManifest, type DeploymentManifest } from '#config/deployment-auth'
+import { validateReadRpcUrls } from '#monitoring/connectivity'
 
 export type DeploymentSettings = {
 	coordinatorAddresses: readonly Address[]
@@ -35,11 +36,7 @@ function addressArray(value: unknown, name: string) {
 
 function urlArray(value: unknown) {
 	if (!Array.isArray(value) || value.length > 8 || value.some(item => typeof item !== 'string')) throw new Error('Quorum RPC URLs must contain no more than 8 URLs')
-	return value.map(item => {
-		const url = new URL(String(item))
-		if (url.protocol !== 'http:' && url.protocol !== 'https:') throw new Error('Quorum RPC URLs must use http or https')
-		return url.toString()
-	})
+	return validateReadRpcUrls(value.map(item => String(item)))
 }
 
 export function validateDeploymentSettings(value: unknown): DeploymentSettings {
@@ -69,6 +66,12 @@ export function validateDeploymentSettings(value: unknown): DeploymentSettings {
 
 export function replacePrimaryRepToken(tokenAddresses: readonly Address[], previousRep: Address, nextRep: Address) {
 	return [nextRep, ...tokenAddresses.filter(address => address.toLowerCase() !== previousRep.toLowerCase() && address.toLowerCase() !== nextRep.toLowerCase())]
+}
+
+export function assertFocusedDeploymentCompatible(rep: Address, centralizedMarkets: { assetAddress: Address }) {
+	if (rep.toLowerCase() !== centralizedMarkets.assetAddress.toLowerCase()) {
+		throw new Error('Focused deployment updates cannot change REP without updating the centralized market configuration in the complete configuration editor')
+	}
 }
 
 export function prepareDeploymentTokenTransition(activeTokenAddresses: readonly Address[], restartTokenAddresses: readonly Address[] | undefined, previousRep: Address, nextRep: Address) {

--- a/bots/open-oracle-arbitrager/src/config/settings-store.ts
+++ b/bots/open-oracle-arbitrager/src/config/settings-store.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from 'node:crypto'
 import { mkdir, open, readFile, rename, rm } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import { getAddress, type Address, type Hex } from '#ethereum'
-import { validateConnectivitySettings, type ConnectivitySettings, type NetworkName } from '#monitoring/connectivity'
+import { validateConnectivitySettings, validateIndependentReadRpcUrls, type ConnectivitySettings, type NetworkName } from '#monitoring/connectivity'
 import { decimalWeth, parseDecimalWeth, updateStrategyFromRequest, type MutableStrategy, type StrategySettings } from '#state/operator-state'
 import { signerCandidate } from '#config/signer'
 import { validateSubmissionSettings, type SubmissionSettings } from '#execution/transaction-submission'
@@ -179,6 +179,13 @@ function validateRuntimeSettings(value: unknown): RuntimeSettings {
 	}
 }
 
+export function validateSubmissionForConnectivity(submission: SubmissionSettings, connectivity: ConnectivitySettings) {
+	if (submission.mode === 'public' && submission.minimumRelaySuccesses > connectivity.publicRpcUrls.length) {
+		throw new Error('Public submission minimumRelaySuccesses cannot exceed the configured public RPC count')
+	}
+	return submission
+}
+
 export function parseOperatorSettings(value: unknown, preservedPrivateKey?: Hex): PersistedOperatorSettings {
 	const record = requiredRecord(value)
 	validatedKeys(record)
@@ -199,19 +206,22 @@ export function parseOperatorSettings(value: unknown, preservedPrivateKey?: Hex)
 	const candidate = signerCandidate(privateKeyValue ?? null)
 	if (!Array.isArray(record['tokenAddresses']) || record['tokenAddresses'].some(address => typeof address !== 'string')) throw new Error('Operator tokenAddresses must be an array of addresses')
 	const deployment = validateDeploymentSettings(record['deployment'])
+	const connectivity = validateConnectivitySettings(record['connectivity'])
+	validateIndependentReadRpcUrls(connectivity.readRpcUrl, deployment.quorumRpcUrls)
 	const chainId = record['network'] === 'mainnet' ? 1 : 11_155_111
 	const centralizedMarkets = parseCentralizedMarketSettings(record['centralizedMarkets'] ?? defaultCentralizedMarkets(deployment.rep, chainId))
 	if (centralizedMarkets.assetAddress.toLowerCase() !== deployment.rep.toLowerCase() || centralizedMarkets.assetChainId !== chainId) throw new Error('Centralized market configuration must target the configured REP deployment and chain')
+	const submission = validateSubmissionForConnectivity(validateSubmissionSettings(record['submission']), connectivity)
 	return {
 		centralizedMarkets,
-		connectivity: validateConnectivitySettings(record['connectivity']),
+		connectivity,
 		deployment,
 		network: record['network'],
 		paused: record['paused'],
 		privateKey: candidate.privateKey,
 		runtime: validateRuntimeSettings(record['runtime']),
 		strategy,
-		submission: validateSubmissionSettings(record['submission']),
+		submission,
 		tokenAddresses: record['tokenAddresses'].map(address => getAddress(String(address))),
 	}
 }

--- a/bots/open-oracle-arbitrager/src/dashboard/dashboard-format.ts
+++ b/bots/open-oracle-arbitrager/src/dashboard/dashboard-format.ts
@@ -3,6 +3,29 @@ import type { MarketPricePoint } from '#monitoring/market-monitor'
 
 const DECIMAL_SCALE = 18
 
+export function singleFlight<T>(operation: () => Promise<T>) {
+	let inFlight: Promise<T> | undefined
+	let rerunRequested = false
+	return () => {
+		if (inFlight !== undefined) {
+			rerunRequested = true
+			return inFlight
+		}
+		inFlight = (async () => {
+			rerunRequested = false
+			let result = await operation()
+			while (rerunRequested) {
+				rerunRequested = false
+				result = await operation()
+			}
+			return result
+		})().finally(() => {
+			inFlight = undefined
+		})
+		return inFlight
+	}
+}
+
 function parseSignedDecimal(value: string) {
 	if (!/^-?(?:0|[1-9]\d*)(?:\.\d{1,18})?$/.test(value)) throw new Error(`Invalid decimal amount: ${value}`)
 	const negative = value.startsWith('-')

--- a/bots/open-oracle-arbitrager/src/dashboard/dashboard.ts
+++ b/bots/open-oracle-arbitrager/src/dashboard/dashboard.ts
@@ -14,6 +14,7 @@ import {
 	requiredSignerPrivateKey,
 	selectedTokenPriceHistory,
 	signerControlState,
+	singleFlight,
 	sumSignedDecimals,
 	transactionKindLabel,
 	venueLabel,
@@ -829,7 +830,7 @@ function render(snapshot: OperatorSnapshot) {
 	}
 }
 
-async function refresh() {
+const refresh = singleFlight(async () => {
 	try {
 		const value: unknown = await api<unknown>('/api/state')
 		if (!isSnapshot(value)) throw new Error('Bot returned an invalid state snapshot')
@@ -845,7 +846,7 @@ async function refresh() {
 		setText('notice-copy', error instanceof Error ? error.message : String(error))
 		element('notice').dataset['tone'] = 'danger'
 	}
-}
+})
 
 element('refresh-button').addEventListener('click', () => void refresh())
 element('reload-configuration-button').addEventListener('click', () => void loadCompleteConfiguration())

--- a/bots/open-oracle-arbitrager/src/monitoring/connectivity.ts
+++ b/bots/open-oracle-arbitrager/src/monitoring/connectivity.ts
@@ -1,1 +1,9 @@
 export * from '@zoltar/bot-shared/monitoring/connectivity'
+
+import { validateConnectivitySettings, validateIndependentReadRpcUrls, type ConnectivitySettings } from '@zoltar/bot-shared/monitoring/connectivity'
+
+export function validateConnectivitySettingsForQuorum(value: unknown, quorumRpcUrls: readonly string[]): ConnectivitySettings {
+	const connectivity = validateConnectivitySettings(value)
+	validateIndependentReadRpcUrls(connectivity.readRpcUrl, quorumRpcUrls)
+	return connectivity
+}

--- a/bots/open-oracle-arbitrager/src/monitoring/market-monitor.ts
+++ b/bots/open-oracle-arbitrager/src/monitoring/market-monitor.ts
@@ -1,4 +1,5 @@
-import { appendFile, mkdir, readFile } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
+import { mkdir, open, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import { formatUnits, getAddress, isAddress, keccak256, type Address, type Chain, type Hex, type PublicClient, type Transport, zeroAddress } from '#ethereum'
 import { augurMarketAbi, augurUniverseAbi, constantProductFactoryAbi, constantProductPairAbi, erc20Abi, factoryAbi, poolAbi } from '#contracts/abi'
@@ -13,6 +14,8 @@ export type TokenConfiguration = {
 }
 
 export const MAX_OBSERVED_MONITORING_TOKENS = 64
+export const PRICE_HISTORY_TAIL_MAXIMUM_BYTES = 8 * 1_024 * 1_024
+const PRICE_HISTORY_RECORD_MAXIMUM_BYTES = 4 * 1_024
 
 export type MarketPoolSnapshot = {
 	address: Address
@@ -266,10 +269,18 @@ export function missingPricePoints(existing: readonly MarketPricePoint[], candid
 	return candidates.filter(point => !recorded.has(`${point.blockNumber}:${point.pool.toLowerCase()}`))
 }
 
-export async function appendPriceHistory(path: string, points: readonly MarketPricePoint[]) {
+export async function appendPriceHistory(path: string, points: readonly MarketPricePoint[], maximum = 2_000) {
 	if (points.length === 0) return
+	if (!Number.isSafeInteger(maximum) || maximum < 1) throw new Error('Price history maximum must be a positive integer')
 	await mkdir(dirname(path), { recursive: true })
-	await appendFile(path, `${points.map(point => JSON.stringify(point)).join('\n')}\n`, 'utf8')
+	const retained = [...(await loadPriceHistory(path, maximum)), ...points].slice(-maximum)
+	const temporaryPath = `${path}.${process.pid.toString()}.${randomUUID()}.tmp`
+	try {
+		await writeFile(temporaryPath, `${retained.map(point => JSON.stringify(point)).join('\n')}\n`, { encoding: 'utf8', mode: 0o600 })
+		await rename(temporaryPath, path)
+	} finally {
+		await rm(temporaryPath, { force: true })
+	}
 }
 
 function parsePriceHistoryPoint(value: unknown): MarketPricePoint | undefined {
@@ -313,11 +324,38 @@ function parsePriceHistoryPoint(value: unknown): MarketPricePoint | undefined {
 }
 
 export async function loadPriceHistory(path: string, maximum = 2_000) {
+	if (!Number.isSafeInteger(maximum) || maximum < 1) throw new Error('Price history maximum must be a positive integer')
+	let handle: Awaited<ReturnType<typeof open>> | undefined
 	try {
-		const contents = await readFile(path, 'utf8')
+		handle = await open(path, 'r')
+		const { size } = await handle.stat()
+		const chunks: Buffer[] = []
+		let position = size
+		let remainingBytes = Math.min(size, PRICE_HISTORY_TAIL_MAXIMUM_BYTES)
+		let newlineCount = 0
+		while (position > 0 && remainingBytes > 0 && newlineCount <= maximum) {
+			const length = Math.min(position, remainingBytes, 64 * 1_024)
+			position -= length
+			remainingBytes -= length
+			const chunk = Buffer.allocUnsafe(length)
+			let offset = 0
+			while (offset < length) {
+				const { bytesRead } = await handle.read(chunk, offset, length - offset, position + offset)
+				if (bytesRead === 0) throw new Error(`Price history ${path} ended during a bounded read`)
+				offset += bytesRead
+			}
+			chunks.unshift(chunk)
+			for (const byte of chunk) if (byte === 10) newlineCount++
+		}
+		let contents = Buffer.concat(chunks).toString('utf8')
+		if (position > 0) contents = contents.slice(contents.indexOf('\n') + 1)
 		const points: MarketPricePoint[] = []
 		for (const [index, line] of contents.split('\n').entries()) {
 			if (line.trim().length === 0) continue
+			if (Buffer.byteLength(line, 'utf8') > PRICE_HISTORY_RECORD_MAXIMUM_BYTES) {
+				console.warn(`Skipping oversized price history record at line ${(index + 1).toString()} in ${path}`)
+				continue
+			}
 			try {
 				const point = parsePriceHistoryPoint(JSON.parse(line))
 				if (point !== undefined) {
@@ -334,5 +372,7 @@ export async function loadPriceHistory(path: string, maximum = 2_000) {
 	} catch (error) {
 		if (typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT') return []
 		throw error
+	} finally {
+		await handle?.close()
 	}
 }

--- a/bots/open-oracle-arbitrager/tests/config/deployment-settings.test.ts
+++ b/bots/open-oracle-arbitrager/tests/config/deployment-settings.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test'
-import { prepareDeploymentTokenTransition, replacePrimaryRepToken } from '#config/deployment-settings'
+import { assertFocusedDeploymentCompatible, prepareDeploymentTokenTransition, replacePrimaryRepToken, validateDeploymentSettings } from '#config/deployment-settings'
 import type { Address } from '#ethereum'
 
 const address = (digit: string) => `0x${digit.repeat(40)}` as Address
@@ -21,4 +21,30 @@ test('keeps the live scan catalog unchanged while preparing restart deployment s
 
 	expect(transition.active).toEqual([activeRep, explicitToken])
 	expect(transition.restart).toEqual([restartRep, explicitToken])
+})
+
+test('rejects insecure or credential-bearing quorum RPC URLs', () => {
+	const base = {
+		coordinatorAddresses: [],
+		deploymentManifest: undefined,
+		executor: undefined,
+		openOracle: address('1'),
+		quorumRpcUrls: ['https://quorum.example'],
+		rep: address('2'),
+		uniswapFactory: address('3'),
+		uniswapQuoter: address('4'),
+		uniswapRouter: undefined,
+		uniswapV2Router: undefined,
+		uniswapV4PoolManager: undefined,
+		uniswapV4Quoter: undefined,
+		weth: address('5'),
+	}
+	expect(() => validateDeploymentSettings({ ...base, quorumRpcUrls: ['http://quorum.example'] })).toThrow('HTTPS or loopback HTTP')
+	expect(() => validateDeploymentSettings({ ...base, quorumRpcUrls: ['https://user:secret@quorum.example'] })).toThrow('embedded credentials')
+})
+
+test('rejects a focused REP update that leaves centralized-market identity stale', () => {
+	const currentAsset = address('1')
+	expect(() => assertFocusedDeploymentCompatible(address('2'), { assetAddress: currentAsset })).toThrow('centralized market configuration')
+	expect(() => assertFocusedDeploymentCompatible(currentAsset, { assetAddress: currentAsset })).not.toThrow()
 })

--- a/bots/open-oracle-arbitrager/tests/config/settings-store.test.ts
+++ b/bots/open-oracle-arbitrager/tests/config/settings-store.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, open, readFile, rename, rm, stat, writeFile } from 'nod
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { Hex } from '#ethereum'
-import { CONFIGURATION_REVISION_CONFLICT, loadOperatorSettings, loadOperatorSettingsWithRevision, saveOperatorSettings, type OperatorSettingsFilesystem } from '#config/settings-store'
+import { CONFIGURATION_REVISION_CONFLICT, loadOperatorSettings, loadOperatorSettingsWithRevision, parseOperatorSettings, saveOperatorSettings, serializeOperatorSettings, type OperatorSettingsFilesystem } from '#config/settings-store'
 
 const temporaryDirectories: string[] = []
 const privateKey = `0x${'11'.repeat(32)}` as Hex
@@ -90,6 +90,17 @@ function settings(privateKeyValue: Hex | undefined) {
 }
 
 describe('operator settings persistence', () => {
+	test('rejects a public submission threshold above the configured RPC count', () => {
+		const stored = serializeOperatorSettings(settings(undefined))
+		expect(() =>
+			parseOperatorSettings({
+				...stored,
+				connectivity: { ...stored.connectivity, publicRpcUrls: ['https://submit-one.example/'] },
+				submission: { minimumRelaySuccesses: 2, mode: 'public', relayUrls: [] },
+			}),
+		).toThrow('cannot exceed the configured public RPC count')
+	})
+
 	test('syncs settings contents and the parent directory before returning success', async () => {
 		const events: string[] = []
 		let opened = 0

--- a/bots/open-oracle-arbitrager/tests/dashboard/dashboard-format.test.ts
+++ b/bots/open-oracle-arbitrager/tests/dashboard/dashboard-format.test.ts
@@ -13,6 +13,7 @@ import {
 	requiredSignerPrivateKey,
 	selectedTokenPriceHistory,
 	signerControlState,
+	singleFlight,
 	sumSignedDecimals,
 	transactionKindLabel,
 	venueLabel,
@@ -54,6 +55,25 @@ describe('dashboard exact ETH formatting', () => {
 			inputDisabled: true,
 			setDisabled: true,
 		})
+	})
+
+	test('serializes overlapping dashboard refreshes and preserves one trailing request', async () => {
+		let calls = 0
+		let release: (() => void) | undefined
+		const refresh = singleFlight(async () => {
+			calls++
+			if (calls === 1) {
+				await new Promise<void>(resolve => {
+					release = resolve
+				})
+			}
+		})
+		const first = refresh()
+		const second = refresh()
+		expect(calls).toBe(1)
+		release?.()
+		await Promise.all([first, second])
+		expect(calls).toBe(2)
 	})
 
 	test('shows block delay against the operator computer without hiding clock skew', () => {

--- a/bots/open-oracle-arbitrager/tests/execution/transaction-submission.test.ts
+++ b/bots/open-oracle-arbitrager/tests/execution/transaction-submission.test.ts
@@ -311,6 +311,21 @@ describe('signed transaction delivery', () => {
 		])
 	})
 
+	test('enforces the configured successful relay threshold during bundle submission', async () => {
+		const accepted = relay(() => Response.json({ id: 1, jsonrpc: '2.0', result: { bundleHash: expectedBundleHash([serializedTransaction]) } }))
+		const rejected = relay(() => Response.json({ error: { code: -32_000, message: 'submission rejected' }, id: 1, jsonrpc: '2.0' }))
+		await expect(
+			submitSignedBundle({
+				address,
+				minimumSuccessfulRelays: 2,
+				relayUrls: [accepted, rejected],
+				signMessage: () => Promise.resolve(signature),
+				targetBlockNumber: 100n,
+				transactions: [serializedTransaction],
+			}),
+		).rejects.toThrow('required 2 accepting relays')
+	})
+
 	test.each(['', 'bundle', '0x1234'])('rejects malformed relay bundle hash %p', async bundleHash => {
 		const endpoint = relay(() => Response.json({ id: 1, jsonrpc: '2.0', result: { bundleHash } }))
 		await expect(

--- a/bots/open-oracle-arbitrager/tests/monitoring/connectivity.test.ts
+++ b/bots/open-oracle-arbitrager/tests/monitoring/connectivity.test.ts
@@ -9,6 +9,7 @@ import {
 	updateConnectivityEndpointChecks,
 	updateSubmissionEndpointChecks,
 	validateConnectivitySettings,
+	validateConnectivitySettingsForQuorum,
 	validateIndependentReadRpcUrls,
 	validateReadRpcUrls,
 	withConnectivityChecks,
@@ -42,8 +43,13 @@ function rpc(handler: (method: string, params: readonly unknown[]) => unknown | 
 
 describe('operator connectivity', () => {
 	test('rejects a quorum that only varies paths on the same RPC origin', () => {
+		expect(() => validateIndependentReadRpcUrls('https://rpc.example', ['https://rpc.example'])).toThrow('independent origins')
 		expect(() => validateIndependentReadRpcUrls('https://rpc.example/read', ['https://rpc.example/quorum'])).toThrow('independent origins')
 		expect(validateIndependentReadRpcUrls('https://one.example', ['https://two.example'])).toEqual(['https://two.example/'])
+	})
+
+	test('rejects live connectivity updates that duplicate the deployment quorum origin', () => {
+		expect(() => validateConnectivitySettingsForQuorum({ publicRpcUrls: ['https://public.example'], readRpcUrl: 'https://quorum.example/read' }, ['https://quorum.example/independent'])).toThrow('independent origins')
 	})
 
 	test('redacts RPC path and query credentials from endpoint labels', () => {

--- a/bots/open-oracle-arbitrager/tests/monitoring/market-monitor.test.ts
+++ b/bots/open-oracle-arbitrager/tests/monitoring/market-monitor.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test'
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, open, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { Address } from '#ethereum'
@@ -15,6 +15,7 @@ import {
 	missingPricePoints,
 	payoutDistributionHash,
 	poolSpotPriceWeth,
+	PRICE_HISTORY_TAIL_MAXIMUM_BYTES,
 	pricePoints,
 	tokenCatalogForScan,
 	type TokenMarketSnapshot,
@@ -115,6 +116,48 @@ test('persists per-pool price history across restarts', async () => {
 	const points = pricePoints(markets, 123n, '2026-07-25T00:00:00.000Z')
 	await appendPriceHistory(path, points)
 	expect(await loadPriceHistory(path)).toEqual(points)
+})
+
+test('bounds the on-disk price history while appending new samples', async () => {
+	const directory = await mkdtemp(join(tmpdir(), 'zoltar-market-history-'))
+	temporaryDirectories.push(directory)
+	const path = join(directory, 'prices.jsonl')
+	const base = {
+		blockNumber: '1',
+		pool: '0x0000000000000000000000000000000000000002' as Address,
+		priceWeth: '0.0042',
+		sampledAt: '2026-07-25T00:00:00.000Z',
+		symbol: 'REPv2',
+		token: '0x0000000000000000000000000000000000000001' as Address,
+		venue: 'Uniswap V3 0.3%',
+	}
+	await appendPriceHistory(path, [base], 2)
+	await appendPriceHistory(path, [{ ...base, blockNumber: '2' }], 2)
+	await appendPriceHistory(path, [{ ...base, blockNumber: '3' }], 2)
+	expect((await loadPriceHistory(path, 10)).map(point => point.blockNumber)).toEqual(['2', '3'])
+})
+
+test('does not scan past a bounded tail for an oversized unterminated record', async () => {
+	const directory = await mkdtemp(join(tmpdir(), 'zoltar-market-history-'))
+	temporaryDirectories.push(directory)
+	const path = join(directory, 'prices.jsonl')
+	const valid = {
+		blockNumber: '1',
+		pool: '0x0000000000000000000000000000000000000002' as Address,
+		priceWeth: '0.0042',
+		sampledAt: '2026-07-25T00:00:00.000Z',
+		symbol: 'REPv2',
+		token: '0x0000000000000000000000000000000000000001' as Address,
+		venue: 'Uniswap V3 0.3%',
+	}
+	const handle = await open(path, 'w')
+	try {
+		await handle.writeFile(`${JSON.stringify(valid)}\n`)
+		await handle.truncate(PRICE_HISTORY_TAIL_MAXIMUM_BYTES * 2)
+	} finally {
+		await handle.close()
+	}
+	expect(await loadPriceHistory(path, 1)).toEqual([])
 })
 
 test('loads valid price history around truncated and structurally invalid records', async () => {

--- a/bots/shared/src/execution/transaction-submission.ts
+++ b/bots/shared/src/execution/transaction-submission.ts
@@ -304,8 +304,20 @@ export async function simulateSignedBundleEveryRelay(parameters: {
 	return { failedTargets, successful }
 }
 
-export async function submitSignedBundle(parameters: { address: Address; relayUrls: readonly string[]; signMessage: (message: string | Uint8Array) => Promise<Hex>; targetBlockNumber: bigint; timeoutMilliseconds?: number | undefined; transactions: readonly Hex[] }): Promise<SubmittedBundle> {
+export async function submitSignedBundle(parameters: {
+	address: Address
+	minimumSuccessfulRelays?: number | undefined
+	relayUrls: readonly string[]
+	signMessage: (message: string | Uint8Array) => Promise<Hex>
+	targetBlockNumber: bigint
+	timeoutMilliseconds?: number | undefined
+	transactions: readonly Hex[]
+}): Promise<SubmittedBundle> {
 	if (parameters.transactions.length === 0) throw new Error('Bundle must contain at least one transaction')
+	const minimumSuccessfulRelays = parameters.minimumSuccessfulRelays ?? 1
+	if (!Number.isSafeInteger(minimumSuccessfulRelays) || minimumSuccessfulRelays < 1 || minimumSuccessfulRelays > parameters.relayUrls.length) {
+		throw new Error('Bundle submission relay threshold must be between 1 and the configured relay count')
+	}
 	const expectedBundleHash = bundleIdentity(parameters.transactions).bundleHash
 	const body = JSON.stringify({
 		id: 1,
@@ -341,7 +353,12 @@ export async function submitSignedBundle(parameters: { address: Address; relayUr
 		if (result.status === 'fulfilled') acceptedTargets.push(target)
 		else failedTargets.push({ error: rejectionMessage(result.reason), target })
 	}
-	if (acceptedTargets.length === 0) throw new SubmissionFailure(`Every private relay rejected the bundle: ${failedTargets.map(result => `${result.target}: ${result.error ?? 'unknown error'}`).join('; ')}`, failedTargets)
+	if (acceptedTargets.length < minimumSuccessfulRelays) {
+		if (acceptedTargets.length === 0 && minimumSuccessfulRelays === 1) {
+			throw new SubmissionFailure(`Every private relay rejected the bundle: ${failedTargets.map(result => `${result.target}: ${result.error ?? 'unknown error'}`).join('; ')}`, failedTargets)
+		}
+		throw new SubmissionFailure(`Bundle submission required ${minimumSuccessfulRelays.toString()} accepting relays but received ${acceptedTargets.length.toString()}: ${failedTargets.map(result => `${result.target}: ${result.error ?? 'unknown error'}`).join('; ')}`, failedTargets)
+	}
 	return { acceptedTargets, failedTargets }
 }
 

--- a/bots/shared/src/monitoring/centralized-markets.ts
+++ b/bots/shared/src/monitoring/centralized-markets.ts
@@ -550,12 +550,13 @@ export function aggregateCentralizedMarketObservations(observations: readonly Ce
 	}
 }
 
-export async function observeCentralizedMarkets(settings: CentralizedMarketSettings, assetId: string, chainId: number, factory: CentralizedExchangeFactory = ccxtExchangeFactory, now = Date.now()): Promise<CentralizedMarketEstimate | undefined> {
+export async function observeCentralizedMarkets(settings: CentralizedMarketSettings, assetId: string, chainId: number, factory: CentralizedExchangeFactory = ccxtExchangeFactory, now?: number): Promise<CentralizedMarketEstimate | undefined> {
 	if (settings.sources.length === 0) return undefined
 	if (settings.assetAddress.toLowerCase() !== assetId.toLowerCase() || settings.assetChainId !== chainId) throw new Error('Centralized market configuration does not match the exact REP asset and chain')
-	const settled = await Promise.allSettled(settings.sources.map(source => observeSource(source, settings, assetId, chainId, factory, now)))
+	const observedAt = now ?? Date.now()
+	const settled = await Promise.allSettled(settings.sources.map(source => observeSource(source, settings, assetId, chainId, factory, observedAt)))
 	const observations = settled.flatMap(result => (result.status === 'fulfilled' ? [result.value] : []))
-	const estimate = aggregateCentralizedMarketObservations(observations, settings, assetId, now)
+	const estimate = aggregateCentralizedMarketObservations(observations, settings, assetId, now ?? Date.now())
 	if (estimate === undefined) return undefined
 	const errors = settled.flatMap((result, index) => {
 		if (result.status === 'fulfilled') return []

--- a/bots/shared/src/monitoring/connectivity.ts
+++ b/bots/shared/src/monitoring/connectivity.ts
@@ -63,7 +63,7 @@ export function validateReadRpcUrls(values: readonly string[]) {
 
 export function validateIndependentReadRpcUrls(primary: string, values: readonly string[]) {
 	const normalizedPrimary = endpointUrl(primary.trim())
-	const normalized = validateReadRpcUrls(values).filter(value => value !== normalizedPrimary)
+	const normalized = validateReadRpcUrls(values)
 	const origins = [new URL(normalizedPrimary).origin, ...normalized.map(value => new URL(value).origin)]
 	if (new Set(origins).size !== origins.length) throw new Error('Read RPC quorum must use independent origins; changing only the URL path does not create an independent provider')
 	return normalized

--- a/bots/shared/tests/centralized-markets.test.ts
+++ b/bots/shared/tests/centralized-markets.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test'
+import { describe, expect, spyOn, test } from 'bun:test'
 import {
 	aggregateCentralizedMarketObservations,
 	centralizedMarketConfigurationAllowsExecution,
@@ -69,6 +69,27 @@ function observation(exchangeId: string, priceRepPerEth: bigint, timestamp = 10_
 }
 
 describe('centralized market observations', () => {
+	test('validates exchange timestamps against the time after requests complete', async () => {
+		let clockReads = 0
+		const now = spyOn(Date, 'now').mockImplementation(() => (clockReads++ === 0 ? 10_000 : 10_001))
+		const factory: CentralizedExchangeFactory = () => ({
+			fetchOrderBook: async () => ({
+				asks: [[10.1, 1_000]],
+				bids: [[9.9, 1_000]],
+				timestamp: 10_001,
+			}),
+			fetchTicker: async () => ({ ask: 2_010, bid: 1_990, last: 2_000, timestamp: 10_001 }),
+			loadMarkets: async () => ({}),
+		})
+		try {
+			const estimate = await observeCentralizedMarkets(settings, REP_ASSET, 1, factory)
+			expect(estimate?.reliable).toBe(true)
+			expect(estimate?.observations).toHaveLength(2)
+		} finally {
+			now.mockRestore()
+		}
+	})
+
 	test('uses a cross-venue median and executable depth to validate a DEX price', () => {
 		const estimate = aggregateCentralizedMarketObservations([observation('alpha', 200n * 10n ** 18n), observation('beta', 202n * 10n ** 18n)], settings, REP_ASSET, 10_000)
 		if (estimate === undefined) throw new Error('Expected a centralized market estimate')

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
   },
   "overrides": {
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "fast-uri": "3.1.4",
     "postcss": "8.5.23",
     "tmp": "0.2.7",
@@ -553,7 +553,7 @@
 
     "binary-search-bounds": ["binary-search-bounds@2.0.5", "", {}, "sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA=="],
 
-    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"tevm": "1.0.0-rc.151"
 	},
 	"overrides": {
-		"brace-expansion": "5.0.8",
+		"brace-expansion": "5.0.9",
 		"fast-uri": "3.1.4",
 		"postcss": "8.5.23",
 		"tmp": "0.2.7",

--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -24,7 +24,7 @@
     },
   },
   "overrides": {
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "fast-uri": "3.1.4",
     "postcss": "8.5.23",
     "tmp": "0.2.7",
@@ -451,7 +451,7 @@
 
     "better-typescript-lib": ["better-typescript-lib@2.11.0", "", { "dependencies": { "@typescript/lib-decorators": "npm:@better-typescript-lib/decorators@2.11.0", "@typescript/lib-dom": "npm:@better-typescript-lib/dom@2.11.0", "@typescript/lib-es2015": "npm:@better-typescript-lib/es2015@2.11.0", "@typescript/lib-es2016": "npm:@better-typescript-lib/es2016@2.11.0", "@typescript/lib-es2017": "npm:@better-typescript-lib/es2017@2.11.0", "@typescript/lib-es2018": "npm:@better-typescript-lib/es2018@2.11.0", "@typescript/lib-es2019": "npm:@better-typescript-lib/es2019@2.11.0", "@typescript/lib-es2020": "npm:@better-typescript-lib/es2020@2.11.0", "@typescript/lib-es2021": "npm:@better-typescript-lib/es2021@2.11.0", "@typescript/lib-es2022": "npm:@better-typescript-lib/es2022@2.11.0", "@typescript/lib-es2023": "npm:@better-typescript-lib/es2023@2.11.0", "@typescript/lib-es2024": "npm:@better-typescript-lib/es2024@2.11.0", "@typescript/lib-es5": "npm:@better-typescript-lib/es5@2.11.0", "@typescript/lib-es6": "npm:@better-typescript-lib/es6@2.11.0", "@typescript/lib-esnext": "npm:@better-typescript-lib/esnext@2.11.0", "@typescript/lib-scripthost": "npm:@better-typescript-lib/scripthost@2.11.0", "@typescript/lib-webworker": "npm:@better-typescript-lib/webworker@2.11.0" }, "peerDependencies": { "typescript": ">=4.5.2" } }, "sha512-dwaPodcG5lVepyeoEmwRSpRqKWOso5CRktnMcPKlE4jjcHLGjkBhZXIMe6EFD9ALG/Ru3kwOO1t6TNNQ6Pf1Jw=="],
 
-    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -24,7 +24,7 @@
 		"tevm": "1.0.0-rc.151"
 	},
 	"overrides": {
-		"brace-expansion": "5.0.8",
+		"brace-expansion": "5.0.9",
 		"fast-uri": "3.1.4",
 		"postcss": "8.5.23",
 		"tmp": "0.2.7",


### PR DESCRIPTION
## Summary

This PR fixes ten focused safety, correctness, and reliability issues across the liquidator, OpenOracle arbitrager, and shared bot code. Each deterministic defect has regression coverage that failed before its implementation fix.

## Issues and fixes

1. **CEX observations used a pre-request freshness clock.** Slow exchange calls could make stale exchange-native data appear fresh because freshness was evaluated against the time captured before the requests. The observer now keeps a consistent request-start timestamp for locally timestamped observations but evaluates freshness against the time after all requests complete.

2. **A blocked top liquidation candidate starved lower eligible candidates.** The liquidator previously selected the highest-ranked candidate before applying pool and market execution guards, then stopped when that candidate was blocked. Candidate selection now sorts by the configured priority and chooses the first candidate whose pool passes the relevant live or dry-run guards.

3. **Private bundle submission ignored the configured relay threshold.** Bundle fan-out succeeded when any relay accepted it even when `minimumRelaySuccesses` required more. The shared submission primitive now validates and enforces the threshold, and both OpenOracle entry and lifecycle bundle paths pass the configured value.

4. **Public submission thresholds could exceed the public RPC count.** Such a configuration could never satisfy its own delivery policy. Startup parsing and focused submission/connectivity updates now reject impossible public thresholds atomically.

5. **The primary read RPC could duplicate a quorum provider.** Exact duplicates and same-origin URLs with different paths could be counted as independent reads. Startup and focused configuration updates now cross-check the primary read URL against every deployment quorum origin.

6. **Focused deployment updates could leave REP market identity stale.** Changing the deployment REP address without changing centralized-market settings created an inconsistent restart configuration. Focused updates now reject this transition and direct operators to the complete configuration editor, where both fields can change together.

7. **Deployment quorum URL validation was weaker than runtime RPC validation.** Quorum URLs accepted insecure remote HTTP endpoints and credential- or fragment-bearing URLs. Deployment settings now reuse the hardened shared validator: HTTPS is required except for loopback HTTP, secrets/fragments are rejected, and origins must be independent.

8. **Liquidator processes had no complete state/signer ownership lifecycle.** Concurrent dry-run/live processes could write the same durable state, and live signers could be reused across processes. The liquidator now always owns an exclusive state-file lock, live mode additionally owns chain/signer locks, successful live signer replacements retain their reservations, and failed replacements release them. Signal handlers are installed before acquisition; SIGINT/SIGTERM during acquisition releases newly created locks; dashboard draining is awaited before locks are released on all exit paths. Subprocess tests verify signal-during-acquisition cleanup, lock retention during server drain, and immediate restart.

9. **Dashboard polling could overlap or discard a needed refresh.** Both dashboards now run only one state request at a time and collapse overlapping requests into one serialized trailing refresh. This prevents request storms without losing a post-mutation or recovery refresh that must render newer state.

10. **OpenOracle price history grew and loaded without a hard I/O bound.** History append now atomically rewrites the newest 2,000 records with owner-only temporary files. Startup reads backward in bounded chunks, never scans beyond an 8 MiB tail, and skips records above 4 KiB, including oversized unterminated tails.

## Validation

- `bun run tsc`
- Root behavior suite: 2,666 passed, 16 expected network skips, 0 failed
- Liquidator suite: 72 passed, 0 failed
- OpenOracle arbitrager suite: 270 passed, 0 failed
- Shared bot suite: 41 passed, 0 failed
- Root and bot-package `bun run format:check`
- `bun run check`
- `bun run knip`
- `git diff --check`
- Final code review: 99/100, no findings
- Visual review: 98/100, no findings

Generated-artifact freshness was not run separately because no contracts, generators, tracked generated output, or artifact policy changed. Documentation review was not applicable because no documentation changed.

## UI QA

There are no intentional copy, layout, or style changes. Chromium fixture QA covered desktop (1440×900) and narrow/mobile (390×844) states for both dashboards, including loading, running/dry-run, paused/live, recovery, mutation failures, signer actions, long identifiers, and dense market data. No mobile overflow or uncaught runtime errors were observed.

![OpenOracle dashboard desktop fixture](https://raw.githubusercontent.com/AugurProject/zoltar/9459b401f8ec53db98c70fef8dd5240c5b846dfb/bots/open-oracle-arbitrager/docs/assets/dashboard-overview.png)
