### PR TITLE
Prefer liquid Uniswap prices for Open Oracle reports

### DIFF
--- a/scripts/coverage-report.mts
+++ b/scripts/coverage-report.mts
@@ -561,7 +561,7 @@ function formatMetric(value: CoverageMetric) {
 	return `${value.percentage.toFixed(2)}% (${value.covered}/${value.total})`
 }
 
-function renderMarkdown(report: CompleteCoverage, testFileCount: number, policyResult: ReturnType<typeof evaluateCoveragePolicy>) {
+export function renderMarkdown(report: CompleteCoverage, testFileCount: number, policyResult: ReturnType<typeof evaluateCoveragePolicy>) {
 	const lines = ['# Coverage summary', '', `Canonical test files: ${testFileCount}`, '', '| TypeScript surface | Lines | Functions | Branches | Loaded source | Unloaded executable source |', '| --- | ---: | ---: | ---: | ---: | ---: |']
 	for (const surfaceName of ['ui', 'shared', 'tooling'] as const) {
 		const surface = report.typescript.surfaces[surfaceName]
@@ -581,6 +581,9 @@ function renderMarkdown(report: CompleteCoverage, testFileCount: number, policyR
 	}
 	if (report.solidity !== undefined && report.solidity.uncoveredFirstPartyLines.length > 0) {
 		lines.push('', '## Uncovered first-party Solidity lines', '', ...report.solidity.uncoveredFirstPartyLines.map(line => `- \`${line}\``))
+	}
+	if (report.solidity !== undefined && report.solidity.uncoveredImportedLines.length > 0) {
+		lines.push('', '## Uncovered imported Solidity lines', '', ...report.solidity.uncoveredImportedLines.map(line => `- \`${line}\``))
 	}
 	lines.push('', `Policy: ${policyResult.passed ? 'passed' : 'failed'}`)
 	if (!policyResult.passed) lines.push('', ...policyResult.failures.map(failure => `- ${failure}`))

--- a/scripts/coverage-report.test.ts
+++ b/scripts/coverage-report.test.ts
@@ -2,7 +2,21 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, test } from 'bun:test'
-import { buildTypeScriptCoverage, calculateChangedLineCoverage, classifyTypeScriptSource, evaluateCoveragePolicy, mergeLcovRecords, parseChangedLines, parseLcov, readTaskChangedLines, readTrackedTypeScriptSources, resolveCoverageBaseRef, summarizeSolidityCoverage, type CoveragePolicy } from './coverage-report.mts'
+import {
+	buildTypeScriptCoverage,
+	calculateChangedLineCoverage,
+	classifyTypeScriptSource,
+	evaluateCoveragePolicy,
+	mergeLcovRecords,
+	parseChangedLines,
+	parseLcov,
+	readTaskChangedLines,
+	readTrackedTypeScriptSources,
+	renderMarkdown,
+	resolveCoverageBaseRef,
+	summarizeSolidityCoverage,
+	type CoveragePolicy,
+} from './coverage-report.mts'
 
 describe('TypeScript coverage accounting', () => {
 	test('uses weighted executable totals instead of averaging file percentages', () => {
@@ -184,6 +198,34 @@ describe('coverage policy', () => {
 		)
 
 		expect(result.failures).toContain('TypeScript ui line coverage 88.0565% is below 88.060%')
+	})
+})
+
+describe('coverage summary markdown', () => {
+	test('lists uncovered imported Solidity lines separately from first-party lines', () => {
+		const report = {
+			typescript: {
+				surfaces: {
+					ui: surface(100, 100),
+					shared: surface(100, 100),
+					tooling: surface(100, 100),
+				},
+				excludedFiles: [],
+			},
+			solidity: {
+				firstParty: metric(100),
+				imported: metric(0),
+				all: metric(99),
+				uncoveredFirstPartyLines: ['solidity/contracts/Protocol.sol:2'],
+				uncoveredImportedLines: ['solidity/contracts/peripherals/WETH9.sol:9'],
+			},
+		}
+		const markdown = renderMarkdown(report, 1, { failures: [], passed: true })
+
+		expect(markdown).toContain('## Uncovered first-party Solidity lines')
+		expect(markdown).toContain('- `solidity/contracts/Protocol.sol:2`')
+		expect(markdown).toContain('## Uncovered imported Solidity lines')
+		expect(markdown).toContain('- `solidity/contracts/peripherals/WETH9.sol:9`')
 	})
 })
 

--- a/ui/ts/protocol/openOracle.ts
+++ b/ui/ts/protocol/openOracle.ts
@@ -668,18 +668,12 @@ export async function loadOracleManagerQueueOperationEthValue(client: Pick<Write
 	return funding.includeBuffer ? addOpenOracleBountyBuffer(funding.costAttoEth) : funding.costAttoEth
 }
 
-async function getCoordinatorInitialReportPrice(client: CoordinatorInitialReportClient, managerAddress: Address) {
-	const [minimumToken1ReportAttoEth, lastPrice, rawReputationTokenAddress] = await Promise.all([
+async function getCoordinatorInitialReportPrice(client: CoordinatorInitialReportClient, managerAddress: Address, requestedInitialAttoWeth = 0n) {
+	const [minimumToken1ReportAttoEth, rawReputationTokenAddress] = await Promise.all([
 		client.readContract({
 			address: managerAddress,
 			abi: peripherals_OpenOraclePriceCoordinator_OpenOraclePriceCoordinator.abi,
 			functionName: 'minimumToken1ReportAttoEth',
-			args: [],
-		}),
-		client.readContract({
-			address: managerAddress,
-			abi: peripherals_OpenOraclePriceCoordinator_OpenOraclePriceCoordinator.abi,
-			functionName: 'lastPrice',
 			args: [],
 		}),
 		client.readContract({
@@ -690,12 +684,10 @@ async function getCoordinatorInitialReportPrice(client: CoordinatorInitialReport
 		}),
 	])
 	const reputationTokenAddress = getAddress(rawReputationTokenAddress)
-	if (lastPrice === 0n) {
-		const quote = await loadOpenOracleInitialReportPrice(client, getWethAddress(), reputationTokenAddress, minimumToken1ReportAttoEth)
-		const proposedRepPerEthPrice = (quote.token2Amount * COORDINATOR_PRICE_PRECISION) / minimumToken1ReportAttoEth
-		return proposedRepPerEthPrice > 0n ? proposedRepPerEthPrice : 1n
-	}
-	return lastPrice
+	const initialReportAttoWeth = requestedInitialAttoWeth > minimumToken1ReportAttoEth ? requestedInitialAttoWeth : minimumToken1ReportAttoEth
+	const quote = await loadOpenOracleInitialReportPrice(client, getWethAddress(), reputationTokenAddress, initialReportAttoWeth)
+	const proposedRepPerEthPrice = (quote.token2Amount * COORDINATOR_PRICE_PRECISION) / initialReportAttoWeth
+	return proposedRepPerEthPrice > 0n ? proposedRepPerEthPrice : 1n
 }
 
 export async function loadCoordinatorInitialReportFundingRequirement(client: CoordinatorInitialReportClient, managerAddress: Address, walletAddress: Address, proposedRepPerEthPrice?: bigint, requestedInitialAttoWeth = 0n) {
@@ -712,7 +704,7 @@ export async function loadCoordinatorInitialReportFundingRequirement(client: Coo
 			functionName: 'balanceOf',
 			args: [walletAddress],
 		}),
-		proposedRepPerEthPrice ?? getCoordinatorInitialReportPrice(client, managerAddress),
+		proposedRepPerEthPrice ?? getCoordinatorInitialReportPrice(client, managerAddress, requestedInitialAttoWeth),
 		client.readContract({
 			address: managerAddress,
 			abi: peripherals_OpenOraclePriceCoordinator_OpenOraclePriceCoordinator.abi,
@@ -785,7 +777,7 @@ async function fundCoordinatorInitialReport(client: WriteClient, managerAddress:
 
 export async function requestOraclePrice(client: WriteClient, managerAddress: Address, proposedRepPerEthPrice?: bigint, requestedInitialAttoWeth = 0n, reviewedRequestValueAttoEth?: bigint) {
 	await assertCoordinatorRequestPriceAllowed(client, managerAddress)
-	const resolvedInitialReportPrice = proposedRepPerEthPrice ?? (await getCoordinatorInitialReportPrice(client, managerAddress))
+	const resolvedInitialReportPrice = proposedRepPerEthPrice ?? (await getCoordinatorInitialReportPrice(client, managerAddress, requestedInitialAttoWeth))
 	await fundCoordinatorInitialReport(client, managerAddress, resolvedInitialReportPrice, requestedInitialAttoWeth)
 	const callParams = {
 		address: managerAddress,
@@ -906,7 +898,7 @@ export async function disputeOracleReport(client: WriteClient, openOracleAddress
 }
 export async function queueSecurityPoolLiquidation(client: WriteClient, managerAddress: Address, targetVault: Address, amount: bigint, validForSeconds: bigint, requestedInitialAttoWeth = 0n) {
 	const queueOperationValueAttoEth = await loadOracleManagerQueueOperationEthValue(client, managerAddress)
-	const proposedRepPerEthPrice = queueOperationValueAttoEth > 0n ? await getCoordinatorInitialReportPrice(client, managerAddress) : 0n
+	const proposedRepPerEthPrice = queueOperationValueAttoEth > 0n ? await getCoordinatorInitialReportPrice(client, managerAddress, requestedInitialAttoWeth) : 0n
 	if (queueOperationValueAttoEth > 0n) {
 		await fundCoordinatorInitialReport(client, managerAddress, proposedRepPerEthPrice, requestedInitialAttoWeth)
 	}
@@ -928,7 +920,7 @@ export async function queueSecurityPoolLiquidation(client: WriteClient, managerA
 }
 export async function queueOracleManagerOperation(client: WriteClient, managerAddress: Address, operation: OracleQueueOperation, targetVault: Address, amount: bigint, validForSeconds: bigint, proposedRepPerEthPrice?: bigint, requestedInitialAttoWeth = 0n) {
 	const queueOperationValueAttoEth = await loadOracleManagerQueueOperationEthValue(client, managerAddress)
-	const resolvedInitialReportPrice = queueOperationValueAttoEth > 0n ? (proposedRepPerEthPrice ?? (await getCoordinatorInitialReportPrice(client, managerAddress))) : (proposedRepPerEthPrice ?? 0n)
+	const resolvedInitialReportPrice = queueOperationValueAttoEth > 0n ? (proposedRepPerEthPrice ?? (await getCoordinatorInitialReportPrice(client, managerAddress, requestedInitialAttoWeth))) : (proposedRepPerEthPrice ?? 0n)
 	if (queueOperationValueAttoEth > 0n) {
 		await fundCoordinatorInitialReport(client, managerAddress, resolvedInitialReportPrice, requestedInitialAttoWeth)
 	}

--- a/ui/ts/protocol/openOraclePricing.ts
+++ b/ui/ts/protocol/openOraclePricing.ts
@@ -49,31 +49,35 @@ export async function loadOpenOracleInitialReportPriceResult(client: Parameters<
 		}
 	}
 	let v4Failure: unknown = 'Uniswap V4 returned an unusable quote'
+	let v4Quote: Extract<OpenOracleInitialReportPriceLoadResult, { status: 'success' }> | undefined
 	try {
 		const { amountOut: token2Amount, source } = await quoteBestExactInputWithSource(client, token1, token2, token1Amount)
 		const price = calculateOpenOraclePrice(token1Amount, token2Amount)
-		if (price !== undefined) return { price, priceSource: source.protocol === 'mock' ? 'MOCK' : 'Uniswap V4', priceSourceUrl: source.poolUrl, status: 'success', token2Amount }
+		if (price !== undefined) {
+			v4Quote = { price, priceSource: source.protocol === 'mock' ? 'MOCK' : 'Uniswap V4', priceSourceUrl: source.poolUrl, status: 'success', token2Amount }
+			if (source.protocol === 'mock') return v4Quote
+		}
 	} catch (error) {
 		v4Failure = error
 	}
 	const attemptedSources: OpenOracleInitialReportQuoteSource[] = ['Uniswap V4', 'Uniswap V3']
+	let v3Failure: unknown = 'Uniswap V3 returned an unusable quote'
+	let v3Quote: Extract<OpenOracleInitialReportPriceLoadResult, { status: 'success' }> | undefined
 	try {
 		const { amountOut: token2Amount, source } = await quoteBestV3ExactInputWithSource(client, token1, token2, token1Amount)
 		const price = calculateOpenOraclePrice(token1Amount, token2Amount)
-		if (price !== undefined) return { price, priceSource: source.protocol === 'mock' ? 'MOCK' : 'Uniswap V3', priceSourceUrl: source.poolUrl, status: 'success', token2Amount }
-		return {
-			attemptedSources,
-			failureKind: 'quote-failed',
-			reason: formatOpenOraclePriceLoadError(v4Failure, 'Uniswap V3 returned an unusable quote'),
-			status: 'failure',
-		}
-	} catch (v3Error) {
-		return {
-			attemptedSources,
-			failureKind: 'quote-failed',
-			reason: formatOpenOraclePriceLoadError(v4Failure, v3Error),
-			status: 'failure',
-		}
+		if (price !== undefined) v3Quote = { price, priceSource: source.protocol === 'mock' ? 'MOCK' : 'Uniswap V3', priceSourceUrl: source.poolUrl, status: 'success', token2Amount }
+	} catch (error) {
+		v3Failure = error
+	}
+
+	if (v4Quote !== undefined && (v3Quote === undefined || v4Quote.token2Amount >= v3Quote.token2Amount)) return v4Quote
+	if (v3Quote !== undefined) return v3Quote
+	return {
+		attemptedSources,
+		failureKind: 'quote-failed',
+		reason: formatOpenOraclePriceLoadError(v4Failure, v3Failure),
+		status: 'failure',
 	}
 }
 

--- a/ui/ts/tests/features/open-oracle/openOracle.test.ts
+++ b/ui/ts/tests/features/open-oracle/openOracle.test.ts
@@ -13,6 +13,7 @@ import {
 	loadOpenOracleReportSummaries,
 	loadOracleManagerDetails,
 	queueOracleManagerOperation,
+	queueSecurityPoolLiquidation,
 	requestOraclePrice,
 	settleOracleReport,
 	withdrawOpenOracleBalance,
@@ -38,7 +39,7 @@ import { loadOpenOracleInitialReportPrice, loadOpenOracleInitialReportPriceResul
 import { getDefaultOpenOracleCreateFormState } from '../../../features/markets/lib/marketForm.js'
 import { ORACLE_MANAGER_PRICE_VALID_FOR_SECONDS } from '../../../features/security-pools/lib/securityVault.js'
 import { createConnectedReadClient, createWalletWriteClient } from '../../../lib/clients.js'
-import { ETH_ADDRESS, REP_ADDRESS, USDC_ADDRESS } from '../../../protocol/uniswapQuoter.js'
+import { ETH_ADDRESS, REP_ADDRESS, UNISWAP_V4_QUOTER_ADDRESS, USDC_ADDRESS } from '../../../protocol/uniswapQuoter.js'
 import { peripherals_openOracle_OpenOracle_OpenOracle } from '../../../contractArtifact.js'
 import type { InjectedEthereum } from '../../../injectedEthereum.js'
 import type { WriteContractClient } from '../../../protocol/core.js'
@@ -426,6 +427,35 @@ describe('Open Oracle helpers', () => {
 		await expect(loadOpenOracleInitialReportPrice(createFailingQuoteClient('no pool'), getAddress('0x00000000000000000000000000000000000000a1'), getAddress('0x00000000000000000000000000000000000000a2'), 100n)).rejects.toThrow(
 			'Failed to fetch price from Uniswap. Uniswap V4 quote failed: no pool. Uniswap V3 quote failed: no pool',
 		)
+	})
+
+	test('initial report price helpers select the Uniswap version with the most executable liquidity', async () => {
+		const client = createConnectedReadClient()
+		client.simulateContract = async parameters => {
+			if (parameters.address === UNISWAP_V4_QUOTER_ADDRESS) return { result: [25n, 0n], request: {} as never } as never
+			return { result: [40n, 0n, 0, 0n], request: {} as never } as never
+		}
+		client.readContract = async () => zeroAddress as never
+
+		await expect(loadOpenOracleInitialReportPrice(client, REP_ADDRESS, WETH_ADDRESS, 100n)).resolves.toEqual({
+			price: 2_500_000_000_000_000_000_000_000_000_000n,
+			priceSource: 'Uniswap V3',
+			token2Amount: 40n,
+		})
+	})
+
+	test('initial report price helpers retain a usable V4 quote when V3 is unavailable', async () => {
+		const client = createConnectedReadClient()
+		client.simulateContract = async parameters => {
+			if (parameters.address === UNISWAP_V4_QUOTER_ADDRESS) return { result: [25n, 0n], request: {} as never } as never
+			throw new Error('no v3 pool')
+		}
+
+		await expect(loadOpenOracleInitialReportPrice(client, REP_ADDRESS, WETH_ADDRESS, 100n)).resolves.toEqual({
+			price: 4_000_000_000_000_000_000_000_000_000_000n,
+			priceSource: 'Uniswap V4',
+			token2Amount: 25n,
+		})
 	})
 
 	test('initial report price helpers report both Uniswap V4 and V3 failures when fallback was attempted', async () => {
@@ -938,24 +968,8 @@ describe('Open Oracle helpers', () => {
 		expect(reportDetails.currentAmount2).toBe(requestedInitialAttoWeth)
 	})
 
-	test('requestOraclePrice derives stale cached price refresh amounts with coordinator 1e18 precision', async () => {
+	test('requestOraclePrice rejects a stale cached price when a fresh Uniswap quote is unavailable', async () => {
 		const seededRepEthPrice = 2n * 10n ** 18n
-		const minimumToken1ReportAttoEth = await client.readContract({
-			address: managerAddress,
-			abi: [
-				{
-					type: 'function',
-					name: 'minimumToken1ReportAttoEth',
-					stateMutability: 'view',
-					inputs: [],
-					outputs: [{ name: '', type: 'uint256' }],
-				},
-			],
-			functionName: 'minimumToken1ReportAttoEth',
-			args: [],
-		})
-		if (typeof minimumToken1ReportAttoEth !== 'bigint') throw new Error('expected bigint minimumToken1ReportAttoEth')
-		const seededAmount2 = minimumToken1ReportAttoEth * 2n
 		const seededRequestEthCost = await getRequestPriceCostAttoEth(client, managerAddress)
 
 		await requestPriceWithValue(client, managerAddress, seededRequestEthCost, seededRepEthPrice)
@@ -964,13 +978,8 @@ describe('Open Oracle helpers', () => {
 		await settleOracleReport(uiWriteClient, getOpenOracleAddress(), seededReportId)
 		await mockWindow.advanceTime(ORACLE_MANAGER_PRICE_VALID_FOR_SECONDS + 1n)
 
-		await requestOraclePrice(uiWriteClient, managerAddress)
-
-		const staleRefreshReportId = (await loadOracleManagerDetails(uiReadClient, managerAddress)).pendingReportId
-		const staleRefreshDetails = await loadOpenOracleReportDetails(uiReadClient, getOpenOracleAddress(), staleRefreshReportId)
-		expect(staleRefreshDetails.currentAmount1).toBe(minimumToken1ReportAttoEth)
-		expect(staleRefreshDetails.currentAmount2).toBe(seededAmount2)
-		expect(seededRepEthPrice).toBe((staleRefreshDetails.currentAmount2 * 10n ** 18n) / staleRefreshDetails.currentAmount1)
+		await expect(requestOraclePrice(uiWriteClient, managerAddress)).rejects.toThrow('Failed to fetch price from Uniswap')
+		expect((await loadOracleManagerDetails(uiReadClient, managerAddress)).pendingReportId).toBe(0n)
 	})
 
 	test('requestOraclePrice rejects fresh cached prices before wrap or approval side effects', async () => {
@@ -1011,7 +1020,7 @@ describe('Open Oracle helpers', () => {
 			const address = parameters.address as Address
 			const functionName = parameters.functionName as string
 			if (functionName === 'minimumToken1ReportAttoEth') return minimumToken1ReportAttoEth as never
-			if (functionName === 'lastPrice') return 0n as never
+			if (functionName === 'lastPrice') throw new Error('A cached price must not be used for a new initial report')
 			if (functionName === 'reputationToken') return reputationTokenAddress as never
 			if (functionName === 'balanceOf' && address === WETH_ADDRESS) return currentWethBalanceAttoEth as never
 			if (functionName === 'balanceOf' && address === reputationTokenAddress) return currentRepBalanceAttoRep as never
@@ -1051,6 +1060,43 @@ describe('Open Oracle helpers', () => {
 		expect(funding.maximumInitialAttoWeth).toBe(requestedInitialAttoWeth)
 		expect(funding.initialReportAmount2).toBe(500n)
 		expect(funding.wethShortfallAttoEth).toBe(requestedInitialAttoWeth)
+	})
+
+	test('loadCoordinatorInitialReportFundingRequirement selects liquidity at the requested report size', async () => {
+		const minimumToken1ReportAttoEth = 100n
+		const requestedInitialAttoWeth = 250n
+		const reputationTokenAddress = getAddress('0x00000000000000000000000000000000000000f1')
+		const quotedExactAmounts: bigint[] = []
+		const mockClient = createConnectedReadClient()
+		mockClient.readContract = async parameters => {
+			const address = parameters.address as Address
+			const functionName = parameters.functionName as string
+			if (functionName === 'minimumToken1ReportAttoEth') return minimumToken1ReportAttoEth as never
+			if (functionName === 'reputationToken') return reputationTokenAddress as never
+			if (functionName === 'balanceOf' && address === WETH_ADDRESS) return 0n as never
+			if (functionName === 'balanceOf' && address === reputationTokenAddress) return 1_000n as never
+			if (functionName === 'getPool') return zeroAddress as never
+			throw new Error(`Unexpected read ${functionName} for ${address}`)
+		}
+		mockClient.simulateContract = async parameters => {
+			const args = parameters.args
+			if (!Array.isArray(args)) throw new Error('Expected Uniswap quote arguments')
+			const quoteParameters: unknown = args[0]
+			if (typeof quoteParameters !== 'object' || quoteParameters === null) throw new Error('Expected Uniswap quote parameters')
+			let exactAmount: unknown
+			if ('exactAmount' in quoteParameters) exactAmount = quoteParameters.exactAmount
+			else if ('amountIn' in quoteParameters) exactAmount = quoteParameters.amountIn
+			if (typeof exactAmount !== 'bigint') throw new Error('Expected an exact Uniswap quote amount')
+			quotedExactAmounts.push(exactAmount)
+			if (parameters.address === UNISWAP_V4_QUOTER_ADDRESS) return { result: [50n, 0n], request: {} as never } as never
+			return { result: [100n, 0n, 0, 0n], request: {} as never } as never
+		}
+
+		const funding = await loadCoordinatorInitialReportFundingRequirement(mockClient, managerAddress, uiWriteClient.account.address, undefined, requestedInitialAttoWeth)
+
+		expect(quotedExactAmounts).toEqual(Array.from({ length: 8 }, () => requestedInitialAttoWeth))
+		expect(funding.proposedRepPerEthPrice).toBe(400_000_000_000_000_000n)
+		expect(funding.initialReportAmount2).toBe(100n)
 	})
 
 	test('requestOraclePrice rejects an unavailable first-report REP quote instead of assuming a price', async () => {
@@ -1143,6 +1189,67 @@ describe('Open Oracle helpers', () => {
 		expect(result.queuedOperation?.operation).toBe('setCoverageCommitment')
 		expect(result.queuedOperation?.operationId).toBeGreaterThan(0n)
 		expect(result.stagedExecution).toBeUndefined()
+	})
+
+	test('automatic coordinator operations select Uniswap liquidity at the requested report size', async () => {
+		const minimumToken1ReportAttoEth = 100n
+		const requestedInitialAttoWeth = 250n
+		const reputationTokenAddress = getAddress('0x00000000000000000000000000000000000000f1')
+		const transactionHash = `0x${'3'.repeat(64)}` as Hash
+		const runOperation = async (operation: 'request' | 'liquidation-helper' | 'generic') => {
+			const quotedExactAmounts: bigint[] = []
+			const preparedQueueArguments: Array<readonly unknown[]> = []
+			const onTransactionPrepared: NonNullable<typeof uiWriteClient.onTransactionPrepared> = preview => {
+				if ((preview.functionName === 'requestPrice' || preview.functionName === 'requestPriceIfNeededAndStageOperation') && preview.args !== undefined) preparedQueueArguments.push(preview.args)
+			}
+			const readContract: typeof uiWriteClient.readContract = async parameters => {
+				if (parameters.functionName === 'lastPrice') return 0n as never
+				if (parameters.functionName === 'getPendingSettlementOperationIds') return [] as never
+				if (parameters.functionName === 'MAX_PENDING_SETTLEMENT_OPERATIONS') return 8n as never
+				if (parameters.functionName === 'pendingReportId') return 0n as never
+				if (parameters.functionName === 'getQueuedOperationCostAttoEth') return 0n as never
+				if (parameters.functionName === 'getRequestPriceCostAttoEth') return 10n as never
+				if (parameters.functionName === 'isPriceValid') return false as never
+				if (parameters.functionName === 'minimumToken1ReportAttoEth') return minimumToken1ReportAttoEth as never
+				if (parameters.functionName === 'reputationToken') return reputationTokenAddress as never
+				if (parameters.functionName === 'balanceOf') return 1_000n as never
+				if (parameters.functionName === 'getPool') return zeroAddress as never
+				throw new Error(`Unexpected read ${parameters.functionName} for ${parameters.address}`)
+			}
+			const simulateContract: typeof uiWriteClient.simulateContract = async parameters => {
+				const args = parameters.args
+				if (!Array.isArray(args)) throw new Error('Expected Uniswap quote arguments')
+				const quoteParameters: unknown = args[0]
+				if (typeof quoteParameters !== 'object' || quoteParameters === null) throw new Error('Expected Uniswap quote parameters')
+				let exactAmount: unknown
+				if ('exactAmount' in quoteParameters) exactAmount = quoteParameters.exactAmount
+				else if ('amountIn' in quoteParameters) exactAmount = quoteParameters.amountIn
+				if (typeof exactAmount !== 'bigint') throw new Error('Expected an exact Uniswap quote amount')
+				quotedExactAmounts.push(exactAmount)
+				if (parameters.address === UNISWAP_V4_QUOTER_ADDRESS) return { result: [50n, 0n], request: {} as never } as never
+				return { result: [100n, 0n, 0, 0n], request: {} as never } as never
+			}
+			const mockClient = {
+				...uiWriteClient,
+				onTransactionPrepared,
+				readContract,
+				simulateContract,
+				sendTransaction: async () => transactionHash,
+				waitForTransactionReceipt: async () => createSuccessfulReceipt(transactionHash, managerAddress),
+			}
+
+			if (operation === 'request') await requestOraclePrice(mockClient, managerAddress, undefined, requestedInitialAttoWeth, 12n)
+			else if (operation === 'liquidation-helper') await queueSecurityPoolLiquidation(mockClient, managerAddress, client.account.address, 1n, DEFAULT_SELF_OPERATION_TIMEOUT_SECONDS, requestedInitialAttoWeth)
+			else await queueOracleManagerOperation(mockClient, managerAddress, 'liquidation', client.account.address, 1n, DEFAULT_SELF_OPERATION_TIMEOUT_SECONDS, undefined, requestedInitialAttoWeth)
+
+			expect(quotedExactAmounts).toEqual(Array.from({ length: 8 }, () => requestedInitialAttoWeth))
+			const expectedArguments = operation === 'request' ? [400_000_000_000_000_000n, requestedInitialAttoWeth] : [expect.anything(), client.account.address, 1n, DEFAULT_SELF_OPERATION_TIMEOUT_SECONDS, 400_000_000_000_000_000n, requestedInitialAttoWeth]
+			expect(preparedQueueArguments).toEqual([expectedArguments])
+		}
+
+		await runOperation('request')
+		await runOperation('liquidation-helper')
+		await runOperation('generic')
 	})
 
 	test('queueOracleManagerOperation preserves incremental ids when adding to the pending settlement list', async () => {


### PR DESCRIPTION
## Summary

- print uncovered imported Solidity lines in the coverage Markdown summary
- compare Uniswap V4 and V3 exact-input quotes and select the greatest executable output
- always refresh automatic coordinator proposals from Uniswap instead of reusing a stale cached price
- quote at the actual initial report size across direct requests and queued operations
- fail closed when no usable Uniswap quote is available

## Proposer safety

This removes the stale-price path that could fund a new report without consulting Uniswap. Selection uses the best executable output at the actual report size, including caller-requested sizes above the coordinator minimum. A single-block DEX quote is still not a manipulation-proof or time-weighted oracle.

## Validation

- bun run tsc
- bun test scripts/coverage-report.test.ts — 13 passed
- bun test ui/ts/tests/features/open-oracle/openOracle.test.ts — 46 passed
- bun run format:check
- bun run check:changed
- bun run knip
- git diff --check

Final review: 88/100 with no findings. Visual review: 84/100 with no findings. No screenshots are included because no visible layout, style, or copy changed and the collaborative browser automation host was unavailable during QA.