### PR TITLE
Improve testnet deployment CLI and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,17 @@ Remove the key from the shell when the command finishes:
 unset PRIVATE_KEY
 ```
 
-The deployer reads the exported `PRIVATE_KEY` automatically. It intentionally
-does not accept a private-key command-line option, so the key does not need to
-appear in shell history. Run `bun run deploy:testnet -- --help` for the
-command-line form of each other option. Those options also accept uppercase
-arguments after `--` or environment variables.
+The deployer reads the exported `PRIVATE_KEY` automatically. You can instead
+pass the key directly, but the complete command—and therefore the key—may be
+saved in shell history:
+
+```bash
+bun run deploy:testnet -- --private-key=0x... --rpc-url=https://rpc.example --chain-id=11155111 --max-fee-per-gas-gwei=100 --max-total-cost-eth=20
+```
+
+Run `bun run deploy:testnet -- --help` for all options. Options other than
+`--private-key` also accept uppercase arguments after `--` or environment
+variables.
 
 | Input | Default | Purpose |
 | --- | --- | --- |
@@ -152,7 +158,7 @@ arguments after `--` or environment variables.
 | `CHAIN_ID` / `--chain-id` | `11155111` | Expected decimal chain ID |
 | `MAX_FEE_PER_GAS_GWEI` / `--max-fee-per-gas-gwei` | `100` | Rejects higher RPC fee suggestions |
 | `MAX_TOTAL_COST_ETH` / `--max-total-cost-eth` | `20` | Caps the conservative preflight estimate and transaction budget |
-| `PRIVATE_KEY` | Required | Environment-only, `0x`-prefixed 32-byte deployer key |
+| `PRIVATE_KEY` / `--private-key` | Required | `0x`-prefixed 32-byte deployer key |
 
 The defaults are authorization limits, not a spend forecast or a required
 balance. Before sending a transaction, the command checks the RPC chain ID, EVM

--- a/README.md
+++ b/README.md
@@ -90,62 +90,110 @@ dependent deployment address.
 
 ## Testnet deployment
 
-Deploy the complete deterministic infrastructure with an explicitly selected RPC
-endpoint. First load `PRIVATE_KEY` from a protected secret manager or hidden
-prompt; do not paste it into the command because shells may save it in history.
-Use a dedicated testnet account funded with enough testnet ETH to finish the
-remaining deployment.
+The testnet deployer installs the complete deterministic infrastructure. It is
+safe to rerun: existing contracts are skipped only when their runtime bytecode
+matches, and an unexpected contract at a target address stops the deployment.
+
+### Before you deploy
+
+- Complete [Setup](#setup).
+- Use a dedicated testnet account and fund it with enough testnet ETH for the
+  remaining steps.
+- Use an HTTPS RPC endpoint. Loopback HTTP endpoints are accepted for local test
+  networks.
+- Ensure the deployer account has no pending transactions.
+
+Sepolia is the default target (chain ID `11155111`). A different testnet must
+support EIP-1559, the Cancun opcodes used by Zoltar and Uniswap V4, and the Osaka
+`CLZ` opcode used by the compiled contracts. The deployer rejects Ethereum
+mainnet (chain ID `1`).
+
+### Deploy with GitHub Actions
+
+Use the [`Deploy Testnet Contracts`](./.github/workflows/deploy-testnet.yml)
+workflow for a deployment from `main`:
+
+1. Create a protected GitHub environment named `testnet-deployment`.
+1. Add the deployer's private key as the environment secret
+   `TESTNET_DEPLOYER_PRIVATE_KEY`.
+1. Open **Actions → Deploy Testnet Contracts → Run workflow**.
+1. Select `main`, complete the inputs, and enter `DEPLOY` as the confirmation.
+1. Review the job summary for each planned deployment's result and address. It
+   includes transaction hashes for contracts deployed during the run.
+
+Use a public RPC URL without credentials. Workflow inputs are stored in GitHub
+metadata and are not secret.
+
+### Deploy locally
+
+Load `PRIVATE_KEY` from a secret manager or hidden prompt. Never paste the key
+into a command because it may be saved in shell history. For example, in Bash:
+
+```bash
+read -rsp 'Testnet deployer private key: ' PRIVATE_KEY
+printf '\n'
+export PRIVATE_KEY
+```
+
+Run the deployer with an explicit RPC endpoint and spending limits:
 
 ```bash
 bun run deploy:testnet -- \
-RPC_URL=https://... MAX_FEE_PER_GAS_GWEI=100 MAX_TOTAL_COST_ETH=20
+  --rpc-url=https://rpc.example \
+  --chain-id=11155111 \
+  --max-fee-per-gas-gwei=100 \
+  --max-total-cost-eth=20
 ```
 
-The chain ID defaults to Sepolia (`11155111`). Set `CHAIN_ID` for any other EVM
-testnet that supports the protocol's required Cancun opcodes and Osaka `CLZ`
-opcode; chain ID `1` is intentionally rejected. Older pre-Cancun or pre-Osaka
-chains cannot execute the pinned protocol and Uniswap V4 bytecode. The fee ceiling
-defaults to 100 gwei and the total-cost authorization defaults to 20 testnet ETH.
-That default leaves headroom above the current conservative full-plan bound at
-100 gwei; it is an authorization cap, not a spend forecast or required balance.
-`RPC_URL`, `MAX_FEE_PER_GAS_GWEI`, and `MAX_TOTAL_COST_ETH` can be passed as the
-uppercase command arguments shown above, as lowercase `--rpc-url=...` style
-options, or as environment variables. `PRIVATE_KEY` remains environment-only so
-it is not exposed in command history.
+Remove the key from the shell when the command finishes:
 
-Before funding or signing, the command verifies the selected chain, required EVM
-opcodes, EIP-1559 support, fee limits, and acceptance of the fixed canonical
-legacy deployer transactions. It then identifies every missing step and calculates
-a deliberately conservative upper-bound cost at the selected fee ceiling. The
-allowances are about 50% above measured deployment gas and rounded upward; the
-largest deployments use the signer's 30-million-gas transaction ceiling. Missing
-canonical deployers also include their fixed raw-transaction cost and an allowance
-for atomic funding. If the estimate exceeds `MAX_TOTAL_COST_ETH`, the command exits
-before any funding or deployment transaction. The per-transaction budget remains
-active as a second guard. Each retry estimates only contracts that are still
-missing. A network that rejects the canonical transactions must provide both
-canonical deployers as predeploys.
+```bash
+unset PRIVATE_KEY
+```
 
-The command validates each expected runtime, skips deterministic addresses only
-when their code matches, fails closed when an address contains different code,
-and resumes from the first missing deployment. Atomic funding transactions refund
-surplus if another process wins a deployment race. Every supported testnet plan
-includes deterministic WETH and genesis REP contracts. The same plan covers the canonical CREATE2 deployer and
-Permit2, a deterministic Uniswap V3 factory, SwapRouter, and QuoterV2, plus a
-Uniswap V4 PoolManager and Quoter. It does not create pools or add liquidity. The deployed
-protocol factories create per-market security pools, share tokens, oracle
-coordinators, auctions, escalation games, delegates, and child-universe
-contracts when those features are used. Constructor-created support contracts
-are not separate bootstrap steps; the command verifies all twelve bootstrap
-descendants after their parent factories are deployed.
+Run `bun run deploy:testnet -- --help` for the command-line form of each option.
+Except for `PRIVATE_KEY`, options also accept uppercase arguments after `--` or
+environment variables.
 
-The deployment workflow is
-[`deploy-testnet.yml`](./.github/workflows/deploy-testnet.yml). Create and protect
-the `testnet-deployment` environment, add its
-`TESTNET_DEPLOYER_PRIVATE_KEY` secret, and dispatch **Deploy Testnet Contracts**
-from `main`. Supply the public HTTPS RPC URL, chain ID, fee ceiling, and total
-budget, then enter `DEPLOY` in the confirmation input. Workflow inputs are
-visible in GitHub metadata, so do not supply an RPC URL containing credentials.
+| Input | Default | Purpose |
+| --- | --- | --- |
+| `RPC_URL` / `--rpc-url` | Required | RPC endpoint for the target network |
+| `CHAIN_ID` / `--chain-id` | `11155111` | Expected decimal chain ID |
+| `MAX_FEE_PER_GAS_GWEI` / `--max-fee-per-gas-gwei` | `100` | Rejects higher RPC fee suggestions |
+| `MAX_TOTAL_COST_ETH` / `--max-total-cost-eth` | `20` | Caps the conservative preflight estimate and transaction budget |
+| `PRIVATE_KEY` | Required | Environment-only, `0x`-prefixed 32-byte deployer key |
+
+The defaults are authorization limits, not a spend forecast or a required
+balance. Before sending a transaction, the command checks the RPC chain ID, EVM
+features, EIP-1559 support, canonical deployer compatibility, expected bytecode,
+and fee limits. It then estimates only the missing deployment steps. If the
+conservative estimate exceeds `MAX_TOTAL_COST_ETH`, it exits before funding or
+deploying anything. Per-transaction checks enforce the same budget while the
+deployment runs.
+
+If a run is interrupted, wait for all pending transactions to settle and rerun
+the same command. The deployer revalidates completed contracts and resumes with
+the first missing step. A testnet that rejects the fixed legacy transactions for
+the canonical deployers must provide both deployers as predeploys.
+
+A successful local run exits with status `0` after logging each planned contract
+as `deployed` or `skip` and verifying the bootstrap support contracts.
+
+### Deployed infrastructure
+
+Every deployment includes:
+
+- deterministic WETH and genesis REP
+- the canonical CREATE2 deployer and Permit2
+- a deterministic Uniswap V3 factory, SwapRouter, and QuoterV2
+- a Uniswap V4 PoolManager and Quoter
+- the Zoltar and Augur Statoblast protocol factories and their bootstrap support
+  contracts
+
+The command does not create Uniswap pools or add liquidity. Protocol factories
+create market-specific security pools, share tokens, oracle coordinators,
+auctions, escalation games, delegates, and child-universe contracts later, when
+those features are used.
 
 ## Browser Simulation
 

--- a/README.md
+++ b/README.md
@@ -125,19 +125,13 @@ Load `PRIVATE_KEY` from a secret manager or hidden prompt. Never paste the key
 into a command because it may be saved in shell history. For example, in Bash:
 
 ```bash
-read -rsp 'Testnet deployer private key: ' PRIVATE_KEY
-printf '\n'
-export PRIVATE_KEY
+read -rsp 'Testnet deployer private key: ' PRIVATE_KEY && echo && export PRIVATE_KEY
 ```
 
 Run the deployer with an explicit RPC endpoint and spending limits:
 
 ```bash
-bun run deploy:testnet -- \
-  --rpc-url=https://rpc.example \
-  --chain-id=11155111 \
-  --max-fee-per-gas-gwei=100 \
-  --max-total-cost-eth=20
+bun run deploy:testnet -- --rpc-url=https://rpc.example --chain-id=11155111 --max-fee-per-gas-gwei=100 --max-total-cost-eth=20
 ```
 
 Remove the key from the shell when the command finishes:
@@ -146,9 +140,11 @@ Remove the key from the shell when the command finishes:
 unset PRIVATE_KEY
 ```
 
-Run `bun run deploy:testnet -- --help` for the command-line form of each option.
-Except for `PRIVATE_KEY`, options also accept uppercase arguments after `--` or
-environment variables.
+The deployer reads the exported `PRIVATE_KEY` automatically. It intentionally
+does not accept a private-key command-line option, so the key does not need to
+appear in shell history. Run `bun run deploy:testnet -- --help` for the
+command-line form of each other option. Those options also accept uppercase
+arguments after `--` or environment variables.
 
 | Input | Default | Purpose |
 | --- | --- | --- |

--- a/scripts/deploy-testnet.mts
+++ b/scripts/deploy-testnet.mts
@@ -139,7 +139,7 @@ export function parseRpcUrl(value: string | undefined) {
 }
 
 export function parsePrivateKey(value: string | undefined) {
-	if (!isPrivateKey(value)) throw new Error('PRIVATE_KEY must be a 32-byte 0x-prefixed private key')
+	if (!isPrivateKey(value)) throw new Error('PRIVATE_KEY or --private-key must be a 32-byte 0x-prefixed private key')
 	return value
 }
 
@@ -168,7 +168,7 @@ export function parseDeploymentCommandLine(argv = process.argv.slice(2), environ
 		chainId: parseChainId(commandLineValue('chain-id', 'CHAIN_ID', argv) ?? environment['CHAIN_ID']),
 		maxFeePerGas: parseMaxFeePerGas(commandLineValue('max-fee-per-gas-gwei', 'MAX_FEE_PER_GAS_GWEI', argv) ?? environment['MAX_FEE_PER_GAS_GWEI']),
 		maxTotalCost: parseMaxTotalCost(commandLineValue('max-total-cost-eth', 'MAX_TOTAL_COST_ETH', argv) ?? environment['MAX_TOTAL_COST_ETH']),
-		privateKey: parsePrivateKey(environment['PRIVATE_KEY']),
+		privateKey: parsePrivateKey(option('private-key', [...argv]) ?? environment['PRIVATE_KEY']),
 		rpcUrl: parseRpcUrl(commandLineValue('rpc-url', 'RPC_URL', argv) ?? environment['RPC_URL']),
 	}
 }
@@ -517,10 +517,12 @@ export async function deployTestnet(parameters: { chainId: number; maxFeePerGas?
 export function getDeploymentHelp() {
 	return `Deploy the complete deterministic Zoltar infrastructure to an EVM testnet
 
-Load PRIVATE_KEY into the environment from a secret manager or hidden prompt.
+Load PRIVATE_KEY into the environment from a secret manager or hidden prompt,
+or pass --private-key=0x... if shell history exposure is acceptable.
 Pass RPC and cost limits as uppercase assignments after --, for example:
   bun run deploy:testnet -- RPC_URL=https://... MAX_FEE_PER_GAS_GWEI=100 MAX_TOTAL_COST_ETH=20
 
+  --private-key=0x...    Required unless PRIVATE_KEY is set
   --rpc-url=https://...   Required unless RPC_URL is set
   --chain-id=11155111     Defaults to Sepolia chain ID 11155111
   --max-fee-per-gas-gwei=100  Rejects higher RPC fee suggestions

--- a/scripts/deploy-testnet.test.ts
+++ b/scripts/deploy-testnet.test.ts
@@ -61,6 +61,16 @@ describe('testnet deployment inputs', () => {
 		expect(() => parsePrivateKey(undefined)).toThrow('32-byte 0x-prefixed')
 	})
 
+	test('accepts a private key command-line option before the environment fallback', () => {
+		const commandLinePrivateKey = '0x1212121212121212121212121212121212121212121212121212121212121212'
+		const environmentPrivateKey = '0x3434343434343434343434343434343434343434343434343434343434343434'
+		expect(
+			parseDeploymentCommandLine(['--rpc-url=https://rpc.example.test', `--private-key=${commandLinePrivateKey}`], {
+				PRIVATE_KEY: environmentPrivateKey,
+			}),
+		).toMatchObject({ privateKey: commandLinePrivateKey })
+	})
+
 	test('parses positive fee and total deployment limits', () => {
 		expect(parseMaxFeePerGas(undefined)).toBe(100_000_000_000n)
 		expect(parseMaxFeePerGas('1.5')).toBe(1_500_000_000n)
@@ -87,8 +97,10 @@ describe('testnet deployment inputs', () => {
 		})
 	})
 
-	test('never suggests placing the private key in a shell command', () => {
+	test('warns about command history when documenting the private key option', () => {
 		expect(getDeploymentHelp()).not.toContain('PRIVATE_KEY=0x')
+		expect(getDeploymentHelp()).toContain('--private-key=0x...')
+		expect(getDeploymentHelp()).toContain('shell history exposure')
 	})
 
 	test('uses the same canonicalized chain input for workflow concurrency and deployment', async () => {


### PR DESCRIPTION
## Summary

- reorganize the testnet deployment guide around prerequisites and separate GitHub Actions and local workflows
- accept `--private-key=0x...` with precedence over the `PRIVATE_KEY` environment fallback
- document safe private-key handling, supported inputs, defaults, spending limits, resumability, and deployed infrastructure
- warn that passing a key on the command line may expose it through shell history

## Validation

- `bun run tsc`
- `bun test scripts/deploy-testnet.test.ts --timeout 300000` — 28 tests, 186 assertions
- `bun run format:check`
- `bun run check:changed`
- `bun run knip`
- `git diff --check`
- branch-current gate: `HEAD..origin/main` = 0

The focused regression test was confirmed failing before implementation, then passed after the CLI parser change. The full suite was skipped because the narrow parser/help behavior is covered by the complete deploy-testnet test file. Generated-clean was skipped because contracts, generators, and artifact policy were unchanged. The collaborative Markdown preview was unavailable in this environment.

## Review

- documentation review: 98/100, no findings
- visual review: 88/100, no findings; live-preview evidence unavailable
- final review: 98/100, no findings