### PR TITLE
Add Compose startup for operator bots

### DIFF
--- a/bots/liquidator/.env.example
+++ b/bots/liquidator/.env.example
@@ -1,0 +1,6 @@
+# Use at least 16 characters. Keep the real .env file private.
+ZOLTAR_BOT_DASHBOARD_PASSWORD=''
+
+# Use the owner of .state (`id -u` and `id -g`).
+LIQUIDATOR_UID=''
+LIQUIDATOR_GID=''

--- a/bots/liquidator/.gitignore
+++ b/bots/liquidator/.gitignore
@@ -1,2 +1,3 @@
+/.env
 .state/
 node_modules/

--- a/bots/liquidator/README.md
+++ b/bots/liquidator/README.md
@@ -24,8 +24,47 @@ threshold.
 
 ## Operator setup
 
+### Docker Compose
+
+From the monorepo root, create the private environment and operator files:
+
 ```bash
-cp config/operator.example.json .state/operator.json
+cd bots/liquidator
+install -m 600 .env.example .env
+install -d -m 700 .state
+install -m 600 config/operator.example.json .state/operator.json
+```
+
+In `.env`, set a unique dashboard password of at least 16 characters. Set
+`LIQUIDATOR_UID` and `LIQUIDATOR_GID` to the output of `id -u` and `id -g`; this
+lets the container read and update the owner-only state files without making them
+public.
+
+In `.state/operator.json`, add the reviewed deployment and RPC settings and set
+`runtime.uiHost` to `0.0.0.0`. These settings are not editable from the liquidator
+dashboard, and the operator file must remain owner-only. Keep `runtime.execute`
+false while testing the setup. Then build and start the bot:
+
+```bash
+docker compose up --build --detach
+```
+
+Open `http://127.0.0.1:4183` and sign in as `operator` with the password from
+`.env`. Run `docker compose down` to stop the bot and `docker compose up --detach`
+to start it again. The bind-mounted `.state` directory preserves its configuration,
+history, and recovery state.
+
+Do not publish the dashboard on a public interface. Loopback RPC URLs refer to
+the container itself, so use a container-reachable RPC address when the node runs
+elsewhere.
+
+### Bun
+
+From `bots/liquidator`:
+
+```bash
+install -d -m 700 .state
+install -m 600 config/operator.example.json .state/operator.json
 bun install --frozen-lockfile
 bun run run
 ```
@@ -34,7 +73,7 @@ Set `ZOLTAR_LIQUIDATOR_CONFIG` to use another operator file. The bot accepts no
 command-line arguments. The dashboard defaults to
 `http://127.0.0.1:4183`.
 
-Loopback dashboards need no password. If `runtime.uiHost` is `0.0.0.0`, set
+Native loopback dashboards need no password. If `runtime.uiHost` is `0.0.0.0`, set
 `ZOLTAR_BOT_DASHBOARD_PASSWORD` to at least 16 characters before startup. The
 browser's HTTP Basic prompt uses username `operator` and that password. Keep the
 listener on a trusted network or behind an authenticated TLS proxy: Basic

--- a/bots/liquidator/compose.yaml
+++ b/bots/liquidator/compose.yaml
@@ -1,0 +1,15 @@
+name: zoltar-liquidator
+
+services:
+  liquidator:
+    build:
+      context: ../..
+      dockerfile: bots/liquidator/Dockerfile
+    image: zoltar-liquidator
+    user: ${LIQUIDATOR_UID:?Set LIQUIDATOR_UID in .env}:${LIQUIDATOR_GID:?Set LIQUIDATOR_GID in .env}
+    environment:
+      ZOLTAR_BOT_DASHBOARD_PASSWORD: ${ZOLTAR_BOT_DASHBOARD_PASSWORD:?Set ZOLTAR_BOT_DASHBOARD_PASSWORD in .env}
+    ports:
+      - 127.0.0.1:4183:4183
+    volumes:
+      - ./.state:/app/bots/liquidator/.state

--- a/bots/open-oracle-arbitrager/.env.example
+++ b/bots/open-oracle-arbitrager/.env.example
@@ -1,0 +1,2 @@
+# Use at least 16 characters. Keep the real .env file private.
+ZOLTAR_BOT_DASHBOARD_PASSWORD=''

--- a/bots/open-oracle-arbitrager/.gitignore
+++ b/bots/open-oracle-arbitrager/.gitignore
@@ -1,3 +1,4 @@
+/.env
 /.state/
 /artifacts/
 /node_modules/

--- a/bots/open-oracle-arbitrager/Dockerfile
+++ b/bots/open-oracle-arbitrager/Dockerfile
@@ -30,8 +30,10 @@ COPY bots/open-oracle-arbitrager/README.md ./bots/open-oracle-arbitrager/README.
 COPY bots/open-oracle-arbitrager/config/ ./bots/open-oracle-arbitrager/config/
 COPY bots/open-oracle-arbitrager/docs/ ./bots/open-oracle-arbitrager/docs/
 COPY bots/open-oracle-arbitrager/scripts/check-market-fixture.mts ./bots/open-oracle-arbitrager/scripts/check-market-fixture.mts
+COPY bots/open-oracle-arbitrager/scripts/docker-entrypoint.sh ./bots/open-oracle-arbitrager/scripts/docker-entrypoint.sh
 COPY bots/open-oracle-arbitrager/src/ ./bots/open-oracle-arbitrager/src/
-RUN install -d -m 0700 -o bun -g bun bots/open-oracle-arbitrager/.state
+RUN chmod 0755 bots/open-oracle-arbitrager/scripts/docker-entrypoint.sh \
+	&& install -d -m 0700 -o bun -g bun bots/open-oracle-arbitrager/.state
 
 USER bun
 WORKDIR /app/bots/open-oracle-arbitrager
@@ -39,4 +41,5 @@ WORKDIR /app/bots/open-oracle-arbitrager
 EXPOSE 4173
 VOLUME ["/app/bots/open-oracle-arbitrager/.state"]
 
-ENTRYPOINT ["bun", "run", "run"]
+ENTRYPOINT ["./scripts/docker-entrypoint.sh"]
+CMD ["bun", "run", "run"]

--- a/bots/open-oracle-arbitrager/Dockerfile.dockerignore
+++ b/bots/open-oracle-arbitrager/Dockerfile.dockerignore
@@ -20,6 +20,7 @@
 !bots/open-oracle-arbitrager/docs/**
 !bots/open-oracle-arbitrager/scripts/
 !bots/open-oracle-arbitrager/scripts/check-market-fixture.mts
+!bots/open-oracle-arbitrager/scripts/docker-entrypoint.sh
 !bots/open-oracle-arbitrager/src/
 !bots/open-oracle-arbitrager/src/**
 !bots/shared/package.json

--- a/bots/open-oracle-arbitrager/README.md
+++ b/bots/open-oracle-arbitrager/README.md
@@ -201,21 +201,15 @@ Build from the monorepo root so Docker can include the local `shared/` package:
 docker build --file bots/open-oracle-arbitrager/Dockerfile --tag zoltar-open-oracle-arbitrager .
 ```
 
-From the monorepo root, create the mounted state directory and configuration:
+The build creates the image but does not start it. Before starting the container,
+create the mounted state directory and configuration from the monorepo root:
 
 ```bash
 install -d -m 700 bots/open-oracle-arbitrager/.state
 install -m 600 bots/open-oracle-arbitrager/config/operator.example.json bots/open-oracle-arbitrager/.state/operator.json
 ```
 
-For a one-shot scan, edit the file so `runtime.once` is `true` and `runtime.ui`
-is `false`, then run:
-
-```bash
-docker run --rm --mount type=bind,source="$PWD/bots/open-oracle-arbitrager/.state",target=/app/bots/open-oracle-arbitrager/.state zoltar-open-oracle-arbitrager
-```
-
-To run the bot with its dashboard:
+Now start the bot with its dashboard:
 
 1. In `bots/open-oracle-arbitrager/.state/operator.json`, set `runtime.once` to
    `false`, `runtime.ui` to `true`, and `runtime.uiHost` to `0.0.0.0`.
@@ -244,6 +238,13 @@ credentials, or manifests containing private infrastructure into the image.
 Do not attach the bot to a Docker network shared with untrusted containers. Loopback
 RPC URLs refer to the container itself, so use a container-reachable RPC address
 when the node runs elsewhere.
+
+For a one-shot scan instead of the dashboard, edit the file so `runtime.once` is
+`true` and `runtime.ui` is `false`, then run:
+
+```bash
+docker run --rm --mount type=bind,source="$PWD/bots/open-oracle-arbitrager/.state",target=/app/bots/open-oracle-arbitrager/.state zoltar-open-oracle-arbitrager
+```
 
 ## Monitor without trading
 

--- a/bots/open-oracle-arbitrager/README.md
+++ b/bots/open-oracle-arbitrager/README.md
@@ -198,42 +198,46 @@ bun run reconcile -- [reconciliation options]
 Build from the monorepo root so Docker can include the local `shared/` package:
 
 ```bash
-docker build \
-  --file bots/open-oracle-arbitrager/Dockerfile \
-  --tag zoltar-open-oracle-arbitrager \
-  .
+docker build --file bots/open-oracle-arbitrager/Dockerfile --tag zoltar-open-oracle-arbitrager .
 ```
 
 From the monorepo root, create the mounted state directory and configuration:
 
 ```bash
 install -d -m 700 bots/open-oracle-arbitrager/.state
-install -m 600 bots/open-oracle-arbitrager/config/operator.example.json \
-  bots/open-oracle-arbitrager/.state/operator.json
+install -m 600 bots/open-oracle-arbitrager/config/operator.example.json bots/open-oracle-arbitrager/.state/operator.json
 ```
 
 For a one-shot scan, edit the file so `runtime.once` is `true` and `runtime.ui`
 is `false`, then run:
 
 ```bash
-docker run --rm \
-  --mount type=bind,source="$PWD/bots/open-oracle-arbitrager/.state",target=/app/bots/open-oracle-arbitrager/.state \
-  zoltar-open-oracle-arbitrager
+docker run --rm --mount type=bind,source="$PWD/bots/open-oracle-arbitrager/.state",target=/app/bots/open-oracle-arbitrager/.state zoltar-open-oracle-arbitrager
 ```
 
-For the dashboard, set `runtime.once` to `false`, `runtime.ui` to `true`, and
-`runtime.uiHost` to `0.0.0.0`. Set a password of at least 16 characters and bind
-the published host port to loopback:
+To run the bot with its dashboard:
 
-```bash
-docker run --rm \
-  --mount type=bind,source="$PWD/bots/open-oracle-arbitrager/.state",target=/app/bots/open-oracle-arbitrager/.state \
-  --env ZOLTAR_BOT_DASHBOARD_PASSWORD="$ZOLTAR_BOT_DASHBOARD_PASSWORD" \
-  --publish 127.0.0.1:4173:4173 \
-  zoltar-open-oracle-arbitrager
-```
+1. In `bots/open-oracle-arbitrager/.state/operator.json`, set `runtime.once` to
+   `false`, `runtime.ui` to `true`, and `runtime.uiHost` to `0.0.0.0`.
+2. Export a dashboard password of at least 16 characters in the terminal that will
+   run Docker:
 
-Open `http://127.0.0.1:4173` and authenticate as `operator` with that password.
+   ```bash
+   export ZOLTAR_BOT_DASHBOARD_PASSWORD='replace-with-a-long-unique-password'
+   ```
+
+3. From the monorepo root, start the container and leave it running. The published
+   host port is bound to loopback:
+
+   ```bash
+   docker run --rm --mount type=bind,source="$PWD/bots/open-oracle-arbitrager/.state",target=/app/bots/open-oracle-arbitrager/.state --env ZOLTAR_BOT_DASHBOARD_PASSWORD="$ZOLTAR_BOT_DASHBOARD_PASSWORD" --publish 127.0.0.1:4173:4173 zoltar-open-oracle-arbitrager
+   ```
+
+4. Open `http://127.0.0.1:4173` in a browser on the same machine. When the browser
+   prompts for credentials, enter `operator` as the username and the exported
+   password as the password. The dashboard remains available while the container
+   is running; press Ctrl+C in its terminal to stop it.
+
 Do not publish the dashboard on a public interface:
 it controls signer and execution settings. Do not bake private keys, RPC
 credentials, or manifests containing private infrastructure into the image.
@@ -312,9 +316,7 @@ is deterministic; use the same 32-byte `--salt` to obtain the same address on ev
 chain where the canonical CREATE2 proxy and executor init code are identical:
 
 ```bash
-PRIVATE_KEY=0xYourDeploymentPrivateKey \
-ETH_RPC_URL=https://your-private-mainnet-rpc.example \
-  bun run deploy-executor -- --network=mainnet --salt=0x0000000000000000000000000000000000000000000000000000000000000000
+PRIVATE_KEY=0xYourDeploymentPrivateKey ETH_RPC_URL=https://your-private-mainnet-rpc.example bun run deploy-executor -- --network=mainnet --salt=0x0000000000000000000000000000000000000000000000000000000000000000
 ```
 
 ### Executor ABI source
@@ -394,16 +396,9 @@ The parser and schema bind `mainnet` to chain ID `1` and `sepolia` to chain ID
 can verify the file.
 
 ```bash
-bun run manifest -- generate \
-  --network=sepolia \
-  --rpc-url=https://first-provider.example \
-  --contract=executor:0x... \
-  --contract=open-oracle:0x... \
-  --output=/secure/operator/sepolia-deployments.json
+bun run manifest -- generate --network=sepolia --rpc-url=https://first-provider.example --contract=executor:0x... --contract=open-oracle:0x... --output=/secure/operator/sepolia-deployments.json
 
-bun run manifest -- verify \
-  --rpc-url=https://independent-provider.example \
-  --manifest=/secure/operator/sepolia-deployments.json
+bun run manifest -- verify --rpc-url=https://independent-provider.example --manifest=/secure/operator/sepolia-deployments.json
 ```
 
 `config/execution-manifest.example.json` is deliberately placeholder-only and must never
@@ -533,29 +528,13 @@ Grant ERC-20 and OpenOracle internal allowances from the dedicated bot account
 (replace the addresses and use the selected network RPC):
 
 ```bash
-cast send 0xWETH \
-  "approve(address,uint256)" \
-  0xExecutor \
-  0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff \
-  --private-key "$PRIVATE_KEY" --rpc-url "$ETH_RPC_URL"
+cast send 0xWETH "approve(address,uint256)" 0xExecutor 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff --private-key "$PRIVATE_KEY" --rpc-url "$ETH_RPC_URL"
 
-cast send 0xReportToken \
-  "approve(address,uint256)" \
-  0xExecutor \
-  0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff \
-  --private-key "$PRIVATE_KEY" --rpc-url "$ETH_RPC_URL"
+cast send 0xReportToken "approve(address,uint256)" 0xExecutor 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff --private-key "$PRIVATE_KEY" --rpc-url "$ETH_RPC_URL"
 
-cast send 0xOpenOracle \
-  "approveInternal(address,address,uint256)" \
-  0xExecutor 0xWETH \
-  0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff \
-  --private-key "$PRIVATE_KEY" --rpc-url "$ETH_RPC_URL"
+cast send 0xOpenOracle "approveInternal(address,address,uint256)" 0xExecutor 0xWETH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff --private-key "$PRIVATE_KEY" --rpc-url "$ETH_RPC_URL"
 
-cast send 0xOpenOracle \
-  "approveInternal(address,address,uint256)" \
-  0xExecutor 0xReportToken \
-  0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff \
-  --private-key "$PRIVATE_KEY" --rpc-url "$ETH_RPC_URL"
+cast send 0xOpenOracle "approveInternal(address,address,uint256)" 0xExecutor 0xReportToken 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff --private-key "$PRIVATE_KEY" --rpc-url "$ETH_RPC_URL"
 ```
 
 Maximum allowances avoid missing an opportunity after a finite allowance is
@@ -1183,16 +1162,7 @@ an independently calculated realized P&amp;L or an explicit declaration that P&a
 is unavailable:
 
 ```bash
-PRIVATE_KEY=0x... bun run reconcile -- \
-  --position-file=.state/positions-sepolia.json \
-  --report-id=42 \
-  --confirm-report-id=42 \
-  --evidence='receipts and balance snapshots archived under incident-42' \
-  --note='residual REP sold manually; balances checked on all configured read RPCs' \
-  --external-cost-eth=0.003 \
-  --final-wallet-weth=4.2 \
-  --final-wallet-token=85 \
-  --pnl-unavailable=true
+PRIVATE_KEY=0x... bun run reconcile -- --position-file=.state/positions-sepolia.json --report-id=42 --confirm-report-id=42 --evidence='receipts and balance snapshots archived under incident-42' --note='residual REP sold manually; balances checked on all configured read RPCs' --external-cost-eth=0.003 --final-wallet-weth=4.2 --final-wallet-token=85 --pnl-unavailable=true
 ```
 
 Use `--realized-net-profit-eth=-0.04 --acknowledge-pnl-is-all-in=true` instead of

--- a/bots/open-oracle-arbitrager/README.md
+++ b/bots/open-oracle-arbitrager/README.md
@@ -195,56 +195,43 @@ bun run reconcile -- [reconciliation options]
 
 ## Docker
 
-Build from the monorepo root so Docker can include the local `shared/` package:
+Docker Compose builds the image, keeps bot state in a named volume, publishes the
+dashboard only on host loopback, and starts the bot. From the monorepo root, create
+the local environment file:
 
 ```bash
-docker build --file bots/open-oracle-arbitrager/Dockerfile --tag zoltar-open-oracle-arbitrager .
+cd bots/open-oracle-arbitrager
+install -m 600 .env.example .env
 ```
 
-The build creates the image but does not start it. Before starting the container,
-create the mounted state directory and configuration from the monorepo root:
+Edit `.env` and set a unique dashboard password of at least 16 characters. Then
+build and start the container:
 
 ```bash
-install -d -m 700 bots/open-oracle-arbitrager/.state
-install -m 600 bots/open-oracle-arbitrager/config/operator.example.json bots/open-oracle-arbitrager/.state/operator.json
+docker compose up --build --detach
 ```
 
-Now start the bot with its dashboard:
+On first start, the container creates a paused, dry-run configuration in its
+persistent volume. Open `http://127.0.0.1:4173` and sign in as `operator` with the
+password from `.env`.
 
-1. In `bots/open-oracle-arbitrager/.state/operator.json`, set `runtime.once` to
-   `false`, `runtime.ui` to `true`, and `runtime.uiHost` to `0.0.0.0`.
-2. Export a dashboard password of at least 16 characters in the terminal that will
-   run Docker:
-
-   ```bash
-   export ZOLTAR_BOT_DASHBOARD_PASSWORD='replace-with-a-long-unique-password'
-   ```
-
-3. From the monorepo root, start the container and leave it running. The published
-   host port is bound to loopback:
-
-   ```bash
-   docker run --rm --mount type=bind,source="$PWD/bots/open-oracle-arbitrager/.state",target=/app/bots/open-oracle-arbitrager/.state --env ZOLTAR_BOT_DASHBOARD_PASSWORD="$ZOLTAR_BOT_DASHBOARD_PASSWORD" --publish 127.0.0.1:4173:4173 zoltar-open-oracle-arbitrager
-   ```
-
-4. Open `http://127.0.0.1:4173` in a browser on the same machine. When the browser
-   prompts for credentials, enter `operator` as the username and the exported
-   password as the password. The dashboard remains available while the container
-   is running; press Ctrl+C in its terminal to stop it.
-
-Do not publish the dashboard on a public interface:
-it controls signer and execution settings. Do not bake private keys, RPC
-credentials, or manifests containing private infrastructure into the image.
-Do not attach the bot to a Docker network shared with untrusted containers. Loopback
-RPC URLs refer to the container itself, so use a container-reachable RPC address
-when the node runs elsewhere.
-
-For a one-shot scan instead of the dashboard, edit the file so `runtime.once` is
-`true` and `runtime.ui` is `false`, then run:
+Open [**Complete bot configuration**](http://127.0.0.1:4173/#complete-configuration),
+add the reviewed deployment and endpoint settings, and save them. Configuration
+changes apply after restart:
 
 ```bash
-docker run --rm --mount type=bind,source="$PWD/bots/open-oracle-arbitrager/.state",target=/app/bots/open-oracle-arbitrager/.state zoltar-open-oracle-arbitrager
+docker compose restart
 ```
+
+Run `docker compose down` to stop the bot and `docker compose up --detach` to start
+it again. Compose preserves the operator configuration and bot history unless you
+explicitly delete the named volume.
+
+Do not publish the dashboard on a public interface: it controls signer and execution
+settings. Do not bake private keys, RPC credentials, or manifests containing private
+infrastructure into the image. Do not attach the bot to a Docker network shared
+with untrusted containers. Loopback RPC URLs refer to the container itself, so use
+a container-reachable RPC address when the node runs elsewhere.
 
 ## Monitor without trading
 

--- a/bots/open-oracle-arbitrager/compose.yaml
+++ b/bots/open-oracle-arbitrager/compose.yaml
@@ -1,0 +1,17 @@
+name: zoltar-open-oracle-arbitrager
+
+services:
+  arbitrager:
+    build:
+      context: ../..
+      dockerfile: bots/open-oracle-arbitrager/Dockerfile
+    image: zoltar-open-oracle-arbitrager
+    environment:
+      ZOLTAR_BOT_DASHBOARD_PASSWORD: ${ZOLTAR_BOT_DASHBOARD_PASSWORD:?Set ZOLTAR_BOT_DASHBOARD_PASSWORD in .env}
+    ports:
+      - 127.0.0.1:4173:4173
+    volumes:
+      - arbitrager-state:/app/bots/open-oracle-arbitrager/.state
+
+volumes:
+  arbitrager-state:

--- a/bots/open-oracle-arbitrager/scripts/docker-entrypoint.sh
+++ b/bots/open-oracle-arbitrager/scripts/docker-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+set -eu
+
+settings_file='.state/operator.json'
+temporary_file=''
+
+cleanup() {
+	if [ -n "$temporary_file" ]; then
+		rm -f "$temporary_file"
+	fi
+}
+
+trap cleanup EXIT HUP INT TERM
+
+if [ ! -e "$settings_file" ]; then
+	umask 077
+	temporary_file=$(mktemp '.state/operator.json.XXXXXX')
+	sed 's/"uiHost": "127.0.0.1"/"uiHost": "0.0.0.0"/' config/operator.example.json > "$temporary_file"
+	chmod 600 "$temporary_file"
+	mv "$temporary_file" "$settings_file"
+	temporary_file=''
+fi
+
+if [ -f "$settings_file" ]; then
+	chmod 600 "$settings_file"
+fi
+
+trap - EXIT HUP INT TERM
+exec "$@"

--- a/bots/open-oracle-arbitrager/tests/docker-entrypoint.test.ts
+++ b/bots/open-oracle-arbitrager/tests/docker-entrypoint.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const entrypoint = join(import.meta.dir, '..', 'scripts', 'docker-entrypoint.sh')
+const example = join(import.meta.dir, '..', 'config', 'operator.example.json')
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+	await Promise.all(temporaryDirectories.splice(0).map(directory => rm(directory, { force: true, recursive: true })))
+})
+
+async function fixture() {
+	const directory = await mkdtemp(join(tmpdir(), 'zoltar-arbitrager-docker-'))
+	temporaryDirectories.push(directory)
+	await mkdir(join(directory, '.state'))
+	await mkdir(join(directory, 'config'))
+	await writeFile(join(directory, 'config', 'operator.example.json'), await readFile(example))
+	return directory
+}
+
+async function runEntrypoint(directory: string, path = process.env['PATH']) {
+	const child = Bun.spawn([entrypoint, '/bin/true'], { cwd: directory, env: { ...process.env, PATH: path }, stderr: 'pipe', stdout: 'pipe' })
+	const exitCode = await child.exited
+	if (exitCode !== 0) throw new Error(`Docker entrypoint exited ${exitCode.toString()}: ${await new Response(child.stderr).text()}`)
+}
+
+describe('Docker entrypoint', () => {
+	test('creates a private Compose-ready operator configuration on first start', async () => {
+		const directory = await fixture()
+		await runEntrypoint(directory)
+
+		const settingsFile = join(directory, '.state', 'operator.json')
+		const settings = await readFile(settingsFile, 'utf8')
+		expect(settings).toContain('"paused": true')
+		expect(settings).toContain('"execute": false')
+		expect(settings).toContain('"once": false')
+		expect(settings).toContain('"ui": true')
+		expect(settings).toContain('"uiHost": "0.0.0.0"')
+		expect(settings).not.toContain('"uiHost": "127.0.0.1"')
+		expect((await stat(settingsFile)).mode & 0o777).toBe(0o600)
+	})
+
+	test('preserves an existing operator configuration', async () => {
+		const directory = await fixture()
+		const settingsFile = join(directory, '.state', 'operator.json')
+		await writeFile(settingsFile, 'existing settings')
+		await chmod(settingsFile, 0o644)
+
+		await runEntrypoint(directory)
+
+		expect(await readFile(settingsFile, 'utf8')).toBe('existing settings')
+		expect((await stat(settingsFile)).mode & 0o777).toBe(0o600)
+	})
+
+	test('does not preserve a partial configuration when initialization fails', async () => {
+		const directory = await fixture()
+		const executableDirectory = join(directory, 'bin')
+		await mkdir(executableDirectory)
+		const failingSed = join(executableDirectory, 'sed')
+		await writeFile(failingSed, '#!/bin/sh\nprintf partial\nexit 1\n')
+		await chmod(failingSed, 0o755)
+
+		await expect(runEntrypoint(directory, `${executableDirectory}:${process.env['PATH'] ?? ''}`)).rejects.toThrow('Docker entrypoint exited 1')
+		expect(await Bun.file(join(directory, '.state', 'operator.json')).exists()).toBe(false)
+
+		await runEntrypoint(directory)
+		expect(await Bun.file(join(directory, '.state', 'operator.json')).exists()).toBe(true)
+	})
+})


### PR DESCRIPTION
## Summary

- add secure `.env` templates and Compose startup for the OpenOracle arbitrager and security-pool liquidator
- initialize the arbitrager safe dry-run configuration in a persistent named volume
- preserve liquidator owner-only host state with explicit UID/GID mapping
- replace long manual Docker instructions with short build, start, connect, restart, and stop flows
- keep every README command on one physical line

## Why

The previous Docker instructions were long and left the transition from building an image to running and connecting to the dashboard unclear. Compose now owns the build, loopback port, password injection, persistent state, and detached lifecycle while retaining each bot configuration model.

## Validation

- `bun run tsc`
- `bun run knip`
- `bun run check:changed`
- arbitrager entrypoint tests: 3 passed, 0 failed
- liquidator `bun run format:check`
- shell syntax check for the arbitrager entrypoint
- parsed and asserted both Compose models
- rendered and asserted both README quick starts
- `git diff --check`
- documentation review: 98/100, no findings
- visual review: 87/100, no findings
- final review: 89/100, no findings

The arbitrager package format command still reports the pre-existing untouched Solidity formatting issue in `contracts/OpenOracleArbitrageExecutor.sol`; intended changed files pass formatting. Docker and the collaborative browser are unavailable in this environment, so an actual Compose build/start and desktop/mobile screenshots could not be performed.

The branch is current with `main`.