### PR TITLE
Fix arbitrager Docker entrypoint line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,3 +14,7 @@
 
 # Third-party Solidity sources are intentionally vendored for compilation.
 /solidity/contracts/peripherals/openOracle/openzeppelin/** linguist-vendored=true
+
+# Shell entrypoints must retain Unix line endings so their shebangs are executable
+# inside Linux containers, including when the repository is checked out on Windows.
+*.sh text eol=lf

--- a/bots/open-oracle-arbitrager/scripts/docker-entrypoint.sh
+++ b/bots/open-oracle-arbitrager/scripts/docker-entrypoint.sh
@@ -2,6 +2,7 @@
 
 set -eu
 
+# Compose persists operator state in this mounted directory.
 settings_file='.state/operator.json'
 temporary_file=''
 

--- a/bots/open-oracle-arbitrager/tests/docker-entrypoint.test.ts
+++ b/bots/open-oracle-arbitrager/tests/docker-entrypoint.test.ts
@@ -27,6 +27,12 @@ async function runEntrypoint(directory: string, path = process.env['PATH']) {
 }
 
 describe('Docker entrypoint', () => {
+	test('has a Linux-compatible shell shebang', async () => {
+		const source = await readFile(entrypoint, 'utf8')
+		expect(source.startsWith('#!/bin/sh\n')).toBe(true)
+		expect(source).not.toContain('\r')
+	})
+
 	test('creates a private Compose-ready operator configuration on first start', async () => {
 		const directory = await fixture()
 		await runEntrypoint(directory)


### PR DESCRIPTION
## Summary

- enforce LF checkouts for shell scripts so Linux shebangs remain executable
- update the arbitrager entrypoint in the same commit so existing clones check it out under the new line-ending policy
- add regression coverage for the exact `/bin/sh\n` shebang and absence of carriage returns

## Why

A CRLF checkout turns the entrypoint interpreter into `/bin/sh\r`. Linux then reports the existing script as `no such file or directory` before any shell code runs. The repository now declares Unix line endings for shell scripts at the Git boundary instead of repairing source during the Docker build.

The liquidator and AugurScan images invoke Bun directly. The UI entrypoint is created inside its Linux build layer, so those images do not share this checked-out-script failure path.

## Validation

- `git check-attr text eol -- bots/open-oracle-arbitrager/scripts/docker-entrypoint.sh` — `text: set`, `eol: lf`
- `git ls-files --eol bots/open-oracle-arbitrager/scripts/docker-entrypoint.sh` — index and worktree LF
- `sh -n bots/open-oracle-arbitrager/scripts/docker-entrypoint.sh`
- `bun test bots/open-oracle-arbitrager/tests/docker-entrypoint.test.ts` — 4 passed
- `bun run tsc`
- `bun run ensure-contract-artifacts && bun run check:shared-dependencies && bun run test:run -- --bail=1` — 2,797 passed, 16 intentional skips, 0 failed
- `bun run format:check`
- `bun run check:changed`
- `bun run knip`
- `git diff --check`
- final read-only review — 98/100, no findings

An actual Docker build was not run because the validation environment does not provide a Docker CLI or daemon.