### PR TITLE
Fix shared dependencies in bot Docker images

### DIFF
--- a/bots/liquidator/Dockerfile
+++ b/bots/liquidator/Dockerfile
@@ -8,7 +8,9 @@ WORKDIR /app
 COPY bots/shared/package.json bots/shared/bun.lock ./bots/shared/
 COPY bots/shared/src/ ./bots/shared/src/
 COPY bots/liquidator/package.json bots/liquidator/bun.lock ./bots/liquidator/
-RUN cd bots/liquidator \
+RUN cd bots/shared \
+	&& bun install --frozen-lockfile --production \
+	&& cd ../liquidator \
 	&& bun install --frozen-lockfile --production
 
 COPY bots/liquidator/README.md ./bots/liquidator/README.md

--- a/bots/liquidator/tests/docker-packaging.test.ts
+++ b/bots/liquidator/tests/docker-packaging.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'bun:test'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const dockerfile = join(import.meta.dir, '..', 'Dockerfile')
+
+test('installs production dependencies where shared bot sources can resolve them', async () => {
+	const source = await readFile(dockerfile, 'utf8')
+	expect(source).toContain('cd bots/shared \\\n\t&& bun install --frozen-lockfile --production')
+})

--- a/bots/open-oracle-arbitrager/Dockerfile
+++ b/bots/open-oracle-arbitrager/Dockerfile
@@ -23,7 +23,9 @@ COPY --from=shared-builder /source/shared/ ./shared/
 COPY bots/shared/package.json bots/shared/bun.lock ./bots/shared/
 COPY bots/shared/src/ ./bots/shared/src/
 COPY bots/open-oracle-arbitrager/package.json bots/open-oracle-arbitrager/bun.lock ./bots/open-oracle-arbitrager/
-RUN cd bots/open-oracle-arbitrager \
+RUN cd bots/shared \
+	&& bun install --frozen-lockfile --production \
+	&& cd ../open-oracle-arbitrager \
 	&& bun install --frozen-lockfile --production
 
 COPY bots/open-oracle-arbitrager/README.md ./bots/open-oracle-arbitrager/README.md

--- a/bots/open-oracle-arbitrager/tests/docker-entrypoint.test.ts
+++ b/bots/open-oracle-arbitrager/tests/docker-entrypoint.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 const entrypoint = join(import.meta.dir, '..', 'scripts', 'docker-entrypoint.sh')
+const dockerfile = join(import.meta.dir, '..', 'Dockerfile')
 const example = join(import.meta.dir, '..', 'config', 'operator.example.json')
 const temporaryDirectories: string[] = []
 
@@ -27,6 +28,11 @@ async function runEntrypoint(directory: string, path = process.env['PATH']) {
 }
 
 describe('Docker entrypoint', () => {
+	test('installs production dependencies where shared bot sources can resolve them', async () => {
+		const source = await readFile(dockerfile, 'utf8')
+		expect(source).toContain('cd bots/shared \\\n\t&& bun install --frozen-lockfile --production')
+	})
+
 	test('has a Linux-compatible shell shebang', async () => {
 		const source = await readFile(entrypoint, 'utf8')
 		expect(source.startsWith('#!/bin/sh\n')).toBe(true)


### PR DESCRIPTION
## Summary

- install the shared bot package production dependencies inside both bot images
- keep each bot production install frozen to its existing lockfile
- add packaging regressions for the arbitrager and liquidator Dockerfiles

## Why

The bot packages consume `@zoltar/bot-shared` through a sibling `file:` dependency, while its TypeScript sources resolve imports from `/app/bots/shared`. Installing only from the consuming bot directory can leave dependencies such as `@noble/hashes` and `ccxt` unavailable from that source location at runtime.

## Validation

- `cd bots/open-oracle-arbitrager && bun run test` — 280 passed
- `cd bots/liquidator && bun run test` — 88 passed
- `bun run tsc`
- `bun run format:check`
- `cd bots/liquidator && bun run format:check`
- targeted Biome formatting check for the changed arbitrager test
- `bun run check:changed`
- `bun run knip`
- `git diff --check`

Docker image builds were not run because Docker is unavailable in the validation environment. The arbitrager-wide formatter still reports a pre-existing formatting issue in the unchanged `contracts/OpenOracleArbitrageExecutor.sol`; the changed arbitrager test passes its targeted formatter.