### PR TITLE
Fix arbitrager shared dependency install

### DIFF
--- a/bots/open-oracle-arbitrager/Dockerfile
+++ b/bots/open-oracle-arbitrager/Dockerfile
@@ -8,7 +8,7 @@ RUN git init
 
 COPY package.json bun.lock ./
 COPY scripts/ ./scripts/
-COPY shared/package.json shared/tsconfig.json ./shared/
+COPY shared/package.json shared/bun.lock shared/tsconfig.json ./shared/
 COPY shared/ts/ ./shared/ts/
 RUN mkdir -p shared/js \
 	&& bun install --frozen-lockfile \
@@ -23,7 +23,9 @@ COPY --from=shared-builder /source/shared/ ./shared/
 COPY bots/shared/package.json bots/shared/bun.lock ./bots/shared/
 COPY bots/shared/src/ ./bots/shared/src/
 COPY bots/open-oracle-arbitrager/package.json bots/open-oracle-arbitrager/bun.lock ./bots/open-oracle-arbitrager/
-RUN cd bots/shared \
+RUN cd shared \
+	&& bun install --frozen-lockfile --production \
+	&& cd ../bots/shared \
 	&& bun install --frozen-lockfile --production \
 	&& cd ../open-oracle-arbitrager \
 	&& bun install --frozen-lockfile --production

--- a/bots/open-oracle-arbitrager/Dockerfile.dockerignore
+++ b/bots/open-oracle-arbitrager/Dockerfile.dockerignore
@@ -6,6 +6,7 @@
 !scripts/**
 !shared/
 !shared/package.json
+!shared/bun.lock
 !shared/tsconfig.json
 !shared/ts/
 !shared/ts/**

--- a/bots/open-oracle-arbitrager/tests/docker-entrypoint.test.ts
+++ b/bots/open-oracle-arbitrager/tests/docker-entrypoint.test.ts
@@ -30,7 +30,8 @@ async function runEntrypoint(directory: string, path = process.env['PATH']) {
 describe('Docker entrypoint', () => {
 	test('installs production dependencies where shared bot sources can resolve them', async () => {
 		const source = await readFile(dockerfile, 'utf8')
-		expect(source).toContain('cd bots/shared \\\n\t&& bun install --frozen-lockfile --production')
+		expect(source).toContain('cd shared \\\n\t&& bun install --frozen-lockfile --production')
+		expect(source).toContain('cd ../bots/shared \\\n\t&& bun install --frozen-lockfile --production')
 	})
 
 	test('has a Linux-compatible shell shebang', async () => {


### PR DESCRIPTION
## Summary

- install production dependencies in the copied root shared package so its compiled Ethereum module can resolve @noble/hashes
- include the shared package lockfile in the arbitrager Docker build context
- extend Docker packaging regression coverage for both shared package locations

## Root cause

The arbitrager image copied compiled @zoltar/shared output to /app/shared, while installing dependencies only under sibling bot directories. Bun resolves imports relative to /app/shared/js, so @noble/hashes was unreachable even though it appeared in the arbitrager manifest.

The liquidator does not have the same topology: it uses /app/bots/shared, and its Dockerfile already installs dependencies directly in that package directory. Its packaging regression test remains green.

## Validation

- cd bots/open-oracle-arbitrager && bun test ./tests/docker-entrypoint.test.ts
- cd bots/liquidator && bun test ./tests/docker-packaging.test.ts
- bun run tsc
- bun run format:check
- bun run check:changed
- bun run knip
- git diff --check

Docker is unavailable in the validation environment, so an image build/run could not be performed. The focused Dockerfile regression test failed before the implementation and passes after it.

Final read-only review: 98/100, no findings.