### PR TITLE
Retry rate-limited transaction receipt polling

### DIFF
--- a/scripts/deploy-testnet.mts
+++ b/scripts/deploy-testnet.mts
@@ -15,6 +15,7 @@ import { ARACHNID_CREATE2_DEPLOYER_ADDRESS, ARACHNID_CREATE2_DEPLOYER_RUNTIME_CO
 const DEFAULT_CHAIN_ID = 11_155_111
 export const DEFAULT_MAX_FEE_PER_GAS_GWEI = '100'
 export const DEFAULT_MAX_TOTAL_COST_ETH = '20'
+export const DEPLOYMENT_RECEIPT_TIMEOUT_MILLISECONDS = 60 * 60 * 1_000
 const CANCUN_CAPABILITY_PROBE = '0x6000600060005e600160005d60005c60005260206000f3'
 const CANCUN_CAPABILITY_RESULT = '0x0000000000000000000000000000000000000000000000000000000000000001'
 const OSAKA_CAPABILITY_PROBE = '0x5f1e60005260206000f3'
@@ -290,6 +291,15 @@ export function createBudgetedTransactionSender(wallet: BudgetedWallet, account:
 	return sendTransaction
 }
 
+export function createDeploymentReceiptWaiter(client: Pick<WriteClient, 'waitForTransactionReceipt'>) {
+	const waitForTransactionReceipt: WriteClient['waitForTransactionReceipt'] = async parameters =>
+		await client.waitForTransactionReceipt({
+			...parameters,
+			timeout: parameters.timeout ?? DEPLOYMENT_RECEIPT_TIMEOUT_MILLISECONDS,
+		})
+	return waitForTransactionReceipt
+}
+
 export function createPreparedDeploymentClient(parameters: { chain: Chain; maxFeePerGas?: bigint; maxTotalCost?: bigint; privateKey: Hex; rpcUrl: string }): WriteClient {
 	const account = privateKeyToAccount(parameters.privateKey)
 	const wallet = createWalletClient({
@@ -304,6 +314,7 @@ export function createPreparedDeploymentClient(parameters: { chain: Chain; maxFe
 		maxFeePerGas: parameters.maxFeePerGas ?? parseMaxFeePerGas(undefined),
 		maxTotalCost,
 	})
+	const waitForTransactionReceipt = createDeploymentReceiptWaiter(wallet)
 
 	return {
 		...wallet,
@@ -312,6 +323,7 @@ export function createPreparedDeploymentClient(parameters: { chain: Chain; maxFe
 		recordCanonicalRawTransaction: budget.recordCanonicalRawTransaction,
 		requiresWalletConfirmation: false,
 		sendTransaction,
+		waitForTransactionReceipt,
 	}
 }
 

--- a/scripts/deploy-testnet.test.ts
+++ b/scripts/deploy-testnet.test.ts
@@ -12,6 +12,8 @@ import {
 	createBudgetedTransactionSender,
 	createCompleteDeploymentPlan,
 	createDeploymentBudget,
+	createDeploymentReceiptWaiter,
+	DEPLOYMENT_RECEIPT_TIMEOUT_MILLISECONDS,
 	deployTestnet,
 	getDeploymentHelp,
 	parseDeploymentCommandLine,
@@ -160,6 +162,22 @@ describe('testnet deployment inputs', () => {
 	test('requires EIP-1559 even when every deployment step could be skipped', async () => {
 		await expect(assertEip1559Compatible({ getBlock: async () => ({ baseFeePerGas: 1n }) as never }, 11_155_111)).resolves.toBeUndefined()
 		await expect(assertEip1559Compatible({ getBlock: async () => ({ baseFeePerGas: undefined }) as never }, 84_532)).rejects.toThrow('does not expose the EIP-1559 base fee')
+	})
+
+	test('waits significantly longer for deployment transaction receipts', async () => {
+		const requests: Parameters<WriteClient['waitForTransactionReceipt']>[0][] = []
+		const waitForTransactionReceipt = createDeploymentReceiptWaiter({
+			waitForTransactionReceipt: async parameters => {
+				requests.push(parameters)
+				return { status: 'success' } as never
+			},
+		})
+
+		await waitForTransactionReceipt({ hash: FIRST_HASH })
+		await waitForTransactionReceipt({ hash: SECOND_HASH, timeout: 12_345 })
+
+		expect(DEPLOYMENT_RECEIPT_TIMEOUT_MILLISECONDS).toBe(60 * 60 * 1_000)
+		expect(requests.map(request => request.timeout)).toEqual([DEPLOYMENT_RECEIPT_TIMEOUT_MILLISECONDS, 12_345])
 	})
 
 	test('enforces chain and RPC safety at the transaction-capable entry point', async () => {

--- a/shared/ts/ethereum.test.ts
+++ b/shared/ts/ethereum.test.ts
@@ -1002,6 +1002,94 @@ describe('shared ethereum compatibility layer', () => {
 		expect(calls.map(call => call.method)).toEqual(['eth_getTransactionReceipt', 'eth_getTransactionReceipt'])
 	})
 
+	test('waitForTransactionReceipt does not retry a rate-limited request after its deadline', async () => {
+		let receiptRequests = 0
+		const clockValues = [0, 0, 1]
+		const originalDateNow = Date.now
+		const provider = createProvider(({ method }) => {
+			if (method !== 'eth_getTransactionReceipt') throw new Error(`Unexpected rpc method: ${method}`)
+			receiptRequests += 1
+			if (receiptRequests === 1) throw { code: 429, message: 'rate limit exceeded' }
+			throw new Error('Receipt request ran after the deadline')
+		}, [])
+		const client = createPublicClient({ chain: mainnet, transport: custom(provider) })
+
+		Date.now = () => clockValues.shift() ?? 1
+		try {
+			await expect(client.waitForTransactionReceipt({ hash: RECEIPT_HASH, pollingInterval: 2, timeout: 1 })).rejects.toThrow('rate limit exceeded')
+		} finally {
+			Date.now = originalDateNow
+		}
+
+		expect(receiptRequests).toBe(1)
+	})
+
+	test('waitForTransactionReceipt preserves replacement scan progress across rate limits', async () => {
+		const originalHash = `0x${'77'.repeat(32)}` satisfies Hash
+		const replacementHash = `0x${'88'.repeat(32)}` satisfies Hash
+		const calls: { method: string; params: unknown }[] = []
+		let secondBlockRequests = 0
+		const originalTransaction = {
+			from: OWNER_ADDRESS,
+			gas: '0x5208',
+			hash: originalHash,
+			input: '0xabcd',
+			nonce: '0x9',
+			to: RECIPIENT_ADDRESS,
+			transactionIndex: null,
+			type: '0x2',
+			value: '0x7',
+		}
+		const replacementTransaction = {
+			...originalTransaction,
+			hash: replacementHash,
+			transactionIndex: '0x0',
+		}
+		const provider = createProvider(({ method, params }) => {
+			if (method === 'eth_getTransactionByHash') return originalTransaction
+			if (method === 'eth_getTransactionReceipt') {
+				const hash = getArrayEntry(params, 0, 'receipt params')
+				if (hash === originalHash) return null
+				return {
+					blockHash: BLOCK_HASH,
+					blockNumber: '0x1',
+					cumulativeGasUsed: '0x5208',
+					effectiveGasPrice: '0x9',
+					from: OWNER_ADDRESS,
+					gasUsed: '0x5208',
+					logs: [],
+					status: '0x1',
+					to: RECIPIENT_ADDRESS,
+					transactionHash: replacementHash,
+					transactionIndex: '0x0',
+					type: '0x2',
+				}
+			}
+			if (method === 'eth_blockNumber') return '0x1'
+			if (method === 'eth_getBlockByNumber') {
+				const blockNumber = getArrayEntry(params, 0, 'replacement block params')
+				if (blockNumber === '0x1') {
+					secondBlockRequests += 1
+					if (secondBlockRequests === 1) throw { code: 429, message: 'rate limit exceeded' }
+				}
+				return {
+					hash: BLOCK_HASH,
+					number: blockNumber,
+					parentHash: `0x${'44'.repeat(32)}`,
+					timestamp: '0x5',
+					transactions: blockNumber === '0x1' ? [replacementTransaction] : [],
+				}
+			}
+			throw new Error(`Unexpected rpc method: ${method}`)
+		}, calls)
+		const client = createPublicClient({ chain: mainnet, transport: custom(provider) })
+
+		const receipt = await client.waitForTransactionReceipt({ hash: originalHash, onReplaced: () => undefined, pollingInterval: 0, timeout: 50 })
+
+		expect(receipt.transactionHash).toBe(replacementHash)
+		expect(calls.filter(call => call.method === 'eth_getBlockByNumber').map(call => getArrayEntry(call.params, 0, 'block params'))).toEqual(['0x0', '0x1', '0x1'])
+	})
+
 	test('waitForTransactionReceipt scans previous blocks for delayed replacement detection', async () => {
 		const originalHash = `0x${'77'.repeat(32)}` satisfies Hash
 		const replacementHash = `0x${'88'.repeat(32)}` satisfies Hash

--- a/shared/ts/ethereum.test.ts
+++ b/shared/ts/ethereum.test.ts
@@ -965,6 +965,43 @@ describe('shared ethereum compatibility layer', () => {
 		expect(calls.map(call => call.method)).toEqual(['eth_getTransactionReceipt', 'eth_getTransactionReceipt'])
 	})
 
+	test('waitForTransactionReceipt retries rate-limited receipt requests', async () => {
+		let receiptRequests = 0
+		const calls: { method: string; params: unknown }[] = []
+		const provider = createProvider(({ method }) => {
+			if (method !== 'eth_getTransactionReceipt') throw new Error(`Unexpected rpc method: ${method}`)
+			receiptRequests += 1
+			if (receiptRequests === 1) throw { code: 429, message: 'HTTP 429 while calling eth_getTransactionReceipt' }
+			return {
+				blockHash: BLOCK_HASH,
+				blockNumber: '0x1',
+				cumulativeGasUsed: '0x5208',
+				effectiveGasPrice: '0x3',
+				from: OWNER_ADDRESS,
+				gasUsed: '0x5208',
+				logs: [],
+				status: '0x1',
+				to: RECIPIENT_ADDRESS,
+				transactionHash: RECEIPT_HASH,
+				transactionIndex: '0x0',
+				type: '0x2',
+			}
+		}, calls)
+		const client = createPublicClient({
+			chain: mainnet,
+			transport: custom(provider),
+		})
+
+		const receipt = await client.waitForTransactionReceipt({
+			hash: RECEIPT_HASH,
+			pollingInterval: 0,
+			timeout: 50,
+		})
+
+		expect(receipt.transactionHash).toBe(RECEIPT_HASH)
+		expect(calls.map(call => call.method)).toEqual(['eth_getTransactionReceipt', 'eth_getTransactionReceipt'])
+	})
+
 	test('waitForTransactionReceipt scans previous blocks for delayed replacement detection', async () => {
 		const originalHash = `0x${'77'.repeat(32)}` satisfies Hash
 		const replacementHash = `0x${'88'.repeat(32)}` satisfies Hash

--- a/shared/ts/ethereum.ts
+++ b/shared/ts/ethereum.ts
@@ -1049,6 +1049,7 @@ async function requestTransport<TValue>(transport: Transport, parameters: Client
 	})
 	if (!response.ok) {
 		throw new RpcError(`HTTP ${response.status} while calling ${parameters.method}`, {
+			code: response.status,
 			shortMessage: `HTTP ${response.status} while calling ${parameters.method}`,
 		})
 	}
@@ -1170,6 +1171,10 @@ function isBlockTransaction(value: unknown): value is BlockTransaction {
 
 function isTransactionNotFoundError(error: unknown) {
 	return error instanceof Error && error.message.includes('could not be found')
+}
+
+function isRateLimitError(error: unknown) {
+	return error instanceof RpcError && (error.code === 429 || error.code === '429' || error.message.includes('HTTP 429'))
 }
 
 function getReplacementReason(originalTransaction: BlockTransaction, replacementTransaction: BlockTransaction): ReplacementReason {
@@ -1455,48 +1460,76 @@ function buildPublicClientActions<TTransport extends Transport, TChain extends C
 			const pollingInterval = parameters.pollingInterval ?? 1_000
 			const startTime = Date.now()
 			const actions = buildPublicClientActions({ chain, transport })
+			const waitForNextPoll = async () => {
+				await new Promise(resolve => {
+					setTimeout(resolve, pollingInterval)
+				})
+			}
+			const retryRateLimited = async <TValue>(operation: () => Promise<TValue>) => {
+				while (true) {
+					try {
+						return await operation()
+					} catch (error) {
+						if (!isRateLimitError(error) || Date.now() - startTime >= timeoutMilliseconds) throw error
+						await waitForNextPoll()
+					}
+				}
+			}
 			let originalTransaction: BlockTransaction | undefined
 			let lastScannedReplacementBlock: bigint | undefined
 			if (parameters.onReplaced !== undefined) {
 				try {
-					originalTransaction = await actions.getTransaction({
-						hash: parameters.hash,
-					})
+					originalTransaction = await retryRateLimited(
+						async () =>
+							await actions.getTransaction({
+								hash: parameters.hash,
+							}),
+					)
 				} catch (error) {
 					if (!isTransactionNotFoundError(error)) throw error
 				}
 			}
 			while (true) {
 				try {
-					return await actions.getTransactionReceipt({
-						hash: parameters.hash,
-					})
+					return await retryRateLimited(
+						async () =>
+							await actions.getTransactionReceipt({
+								hash: parameters.hash,
+							}),
+					)
 				} catch (error) {
 					if (!isTransactionNotFoundError(error)) throw error
 					if (parameters.onReplaced !== undefined && originalTransaction === undefined) {
 						try {
-							originalTransaction = await actions.getTransaction({
-								hash: parameters.hash,
-							})
+							originalTransaction = await retryRateLimited(
+								async () =>
+									await actions.getTransaction({
+										hash: parameters.hash,
+									}),
+							)
 						} catch (transactionError) {
 							if (!isTransactionNotFoundError(transactionError)) throw transactionError
 						}
 					}
 					if (originalTransaction !== undefined) {
-						const latestBlockNumber = await actions.getBlockNumber()
+						const transactionToReplace = originalTransaction
+						const latestBlockNumber = await retryRateLimited(async () => await actions.getBlockNumber())
 						let firstScanBlock = lastScannedReplacementBlock === undefined ? 0n : lastScannedReplacementBlock + 1n
 						if (lastScannedReplacementBlock === undefined && latestBlockNumber > REPLACEMENT_SCAN_BLOCK_DEPTH) {
 							firstScanBlock = latestBlockNumber - REPLACEMENT_SCAN_BLOCK_DEPTH
 						}
-						const replacementTransaction = firstScanBlock > latestBlockNumber ? undefined : await findReplacementTransaction(actions, originalTransaction, { fromBlock: firstScanBlock, toBlock: latestBlockNumber })
+						const replacementTransaction = firstScanBlock > latestBlockNumber ? undefined : await retryRateLimited(async () => await findReplacementTransaction(actions, transactionToReplace, { fromBlock: firstScanBlock, toBlock: latestBlockNumber }))
 						lastScannedReplacementBlock = latestBlockNumber
 						if (replacementTransaction !== undefined) {
-							const transactionReceipt = await actions.getTransactionReceipt({
-								hash: replacementTransaction.hash,
-							})
+							const transactionReceipt = await retryRateLimited(
+								async () =>
+									await actions.getTransactionReceipt({
+										hash: replacementTransaction.hash,
+									}),
+							)
 							parameters.onReplaced?.({
-								reason: getReplacementReason(originalTransaction, replacementTransaction),
-								replacedTransaction: originalTransaction,
+								reason: getReplacementReason(transactionToReplace, replacementTransaction),
+								replacedTransaction: transactionToReplace,
 								transaction: replacementTransaction,
 								transactionReceipt,
 							})
@@ -1504,9 +1537,7 @@ function buildPublicClientActions<TTransport extends Transport, TChain extends C
 						}
 					}
 					if (Date.now() - startTime >= timeoutMilliseconds) throw error
-					await new Promise(resolve => {
-						setTimeout(resolve, pollingInterval)
-					})
+					await waitForNextPoll()
 				}
 			}
 		},

--- a/shared/ts/ethereum.ts
+++ b/shared/ts/ethereum.ts
@@ -1185,9 +1185,9 @@ function getReplacementReason(originalTransaction: BlockTransaction, replacement
 
 const REPLACEMENT_SCAN_BLOCK_DEPTH = 12n
 
-async function findReplacementTransaction(actions: PublicClientActions, originalTransaction: BlockTransaction, parameters: { fromBlock: bigint; toBlock: bigint }) {
+async function findReplacementTransaction(actions: PublicClientActions, originalTransaction: BlockTransaction, parameters: { fromBlock: bigint; toBlock: bigint }, blockReader: Pick<PublicClientActions, 'getBlock'> = actions) {
 	for (let blockNumber = parameters.fromBlock; blockNumber <= parameters.toBlock; blockNumber += 1n) {
-		const block = await actions.getBlock({
+		const block = await blockReader.getBlock({
 			blockNumber,
 			includeTransactions: true,
 		})
@@ -1460,9 +1460,9 @@ function buildPublicClientActions<TTransport extends Transport, TChain extends C
 			const pollingInterval = parameters.pollingInterval ?? 1_000
 			const startTime = Date.now()
 			const actions = buildPublicClientActions({ chain, transport })
-			const waitForNextPoll = async () => {
+			const waitForNextPoll = async (delayMilliseconds = pollingInterval) => {
 				await new Promise(resolve => {
-					setTimeout(resolve, pollingInterval)
+					setTimeout(resolve, delayMilliseconds)
 				})
 			}
 			const retryRateLimited = async <TValue>(operation: () => Promise<TValue>) => {
@@ -1470,8 +1470,11 @@ function buildPublicClientActions<TTransport extends Transport, TChain extends C
 					try {
 						return await operation()
 					} catch (error) {
-						if (!isRateLimitError(error) || Date.now() - startTime >= timeoutMilliseconds) throw error
-						await waitForNextPoll()
+						if (!isRateLimitError(error)) throw error
+						const remainingMilliseconds = timeoutMilliseconds - (Date.now() - startTime)
+						if (remainingMilliseconds <= 0) throw error
+						await waitForNextPoll(Math.min(pollingInterval, remainingMilliseconds))
+						if (Date.now() - startTime >= timeoutMilliseconds) throw error
 					}
 				}
 			}
@@ -1518,7 +1521,7 @@ function buildPublicClientActions<TTransport extends Transport, TChain extends C
 						if (lastScannedReplacementBlock === undefined && latestBlockNumber > REPLACEMENT_SCAN_BLOCK_DEPTH) {
 							firstScanBlock = latestBlockNumber - REPLACEMENT_SCAN_BLOCK_DEPTH
 						}
-						const replacementTransaction = firstScanBlock > latestBlockNumber ? undefined : await retryRateLimited(async () => await findReplacementTransaction(actions, transactionToReplace, { fromBlock: firstScanBlock, toBlock: latestBlockNumber }))
+						const replacementTransaction = firstScanBlock > latestBlockNumber ? undefined : await findReplacementTransaction(actions, transactionToReplace, { fromBlock: firstScanBlock, toBlock: latestBlockNumber }, { getBlock: async parameters => await retryRateLimited(async () => await actions.getBlock(parameters)) })
 						lastScannedReplacementBlock = latestBlockNumber
 						if (replacementTransaction !== undefined) {
 							const transactionReceipt = await retryRateLimited(


### PR DESCRIPTION
## Summary

- treat HTTP/RPC 429 responses as transient while polling transaction receipts
- wait up to one hour for `deploy:testnet` transaction receipts while preserving explicit timeout overrides
- retry replacement-scan block requests in place so rate limits do not discard scan progress
- cap retry sleeps to the remaining deadline and prevent RPC requests after timeout
- add regressions for receipt retries, strict timeout boundaries, replacement scan progress, and the deployment-specific one-hour timeout

## Why

`deploy:testnet` previously aborted a Sepolia deployment when its RPC provider returned HTTP 429 from `eth_getTransactionReceipt`. Deployment polling now waits and retries for up to one hour, allowing slow transaction inclusion without changing the default timeout for other clients.

## Validation

- `bun run tsc`
- `bun run ensure-contract-artifacts && bun run check:shared-dependencies && bun run test:run -- --bail=1` (2,801 passed, 16 existing network-dependent skips)
- `bun run format:check`
- `bun run check`
- `bun run knip`
- `bun run check:generated-clean`
- `git diff --check`

No UI surfaces changed, so screenshots and browser QA are not applicable.