### PR TITLE
Configure bot RPCs from environment

### DIFF
--- a/bots/liquidator/.env.example
+++ b/bots/liquidator/.env.example
@@ -1,6 +1,10 @@
 # Use at least 16 characters. Keep the real .env file private.
 ZOLTAR_BOT_DASHBOARD_PASSWORD=''
 
+# Comma-separated RPC URLs. The first is the primary reader, all are used for
+# public broadcast, and the remaining URLs form the independent read quorum.
+ZOLTAR_BOT_RPC_URLS=''
+
 # Use the owner of .state (`id -u` and `id -g`).
 LIQUIDATOR_UID=''
 LIQUIDATOR_GID=''

--- a/bots/liquidator/README.md
+++ b/bots/liquidator/README.md
@@ -35,15 +35,21 @@ install -d -m 700 .state
 install -m 600 config/operator.example.json .state/operator.json
 ```
 
-In `.env`, set a unique dashboard password of at least 16 characters. Set
-`LIQUIDATOR_UID` and `LIQUIDATOR_GID` to the output of `id -u` and `id -g`; this
-lets the container read and update the owner-only state files without making them
-public.
+In `.env`, set a unique dashboard password of at least 16 characters and set
+`ZOLTAR_BOT_RPC_URLS` to a comma-separated list of RPC URLs. The first URL is the
+primary reader, every URL receives public transaction broadcasts, and every URL
+after the first is an independent quorum reader. Live execution therefore requires
+at least two independently operated origins. Set `LIQUIDATOR_UID` and
+`LIQUIDATOR_GID` to the output of `id -u` and `id -g`; this lets the container read
+and update the owner-only state files without making them public.
 
-In `.state/operator.json`, add the reviewed deployment and RPC settings and set
-`runtime.uiHost` to `0.0.0.0`. These settings are not editable from the liquidator
-dashboard, and the operator file must remain owner-only. Keep `runtime.execute`
-false while testing the setup. Then build and start the bot:
+In `.state/operator.json`, add the reviewed deployment settings and set
+`runtime.uiHost` to `0.0.0.0`. The file's connectivity settings remain the fallback
+when `ZOLTAR_BOT_RPC_URLS` is blank; a non-empty environment value overrides all
+three RPC roles at startup without modifying the file. These settings are not
+editable from the liquidator dashboard, and the operator file must remain
+owner-only. Keep `runtime.execute` false while testing the setup. Then build and
+start the bot:
 
 ```bash
 docker compose up --build --detach
@@ -72,6 +78,10 @@ bun run run
 Set `ZOLTAR_LIQUIDATOR_CONFIG` to use another operator file. The bot accepts no
 command-line arguments. The dashboard defaults to
 `http://127.0.0.1:4183`.
+
+`ZOLTAR_BOT_RPC_URLS` applies to direct Bun runs as well as Compose. Separate URLs
+with commas; URL query parameters are supported, but the separator itself must not
+appear inside a URL.
 
 Native loopback dashboards need no password. If `runtime.uiHost` is `0.0.0.0`, set
 `ZOLTAR_BOT_DASHBOARD_PASSWORD` to at least 16 characters before startup. The

--- a/bots/liquidator/compose.yaml
+++ b/bots/liquidator/compose.yaml
@@ -9,6 +9,7 @@ services:
     user: ${LIQUIDATOR_UID:?Set LIQUIDATOR_UID in .env}:${LIQUIDATOR_GID:?Set LIQUIDATOR_GID in .env}
     environment:
       ZOLTAR_BOT_DASHBOARD_PASSWORD: ${ZOLTAR_BOT_DASHBOARD_PASSWORD:?Set ZOLTAR_BOT_DASHBOARD_PASSWORD in .env}
+      ZOLTAR_BOT_RPC_URLS: ${ZOLTAR_BOT_RPC_URLS:-}
     ports:
       - 127.0.0.1:4183:4183
     volumes:

--- a/bots/liquidator/src/cli/run.ts
+++ b/bots/liquidator/src/cli/run.ts
@@ -5,7 +5,7 @@ import { checkConnectivity, endpointLabel, readRpcChainId } from '@zoltar/bot-sh
 import { quorumValue } from '@zoltar/bot-shared/monitoring/read-quorum'
 import { pollUntilStopped } from '@zoltar/bot-shared/monitoring/resilience'
 import { signerCandidate } from '@zoltar/bot-shared/config/signer'
-import { loadSettings, parseDesiredPools, parseStrategy, saveSettings, serializedSettings, type OperatorSettings } from '#config/settings'
+import { loadSettings, parseDesiredPools, parseStrategy, saveSettings, serializedSettings, settingsForPersistence, type OperatorSettings } from '#config/settings'
 import { startDashboardServer } from '#dashboard/dashboard-server'
 import { dryRunCandidate, executeLiquidation, executeOriginPoolDeployment, executeVaultMigration, maintainVault, TransactionAwaitingCanonicalFinality } from '#execution/liquidation-executor'
 import { scanPools } from '#monitoring/pool-monitor'
@@ -62,7 +62,7 @@ async function runOperator(loaded: Awaited<ReturnType<typeof loadSettings>>, pro
 	const persistSettings = async (update: (current: OperatorSettings) => OperatorSettings) => {
 		await queueSettingsUpdate(async () => {
 			const next = update(settings)
-			settingsRevision = await saveSettings(loaded.path, next, settingsRevision)
+			settingsRevision = await saveSettings(loaded.path, settingsForPersistence(next, loaded.persistedConnectivity), settingsRevision)
 			settings = next
 		})
 	}

--- a/bots/liquidator/src/config/settings.ts
+++ b/bots/liquidator/src/config/settings.ts
@@ -3,7 +3,7 @@ import { dirname, resolve } from 'node:path'
 import { mkdir, open, readFile, rename, rm } from 'node:fs/promises'
 import { bigintToSafeNumber, getAddress, type Address, type Hex } from '@zoltar/bot-shared/ethereum'
 import { signerCandidate } from '@zoltar/bot-shared/config/signer'
-import { validateConnectivitySettings, validateIndependentReadRpcUrls, type ConnectivitySettings, type NetworkName } from '@zoltar/bot-shared/monitoring/connectivity'
+import { rpcConfigurationWithEnvironmentOverride, validateConnectivitySettings, validateIndependentReadRpcUrls, type ConnectivitySettings, type NetworkName } from '@zoltar/bot-shared/monitoring/connectivity'
 import { validateSubmissionSettings, type SubmissionSettings } from '@zoltar/bot-shared/execution/transaction-submission'
 import { parseCentralizedMarketSettings, serializeCentralizedMarketSettings, type CentralizedMarketSettings } from '@zoltar/bot-shared/monitoring/centralized-markets'
 
@@ -236,26 +236,32 @@ export function parseStrategy(value: unknown): StrategySettings {
 	return parsed
 }
 
-export function parseSettings(value: unknown): OperatorSettings {
-	const root = record(value, 'operator settings')
-	if (root['version'] !== 1) throw new Error('operator settings version must be 1')
-	const deployment = record(root['deployment'], 'deployment')
-	const network = record(root['network'], 'network')
-	const runtime = record(root['runtime'], 'runtime')
-	const connectivity = record(root['connectivity'], 'connectivity')
-	const parsedConnectivity = validateConnectivitySettings({
+function parseConnectivity(value: unknown): OperatorSettings['connectivity'] {
+	const connectivity = record(value, 'connectivity')
+	const parsed = validateConnectivitySettings({
 		publicRpcUrls: connectivity['publicRpcUrls'],
 		readRpcUrl: connectivity['readRpcUrl'],
 	})
 	const rawQuorumRpcUrls = connectivity['quorumRpcUrls']
 	if (!Array.isArray(rawQuorumRpcUrls) || rawQuorumRpcUrls.some(value => typeof value !== 'string')) throw new Error('connectivity.quorumRpcUrls must be an array of RPC URLs')
 	const quorumRpcUrls = validateIndependentReadRpcUrls(
-		parsedConnectivity.readRpcUrl,
+		parsed.readRpcUrl,
 		rawQuorumRpcUrls.map(value => {
 			if (typeof value !== 'string') throw new Error('connectivity.quorumRpcUrls must contain only strings')
 			return value
 		}),
 	)
+	return { ...parsed, quorumRpcUrls }
+}
+
+export function parseSettings(value: unknown, rpcEnvironmentValue?: string): OperatorSettings {
+	const root = record(value, 'operator settings')
+	if (root['version'] !== 1) throw new Error('operator settings version must be 1')
+	const deployment = record(root['deployment'], 'deployment')
+	const network = record(root['network'], 'network')
+	const runtime = record(root['runtime'], 'runtime')
+	const persistedConnectivity = parseConnectivity(root['connectivity'])
+	const rpcConfiguration = rpcConfigurationWithEnvironmentOverride(persistedConnectivity, persistedConnectivity.quorumRpcUrls, rpcEnvironmentValue)
 	const selectedPools = root['selectedPools']
 	if (!Array.isArray(selectedPools)) throw new Error('selectedPools must be an array')
 	const approvedUniverses = root['approvedUniverses']
@@ -280,8 +286,8 @@ export function parseSettings(value: unknown): OperatorSettings {
 		})(),
 		centralizedMarkets: parseCentralizedMarketSettings(root['centralizedMarkets']),
 		connectivity: {
-			...parsedConnectivity,
-			quorumRpcUrls,
+			...rpcConfiguration.connectivity,
+			quorumRpcUrls: [...rpcConfiguration.quorumRpcUrls],
 		},
 		deployment: {
 			securityPoolFactory: getAddress(string(deployment['securityPoolFactory'], 'deployment.securityPoolFactory')),
@@ -382,13 +388,24 @@ function revision(contents: string) {
 	return createHash('sha256').update(contents).digest('hex')
 }
 
-export async function loadSettings(path = resolve(process.env['ZOLTAR_LIQUIDATOR_CONFIG'] ?? defaultSettingsPath)) {
+export async function loadSettings(path = resolve(process.env['ZOLTAR_LIQUIDATOR_CONFIG'] ?? defaultSettingsPath), rpcEnvironmentValue = process.env['ZOLTAR_BOT_RPC_URLS']) {
 	const contents = await readFile(path, 'utf8').catch(error => {
 		if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return undefined
 		throw error
 	})
 	if (contents === undefined) throw new Error(`Missing liquidator configuration at ${path}. Copy config/operator.example.json there and edit it.`)
-	return { path, revision: revision(contents), settings: parseSettings(JSON.parse(contents)) }
+	const document: unknown = JSON.parse(contents)
+	const persistedConnectivity = parseConnectivity(record(document, 'operator settings')['connectivity'])
+	return {
+		path,
+		persistedConnectivity,
+		revision: revision(contents),
+		settings: parseSettings(document, rpcEnvironmentValue),
+	}
+}
+
+export function settingsForPersistence(settings: OperatorSettings, persistedConnectivity: OperatorSettings['connectivity']): OperatorSettings {
+	return { ...settings, connectivity: persistedConnectivity }
 }
 
 export async function saveSettings(path: string, settings: OperatorSettings, expectedRevision: string, filesystem: SettingsFilesystem = settingsFilesystem) {

--- a/bots/liquidator/tests/config/settings.test.ts
+++ b/bots/liquidator/tests/config/settings.test.ts
@@ -1,7 +1,10 @@
 import { createHash } from 'node:crypto'
 import { describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { getAddress } from '../helpers/ethereum.ts'
-import { parseSettings, parseStrategy, saveSettings, serializedSettings, type SettingsFilesystem } from '../../src/config/settings.ts'
+import { loadSettings, parseSettings, parseStrategy, saveSettings, serializedSettings, settingsForPersistence, type SettingsFilesystem } from '../../src/config/settings.ts'
 
 const settings = {
 	approvedUniverses: ['0'],
@@ -118,6 +121,65 @@ describe('liquidator settings', () => {
 				runtime: { ...settings.runtime, execute: true },
 			}),
 		).toThrow('independent quorum RPC')
+	})
+
+	test('uses the environment RPC list for every RPC role', () => {
+		const parsed = parseSettings(settings, 'https://primary.example,https://secondary.example')
+		expect(parsed.connectivity).toEqual({
+			publicRpcUrls: ['https://primary.example/', 'https://secondary.example/'],
+			quorumRpcUrls: ['https://secondary.example/'],
+			readRpcUrl: 'https://primary.example/',
+		})
+	})
+
+	test('rejects an environment quorum that repeats the primary RPC', () => {
+		expect(() => parseSettings(settings, 'https://primary.example,https://primary.example')).toThrow('independent origins')
+	})
+
+	test('keeps file RPC fallbacks after saving an unrelated environment-overridden setting', async () => {
+		const directory = await mkdtemp(join(tmpdir(), 'zoltar-liquidator-rpc-environment-'))
+		try {
+			const path = join(directory, 'operator.json')
+			await writeFile(path, JSON.stringify(settings), 'utf8')
+			const loaded = await loadSettings(path, 'https://primary.example,https://secondary.example')
+			expect(loaded.settings.connectivity.readRpcUrl).toBe('https://primary.example/')
+			await saveSettings(path, settingsForPersistence({ ...loaded.settings, paused: true }, loaded.persistedConnectivity), loaded.revision)
+			const reloaded = await loadSettings(path, '')
+			expect(reloaded.settings.paused).toBe(true)
+			expect(reloaded.settings.connectivity).toEqual({
+				publicRpcUrls: ['https://public.example/'],
+				quorumRpcUrls: [],
+				readRpcUrl: 'https://read.example/',
+			})
+		} finally {
+			await rm(directory, { force: true, recursive: true })
+		}
+	})
+
+	test('allows environment quorum RPCs to satisfy live execution without changing an empty file fallback', async () => {
+		const directory = await mkdtemp(join(tmpdir(), 'zoltar-liquidator-live-rpc-environment-'))
+		try {
+			const path = join(directory, 'operator.json')
+			const liveSettings = {
+				...settings,
+				deployment: {
+					securityPoolFactory: '0x0000000000000000000000000000000000000001',
+					weth: '0x0000000000000000000000000000000000000002',
+					zoltar: '0x0000000000000000000000000000000000000003',
+				},
+				privateKey: `0x${'11'.repeat(32)}`,
+				runtime: { ...settings.runtime, execute: true },
+			}
+			await writeFile(path, JSON.stringify(liveSettings), 'utf8')
+			const loaded = await loadSettings(path, 'https://primary.example,https://secondary.example')
+			expect(loaded.settings.connectivity.quorumRpcUrls).toEqual(['https://secondary.example/'])
+			expect(loaded.persistedConnectivity.quorumRpcUrls).toEqual([])
+			await saveSettings(path, settingsForPersistence({ ...loaded.settings, paused: true }, loaded.persistedConnectivity), loaded.revision)
+			const savedDocument = JSON.parse(await Bun.file(path).text()) as { connectivity: { quorumRpcUrls: string[]; readRpcUrl: string } }
+			expect(savedDocument.connectivity).toMatchObject({ quorumRpcUrls: [], readRpcUrl: 'https://read.example/' })
+		} finally {
+			await rm(directory, { force: true, recursive: true })
+		}
 	})
 
 	test('requires a deployed WETH contract for live execution', () => {

--- a/bots/open-oracle-arbitrager/.env.example
+++ b/bots/open-oracle-arbitrager/.env.example
@@ -1,2 +1,6 @@
 # Use at least 16 characters. Keep the real .env file private.
 ZOLTAR_BOT_DASHBOARD_PASSWORD=''
+
+# Comma-separated RPC URLs. The first is the primary reader, all are used for
+# public broadcast, and the remaining URLs form the independent read quorum.
+ZOLTAR_BOT_RPC_URLS=''

--- a/bots/open-oracle-arbitrager/README.md
+++ b/bots/open-oracle-arbitrager/README.md
@@ -204,8 +204,11 @@ cd bots/open-oracle-arbitrager
 install -m 600 .env.example .env
 ```
 
-Edit `.env` and set a unique dashboard password of at least 16 characters. Then
-build and start the container:
+Edit `.env`, set a unique dashboard password of at least 16 characters, and set
+`ZOLTAR_BOT_RPC_URLS` to a comma-separated list of RPC URLs. The first URL is the
+primary reader, every URL receives public transaction broadcasts, and every URL
+after the first is an independent quorum reader. Live execution therefore requires
+at least two independently operated origins. Then build and start the container:
 
 ```bash
 docker compose up --build --detach
@@ -650,9 +653,12 @@ security.
 
 ## Persistent operator settings
 
-`.state/operator.json` is the only source of bot settings. The bot accepts no
-command-line arguments and does not read operational settings from environment
-variables. Copy the example before first startup:
+`.state/operator.json` is the source of persisted bot settings. The bot accepts no
+command-line arguments. `ZOLTAR_BOT_RPC_URLS` can override its RPC settings at
+startup; the first comma-separated URL becomes the primary reader, all listed URLs
+become public broadcast endpoints, and the remaining URLs become quorum readers.
+The override does not modify the settings file, whose connectivity values remain
+the fallback when the variable is blank. Copy the example before first startup:
 
 ```bash
 install -d -m 700 .state
@@ -661,7 +667,8 @@ install -m 600 config/operator.example.json .state/operator.json
 
 `OPEN_ORACLE_ARBITRAGER_CONFIG` may locate a different file; it does not override
 any value inside the document. This locator is useful for service managers and
-tests.
+tests. `ZOLTAR_BOT_RPC_URLS` applies to direct Bun runs as well as Compose. URL query
+parameters are supported, but the comma separator must not appear inside a URL.
 
 Direct file editing is an offline workflow: stop the bot, edit the configuration,
 and restart it. While the bot is running, use the dashboard only; do not edit the

--- a/bots/open-oracle-arbitrager/compose.yaml
+++ b/bots/open-oracle-arbitrager/compose.yaml
@@ -8,6 +8,7 @@ services:
     image: zoltar-open-oracle-arbitrager
     environment:
       ZOLTAR_BOT_DASHBOARD_PASSWORD: ${ZOLTAR_BOT_DASHBOARD_PASSWORD:?Set ZOLTAR_BOT_DASHBOARD_PASSWORD in .env}
+      ZOLTAR_BOT_RPC_URLS: ${ZOLTAR_BOT_RPC_URLS:-}
     ports:
       - 127.0.0.1:4173:4173
     volumes:

--- a/bots/open-oracle-arbitrager/src/cli/deploy-executor.ts
+++ b/bots/open-oracle-arbitrager/src/cli/deploy-executor.ts
@@ -32,5 +32,5 @@ const account = privateKeyToAccount(privateKeyValue as Hex)
 const salt = option('salt') ?? `0x${'00'.repeat(32)}`
 const plan = executorDeploymentPlan(salt)
 console.log(`predicted=${plan.address} network=${networkName} deployer=${account.address}`)
-const deployment = await deployExecutorCreate2({ chain: network.chain, privateKey: privateKeyValue as Hex, rpcUrl, salt })
+const deployment = await deployExecutorCreate2({ chain: network.chain, privateKey: privateKeyValue as Hex, rpcUrls: [rpcUrl], salt })
 console.log(`executor=${deployment.address} transaction=${deployment.transactionHash ?? 'already-deployed'}`)

--- a/bots/open-oracle-arbitrager/src/config/configuration.ts
+++ b/bots/open-oracle-arbitrager/src/config/configuration.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path'
 import type { Address, Hex } from '#ethereum'
 import type { DeploymentManifest } from '#config/deployment-auth'
-import { validateIndependentReadRpcUrls, type ConnectivitySettings } from '#monitoring/connectivity'
+import { rpcConfigurationWithEnvironmentOverride, validateIndependentReadRpcUrls, type ConnectivitySettings } from '#monitoring/connectivity'
 import { type MutableStrategy } from '#state/operator-state'
 import { networkConfiguration, type NetworkConfiguration } from '#config/network'
 import type { RiskLimits } from '#core/safety-controls'
@@ -62,17 +62,19 @@ export async function loadConfiguration(): Promise<Configuration> {
 		rep: deployment.rep,
 		weth: deployment.weth,
 	})
-	const quorumRpcUrls = validateIndependentReadRpcUrls(saved.connectivity.readRpcUrl, deployment.quorumRpcUrls)
+	const savedQuorumRpcUrls = validateIndependentReadRpcUrls(saved.connectivity.readRpcUrl, deployment.quorumRpcUrls)
+	const rpcConfiguration = rpcConfigurationWithEnvironmentOverride(saved.connectivity, savedQuorumRpcUrls, process.env['ZOLTAR_BOT_RPC_URLS'])
+	const quorumRpcUrls = [...rpcConfiguration.quorumRpcUrls]
+	if (saved.runtime.execute && quorumRpcUrls.length === 0) throw new Error('Execution is enabled, but the effective RPC configuration has no independent quorum reader')
 	if (saved.runtime.execute && deployment.executor === undefined) throw new Error('Execution is enabled, but deployment.executor is not configured')
 	if (saved.runtime.execute && deployment.uniswapRouter === undefined) throw new Error('Execution is enabled, but deployment.uniswapRouter is not configured')
-	if (saved.runtime.execute && quorumRpcUrls.length === 0) throw new Error('Execution is enabled, but deployment.quorumRpcUrls has no independent read RPC')
 	if (saved.runtime.execute && deployment.coordinatorAddresses.length === 0) throw new Error('Execution is enabled, but deployment.coordinatorAddresses is empty')
 	if (saved.runtime.execute && deployment.deploymentManifest === undefined) throw new Error('Execution is enabled, but deployment.deploymentManifest is not configured')
 	assertDistinctPersistentPaths(settingsFile, saved.runtime)
 	return {
 		...saved.strategy,
 		centralizedMarkets: saved.centralizedMarkets,
-		connectivity: saved.connectivity,
+		connectivity: rpcConfiguration.connectivity,
 		coordinatorAddresses: [...deployment.coordinatorAddresses],
 		deploymentManifest: deployment.deploymentManifest,
 		execute: saved.runtime.execute,

--- a/bots/open-oracle-arbitrager/src/execution/create2-executor.ts
+++ b/bots/open-oracle-arbitrager/src/execution/create2-executor.ts
@@ -1,5 +1,7 @@
-import { concatHex, createPublicClient, createWalletClient, getCreate2Address, http, keccak256, privateKeyToAccount, type Address, type Chain, type Hash, type Hex } from '#ethereum'
+import { concatHex, createPublicClient, createWalletClient, custom, getCreate2Address, http, isHex, keccak256, privateKeyToAccount, type Address, type Chain, type Hash, type Hex } from '#ethereum'
 import { executorArtifact } from '#contracts/artifacts.generated'
+import { submitSignedTransaction, validateSubmissionSettings } from '#execution/transaction-submission'
+import { endpointLabel, sendRawTransactionToRpc } from '#monitoring/connectivity'
 
 export const deterministicDeploymentProxy = '0x4e59b44847b379578588920cA78FbF26c0B4956C' as Address
 export const deterministicDeploymentProxyCode = '0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3' as Hex
@@ -38,19 +40,65 @@ export function assertExecutorDeploymentReceipt(status: 'reverted' | 'success', 
 	if (status !== 'success') throw new Error(`CREATE2 executor deployment reverted: ${transactionHash}`)
 }
 
-export async function deployExecutorCreate2(parameters: { chain: Chain; privateKey: Hex; rpcUrl: string; salt: unknown }) {
+const executorPublicSubmissionSettings = validateSubmissionSettings({ minimumBundleRelaySuccesses: 1, mode: 'public', relayUrls: [] })
+
+export async function submitExecutorDeploymentTransaction(parameters: { account: Address; publicRpcUrls: readonly string[]; publicSubmit: (rpcUrl: string, serializedTransaction: Hex) => Promise<Hex>; serializedTransaction: Hex; transactionHash: Hex }) {
+	return await submitSignedTransaction({
+		address: parameters.account,
+		hash: parameters.transactionHash,
+		maxBlockNumber: 0n,
+		publicRpcUrls: parameters.publicRpcUrls,
+		publicSubmit: parameters.publicSubmit,
+		serializedTransaction: parameters.serializedTransaction,
+		settings: executorPublicSubmissionSettings,
+		signMessage: async () => {
+			throw new Error('Public executor deployment does not sign relay messages')
+		},
+	})
+}
+
+export async function deployExecutorCreate2(parameters: { chain: Chain; privateKey: Hex; rpcUrls: readonly string[]; salt: unknown }) {
 	const plan = executorDeploymentPlan(parameters.salt)
-	const publicClient = createPublicClient({ chain: parameters.chain, transport: http(parameters.rpcUrl) })
-	const chainId = await publicClient.getChainId()
-	const proxyCode = await publicClient.getCode({ address: deterministicDeploymentProxy })
-	assertExecutorDeploymentEnvironment(chainId, parameters.chain.id, proxyCode)
 	const expectedRuntimeCodeHash = keccak256(`0x${executorArtifact.evm.deployedBytecode.object}`)
-	const existingCode = await publicClient.getCode({ address: plan.address })
-	if (executorCodeStatus(existingCode, expectedRuntimeCodeHash) === 'verified') {
-		return { address: plan.address, alreadyDeployed: true, transactionHash: undefined }
+	let publicClient: ReturnType<typeof createPublicClient> | undefined
+	const preflightFailures: string[] = []
+	for (const rpcUrl of parameters.rpcUrls) {
+		try {
+			const candidate = createPublicClient({ chain: parameters.chain, transport: http(rpcUrl) })
+			const chainId = await candidate.getChainId()
+			const proxyCode = await candidate.getCode({ address: deterministicDeploymentProxy })
+			assertExecutorDeploymentEnvironment(chainId, parameters.chain.id, proxyCode)
+			const existingCode = await candidate.getCode({ address: plan.address })
+			if (executorCodeStatus(existingCode, expectedRuntimeCodeHash) === 'verified') return { address: plan.address, alreadyDeployed: true, transactionHash: undefined }
+			publicClient = candidate
+			break
+		} catch (error) {
+			preflightFailures.push(`${endpointLabel(rpcUrl)}: ${error instanceof Error ? error.message : String(error)}`)
+		}
 	}
+	if (publicClient === undefined) throw new Error(`Every public RPC failed executor deployment preflight: ${preflightFailures.join('; ')}`)
 	const account = privateKeyToAccount(parameters.privateKey)
-	const wallet = createWalletClient({ account, chain: parameters.chain, transport: http(parameters.rpcUrl) })
+	const wallet = createWalletClient({
+		account,
+		chain: parameters.chain,
+		transport: custom({
+			request: async ({ method, params }) => {
+				if (method !== 'eth_sendRawTransaction' || !Array.isArray(params) || params.length !== 1 || typeof params[0] !== 'string' || !isHex(params[0])) {
+					throw new Error('Executor deployment transport accepts only one serialized transaction')
+				}
+				const serializedTransaction: Hex = `0x${params[0].slice(2)}`
+				const transactionHash = keccak256(serializedTransaction)
+				await submitExecutorDeploymentTransaction({
+					account: account.address,
+					publicRpcUrls: parameters.rpcUrls,
+					publicSubmit: sendRawTransactionToRpc,
+					serializedTransaction,
+					transactionHash,
+				})
+				return transactionHash
+			},
+		}),
+	})
 	const transactionHash = await wallet.sendTransaction({ data: plan.calldata, to: deterministicDeploymentProxy })
 	const receipt = await publicClient.waitForTransactionReceipt({ hash: transactionHash })
 	assertExecutorDeploymentReceipt(receipt.status, receipt.transactionHash)

--- a/bots/open-oracle-arbitrager/src/execution/create2-executor.ts
+++ b/bots/open-oracle-arbitrager/src/execution/create2-executor.ts
@@ -57,11 +57,39 @@ export async function submitExecutorDeploymentTransaction(parameters: { account:
 	})
 }
 
+async function waitForExecutorDeployment(parameters: { address: Address; clients: readonly { client: ReturnType<typeof createPublicClient>; rpcUrl: string }[]; expectedRuntimeCodeHash: Hex; transactionHash: Hash }, timeoutMilliseconds = 180_000) {
+	const deadline = Date.now() + timeoutMilliseconds
+	let failures: string[] = []
+	while (true) {
+		const settled = await Promise.allSettled(
+			parameters.clients.map(async ({ client, rpcUrl }) => {
+				const receipt = await client.getTransactionReceipt({ hash: parameters.transactionHash })
+				assertExecutorDeploymentReceipt(receipt.status, receipt.transactionHash)
+				const deployedCode = await client.getCode({ address: parameters.address })
+				if (executorCodeStatus(deployedCode, parameters.expectedRuntimeCodeHash) !== 'verified') throw new Error('CREATE2 deployment did not produce executor runtime bytecode')
+				return { receipt, rpcUrl }
+			}),
+		)
+		const confirmed = settled.find(result => result.status === 'fulfilled')
+		if (confirmed?.status === 'fulfilled') return confirmed.value.receipt
+		failures = settled.map((result, index) => {
+			const endpoint = parameters.clients[index]
+			if (endpoint === undefined) return 'Unknown RPC: missing deployment confirmation result'
+			return `${endpointLabel(endpoint.rpcUrl)}: ${result.status === 'rejected' ? (result.reason instanceof Error ? result.reason.message : String(result.reason)) : 'unknown confirmation failure'}`
+		})
+		if (Date.now() >= deadline) throw new Error(`Every public RPC failed executor deployment confirmation: ${failures.join('; ')}`)
+		await new Promise(resolve => {
+			setTimeout(resolve, 1_000)
+		})
+	}
+}
+
 export async function deployExecutorCreate2(parameters: { chain: Chain; privateKey: Hex; rpcUrls: readonly string[]; salt: unknown }) {
 	const plan = executorDeploymentPlan(parameters.salt)
 	const expectedRuntimeCodeHash = keccak256(`0x${executorArtifact.evm.deployedBytecode.object}`)
-	let publicClient: ReturnType<typeof createPublicClient> | undefined
-	let preparationRpcUrl: string | undefined
+	const account = privateKeyToAccount(parameters.privateKey)
+	const clients: { client: ReturnType<typeof createPublicClient>; rpcUrl: string }[] = []
+	let prepared: { gas: bigint; gasPrice: bigint; nonce: bigint } | undefined
 	const preflightFailures: string[] = []
 	for (const rpcUrl of parameters.rpcUrls) {
 		try {
@@ -71,24 +99,24 @@ export async function deployExecutorCreate2(parameters: { chain: Chain; privateK
 			assertExecutorDeploymentEnvironment(chainId, parameters.chain.id, proxyCode)
 			const existingCode = await candidate.getCode({ address: plan.address })
 			if (executorCodeStatus(existingCode, expectedRuntimeCodeHash) === 'verified') return { address: plan.address, alreadyDeployed: true, transactionHash: undefined }
-			publicClient = candidate
-			preparationRpcUrl = rpcUrl
-			break
+			clients.push({ client: candidate, rpcUrl })
+			if (prepared === undefined) {
+				const [nonce, gas, gasPrice] = await Promise.all([readRpcPendingNonce(rpcUrl, account.address), estimateRpcTransactionGas(rpcUrl, { data: plan.calldata, from: account.address, to: deterministicDeploymentProxy }), readRpcGasPrice(rpcUrl)])
+				prepared = { gas, gasPrice, nonce }
+			}
 		} catch (error) {
 			preflightFailures.push(`${endpointLabel(rpcUrl)}: ${error instanceof Error ? error.message : String(error)}`)
 		}
 	}
-	if (publicClient === undefined || preparationRpcUrl === undefined) throw new Error(`Every public RPC failed executor deployment preflight: ${preflightFailures.join('; ')}`)
-	const account = privateKeyToAccount(parameters.privateKey)
+	if (prepared === undefined) throw new Error(`Every public RPC failed executor deployment preflight or transaction preparation: ${preflightFailures.join('; ')}`)
 	const signTransaction = account.signTransaction
 	if (signTransaction === undefined) throw new Error('Executor deployment requires a local transaction signer')
-	const [nonce, gas, gasPrice] = await Promise.all([readRpcPendingNonce(preparationRpcUrl, account.address), estimateRpcTransactionGas(preparationRpcUrl, { data: plan.calldata, from: account.address, to: deterministicDeploymentProxy }), readRpcGasPrice(preparationRpcUrl)])
 	const serializedTransaction = await signTransaction({
 		chainId: parameters.chain.id,
 		data: plan.calldata,
-		gas,
-		gasPrice,
-		nonce,
+		gas: prepared.gas,
+		gasPrice: prepared.gasPrice,
+		nonce: prepared.nonce,
 		to: deterministicDeploymentProxy,
 	})
 	const transactionHash = keccak256(serializedTransaction)
@@ -99,9 +127,6 @@ export async function deployExecutorCreate2(parameters: { chain: Chain; privateK
 		serializedTransaction,
 		transactionHash,
 	})
-	const receipt = await publicClient.waitForTransactionReceipt({ hash: transactionHash })
-	assertExecutorDeploymentReceipt(receipt.status, receipt.transactionHash)
-	const deployedCode = await publicClient.getCode({ address: plan.address })
-	if (executorCodeStatus(deployedCode, expectedRuntimeCodeHash) !== 'verified') throw new Error('CREATE2 deployment did not produce executor runtime bytecode')
+	await waitForExecutorDeployment({ address: plan.address, clients, expectedRuntimeCodeHash, transactionHash })
 	return { address: plan.address, alreadyDeployed: false, transactionHash: transactionHash as Hash }
 }

--- a/bots/open-oracle-arbitrager/src/execution/create2-executor.ts
+++ b/bots/open-oracle-arbitrager/src/execution/create2-executor.ts
@@ -1,7 +1,7 @@
-import { concatHex, createPublicClient, createWalletClient, custom, getCreate2Address, http, isHex, keccak256, privateKeyToAccount, type Address, type Chain, type Hash, type Hex } from '#ethereum'
+import { concatHex, createPublicClient, getCreate2Address, http, keccak256, privateKeyToAccount, type Address, type Chain, type Hash, type Hex } from '#ethereum'
 import { executorArtifact } from '#contracts/artifacts.generated'
 import { submitSignedTransaction, validateSubmissionSettings } from '#execution/transaction-submission'
-import { endpointLabel, sendRawTransactionToRpc } from '#monitoring/connectivity'
+import { endpointLabel, estimateRpcTransactionGas, readRpcGasPrice, readRpcPendingNonce, sendRawTransactionToRpc } from '#monitoring/connectivity'
 
 export const deterministicDeploymentProxy = '0x4e59b44847b379578588920cA78FbF26c0B4956C' as Address
 export const deterministicDeploymentProxyCode = '0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3' as Hex
@@ -61,6 +61,7 @@ export async function deployExecutorCreate2(parameters: { chain: Chain; privateK
 	const plan = executorDeploymentPlan(parameters.salt)
 	const expectedRuntimeCodeHash = keccak256(`0x${executorArtifact.evm.deployedBytecode.object}`)
 	let publicClient: ReturnType<typeof createPublicClient> | undefined
+	let preparationRpcUrl: string | undefined
 	const preflightFailures: string[] = []
 	for (const rpcUrl of parameters.rpcUrls) {
 		try {
@@ -71,35 +72,33 @@ export async function deployExecutorCreate2(parameters: { chain: Chain; privateK
 			const existingCode = await candidate.getCode({ address: plan.address })
 			if (executorCodeStatus(existingCode, expectedRuntimeCodeHash) === 'verified') return { address: plan.address, alreadyDeployed: true, transactionHash: undefined }
 			publicClient = candidate
+			preparationRpcUrl = rpcUrl
 			break
 		} catch (error) {
 			preflightFailures.push(`${endpointLabel(rpcUrl)}: ${error instanceof Error ? error.message : String(error)}`)
 		}
 	}
-	if (publicClient === undefined) throw new Error(`Every public RPC failed executor deployment preflight: ${preflightFailures.join('; ')}`)
+	if (publicClient === undefined || preparationRpcUrl === undefined) throw new Error(`Every public RPC failed executor deployment preflight: ${preflightFailures.join('; ')}`)
 	const account = privateKeyToAccount(parameters.privateKey)
-	const wallet = createWalletClient({
-		account,
-		chain: parameters.chain,
-		transport: custom({
-			request: async ({ method, params }) => {
-				if (method !== 'eth_sendRawTransaction' || !Array.isArray(params) || params.length !== 1 || typeof params[0] !== 'string' || !isHex(params[0])) {
-					throw new Error('Executor deployment transport accepts only one serialized transaction')
-				}
-				const serializedTransaction: Hex = `0x${params[0].slice(2)}`
-				const transactionHash = keccak256(serializedTransaction)
-				await submitExecutorDeploymentTransaction({
-					account: account.address,
-					publicRpcUrls: parameters.rpcUrls,
-					publicSubmit: sendRawTransactionToRpc,
-					serializedTransaction,
-					transactionHash,
-				})
-				return transactionHash
-			},
-		}),
+	const signTransaction = account.signTransaction
+	if (signTransaction === undefined) throw new Error('Executor deployment requires a local transaction signer')
+	const [nonce, gas, gasPrice] = await Promise.all([readRpcPendingNonce(preparationRpcUrl, account.address), estimateRpcTransactionGas(preparationRpcUrl, { data: plan.calldata, from: account.address, to: deterministicDeploymentProxy }), readRpcGasPrice(preparationRpcUrl)])
+	const serializedTransaction = await signTransaction({
+		chainId: parameters.chain.id,
+		data: plan.calldata,
+		gas,
+		gasPrice,
+		nonce,
+		to: deterministicDeploymentProxy,
 	})
-	const transactionHash = await wallet.sendTransaction({ data: plan.calldata, to: deterministicDeploymentProxy })
+	const transactionHash = keccak256(serializedTransaction)
+	await submitExecutorDeploymentTransaction({
+		account: account.address,
+		publicRpcUrls: parameters.rpcUrls,
+		publicSubmit: sendRawTransactionToRpc,
+		serializedTransaction,
+		transactionHash,
+	})
 	const receipt = await publicClient.waitForTransactionReceipt({ hash: transactionHash })
 	assertExecutorDeploymentReceipt(receipt.status, receipt.transactionHash)
 	const deployedCode = await publicClient.getCode({ address: plan.address })

--- a/bots/open-oracle-arbitrager/src/runtime/operator-control-plane.ts
+++ b/bots/open-oracle-arbitrager/src/runtime/operator-control-plane.ts
@@ -27,6 +27,11 @@ export type PendingOperatorUpdates = {
 	tokenAddresses: Address[] | undefined
 }
 
+export async function deployExecutorFromConnectivity(parameters: { chain: Configuration['network']['chain']; connectivity: ConnectivitySettings; privateKey: Hex; salt: unknown }, deploy: typeof deployExecutorCreate2 = deployExecutorCreate2) {
+	if (parameters.connectivity.publicRpcUrls.length === 0) throw new Error('Configure a public submission RPC before deploying the executor')
+	return await deploy({ chain: parameters.chain, privateKey: parameters.privateKey, rpcUrls: parameters.connectivity.publicRpcUrls, salt: parameters.salt })
+}
+
 export function startOperatorControlPlane(parameters: { config: Configuration; fixedState: OperatorSnapshotFixedState & { deployment: DeploymentSettings }; getCursor: () => SyncCursor | undefined; lockManager: ExecutionLockManager | undefined; signerOperationGate: SignerOperationGate; state: OperatorState }) {
 	const { config, fixedState, lockManager, signerOperationGate, state } = parameters
 	const pending: PendingOperatorUpdates = {
@@ -134,13 +139,12 @@ export function startOperatorControlPlane(parameters: { config: Configuration; f
 			if (typeof value !== 'object' || value === null || Array.isArray(value) || Object.keys(value).length !== 1 || !('salt' in value)) throw new Error('Executor deployment requires only a CREATE2 salt')
 			if (config.execute && !state.paused) throw new Error('Pause execution before deploying with the active signer')
 			if (config.privateKey === undefined) throw new Error('Set an execution signer before deploying the executor')
-			const deploymentRpcUrl = (pending.connectivity ?? config.connectivity).publicRpcUrls[0]
-			if (deploymentRpcUrl === undefined) throw new Error('Configure a public submission RPC before deploying the executor')
+			const deploymentConnectivity = pending.connectivity ?? config.connectivity
 			const plan = executorDeploymentPlan(value['salt'])
 			if (!signerOperationGate.acquire('deployment')) throw new Error('Wait for the active signer operation to finish before deploying the executor')
 			let deployed: Awaited<ReturnType<typeof deployExecutorCreate2>>
 			try {
-				deployed = await deployExecutorCreate2({ chain: config.network.chain, privateKey: config.privateKey, rpcUrl: deploymentRpcUrl, salt: plan.salt })
+				deployed = await deployExecutorFromConnectivity({ chain: config.network.chain, connectivity: deploymentConnectivity, privateKey: config.privateKey, salt: plan.salt })
 			} finally {
 				signerOperationGate.release('deployment')
 			}

--- a/bots/open-oracle-arbitrager/tests/config/configuration.test.ts
+++ b/bots/open-oracle-arbitrager/tests/config/configuration.test.ts
@@ -150,6 +150,44 @@ describe('file-only startup configuration', () => {
 		expect(result.output).toContain('config/operator.example.json')
 	})
 
+	test('uses the environment RPC list for every RPC role', async () => {
+		const directory = await temporaryDirectory()
+		const path = join(directory, 'operator.json')
+		await saveOperatorSettings(path, settings('https://saved.example/', 4173))
+		const child = Bun.spawn([executable, '-e', "const { loadConfiguration } = await import('./src/config/configuration.ts'); const value = await loadConfiguration(); console.log(JSON.stringify({ connectivity: value.connectivity, quorumRpcUrls: value.quorumRpcUrls }))"], {
+			cwd: join(import.meta.dir, '..', '..'),
+			env: {
+				...process.env,
+				OPEN_ORACLE_ARBITRAGER_CONFIG: path,
+				ZOLTAR_BOT_RPC_URLS: 'https://primary.example,https://secondary.example',
+			},
+			stderr: 'pipe',
+			stdout: 'pipe',
+		})
+		const [exitCode, stderr, stdout] = await Promise.all([child.exited, new Response(child.stderr).text(), new Response(child.stdout).text()])
+		expect(exitCode, stderr).toBe(0)
+		expect(JSON.parse(stdout)).toEqual({
+			connectivity: {
+				publicRpcUrls: ['https://primary.example/', 'https://secondary.example/'],
+				readRpcUrl: 'https://primary.example/',
+			},
+			quorumRpcUrls: ['https://secondary.example/'],
+		})
+	})
+
+	test('reports a missing effective quorum when one environment RPC overrides saved quorum readers', async () => {
+		const directory = await temporaryDirectory()
+		const path = join(directory, 'operator.json')
+		const value = settings('https://saved.example/', 4173)
+		value.runtime.execute = true
+		value.deployment.quorumRpcUrls = ['https://saved-quorum.example/']
+		await saveOperatorSettings(path, value)
+		const result = await runToExit(path, [], { ZOLTAR_BOT_RPC_URLS: 'https://primary.example' })
+		expect(result.exitCode).toBe(1)
+		expect(result.output).toContain('effective RPC configuration has no independent quorum reader')
+		expect(result.output).not.toContain('deployment.quorumRpcUrls')
+	})
+
 	test('rejects invalid file settings before RPC activity', async () => {
 		const directory = await temporaryDirectory()
 		const path = join(directory, 'operator.json')

--- a/bots/open-oracle-arbitrager/tests/execution/create2-executor.test.ts
+++ b/bots/open-oracle-arbitrager/tests/execution/create2-executor.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'bun:test'
-import { assertExecutorDeploymentEnvironment, assertExecutorDeploymentReceipt, deterministicDeploymentProxy, deterministicDeploymentProxyCode, executorCodeStatus, executorDeploymentPlan, submitExecutorDeploymentTransaction } from '#execution/create2-executor'
-import { keccak256, mainnet } from '#ethereum'
+import { assertExecutorDeploymentEnvironment, assertExecutorDeploymentReceipt, deployExecutorCreate2, deterministicDeploymentProxy, deterministicDeploymentProxyCode, executorCodeStatus, executorDeploymentPlan, submitExecutorDeploymentTransaction } from '#execution/create2-executor'
+import { executorArtifact } from '#contracts/artifacts.generated'
+import { keccak256, mainnet, privateKeyToAccount } from '#ethereum'
 import type { Hex } from '#ethereum'
 import { deployExecutorFromConnectivity } from '../../src/runtime/operator-control-plane.ts'
 
@@ -82,4 +83,84 @@ test('passes every effective public RPC from the dashboard deployment path', asy
 	)
 
 	expect(receivedRpcUrls).toEqual(publicRpcUrls)
+})
+
+test('deploys through preflight, signed multi-RPC broadcast, receipt polling, and code verification', async () => {
+	const privateKey = `0x${'11'.repeat(32)}` as Hex
+	const account = privateKeyToAccount(privateKey)
+	const salt = `0x${'22'.repeat(32)}` as Hex
+	const plan = executorDeploymentPlan(salt)
+	const runtimeCode = `0x${executorArtifact.evm.deployedBytecode.object}` as Hex
+	const broadcastRequests: { transaction: Hex; url: string }[] = []
+	let deployed = false
+	let transactionHash = `0x${'00'.repeat(32)}` as Hex
+
+	const rpcResponse = (result: unknown) => Response.json({ id: 1, jsonrpc: '2.0', result })
+	const handler = (name: string, rejectBroadcast: boolean) => async (request: Request) => {
+		const body: unknown = await request.json()
+		if (typeof body !== 'object' || body === null || Array.isArray(body) || !('method' in body) || typeof body.method !== 'string' || !('params' in body) || !Array.isArray(body.params)) {
+			return new Response('invalid request', { status: 400 })
+		}
+		if (body.method === 'eth_chainId') return rpcResponse('0x1')
+		if (body.method === 'eth_getTransactionCount') return rpcResponse('0x0')
+		if (body.method === 'eth_estimateGas') return rpcResponse('0x300000')
+		if (body.method === 'eth_gasPrice') return rpcResponse('0x3b9aca00')
+		if (body.method === 'eth_getCode') {
+			const address = body.params[0]
+			if (typeof address !== 'string') return new Response('invalid address', { status: 400 })
+			if (address.toLowerCase() === deterministicDeploymentProxy.toLowerCase()) return rpcResponse(deterministicDeploymentProxyCode)
+			if (address.toLowerCase() === plan.address.toLowerCase()) return rpcResponse(deployed ? runtimeCode : '0x')
+			return rpcResponse('0x')
+		}
+		if (body.method === 'eth_sendRawTransaction') {
+			const transaction = body.params[0]
+			if (typeof transaction !== 'string' || !transaction.startsWith('0x')) return new Response('invalid transaction', { status: 400 })
+			const normalizedTransaction: Hex = `0x${transaction.slice(2)}`
+			broadcastRequests.push({ transaction: normalizedTransaction, url: name })
+			if (rejectBroadcast) return new Response('primary unavailable', { status: 503 })
+			transactionHash = keccak256(normalizedTransaction)
+			deployed = true
+			return rpcResponse(transactionHash)
+		}
+		if (body.method === 'eth_getTransactionReceipt') {
+			return rpcResponse({
+				blockHash: `0x${'aa'.repeat(32)}`,
+				blockNumber: '0x64',
+				contractAddress: null,
+				cumulativeGasUsed: '0x5208',
+				effectiveGasPrice: '0x1',
+				from: account.address,
+				gasUsed: '0x5208',
+				logs: [],
+				logsBloom: `0x${'00'.repeat(256)}`,
+				status: '0x1',
+				to: deterministicDeploymentProxy,
+				transactionHash,
+				transactionIndex: '0x0',
+				type: '0x2',
+			})
+		}
+		return new Response(`unexpected method ${body.method}`, { status: 500 })
+	}
+
+	const primary = Bun.serve({ fetch: handler('primary', true), port: 0 })
+	const secondary = Bun.serve({ fetch: handler('secondary', false), port: 0 })
+	try {
+		const primaryPort = primary.port
+		const secondaryPort = secondary.port
+		if (primaryPort === undefined || secondaryPort === undefined) throw new Error('Mock RPC server did not expose a port')
+		const result = await deployExecutorCreate2({
+			chain: mainnet,
+			privateKey,
+			rpcUrls: [`http://127.0.0.1:${primaryPort.toString()}`, `http://127.0.0.1:${secondaryPort.toString()}`],
+			salt,
+		})
+		expect(result).toEqual({ address: plan.address, alreadyDeployed: false, transactionHash })
+		expect(broadcastRequests).toHaveLength(2)
+		expect(broadcastRequests.map(request => request.url)).toEqual(['primary', 'secondary'])
+		expect(broadcastRequests[0]?.transaction).toBe(broadcastRequests[1]?.transaction)
+	} finally {
+		primary.stop(true)
+		secondary.stop(true)
+	}
 })

--- a/bots/open-oracle-arbitrager/tests/execution/create2-executor.test.ts
+++ b/bots/open-oracle-arbitrager/tests/execution/create2-executor.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from 'bun:test'
-import { assertExecutorDeploymentEnvironment, assertExecutorDeploymentReceipt, deterministicDeploymentProxy, deterministicDeploymentProxyCode, executorCodeStatus, executorDeploymentPlan } from '#execution/create2-executor'
-import { keccak256 } from '#ethereum'
+import { assertExecutorDeploymentEnvironment, assertExecutorDeploymentReceipt, deterministicDeploymentProxy, deterministicDeploymentProxyCode, executorCodeStatus, executorDeploymentPlan, submitExecutorDeploymentTransaction } from '#execution/create2-executor'
+import { keccak256, mainnet } from '#ethereum'
 import type { Hex } from '#ethereum'
+import { deployExecutorFromConnectivity } from '../../src/runtime/operator-control-plane.ts'
 
 test('derives a stable executor address and canonical proxy calldata from a bytes32 salt', () => {
 	const salt = `0x${'00'.repeat(32)}` as Hex
@@ -36,4 +37,49 @@ test('rejects a reverted CREATE2 receipt', () => {
 	const hash = `0x${'11'.repeat(32)}` as Hex
 	expect(() => assertExecutorDeploymentReceipt('reverted', hash)).toThrow(`reverted: ${hash}`)
 	expect(() => assertExecutorDeploymentReceipt('success', hash)).not.toThrow()
+})
+
+test('broadcasts one signed executor deployment through every public RPC and tolerates one failure', async () => {
+	const transactionHash = `0x${'22'.repeat(32)}` as Hex
+	const serializedTransaction = '0x1234' as Hex
+	const submissions: { transaction: Hex; url: string }[] = []
+	const result = await submitExecutorDeploymentTransaction({
+		account: `0x${'11'.repeat(20)}`,
+		publicRpcUrls: ['https://primary.example', 'https://secondary.example'],
+		publicSubmit: async (url, transaction) => {
+			submissions.push({ transaction, url })
+			if (url.includes('primary')) throw new Error('primary unavailable')
+			return transactionHash
+		},
+		serializedTransaction,
+		transactionHash,
+	})
+
+	expect(submissions).toEqual([
+		{ transaction: serializedTransaction, url: 'https://primary.example' },
+		{ transaction: serializedTransaction, url: 'https://secondary.example' },
+	])
+	expect(result.hash).toBe(transactionHash)
+	expect(result.acceptedTargets).toEqual(['https://secondary.example'])
+	expect(result.failedTargets).toHaveLength(1)
+})
+
+test('passes every effective public RPC from the dashboard deployment path', async () => {
+	const primaryRpcUrl = 'https://primary.example/'
+	const publicRpcUrls = [primaryRpcUrl, 'https://secondary.example/']
+	let receivedRpcUrls: readonly string[] = []
+	await deployExecutorFromConnectivity(
+		{
+			chain: mainnet,
+			connectivity: { publicRpcUrls, readRpcUrl: primaryRpcUrl },
+			privateKey: `0x${'11'.repeat(32)}`,
+			salt: `0x${'22'.repeat(32)}`,
+		},
+		async parameters => {
+			receivedRpcUrls = parameters.rpcUrls
+			return { address: `0x${'33'.repeat(20)}`, alreadyDeployed: false, transactionHash: `0x${'44'.repeat(32)}` }
+		},
+	)
+
+	expect(receivedRpcUrls).toEqual(publicRpcUrls)
 })

--- a/bots/open-oracle-arbitrager/tests/execution/create2-executor.test.ts
+++ b/bots/open-oracle-arbitrager/tests/execution/create2-executor.test.ts
@@ -85,7 +85,7 @@ test('passes every effective public RPC from the dashboard deployment path', asy
 	expect(receivedRpcUrls).toEqual(publicRpcUrls)
 })
 
-test('deploys through preflight, signed multi-RPC broadcast, receipt polling, and code verification', async () => {
+async function runDeploymentScenario(options: { primaryPreparationFails: boolean; primaryReceiptFails: boolean }) {
 	const privateKey = `0x${'11'.repeat(32)}` as Hex
 	const account = privateKeyToAccount(privateKey)
 	const salt = `0x${'22'.repeat(32)}` as Hex
@@ -96,7 +96,7 @@ test('deploys through preflight, signed multi-RPC broadcast, receipt polling, an
 	let transactionHash = `0x${'00'.repeat(32)}` as Hex
 
 	const rpcResponse = (result: unknown) => Response.json({ id: 1, jsonrpc: '2.0', result })
-	const handler = (name: string, rejectBroadcast: boolean) => async (request: Request) => {
+	const handler = (name: 'primary' | 'secondary') => async (request: Request) => {
 		const body: unknown = await request.json()
 		if (typeof body !== 'object' || body === null || Array.isArray(body) || !('method' in body) || typeof body.method !== 'string' || !('params' in body) || !Array.isArray(body.params)) {
 			return new Response('invalid request', { status: 400 })
@@ -104,7 +104,7 @@ test('deploys through preflight, signed multi-RPC broadcast, receipt polling, an
 		if (body.method === 'eth_chainId') return rpcResponse('0x1')
 		if (body.method === 'eth_getTransactionCount') return rpcResponse('0x0')
 		if (body.method === 'eth_estimateGas') return rpcResponse('0x300000')
-		if (body.method === 'eth_gasPrice') return rpcResponse('0x3b9aca00')
+		if (body.method === 'eth_gasPrice') return name === 'primary' && options.primaryPreparationFails ? new Response('primary preparation unavailable', { status: 503 }) : rpcResponse('0x3b9aca00')
 		if (body.method === 'eth_getCode') {
 			const address = body.params[0]
 			if (typeof address !== 'string') return new Response('invalid address', { status: 400 })
@@ -117,12 +117,13 @@ test('deploys through preflight, signed multi-RPC broadcast, receipt polling, an
 			if (typeof transaction !== 'string' || !transaction.startsWith('0x')) return new Response('invalid transaction', { status: 400 })
 			const normalizedTransaction: Hex = `0x${transaction.slice(2)}`
 			broadcastRequests.push({ transaction: normalizedTransaction, url: name })
-			if (rejectBroadcast) return new Response('primary unavailable', { status: 503 })
+			if (name === 'primary') return new Response('primary broadcast unavailable', { status: 503 })
 			transactionHash = keccak256(normalizedTransaction)
 			deployed = true
 			return rpcResponse(transactionHash)
 		}
 		if (body.method === 'eth_getTransactionReceipt') {
+			if (name === 'primary' && options.primaryReceiptFails) return new Response('primary receipt unavailable', { status: 503 })
 			return rpcResponse({
 				blockHash: `0x${'aa'.repeat(32)}`,
 				blockNumber: '0x64',
@@ -143,8 +144,8 @@ test('deploys through preflight, signed multi-RPC broadcast, receipt polling, an
 		return new Response(`unexpected method ${body.method}`, { status: 500 })
 	}
 
-	const primary = Bun.serve({ fetch: handler('primary', true), port: 0 })
-	const secondary = Bun.serve({ fetch: handler('secondary', false), port: 0 })
+	const primary = Bun.serve({ fetch: handler('primary'), port: 0 })
+	const secondary = Bun.serve({ fetch: handler('secondary'), port: 0 })
 	try {
 		const primaryPort = primary.port
 		const secondaryPort = secondary.port
@@ -155,12 +156,23 @@ test('deploys through preflight, signed multi-RPC broadcast, receipt polling, an
 			rpcUrls: [`http://127.0.0.1:${primaryPort.toString()}`, `http://127.0.0.1:${secondaryPort.toString()}`],
 			salt,
 		})
-		expect(result).toEqual({ address: plan.address, alreadyDeployed: false, transactionHash })
-		expect(broadcastRequests).toHaveLength(2)
-		expect(broadcastRequests.map(request => request.url)).toEqual(['primary', 'secondary'])
-		expect(broadcastRequests[0]?.transaction).toBe(broadcastRequests[1]?.transaction)
+		return { broadcastRequests, expected: { address: plan.address, alreadyDeployed: false, transactionHash }, result }
 	} finally {
 		primary.stop(true)
 		secondary.stop(true)
 	}
+}
+
+test('falls back when the primary fails transaction preparation before signed multi-RPC broadcast', async () => {
+	const { broadcastRequests, expected, result } = await runDeploymentScenario({ primaryPreparationFails: true, primaryReceiptFails: false })
+	expect(result).toEqual(expected)
+	expect(broadcastRequests.map(request => request.url)).toEqual(['primary', 'secondary'])
+	expect(broadcastRequests[0]?.transaction).toBe(broadcastRequests[1]?.transaction)
+})
+
+test('confirms through the secondary when the primary fails receipt polling after broadcast', async () => {
+	const { broadcastRequests, expected, result } = await runDeploymentScenario({ primaryPreparationFails: false, primaryReceiptFails: true })
+	expect(result).toEqual(expected)
+	expect(broadcastRequests).toHaveLength(2)
+	expect(broadcastRequests[0]?.transaction).toBe(broadcastRequests[1]?.transaction)
 })

--- a/bots/shared/src/monitoring/connectivity.ts
+++ b/bots/shared/src/monitoring/connectivity.ts
@@ -65,7 +65,8 @@ export function validateReadRpcUrls(values: readonly string[]) {
 
 export function validateIndependentReadRpcUrls(primary: string, values: readonly string[]) {
 	const normalizedPrimary = endpointUrl(primary.trim())
-	const normalized = validateReadRpcUrls(values)
+	if (values.length > 8) throw new Error('At most 8 read quorum RPC URLs are supported')
+	const normalized = values.map(value => endpointUrl(value.trim()))
 	const origins = [new URL(normalizedPrimary).origin, ...normalized.map(value => new URL(value).origin)]
 	if (new Set(origins).size !== origins.length) throw new Error('Read RPC quorum must use independent origins; changing only the URL path does not create an independent provider')
 	return normalized
@@ -83,6 +84,20 @@ export function validateConnectivitySettings(value: unknown): ConnectivitySettin
 	const publicRpcUrls = [...new Set(record['publicRpcUrls'].map(url => endpointUrl(String(url).trim())))]
 	if (publicRpcUrls.length === 0) throw new Error('At least one public RPC URL is required')
 	return { publicRpcUrls, readRpcUrl }
+}
+
+export function rpcConfigurationWithEnvironmentOverride(connectivity: ConnectivitySettings, quorumRpcUrls: readonly string[], environmentValue: string | undefined) {
+	if (environmentValue === undefined || environmentValue.trim() === '') return { connectivity, quorumRpcUrls }
+	const entries = environmentValue.split(',').map(value => value.trim())
+	if (entries.some(value => value === '')) throw new Error('ZOLTAR_BOT_RPC_URLS must not contain empty entries')
+	if (entries.length > 8) throw new Error('At most 8 RPC URLs are supported in ZOLTAR_BOT_RPC_URLS')
+	const urls = entries.map(endpointUrl)
+	const readRpcUrl = urls[0]
+	if (readRpcUrl === undefined) throw new Error('ZOLTAR_BOT_RPC_URLS must contain at least one RPC URL')
+	return {
+		connectivity: validateConnectivitySettings({ publicRpcUrls: urls, readRpcUrl }),
+		quorumRpcUrls: validateIndependentReadRpcUrls(readRpcUrl, urls.slice(1)),
+	}
 }
 
 async function rpcRequest(url: string, method: string, params: readonly unknown[], timeoutMilliseconds: number) {

--- a/bots/shared/src/monitoring/connectivity.ts
+++ b/bots/shared/src/monitoring/connectivity.ts
@@ -1,4 +1,4 @@
-import type { Hex } from '../ethereum.ts'
+import type { Address, Hex } from '../ethereum.ts'
 import { bigintToSafeNumber } from '../ethereum/codec.ts'
 import type { SubmissionSettings } from '../execution/transaction-submission.ts'
 import { boundedJsonResponse, DEFAULT_RPC_RESPONSE_BYTES } from '../infrastructure/bounded-json.ts'
@@ -132,6 +132,23 @@ export async function sendRawTransactionToRpc(url: string, serializedTransaction
 	const result = await rpcRequest(url, 'eth_sendRawTransaction', [serializedTransaction], timeoutMilliseconds)
 	if (typeof result !== 'string' || !/^0x[0-9a-fA-F]{64}$/.test(result)) throw new Error('RPC returned an invalid transaction hash')
 	return result as Hex
+}
+
+function rpcQuantity(value: unknown, label: string) {
+	if (typeof value !== 'string' || !/^0x[0-9a-fA-F]+$/.test(value)) throw new Error(`RPC returned an invalid ${label}`)
+	return BigInt(value)
+}
+
+export async function readRpcPendingNonce(url: string, address: Address, timeoutMilliseconds = 10_000) {
+	return rpcQuantity(await rpcRequest(url, 'eth_getTransactionCount', [address, 'pending'], timeoutMilliseconds), 'pending nonce')
+}
+
+export async function estimateRpcTransactionGas(url: string, transaction: { data: Hex; from: Address; to: Address }, timeoutMilliseconds = 10_000) {
+	return rpcQuantity(await rpcRequest(url, 'eth_estimateGas', [transaction], timeoutMilliseconds), 'gas estimate')
+}
+
+export async function readRpcGasPrice(url: string, timeoutMilliseconds = 10_000) {
+	return rpcQuantity(await rpcRequest(url, 'eth_gasPrice', [], timeoutMilliseconds), 'gas price')
 }
 
 export async function checkRpcEndpoint(url: string, expectedChainId: number, kind: EndpointCheck['kind']): Promise<EndpointCheck> {

--- a/bots/shared/tests/shared-primitives.test.ts
+++ b/bots/shared/tests/shared-primitives.test.ts
@@ -11,6 +11,7 @@ import { paddedTransactionGas, prepareSignedTransaction, submitSignedTransaction
 import { createPublicClient, custom, encodeAbiParameters, http, parseTransaction, privateKeyToAccount } from '../src/ethereum.ts'
 import { bigintToSafeNumber } from '../src/ethereum/codec.ts'
 import { confirmCanonicalReceiptFinality } from '../src/execution/canonical-finality.ts'
+import { rpcConfigurationWithEnvironmentOverride } from '../src/monitoring/connectivity.ts'
 
 const temporaryDirectories: string[] = []
 
@@ -19,6 +20,40 @@ afterEach(async () => {
 })
 
 describe('shared bot primitives', () => {
+	test('maps an environment RPC list to read, broadcast, and quorum roles', () => {
+		const overridden = rpcConfigurationWithEnvironmentOverride(
+			{
+				publicRpcUrls: ['https://saved-public.example'],
+				readRpcUrl: 'https://saved-read.example',
+			},
+			['https://saved-quorum.example'],
+			'https://primary.example/rpc, https://secondary.example/key,https://third.example',
+		)
+
+		expect(overridden).toEqual({
+			connectivity: {
+				publicRpcUrls: ['https://primary.example/rpc', 'https://secondary.example/key', 'https://third.example/'],
+				readRpcUrl: 'https://primary.example/rpc',
+			},
+			quorumRpcUrls: ['https://secondary.example/key', 'https://third.example/'],
+		})
+	})
+
+	test('keeps saved RPC roles when the environment override is blank', () => {
+		const connectivity = { publicRpcUrls: ['https://saved-public.example'], readRpcUrl: 'https://saved-read.example' }
+		const quorumRpcUrls = ['https://saved-quorum.example']
+		expect(rpcConfigurationWithEnvironmentOverride(connectivity, quorumRpcUrls, '')).toEqual({ connectivity, quorumRpcUrls })
+	})
+
+	test('rejects ambiguous or non-independent environment RPC lists', () => {
+		const connectivity = { publicRpcUrls: ['https://saved-public.example'], readRpcUrl: 'https://saved-read.example' }
+		expect(() => rpcConfigurationWithEnvironmentOverride(connectivity, [], 'https://one.example,')).toThrow('must not contain empty entries')
+		expect(() => rpcConfigurationWithEnvironmentOverride(connectivity, [], 'https://one.example,https://one.example')).toThrow('independent origins')
+		expect(() => rpcConfigurationWithEnvironmentOverride(connectivity, [], 'https://one.example/a,https://one.example/b')).toThrow('independent origins')
+		expect(() => rpcConfigurationWithEnvironmentOverride(connectivity, [], 'https://one.example,https://two.example,https://two.example')).toThrow('independent origins')
+		expect(() => rpcConfigurationWithEnvironmentOverride(connectivity, [], 'https://one.example,https://two.example,https://three.example,https://two.example')).toThrow('independent origins')
+	})
+
 	test('converts bigint values only inside the safe integer range', () => {
 		expect(bigintToSafeNumber(9_007_199_254_740_991n)).toBe(Number.MAX_SAFE_INTEGER)
 		expect(() => bigintToSafeNumber(9_007_199_254_740_992n)).toThrow('safe integer range')


### PR DESCRIPTION
## Summary

- add `ZOLTAR_BOT_RPC_URLS` to the liquidator and OpenOracle arbitrager `.env`/Compose configuration
- use the first URL for primary reads, every URL for public transaction broadcast, and remaining independent origins for read quorum
- preserve persisted JSON RPC settings as the fallback when the environment override is blank
- keep liquidator dashboard saves from persisting temporary environment overrides
- make arbitrager CREATE2 deployment prepare, broadcast, confirm, and verify across RPC failover

## Why

Public RPC providers can reject log queries or become unavailable. Operators need to select their own provider and configure independent alternatives without rewriting bot JSON settings. Multi-endpoint broadcast and lifecycle failover also prevent a single public RPC from blocking executor deployment or transaction submission.

## Configuration

```env
ZOLTAR_BOT_RPC_URLS=https://primary.example,https://secondary.example
```

The first endpoint is the primary reader. All endpoints receive public transaction broadcasts, and endpoints after the first are independent quorum readers.

## Validation

- `bun run tsc`
- `bun run ensure-contract-artifacts && bun run check:shared-dependencies && bun run test:run -- --bail=1` — 2,801 passed, 16 network-dependent skipped
- shared bot typecheck/tests — 59 passed
- liquidator typecheck/tests — 92 passed
- OpenOracle arbitrager typecheck/tests — 286 passed
- `bun run format:check`
- `bun run check:changed`
- `bun run knip`
- `bun run check:generated-clean`
- `git diff --check`

Docker Compose rendering was not run because Docker is unavailable in the validation environment. No rendered UI changed, so browser QA and screenshots are not applicable.
