### PR TITLE
Retry rate-limited RPC requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
 		"ui:serve": "bun run app:serve",
 		"ui:vendor": "cd ui && bun ./build/vendor.mts",
 		"cleanup:foundry-anvil-state": "bun ./scripts/cleanup-foundry-anvil-state.mts",
-		"deploy:testnet": "bun ./scripts/deploy-testnet.mts",
+		"deploy:testnet": "bun run ensure-shared-build && bun run refresh:shared-dependencies && bun ./scripts/deploy-testnet.mts",
 		"gas-costs": "cd solidity && bun run gas-costs",
 		"test": "bun run ensure-contract-artifacts && bun run check:shared-dependencies && bun run tsc && bun run test:run",
 		"test:run": "bun ./scripts/run-tests.mts",

--- a/shared/ts/ethereum.test.ts
+++ b/shared/ts/ethereum.test.ts
@@ -16,6 +16,7 @@ import {
 	getAddress,
 	getCreate2Address,
 	hexToBytes,
+	http,
 	isAddress,
 	isHex,
 	keccak256,
@@ -27,6 +28,7 @@ import {
 	parseUnits,
 	privateKeyToAccount,
 	publicActions,
+	RATE_LIMIT_RETRY_DELAY_MILLISECONDS,
 	recoverTransactionAddress,
 	toHex,
 	type EIP1193Provider,
@@ -989,7 +991,7 @@ describe('shared ethereum compatibility layer', () => {
 		}, calls)
 		const client = createPublicClient({
 			chain: mainnet,
-			transport: custom(provider),
+			transport: custom(provider, { retryCount: 0, retryDelay: 0 }),
 		})
 
 		const receipt = await client.waitForTransactionReceipt({
@@ -1012,7 +1014,7 @@ describe('shared ethereum compatibility layer', () => {
 			if (receiptRequests === 1) throw { code: 429, message: 'rate limit exceeded' }
 			throw new Error('Receipt request ran after the deadline')
 		}, [])
-		const client = createPublicClient({ chain: mainnet, transport: custom(provider) })
+		const client = createPublicClient({ chain: mainnet, transport: custom(provider, { retryCount: 0, retryDelay: 0 }) })
 
 		Date.now = () => clockValues.shift() ?? 1
 		try {
@@ -1082,7 +1084,7 @@ describe('shared ethereum compatibility layer', () => {
 			}
 			throw new Error(`Unexpected rpc method: ${method}`)
 		}, calls)
-		const client = createPublicClient({ chain: mainnet, transport: custom(provider) })
+		const client = createPublicClient({ chain: mainnet, transport: custom(provider, { retryCount: 0, retryDelay: 0 }) })
 
 		const receipt = await client.waitForTransactionReceipt({ hash: originalHash, onReplaced: () => undefined, pollingInterval: 0, timeout: 50 })
 
@@ -1450,6 +1452,65 @@ describe('shared ethereum compatibility layer', () => {
 		)
 		expect(await recoverTransactionAddress({ serializedTransaction: capturedRawTransaction })).toBe(ACCOUNT_ADDRESS)
 		expect(localCalls).toHaveLength(1)
+	})
+
+	test('HTTP transport retries rate limits for reads, receipt requests, and raw transaction broadcasts', async () => {
+		expect(RATE_LIMIT_RETRY_DELAY_MILLISECONDS).toBe(10_000)
+		expect(http('https://rpc.example.test').retryDelay).toBe(RATE_LIMIT_RETRY_DELAY_MILLISECONDS)
+		const responses = [
+			new Response(undefined, { status: 429 }),
+			Response.json({ id: 1, jsonrpc: '2.0', result: '0x1234' }),
+			new Response(undefined, { status: 429 }),
+			Response.json({
+				id: 1,
+				jsonrpc: '2.0',
+				result: {
+					blockHash: BLOCK_HASH,
+					blockNumber: '0x1',
+					cumulativeGasUsed: '0x5208',
+					effectiveGasPrice: '0x3',
+					from: OWNER_ADDRESS,
+					gasUsed: '0x5208',
+					logs: [],
+					status: '0x1',
+					to: RECIPIENT_ADDRESS,
+					transactionHash: RECEIPT_HASH,
+					transactionIndex: '0x0',
+					type: '0x2',
+				},
+			}),
+			new Response(undefined, { status: 429 }),
+			Response.json({ error: { code: -32_000, message: 'already known' }, id: 1, jsonrpc: '2.0' }),
+		]
+		const originalFetch = globalThis.fetch
+		const testFetch = async () => {
+			const response = responses.shift()
+			if (response === undefined) throw new Error('Unexpected HTTP RPC request')
+			return response
+		}
+		testFetch.preconnect = originalFetch.preconnect
+		globalThis.fetch = testFetch
+		try {
+			const client = createWalletClient({
+				account: privateKeyToAccount(PRIVATE_KEY),
+				chain: mainnet,
+				transport: http('https://rpc.example.test', { retryDelay: 0 }),
+			})
+
+			expect(await client.getCode({ address: TOKEN_ADDRESS })).toBe('0x1234')
+			expect(
+				await client.waitForTransactionReceipt({
+					hash: RECEIPT_HASH,
+					pollingInterval: 0,
+					timeout: 50,
+				}),
+			).toMatchObject({ transactionHash: RECEIPT_HASH })
+			expect(await client.sendRawTransaction({ serializedTransaction: '0x1234' })).toBe(keccak256('0x1234'))
+		} finally {
+			globalThis.fetch = originalFetch
+		}
+
+		expect(responses).toHaveLength(0)
 	})
 
 	test('wallet client defaults simulations and gas estimates to its configured account', async () => {

--- a/shared/ts/ethereum.ts
+++ b/shared/ts/ethereum.ts
@@ -340,13 +340,23 @@ export type ParsedTransaction = {
 	value?: bigint | undefined
 }
 
+type TransportRetryOptions = {
+	batch?: unknown
+	retryCount?: number | undefined
+	retryDelay?: number | undefined
+}
+
 type TypedTransport =
 	| {
 			kind: 'custom'
 			provider: EIP1193Provider
+			retryCount: number
+			retryDelay: number
 	  }
 	| {
 			kind: 'http'
+			retryCount: number
+			retryDelay: number
 			url: string
 	  }
 
@@ -397,6 +407,9 @@ type ClientRequestParameters = {
 
 type BlockTag = 'earliest' | 'latest' | 'pending'
 type LogTopicFilter = Hex | readonly Hex[] | null
+
+const DEFAULT_RATE_LIMIT_RETRY_COUNT = 3
+export const RATE_LIMIT_RETRY_DELAY_MILLISECONDS = 10_000
 
 type PublicClientShape<TTransport extends Transport, TChain extends Chain | undefined> = {
 	chain: TChain
@@ -1023,7 +1036,7 @@ function ensureConstructorAbi(abi: readonly unknown[]) {
 			]
 }
 
-async function requestTransport<TValue>(transport: Transport, parameters: ClientRequestParameters): Promise<TValue> {
+async function requestTransportOnce<TValue>(transport: Transport, parameters: ClientRequestParameters): Promise<TValue> {
 	if (transport.kind === 'custom') {
 		try {
 			return (await transport.provider.request({
@@ -1070,6 +1083,33 @@ async function requestTransport<TValue>(transport: Transport, parameters: Client
 		})
 	}
 	return payload.result as TValue
+}
+
+async function retryRateLimited<TValue>(operation: () => Promise<TValue>, options: { retryCount?: number | undefined; retryDelay: number; startTime?: number | undefined; timeout?: number | undefined }) {
+	const startTime = options.timeout === undefined ? undefined : (options.startTime ?? Date.now())
+	let retries = 0
+	while (true) {
+		try {
+			return await operation()
+		} catch (error) {
+			if (!isRateLimitError(error) || (options.retryCount !== undefined && retries >= options.retryCount)) throw error
+			const remainingMilliseconds = options.timeout === undefined || startTime === undefined ? undefined : options.timeout - (Date.now() - startTime)
+			if (remainingMilliseconds !== undefined && remainingMilliseconds <= 0) throw error
+			const delayMilliseconds = remainingMilliseconds === undefined ? options.retryDelay : Math.min(options.retryDelay, remainingMilliseconds)
+			await new Promise(resolve => {
+				setTimeout(resolve, delayMilliseconds)
+			})
+			if (options.timeout !== undefined && startTime !== undefined && Date.now() - startTime >= options.timeout) throw error
+			retries += 1
+		}
+	}
+}
+
+async function requestTransport<TValue>(transport: Transport, parameters: ClientRequestParameters): Promise<TValue> {
+	return await retryRateLimited(async () => await requestTransportOnce<TValue>(transport, parameters), {
+		retryCount: transport.retryCount,
+		retryDelay: transport.retryDelay,
+	})
 }
 
 function toRpcError(error: unknown, fallbackMessage: string) {
@@ -1175,6 +1215,10 @@ function isTransactionNotFoundError(error: unknown) {
 
 function isRateLimitError(error: unknown) {
 	return error instanceof RpcError && (error.code === 429 || error.code === '429' || error.message.includes('HTTP 429'))
+}
+
+function isAlreadyKnownTransactionError(error: unknown) {
+	return error instanceof RpcError && error.message.toLowerCase().includes('already known')
 }
 
 function getReplacementReason(originalTransaction: BlockTransaction, replacementTransaction: BlockTransaction): ReplacementReason {
@@ -1459,30 +1503,23 @@ function buildPublicClientActions<TTransport extends Transport, TChain extends C
 			const timeoutMilliseconds = parameters.timeout ?? 180_000
 			const pollingInterval = parameters.pollingInterval ?? 1_000
 			const startTime = Date.now()
-			const actions = buildPublicClientActions({ chain, transport })
-			const waitForNextPoll = async (delayMilliseconds = pollingInterval) => {
+			const actions = buildPublicClientActions({ chain, transport: { ...transport, retryCount: 0 } })
+			const waitForNextPoll = async () => {
 				await new Promise(resolve => {
-					setTimeout(resolve, delayMilliseconds)
+					setTimeout(resolve, pollingInterval)
 				})
 			}
-			const retryRateLimited = async <TValue>(operation: () => Promise<TValue>) => {
-				while (true) {
-					try {
-						return await operation()
-					} catch (error) {
-						if (!isRateLimitError(error)) throw error
-						const remainingMilliseconds = timeoutMilliseconds - (Date.now() - startTime)
-						if (remainingMilliseconds <= 0) throw error
-						await waitForNextPoll(Math.min(pollingInterval, remainingMilliseconds))
-						if (Date.now() - startTime >= timeoutMilliseconds) throw error
-					}
-				}
-			}
+			const retryReceiptRateLimited = async <TValue>(operation: () => Promise<TValue>) =>
+				await retryRateLimited(operation, {
+					retryDelay: transport.retryDelay,
+					startTime,
+					timeout: timeoutMilliseconds,
+				})
 			let originalTransaction: BlockTransaction | undefined
 			let lastScannedReplacementBlock: bigint | undefined
 			if (parameters.onReplaced !== undefined) {
 				try {
-					originalTransaction = await retryRateLimited(
+					originalTransaction = await retryReceiptRateLimited(
 						async () =>
 							await actions.getTransaction({
 								hash: parameters.hash,
@@ -1494,7 +1531,7 @@ function buildPublicClientActions<TTransport extends Transport, TChain extends C
 			}
 			while (true) {
 				try {
-					return await retryRateLimited(
+					return await retryReceiptRateLimited(
 						async () =>
 							await actions.getTransactionReceipt({
 								hash: parameters.hash,
@@ -1504,7 +1541,7 @@ function buildPublicClientActions<TTransport extends Transport, TChain extends C
 					if (!isTransactionNotFoundError(error)) throw error
 					if (parameters.onReplaced !== undefined && originalTransaction === undefined) {
 						try {
-							originalTransaction = await retryRateLimited(
+							originalTransaction = await retryReceiptRateLimited(
 								async () =>
 									await actions.getTransaction({
 										hash: parameters.hash,
@@ -1516,15 +1553,16 @@ function buildPublicClientActions<TTransport extends Transport, TChain extends C
 					}
 					if (originalTransaction !== undefined) {
 						const transactionToReplace = originalTransaction
-						const latestBlockNumber = await retryRateLimited(async () => await actions.getBlockNumber())
+						const latestBlockNumber = await retryReceiptRateLimited(async () => await actions.getBlockNumber())
 						let firstScanBlock = lastScannedReplacementBlock === undefined ? 0n : lastScannedReplacementBlock + 1n
 						if (lastScannedReplacementBlock === undefined && latestBlockNumber > REPLACEMENT_SCAN_BLOCK_DEPTH) {
 							firstScanBlock = latestBlockNumber - REPLACEMENT_SCAN_BLOCK_DEPTH
 						}
-						const replacementTransaction = firstScanBlock > latestBlockNumber ? undefined : await findReplacementTransaction(actions, transactionToReplace, { fromBlock: firstScanBlock, toBlock: latestBlockNumber }, { getBlock: async parameters => await retryRateLimited(async () => await actions.getBlock(parameters)) })
+						const replacementTransaction =
+							firstScanBlock > latestBlockNumber ? undefined : await findReplacementTransaction(actions, transactionToReplace, { fromBlock: firstScanBlock, toBlock: latestBlockNumber }, { getBlock: async parameters => await retryReceiptRateLimited(async () => await actions.getBlock(parameters)) })
 						lastScannedReplacementBlock = latestBlockNumber
 						if (replacementTransaction !== undefined) {
-							const transactionReceipt = await retryRateLimited(
+							const transactionReceipt = await retryReceiptRateLimited(
 								async () =>
 									await actions.getTransactionReceipt({
 										hash: replacementTransaction.hash,
@@ -1654,13 +1692,19 @@ export function createWalletClient<TTransport extends Transport = Transport, TCh
 				...parameters,
 				account: parameters.account ?? normalizedAccount,
 			}),
-		sendRawTransaction: async parameters =>
-			normalizeHash(
-				await requestTransport<string>(transport, {
-					method: 'eth_sendRawTransaction',
-					params: [parameters.serializedTransaction],
-				}),
-			),
+		sendRawTransaction: async parameters => {
+			try {
+				return normalizeHash(
+					await requestTransport<string>(transport, {
+						method: 'eth_sendRawTransaction',
+						params: [parameters.serializedTransaction],
+					}),
+				)
+			} catch (error) {
+				if (!isAlreadyKnownTransactionError(error)) throw error
+				return keccak256(parameters.serializedTransaction)
+			}
+		},
 		simulateContract: async parameters =>
 			await baseClient.simulateContract({
 				...parameters,
@@ -1730,17 +1774,27 @@ export function createWalletClient<TTransport extends Transport = Transport, TCh
 	return walletClient
 }
 
-export function http(url: string, _options?: unknown) {
+function normalizeTransportRetryOptions(options: TransportRetryOptions = {}) {
+	const retryCount = options.retryCount ?? DEFAULT_RATE_LIMIT_RETRY_COUNT
+	const retryDelay = options.retryDelay ?? RATE_LIMIT_RETRY_DELAY_MILLISECONDS
+	if (!Number.isSafeInteger(retryCount) || retryCount < 0) throw new Error('RPC retry count must be a non-negative safe integer')
+	if (!Number.isSafeInteger(retryDelay) || retryDelay < 0) throw new Error('RPC retry delay must be a non-negative safe integer')
+	return { retryCount, retryDelay }
+}
+
+export function http(url: string, options?: TransportRetryOptions) {
 	return {
 		kind: 'http',
+		...normalizeTransportRetryOptions(options),
 		url,
 	} satisfies Transport
 }
 
-export function custom(provider: EIP1193Provider, _options?: unknown) {
+export function custom(provider: EIP1193Provider, options?: TransportRetryOptions) {
 	return {
 		kind: 'custom',
 		provider,
+		...normalizeTransportRetryOptions(options),
 	} satisfies Transport
 }
 


### PR DESCRIPTION
## Summary

- centralize HTTP 429 retries for all shared RPC transport methods
- wait 10 seconds between retries while preserving receipt timeout handling
- recover safely when a repeated raw transaction is already known
- refresh the generated shared runtime before `deploy:testnet` runs

## Validation

- `bun test shared/ts/ethereum.test.ts --timeout 30000` — 22 passed
- `bun run tsc`
- `bun run ensure-contract-artifacts && bun run check:shared-dependencies && bun run test:run -- --bail=1` — 2,802 passed, 16 opt-in external tests skipped
- `bun run format:check`
- `bun run check`
- `bun run knip`
- `bun run check:generated-clean`
- `bun run deploy:testnet -- --help`
- `git diff --check`

The skipped tests require explicit external Uniswap/mainnet integration or fork flags. This change does not affect rendered UI, so browser QA and screenshots are not applicable.

Final isolated review: 98/100, no findings.