### PR TITLE
Improve testnet deployment log hierarchy

### DIFF
--- a/scripts/deploy-testnet.mts
+++ b/scripts/deploy-testnet.mts
@@ -116,6 +116,24 @@ type CodeReader = {
 	getCode: (parameters: { address: Address }) => Promise<Hex | undefined>
 }
 
+function formatDeploymentLogBranch(title: string, fields: readonly (readonly [label: string, value: string])[]) {
+	const lines = [`  ├─ ${title}`]
+	for (const [index, [label, value]] of fields.entries()) {
+		const connector = index === fields.length - 1 ? '└─' : '├─'
+		lines.push(`  │  ${connector} ${label}: ${value}`)
+	}
+	return lines.join('\n')
+}
+
+function formatLogSection(title: string, fields: readonly (readonly [label: string, value: string])[]) {
+	const lines = [title]
+	for (const [index, [label, value]] of fields.entries()) {
+		const connector = index === fields.length - 1 ? '└─' : '├─'
+		lines.push(`  ${connector} ${label}: ${value}`)
+	}
+	return lines.join('\n')
+}
+
 function option(name: string, argv = process.argv.slice(2)) {
 	const prefix = `--${name}=`
 	return argv.find(argument => argument.startsWith(prefix))?.slice(prefix.length)
@@ -275,7 +293,7 @@ type DeploymentBudget = ReturnType<typeof createDeploymentBudget>
 export function createBudgetedTransactionSender(wallet: BudgetedWallet, account: Account, limits: { budget?: DeploymentBudget; maxFeePerGas: bigint; maxTotalCost: bigint }, log: (message: string) => void = () => undefined) {
 	const budget = limits.budget ?? createDeploymentBudget(limits.maxTotalCost)
 	const sendTransaction: WriteClient['sendTransaction'] = async transaction => {
-		log(`transaction prepare account=${account.address} fetching_nonce_and_fees`)
+		log(formatDeploymentLogBranch('Prepare transaction', [['Account', account.address]]))
 		const [nonce, gasPrice, block] = await Promise.all([wallet.getTransactionCount({ address: account.address, blockTag: 'pending' }), wallet.getGasPrice(), wallet.getBlock()])
 		const baseFeePerGas = block.baseFeePerGas
 		if (baseFeePerGas === undefined) throw new Error('Deployment transactions require an EIP-1559 base fee')
@@ -284,7 +302,14 @@ export function createBudgetedTransactionSender(wallet: BudgetedWallet, account:
 		const maxPriorityFeePerGas = gasPrice > baseFeePerGas ? gasPrice - baseFeePerGas : 0n
 		const candidateMaxFeePerGas = baseFeePerGas * 2n + maxPriorityFeePerGas
 		const maxFeePerGas = candidateMaxFeePerGas > limits.maxFeePerGas ? limits.maxFeePerGas : candidateMaxFeePerGas
-		log(`transaction estimate nonce=${nonce.toString()} base_fee=${formatEther(baseFeePerGas * 1_000_000_000n)} gwei priority_fee=${formatEther(maxPriorityFeePerGas * 1_000_000_000n)} gwei max_fee=${formatEther(maxFeePerGas * 1_000_000_000n)} gwei`)
+		log(
+			formatDeploymentLogBranch('Estimate transaction', [
+				['Nonce', nonce.toString()],
+				['Base fee', `${formatEther(baseFeePerGas * 1_000_000_000n)} gwei`],
+				['Priority fee', `${formatEther(maxPriorityFeePerGas * 1_000_000_000n)} gwei`],
+				['Maximum fee', `${formatEther(maxFeePerGas * 1_000_000_000n)} gwei`],
+			]),
+		)
 		const gas = paddedGas(
 			await wallet.estimateGas({
 				account: account.address,
@@ -298,7 +323,15 @@ export function createBudgetedTransactionSender(wallet: BudgetedWallet, account:
 		const transactionValue = transaction.value ?? transaction.amount ?? 0n
 		const worstCaseCost = gas * maxFeePerGas + transactionValue
 		budget.recordWalletTransaction(worstCaseCost)
-		log(`transaction submit nonce=${nonce.toString()} to=${transaction.to ?? 'contract_creation'} gas=${gas.toString()} value=${formatEther(transactionValue)} ETH worst_case_cost=${formatEther(worstCaseCost)} ETH`)
+		log(
+			formatDeploymentLogBranch('Submit transaction', [
+				['Nonce', nonce.toString()],
+				['To', transaction.to ?? 'contract creation'],
+				['Gas limit', gas.toString()],
+				['Value', `${formatEther(transactionValue)} ETH`],
+				['Maximum cost', `${formatEther(worstCaseCost)} ETH`],
+			]),
+		)
 		const hash = await wallet.sendTransaction({
 			...transaction,
 			account,
@@ -308,7 +341,12 @@ export function createBudgetedTransactionSender(wallet: BudgetedWallet, account:
 			maxPriorityFeePerGas,
 			nonce,
 		})
-		log(`transaction submitted nonce=${nonce.toString()} hash=${hash}`)
+		log(
+			formatDeploymentLogBranch('Transaction submitted', [
+				['Nonce', nonce.toString()],
+				['Transaction', hash],
+			]),
+		)
 		return hash
 	}
 	return sendTransaction
@@ -317,12 +355,24 @@ export function createBudgetedTransactionSender(wallet: BudgetedWallet, account:
 export function createDeploymentReceiptWaiter(client: Pick<WriteClient, 'waitForTransactionReceipt'>, log: (message: string) => void = () => undefined) {
 	const waitForTransactionReceipt: WriteClient['waitForTransactionReceipt'] = async parameters => {
 		const timeout = parameters.timeout ?? DEPLOYMENT_RECEIPT_TIMEOUT_MILLISECONDS
-		log(`receipt wait hash=${parameters.hash} timeout=${(timeout / 1_000).toString()}s`)
+		log(
+			formatDeploymentLogBranch('Wait for receipt', [
+				['Transaction', parameters.hash],
+				['Timeout', `${(timeout / 1_000).toString()}s`],
+			]),
+		)
 		const receipt = await client.waitForTransactionReceipt({
 			...parameters,
 			timeout,
 		})
-		log(`receipt confirmed hash=${receipt.transactionHash} status=${receipt.status} block=${receipt.blockNumber.toString()} gas_used=${receipt.gasUsed.toString()}`)
+		log(
+			formatDeploymentLogBranch('Receipt confirmed', [
+				['Transaction', receipt.transactionHash],
+				['Status', receipt.status],
+				['Block', receipt.blockNumber.toString()],
+				['Gas used', receipt.gasUsed.toString()],
+			]),
+		)
 		return receipt
 	}
 	return waitForTransactionReceipt
@@ -425,23 +475,33 @@ export async function runDeploymentPlan<TClient extends CodeReader>(steps: reado
 		if (await assertDeploymentPlanStepRuntimeCode(step, client, await client.getCode({ address: step.address }))) {
 			completed.add(step.id)
 			results.push({ address: step.address, id: step.id, label: step.label, status: 'skipped', transactionHash: undefined })
-			log(`skip ${step.id} ${step.address}`)
+			log(
+				formatLogSection(`${step.label} (${step.id})`, [
+					['Address', step.address],
+					['Status', 'already deployed'],
+				]),
+			)
 			continue
 		}
 
-		log(`deploy ${step.id} ${step.address}`)
-		const transactionHash = await step.deploy(client)
-		const code = await client.getCode({ address: step.address })
-		if (!hasCode(code)) throw new Error(`${step.label} deployment transaction ${transactionHash} succeeded without installing code at ${step.address}`)
-		await assertDeploymentPlanStepRuntimeCode(step, client, code)
-		completed.add(step.id)
-		if (transactionHash === ZERO_HASH) {
-			results.push({ address: step.address, id: step.id, label: step.label, status: 'skipped', transactionHash: undefined })
-			log(`skip ${step.id} ${step.address} installed without a submitted transaction`)
-			continue
+		log(`${step.label} (${step.id})\n  ├─ Address: ${step.address}`)
+		try {
+			const transactionHash = await step.deploy(client)
+			const code = await client.getCode({ address: step.address })
+			if (!hasCode(code)) throw new Error(`${step.label} deployment transaction ${transactionHash} succeeded without installing code at ${step.address}`)
+			await assertDeploymentPlanStepRuntimeCode(step, client, code)
+			completed.add(step.id)
+			if (transactionHash === ZERO_HASH) {
+				results.push({ address: step.address, id: step.id, label: step.label, status: 'skipped', transactionHash: undefined })
+				log('  └─ Status: ready (installed without a submitted transaction)')
+				continue
+			}
+			results.push({ address: step.address, id: step.id, label: step.label, status: 'deployed', transactionHash })
+			log(`  ├─ Transaction: ${transactionHash}\n  └─ Status: deployed`)
+		} catch (error) {
+			log('  └─ Status: failed')
+			throw error
 		}
-		results.push({ address: step.address, id: step.id, label: step.label, status: 'deployed', transactionHash })
-		log(`deployed ${step.id} ${transactionHash}`)
 	}
 	return results
 }
@@ -543,7 +603,14 @@ export async function deployTestnet(parameters: { chainId: number; maxFeePerGas?
 	}
 	const plan = createCompleteDeploymentPlan(profile, uniswap)
 	const estimate = await preflightDeploymentPlan(plan, client, CONSERVATIVE_DEPLOYMENT_GAS, authorizedMaxFeePerGas, authorizedMaxTotalCost)
-	log(`preflight missing=${estimate.missingStepIds.length.toString()} estimated_upper_bound=${formatEther(estimate.estimatedCostAttoEth)} ETH max_total=${formatEther(authorizedMaxTotalCost)} ETH fee_ceiling=${formatEther(authorizedMaxFeePerGas * 1_000_000_000n)} gwei`)
+	log(
+		formatLogSection('Preflight', [
+			['Missing contracts', estimate.missingStepIds.length.toString()],
+			['Estimated maximum cost', `${formatEther(estimate.estimatedCostAttoEth)} ETH`],
+			['Authorized total', `${formatEther(authorizedMaxTotalCost)} ETH`],
+			['Fee ceiling', `${formatEther(authorizedMaxFeePerGas * 1_000_000_000n)} gwei`],
+		]),
+	)
 	if (!hasCode(proxyCode)) {
 		const activity = await getProxyDeployerActivity(client)
 		if (activity.pending) throw new Error('The deterministic proxy deployer has pending funding or deployment activity. Wait for it to settle, then retry.')
@@ -556,7 +623,12 @@ export async function deployTestnet(parameters: { chainId: number; maxFeePerGas?
 		}
 	}
 
-	log(`network chain=${chainId.toString()} deployer=${client.account.address}`)
+	log(
+		formatLogSection('Network', [
+			['Chain ID', chainId.toString()],
+			['Deployer', client.account.address],
+		]),
+	)
 	const results = await runDeploymentPlan(plan, client, log)
 	await assertProxyCode(client)
 	const bootstrapDescendants = await assertBootstrapDescendantCode(client, profile)

--- a/scripts/deploy-testnet.test.ts
+++ b/scripts/deploy-testnet.test.ts
@@ -182,7 +182,12 @@ describe('testnet deployment inputs', () => {
 
 		expect(DEPLOYMENT_RECEIPT_TIMEOUT_MILLISECONDS).toBe(60 * 60 * 1_000)
 		expect(requests.map(request => request.timeout)).toEqual([DEPLOYMENT_RECEIPT_TIMEOUT_MILLISECONDS, 12_345])
-		expect(logs).toEqual([`receipt wait hash=${FIRST_HASH} timeout=3600s`, `receipt confirmed hash=${FIRST_HASH} status=success block=99 gas_used=123456`, `receipt wait hash=${SECOND_HASH} timeout=12.345s`, `receipt confirmed hash=${SECOND_HASH} status=success block=99 gas_used=123456`])
+		expect(logs).toEqual([
+			`  ├─ Wait for receipt\n  │  ├─ Transaction: ${FIRST_HASH}\n  │  └─ Timeout: 3600s`,
+			`  ├─ Receipt confirmed\n  │  ├─ Transaction: ${FIRST_HASH}\n  │  ├─ Status: success\n  │  ├─ Block: 99\n  │  └─ Gas used: 123456`,
+			`  ├─ Wait for receipt\n  │  ├─ Transaction: ${SECOND_HASH}\n  │  └─ Timeout: 12.345s`,
+			`  ├─ Receipt confirmed\n  │  ├─ Transaction: ${SECOND_HASH}\n  │  ├─ Status: success\n  │  ├─ Block: 99\n  │  └─ Gas used: 123456`,
+		])
 	})
 
 	test('enforces chain and RPC safety at the transaction-capable entry point', async () => {
@@ -224,10 +229,10 @@ describe('testnet deployment transaction authorization', () => {
 		expect(await send({ to: FIRST_ADDRESS, value: 1n })).toBe(FIRST_HASH)
 		expect(submitted).toMatchObject({ gas: 130_000n, gasPrice: undefined, maxFeePerGas: 30n, maxPriorityFeePerGas: 10n, nonce: 7n, to: FIRST_ADDRESS, value: 1n })
 		expect(logs).toEqual([
-			`transaction prepare account=${account.address} fetching_nonce_and_fees`,
-			'transaction estimate nonce=7 base_fee=0.00000001 gwei priority_fee=0.00000001 gwei max_fee=0.00000003 gwei',
-			`transaction submit nonce=7 to=${FIRST_ADDRESS} gas=130000 value=0.000000000000000001 ETH worst_case_cost=0.000000000003900001 ETH`,
-			`transaction submitted nonce=7 hash=${FIRST_HASH}`,
+			`  ├─ Prepare transaction\n  │  └─ Account: ${account.address}`,
+			'  ├─ Estimate transaction\n  │  ├─ Nonce: 7\n  │  ├─ Base fee: 0.00000001 gwei\n  │  ├─ Priority fee: 0.00000001 gwei\n  │  └─ Maximum fee: 0.00000003 gwei',
+			`  ├─ Submit transaction\n  │  ├─ Nonce: 7\n  │  ├─ To: ${FIRST_ADDRESS}\n  │  ├─ Gas limit: 130000\n  │  ├─ Value: 0.000000000000000001 ETH\n  │  └─ Maximum cost: 0.000000000003900001 ETH`,
+			`  ├─ Transaction submitted\n  │  ├─ Nonce: 7\n  │  └─ Transaction: ${FIRST_HASH}`,
 		])
 	})
 
@@ -445,6 +450,7 @@ describe('testnet deployment plan', () => {
 	test('skips existing code and deploys missing dependent steps in order', async () => {
 		const code = new Map<Address, Hex>([[FIRST_ADDRESS, '0x01']])
 		const deployed: string[] = []
+		const logs: string[] = []
 		const client = {
 			getCode: async ({ address }: { address: Address }) => code.get(address),
 		}
@@ -472,7 +478,7 @@ describe('testnet deployment plan', () => {
 				},
 			],
 			client,
-			() => undefined,
+			message => logs.push(message),
 		)
 
 		expect(deployed).toEqual(['second'])
@@ -480,6 +486,7 @@ describe('testnet deployment plan', () => {
 			{ address: FIRST_ADDRESS, id: 'first', label: 'First', status: 'skipped', transactionHash: undefined },
 			{ address: SECOND_ADDRESS, id: 'second', label: 'Second', status: 'deployed', transactionHash: SECOND_HASH },
 		])
+		expect(logs).toEqual([`First (first)\n  ├─ Address: ${FIRST_ADDRESS}\n  └─ Status: already deployed`, `Second (second)\n  ├─ Address: ${SECOND_ADDRESS}`, `  ├─ Transaction: ${SECOND_HASH}\n  └─ Status: deployed`])
 	})
 
 	test('reports code installed without a submitted transaction as skipped', async () => {
@@ -504,7 +511,7 @@ describe('testnet deployment plan', () => {
 		)
 
 		expect(results).toEqual([{ address: FIRST_ADDRESS, id: 'proxyDeployer', label: 'Proxy Deployer', status: 'skipped', transactionHash: undefined }])
-		expect(logs).toEqual([`deploy proxyDeployer ${FIRST_ADDRESS}`, `skip proxyDeployer ${FIRST_ADDRESS} installed without a submitted transaction`])
+		expect(logs).toEqual([`Proxy Deployer (proxyDeployer)\n  ├─ Address: ${FIRST_ADDRESS}`, '  └─ Status: ready (installed without a submitted transaction)'])
 		expect(logs.join('\n')).not.toContain(ZERO_HASH)
 	})
 
@@ -512,6 +519,7 @@ describe('testnet deployment plan', () => {
 		const client = {
 			getCode: async () => undefined,
 		}
+		const logs: string[] = []
 		await expect(
 			runDeploymentPlan(
 				[
@@ -542,9 +550,33 @@ describe('testnet deployment plan', () => {
 					},
 				],
 				client,
-				() => undefined,
+				message => logs.push(message),
 			),
 		).rejects.toThrow('succeeded without installing code')
+		expect(logs).toEqual([`First (first)\n  ├─ Address: ${FIRST_ADDRESS}`, '  └─ Status: failed'])
+	})
+
+	test('closes the contract log when deployment fails', async () => {
+		const logs: string[] = []
+		await expect(
+			runDeploymentPlan(
+				[
+					{
+						address: FIRST_ADDRESS,
+						dependencies: [],
+						deploy: async () => {
+							throw new Error('RPC unavailable')
+						},
+						expectedRuntimeCodeHash: keccak256('0x01'),
+						id: 'first',
+						label: 'First',
+					},
+				],
+				{ getCode: async () => undefined },
+				message => logs.push(message),
+			),
+		).rejects.toThrow('RPC unavailable')
+		expect(logs).toEqual([`First (first)\n  ├─ Address: ${FIRST_ADDRESS}`, '  └─ Status: failed'])
 	})
 
 	test('rejects incorrect code at direct deployment and descendant addresses', async () => {


### PR DESCRIPTION
## Summary

- group deployment output by contract and transaction lifecycle
- label fee, gas, receipt, and status fields for easier scanning
- close successful, skipped, canonical no-transaction, and failed deployment trees with explicit statuses
- add exact-output regression coverage for each lifecycle path

## Validation

- `bun test scripts/deploy-testnet.test.ts --bail`
- `bun run tsc`
- `bun run format:check`
- `bun run check:changed`
- `bun run knip`
- `git diff --check`

## Review

- final read-only review: 98/100, no findings
- UI screenshots are not applicable because this changes terminal output only