### PR TITLE
Refresh contract artifacts before testnet deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
 		"ui:serve": "bun run app:serve",
 		"ui:vendor": "cd ui && bun ./build/vendor.mts",
 		"cleanup:foundry-anvil-state": "bun ./scripts/cleanup-foundry-anvil-state.mts",
-		"deploy:testnet": "bun run ensure-shared-build && bun run refresh:shared-dependencies && bun ./scripts/deploy-testnet.mts",
+		"deploy:testnet": "bun run ensure-contract-artifacts && bun run refresh:shared-dependencies && bun ./scripts/deploy-testnet.mts",
 		"gas-costs": "cd solidity && bun run gas-costs",
 		"test": "bun run ensure-contract-artifacts && bun run check:shared-dependencies && bun run tsc && bun run test:run",
 		"test:run": "bun ./scripts/run-tests.mts",

--- a/scripts/deploy-testnet.test.ts
+++ b/scripts/deploy-testnet.test.ts
@@ -116,6 +116,11 @@ describe('testnet deployment inputs', () => {
 		}
 	})
 
+	test('refreshes contract artifacts before loading the deployment script', async () => {
+		const packageJson = await Bun.file(new URL('../package.json', import.meta.url)).json()
+		expect(packageJson.scripts?.['deploy:testnet']).toStartWith('bun run ensure-contract-artifacts &&')
+	})
+
 	test('refuses to start a deployment while its account has a pending transaction', async () => {
 		await expect(
 			assertNoPendingDeployerTransactions(


### PR DESCRIPTION
## Summary

- refresh Solidity and UI contract artifacts before loading the testnet deployment script
- preserve shared dependency synchronization after artifact freshness checks
- add regression coverage for the deployment command ordering

## Why

`deploy:testnet` previously refreshed only shared outputs. Because the deployment script statically imports the ignored UI contract artifact, a stale artifact could determine both CREATE2 addresses and deployed bytecode while runtime verification used current pinned hashes. This caused a stale OpenOracle build to be deployed on Sepolia before the exact runtime hash check rejected it.

Running `ensure-contract-artifacts` before the deployment module loads keeps address derivation, deployed bytecode, and pinned runtime verification in sync.

## Validation

- failing-first focused regression test
- `bun run tsc`
- `bun run ensure-contract-artifacts && bun run check:shared-dependencies && bun run test:run -- --bail=1`
- `bun run format:check`
- `bun run check`
- `bun run knip`
- `git diff --check`

Final read-only review: 100/100, no findings.

## UI evidence

Not applicable; this change affects deployment command wiring and tests only.