### PR TITLE
Validate deployment artifact runtime hashes

### DIFF
--- a/scripts/deploy-testnet.mts
+++ b/scripts/deploy-testnet.mts
@@ -6,7 +6,16 @@ import * as process from 'node:process'
 import * as url from 'node:url'
 import { createWalletClient, defineChain, formatEther, http, keccak256, parseUnits, privateKeyToAccount, type Account, type Address, type Chain, type Hash, type Hex } from '@zoltar/shared/ethereum'
 import { getBootstrapDescendantAddresses } from '../ui/ts/protocol/deploymentHelpers.ts'
-import { CANONICAL_DEPLOYER_RAW_GAS_PRICE, CANONICAL_DEPLOYER_RAW_TRANSACTION_COST, EXPECTED_SEPOLIA_DEPLOYMENT_RUNTIME_CODE_HASHES, getDeploymentSteps, getProxyDeployerActivity, getProxyDeployerFundingShortfall, PROXY_DEPLOYER_RUNTIME_CODE } from '../ui/ts/protocol/deployment.ts'
+import {
+	assertStaticDeploymentArtifactRuntimeCodeHashes,
+	CANONICAL_DEPLOYER_RAW_GAS_PRICE,
+	CANONICAL_DEPLOYER_RAW_TRANSACTION_COST,
+	EXPECTED_SEPOLIA_DEPLOYMENT_RUNTIME_CODE_HASHES,
+	getDeploymentSteps,
+	getProxyDeployerActivity,
+	getProxyDeployerFundingShortfall,
+	PROXY_DEPLOYER_RUNTIME_CODE,
+} from '../ui/ts/protocol/deployment.ts'
 import { PROXY_DEPLOYER_ADDRESS } from '../ui/ts/protocol/deploymentHelpers.ts'
 import { SEPOLIA_NETWORK_PROFILE, type NetworkProfile } from '../ui/ts/lib/networkProfile.ts'
 import type { WriteClient } from '../ui/ts/lib/chainBackend.ts'
@@ -575,6 +584,7 @@ async function writeGitHubSummary(chainId: number, account: Address, results: re
 }
 
 export async function deployTestnet(parameters: { chainId: number; maxFeePerGas?: bigint; maxTotalCost?: bigint; privateKey: Hex; rpcUrl: string; log?: (message: string) => void; writeGitHubSummary?: boolean }) {
+	assertStaticDeploymentArtifactRuntimeCodeHashes()
 	const chainId = parseChainId(parameters.chainId.toString())
 	const rpcUrl = parseRpcUrl(parameters.rpcUrl)
 	const log = parameters.log ?? console.log

--- a/ui/ts/protocol/deployment.ts
+++ b/ui/ts/protocol/deployment.ts
@@ -4,8 +4,11 @@ import { createDeploymentStatusOracleAddressHelper } from '@zoltar/shared/deploy
 import {
 	DeploymentStatusOracle_DeploymentStatusOracle,
 	ScalarOutcomes_ScalarOutcomes,
+	ZoltarQuestionData_ZoltarQuestionData,
 	peripherals_EscalationGameClaimDelegate_EscalationGameClaimDelegate,
+	peripherals_Multicall3_Multicall3,
 	peripherals_SecurityPoolUtils_SecurityPoolUtils,
+	peripherals_WETH9_WETH9,
 	peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory,
 	peripherals_openOracle_OpenOracle_OpenOracle,
 } from '../contractArtifact.js'
@@ -56,6 +59,34 @@ export const EXPECTED_SEPOLIA_DEPLOYMENT_RUNTIME_CODE_HASHES: Readonly<Record<De
 	zoltar: '0xab10fc74b97acd4e7a97007283f9f341ddfa81cf894fdfe5c9caf0bb939946b2',
 	zoltarQuestionData: '0xcacb1ffe2a738ceda0aced156f7ff50b405b57d66a6c1307e5d8ff87789a4340',
 }
+
+export const STATIC_DEPLOYMENT_ARTIFACT_RUNTIME_CODE_BY_STEP_ID = {
+	deploymentStatusOracle: `0x${DeploymentStatusOracle_DeploymentStatusOracle.evm.deployedBytecode.object}`,
+	escalationGameClaimDelegate: `0x${peripherals_EscalationGameClaimDelegate_EscalationGameClaimDelegate.evm.deployedBytecode.object}`,
+	multicall3: `0x${peripherals_Multicall3_Multicall3.evm.deployedBytecode.object}`,
+	openOracle: `0x${peripherals_openOracle_OpenOracle_OpenOracle.evm.deployedBytecode.object}`,
+	scalarOutcomes: `0x${ScalarOutcomes_ScalarOutcomes.evm.deployedBytecode.object}`,
+	uniformPriceDualCapBatchAuctionFactory: `0x${peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory.evm.deployedBytecode.object}`,
+	weth: `0x${peripherals_WETH9_WETH9.evm.deployedBytecode.object}`,
+	zoltarQuestionData: `0x${ZoltarQuestionData_ZoltarQuestionData.evm.deployedBytecode.object}`,
+} satisfies Readonly<Partial<Record<DeploymentStepId, Hex>>>
+
+export function assertStaticDeploymentArtifactRuntimeCodeHashes(
+	parameters: { expectedRuntimeCodeHashes: Readonly<Record<string, Hash | undefined>>; runtimeCodeByStepId: Readonly<Record<string, Hex>> } = {
+		expectedRuntimeCodeHashes: EXPECTED_SEPOLIA_DEPLOYMENT_RUNTIME_CODE_HASHES,
+		runtimeCodeByStepId: STATIC_DEPLOYMENT_ARTIFACT_RUNTIME_CODE_BY_STEP_ID,
+	},
+) {
+	for (const [id, runtimeCode] of Object.entries(parameters.runtimeCodeByStepId)) {
+		const expectedRuntimeCodeHash = parameters.expectedRuntimeCodeHashes[id]
+		if (expectedRuntimeCodeHash === undefined) throw new Error(`Static deployment artifact ${id} has no pinned expected runtime code hash`)
+		const artifactRuntimeCodeHash = keccak256(runtimeCode)
+		if (artifactRuntimeCodeHash !== expectedRuntimeCodeHash) {
+			throw new Error(`Local runtime code for ${id} does not match its pinned expected hash: expected ${expectedRuntimeCodeHash}, artifact contains ${artifactRuntimeCodeHash}. Run bun run compile-contracts and refresh the pinned deployment hashes if the bytecode change is intentional.`)
+		}
+	}
+}
+
 const EXPECTED_MAINNET_DEPLOYMENT_RUNTIME_CODE_HASHES: Readonly<Partial<Record<DeploymentStepId, Hash>>> = {
 	deploymentStatusOracle: '0xa8385e5704060e4e97fdaba0f7bf6ef692162bacc83533ebd616b455d2b190e1',
 	escalationGameClaimDelegate: '0x08ab4e84d9d88edd1d398d2554b85e1f1b969bb6a815370cc8dbae60a93d4360',

--- a/ui/ts/tests/protocol/deployment.test.ts
+++ b/ui/ts/tests/protocol/deployment.test.ts
@@ -14,7 +14,7 @@ import { createFakeBackend, createFakeSimulationProfile } from '../testUtils/fak
 import { MAINNET_NETWORK_PROFILE, SEPOLIA_NETWORK_PROFILE } from '../../lib/networkProfile.js'
 import { SEPOLIA_GENESIS_REP_INIT_CODE, SEPOLIA_WETH_INIT_CODE } from '../../lib/sepoliaDeploymentConfig.js'
 import { DeploymentStatusOracle_DeploymentStatusOracle, ScalarOutcomes_ScalarOutcomes, peripherals_factories_UniformPriceDualCapBatchAuctionFactory_UniformPriceDualCapBatchAuctionFactory } from '../../contractArtifact.js'
-import { ATOMIC_FUNDING_BYTECODE, ATOMIC_FUNDING_SOURCE, EXPECTED_SEPOLIA_DEPLOYMENT_RUNTIME_CODE_HASHES, PROXY_DEPLOYER_RUNTIME_CODE } from '../../protocol/deployment.js'
+import { ATOMIC_FUNDING_BYTECODE, ATOMIC_FUNDING_SOURCE, EXPECTED_SEPOLIA_DEPLOYMENT_RUNTIME_CODE_HASHES, PROXY_DEPLOYER_RUNTIME_CODE, STATIC_DEPLOYMENT_ARTIFACT_RUNTIME_CODE_BY_STEP_ID, assertStaticDeploymentArtifactRuntimeCodeHashes } from '../../protocol/deployment.js'
 
 const require = createRequire(import.meta.url)
 const rootSolcPath = fileURLToPath(new URL('../../../../node_modules/solc/index.js', import.meta.url))
@@ -68,6 +68,17 @@ function createMockReadClient({ getCode, readContract }: { getCode: MockReadClie
 }
 
 describe('contract deployment internals', () => {
+	test('rejects generated deployment artifacts that do not match the pinned runtime hashes', () => {
+		expect(Object.keys(STATIC_DEPLOYMENT_ARTIFACT_RUNTIME_CODE_BY_STEP_ID).sort()).toEqual(['deploymentStatusOracle', 'escalationGameClaimDelegate', 'multicall3', 'openOracle', 'scalarOutcomes', 'uniformPriceDualCapBatchAuctionFactory', 'weth', 'zoltarQuestionData'])
+		expect(() => assertStaticDeploymentArtifactRuntimeCodeHashes()).not.toThrow()
+		expect(() =>
+			assertStaticDeploymentArtifactRuntimeCodeHashes({
+				expectedRuntimeCodeHashes: { openOracle: keccak256('0x01') },
+				runtimeCodeByStepId: { openOracle: '0x02' },
+			}),
+		).toThrow('Local runtime code for openOracle does not match its pinned expected hash')
+	})
+
 	test('atomic canonical-signer funding bytecode matches its pinned source and compiler settings', () => {
 		const output = requireRecord(
 			JSON.parse(


### PR DESCRIPTION
## Summary

- validate statically hashable generated deployment runtimes against pinned Sepolia hashes before RPC or deployment work
- cover OpenOracle and every other eligible static deployment artifact
- reject stale artifacts with an actionable error and regression coverage

## Why

A stale OpenOracle artifact could pass the freshness cache, derive an old CREATE2 address, and only fail after encountering its deployed runtime on Sepolia. This adds a bytecode-integrity check at the deployment entry point so the mismatch is reported locally before any network work.

## Validation

- bun run tsc
- 71 focused deployment tests passed
- bun run format:check
- bun run check:changed
- bun run knip
- git diff --check
- full suite reached 2,594 passes and one Chromium DevTools timeout under parallel load; the exact timed-out browser test passed when rerun alone
- final read-only review: 98/100, no findings

## UI

No rendered UI changes; screenshots are not applicable.