### PR TITLE
Retry deployment verification across stale RPC state

### DIFF
--- a/scripts/deploy-testnet.mts
+++ b/scripts/deploy-testnet.mts
@@ -19,7 +19,8 @@ import {
 import { PROXY_DEPLOYER_ADDRESS } from '../ui/ts/protocol/deploymentHelpers.ts'
 import { SEPOLIA_NETWORK_PROFILE, type NetworkProfile } from '../ui/ts/lib/networkProfile.ts'
 import type { WriteClient } from '../ui/ts/lib/chainBackend.ts'
-import { ARACHNID_CREATE2_DEPLOYER_ADDRESS, ARACHNID_CREATE2_DEPLOYER_RUNTIME_CODE, getUniswapDeployment, type UniswapDeployment } from './uniswap-deployment.mts'
+import { readWithRpcStateRetries, type RpcStateRetryWait } from '../ui/ts/protocol/core.ts'
+import { ARACHNID_CREATE2_DEPLOYER_ADDRESS, ARACHNID_CREATE2_DEPLOYER_RUNTIME_CODE, getUniswapDeployment, resolveCanonicalCreate2DeployerForPreflight, type UniswapDeployment } from './uniswap-deployment.mts'
 
 const DEFAULT_CHAIN_ID = 11_155_111
 export const DEFAULT_MAX_FEE_PER_GAS_GWEI = '100'
@@ -475,13 +476,13 @@ async function assertDeploymentPlanStepRuntimeCode<TClient>(step: DeploymentPlan
 	return assertExpectedRuntimeCode(step.id, step.address, code, step.expectedRuntimeCodeHash)
 }
 
-export async function runDeploymentPlan<TClient extends CodeReader>(steps: readonly DeploymentPlanStep<TClient>[], client: TClient, log: (message: string) => void = console.log): Promise<DeploymentStepResult[]> {
+export async function runDeploymentPlan<TClient extends CodeReader>(steps: readonly DeploymentPlanStep<TClient>[], client: TClient, log: (message: string) => void = console.log, wait?: RpcStateRetryWait, knownInstalledAddresses: ReadonlySet<Address> = new Set()): Promise<DeploymentStepResult[]> {
 	const completed = new Set<string>()
 	const results: DeploymentStepResult[] = []
 	for (const step of steps) {
 		const missingDependency = step.dependencies.find(dependency => !completed.has(dependency))
 		if (missingDependency !== undefined) throw new Error(`${step.label} requires incomplete deployment step ${missingDependency}`)
-		if (await assertDeploymentPlanStepRuntimeCode(step, client, await client.getCode({ address: step.address }))) {
+		if (knownInstalledAddresses.has(step.address) || (await assertDeploymentPlanStepRuntimeCode(step, client, await client.getCode({ address: step.address })))) {
 			completed.add(step.id)
 			results.push({ address: step.address, id: step.id, label: step.label, status: 'skipped', transactionHash: undefined })
 			log(
@@ -496,7 +497,7 @@ export async function runDeploymentPlan<TClient extends CodeReader>(steps: reado
 		log(`${step.label} (${step.id})\n  ├─ Address: ${step.address}`)
 		try {
 			const transactionHash = await step.deploy(client)
-			const code = await client.getCode({ address: step.address })
+			const code = await readWithRpcStateRetries(() => client.getCode({ address: step.address }), hasCode, wait)
 			if (!hasCode(code)) throw new Error(`${step.label} deployment transaction ${transactionHash} succeeded without installing code at ${step.address}`)
 			await assertDeploymentPlanStepRuntimeCode(step, client, code)
 			completed.add(step.id)
@@ -515,7 +516,7 @@ export async function runDeploymentPlan<TClient extends CodeReader>(steps: reado
 	return results
 }
 
-export async function preflightDeploymentPlan<TClient extends CodeReader>(steps: readonly DeploymentPlanStep<TClient>[], client: TClient, gasAllowances: Readonly<Record<string, bigint>>, maxFeePerGas: bigint, maxTotalCost: bigint) {
+export async function preflightDeploymentPlan<TClient extends CodeReader>(steps: readonly DeploymentPlanStep<TClient>[], client: TClient, gasAllowances: Readonly<Record<string, bigint>>, maxFeePerGas: bigint, maxTotalCost: bigint, knownInstalledAddresses: ReadonlySet<Address> = new Set()) {
 	const completed = new Set<string>()
 	const missingStepIds: string[] = []
 	let estimatedGas = 0n
@@ -523,7 +524,7 @@ export async function preflightDeploymentPlan<TClient extends CodeReader>(steps:
 	for (const step of steps) {
 		const missingDependency = step.dependencies.find(dependency => !completed.has(dependency))
 		if (missingDependency !== undefined) throw new Error(`${step.label} requires incomplete deployment step ${missingDependency}`)
-		const installed = await assertDeploymentPlanStepRuntimeCode(step, client, await client.getCode({ address: step.address }))
+		const installed = knownInstalledAddresses.has(step.address) || (await assertDeploymentPlanStepRuntimeCode(step, client, await client.getCode({ address: step.address })))
 		completed.add(step.id)
 		if (installed) continue
 		const gasAllowance = gasAllowances[step.id]
@@ -546,6 +547,24 @@ async function assertProxyCode(client: CodeReader) {
 	if (code.toLowerCase() !== PROXY_DEPLOYER_RUNTIME_CODE.toLowerCase()) throw new Error(`Unexpected code at canonical proxy deployer ${PROXY_DEPLOYER_ADDRESS}`)
 }
 
+export async function assertConfirmedProxyCode(client: CodeReader, wait?: RpcStateRetryWait) {
+	const code = await readWithRpcStateRetries(() => client.getCode({ address: PROXY_DEPLOYER_ADDRESS }), hasCode, wait)
+	if (!hasCode(code)) throw new Error('The deterministic proxy deployer signer nonce has already been consumed, but the canonical proxy is missing')
+	if (code.toLowerCase() !== PROXY_DEPLOYER_RUNTIME_CODE.toLowerCase()) throw new Error(`Unexpected code at canonical proxy deployer ${PROXY_DEPLOYER_ADDRESS}`)
+}
+
+export async function resolveCanonicalProxyDeployerForPreflight(client: CodeReader & Pick<WriteClient, 'getBalance' | 'getTransactionCount'>, wait?: RpcStateRetryWait) {
+	const code = await client.getCode({ address: PROXY_DEPLOYER_ADDRESS })
+	if (hasCode(code)) {
+		if (code.toLowerCase() !== PROXY_DEPLOYER_RUNTIME_CODE.toLowerCase()) throw new Error(`Unexpected code at canonical proxy deployer ${PROXY_DEPLOYER_ADDRESS}`)
+		return true
+	}
+	const activity = await getProxyDeployerActivity(client)
+	if (activity.confirmedNonce === 0n) return false
+	await assertConfirmedProxyCode(client, wait)
+	return true
+}
+
 async function assertCanonicalCreate2DeployerCode(client: CodeReader) {
 	const code = await client.getCode({ address: ARACHNID_CREATE2_DEPLOYER_ADDRESS })
 	if (code === undefined || code === '0x') return
@@ -562,16 +581,29 @@ export function createCompleteDeploymentPlan(profile: NetworkProfile, uniswap: U
 	return [create2DeployerStep, permit2Step, proxyDeployerStep, ...uniswapQuoteSteps, ...protocolStepsWithExternalDependencies].map(step => (!('verifyRuntimeCode' in step) || step.verifyRuntimeCode === undefined ? { ...step, expectedRuntimeCodeHash: getExpectedRuntimeCodeHash(step.id) } : step))
 }
 
-export async function assertBootstrapDescendantCode(client: CodeReader, profile: NetworkProfile) {
+export async function assertBootstrapDescendantCode(client: CodeReader, profile: NetworkProfile, wait?: RpcStateRetryWait, expectedRuntimeCodeHashes?: Readonly<Record<string, Hash>>) {
 	const bootstrapDescendants = getBootstrapDescendantAddresses(profile)
 	if (profile.id === 'simulation') throw new Error('Exact bootstrap descendant runtime-code verification is unavailable for simulation')
-	const expectedRuntimeCodeHashes = EXPECTED_BOOTSTRAP_DESCENDANT_RUNTIME_CODE_HASHES[profile.id]
-	for (const [id, address] of Object.entries(bootstrapDescendants)) {
-		const code = await client.getCode({ address })
+	const resolvedExpectedRuntimeCodeHashes = expectedRuntimeCodeHashes ?? EXPECTED_BOOTSTRAP_DESCENDANT_RUNTIME_CODE_HASHES[profile.id]
+	const entries = Object.entries(bootstrapDescendants)
+	const codes = await readWithRpcStateRetries(
+		async () => {
+			const currentCodes = await Promise.all(entries.map(async ([, address]) => await client.getCode({ address })))
+			for (const [index, [id, address]] of entries.entries()) {
+				const code = currentCodes[index]
+				if (!hasCode(code)) continue
+				const expectedRuntimeCodeHash = resolvedExpectedRuntimeCodeHashes[id]
+				if (expectedRuntimeCodeHash === undefined) throw new Error(`Bootstrap descendant ${id} has no expected runtime code hash for ${profile.id}`)
+				assertExpectedRuntimeCode(id, address, code, expectedRuntimeCodeHash)
+			}
+			return currentCodes
+		},
+		currentCodes => currentCodes.every(hasCode),
+		wait,
+	)
+	for (const [index, [id, address]] of entries.entries()) {
+		const code = codes[index]
 		if (!hasCode(code)) throw new Error(`Bootstrap descendant ${id} is missing at ${address}`)
-		const expectedRuntimeCodeHash = expectedRuntimeCodeHashes[id]
-		if (expectedRuntimeCodeHash === undefined) throw new Error(`Bootstrap descendant ${id} has no expected runtime code hash for ${profile.id}`)
-		assertExpectedRuntimeCode(id, address, code, expectedRuntimeCodeHash)
 	}
 	return bootstrapDescendants
 }
@@ -607,12 +639,16 @@ export async function deployTestnet(parameters: { chainId: number; maxFeePerGas?
 	await assertProxyCode(client)
 	const authorizedMaxFeePerGas = parameters.maxFeePerGas ?? parseMaxFeePerGas(undefined)
 	const authorizedMaxTotalCost = parameters.maxTotalCost ?? parseMaxTotalCost(undefined)
-	const [canonicalCreate2Code, proxyCode] = await Promise.all([client.getCode({ address: ARACHNID_CREATE2_DEPLOYER_ADDRESS }), client.getCode({ address: PROXY_DEPLOYER_ADDRESS })])
-	if (authorizedMaxFeePerGas < CANONICAL_DEPLOYER_RAW_GAS_PRICE && (!hasCode(canonicalCreate2Code) || !hasCode(proxyCode))) {
+	const canonicalCreate2Installed = await resolveCanonicalCreate2DeployerForPreflight(client)
+	const proxyInstalled = await resolveCanonicalProxyDeployerForPreflight(client)
+	if (authorizedMaxFeePerGas < CANONICAL_DEPLOYER_RAW_GAS_PRICE && (!canonicalCreate2Installed || !proxyInstalled)) {
 		throw new Error(`MAX_FEE_PER_GAS_GWEI authorizes ${authorizedMaxFeePerGas.toString()} attoETH per gas, but missing canonical deployers require fixed ${CANONICAL_DEPLOYER_RAW_GAS_PRICE.toString()} attoETH per gas raw transactions`)
 	}
 	const plan = createCompleteDeploymentPlan(profile, uniswap)
-	const estimate = await preflightDeploymentPlan(plan, client, CONSERVATIVE_DEPLOYMENT_GAS, authorizedMaxFeePerGas, authorizedMaxTotalCost)
+	const knownInstalledAddresses = new Set<Address>()
+	if (canonicalCreate2Installed) knownInstalledAddresses.add(ARACHNID_CREATE2_DEPLOYER_ADDRESS)
+	if (proxyInstalled) knownInstalledAddresses.add(PROXY_DEPLOYER_ADDRESS)
+	const estimate = await preflightDeploymentPlan(plan, client, CONSERVATIVE_DEPLOYMENT_GAS, authorizedMaxFeePerGas, authorizedMaxTotalCost, knownInstalledAddresses)
 	log(
 		formatLogSection('Preflight', [
 			['Missing contracts', estimate.missingStepIds.length.toString()],
@@ -621,15 +657,17 @@ export async function deployTestnet(parameters: { chainId: number; maxFeePerGas?
 			['Fee ceiling', `${formatEther(authorizedMaxFeePerGas * 1_000_000_000n)} gwei`],
 		]),
 	)
-	if (!hasCode(proxyCode)) {
+	if (!proxyInstalled) {
 		const activity = await getProxyDeployerActivity(client)
 		if (activity.pending) throw new Error('The deterministic proxy deployer has pending funding or deployment activity. Wait for it to settle, then retry.')
 		await assertProxyCode(client)
 		if (!hasCode(await client.getCode({ address: PROXY_DEPLOYER_ADDRESS }))) {
-			if (activity.confirmedNonce !== 0n) throw new Error('The deterministic proxy deployer signer nonce has already been consumed, but the canonical proxy is missing')
-			const fundingShortfall = await getProxyDeployerFundingShortfall(client)
-			const balance = await client.getBalance({ address: client.account.address })
-			if (balance < fundingShortfall) throw new Error(`Deployer ${client.account.address} needs at least ${formatEther(fundingShortfall)} ETH to finish funding the canonical proxy deployer signer`)
+			if (activity.confirmedNonce !== 0n) await assertConfirmedProxyCode(client)
+			else {
+				const fundingShortfall = await getProxyDeployerFundingShortfall(client)
+				const balance = await client.getBalance({ address: client.account.address })
+				if (balance < fundingShortfall) throw new Error(`Deployer ${client.account.address} needs at least ${formatEther(fundingShortfall)} ETH to finish funding the canonical proxy deployer signer`)
+			}
 		}
 	}
 
@@ -639,7 +677,7 @@ export async function deployTestnet(parameters: { chainId: number; maxFeePerGas?
 			['Deployer', client.account.address],
 		]),
 	)
-	const results = await runDeploymentPlan(plan, client, log)
+	const results = await runDeploymentPlan(plan, client, log, undefined, knownInstalledAddresses)
 	await assertProxyCode(client)
 	const bootstrapDescendants = await assertBootstrapDescendantCode(client, profile)
 	if (parameters.writeGitHubSummary !== false) await writeGitHubSummary(chainId, client.account.address, results)

--- a/scripts/deploy-testnet.test.ts
+++ b/scripts/deploy-testnet.test.ts
@@ -3,8 +3,10 @@ import { getAddress, getCreateAddress, keccak256, privateKeyToAccount, type Addr
 import { getBootstrapDescendantAddresses, getInfraContractAddresses } from '../ui/ts/protocol/deploymentHelpers.ts'
 import { SEPOLIA_NETWORK_PROFILE } from '../ui/ts/lib/networkProfile.ts'
 import type { WriteClient } from '../ui/ts/lib/chainBackend.ts'
+import { PROXY_DEPLOYER_RUNTIME_CODE } from '../ui/ts/protocol/deployment.ts'
 import {
 	assertBootstrapDescendantCode,
+	assertConfirmedProxyCode,
 	assertRequiredEvmCompatible,
 	assertEip1559Compatible,
 	assertNoPendingDeployerTransactions,
@@ -23,6 +25,7 @@ import {
 	parsePrivateKey,
 	parseRpcUrl,
 	preflightDeploymentPlan,
+	resolveCanonicalProxyDeployerForPreflight,
 	runDeploymentPlan,
 } from './deploy-testnet.mts'
 import { getUniswapDeployment } from './uniswap-deployment.mts'
@@ -34,6 +37,40 @@ const SECOND_HASH: Hex = '0x0202020202020202020202020202020202020202020202020202
 const ZERO_HASH: Hex = '0x0000000000000000000000000000000000000000000000000000000000000000'
 
 describe('testnet deployment inputs', () => {
+	test('retries canonical proxy code after its signer nonce is confirmed', async () => {
+		let codeReadCount = 0
+		const retryDelays: number[] = []
+		await assertConfirmedProxyCode(
+			{
+				getCode: async () => {
+					codeReadCount += 1
+					return codeReadCount < 2 ? undefined : PROXY_DEPLOYER_RUNTIME_CODE
+				},
+			},
+			async delayMilliseconds => {
+				retryDelays.push(delayMilliseconds)
+			},
+		)
+
+		expect(retryDelays).toEqual([250])
+	})
+
+	test('rejects unexpected proxy code that appears during confirmed-state resolution', async () => {
+		let codeReadCount = 0
+		await expect(
+			resolveCanonicalProxyDeployerForPreflight(
+				{
+					getBalance: async () => 0n,
+					getCode: async () => {
+						codeReadCount += 1
+						return codeReadCount === 1 ? undefined : '0x1234'
+					},
+					getTransactionCount: async () => 1n,
+				},
+				async () => undefined,
+			),
+		).rejects.toThrow('Unexpected code at canonical proxy deployer')
+	})
 	test('defaults the chain ID to Sepolia and requires an explicitly selected RPC', () => {
 		expect(parseChainId(undefined)).toBe(11_155_111)
 		expect(() => parseRpcUrl(undefined)).toThrow('RPC_URL or --rpc-url is required')
@@ -398,6 +435,28 @@ describe('testnet deployment plan', () => {
 		expect(estimate.estimatedCostAttoEth).toBe(10_000_000_000_005_000n)
 	})
 
+	test('does not charge restrictive resume budgets for canonical code already resolved through a lagging RPC', async () => {
+		const estimate = await preflightDeploymentPlan(
+			[
+				{
+					address: FIRST_ADDRESS,
+					dependencies: [],
+					deploy: async () => FIRST_HASH,
+					expectedRuntimeCodeHash: keccak256('0x01'),
+					id: 'proxyDeployer',
+					label: 'Proxy Deployer',
+				},
+			],
+			{ getCode: async () => undefined },
+			{ proxyDeployer: 500n },
+			1n,
+			1n,
+			new Set([FIRST_ADDRESS]),
+		)
+
+		expect(estimate).toEqual({ estimatedCostAttoEth: 0n, estimatedGas: 0n, missingStepIds: [] })
+	})
+
 	test('covers every bootstrap infrastructure address and orders every dependency first', async () => {
 		const uniswap = await getUniswapDeployment(SEPOLIA_NETWORK_PROFILE.wethAddress)
 		const plan = createCompleteDeploymentPlan(SEPOLIA_NETWORK_PROFILE, uniswap)
@@ -520,6 +579,39 @@ describe('testnet deployment plan', () => {
 		expect(logs.join('\n')).not.toContain(ZERO_HASH)
 	})
 
+	test('keeps exact-known canonical deployments skipped when execution RPC reads are stale', async () => {
+		let deployCalled = false
+		let codeReadCount = 0
+		const results = await runDeploymentPlan(
+			[
+				{
+					address: FIRST_ADDRESS,
+					dependencies: [],
+					deploy: async () => {
+						deployCalled = true
+						return FIRST_HASH
+					},
+					expectedRuntimeCodeHash: keccak256('0x01'),
+					id: 'proxyDeployer',
+					label: 'Proxy Deployer',
+				},
+			],
+			{
+				getCode: async () => {
+					codeReadCount += 1
+					return undefined
+				},
+			},
+			() => undefined,
+			undefined,
+			new Set([FIRST_ADDRESS]),
+		)
+
+		expect(results).toEqual([{ address: FIRST_ADDRESS, id: 'proxyDeployer', label: 'Proxy Deployer', status: 'skipped', transactionHash: undefined }])
+		expect(deployCalled).toBe(false)
+		expect(codeReadCount).toBe(0)
+	})
+
 	test('fails when ordering omits a dependency or a successful transaction installs no code', async () => {
 		const client = {
 			getCode: async () => undefined,
@@ -556,9 +648,40 @@ describe('testnet deployment plan', () => {
 				],
 				client,
 				message => logs.push(message),
+				async () => undefined,
 			),
 		).rejects.toThrow('succeeded without installing code')
 		expect(logs).toEqual([`First (first)\n  ├─ Address: ${FIRST_ADDRESS}`, '  └─ Status: failed'])
+	})
+
+	test('retries code verification when the RPC latest state lags a successful receipt', async () => {
+		let codeReadCount = 0
+		const retryDelays: number[] = []
+		const results = await runDeploymentPlan(
+			[
+				{
+					address: FIRST_ADDRESS,
+					dependencies: [],
+					deploy: async () => FIRST_HASH,
+					expectedRuntimeCodeHash: keccak256('0x01'),
+					id: 'first',
+					label: 'First',
+				},
+			],
+			{
+				getCode: async () => {
+					codeReadCount += 1
+					return codeReadCount < 3 ? undefined : '0x01'
+				},
+			},
+			() => undefined,
+			async delayMilliseconds => {
+				retryDelays.push(delayMilliseconds)
+			},
+		)
+
+		expect(results).toEqual([{ address: FIRST_ADDRESS, id: 'first', label: 'First', status: 'deployed', transactionHash: FIRST_HASH }])
+		expect(retryDelays).toEqual([250])
 	})
 
 	test('closes the contract log when deployment fails', async () => {
@@ -602,7 +725,32 @@ describe('testnet deployment plan', () => {
 			),
 		).rejects.toThrow('Unexpected runtime code for first')
 
-		await expect(assertBootstrapDescendantCode({ getCode: async () => undefined }, SEPOLIA_NETWORK_PROFILE)).rejects.toThrow('Bootstrap descendant liquidationApprovalRegistryDeployer is missing')
+		await expect(assertBootstrapDescendantCode({ getCode: async () => undefined }, SEPOLIA_NETWORK_PROFILE, async () => undefined)).rejects.toThrow('Bootstrap descendant liquidationApprovalRegistryDeployer is missing')
 		await expect(assertBootstrapDescendantCode({ getCode: async () => '0x1234' }, SEPOLIA_NETWORK_PROFILE)).rejects.toThrow('Unexpected runtime code for liquidationApprovalRegistryDeployer')
+	})
+
+	test('retries bootstrap descendants as one batch when RPC code state lags', async () => {
+		const descendants = getBootstrapDescendantAddresses(SEPOLIA_NETWORK_PROFILE)
+		const descendantCount = Object.keys(descendants).length
+		const expectedRuntimeCodeHashes = Object.fromEntries(Object.keys(descendants).map(id => [id, keccak256('0x01')]))
+		const retryDelays: number[] = []
+		let codeReadCount = 0
+
+		await assertBootstrapDescendantCode(
+			{
+				getCode: async () => {
+					codeReadCount += 1
+					return codeReadCount <= descendantCount ? undefined : '0x01'
+				},
+			},
+			SEPOLIA_NETWORK_PROFILE,
+			async delayMilliseconds => {
+				retryDelays.push(delayMilliseconds)
+			},
+			expectedRuntimeCodeHashes,
+		)
+
+		expect(retryDelays).toEqual([250])
+		expect(codeReadCount).toBe(descendantCount * 2)
 	})
 })

--- a/scripts/uniswap-deployment.mts
+++ b/scripts/uniswap-deployment.mts
@@ -1,5 +1,5 @@
 import { concatHex, encodeAbiParameters, encodeDeployData, getAddress, getCreate2Address, keccak256, toHex, type Address, type Hash, type Hex, zeroAddress } from '@zoltar/shared/ethereum'
-import { waitForSubmittedTransactionReceipt } from '../ui/ts/protocol/core.ts'
+import { readWithRpcStateRetries, waitForSubmittedTransactionReceipt, type RpcStateRetryWait } from '../ui/ts/protocol/core.ts'
 import { assertCanonicalRawTransactionFeeCompatible, CANONICAL_DEPLOYER_RAW_TRANSACTION_COST, fundCanonicalDeployerSigner, isInsufficientFundsError } from '../ui/ts/protocol/deployment.ts'
 import { PROXY_DEPLOYER_ADDRESS, ZERO_SALT } from '../ui/ts/protocol/deploymentHelpers.ts'
 import type { WriteClient } from '../ui/ts/lib/chainBackend.ts'
@@ -251,9 +251,31 @@ function arachnidCreate2DeployerShortfall(balance: bigint) {
 	return balance >= ARACHNID_CREATE2_DEPLOYER_FUNDING ? 0n : ARACHNID_CREATE2_DEPLOYER_FUNDING - balance
 }
 
-async function waitForCanonicalCreate2Deployer(client: WriteClient) {
+async function create2DeployerIsInstalledAfterReceipt(client: WriteClient, wait?: RpcStateRetryWait) {
+	return await readWithRpcStateRetries(
+		() => arachnidCreate2DeployerIsInstalled(client),
+		installed => installed,
+		wait,
+	)
+}
+
+async function resolveConfirmedCreate2Deployer(client: WriteClient, wait?: RpcStateRetryWait) {
+	if (!(await create2DeployerIsInstalledAfterReceipt(client, wait))) throw new Error('The canonical CREATE2 deployer signer nonce has already been consumed, but the deployer is missing')
+	accountCanonicalRawTransaction(client)
+	return ARACHNID_CREATE2_DEPLOYER_RAW_TRANSACTION_HASH
+}
+
+export async function resolveCanonicalCreate2DeployerForPreflight(client: WriteClient, wait?: RpcStateRetryWait) {
+	if (await arachnidCreate2DeployerIsInstalled(client)) return true
+	const confirmedNonce = await client.getTransactionCount({ address: ARACHNID_CREATE2_DEPLOYER_SIGNER, blockTag: 'latest' })
+	if (confirmedNonce === 0n) return false
+	if (!(await create2DeployerIsInstalledAfterReceipt(client, wait))) throw new Error('The canonical CREATE2 deployer signer nonce has already been consumed, but the deployer is missing')
+	return true
+}
+
+async function waitForCanonicalCreate2Deployer(client: WriteClient, wait?: RpcStateRetryWait) {
 	const { hash } = await waitForSubmittedTransactionReceipt(client, ARACHNID_CREATE2_DEPLOYER_RAW_TRANSACTION_HASH)
-	if (!(await arachnidCreate2DeployerIsInstalled(client))) throw new Error(`Canonical CREATE2 deployer transaction ${hash} confirmed without installing code at ${ARACHNID_CREATE2_DEPLOYER_ADDRESS}`)
+	if (!(await create2DeployerIsInstalledAfterReceipt(client, wait))) throw new Error(`Canonical CREATE2 deployer transaction ${hash} confirmed without installing code at ${ARACHNID_CREATE2_DEPLOYER_ADDRESS}`)
 	return hash
 }
 
@@ -262,7 +284,7 @@ function accountCanonicalRawTransaction(client: WriteClient) {
 	client.recordCanonicalRawTransaction?.(ARACHNID_CREATE2_DEPLOYER_SIGNER, CANONICAL_DEPLOYER_RAW_TRANSACTION_COST)
 }
 
-async function resolveCreate2DeployerBroadcastRace(client: WriteClient, broadcastError: unknown) {
+async function resolveCreate2DeployerBroadcastRace(client: WriteClient, broadcastError: unknown, wait?: RpcStateRetryWait) {
 	if (await arachnidCreate2DeployerIsInstalled(client)) {
 		client.recordCanonicalRawTransaction?.(ARACHNID_CREATE2_DEPLOYER_SIGNER, CANONICAL_DEPLOYER_RAW_TRANSACTION_COST)
 		return ARACHNID_CREATE2_DEPLOYER_RAW_TRANSACTION_HASH
@@ -270,19 +292,19 @@ async function resolveCreate2DeployerBroadcastRace(client: WriteClient, broadcas
 	const activity = await getArachnidCreate2DeployerActivity(client)
 	if (activity.deploymentPending) {
 		client.recordCanonicalRawTransaction?.(ARACHNID_CREATE2_DEPLOYER_SIGNER, CANONICAL_DEPLOYER_RAW_TRANSACTION_COST)
-		return await waitForCanonicalCreate2Deployer(client)
+		return await waitForCanonicalCreate2Deployer(client, wait)
 	}
 	if (activity.confirmedNonce !== 0n) {
-		if (await arachnidCreate2DeployerIsInstalled(client)) {
-			client.recordCanonicalRawTransaction?.(ARACHNID_CREATE2_DEPLOYER_SIGNER, CANONICAL_DEPLOYER_RAW_TRANSACTION_COST)
-			return ARACHNID_CREATE2_DEPLOYER_RAW_TRANSACTION_HASH
+		try {
+			return await resolveConfirmedCreate2Deployer(client, wait)
+		} catch (error) {
+			throw new Error('The canonical CREATE2 deployer signer nonce was consumed without installing the deployer', { cause: error ?? broadcastError })
 		}
-		throw new Error('The canonical CREATE2 deployer signer nonce was consumed without installing the deployer', { cause: broadcastError })
 	}
 	throw broadcastError
 }
 
-async function broadcastCanonicalCreate2Deployer(client: WriteClient, allowInsufficientFunds: boolean) {
+async function broadcastCanonicalCreate2Deployer(client: WriteClient, allowInsufficientFunds: boolean, wait?: RpcStateRetryWait) {
 	client.assertCanonicalRawTransactionCost?.(ARACHNID_CREATE2_DEPLOYER_SIGNER, CANONICAL_DEPLOYER_RAW_TRANSACTION_COST)
 	let hash: Hash
 	try {
@@ -296,7 +318,7 @@ async function broadcastCanonicalCreate2Deployer(client: WriteClient, allowInsuf
 			return undefined
 		}
 		try {
-			return await resolveCreate2DeployerBroadcastRace(client, error)
+			return await resolveCreate2DeployerBroadcastRace(client, error, wait)
 		} catch (resolvedError) {
 			if (allowInsufficientFunds) throw new Error(`RPC rejected the canonical CREATE2 deployer raw transaction before signer funding: ${resolvedError instanceof Error ? resolvedError.message : String(resolvedError)}`, { cause: resolvedError })
 			throw resolvedError
@@ -304,27 +326,27 @@ async function broadcastCanonicalCreate2Deployer(client: WriteClient, allowInsuf
 	}
 	client.recordCanonicalRawTransaction?.(ARACHNID_CREATE2_DEPLOYER_SIGNER, CANONICAL_DEPLOYER_RAW_TRANSACTION_COST)
 	const { hash: resolvedHash } = await waitForSubmittedTransactionReceipt(client, hash)
-	if (!(await arachnidCreate2DeployerIsInstalled(client))) throw new Error(`Canonical CREATE2 deployer transaction ${resolvedHash} succeeded without installing code at ${ARACHNID_CREATE2_DEPLOYER_ADDRESS}`)
+	if (!(await create2DeployerIsInstalledAfterReceipt(client, wait))) throw new Error(`Canonical CREATE2 deployer transaction ${resolvedHash} succeeded without installing code at ${ARACHNID_CREATE2_DEPLOYER_ADDRESS}`)
 	return resolvedHash
 }
 
-async function deployArachnidCreate2Deployer(client: WriteClient) {
+async function deployArachnidCreate2Deployer(client: WriteClient, wait?: RpcStateRetryWait) {
 	if (await arachnidCreate2DeployerIsInstalled(client)) return ZERO_HASH
 	const activity = await getArachnidCreate2DeployerActivity(client)
 	if (activity.deploymentPending) {
 		accountCanonicalRawTransaction(client)
-		return await waitForCanonicalCreate2Deployer(client)
+		return await waitForCanonicalCreate2Deployer(client, wait)
 	}
 	if (activity.fundingPending) throw new Error('The canonical CREATE2 deployer has pending funding or deployment activity. Wait for it to settle, then retry.')
 	if (await arachnidCreate2DeployerIsInstalled(client)) return ZERO_HASH
-	if (activity.confirmedNonce !== 0n) throw new Error('The canonical CREATE2 deployer signer nonce has already been consumed, but the deployer is missing')
+	if (activity.confirmedNonce !== 0n) return await resolveConfirmedCreate2Deployer(client, wait)
 	const finalActivity = await getArachnidCreate2DeployerActivity(client)
-	if (finalActivity.deploymentPending) return await waitForCanonicalCreate2Deployer(client)
+	if (finalActivity.deploymentPending) return await waitForCanonicalCreate2Deployer(client, wait)
 	if (finalActivity.fundingPending) throw new Error('The canonical CREATE2 deployer has pending funding or deployment activity. Wait for it to settle, then retry.')
 	if (await arachnidCreate2DeployerIsInstalled(client)) return ZERO_HASH
-	if (finalActivity.confirmedNonce !== 0n) throw new Error('The canonical CREATE2 deployer signer nonce has already been consumed, but the deployer is missing')
+	if (finalActivity.confirmedNonce !== 0n) return await resolveConfirmedCreate2Deployer(client, wait)
 	await assertCanonicalRawTransactionFeeCompatible(client, 'Canonical CREATE2 deployer')
-	const preFundingDeploymentHash = await broadcastCanonicalCreate2Deployer(client, true)
+	const preFundingDeploymentHash = await broadcastCanonicalCreate2Deployer(client, true, wait)
 	if (preFundingDeploymentHash !== undefined) return preFundingDeploymentHash
 	const shortfall = arachnidCreate2DeployerShortfall(finalActivity.confirmedBalance)
 	if (shortfall > 0n) {
@@ -342,11 +364,11 @@ async function deployArachnidCreate2Deployer(client: WriteClient) {
 	const postFundingActivity = await getArachnidCreate2DeployerActivity(client)
 	if (postFundingActivity.deploymentPending) {
 		accountCanonicalRawTransaction(client)
-		return await waitForCanonicalCreate2Deployer(client)
+		return await waitForCanonicalCreate2Deployer(client, wait)
 	}
 	if (postFundingActivity.fundingPending) throw new Error('The canonical CREATE2 deployer has pending funding or deployment activity. Wait for it to settle, then retry.')
-	if (postFundingActivity.confirmedNonce !== 0n) throw new Error('The canonical CREATE2 deployer signer nonce has already been consumed, but the deployer is missing')
-	const resolvedHash = await broadcastCanonicalCreate2Deployer(client, false)
+	if (postFundingActivity.confirmedNonce !== 0n) return await resolveConfirmedCreate2Deployer(client, wait)
+	const resolvedHash = await broadcastCanonicalCreate2Deployer(client, false, wait)
 	if (resolvedHash === undefined) throw new Error('Canonical CREATE2 deployer broadcast unexpectedly returned without a transaction hash')
 	return resolvedHash
 }
@@ -357,7 +379,7 @@ async function deployPermit2(client: WriteClient, initCode: Hex) {
 	return resolvedHash
 }
 
-export async function getUniswapDeployment(wethAddress: Address): Promise<UniswapDeployment> {
+export async function getUniswapDeployment(wethAddress: Address, wait?: RpcStateRetryWait): Promise<UniswapDeployment> {
 	const artifacts = await getUniswapDeploymentArtifacts()
 	const permit2Compilation = artifacts.permit2
 	const permit2InitCode = permit2Compilation.initCode
@@ -404,7 +426,7 @@ export async function getUniswapDeployment(wethAddress: Address): Promise<Uniswa
 			{
 				address: ARACHNID_CREATE2_DEPLOYER_ADDRESS,
 				dependencies: [],
-				deploy: deployArachnidCreate2Deployer,
+				deploy: async client => await deployArachnidCreate2Deployer(client, wait),
 				id: 'arachnidCreate2Deployer',
 				label: 'Canonical CREATE2 Deployer',
 			},

--- a/scripts/uniswap-deployment.test.ts
+++ b/scripts/uniswap-deployment.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import { concatHex, getAddress, type Hash, type Hex, type TransactionReceipt } from '@zoltar/shared/ethereum'
 import { SEPOLIA_NETWORK_PROFILE } from '../ui/ts/lib/networkProfile.ts'
 import type { WriteClient } from '../ui/ts/lib/chainBackend.ts'
-import { ARACHNID_CREATE2_DEPLOYER_ADDRESS, ARACHNID_CREATE2_DEPLOYER_RUNTIME_CODE, PERMIT2_ADDRESS, assertPermit2ImmutableValues, assertUniswapDeploymentArtifact, getUniswapDeployment } from './uniswap-deployment.mts'
+import { ARACHNID_CREATE2_DEPLOYER_ADDRESS, ARACHNID_CREATE2_DEPLOYER_RUNTIME_CODE, PERMIT2_ADDRESS, assertPermit2ImmutableValues, assertUniswapDeploymentArtifact, getUniswapDeployment, resolveCanonicalCreate2DeployerForPreflight } from './uniswap-deployment.mts'
 
 const WETH = getAddress('0x65156FD21726b8efcB627fa38c506E3f3542F601')
 
@@ -18,6 +18,25 @@ function successReceipt(): TransactionReceipt {
 }
 
 describe('Uniswap testnet deployment', () => {
+	test('resolves confirmed CREATE2 code before fee and budget preflight', async () => {
+		let codeReadCount = 0
+		const retryDelays: number[] = []
+		const installed = await resolveCanonicalCreate2DeployerForPreflight(
+			asWriteClient({
+				getCode: async () => {
+					codeReadCount += 1
+					return codeReadCount < 3 ? undefined : ARACHNID_CREATE2_DEPLOYER_RUNTIME_CODE
+				},
+				getTransactionCount: async () => 1n,
+			}),
+			async delayMilliseconds => {
+				retryDelays.push(delayMilliseconds)
+			},
+		)
+
+		expect(installed).toBe(true)
+		expect(retryDelays).toEqual([250])
+	})
 	test('accepts the pinned deployment artifact with Windows line endings', async () => {
 		const artifact = await Bun.file(new URL('./artifacts/uniswap-deployment.json', import.meta.url)).text()
 		expect(() => assertUniswapDeploymentArtifact(artifact.replaceAll('\n', '\r\n'))).not.toThrow()
@@ -114,6 +133,31 @@ describe('Uniswap testnet deployment', () => {
 		expect(accountedRawTransactions).toBe(1)
 	})
 
+	test('retries CREATE2 deployer code verification when RPC state lags the confirmed receipt', async () => {
+		const retryDelays: number[] = []
+		const step = (
+			await getUniswapDeployment(WETH, async delayMilliseconds => {
+				retryDelays.push(delayMilliseconds)
+			})
+		).steps.find(candidate => candidate.id === 'arachnidCreate2Deployer')
+		if (step === undefined) throw new Error('Expected canonical CREATE2 deployer step')
+		let codeReadCount = 0
+		const client = asWriteClient({
+			assertCanonicalRawTransactionCost: () => undefined,
+			getBalance: async () => 10_000_000_000_000_000n,
+			getCode: async () => {
+				codeReadCount += 1
+				return codeReadCount < 3 ? undefined : ARACHNID_CREATE2_DEPLOYER_RUNTIME_CODE
+			},
+			getTransactionCount: async parameters => (parameters.blockTag === 'pending' ? 1n : 0n),
+			recordCanonicalRawTransaction: () => undefined,
+			waitForTransactionReceipt: async () => successReceipt(),
+		})
+
+		expect(await step.deploy(client)).not.toBe(`0x${'0'.repeat(64)}`)
+		expect(retryDelays).toEqual([250])
+	})
+
 	test('accepts an already-known canonical CREATE2 deployer broadcast race', async () => {
 		const step = (await getUniswapDeployment(WETH)).steps.find(candidate => candidate.id === 'arachnidCreate2Deployer')
 		if (step === undefined) throw new Error('Expected canonical CREATE2 deployer step')
@@ -168,6 +212,74 @@ describe('Uniswap testnet deployment', () => {
 		})
 
 		expect(await step.deploy(client)).not.toBe(`0x${'0'.repeat(64)}`)
+	})
+
+	test('retries stale CREATE2 code after a broadcast reports an already-confirmed nonce', async () => {
+		const retryDelays: number[] = []
+		const step = (
+			await getUniswapDeployment(WETH, async delayMilliseconds => {
+				retryDelays.push(delayMilliseconds)
+			})
+		).steps.find(candidate => candidate.id === 'arachnidCreate2Deployer')
+		if (step === undefined) throw new Error('Expected canonical CREATE2 deployer step')
+		let confirmed = false
+		let codeReadCount = 0
+		const client = asWriteClient({
+			getBalance: async () => 10_000_000_000_000_000n,
+			getCode: async () => {
+				codeReadCount += 1
+				return codeReadCount < 6 ? undefined : ARACHNID_CREATE2_DEPLOYER_RUNTIME_CODE
+			},
+			getTransactionCount: async () => (confirmed ? 1n : 0n),
+			recordCanonicalRawTransaction: () => undefined,
+			sendRawTransaction: async () => {
+				confirmed = true
+				throw new Error('nonce too low')
+			},
+			sendTransaction: async () => {
+				throw new Error('Funding should not be sent')
+			},
+			waitForTransactionReceipt: async () => {
+				throw new Error('An already confirmed deployment should not be awaited')
+			},
+		})
+
+		expect(await step.deploy(client)).not.toBe(`0x${'0'.repeat(64)}`)
+		expect(retryDelays).toEqual([250])
+	})
+
+	test('accepts delayed CREATE2 code after its signer nonce was already confirmed', async () => {
+		const retryDelays: number[] = []
+		const step = (
+			await getUniswapDeployment(WETH, async delayMilliseconds => {
+				retryDelays.push(delayMilliseconds)
+			})
+		).steps.find(candidate => candidate.id === 'arachnidCreate2Deployer')
+		if (step === undefined) throw new Error('Expected canonical CREATE2 deployer step')
+		let codeReadCount = 0
+		let transactionSubmitted = false
+		const client = asWriteClient({
+			getBalance: async () => 10_000_000_000_000_000n,
+			getCode: async () => {
+				codeReadCount += 1
+				return codeReadCount < 4 ? undefined : ARACHNID_CREATE2_DEPLOYER_RUNTIME_CODE
+			},
+			getTransactionCount: async () => 1n,
+			recordCanonicalRawTransaction: () => undefined,
+			sendRawTransaction: async () => {
+				transactionSubmitted = true
+				return `0x${'1'.repeat(64)}` as Hash
+			},
+			sendTransaction: async () => {
+				transactionSubmitted = true
+				return `0x${'2'.repeat(64)}` as Hash
+			},
+			waitForTransactionReceipt: async () => successReceipt(),
+		})
+
+		expect(await step.deploy(client)).not.toBe(`0x${'0'.repeat(64)}`)
+		expect(retryDelays).toEqual([250])
+		expect(transactionSubmitted).toBe(false)
 	})
 
 	test('rejects unexpected code installed during a canonical CREATE2 deployer broadcast race', async () => {
@@ -235,6 +347,39 @@ describe('Uniswap testnet deployment', () => {
 
 		await expect(step.deploy(client)).rejects.toThrow('before signer funding')
 		expect(fundingCalled).toBe(false)
+	})
+
+	test('retries delayed CREATE2 code when deployment confirms during signer funding', async () => {
+		let codeVisible = false
+		let funded = false
+		let rawBroadcastCount = 0
+		const retryDelays: number[] = []
+		const step = (
+			await getUniswapDeployment(WETH, async delayMilliseconds => {
+				retryDelays.push(delayMilliseconds)
+				codeVisible = true
+			})
+		).steps.find(candidate => candidate.id === 'arachnidCreate2Deployer')
+		if (step === undefined) throw new Error('Expected canonical CREATE2 deployer step')
+		const client = asWriteClient({
+			getBalance: async () => (funded ? 10_000_000_000_000_000n : 0n),
+			getCode: async () => (codeVisible ? ARACHNID_CREATE2_DEPLOYER_RUNTIME_CODE : undefined),
+			getTransactionCount: async () => (funded ? 1n : 0n),
+			recordCanonicalRawTransaction: () => undefined,
+			sendRawTransaction: async () => {
+				rawBroadcastCount += 1
+				throw new Error('insufficient funds for gas')
+			},
+			sendTransaction: async () => {
+				funded = true
+				return `0x${'2'.repeat(64)}` as Hash
+			},
+			waitForTransactionReceipt: async () => successReceipt(),
+		})
+
+		expect(await step.deploy(client)).not.toBe(`0x${'0'.repeat(64)}`)
+		expect(retryDelays).toEqual([250])
+		expect(rawBroadcastCount).toBe(1)
 	})
 
 	test('enforces CREATE2 raw-transaction cost authorization before broadcast', async () => {

--- a/ui/ts/features/deployment/hooks/useDeploymentFlow.ts
+++ b/ui/ts/features/deployment/hooks/useDeploymentFlow.ts
@@ -11,6 +11,7 @@ import { assertActiveWallet } from '../../../lib/assertActiveWallet.js'
 import type { WriteOperationsParameters } from '../../../types/app.js'
 import type { DeploymentStatus, DeploymentStepId } from '../../../types/contracts.js'
 import { assertDeploymentStepRuntimeCode } from '../../../protocol/deployment.js'
+import { readWithRpcStateRetries, type RpcStateRetryWait } from '../../../protocol/core.js'
 
 type UseDeploymentFlowParameters = {
 	accountAddress: Address | undefined
@@ -22,9 +23,10 @@ type UseDeploymentFlowParameters = {
 	onTransactionPrepared?: WriteOperationsParameters['onTransactionPrepared']
 	onTransactionRequested: WriteOperationsParameters['onTransactionRequested']
 	onTransactionSubmitted: (hash: Hash) => void
+	rpcStateRetryWait?: RpcStateRetryWait
 }
 
-export function useDeploymentFlow({ accountAddress, deploymentStatuses, onTransactionFailed, onTransactionFinished, onTransactionPresented, onTransactionPrepared, onTransactionRequested, onTransactionSubmitted, setDeploymentStatuses }: UseDeploymentFlowParameters) {
+export function useDeploymentFlow({ accountAddress, deploymentStatuses, onTransactionFailed, onTransactionFinished, onTransactionPresented, onTransactionPrepared, onTransactionRequested, onTransactionSubmitted, rpcStateRetryWait, setDeploymentStatuses }: UseDeploymentFlowParameters) {
 	const busyStepId = useSignal<DeploymentStepId | undefined>(undefined)
 	const deploymentFeedback = useSignal<ActionFeedback<DeploymentStepId | 'deployNextMissing'> | undefined>(undefined)
 	const errorMessage = useSignal<string | undefined>(undefined)
@@ -72,7 +74,11 @@ export function useDeploymentFlow({ accountAddress, deploymentStatuses, onTransa
 			}
 			onTransactionRequested(createDeploymentTransactionIntent(step.label))
 			const hash = await step.deploy(client)
-			const code = await client.getCode({ address: step.address })
+			const code = await readWithRpcStateRetries(
+				() => client.getCode({ address: step.address }),
+				candidate => candidate !== undefined && candidate !== '0x',
+				rpcStateRetryWait,
+			)
 			if (!assertDeploymentStepRuntimeCode(step, code)) {
 				const message = 'Deployment verification failed: no contract code was found at the expected address. Check the selected network and retry.'
 				errorMessage.value = message

--- a/ui/ts/protocol/core.ts
+++ b/ui/ts/protocol/core.ts
@@ -4,6 +4,20 @@ import type { ReadClient, WriteClient } from '../types/contracts.js'
 import type { TransactionRequestPreview } from '../lib/chainBackend.js'
 import { getContractLabel } from './contractLabels.js'
 
+const RPC_STATE_RETRY_DELAYS_MILLISECONDS = [250, 500, 1_000, 2_000, 4_000] as const
+
+export type RpcStateRetryWait = (milliseconds: number) => Promise<void>
+
+export async function readWithRpcStateRetries<T>(read: () => Promise<T>, isReady: (value: T) => boolean, wait: RpcStateRetryWait = async milliseconds => await new Promise(resolve => setTimeout(resolve, milliseconds))) {
+	let value = await read()
+	for (const delayMilliseconds of RPC_STATE_RETRY_DELAYS_MILLISECONDS) {
+		if (isReady(value)) return value
+		await wait(delayMilliseconds)
+		value = await read()
+	}
+	return value
+}
+
 export type ContractRevertReasonParams = {
 	account?: Account | Address | undefined | null
 	abi: Abi | readonly unknown[]

--- a/ui/ts/protocol/deployment.ts
+++ b/ui/ts/protocol/deployment.ts
@@ -25,7 +25,7 @@ import {
 	getZoltarInitCode,
 	getZoltarQuestionDataByteCode,
 } from './deploymentHelpers.js'
-import { waitForSubmittedTransactionReceipt } from './core.js'
+import { readWithRpcStateRetries, waitForSubmittedTransactionReceipt, type RpcStateRetryWait } from './core.js'
 import type { DeploymentStatusSnapshot, DeploymentStep, DeploymentStepId, ReadClient, WriteClient } from '../types/contracts.js'
 import type { TransactionRequestPreview } from '../lib/chainBackend.js'
 import { getRuntimeNetworkProfile, type NetworkProfile } from '../lib/networkProfile.js'
@@ -195,13 +195,27 @@ function accountCanonicalRawTransaction(client: WriteClient, signer: Address) {
 	client.recordCanonicalRawTransaction?.(signer, CANONICAL_DEPLOYER_RAW_TRANSACTION_COST)
 }
 
-async function waitForCanonicalProxyDeployer(client: WriteClient) {
+async function proxyDeployerIsInstalledAfterReceipt(client: WriteClient, wait?: RpcStateRetryWait) {
+	return await readWithRpcStateRetries(
+		() => proxyDeployerIsInstalled(client),
+		installed => installed,
+		wait,
+	)
+}
+
+async function resolveConfirmedProxyDeployer(client: WriteClient, wait?: RpcStateRetryWait) {
+	if (!(await proxyDeployerIsInstalledAfterReceipt(client, wait))) throw new Error('The deterministic proxy deployer signer nonce has already been consumed, but the canonical proxy is missing')
+	accountCanonicalRawTransaction(client, PROXY_DEPLOYER_SIGNER)
+	return PROXY_DEPLOYER_RAW_TRANSACTION_HASH
+}
+
+async function waitForCanonicalProxyDeployer(client: WriteClient, wait?: RpcStateRetryWait) {
 	const { hash } = await waitForSubmittedTransactionReceipt(client, PROXY_DEPLOYER_RAW_TRANSACTION_HASH)
-	if (!(await proxyDeployerIsInstalled(client))) throw new Error(`Canonical proxy deployer transaction ${hash} confirmed without installing code at ${PROXY_DEPLOYER_ADDRESS}`)
+	if (!(await proxyDeployerIsInstalledAfterReceipt(client, wait))) throw new Error(`Canonical proxy deployer transaction ${hash} confirmed without installing code at ${PROXY_DEPLOYER_ADDRESS}`)
 	return hash
 }
 
-async function resolveProxyDeployerBroadcastRace(client: WriteClient, broadcastError: unknown) {
+async function resolveProxyDeployerBroadcastRace(client: WriteClient, broadcastError: unknown, wait?: RpcStateRetryWait) {
 	if (await proxyDeployerIsInstalled(client)) {
 		client.recordCanonicalRawTransaction?.(PROXY_DEPLOYER_SIGNER, CANONICAL_DEPLOYER_RAW_TRANSACTION_COST)
 		return PROXY_DEPLOYER_RAW_TRANSACTION_HASH
@@ -209,19 +223,19 @@ async function resolveProxyDeployerBroadcastRace(client: WriteClient, broadcastE
 	const activity = await getProxyDeployerActivity(client)
 	if (activity.deploymentPending) {
 		client.recordCanonicalRawTransaction?.(PROXY_DEPLOYER_SIGNER, CANONICAL_DEPLOYER_RAW_TRANSACTION_COST)
-		return await waitForCanonicalProxyDeployer(client)
+		return await waitForCanonicalProxyDeployer(client, wait)
 	}
 	if (activity.confirmedNonce !== 0n) {
-		if (await proxyDeployerIsInstalled(client)) {
-			client.recordCanonicalRawTransaction?.(PROXY_DEPLOYER_SIGNER, CANONICAL_DEPLOYER_RAW_TRANSACTION_COST)
-			return PROXY_DEPLOYER_RAW_TRANSACTION_HASH
+		try {
+			return await resolveConfirmedProxyDeployer(client, wait)
+		} catch (error) {
+			throw new Error('The deterministic proxy deployer signer nonce was consumed without installing the canonical proxy', { cause: error ?? broadcastError })
 		}
-		throw new Error('The deterministic proxy deployer signer nonce was consumed without installing the canonical proxy', { cause: broadcastError })
 	}
 	throw broadcastError
 }
 
-async function broadcastCanonicalProxyDeployer(client: WriteClient, allowInsufficientFunds: boolean) {
+async function broadcastCanonicalProxyDeployer(client: WriteClient, allowInsufficientFunds: boolean, wait?: RpcStateRetryWait) {
 	markDeploymentTransactionPrepared(client, {
 		account: PROXY_DEPLOYER_SIGNER,
 		data: PROXY_DEPLOYER_RAW_TRANSACTION,
@@ -244,7 +258,7 @@ async function broadcastCanonicalProxyDeployer(client: WriteClient, allowInsuffi
 			return undefined
 		}
 		try {
-			return await resolveProxyDeployerBroadcastRace(client, error)
+			return await resolveProxyDeployerBroadcastRace(client, error, wait)
 		} catch (resolvedError) {
 			if (allowInsufficientFunds) throw new Error(`RPC rejected the canonical proxy deployer raw transaction before signer funding: ${resolvedError instanceof Error ? resolvedError.message : String(resolvedError)}`, { cause: resolvedError })
 			throw resolvedError
@@ -252,7 +266,7 @@ async function broadcastCanonicalProxyDeployer(client: WriteClient, allowInsuffi
 	}
 	client.recordCanonicalRawTransaction?.(PROXY_DEPLOYER_SIGNER, CANONICAL_DEPLOYER_RAW_TRANSACTION_COST)
 	const { hash: resolvedDeployHash } = await waitForSubmittedTransactionReceipt(client, deployHash)
-	if (!(await proxyDeployerIsInstalled(client))) throw new Error(`Canonical proxy deployer transaction ${resolvedDeployHash} confirmed without installing code at ${PROXY_DEPLOYER_ADDRESS}`)
+	if (!(await proxyDeployerIsInstalledAfterReceipt(client, wait))) throw new Error(`Canonical proxy deployer transaction ${resolvedDeployHash} confirmed without installing code at ${PROXY_DEPLOYER_ADDRESS}`)
 	return resolvedDeployHash
 }
 
@@ -349,7 +363,7 @@ async function deployViaProxy(client: WriteClient, bytecode: Hex) {
 	return resolvedHash
 }
 
-async function ensureProxyDeployerDeployed(client: WriteClient) {
+async function ensureProxyDeployerDeployed(client: WriteClient, wait?: RpcStateRetryWait) {
 	if (await proxyDeployerIsInstalled(client)) return undefined
 	if (client.installSimulationProxyDeployer !== undefined) {
 		await client.installSimulationProxyDeployer({
@@ -361,15 +375,15 @@ async function ensureProxyDeployerDeployed(client: WriteClient) {
 	const activity = await getProxyDeployerActivity(client)
 	if (activity.deploymentPending) {
 		accountCanonicalRawTransaction(client, PROXY_DEPLOYER_SIGNER)
-		return await waitForCanonicalProxyDeployer(client)
+		return await waitForCanonicalProxyDeployer(client, wait)
 	}
 	if (activity.fundingPending) {
 		throw new Error('The deterministic proxy deployer has pending funding or deployment activity. Wait for it to settle, then retry.')
 	}
 	if (await proxyDeployerIsInstalled(client)) return undefined
-	if (activity.confirmedNonce !== 0n) throw new Error('The deterministic proxy deployer signer nonce has already been consumed, but the canonical proxy is missing')
+	if (activity.confirmedNonce !== 0n) return await resolveConfirmedProxyDeployer(client, wait)
 	await assertCanonicalRawTransactionFeeCompatible(client, 'Deterministic proxy deployer')
-	const preFundingDeploymentHash = await broadcastCanonicalProxyDeployer(client, true)
+	const preFundingDeploymentHash = await broadcastCanonicalProxyDeployer(client, true, wait)
 	if (preFundingDeploymentHash !== undefined) return preFundingDeploymentHash
 
 	const fundingShortfall = await getProxyDeployerFundingShortfall(client)
@@ -380,7 +394,7 @@ async function ensureProxyDeployerDeployed(client: WriteClient) {
 		}
 		if (await proxyDeployerIsInstalled(client)) return undefined
 		const confirmedNonce = await client.getTransactionCount({ address: PROXY_DEPLOYER_SIGNER, blockTag: 'latest' })
-		if (confirmedNonce !== 0n) throw new Error('The deterministic proxy deployer signer nonce has already been consumed, but the canonical proxy is missing')
+		if (confirmedNonce !== 0n) return await resolveConfirmedProxyDeployer(client, wait)
 		const finalFundingShortfall = await getProxyDeployerFundingShortfall(client)
 		if (finalFundingShortfall > 0n) {
 			await fundCanonicalDeployerSigner(client, {
@@ -398,12 +412,12 @@ async function ensureProxyDeployerDeployed(client: WriteClient) {
 	const postFundingActivity = await getProxyDeployerActivity(client)
 	if (postFundingActivity.deploymentPending) {
 		accountCanonicalRawTransaction(client, PROXY_DEPLOYER_SIGNER)
-		return await waitForCanonicalProxyDeployer(client)
+		return await waitForCanonicalProxyDeployer(client, wait)
 	}
 	if (postFundingActivity.fundingPending) throw new Error('The deterministic proxy deployer has pending funding or deployment activity. Wait for it to settle, then retry.')
-	if (postFundingActivity.confirmedNonce !== 0n) throw new Error('The deterministic proxy deployer signer nonce has already been consumed, but the canonical proxy is missing')
+	if (postFundingActivity.confirmedNonce !== 0n) return await resolveConfirmedProxyDeployer(client, wait)
 
-	const resolvedDeployHash = await broadcastCanonicalProxyDeployer(client, false)
+	const resolvedDeployHash = await broadcastCanonicalProxyDeployer(client, false, wait)
 	if (resolvedDeployHash === undefined) throw new Error('Canonical proxy deployer broadcast unexpectedly returned without a transaction hash')
 	return resolvedDeployHash
 }
@@ -419,7 +433,7 @@ async function loadDeploymentStatusOracleMask(client: Pick<ReadClient, 'readCont
 	)
 }
 
-export function getDeploymentSteps(profile: NetworkProfile = getRuntimeNetworkProfile()): DeploymentStep[] {
+export function getDeploymentSteps(profile: NetworkProfile = getRuntimeNetworkProfile(), wait?: RpcStateRetryWait): DeploymentStep[] {
 	const addresses = getInfraContractAddresses(profile)
 	const testTokenSteps =
 		profile.id === 'sepolia'
@@ -448,7 +462,7 @@ export function getDeploymentSteps(profile: NetworkProfile = getRuntimeNetworkPr
 			address: PROXY_DEPLOYER_ADDRESS,
 			dependencies: [],
 			deploy: async client => {
-				const hash = await ensureProxyDeployerDeployed(client)
+				const hash = await ensureProxyDeployerDeployed(client, wait)
 				return hash ?? ZERO_HASH
 			},
 		},

--- a/ui/ts/tests/features/deployment/useDeploymentFlow.test.tsx
+++ b/ui/ts/tests/features/deployment/useDeploymentFlow.test.tsx
@@ -224,6 +224,7 @@ describe('useDeploymentFlow', () => {
 				onTransactionPresented,
 				onTransactionRequested: () => undefined,
 				onTransactionSubmitted: () => undefined,
+				rpcStateRetryWait: async () => undefined,
 				setDeploymentStatuses,
 			})
 
@@ -244,13 +245,85 @@ describe('useDeploymentFlow', () => {
 		expect(requireHookState(hookState).errorMessage).toBe(failedMessage)
 	})
 
-	test('does not mark a deployment successful when unexpected code is installed', async () => {
+	test('marks deployment successful when expected code appears after an RPC state retry', async () => {
+		let codeReadCount = 0
 		const writeClient = createWalletClient({
 			account: WALLET_ADDRESS,
 			chain: MAINNET_NETWORK_PROFILE.chain,
 			transport: custom({
 				request: async request => {
-					if (request.method === 'eth_getCode') return '0x1234'
+					if (request.method === 'eth_getCode') {
+						codeReadCount += 1
+						return codeReadCount < 3 ? '0x' : '0x1234'
+					}
+					throw new Error(`Unexpected RPC method ${request.method}`)
+				},
+			}),
+		}).extend(publicActions)
+		resetEnvironment?.()
+		resetEnvironment = installActiveEnvironmentForTesting({
+			...createFakeBackend({ accountAddress: WALLET_ADDRESS }),
+			createWriteClient: () => writeClient,
+		})
+		const deploy = mock(async () => `0x${'1'.repeat(64)}` as Hash)
+		const onTransactionFailed = mock(() => undefined)
+		const onTransactionPresented = mock(() => undefined)
+		const retryDelays: number[] = []
+		let deployed = false
+		const deploymentStatuses: DeploymentStatus[] = [
+			{
+				address: getAddress('0x00000000000000000000000000000000000000d1'),
+				dependencies: [],
+				deploy,
+				deployed: false,
+				expectedRuntimeCodeHash: keccak256('0x1234'),
+				id: 'zoltar',
+				label: 'Zoltar',
+			},
+		]
+		let hookState: UseDeploymentFlowState | undefined
+		const Harness = function DeploymentFlowHarness() {
+			hookState = useDeploymentFlow({
+				accountAddress: WALLET_ADDRESS,
+				deploymentStatuses,
+				onTransactionFailed,
+				onTransactionFinished: () => undefined,
+				onTransactionPresented,
+				onTransactionRequested: () => undefined,
+				onTransactionSubmitted: () => undefined,
+				rpcStateRetryWait: async delayMilliseconds => {
+					retryDelays.push(delayMilliseconds)
+				},
+				setDeploymentStatuses: update => {
+					deployed = update(deploymentStatuses)[0]?.deployed ?? false
+				},
+			})
+			return <div />
+		}
+		const renderedComponent = await renderIntoDocument(h(Harness, {}))
+		cleanupRenderedComponent = renderedComponent.cleanup
+
+		await act(async () => {
+			await requireHookState(hookState).deployStep('zoltar')
+		})
+
+		expect(deployed).toBe(true)
+		expect(retryDelays).toEqual([250])
+		expect(onTransactionPresented).toHaveBeenCalledTimes(1)
+		expect(onTransactionFailed).not.toHaveBeenCalled()
+	})
+
+	test('does not mark a deployment successful when unexpected code is installed', async () => {
+		let codeReadCount = 0
+		const writeClient = createWalletClient({
+			account: WALLET_ADDRESS,
+			chain: MAINNET_NETWORK_PROFILE.chain,
+			transport: custom({
+				request: async request => {
+					if (request.method === 'eth_getCode') {
+						codeReadCount += 1
+						return codeReadCount === 1 ? '0x' : '0x1234'
+					}
 					throw new Error(`Unexpected RPC method ${request.method}`)
 				},
 			}),
@@ -297,7 +370,7 @@ describe('useDeploymentFlow', () => {
 		})
 
 		expect(onTransactionFailed).toHaveBeenCalledTimes(1)
-		expect(deploy).not.toHaveBeenCalled()
+		expect(deploy).toHaveBeenCalledTimes(1)
 		expect(setDeploymentStatuses).not.toHaveBeenCalled()
 		expect(requireHookState(hookState).errorMessage).toContain('Unexpected runtime code for zoltar')
 	})

--- a/ui/ts/tests/protocol/deployment.test.ts
+++ b/ui/ts/tests/protocol/deployment.test.ts
@@ -52,8 +52,8 @@ function hashReceipt(status: TransactionReceipt['status']): TransactionReceipt {
 
 const ZERO_HASH = '0x0000000000000000000000000000000000000000000000000000000000000000' as const
 
-function createDeploymentSteps() {
-	return getDeploymentSteps()
+function createDeploymentSteps(wait?: (milliseconds: number) => Promise<void>) {
+	return getDeploymentSteps(undefined, wait)
 }
 
 function createMockReadClient({ getCode, readContract }: { getCode: MockReadClient['getCode']; readContract?: MockReadClient['readContract'] }) {
@@ -616,7 +616,7 @@ describe('contract deployment internals', () => {
 	})
 
 	test('proxy deployer retry refuses funding after its signer nonce was consumed without installing the proxy', async () => {
-		const proxyStep = createDeploymentSteps().find(step => step.id === 'proxyDeployer')
+		const proxyStep = createDeploymentSteps(async () => undefined).find(step => step.id === 'proxyDeployer')
 		if (proxyStep === undefined) throw new Error('Expected proxyDeployer step')
 		let sendCalled = false
 		const client = asWriteClient({
@@ -632,6 +632,38 @@ describe('contract deployment internals', () => {
 
 		await expect(proxyStep.deploy(client)).rejects.toThrow('signer nonce has already been consumed')
 		expect(sendCalled).toBe(false)
+	})
+
+	test('proxy deployer accepts delayed code after its signer nonce was already confirmed', async () => {
+		const retryDelays: number[] = []
+		const proxyStep = createDeploymentSteps(async delayMilliseconds => {
+			retryDelays.push(delayMilliseconds)
+		}).find(step => step.id === 'proxyDeployer')
+		if (proxyStep === undefined) throw new Error('Expected proxyDeployer step')
+		let codeReadCount = 0
+		let transactionSubmitted = false
+		const client = asWriteClient({
+			getBalance: async () => 10_000_000_000_000_000n,
+			getCode: async () => {
+				codeReadCount += 1
+				return codeReadCount < 4 ? undefined : PROXY_DEPLOYER_RUNTIME_CODE
+			},
+			getTransactionCount: async () => 1n,
+			recordCanonicalRawTransaction: () => undefined,
+			sendRawTransaction: async () => {
+				transactionSubmitted = true
+				return `0x${'1'.repeat(64)}` as Hash
+			},
+			sendTransaction: async () => {
+				transactionSubmitted = true
+				return `0x${'2'.repeat(64)}` as Hash
+			},
+			waitForTransactionReceipt: async () => hashReceipt('success'),
+		})
+
+		expect(await proxyStep.deploy(client)).not.toBe(ZERO_HASH)
+		expect(retryDelays).toEqual([250])
+		expect(transactionSubmitted).toBe(false)
 	})
 
 	test('proxy deployer rejects an incompatible base fee without sending or funding', async () => {
@@ -787,6 +819,54 @@ describe('contract deployment internals', () => {
 		expect(accountedRawTransactions).toBe(1)
 	})
 
+	test('proxy deployer retries code verification when RPC state lags the confirmed receipt', async () => {
+		const retryDelays: number[] = []
+		const proxyStep = createDeploymentSteps(async delayMilliseconds => {
+			retryDelays.push(delayMilliseconds)
+		}).find(step => step.id === 'proxyDeployer')
+		if (proxyStep === undefined) throw new Error('Expected proxyDeployer step')
+		let codeReadCount = 0
+		const client = asWriteClient({
+			assertCanonicalRawTransactionCost: () => undefined,
+			getBalance: async () => 10_000_000_000_000_000n,
+			getCode: async () => {
+				codeReadCount += 1
+				return codeReadCount < 3 ? undefined : PROXY_DEPLOYER_RUNTIME_CODE
+			},
+			getTransactionCount: async parameters => (parameters.blockTag === 'pending' ? 1n : 0n),
+			recordCanonicalRawTransaction: () => undefined,
+			sendTransaction: async () => {
+				throw new Error('Funding should not be sent')
+			},
+			waitForTransactionReceipt: async () => hashReceipt('success'),
+		})
+
+		expect(await proxyStep.deploy(client)).not.toBe(ZERO_HASH)
+		expect(retryDelays).toEqual([250])
+	})
+
+	test('proxy deployer still rejects a confirmed transaction that never exposes code', async () => {
+		const retryDelays: number[] = []
+		const proxyStep = createDeploymentSteps(async delayMilliseconds => {
+			retryDelays.push(delayMilliseconds)
+		}).find(step => step.id === 'proxyDeployer')
+		if (proxyStep === undefined) throw new Error('Expected proxyDeployer step')
+		const client = asWriteClient({
+			assertCanonicalRawTransactionCost: () => undefined,
+			getBalance: async () => 10_000_000_000_000_000n,
+			getCode: async () => undefined,
+			getTransactionCount: async parameters => (parameters.blockTag === 'pending' ? 1n : 0n),
+			recordCanonicalRawTransaction: () => undefined,
+			sendTransaction: async () => {
+				throw new Error('Funding should not be sent')
+			},
+			waitForTransactionReceipt: async () => hashReceipt('success'),
+		})
+
+		await expect(proxyStep.deploy(client)).rejects.toThrow('confirmed without installing code')
+		expect(retryDelays).toEqual([250, 500, 1_000, 2_000, 4_000])
+	})
+
 	test('proxy deployer retry accepts an already-known canonical broadcast race', async () => {
 		const proxyStep = createDeploymentSteps().find(step => step.id === 'proxyDeployer')
 		if (proxyStep === undefined) throw new Error('Expected proxyDeployer step')
@@ -842,6 +922,38 @@ describe('contract deployment internals', () => {
 		expect(await proxyStep.deploy(client)).not.toBe(ZERO_HASH)
 	})
 
+	test('proxy deployer retries stale code after a broadcast reports an already-confirmed nonce', async () => {
+		const retryDelays: number[] = []
+		const proxyStep = createDeploymentSteps(async delayMilliseconds => {
+			retryDelays.push(delayMilliseconds)
+		}).find(step => step.id === 'proxyDeployer')
+		if (proxyStep === undefined) throw new Error('Expected proxyDeployer step')
+		let confirmed = false
+		let codeReadCount = 0
+		const client = asWriteClient({
+			getBalance: async () => 10_000_000_000_000_000n,
+			getCode: async () => {
+				codeReadCount += 1
+				return codeReadCount < 5 ? undefined : PROXY_DEPLOYER_RUNTIME_CODE
+			},
+			getTransactionCount: async () => (confirmed ? 1n : 0n),
+			recordCanonicalRawTransaction: () => undefined,
+			sendRawTransaction: async () => {
+				confirmed = true
+				throw new Error('nonce too low')
+			},
+			sendTransaction: async () => {
+				throw new Error('Funding should not be sent')
+			},
+			waitForTransactionReceipt: async () => {
+				throw new Error('An already confirmed deployment should not be awaited')
+			},
+		})
+
+		expect(await proxyStep.deploy(client)).not.toBe(ZERO_HASH)
+		expect(retryDelays).toEqual([250])
+	})
+
 	test('proxy deployer retry rechecks canonical state after funding confirms', async () => {
 		const proxyStep = createDeploymentSteps().find(step => step.id === 'proxyDeployer')
 		if (proxyStep === undefined) throw new Error('Expected proxyDeployer step')
@@ -867,6 +979,37 @@ describe('contract deployment internals', () => {
 
 		expect(await proxyStep.deploy(client)).not.toBe(ZERO_HASH)
 		expect(rawBroadcastCalled).toBe(true)
+	})
+
+	test('proxy deployer retries delayed code when deployment confirms during signer funding', async () => {
+		let codeVisible = false
+		let funded = false
+		let rawBroadcastCount = 0
+		const retryDelays: number[] = []
+		const proxyStep = createDeploymentSteps(async delayMilliseconds => {
+			retryDelays.push(delayMilliseconds)
+			codeVisible = true
+		}).find(step => step.id === 'proxyDeployer')
+		if (proxyStep === undefined) throw new Error('Expected proxyDeployer step')
+		const client = asWriteClient({
+			getBalance: async () => (funded ? 10_000_000_000_000_000n : 0n),
+			getCode: async () => (codeVisible ? PROXY_DEPLOYER_RUNTIME_CODE : undefined),
+			getTransactionCount: async () => (funded ? 1n : 0n),
+			recordCanonicalRawTransaction: () => undefined,
+			sendRawTransaction: async () => {
+				rawBroadcastCount += 1
+				throw new Error('insufficient funds for gas')
+			},
+			sendTransaction: async () => {
+				funded = true
+				return `0x${'2'.repeat(64)}` as Hash
+			},
+			waitForTransactionReceipt: async () => hashReceipt('success'),
+		})
+
+		expect(await proxyStep.deploy(client)).not.toBe(ZERO_HASH)
+		expect(retryDelays).toEqual([250])
+		expect(rawBroadcastCount).toBe(1)
 	})
 
 	test('proxy deployer broadcast races reject unexpected installed code', async () => {


### PR DESCRIPTION
## Summary

- retry post-deployment code reads with bounded backoff when RPC replicas lag confirmed receipts
- cover CLI and UI deployment flows, canonical proxy and CREATE2 deployers, resume/race/funding paths, and final bootstrap-descendant verification
- resolve exact canonical state before fee and budget preflight, and carry verified bootstrap state into execution without re-accounting historical deployment costs
- preserve immediate rejection of unexpected runtime code and bounded failure when code remains absent

## Why

A Sepolia deployment transaction succeeded and installed the expected `ShareTokenFactory` runtime, but the next `eth_getCode(..., "latest")` request hit a lagging RPC replica and returned empty code. The deploy script consequently reported a false deployment failure.

## Validation

- `bun run tsc`
- `bun test scripts/deploy-testnet.test.ts scripts/uniswap-deployment.test.ts ui/ts/tests/protocol/deployment.test.ts ui/ts/tests/features/deployment/useDeploymentFlow.test.tsx` — 103 tests, 457 assertions
- `bun run format:check`
- `bun run check:changed`
- `bun run knip`
- `git diff --check`

## Review and QA

- final reviewer: 96/100, no findings
- visual reviewer: 87/100, no findings
- the UI change only keeps the existing pending state active during bounded RPC-state retries; it changes no rendered components, styles, or copy, so there is no visual delta to screenshot
- browser automation was unavailable in the workspace; the stale-RPC success, permanent-absence, and unexpected-code states are covered deterministically by tests
