### PR TITLE
Fix AugurScan lease stability and RPC diagnostics

### DIFF
--- a/augurScan/src/database.ts
+++ b/augurScan/src/database.ts
@@ -287,11 +287,18 @@ const withIndexerLease = async <T>(lease: IndexerLease, operation: (transaction:
 const withOptionalIndexerLease = async <T>(sql: SQL, lease: IndexerLease | undefined, operation: (sql: SQL) => Promise<T>): Promise<T> =>
 	lease === undefined ? await operation(sql) : await withIndexerLease(lease, operation)
 
+export const scannerDatabaseOptions = (maxConnections: number, connectionTimeoutSeconds: number) => ({
+	max: maxConnections,
+	idleTimeout: 0,
+	maxLifetime: 0,
+	connectionTimeout: connectionTimeoutSeconds,
+})
+
 export class ScannerDatabase {
 	readonly sql: SQL
 
 	constructor(url: string, maxConnections = 10, connectionTimeoutSeconds = 5) {
-		this.sql = new SQL(url, { max: maxConnections, idleTimeout: 30, connectionTimeout: connectionTimeoutSeconds })
+		this.sql = new SQL(url, scannerDatabaseOptions(maxConnections, connectionTimeoutSeconds))
 	}
 
 	async close(): Promise<void> {

--- a/augurScan/src/indexer.ts
+++ b/augurScan/src/indexer.ts
@@ -170,6 +170,17 @@ type RpcRequestQueue = {
 	readonly run: <T>(operation: () => Promise<T>) => Promise<T>
 }
 
+class RpcRequestMethodError extends Error {
+	override name = 'RpcRequestMethodError'
+
+	constructor(
+		readonly method: string,
+		cause: unknown,
+	) {
+		super('RPC method failed', { cause })
+	}
+}
+
 type RpcQueueSaturation = {
 	readonly active: number
 	readonly pending: number
@@ -251,7 +262,13 @@ export const withRpcRequestQueue =
 		const configured = transport(parameters)
 		return {
 			...configured,
-			request: async (request, options) => await queue.run(() => configured.request(request, options)),
+			request: async (request, options) => {
+				try {
+					return await queue.run(() => configured.request(request, options))
+				} catch (error) {
+					throw new RpcRequestMethodError(request.method, error)
+				}
+			},
 		}
 	}
 
@@ -748,6 +765,7 @@ const safeErrorNames = new Set([
 	'SocketError',
 	'TimeoutError',
 	'TypeError',
+	'UnknownNodeError',
 	'UnknownRpcError',
 ])
 
@@ -789,6 +807,21 @@ const safeStandardRpcProviderMessage = (value: unknown): string | undefined => {
 	return safeStandardRpcMessages.get(normalized.replace(/[.!]$/u, ''))
 }
 
+const safeRpcRequestMethod = (value: unknown): string | undefined =>
+	typeof value === 'string' && /^(?:eth|net|web3)_[A-Za-z0-9_]+$/u.test(value) ? value : undefined
+
+const rpcRequestMethodFrom = (error: unknown): string | undefined => {
+	const seen = new Set<unknown>()
+	let current: unknown = error
+	while (typeof current === 'object' && current !== null && !seen.has(current)) {
+		seen.add(current)
+		const method = current instanceof RpcRequestMethodError ? safeRpcRequestMethod(current.method) : undefined
+		if (method !== undefined) return method
+		current = 'cause' in current ? current.cause : undefined
+	}
+	return undefined
+}
+
 export const safeIndexerFailureReason = (error: unknown): string => {
 	const saturation = rpcQueueSaturationFrom(error)
 	if (saturation !== undefined)
@@ -819,6 +852,8 @@ export const safeIndexerFailureReason = (error: unknown): string => {
 	const category = rpcErrorCategory(error)
 	const message = category === undefined ? standardMessage : safeRpcCategoryMessages[category]
 	const details = [names.length === 0 ? 'UnknownError' : names.slice(0, 4).join(' caused by ')]
+	const method = rpcRequestMethodFrom(error)
+	if (method !== undefined) details.push(`method ${method}`)
 	if (status !== undefined) details.push(`HTTP ${status}`)
 	if (code !== undefined) details.push(`code ${code}`)
 	if (message !== undefined) details.push(`message: ${message}`)

--- a/augurScan/tests/indexer-lifecycle.test.ts
+++ b/augurScan/tests/indexer-lifecycle.test.ts
@@ -257,7 +257,7 @@ describe('network indexer lifecycle', () => {
 				fetchFn: async (_input, init) => {
 					const body = parseRpcRequestBody(JSON.parse(String(init?.body)))
 					requestedMethods.push(body.method)
-					if (body.method === 'fail') throw new Error('expected transport failure')
+					if (body.method === 'eth_getLogs') throw new Error('expected transport failure')
 					return Response.json({ id: body.id, jsonrpc: '2.0', result: body.method })
 				},
 				retryCount: 0,
@@ -280,11 +280,41 @@ describe('network indexer lifecycle', () => {
 		await blocker
 		expect(await delayed).toBe('delayed')
 
-		const failed = transport.request({ method: 'fail' })
+		const failed = transport.request({ method: 'eth_getLogs' })
 		const afterFailure = transport.request({ method: 'after-failure' })
-		await expect(failed).rejects.toThrow()
+		let transportFailure: unknown
+		try {
+			await failed
+		} catch (error) {
+			transportFailure = error
+		}
+		expect(safeIndexerFailureReason(transportFailure)).toContain('method eth_getLogs')
 		expect(await afterFailure).toBe('after-failure')
-		expect(requestedMethods).toEqual(['delayed', 'fail', 'after-failure'])
+		expect(requestedMethods).toEqual(['delayed', 'eth_getLogs', 'after-failure'])
+	})
+
+	test('attributes a failed RPC batch to each request method independently', async () => {
+		let fetches = 0
+		const transport = withRpcRequestQueue(
+			http('https://rpc.example', {
+				batch: { batchSize: 50, wait: 0 },
+				fetchFn: async () => {
+					fetches++
+					throw new Error('shared batch failure')
+				},
+				retryCount: 0,
+			}),
+			createRpcRequestQueue(5),
+		)({})
+		const results = await Promise.allSettled([transport.request({ method: 'eth_getLogs' }), transport.request({ method: 'eth_chainId' })])
+		const reasonFrom = (result: PromiseSettledResult<unknown>): string => {
+			if (result.status !== 'rejected') throw new Error('Expected the RPC batch request to fail')
+			return safeIndexerFailureReason(result.reason)
+		}
+
+		expect(fetches).toBe(1)
+		expect(reasonFrom(results[0])).toContain('method eth_getLogs')
+		expect(reasonFrom(results[1])).toContain('method eth_chainId')
 	})
 
 	test('forwards viem request options through the RPC queue', async () => {
@@ -1008,6 +1038,19 @@ describe('network indexer lifecycle', () => {
 		expect(reason).not.toContain(secret)
 		expect(reason).not.toContain('rpc.example')
 		expect(safeIndexerFailureReason(Object.assign(new Error(secret), { code: 'PROVIDER_KEY_SENTINEL', name: `${secret}Error` }))).toBe('UnknownError')
+	})
+
+	test('retains viem unknown-node diagnostics for provider RPC failures', () => {
+		const secret = 'provider-key-sentinel'
+		const error = Object.assign(new Error(`request failed at https://rpc.example/${secret}`), {
+			name: 'UnknownNodeError',
+			shortMessage: 'request rate exceeded',
+		})
+
+		const reason = safeIndexerFailureReason(error)
+		expect(reason).toBe('UnknownNodeError; message: provider rate limit exceeded')
+		expect(reason).not.toContain(secret)
+		expect(reason).not.toContain('rpc.example')
 	})
 
 	test('identifies the active RPC number after provider failover', async () => {

--- a/augurScan/tests/postgres.integration.test.ts
+++ b/augurScan/tests/postgres.integration.test.ts
@@ -13,6 +13,7 @@ import {
 	rewindDepth,
 	ScannerDatabase,
 	type StoredTransaction,
+	scannerDatabaseOptions,
 } from '../src/database.ts'
 import { getAddress, keccak256, stringToHex } from '../src/ethereum.ts'
 import { migrate } from '../src/migrate.ts'
@@ -196,6 +197,15 @@ const indexedBlock = (
 }
 
 describe('database checkpoint fencing', () => {
+	test('keeps reserved advisory-lock sessions alive between RPC operations', () => {
+		expect(scannerDatabaseOptions(10, 5)).toEqual({
+			max: 10,
+			idleTimeout: 0,
+			maxLifetime: 0,
+			connectionTimeout: 5,
+		})
+	})
+
 	test('waits for asynchronous reserved connection release', async () => {
 		let finishRelease: (() => void) | undefined
 		let settled = false


### PR DESCRIPTION
## Summary

- keep Bun SQL connections alive so reserved PostgreSQL advisory-lock sessions do not expire during long RPC operations
- preserve safely validated JSON-RPC method context through transport and batched-request failures
- recognize viem UnknownNodeError diagnostics without exposing RPC credentials or arbitrary provider messages
- add regression coverage for lease configuration, redaction, and independent method attribution within a shared failed HTTP batch

## Why

AugurScan could spend more than 30 seconds on RPC work while its reserved PostgreSQL session was idle. The configured SQL idle timeout then closed the session, causing ERR_POSTGRES_CONNECTION_CLOSED ownership failures and repeated backend PID churn. At the same time, some Infura failures were reduced to UnknownError or TypeError without identifying the operation that failed.

## Validation

- cd augurScan && bun run typecheck
- cd augurScan && bun test — 167 passed, 1 skipped because POSTGRES_TEST_URL and Docker are unavailable
- cd augurScan && bun run check
- bun run tsc
- bun run format:check
- bun run check:changed
- bun run knip
- git diff --check
- final review: 98/100, no findings

The repository-wide test suite was skipped because this is isolated to the standalone AugurScan package and its complete package suite covers the changed behavior. Browser and visual QA do not apply because no rendered behavior changed.