### PR TITLE
Retry deployment scans after RPC rate limits

### DIFF
--- a/augurScan/src/indexer.ts
+++ b/augurScan/src/indexer.ts
@@ -386,40 +386,39 @@ export const planDeploymentAwareLogScan = async (
 				observations: [],
 			}
 		}
+		let deployment: { readonly block: bigint; readonly exact: boolean } | undefined
 		try {
 			const searchStart = contract.deploymentCheckedBlock ?? configuredStartBlock
-			const deployment = await findContractDeploymentBlock(
+			deployment = await findContractDeploymentBlock(
 				searchStart,
 				toBlock,
 				(block) => codeAt(contract.address, block),
 				contract.deploymentCheckedBlock !== undefined,
 			)
-			if (deployment === undefined) {
-				return { inputs: [], observations: [{ contractAddress: contract.address, checkedBlock: toBlock }] }
-			}
-			const observation: ContractDeploymentObservation = {
-				contractAddress: contract.address,
-				checkedBlock: toBlock,
-				deployment: { ...deployment, timestamp: await blockTimestamp(deployment.block) },
-			}
-			return {
-				inputs: [
-					{
-						address: contract.address,
-						fromBlock: deployment.block > fromBlock ? deployment.block : fromBlock,
-						startBlock: deployment.block,
-					},
-				],
-				observations: [observation],
-			}
 		} catch (error) {
-			if (rpcQueueSaturationFrom(error) !== undefined) throw error
+			if (rpcQueueSaturationFrom(error) !== undefined || !isPermanentHistoricalCodeError(error)) throw error
 			onDetectionFailure(contract, error)
 			const fallbackStart = contract.discoveryBlock ?? configuredStartBlock
 			return {
 				inputs: [{ address: contract.address, fromBlock, startBlock: fallbackStart }],
 				observations: [],
 			}
+		}
+		if (deployment === undefined) return { inputs: [], observations: [{ contractAddress: contract.address, checkedBlock: toBlock }] }
+		const observation: ContractDeploymentObservation = {
+			contractAddress: contract.address,
+			checkedBlock: toBlock,
+			deployment: { ...deployment, timestamp: await blockTimestamp(deployment.block) },
+		}
+		return {
+			inputs: [
+				{
+					address: contract.address,
+					fromBlock: deployment.block > fromBlock ? deployment.block : fromBlock,
+					startBlock: deployment.block,
+				},
+			],
+			observations: [observation],
 		}
 	})
 	return { inputs: planned.flatMap(({ inputs }) => inputs), observations: planned.flatMap(({ observations }) => observations) }
@@ -549,6 +548,43 @@ const rpcErrorCategory = (error: unknown): RpcDescriptionCategory | undefined =>
 		current = 'cause' in current ? current.cause : undefined
 	}
 	return firstCategory
+}
+
+const isPermanentHistoricalCodeError = (error: unknown): boolean => {
+	const seen = new Set<unknown>()
+	let current: unknown = error
+	while (typeof current === 'object' && current !== null && !seen.has(current)) {
+		seen.add(current)
+		if ('code' in current && current.code === -32601) return true
+		for (const description of preferredRpcDescriptions(current)) {
+			const normalized = classifiedRpcDescription(description)
+			if (
+				normalized.includes('missing trie node') ||
+				normalized.includes('archive unavailable') ||
+				normalized.includes('archive data unavailable') ||
+				normalized.includes('archival data unavailable') ||
+				normalized.includes('archive node required') ||
+				normalized.includes('requires an archive node') ||
+				normalized.includes('requires archive node') ||
+				normalized.includes('historical state unavailable') ||
+				normalized.includes('historical state is unavailable') ||
+				normalized.includes('historical state not available') ||
+				normalized.includes('historical state is not available') ||
+				normalized.includes('historical data unavailable') ||
+				normalized.includes('historical data is unavailable') ||
+				normalized.includes('historical data not available') ||
+				normalized.includes('historical data is not available') ||
+				normalized.includes('pruned historical state') ||
+				normalized.includes('historical state pruned') ||
+				normalized.includes('method not found') ||
+				normalized.includes('method not supported') ||
+				normalized.includes('unsupported method')
+			)
+				return true
+		}
+		current = 'cause' in current ? current.cause : undefined
+	}
+	return false
 }
 
 export const isSplittableLogRangeError = (error: unknown): boolean => {

--- a/augurScan/tests/indexer-lifecycle.test.ts
+++ b/augurScan/tests/indexer-lifecycle.test.ts
@@ -7,7 +7,7 @@ import {
 	runFencedIndexerTransaction,
 	type StoredTransaction,
 } from '../src/database.ts'
-import { type Address, createPublicClient, decodeFunctionResult, http, parseAbi, toHex } from '../src/ethereum.ts'
+import { type Address, createPublicClient, decodeFunctionResult, http, parseAbi, RpcError, toHex } from '../src/ethereum.ts'
 import {
 	addressActivityFrom,
 	boundedDeploymentRead,
@@ -775,7 +775,7 @@ describe('network indexer lifecycle', () => {
 		expect(checkedBlocks).not.toContain(49n)
 	})
 
-	test('falls back to complete scanning when deployment detection fails', async () => {
+	test('falls back to complete scanning when historical contract code is unavailable', async () => {
 		const contract = { address, label: 'Unresolved', kind: 'openOracle', provenance: 'manifest' } satisfies ContractMetadata
 		const failures: unknown[] = []
 		const plan = await planDeploymentAwareLogScan(
@@ -791,6 +791,69 @@ describe('network indexer lifecycle', () => {
 		)
 		expect(plan).toEqual({ inputs: [{ address, fromBlock: 50n, startBlock: 0n }], observations: [] })
 		expect(failures).toHaveLength(1)
+	})
+
+	test('propagates rate limits instead of broadening the deployment-aware log scan', async () => {
+		const contract = { address, label: 'Unresolved', kind: 'openOracle', provenance: 'manifest' } satisfies ContractMetadata
+		const rateLimit = new Error('RPC method failed', { cause: new RpcError('HTTP 429 while calling eth_getCode', { code: 429 }) })
+		const failures: unknown[] = []
+
+		await expect(
+			planDeploymentAwareLogScan(
+				[contract],
+				50n,
+				100n,
+				0n,
+				async () => {
+					throw rateLimit
+				},
+				async () => new Date(0),
+				(_contract, error) => failures.push(error),
+			),
+		).rejects.toBe(rateLimit)
+		expect(failures).toEqual([])
+	})
+
+	test('propagates unexpected deployment detection errors instead of hiding them with a broad scan', async () => {
+		const contract = { address, label: 'Unresolved', kind: 'openOracle', provenance: 'manifest' } satisfies ContractMetadata
+		for (const failure of [new RpcError('Malformed JSON-RPC response while calling eth_getCode'), new RpcError('state data unavailable')]) {
+			const failures: unknown[] = []
+			await expect(
+				planDeploymentAwareLogScan(
+					[contract],
+					50n,
+					100n,
+					0n,
+					async () => {
+						throw failure
+					},
+					async () => new Date(0),
+					(_contract, error) => failures.push(error),
+				),
+			).rejects.toBe(failure)
+			expect(failures).toEqual([])
+		}
+	})
+
+	test('propagates deployment timestamp failures instead of treating them as code capability failures', async () => {
+		const contract = { address, label: 'Unresolved', kind: 'openOracle', provenance: 'manifest' } satisfies ContractMetadata
+		const timestampFailure = new Error('archive unavailable')
+		const failures: unknown[] = []
+
+		await expect(
+			planDeploymentAwareLogScan(
+				[contract],
+				50n,
+				100n,
+				0n,
+				async () => '0x01',
+				async () => {
+					throw timestampFailure
+				},
+				(_contract, error) => failures.push(error),
+			),
+		).rejects.toBe(timestampFailure)
+		expect(failures).toEqual([])
 	})
 
 	test('propagates wrapped queue saturation instead of falling back during deployment detection', async () => {


### PR DESCRIPTION
## Summary

- propagate rate limits and other transient deployment-detection failures into the indexer retry/backoff lifecycle
- retain broad log-scan fallback only for explicit permanent historical-state or unsupported-method limitations
- keep deployment timestamp failures outside the code-capability fallback
- add regression coverage for HTTP 429, malformed and ambiguous provider errors, timestamp failures, archive fallback, and queue saturation

## Why

Falling back after an HTTP 429 broadens the log query and can increase RPC traffic while the provider is already throttling requests. The indexer should pause and retry instead. Broad scanning remains useful when a provider permanently cannot serve historical eth_getCode requests but can still serve logs.

## Validation

- bun run tsc
- cd augurScan && bun run typecheck
- cd augurScan && bun test tests/indexer-lifecycle.test.ts (75 passed)
- bun run format:check
- bun run check:changed
- cd augurScan && bun run check
- bun run knip
- git diff --check

Standalone AugurScan Knip continues to report only pre-existing unused dependencies and exports unrelated to this change. Full repository tests were not run because the change is isolated to the AugurScan planner and its complete indexer lifecycle test file covers the surrounding RPC retry, fallback, failover, and backoff behavior.

Final review: 98/100, no issues.