### PR TITLE
Make local bot dashboards passwordless

### DIFF
--- a/bots/liquidator/.env.example
+++ b/bots/liquidator/.env.example
@@ -1,2 +1,0 @@
-# Use at least 16 characters. Keep the real .env file private.
-ZOLTAR_BOT_DASHBOARD_PASSWORD=''

--- a/bots/liquidator/README.md
+++ b/bots/liquidator/README.md
@@ -35,15 +35,10 @@ docker compose up --build --force-recreate
 On Windows, run `start.bat` from this directory to start the same Compose command.
 
 On first start, the container creates a paused, dry-run configuration in its named
-volume. Open `http://127.0.0.1:4183` and sign in as `operator` with the local-only
-default password `zoltar-local-dashboard`.
-
-For anything beyond local evaluation, create `.env` from `.env.example` and set a
-unique dashboard password of at least 16 characters before starting Compose:
-
-```bash
-install -m 600 .env.example .env
-```
+volume. Open `http://127.0.0.1:4183`; the dashboard does not require a username or
+password. Compose publishes the port only on host loopback, so connect from another
+machine through a trusted tunnel to the host rather than changing the port binding.
+Keep `ZOLTAR_BOT_DASHBOARD_LOOPBACK_PUBLISHED` paired with that `127.0.0.1` mapping.
 
 Save the chain and RPCs in **Chain and RPC connectivity**, finish the remaining
 configuration, and resume only after reviewing the saved settings. Run
@@ -93,13 +88,15 @@ Compose service checks that endpoint and uses `restart: unless-stopped` if the b
 process exits unexpectedly. Contradictory chain, malformed response, or other safety
 validation failures stop startup instead of being treated as an outage.
 
-Native loopback dashboards need no password. If `runtime.uiHost` is `0.0.0.0`, set
-`ZOLTAR_BOT_DASHBOARD_PASSWORD` to at least 16 characters before startup. The
-browser's HTTP Basic prompt uses username `operator` and that password. Keep the
-listener on a trusted network or behind an authenticated TLS proxy: Basic
-authentication protects access but does not encrypt the private key or settings in
-transit. Mutable requests also retain same-origin and fixed-authority checks, and
-JSON request bodies are capped at 1 MiB.
+Native loopback dashboards and the supplied host-loopback Compose setup need no
+password. Outside that Compose setup, if `runtime.uiHost` is `0.0.0.0`, set
+`ZOLTAR_BOT_DASHBOARD_PASSWORD` to at least 16 characters before startup. For a
+custom network-bound container, remove `ZOLTAR_BOT_DASHBOARD_LOOPBACK_PUBLISHED`
+and explicitly pass the password into the container. The browser's HTTP Basic prompt
+uses username `operator` and that password. Keep the listener on a trusted network
+or behind an authenticated TLS proxy: Basic authentication protects access but does
+not encrypt the private key or settings in transit. Mutable requests also retain
+same-origin and fixed-authority checks, and JSON request bodies are capped at 1 MiB.
 
 Keep `runtime.execute` false until the factory, WETH, signer, selected pools, RPC
 endpoints, gas limits, and REP limits have been reviewed. When execution is

--- a/bots/liquidator/compose.yaml
+++ b/bots/liquidator/compose.yaml
@@ -8,7 +8,8 @@ services:
       dockerfile: bots/liquidator/Dockerfile
     image: zoltar-liquidator
     environment:
-      ZOLTAR_BOT_DASHBOARD_PASSWORD: ${ZOLTAR_BOT_DASHBOARD_PASSWORD:-zoltar-local-dashboard}
+      # Keep this assertion paired with the host-loopback port mapping below.
+      ZOLTAR_BOT_DASHBOARD_LOOPBACK_PUBLISHED: "true"
     ports:
       - 127.0.0.1:4183:4183
     healthcheck:

--- a/bots/liquidator/src/cli/run.ts
+++ b/bots/liquidator/src/cli/run.ts
@@ -53,7 +53,7 @@ async function runOperator(loaded: Awaited<ReturnType<typeof loadSettings>>, pro
 			: createWalletClient({
 					account: privateKeyToAccount(activePrivateKey),
 					chain,
-						transport: readPool.transport,
+					transport: readPool.transport,
 				})
 	const state = initialRuntimeState(settings.paused, wallet?.account.address)
 	const durable = await loadDurableState(settings.runtime.stateFile)
@@ -88,6 +88,7 @@ async function runOperator(loaded: Awaited<ReturnType<typeof loadSettings>>, pro
 					return operatorSnapshot(state, settings.runtime.execute, marketConfigurations(settings))
 				},
 				hostname: settings.runtime.uiHost,
+				loopbackPublished: process.env['ZOLTAR_BOT_DASHBOARD_LOOPBACK_PUBLISHED'] === 'true',
 				password: process.env['ZOLTAR_BOT_DASHBOARD_PASSWORD'],
 				reconcileTransaction: value =>
 					configurationMutationGate.run(async () => {
@@ -324,7 +325,7 @@ async function runOperator(loaded: Awaited<ReturnType<typeof loadSettings>>, pro
 											: createWalletClient({
 													account: privateKeyToAccount(activePrivateKey),
 													chain,
-											transport: readPool.transport,
+													transport: readPool.transport,
 												})
 									state.wallet = wallet?.account.address
 								},
@@ -415,14 +416,14 @@ async function runOperator(loaded: Awaited<ReturnType<typeof loadSettings>>, pro
 							return { client: endpointClient, endpoint, scan: await scanPools(endpointClient, settings, state.wallet) }
 						}),
 					)
-						const available = availableExecutionObservations('liquidation execution snapshot', settled, observation => ({
-							endpoint: observation.endpoint,
-							value: {
-								pools: observation.scan.pools,
-								universes: observation.scan.universes,
-								walletRepByToken: [...observation.scan.walletRepByToken.entries()].sort(([left], [right]) => left.localeCompare(right)),
-							},
-						}))
+					const available = availableExecutionObservations('liquidation execution snapshot', settled, observation => ({
+						endpoint: observation.endpoint,
+						value: {
+							pools: observation.scan.pools,
+							universes: observation.scan.universes,
+							walletRepByToken: [...observation.scan.walletRepByToken.entries()].sort(([left], [right]) => left.localeCompare(right)),
+						},
+					}))
 					const selected = available[0]
 					if (selected === undefined) throw new Error('Liquidation execution snapshot is unavailable')
 					client = selected.client

--- a/bots/liquidator/src/dashboard/dashboard-server.ts
+++ b/bots/liquidator/src/dashboard/dashboard-server.ts
@@ -5,6 +5,7 @@ export type DashboardController = {
 	getConfiguration: () => unknown | Promise<unknown>
 	getState: () => unknown | Promise<unknown>
 	hostname: '0.0.0.0' | '127.0.0.1'
+	loopbackPublished?: boolean
 	password?: string | undefined
 	setApprovedUniverses: (value: unknown) => unknown | Promise<unknown>
 	setMarketConfiguration?: (value: unknown) => unknown | Promise<unknown>
@@ -189,7 +190,7 @@ function publicError(error: unknown, status: number, operation: string, fallback
 }
 
 export function startDashboardServer(port: number, controller: DashboardController) {
-	validateDashboardAuthentication(controller.hostname, controller.password)
+	validateDashboardAuthentication(controller.hostname, controller.password, controller.loopbackPublished)
 	const directory = import.meta.dir
 	const browserSource = Bun.file(join(directory, 'dashboard.ts'))
 	const transpiler = new Bun.Transpiler({ loader: 'ts', target: 'browser' })

--- a/bots/liquidator/tests/dashboard/dashboard-server.test.ts
+++ b/bots/liquidator/tests/dashboard/dashboard-server.test.ts
@@ -41,7 +41,18 @@ describe('liquidator dashboard server', () => {
 				},
 				operatorPath: protectedPath,
 				paused: false,
-				rpcEndpointHealth: [{ consecutiveFailures: 2, error: `RPC https://user:${rpcSecret}@rpc.example/private failed`, lastFailureAt: '2026-08-13T00:00:00.000Z', lastSuccessAt: undefined, latencyMilliseconds: undefined, nextRetryAt: '2026-08-13T00:01:00.000Z', status: 'offline', target: `https://user:${rpcSecret}@rpc.example/private?token=${rpcSecret}` }],
+				rpcEndpointHealth: [
+					{
+						consecutiveFailures: 2,
+						error: `RPC https://user:${rpcSecret}@rpc.example/private failed`,
+						lastFailureAt: '2026-08-13T00:00:00.000Z',
+						lastSuccessAt: undefined,
+						latencyMilliseconds: undefined,
+						nextRetryAt: '2026-08-13T00:01:00.000Z',
+						status: 'offline',
+						target: `https://user:${rpcSecret}@rpc.example/private?token=${rpcSecret}`,
+					},
+				],
 				pendingTransactions: [
 					{
 						hash: `0x${'12'.repeat(32)}`,
@@ -343,5 +354,21 @@ describe('liquidator dashboard server', () => {
 		})
 		expect(mutation.status).toBe(200)
 		expect(paused).toBe(true)
+	})
+
+	test('allows passwordless access through an explicitly loopback-published container port', async () => {
+		const server = startDashboardServer(0, {
+			getConfiguration: () => ({}),
+			getState: () => ({}),
+			hostname: '0.0.0.0',
+			loopbackPublished: true,
+			setApprovedUniverses: value => value,
+			setPaused: value => value,
+			setSelectedPools: value => value,
+			setSigner: value => value,
+			setStrategy: value => value,
+		})
+		servers.push(server)
+		expect((await fetch(`http://127.0.0.1:${server.port}`)).status).toBe(200)
 	})
 })

--- a/bots/liquidator/tests/docker-packaging.test.ts
+++ b/bots/liquidator/tests/docker-packaging.test.ts
@@ -45,8 +45,9 @@ describe('Docker packaging', () => {
 		const source = await readFile(composeFile, 'utf8')
 		expect(source).not.toContain('LIQUIDATOR_UID')
 		expect(source).not.toContain('LIQUIDATOR_GID')
-		expect(source).toContain('${ZOLTAR_BOT_DASHBOARD_PASSWORD:-')
-		expect(source).not.toContain('${ZOLTAR_BOT_DASHBOARD_PASSWORD:?')
+		expect(source).not.toContain('ZOLTAR_BOT_DASHBOARD_PASSWORD')
+		expect(source).toContain('ZOLTAR_BOT_DASHBOARD_LOOPBACK_PUBLISHED: "true"')
+		expect(source).toContain('127.0.0.1:4183:4183')
 	})
 
 	test('creates a private Compose-ready operator configuration on first start', async () => {

--- a/bots/open-oracle-arbitrager/.env.example
+++ b/bots/open-oracle-arbitrager/.env.example
@@ -1,2 +1,0 @@
-# Use at least 16 characters. Keep the real .env file private.
-ZOLTAR_BOT_DASHBOARD_PASSWORD=''

--- a/bots/open-oracle-arbitrager/README.md
+++ b/bots/open-oracle-arbitrager/README.md
@@ -132,7 +132,7 @@ for the report lifecycle assumptions and economics used by the arbitrager.
   as realized.
 
 Do not use a key that controls unrelated protocol or treasury funds. By default, the
-dashboard binds to `127.0.0.1`; the protected-container exception is documented
+dashboard binds to `127.0.0.1`; the host-loopback container setup is documented
 under [Docker](#docker). The execution key still lives in the bot process and must
 be protected like any hot wallet.
 
@@ -218,15 +218,11 @@ lost, restore the complete bot state before resuming live execution with the sam
 signer. Do not reuse that signer from incomplete recovery state.
 
 On first start, the container creates a paused, dry-run configuration in its
-persistent volume. Open `http://127.0.0.1:4173` and sign in as `operator` with the
-local-only default password `zoltar-local-dashboard`.
-
-For anything beyond local evaluation, create `.env` from `.env.example` and set a
-unique dashboard password of at least 16 characters before starting Compose:
-
-```bash
-install -m 600 .env.example .env
-```
+persistent volume. Open `http://127.0.0.1:4173`; the dashboard does not require a
+username or password. Compose publishes the port only on host loopback, so connect
+from another machine through a trusted tunnel to the host rather than changing the
+port binding. Keep `ZOLTAR_BOT_DASHBOARD_LOOPBACK_PUBLISHED` paired with that
+`127.0.0.1` mapping.
 
 In **Chain and RPC connectivity**, select the chain, enter its read and public RPC URLs, and
 save so every endpoint is checked against that chain. Reload the dashboard, then
@@ -675,10 +671,14 @@ The UI is local-only by default. A private key entered there is sent over HTTP t
 loopback endpoint, immediately cleared from the input, and never echoed by the API
 or written to logs or transaction history. In the documented Docker setup, the
 process listens on the container interface while Docker publishes it only on host
-loopback. Binding to `0.0.0.0` requires `ZOLTAR_BOT_DASHBOARD_PASSWORD`; authenticate
-as `operator` in the browser's HTTP Basic prompt. This protects access but does not
-encrypt traffic, so keep that container network free of untrusted peers or terminate
-TLS at an authenticated proxy. JSON API bodies are capped at 1 MiB. The key is kept in memory unless
+loopback; this supplied Compose path does not require a password. Outside that
+explicit host-loopback setup, binding to `0.0.0.0` requires a
+`ZOLTAR_BOT_DASHBOARD_PASSWORD` of at least 16 characters. For a custom network-bound
+container, remove `ZOLTAR_BOT_DASHBOARD_LOOPBACK_PUBLISHED` and explicitly pass the
+password into the container. Authenticate as `operator` in the browser's HTTP Basic
+prompt. Basic authentication protects access but does not encrypt traffic, so keep
+that network free of untrusted peers or terminate TLS at an authenticated proxy.
+JSON API bodies are capped at 1 MiB. The key is kept in memory unless
 **Save this new key in plaintext for future restarts** is selected. That explicit
 choice stores the key in the owner-only operator settings file; protect the host,
 backups, and settings path as wallet credentials. **Forget saved key** atomically

--- a/bots/open-oracle-arbitrager/compose.yaml
+++ b/bots/open-oracle-arbitrager/compose.yaml
@@ -8,7 +8,8 @@ services:
       dockerfile: bots/open-oracle-arbitrager/Dockerfile
     image: zoltar-open-oracle-arbitrager
     environment:
-      ZOLTAR_BOT_DASHBOARD_PASSWORD: ${ZOLTAR_BOT_DASHBOARD_PASSWORD:-zoltar-local-dashboard}
+      # Keep this assertion paired with the host-loopback port mapping below.
+      ZOLTAR_BOT_DASHBOARD_LOOPBACK_PUBLISHED: "true"
     ports:
       - 127.0.0.1:4173:4173
     healthcheck:

--- a/bots/open-oracle-arbitrager/src/dashboard/dashboard-server.ts
+++ b/bots/open-oracle-arbitrager/src/dashboard/dashboard-server.ts
@@ -9,6 +9,7 @@ type DashboardController = {
 	getConfiguration?: () => unknown | Promise<unknown>
 	getSnapshot: () => OperatorSnapshot | Promise<OperatorSnapshot>
 	hostname?: '0.0.0.0' | '127.0.0.1'
+	loopbackPublished?: boolean
 	password?: string | undefined
 	setPaused: (paused: boolean) => void | Promise<void>
 	updateConnectivity: (value: unknown) => unknown | Promise<unknown>
@@ -122,7 +123,7 @@ export function startDashboardServer(port: number, controller: DashboardControll
 	const browserFormatSource = Bun.file(join(directory, 'dashboard-format.ts'))
 	const transpiler = new Bun.Transpiler({ loader: 'ts', target: 'browser' })
 	const hostname = controller.hostname ?? '127.0.0.1'
-	validateDashboardAuthentication(hostname, controller.password)
+	validateDashboardAuthentication(hostname, controller.password, controller.loopbackPublished)
 	let authority = ''
 	const server = Bun.serve({
 		hostname,

--- a/bots/open-oracle-arbitrager/src/runtime/operator-control-plane.ts
+++ b/bots/open-oracle-arbitrager/src/runtime/operator-control-plane.ts
@@ -133,6 +133,7 @@ export function startOperatorControlPlane(parameters: {
 		},
 		getSnapshot: () => operatorSnapshot(state, pending.strategy ?? config, pending.submission ?? config.submission, pending.connectivity ?? config.connectivity, fixedState, config.riskLimits),
 		hostname: config.uiHost,
+		loopbackPublished: process.env['ZOLTAR_BOT_DASHBOARD_LOOPBACK_PUBLISHED'] === 'true',
 		password: process.env['ZOLTAR_BOT_DASHBOARD_PASSWORD'],
 		updateConfiguration: value =>
 			queueSettingsUpdate(async () => {

--- a/bots/open-oracle-arbitrager/tests/dashboard/dashboard-server.test.ts
+++ b/bots/open-oracle-arbitrager/tests/dashboard/dashboard-server.test.ts
@@ -529,3 +529,28 @@ test('supports a container bind while retaining loopback request authority', asy
 	const response = await fetch(origin, { headers: { authorization } })
 	expect(response.status).toBe(200)
 })
+
+test('allows passwordless access through an explicitly loopback-published container port', async () => {
+	const server = startDashboardServer(0, {
+		getSnapshot: () => {
+			throw new Error('Not needed')
+		},
+		hostname: '0.0.0.0',
+		loopbackPublished: true,
+		setPaused: () => undefined,
+		updateConnectivity: () => {
+			throw new Error('Not needed')
+		},
+		updateSigner: () => {
+			throw new Error('Not needed')
+		},
+		updateSubmission: () => {
+			throw new Error('Not needed')
+		},
+		updateStrategy: () => {
+			throw new Error('Not needed')
+		},
+	})
+	servers.push(server)
+	expect((await fetch(`http://127.0.0.1:${server.port}`)).status).toBe(200)
+})

--- a/bots/open-oracle-arbitrager/tests/docker-entrypoint.test.ts
+++ b/bots/open-oracle-arbitrager/tests/docker-entrypoint.test.ts
@@ -36,10 +36,11 @@ describe('Docker entrypoint', () => {
 		expect(source).toContain('docker compose up --build --force-recreate\nset "exit_code=%errorlevel%"\npopd\npause\nexit /b %exit_code%')
 	})
 
-	test('provides a local-only dashboard password when .env is absent', async () => {
+	test('publishes the passwordless dashboard only on host loopback', async () => {
 		const source = await readFile(composeFile, 'utf8')
-		expect(source).toContain('${ZOLTAR_BOT_DASHBOARD_PASSWORD:-')
-		expect(source).not.toContain('${ZOLTAR_BOT_DASHBOARD_PASSWORD:?')
+		expect(source).not.toContain('ZOLTAR_BOT_DASHBOARD_PASSWORD')
+		expect(source).toContain('ZOLTAR_BOT_DASHBOARD_LOOPBACK_PUBLISHED: "true"')
+		expect(source).toContain('127.0.0.1:4173:4173')
 	})
 
 	test('installs production dependencies where shared bot sources can resolve them', async () => {

--- a/bots/shared/src/dashboard/security.ts
+++ b/bots/shared/src/dashboard/security.ts
@@ -2,8 +2,8 @@ import { timingSafeEqual } from 'node:crypto'
 
 const MAXIMUM_DASHBOARD_JSON_BYTES = 1024 * 1024
 
-export function validateDashboardAuthentication(hostname: '0.0.0.0' | '127.0.0.1', password: string | undefined) {
-	if (hostname === '0.0.0.0' && (password === undefined || password.length < 16)) {
+export function validateDashboardAuthentication(hostname: '0.0.0.0' | '127.0.0.1', password: string | undefined, loopbackPublished = false) {
+	if (hostname === '0.0.0.0' && !loopbackPublished && (password === undefined || password.length < 16)) {
 		throw new Error('ZOLTAR_BOT_DASHBOARD_PASSWORD must contain at least 16 characters when the dashboard binds to 0.0.0.0')
 	}
 }


### PR DESCRIPTION
## Summary

- remove the default HTTP Basic credentials from the supplied arbitrager and liquidator Compose dashboards
- keep both dashboards published only on host loopback (`127.0.0.1`)
- add an explicit host-loopback publication assertion while preserving fail-closed password requirements for custom network-bound launches
- update regression coverage and operator documentation, and remove obsolete password `.env.example` files

## Security model

The container processes still listen on their bridge interfaces so Docker can publish them, but the supplied manifests expose ports only at `127.0.0.1:4173` and `127.0.0.1:4183`. The passwordless exception is explicit and documented as valid only with those mappings. Custom network-bound containers must remove the assertion and pass a dashboard password of at least 16 characters.

## Validation

- `bun run tsc`
- `bun run ensure-contract-artifacts && bun run check:shared-dependencies && bun run test:run -- --bail=1` — 2,874 passed, 16 environment-dependent skips, 0 failed
- bot package type checks and suites — shared 70 passed, arbitrager 333 passed, liquidator 119 passed
- `bun run check`
- `bun run knip`
- focused dashboard authentication and packaging tests — 21 passed
- `git diff --check origin/main...HEAD`

Desktop and mobile fixture QA confirmed passwordless HTTP 200 access and no rendered regressions. This is an access-control/configuration change with no intentional visual difference, so there are no before/after UI images.

## Review

- documentation review: 98/100, no remaining issues
- visual review: 96/100, no issues
- synchronized final review: 98/100, no issues
