### PR TITLE
Fix empty trading UI deployment build arg

### DIFF
--- a/trading/ui/build/build.mts
+++ b/trading/ui/build/build.mts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
+import { resolveDeploymentSource } from './deployment.mts'
 
 const uiRoot = path.resolve(import.meta.dir, '..')
 const output = path.join(uiRoot, 'dist')
@@ -8,7 +9,7 @@ await fs.mkdir(output, { recursive: true })
 const result = await Bun.build({ entrypoints: [path.join(uiRoot, 'ts/index.tsx')], outdir: output, naming: 'app.js', target: 'browser', minify: false, sourcemap: 'linked' })
 if (!result.success) throw new AggregateError(result.logs, 'Trading UI build failed')
 await Promise.all([fs.copyFile(path.join(uiRoot, 'index.html'), path.join(output, 'index.html')), fs.copyFile(path.join(uiRoot, 'css/app.css'), path.join(output, 'app.css'))])
-const deploymentSource = process.env.TRADING_UI_DEPLOYMENT
+const deploymentSource = resolveDeploymentSource(process.env.TRADING_UI_DEPLOYMENT)
 if (deploymentSource === undefined) await fs.writeFile(path.join(output, 'deployment.json'), 'null\n')
-else await fs.copyFile(path.resolve(deploymentSource), path.join(output, 'deployment.json'))
+else await fs.copyFile(deploymentSource, path.join(output, 'deployment.json'))
 console.log(`Built standalone trading UI in ${output}`)

--- a/trading/ui/build/deployment.mts
+++ b/trading/ui/build/deployment.mts
@@ -1,0 +1,5 @@
+import path from 'node:path'
+
+export function resolveDeploymentSource(value: string | undefined): string | undefined {
+	return value === undefined || value.trim() === '' ? undefined : path.resolve(value)
+}

--- a/trading/ui/ts/tests/build-deployment.test.ts
+++ b/trading/ui/ts/tests/build-deployment.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'bun:test'
+import path from 'node:path'
+import { resolveDeploymentSource } from '../../build/deployment.mts'
+
+describe('trading UI build deployment', () => {
+	test('uses demo mode when the deployment environment variable is empty', () => {
+		expect(resolveDeploymentSource(undefined)).toBeUndefined()
+		expect(resolveDeploymentSource('')).toBeUndefined()
+		expect(resolveDeploymentSource('  ')).toBeUndefined()
+	})
+
+	test('resolves a configured deployment path', () => {
+		expect(resolveDeploymentSource('deployments/local.json')).toBe(path.resolve('deployments/local.json'))
+	})
+})


### PR DESCRIPTION
## Summary

- treat undefined, empty, and whitespace-only `TRADING_UI_DEPLOYMENT` values as demo-mode configuration
- preserve path resolution for configured deployment manifests
- add regression coverage for the empty Compose build argument

## Why

Docker Compose supplies an empty build argument by default. The UI build previously resolved that empty string to the trading working directory, causing Bun to try copying the directory to `ui/dist/deployment.json` and fail with `ENOTSUP`.

## Validation

- `bun run tsc`
- `cd trading && bun run tsc`
- `cd trading && bun test ./ts/tests ./ui/ts/tests` — 159 tests, 3,126 expectations
- direct empty-argument UI build with exact `null` deployment output verification
- `cd trading && bun run format:check`
- `bun run check:changed`
- Biome check for all three task files
- `bun run knip`
- `bun run check:generated-clean`
- `git diff --check origin/main...HEAD`

The Docker Compose build could not be rerun in the agent environment because the Docker CLI is unavailable. The direct build invocation exercises the exact Bun environment-variable failure boundary.

Final review: 98/100, no findings.