### PR TITLE
Apply bot RPC settings without restart

### DIFF
--- a/bots/open-oracle-arbitrager/src/dashboard/dashboard-format.ts
+++ b/bots/open-oracle-arbitrager/src/dashboard/dashboard-format.ts
@@ -27,7 +27,7 @@ export function pauseControlState(state: { connected: boolean; networkConfigured
 }
 
 export function networkTargetStatus(activeNetwork: 'mainnet' | 'sepolia' | undefined, savedNetwork: 'mainnet' | 'sepolia' | undefined) {
-	return activeNetwork === undefined || savedNetwork === undefined || activeNetwork === savedNetwork ? undefined : `Saved for restart: ${savedNetwork}. The active process remains on ${activeNetwork}.`
+	return activeNetwork === undefined || savedNetwork === undefined || activeNetwork === savedNetwork ? undefined : `Applying ${savedNetwork}; the last snapshot was ${activeNetwork}.`
 }
 
 export function singleFlight<T>(operation: () => Promise<T>) {

--- a/bots/open-oracle-arbitrager/src/dashboard/dashboard.ts
+++ b/bots/open-oracle-arbitrager/src/dashboard/dashboard.ts
@@ -979,13 +979,13 @@ function render(snapshot: PublicOperatorSnapshot) {
 	setText('executor-address', snapshot.executor === undefined ? 'Executor not configured' : `Executor ${snapshot.executor}`)
 	setText('network-value', snapshot.networkConfigured ? `Active: ${snapshot.network} · chain ${snapshot.expectedChainId.toString()}` : 'Network not configured')
 	updateNetworkTargetStatus()
-	setText('chain-safety', snapshot.networkConfigured ? `Expected and continuously verifies ${snapshot.network} chain ${snapshot.expectedChainId.toString()}.` : 'Set the chain and RPC endpoints in RPC connectivity, then restart before scanning.')
+	setText('chain-safety', snapshot.networkConfigured ? `Expected and continuously verifies ${snapshot.network} chain ${snapshot.expectedChainId.toString()}.` : 'Set the chain and RPC endpoints in RPC connectivity before scanning.')
 	renderSignerStatus(snapshot)
 	const launchNotice = element('launch-notice')
 	if (!snapshot.networkConfigured) {
 		launchNotice.hidden = false
 		setText('launch-notice-title', 'Network setup required')
-		setText('launch-notice-copy', 'Choose the chain and verified RPC endpoints below. The bot remains paused until the saved network is applied on restart.')
+		setText('launch-notice-copy', 'Choose the chain and verified RPC endpoints below. They apply to the next scan; the bot remains paused until you resume it.')
 		launchNotice.dataset['tone'] = 'warning'
 	} else if (snapshot.network === 'mainnet') {
 		launchNotice.hidden = true
@@ -1353,7 +1353,7 @@ element<HTMLFormElement>('connectivity-form').addEventListener('submit', async e
 				.filter(value => value !== ''),
 			readRpcUrl: element<HTMLInputElement>('read-rpc-url').value.trim(),
 		}
-		const response = await api<{ connectivity: ConnectivitySettings; network: 'mainnet' | 'sepolia'; restartRequired: boolean }>('/api/connectivity', {
+		const response = await api<{ connectivity: ConnectivitySettings; network: 'mainnet' | 'sepolia' }>('/api/connectivity', {
 			body: JSON.stringify({ connectivity, network: selectedNetwork }),
 			headers: { 'content-type': 'application/json' },
 			method: 'PUT',
@@ -1363,7 +1363,7 @@ element<HTMLFormElement>('connectivity-form').addEventListener('submit', async e
 		element<HTMLSelectElement>('network-name').disabled = true
 		persistedNetwork = response.network
 		updateNetworkTargetStatus()
-		setText('connectivity-status', response.restartRequired ? 'Chain and RPCs passed validation and were saved. Restart the bot to apply the selected chain.' : 'RPCs passed chain checks and were saved for the next scan and future restarts.')
+		setText('connectivity-status', 'Chain and RPCs passed validation, were saved, and apply to the next scan.')
 		await refresh()
 	} catch (error) {
 		setText('connectivity-status', error instanceof Error ? error.message : String(error))

--- a/bots/open-oracle-arbitrager/src/runtime/operator-control-plane.ts
+++ b/bots/open-oracle-arbitrager/src/runtime/operator-control-plane.ts
@@ -11,6 +11,7 @@ import { persistSignerSettingsWithProvisionalLock } from '#execution/execution-l
 import type { SignerOperationGate } from '#execution/signer-operation-gate'
 import { validateSubmissionSettings, type SubmissionSettings } from '#execution/transaction-submission'
 import { authenticatedExecutionToken } from '#config/runtime-deployment'
+import { networkConfiguration } from '#config/network'
 import { checkConnectivity, checkSubmissionEndpoints, endpointLabel, updateSubmissionEndpointChecks, validateIndependentReadRpcUrls, type ConnectivitySettings } from '#monitoring/connectivity'
 import { operatorStatusAfterPause, type SyncCursor } from '#monitoring/block-sync'
 import { operatorSnapshot, recordOperation, strategySettings, updateStrategyFromRequest, type MutableStrategy, type OperatorSnapshotFixedState, type OperatorState } from '#state/operator-state'
@@ -137,6 +138,7 @@ export function startOperatorControlPlane(parameters: {
 		password: process.env['ZOLTAR_BOT_DASHBOARD_PASSWORD'],
 		updateConfiguration: value =>
 			queueSettingsUpdate(async () => {
+				const queuedConnectivity = pending.connectivity
 				if (typeof value !== 'object' || value === null || Array.isArray(value) || Object.keys(value).length !== 2 || !('configuration' in value) || !('revision' in value) || typeof value.revision !== 'string') throw new Error('Complete configuration updates require configuration and revision')
 				const latest = await loadOperatorSettingsWithRevision(config.settingsFile)
 				if (latest === undefined || latest.revision !== value.revision) throw configurationRevisionConflict()
@@ -150,7 +152,7 @@ export function startOperatorControlPlane(parameters: {
 					await checkSubmissionEndpoints(next.submission, expectedChainId)
 				}
 				const savedRevision = await persistSettings(next, value.revision)
-				pending.connectivity = undefined
+				pending.connectivity = queuedConnectivity
 				pending.deployment = undefined
 				pending.strategy = undefined
 				pending.submission = undefined
@@ -168,7 +170,7 @@ export function startOperatorControlPlane(parameters: {
 				await persistFocusedSettings(settings => ({ ...settings, paused }))
 				state.paused = paused
 				state.status = operatorStatusAfterPause(paused, parameters.getCursor()?.initial === false, state.lastError !== undefined)
-				recordOperation(state, { category: 'configuration', details: undefined, level: 'info', message: paused ? 'Operator paused' : 'Operator resumed', reason: 'Dashboard command saved for restart', reportId: undefined })
+				recordOperation(state, { category: 'configuration', details: undefined, level: 'info', message: paused ? 'Operator paused' : 'Operator resumed', reason: 'Applied immediately and saved for future starts', reportId: undefined })
 			}),
 		updateConnectivity: async value => {
 			return queueSettingsUpdate(async () => {
@@ -189,18 +191,31 @@ export function startOperatorControlPlane(parameters: {
 					submission: latest.settings.submission,
 					value,
 				})
-				if (!next.restartRequired) {
-					pending.connectivity = next.connectivity
+				pending.connectivity = next.connectivity
+				if (next.restartRequired) {
+					const network = networkConfiguration(next.network, {
+						factory: latest.settings.deployment.uniswapFactory,
+						quoter: latest.settings.deployment.uniswapQuoter,
+						rep: latest.settings.deployment.rep,
+						weth: latest.settings.deployment.weth,
+					})
+					config.network = network
+					config.networkConfigured = true
+					config.centralizedMarkets = { ...config.centralizedMarkets, assetChainId: network.chain.id }
+					fixedState.expectedChainId = network.chain.id
+					fixedState.explorerUrl = network.explorerUrl
+					fixedState.network = network.name
+					fixedState.networkConfigured = true
 				}
 				recordOperation(state, {
 					category: 'configuration',
 					details: next.connectivity.publicRpcUrls.map(endpointLabel).join(', '),
 					level: 'info',
 					message: 'Network and RPC configuration verified and saved',
-					reason: next.restartRequired ? `Restart to apply ${next.network}` : `Read RPC ${endpointLabel(next.connectivity.readRpcUrl)}`,
+					reason: next.restartRequired ? `${next.network} will apply at the next scan boundary` : `Read RPC ${endpointLabel(next.connectivity.readRpcUrl)}`,
 					reportId: undefined,
 				})
-				return next
+				return { connectivity: next.connectivity, network: next.network }
 			})
 		},
 		updateDeployment: value => {

--- a/bots/open-oracle-arbitrager/src/runtime/operator.ts
+++ b/bots/open-oracle-arbitrager/src/runtime/operator.ts
@@ -186,7 +186,7 @@ export async function runOperator(config: Configuration, lockManager: ExecutionL
 		details: config.coordinatorAddresses.length === 0 ? undefined : `Approved coordinators: ${config.coordinatorAddresses.join(', ')}`,
 		level: 'info',
 		message: config.networkConfigured ? 'Operator started' : 'Operator waiting for network configuration',
-		reason: config.networkConfigured ? `${config.network.name} chain ${config.network.chain.id.toString()}` : 'Set the chain and RPC endpoints in the dashboard, then restart',
+		reason: config.networkConfigured ? `${config.network.name} chain ${config.network.chain.id.toString()}` : 'Set the chain and RPC endpoints in the dashboard',
 		reportId: undefined,
 	})
 	console.log(

--- a/bots/open-oracle-arbitrager/tests/config/configuration.test.ts
+++ b/bots/open-oracle-arbitrager/tests/config/configuration.test.ts
@@ -244,9 +244,37 @@ describe('file-only startup configuration', () => {
 			method: 'PUT',
 		})
 		expect(response.status, await response.clone().text()).toBe(200)
-		expect(await response.json()).toMatchObject({ network: 'sepolia', restartRequired: true })
+		expect(await response.json()).toEqual({ connectivity: { publicRpcUrls: [rpcUrl], readRpcUrl: rpcUrl }, network: 'sepolia' })
 		expect((await loadOperatorSettings(path))?.networkConfigured).toBe(true)
-		expect((await waitForJson(origin, '/api/state'))['status']).toBe('paused')
+		const noOpConfiguration = await waitForJson(origin, '/api/configuration')
+		const noOpSave = await fetch(`${origin}/api/configuration`, {
+			body: JSON.stringify(noOpConfiguration),
+			headers: { 'content-type': 'application/json', origin },
+			method: 'PUT',
+		})
+		expect(noOpSave.status, await noOpSave.clone().text()).toBe(200)
+		let configuredState = await waitForJson(origin, '/api/state')
+		for (let attempt = 0; attempt < 100 && configuredState['networkConfigured'] !== true; attempt++) {
+			await Bun.sleep(20)
+			configuredState = await waitForJson(origin, '/api/state')
+		}
+		expect(configuredState).toMatchObject({ expectedChainId: 11_155_111, network: 'sepolia', networkConfigured: true, status: 'paused' })
+		const rpcOrigin = new URL(rpcUrl).origin
+		for (let attempt = 0; attempt < 100 && !(JSON.stringify(configuredState['rpcEndpointHealth']) ?? '').includes(rpcOrigin); attempt++) {
+			await Bun.sleep(20)
+			configuredState = await waitForJson(origin, '/api/state')
+		}
+		expect(JSON.stringify(configuredState['rpcEndpointHealth']) ?? '').toContain(rpcOrigin)
+		const resume = await fetch(`${origin}/api/paused`, {
+			body: JSON.stringify({ paused: false }),
+			headers: { 'content-type': 'application/json', origin },
+			method: 'PUT',
+		})
+		expect(resume.status, await resume.clone().text()).toBe(200)
+		expect(await resume.json()).toEqual({ paused: false })
+		const resumedState = await waitForJson(origin, '/api/state')
+		expect(resumedState['paused']).toBe(false)
+		expect(resumedState['operationLog']).toEqual(expect.arrayContaining([expect.objectContaining({ message: 'Operator resumed', reason: 'Applied immediately and saved for future starts' })]))
 		const configuredContents = await Bun.file(path).text()
 		const oppositeChain = await fetch(`${origin}/api/connectivity`, {
 			body: JSON.stringify({ connectivity: { publicRpcUrls: [rpcUrl], readRpcUrl: rpcUrl }, network: 'mainnet' }),

--- a/bots/open-oracle-arbitrager/tests/dashboard/dashboard-format.test.ts
+++ b/bots/open-oracle-arbitrager/tests/dashboard/dashboard-format.test.ts
@@ -70,7 +70,7 @@ describe('dashboard exact ETH formatting', () => {
 		expect(pauseControlState({ connected: false, networkConfigured: false, paused: false, snapshotAvailable: false })).toEqual({ confirmDisabled: true, pauseDisabled: true })
 	})
 
-	test('loads focused chain and RPC fields from persisted restart settings', () => {
+	test('loads focused chain and RPC fields from persisted settings', () => {
 		expect(persistedConnectivity({ connectivity: { publicRpcUrls: ['https://sepolia.example/'], readRpcUrl: 'https://sepolia.example/' }, network: 'sepolia' })).toEqual({
 			connectivity: { publicRpcUrls: ['https://sepolia.example/'], readRpcUrl: 'https://sepolia.example/' },
 			network: 'sepolia',
@@ -78,11 +78,11 @@ describe('dashboard exact ETH formatting', () => {
 		expect(persistedConnectivity({ connectivity: { publicRpcUrls: [42], readRpcUrl: 'https://rpc.example/' }, network: 'mainnet' })).toBeUndefined()
 	})
 
-	test('keeps connectivity controls locked through refreshes and labels a saved restart target', () => {
+	test('keeps connectivity controls locked through refreshes and labels an applying network target', () => {
 		expect(connectivityControlsDisabled(true, true)).toBe(true)
 		expect(connectivityControlsDisabled(true, false)).toBe(false)
 		expect(connectivityControlsDisabled(false, false)).toBe(true)
-		expect(networkTargetStatus('mainnet', 'sepolia')).toBe('Saved for restart: sepolia. The active process remains on mainnet.')
+		expect(networkTargetStatus('mainnet', 'sepolia')).toBe('Applying sepolia; the last snapshot was mainnet.')
 		expect(networkTargetStatus('sepolia', 'sepolia')).toBeUndefined()
 	})
 

--- a/bots/open-oracle-arbitrager/tests/dashboard/dashboard-server.test.ts
+++ b/bots/open-oracle-arbitrager/tests/dashboard/dashboard-server.test.ts
@@ -71,7 +71,7 @@ test('serves dashboard state and protects mutable controls with same-origin JSON
 			)
 				throw new Error('Invalid test connectivity')
 			connectivity = { publicRpcUrls: value.connectivity.publicRpcUrls.map(String), readRpcUrl: value.connectivity.readRpcUrl }
-			return { connectivity, network: value.network, restartRequired: false }
+			return { connectivity, network: value.network }
 		},
 		updateDeployment: value => {
 			if (typeof value !== 'object' || value === null || !('executor' in value)) throw new Error('Invalid test deployment')
@@ -263,7 +263,7 @@ test('serves dashboard state and protects mutable controls with same-origin JSON
 		method: 'PUT',
 	})
 	expect(connectivityUpdate.status).toBe(200)
-	expect(await connectivityUpdate.json()).toEqual({ connectivity: { publicRpcUrls: ['https://submit.example'], readRpcUrl: 'https://read.example' }, network: 'mainnet', restartRequired: false })
+	expect(await connectivityUpdate.json()).toEqual({ connectivity: { publicRpcUrls: ['https://submit.example'], readRpcUrl: 'https://read.example' }, network: 'mainnet' })
 	expect(connectivity.readRpcUrl).toBe('https://read.example')
 	const mutationCredentialMarker = 'mutation-operator-secret'
 	connectivityFailure = new Error(`RPC https://operator:${mutationCredentialMarker}@rpc.example returned credential-bearing provider text`)


### PR DESCRIPTION
## Summary

- activate the initially selected chain and validated RPC endpoints in the running arbitrager at the next scan boundary
- keep the bot explicitly paused until the operator resumes it, while removing the restart requirement
- preserve queued connectivity across complete-configuration saves and retain the existing cross-chain journal safety guard
- update dashboard status copy and regression coverage for the live application flow

## Why

The dashboard previously persisted an initial chain selection but kept the placeholder in-memory network and RPC clients until process restart. This made a successful RPC update appear applied while the running bot could not use it. The control plane now updates live network metadata and lets the existing scan-boundary mechanism rebuild clients safely.

## Validation

- root TypeScript check passed
- arbitrager TypeScript check passed
- full arbitrager suite passed: 333 tests, 1,142 assertions
- changed-file repository checks passed
- Knip passed
- changed TypeScript files passed Biome formatting
- git diff check passed
- visual review: 96/100, no findings
- final review: 98/100, no findings

The package-wide format check still reports an unrelated existing Prettier issue in the untouched OpenOracleArbitrageExecutor.sol. Generated-artifact checks were skipped because no contracts or generation paths changed.

## Screenshots

### Desktop — validated RPCs apply to the next scan

![Desktop RPC success state](https://sharey.org/FPzi2h.png)

### Mobile — validated RPCs apply to the next scan

![Mobile RPC success state](https://sharey.org/ZEiZRq.png)

Screenshots expire after 90 days.