### PR TITLE
Add Sepolia Erigon archive node

### DIFF
--- a/erigon/Dockerfile
+++ b/erigon/Dockerfile
@@ -1,0 +1,6 @@
+FROM erigontech/erigon:v3.5.5
+
+COPY --chmod=755 erigon/docker-entrypoint.sh /usr/local/bin/zoltar-erigon-entrypoint
+
+ENTRYPOINT ["/usr/local/bin/zoltar-erigon-entrypoint"]
+CMD ["--help"]

--- a/erigon/Dockerfile.dockerignore
+++ b/erigon/Dockerfile.dockerignore
@@ -1,0 +1,2 @@
+**
+!erigon/docker-entrypoint.sh

--- a/erigon/README.md
+++ b/erigon/README.md
@@ -1,0 +1,49 @@
+# Sepolia archive node
+
+This container runs Erigon's embedded execution and consensus clients for Sepolia in archive mode. It retains all historical state and enables persisted receipts, so `eth_getLogs` can query every block from the start of the current month as well as older history.
+
+Erigon also writes its own process logs under `/home/erigon/.local/share/erigon/logs` in the persistent data volume. Those files survive container recreation.
+
+## Start
+
+From this directory, run:
+
+```bash
+docker compose up --build -d
+docker compose logs -f erigon
+```
+
+The first startup lines print the RPC addresses. With the defaults, applications on the host connect to:
+
+```text
+http://localhost:8545
+```
+
+Other services added to this Compose project connect to `http://erigon:8545`. WebSockets use the same addresses with the `ws://` scheme. The host RPC binding is deliberately restricted to `127.0.0.1`; use a reverse proxy with authentication and TLS instead of exposing the debug and trace APIs directly to the internet.
+
+To use another host port, create an `.env` file beside `compose.yaml`:
+
+```dotenv
+ERIGON_RPC_PORT=9545
+```
+
+The printed host address would then be `http://localhost:9545`. The RPC remains available only from the Docker host and other Compose services.
+
+## Data and retention
+
+Chain data and Erigon's file logs live in the `erigon-sepolia-data` named volume. A normal `docker compose down` preserves it. Do not run `docker compose down --volumes` unless you intend to delete the archive and sync it again.
+
+An archive node retains all historical execution state rather than only a rolling window. This is intentionally broader than retaining logs from the first day of the current month and avoids a date-to-block boundary that would become stale. Initial synchronization downloads the historical archive and can take substantial time, disk space, and bandwidth; the RPC listener starts immediately, but historical requests are complete only after the relevant sync stages finish.
+
+The public P2P, Caplin discovery, and snapshot-download ports are published for reliable sync. The JSON-RPC port is only published on loopback. If a host firewall is enabled, allow inbound TCP/UDP `30303`, UDP `4000`, TCP `4001`, and TCP/UDP `42069` as appropriate for the host.
+
+Verify the node and its network after it has started:
+
+```bash
+curl --fail-with-body \
+  --header 'content-type: application/json' \
+  --data '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}' \
+  http://localhost:8545
+```
+
+Sepolia's chain ID is returned as `0xaa36a7`.

--- a/erigon/compose.yaml
+++ b/erigon/compose.yaml
@@ -1,0 +1,37 @@
+services:
+  erigon:
+    build:
+      context: ..
+      dockerfile: erigon/Dockerfile
+    image: zoltar/sepolia-erigon:v3.5.5
+    restart: unless-stopped
+    environment:
+      ERIGON_RPC_PUBLIC_PORT: ${ERIGON_RPC_PORT:-8545}
+    command:
+      - --chain=sepolia
+      - --datadir=/home/erigon/.local/share/erigon
+      - --prune.mode=archive
+      - --persist.receipts=true
+      - --http
+      - --http.addr=0.0.0.0
+      - --http.port=8545
+      - --http.api=eth,erigon,web3,net,debug,trace,txpool
+      - --http.vhosts=localhost,erigon
+      - --ws
+      - --log.dir.path=/home/erigon/.local/share/erigon/logs
+      - --log.dir.prefix=sepolia
+      - --mcp.disable
+    ports:
+      - "127.0.0.1:${ERIGON_RPC_PORT:-8545}:8545"
+      - "30303:30303/tcp"
+      - "30303:30303/udp"
+      - "4000:4000/udp"
+      - "4001:4001/tcp"
+      - "42069:42069/tcp"
+      - "42069:42069/udp"
+    volumes:
+      - erigon-sepolia-data:/home/erigon/.local/share/erigon
+    stop_grace_period: 2m
+
+volumes:
+  erigon-sepolia-data:

--- a/erigon/docker-entrypoint.sh
+++ b/erigon/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+	set -- erigon "$@"
+fi
+
+rpc_public_port=${ERIGON_RPC_PUBLIC_PORT:-8545}
+month_start=$(date -u '+%Y-%m-01T00:00:00Z')
+
+printf '%s\n' \
+	"Sepolia archive retention: all chain history (including logs since ${month_start})" \
+	"RPC endpoint from this host: http://localhost:${rpc_public_port}" \
+	'RPC endpoint from another Compose service: http://erigon:8545'
+
+exec "$@"


### PR DESCRIPTION
## Summary

- add an Erigon v3.5.5 Docker image and Compose service configured as a Sepolia archive node
- persist chain data, receipts, and Erigon process logs in a named volume
- expose RPC on host loopback and print the host and Compose-network RPC addresses at startup
- document startup, retention, network ports, security boundaries, and verification

## Why

This provides a self-hosted Sepolia RPC with historical state and event-log coverage that includes the beginning of the current month and all earlier chain history.

## Validation

- entrypoint execution with a non-default published RPC port
- POSIX shell syntax check
- Compose YAML parse
- scoped Prettier check
- repository format check
- repository changed-file checks
- whitespace checks for all added files
- final reviewer: 88/100, no findings
- visual documentation reviewer: 88/100, no findings

Docker is unavailable in the development environment, so the image build, live synchronization, and RPC readiness checks could not be run locally.