### PR TITLE
Share Docker networking across local services

### DIFF
--- a/augurScan/README.md
+++ b/augurScan/README.md
@@ -13,12 +13,15 @@ Every visible route refreshes automatically after a committed block notification
 From this directory:
 
 ```bash
+docker network inspect zoltar >/dev/null 2>&1 || docker network create zoltar
 docker compose up --build --force-recreate
 ```
 
 On Windows, run `start.bat` from this directory to start the same Compose command.
 
 Open <http://localhost:3000>. PostgreSQL is included and stored in the `augurscan-data` named volume. The website is available while historical backfill is running and reports the indexed block, its timestamp/age, observed head, lag, percentage complete, estimated time remaining, and network errors. Completion is measured from the effective start block stored for the index to the latest observed head. The ETA appears after the indexer or browser has observed enough forward progress to measure throughput.
+
+The Compose services join the shared external `zoltar` network. When this repository's Erigon Compose project is running, set `SEPOLIA_RPC_URL=http://erigon:8545` to use it without exposing RPC beyond the host.
 
 Set private or higher-capacity RPC endpoints in `.env` for reliable historical indexing. The included public defaults are convenient for evaluation but can rate-limit large backfills. On a fresh database, augurScan searches from `MAINNET_START_BLOCK` or `SEPOLIA_START_BLOCK` through the observed head for the earliest deployment whose history it tracks, then begins indexing at that deployment instead of walking earlier empty blocks. If none of those contracts is deployed yet, indexing waits at the block after the observed head. The conservative default floor of block `0` cannot omit protocol history; a later verified floor reduces historical bytecode reads. Before accepting a manifest change, augurScan verifies that every newly tracked deployment is within the stored index range. An earlier deployment stops with a rebuild error and leaves the current canonical index unchanged. An accepted address, label, or kind change resets that network to its stored effective start and durably replays the current manifest.
 
@@ -43,7 +46,7 @@ bun test
 bun run dev
 ```
 
-Local development expects PostgreSQL at `POSTGRES_URL`. The server applies SQL migrations under a PostgreSQL advisory lock before serving. Migration 005 introduces range-index dataset cursors and rejects an older database if it has an indexed network checkpoint or any block row. No legacy checkpoint or activity compatibility is retained. For the Compose setup, run `docker compose down --volumes` to delete the old database, then `docker compose up --build` to rebuild it from each network's automatically discovered effective start. A database without a checkpoint or block row migrates in place.
+Local development expects PostgreSQL at `POSTGRES_URL`. The server applies SQL migrations under a PostgreSQL advisory lock before serving. Migration 005 introduces range-index dataset cursors and rejects an older database if it has an indexed network checkpoint or any block row. No legacy checkpoint or activity compatibility is retained. For the Compose setup, first run the shared-network command under **Start with Docker**. Then run `docker compose down --volumes` to delete the old database and `docker compose up --build` to rebuild it from each network's automatically discovered effective start. A database without a checkpoint or block row migrates in place.
 
 `POSTGRES_URL` must connect directly to PostgreSQL or through a session-mode pooler. The per-network writer lease is a session-level advisory lock and is not compatible with transaction-mode pooling. At acquisition, augurScan records the PostgreSQL backend PID and verifies that later lease checks remain on that backend. If a proxy moves the reserved connection, the indexer reports an actionable `DatabaseConsistencyError` instead of treating the new backend as the lease owner.
 

--- a/augurScan/compose.yaml
+++ b/augurScan/compose.yaml
@@ -47,3 +47,8 @@ services:
 
 volumes:
   augurscan-data:
+
+networks:
+  default:
+    name: zoltar
+    external: true

--- a/augurScan/start.bat
+++ b/augurScan/start.bat
@@ -1,5 +1,6 @@
 @echo off
 pushd "%~dp0" || exit /b 1
+docker network inspect zoltar >nul 2>&1 || docker network create zoltar || exit /b 1
 docker compose up --build --force-recreate
 set "exit_code=%errorlevel%"
 popd

--- a/bots/liquidator/README.md
+++ b/bots/liquidator/README.md
@@ -29,6 +29,7 @@ threshold.
 From this directory, build and start the bot:
 
 ```bash
+docker network inspect zoltar >/dev/null 2>&1 || docker network create zoltar
 docker compose up --build --force-recreate
 ```
 

--- a/bots/liquidator/compose.yaml
+++ b/bots/liquidator/compose.yaml
@@ -23,3 +23,8 @@ services:
 
 volumes:
   liquidator-state:
+
+networks:
+  default:
+    name: zoltar
+    external: true

--- a/bots/liquidator/start.bat
+++ b/bots/liquidator/start.bat
@@ -1,5 +1,6 @@
 @echo off
 pushd "%~dp0" || exit /b 1
+docker network inspect zoltar >nul 2>&1 || docker network create zoltar || exit /b 1
 docker compose up --build --force-recreate
 set "exit_code=%errorlevel%"
 popd

--- a/bots/open-oracle-arbitrager/README.md
+++ b/bots/open-oracle-arbitrager/README.md
@@ -207,6 +207,7 @@ Docker Compose builds the image, keeps bot state in a named volume, publishes th
 dashboard only on host loopback, and starts the bot. From this directory, run:
 
 ```bash
+docker network inspect zoltar >/dev/null 2>&1 || docker network create zoltar
 docker compose up --build --force-recreate
 ```
 

--- a/bots/open-oracle-arbitrager/compose.yaml
+++ b/bots/open-oracle-arbitrager/compose.yaml
@@ -23,3 +23,8 @@ services:
 
 volumes:
   arbitrager-state:
+
+networks:
+  default:
+    name: zoltar
+    external: true

--- a/bots/open-oracle-arbitrager/start.bat
+++ b/bots/open-oracle-arbitrager/start.bat
@@ -1,5 +1,6 @@
 @echo off
 pushd "%~dp0" || exit /b 1
+docker network inspect zoltar >nul 2>&1 || docker network create zoltar || exit /b 1
 docker compose up --build --force-recreate
 set "exit_code=%errorlevel%"
 popd

--- a/erigon/README.md
+++ b/erigon/README.md
@@ -9,6 +9,7 @@ Erigon also writes its own process logs under `/home/erigon/.local/share/erigon/
 From this directory, run:
 
 ```bash
+docker network inspect zoltar >/dev/null 2>&1 || docker network create zoltar
 docker compose up --build -d
 docker compose logs -f erigon
 ```
@@ -21,7 +22,7 @@ The first startup lines print the RPC addresses. With the defaults, applications
 http://localhost:8545
 ```
 
-Other services added to this Compose project connect to `http://erigon:8545`. WebSockets use the same addresses with the `ws://` scheme. The host RPC binding is deliberately restricted to `127.0.0.1`; use a reverse proxy with authentication and TLS instead of exposing the debug and trace APIs directly to the internet.
+Other repository Compose services connect to `http://erigon:8545` through the shared external `zoltar` network. WebSockets use the same addresses with the `ws://` scheme. The host RPC binding is deliberately restricted to `127.0.0.1`; use a reverse proxy with authentication and TLS instead of exposing the debug and trace APIs directly to the internet.
 
 To use another host port, create an `.env` file beside `compose.yaml`:
 

--- a/erigon/compose.yaml
+++ b/erigon/compose.yaml
@@ -35,3 +35,8 @@ services:
 
 volumes:
   erigon-sepolia-data:
+
+networks:
+  default:
+    name: zoltar
+    external: true

--- a/erigon/start.bat
+++ b/erigon/start.bat
@@ -1,5 +1,6 @@
 @echo off
 pushd "%~dp0" || exit /b 1
+docker network inspect zoltar >nul 2>&1 || docker network create zoltar || exit /b 1
 docker compose up --build --force-recreate
 set "exit_code=%errorlevel%"
 popd

--- a/trading/README.md
+++ b/trading/README.md
@@ -32,6 +32,7 @@ Open `http://localhost:4163/?demo=1#/markets`. Demo mode is prominently labeled 
 Build and serve the standalone demo UI from this directory:
 
 ```bash
+docker network inspect zoltar >/dev/null 2>&1 || docker network create zoltar
 docker compose up --build --force-recreate
 ```
 
@@ -44,6 +45,7 @@ Without a deployment build argument, the image contains `deployment.json` set to
 For live use, include a reviewed project-local deployment manifest at build time. The path is relative to `trading/` inside the build context:
 
 ```bash
+docker network inspect zoltar >/dev/null 2>&1 || docker network create zoltar
 TRADING_UI_DEPLOYMENT=deployments/local.json docker compose up --build --force-recreate
 ```
 

--- a/trading/compose.yaml
+++ b/trading/compose.yaml
@@ -10,3 +10,8 @@ services:
     image: zoltar-trading
     ports:
       - 127.0.0.1:4163:4163
+
+networks:
+  default:
+    name: zoltar
+    external: true

--- a/trading/start.bat
+++ b/trading/start.bat
@@ -1,5 +1,6 @@
 @echo off
 pushd "%~dp0" || exit /b 1
+docker network inspect zoltar >nul 2>&1 || docker network create zoltar || exit /b 1
 docker compose up --build --force-recreate
 set "exit_code=%errorlevel%"
 popd


### PR DESCRIPTION
## Summary

- Connect Erigon, AugurScan, trading, and bot Compose projects to the shared `zoltar` network.
- Create the network automatically from Unix and Windows startup instructions.
- Document container-to-container RPC access through `erigon:8545`.

## Testing

- Not run (documentation, Compose configuration, and launcher changes only).