### PR TITLE
Add Windows launcher for UI Docker workflow

### DIFF
--- a/ui/start.bat
+++ b/ui/start.bat
@@ -1,0 +1,7 @@
+@echo off
+pushd "%~dp0.." || exit /b 1
+docker build -f ui/Dockerfile . -t zoltar-ui && docker run --add-host=host.docker.internal:host-gateway zoltar-ui
+set "exit_code=%errorlevel%"
+popd
+pause
+exit /b %exit_code%


### PR DESCRIPTION
## Summary

- add `ui/start.bat` alongside the project’s other Windows launchers
- run the canonical UI Docker build and publish workflow from the repository root
- preserve the command exit code, restore the caller directory, and pause before closing

## Validation

- `bun run check:changed`
- static parity check against the `ui:docker` package script
- `git diff --check`

Browser screenshots are not applicable because this launcher does not change rendered UI or interaction.