### PR TITLE
Fix stale liquidator process locks

### DIFF
--- a/bots/liquidator/Dockerfile
+++ b/bots/liquidator/Dockerfile
@@ -33,6 +33,7 @@ RUN cd shared \
 COPY bots/liquidator/README.md ./bots/liquidator/README.md
 COPY bots/liquidator/config/ ./bots/liquidator/config/
 COPY bots/liquidator/scripts/check-market-sources.mts ./bots/liquidator/scripts/check-market-sources.mts
+COPY bots/liquidator/scripts/check-process-lock-runtime.mts ./bots/liquidator/scripts/check-process-lock-runtime.mts
 COPY bots/liquidator/scripts/docker-entrypoint.sh ./bots/liquidator/scripts/docker-entrypoint.sh
 COPY bots/liquidator/src/ ./bots/liquidator/src/
 RUN chmod 0755 bots/liquidator/scripts/docker-entrypoint.sh \
@@ -40,6 +41,7 @@ RUN chmod 0755 bots/liquidator/scripts/docker-entrypoint.sh \
 
 USER bun
 WORKDIR /app/bots/liquidator
+RUN bun ./scripts/check-process-lock-runtime.mts
 
 EXPOSE 4183
 VOLUME ["/app/bots/liquidator/.state"]

--- a/bots/liquidator/scripts/check-process-lock-runtime.mts
+++ b/bots/liquidator/scripts/check-process-lock-runtime.mts
@@ -1,0 +1,42 @@
+import { acquireExclusiveProcessLock } from '@zoltar/bot-shared/execution/process-lock'
+import { mkdtemp, rm, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const directory = await mkdtemp(join(tmpdir(), 'zoltar-process-lock-runtime-'))
+const lockPath = join(directory, 'operator.lock')
+
+try {
+	const first = await acquireExclusiveProcessLock(lockPath, 'Runtime check lock', {})
+	try {
+		await acquireExclusiveProcessLock(lockPath, 'Runtime check lock', {})
+		throw new Error('A live process lock allowed a competing owner')
+	} catch (error) {
+		if (!(error instanceof Error) || !error.message.includes('already locked')) throw error
+	}
+	const inode = (await stat(lockPath)).ino
+	await first.release()
+	if ((await stat(lockPath)).ino !== inode) throw new Error('Process lock release replaced the stable lock inode')
+
+	const child = Bun.spawn([process.execPath, '--eval', `import { acquireExclusiveProcessLock } from '@zoltar/bot-shared/execution/process-lock'; await acquireExclusiveProcessLock(${JSON.stringify(lockPath)}, 'Runtime check lock', {}); console.log('ready'); await Bun.sleep(60_000)`], {
+		cwd: import.meta.dir,
+		stderr: 'pipe',
+		stdout: 'pipe',
+	})
+	try {
+		const reader = child.stdout.getReader()
+		const next = await reader.read()
+		if (next.done || !new TextDecoder().decode(next.value).includes('ready')) throw new Error(`Process-lock runtime child stopped before acquisition: ${await new Response(child.stderr).text()}`)
+		reader.releaseLock()
+		child.kill('SIGKILL')
+		if ((await child.exited) === 0) throw new Error('Process-lock runtime child was not killed')
+	} finally {
+		if (child.exitCode === null) child.kill('SIGKILL')
+		await child.exited
+	}
+
+	const replacement = await acquireExclusiveProcessLock(lockPath, 'Runtime check lock', {})
+	await replacement.release()
+} finally {
+	await rm(directory, { force: true, recursive: true })
+}

--- a/bots/liquidator/tests/docker-packaging.test.ts
+++ b/bots/liquidator/tests/docker-packaging.test.ts
@@ -42,6 +42,8 @@ describe('Docker packaging', () => {
 		expect(source).toContain('&& bun run shared:build')
 		expect(source).toContain('COPY --from=shared-builder /source/shared/ ./shared/')
 		expect(source).toContain('cd shared \\\n\t&& bun install --frozen-lockfile --production \\\n\t&& cd ../bots/shared \\\n\t&& bun install --frozen-lockfile --production')
+		expect(source).toContain('COPY bots/liquidator/scripts/check-process-lock-runtime.mts ./bots/liquidator/scripts/check-process-lock-runtime.mts')
+		expect(source).toContain('RUN bun ./scripts/check-process-lock-runtime.mts')
 	})
 
 	test('starts without host UID, GID, or .env configuration', async () => {

--- a/bots/shared/src/execution/process-lock.ts
+++ b/bots/shared/src/execution/process-lock.ts
@@ -1,21 +1,47 @@
-import { lstat, mkdir, open, readFile, rm } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { lstat, mkdir, open, readFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
+import { dlopen } from 'bun:ffi'
 import { getAddress, type Address } from '../ethereum.ts'
 
 type ProcessLockFileHandle = {
 	chmod: (mode: number) => Promise<unknown>
 	close: () => Promise<unknown>
+	fd: number
 	sync: () => Promise<unknown>
+	truncate: (length?: number) => Promise<unknown>
 	writeFile: (data: string, options: { encoding: 'utf8' }) => Promise<unknown>
 }
 
 export type ProcessLockFilesystem = {
 	lstat?: (path: string) => Promise<{ isDirectory: () => boolean; isSymbolicLink: () => boolean; mode: number; uid: number }>
 	mkdir: (path: string, options: { mode: number; recursive: true }) => Promise<unknown>
-	open: (path: string, flags: 'wx', mode: number) => Promise<ProcessLockFileHandle>
+	open: (path: string, flags: number, mode: number) => Promise<ProcessLockFileHandle>
 	readFile: (path: string, encoding: 'utf8') => Promise<string>
-	rm: (path: string, options: { force: true }) => Promise<unknown>
+	tryLock: (fileDescriptor: number) => boolean
+}
+
+const nativeFlockCandidates =
+	process.platform === 'darwin' ? ['/usr/lib/libSystem.B.dylib'] : process.platform === 'linux' ? ['libc.so.6', ...(process.arch === 'x64' ? ['/lib/libc.musl-x86_64.so.1', '/lib/ld-musl-x86_64.so.1'] : []), ...(process.arch === 'arm64' ? ['/lib/libc.musl-aarch64.so.1', '/lib/ld-musl-aarch64.so.1'] : [])] : []
+
+let nativeFlock: ((fileDescriptor: number) => number) | undefined
+
+function tryNativeFileLock(fileDescriptor: number) {
+	if (nativeFlock === undefined) {
+		const failures: unknown[] = []
+		for (const candidate of nativeFlockCandidates) {
+			try {
+				const library = dlopen(candidate, { flock: { args: ['i32', 'i32'], returns: 'i32' } })
+				nativeFlock = descriptor => library.symbols.flock(descriptor, 6)
+				break
+			} catch (error) {
+				failures.push(error)
+			}
+		}
+		if (nativeFlock === undefined) throw new AggregateError(failures, 'Native process locking is unavailable on this platform')
+	}
+	return nativeFlock(fileDescriptor) === 0
 }
 
 export type ExclusiveProcessLock = {
@@ -28,7 +54,7 @@ const processLockFilesystem: ProcessLockFilesystem = {
 	mkdir,
 	open,
 	readFile,
-	rm,
+	tryLock: tryNativeFileLock,
 }
 
 async function assertSafeLockDirectory(path: string, filesystem: ProcessLockFilesystem) {
@@ -46,21 +72,34 @@ export async function acquireExclusiveProcessLock(lockPath: string, subject: str
 	await assertSafeLockDirectory(lockDirectory, filesystem)
 	let handle: ProcessLockFileHandle
 	try {
-		handle = await filesystem.open(lockPath, 'wx', 0o600)
+		handle = await filesystem.open(lockPath, constants.O_CREAT | constants.O_NOFOLLOW | constants.O_RDWR, 0o600)
 	} catch (error) {
-		if (typeof error === 'object' && error !== null && 'code' in error && error.code === 'EEXIST') {
-			let owner = 'owner metadata unavailable'
-			try {
-				owner = (await filesystem.readFile(lockPath, 'utf8')).trim()
-			} catch (readError) {
-				void readError
-			}
-			throw new Error(`${subject} is already locked (${owner}). Stop the other process before removing ${lockPath}.`)
+		throw error
+	}
+	let acquired: boolean
+	try {
+		acquired = filesystem.tryLock(handle.fd)
+	} catch (error) {
+		try {
+			await handle.close()
+		} catch (cleanupError) {
+			throw new AggregateError([error, cleanupError], `Failed to acquire and clean up process lock ${lockPath}`)
 		}
 		throw error
 	}
+	if (!acquired) {
+		let owner = 'owner metadata unavailable'
+		try {
+			owner = (await filesystem.readFile(lockPath, 'utf8')).trim()
+		} catch (readError) {
+			void readError
+		}
+		await handle.close()
+		throw new Error(`${subject} is already locked (${owner}). Stop the other process before removing ${lockPath}.`)
+	}
 	const payload = `${JSON.stringify({ acquiredAt: new Date().toISOString(), ...metadata, pid: process.pid })}\n`
 	try {
+		await handle.truncate(0)
 		await handle.writeFile(payload, { encoding: 'utf8' })
 		await handle.chmod(0o600)
 		await handle.sync()
@@ -71,16 +110,10 @@ export async function acquireExclusiveProcessLock(lockPath: string, subject: str
 		} catch (cleanupError) {
 			cleanupErrors.push(cleanupError)
 		}
-		try {
-			await filesystem.rm(lockPath, { force: true })
-		} catch (cleanupError) {
-			cleanupErrors.push(cleanupError)
-		}
 		if (cleanupErrors.length !== 0) throw new AggregateError([error, ...cleanupErrors], `Failed to initialize and clean up process lock ${lockPath}`)
 		throw error
 	}
 	let released = false
-	let handleClosed = false
 	let releaseAttempt: Promise<void> | undefined
 	return {
 		path: lockPath,
@@ -88,10 +121,6 @@ export async function acquireExclusiveProcessLock(lockPath: string, subject: str
 			if (released) return Promise.resolve()
 			if (releaseAttempt !== undefined) return releaseAttempt
 			releaseAttempt = (async () => {
-				if (!handleClosed) {
-					await handle.close()
-					handleClosed = true
-				}
 				let current: string
 				try {
 					current = await filesystem.readFile(lockPath, 'utf8')
@@ -99,7 +128,7 @@ export async function acquireExclusiveProcessLock(lockPath: string, subject: str
 					throw new Error(`Process lock ${lockPath} disappeared before release: ${error instanceof Error ? error.message : String(error)}`)
 				}
 				if (current !== payload) throw new Error(`Process lock ${lockPath} changed ownership before release`)
-				await filesystem.rm(lockPath, { force: true })
+				await handle.close()
 				released = true
 			})().finally(() => {
 				if (!released) releaseAttempt = undefined

--- a/bots/shared/tests/shared-primitives.test.ts
+++ b/bots/shared/tests/shared-primitives.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from 'bun:test'
-import { chmod, mkdtemp, mkdir, open, readFile, rm } from 'node:fs/promises'
+import { chmod, mkdtemp, mkdir, open, readFile, rm, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { initialCursor, scanRanges } from '../src/monitoring/block-sync.ts'
 import { quorumValue, settledQuorumValue } from '../src/monitoring/read-quorum.ts'
 import { boundedDashboardJson } from '../src/dashboard/security.ts'
@@ -776,8 +777,7 @@ describe('shared bot primitives', () => {
 		}
 	})
 
-	test('unlinks a failed lock initialization even when closing the handle fails', async () => {
-		let removed = false
+	test('reports cleanup failure when failed lock initialization cannot close its handle', async () => {
 		await expect(
 			acquireExclusiveProcessLock(
 				'operator.lock',
@@ -790,40 +790,110 @@ describe('shared bot primitives', () => {
 						close: async () => {
 							throw new Error('close failed')
 						},
+						fd: 1,
 						sync: async () => undefined,
+						truncate: async () => undefined,
 						writeFile: async () => {
 							throw new Error('write failed')
 						},
 					}),
 					readFile: async () => '',
-					rm: async () => {
-						removed = true
-					},
+					tryLock: () => true,
 				},
 			),
 		).rejects.toThrow('Failed to initialize and clean up process lock')
-		expect(removed).toBe(true)
 	})
 
-	test('retries process-lock cleanup after a transient unlink failure', async () => {
+	test('closes the file handle when native lock acquisition throws', async () => {
+		let closed = false
+		await expect(
+			acquireExclusiveProcessLock(
+				'operator.lock',
+				'Test lock',
+				{},
+				{
+					mkdir: async () => undefined,
+					open: async () => ({
+						chmod: async () => undefined,
+						close: async () => {
+							closed = true
+						},
+						fd: 1,
+						sync: async () => undefined,
+						truncate: async () => undefined,
+						writeFile: async () => undefined,
+					}),
+					readFile: async () => '',
+					tryLock: () => {
+						throw new Error('native lock unavailable')
+					},
+				},
+			),
+		).rejects.toThrow('native lock unavailable')
+		expect(closed).toBe(true)
+	})
+
+	test('retries process-lock cleanup after a transient close failure without replacing the lock inode', async () => {
 		const directory = await mkdtemp(join(tmpdir(), 'zoltar-process-lock-'))
 		temporaryDirectories.push(directory)
 		const lockPath = join(directory, 'operator.lock')
-		let removals = 0
+		let closes = 0
 		const filesystem = {
 			mkdir,
 			open,
 			readFile,
-			rm: async (path: string, options: { force: true }) => {
-				removals += 1
-				if (removals === 1) throw new Error('transient unlink failure')
-				await rm(path, options)
-			},
+			tryLock: () => true,
 		}
-		const lock = await acquireExclusiveProcessLock(lockPath, 'Test lock', {}, filesystem)
-		await expect(lock.release()).rejects.toThrow('transient unlink failure')
+		const lock = await acquireExclusiveProcessLock(
+			lockPath,
+			'Test lock',
+			{},
+			{
+				...filesystem,
+				open: async (...arguments_) => {
+					const handle = await open(...arguments_)
+					return {
+						chmod: async mode => await handle.chmod(mode),
+						close: async () => {
+							closes += 1
+							if (closes === 1) throw new Error('transient close failure')
+							await handle.close()
+						},
+						fd: handle.fd,
+						sync: async () => await handle.sync(),
+						truncate: async length => await handle.truncate(length),
+						writeFile: async (data, options) => await handle.writeFile(data, options),
+					}
+				},
+			},
+		)
+		const inode = (await stat(lockPath)).ino
+		await expect(lock.release()).rejects.toThrow('transient close failure')
 		await lock.release()
 		const replacement = await acquireExclusiveProcessLock(lockPath, 'Test lock', {}, filesystem)
+		await replacement.release()
+		expect((await stat(lockPath)).isFile()).toBe(true)
+		expect((await stat(lockPath)).ino).toBe(inode)
+	})
+
+	test('reclaims a process lock after its owner is killed', async () => {
+		const directory = await mkdtemp(join(tmpdir(), 'zoltar-killed-process-lock-'))
+		temporaryDirectories.push(directory)
+		const lockPath = join(directory, 'operator.lock')
+		const moduleUrl = pathToFileURL(resolve(import.meta.dir, '../src/execution/process-lock.ts')).href
+		const child = Bun.spawn([process.execPath, '--eval', `import { acquireExclusiveProcessLock } from ${JSON.stringify(moduleUrl)}; await acquireExclusiveProcessLock(${JSON.stringify(lockPath)}, 'Test lock', {}); console.log('ready'); await Bun.sleep(60_000)`], { stderr: 'pipe', stdout: 'pipe' })
+		try {
+			const reader = child.stdout.getReader()
+			const next = await reader.read()
+			if (next.done || !new TextDecoder().decode(next.value).includes('ready')) throw new Error(`Lock subprocess stopped before acquisition: ${await new Response(child.stderr).text()}`)
+			reader.releaseLock()
+			child.kill('SIGKILL')
+			expect(await child.exited).not.toBe(0)
+		} finally {
+			if (child.exitCode === null) child.kill('SIGKILL')
+			await child.exited
+		}
+		const replacement = await acquireExclusiveProcessLock(lockPath, 'Test lock', {})
 		await replacement.release()
 	})
 


### PR DESCRIPTION
## Summary

- replace existence-only liquidator lock files with kernel-backed advisory locks so crashed containers can restart without manual cleanup
- preserve one stable lock inode to prevent split-brain ownership while retaining owner metadata for diagnostics
- add killed-owner, live-owner, cleanup, and inode-stability regressions
- run the lock runtime smoke check in every liquidator Alpine image build

## Why

The liquidator state lock lives in a persistent Docker volume. If the owning container was killed before graceful cleanup, the file survived and every restarted container treated it as a permanently live owner. Kernel advisory ownership is released automatically when a process exits, so stale metadata no longer blocks startup while concurrent live processes remain excluded.

## Validation

- bun run tsc
- canonical full suite: 2,920 passed, 16 network-dependent Uniswap tests skipped, 0 failed
- bot-shared typecheck and shared-primitives suite: 48 passed
- liquidator process-lock and Docker packaging suites: 12 passed
- liquidator process-lock runtime smoke check
- package formatting checks
- bun run check:changed
- bun run knip
- bun run check:generated-clean
- git diff --check

Final read-only review: 88/100 with no findings.

Docker was not installed in the development workspace, so the Alpine image could not be built locally. The Dockerfile now executes the runtime smoke check as part of every image build, using that image target architecture and libc.