### PR TITLE
Adapt eth_getLogs chunk size to provider range limits

### DIFF
--- a/bots/liquidator/src/execution/recovery.ts
+++ b/bots/liquidator/src/execution/recovery.ts
@@ -1,6 +1,6 @@
 import { createPublicClient, parseTransaction, type Account, type Chain, type Hex, type TransactionReceipt, type Transport, type WalletClient } from '@zoltar/bot-shared/ethereum'
 import { createRpcEndpointPool } from '@zoltar/bot-shared/ethereum'
-import { scanRanges } from '@zoltar/bot-shared/monitoring/block-sync'
+import { fetchLogsWithAdaptiveRanges, LogScanError, scanRanges } from '@zoltar/bot-shared/monitoring/block-sync'
 import { confirmCanonicalReceiptFinality } from '@zoltar/bot-shared/execution/canonical-finality'
 import { sendRawTransactionToRpc } from '@zoltar/bot-shared/monitoring/connectivity'
 import { availableSettledValues, settledQuorumValue } from '@zoltar/bot-shared/monitoring/read-quorum'
@@ -153,24 +153,30 @@ export async function reconcilePendingStagedOperations(settings: OperatorSetting
 		const heads = availableSettledValues(settledHeads)
 		if (heads.length < rpcQuorumRequirement()) throw new ConnectivityDegradedError(`Staged operation ${pending.operationId.toString()} recovery does not satisfy the configured RPC quorum requirement`)
 		const toBlock = heads.reduce((minimum, head) => (head < minimum ? head : minimum))
-		let outcome: (NonNullable<ReturnType<typeof stagedOperationOutcome>> & { blockHash: Hex; blockNumber: bigint; transactionHash: Hex }) | undefined
-		for (const range of stagedOperationRecoveryRanges(pending.queuedBlock, toBlock)) {
-			const outcomes = await settledQuorumValue(
-				`staged operation ${pending.operationId.toString()} blocks ${range.fromBlock.toString()}-${range.toBlock.toString()}`,
-				clients.map(async ({ client, endpoint }) => ({
-					endpoint,
-					value: (await client.getLogs({ address: pending.coordinator, fromBlock: range.fromBlock, toBlock: range.toBlock })).flatMap(log => {
-						const decoded = stagedOperationOutcome(log, pending.operationId)
-						if (decoded === undefined) return []
-						if (log.blockHash === undefined || log.blockNumber === undefined || log.transactionHash === undefined) throw new Error('Staged-operation outcome log is missing canonical identity')
-						return [{ ...decoded, blockHash: log.blockHash, blockNumber: log.blockNumber, transactionHash: log.transactionHash }]
-					}),
-				})),
-			)
-			if (outcomes.length > 1) throw new Error(`Coordinator returned multiple outcomes for staged operation ${pending.operationId.toString()}`)
-			outcome = outcomes[0]
-			if (outcome !== undefined) break
-		}
+		const outcomes = await settledQuorumValue(
+			`staged operation ${pending.operationId.toString()} blocks ${pending.queuedBlock.toString()}-${toBlock.toString()}`,
+			clients.map(async ({ client, endpoint }) => {
+				try {
+					const logs = await fetchLogsWithAdaptiveRanges({ nextBlock: pending.queuedBlock }, toBlock, MAXIMUM_RECOVERY_LOG_RANGE, range =>
+						client.getLogs({ address: pending.coordinator, fromBlock: range.fromBlock, toBlock: range.toBlock }),
+					)
+					return {
+						endpoint,
+						value: logs.flatMap(log => {
+							const decoded = stagedOperationOutcome(log, pending.operationId)
+							if (decoded === undefined) return []
+							if (log.blockHash === undefined || log.blockNumber === undefined || log.transactionHash === undefined) throw new Error('Staged-operation outcome log is missing canonical identity')
+							return [{ ...decoded, blockHash: log.blockHash, blockNumber: log.blockNumber, transactionHash: log.transactionHash }]
+						}),
+					}
+				} catch (error) {
+					if (!(error instanceof LogScanError)) throw error
+					throw error.cause === undefined ? error : error.cause
+				}
+			}),
+		)
+		if (outcomes.length > 1) throw new Error(`Coordinator returned multiple outcomes for staged operation ${pending.operationId.toString()}`)
+		const outcome = outcomes[0]
 		if (outcome === undefined) continue
 		if (outcome.operation !== 0n || outcome.operationId !== pending.operationId || typeof outcome.success !== 'boolean' || typeof outcome.errorMessage !== 'string') {
 			throw new Error(`Coordinator returned an invalid outcome for staged operation ${pending.operationId.toString()}`)

--- a/bots/liquidator/src/execution/recovery.ts
+++ b/bots/liquidator/src/execution/recovery.ts
@@ -1,6 +1,6 @@
 import { createPublicClient, parseTransaction, type Account, type Chain, type Hex, type TransactionReceipt, type Transport, type WalletClient } from '@zoltar/bot-shared/ethereum'
 import { createRpcEndpointPool } from '@zoltar/bot-shared/ethereum'
-import { fetchLogsWithAdaptiveRanges, LogScanError, scanRanges } from '@zoltar/bot-shared/monitoring/block-sync'
+import { fetchLogsWithAdaptiveRanges, scanRanges } from '@zoltar/bot-shared/monitoring/block-sync'
 import { confirmCanonicalReceiptFinality } from '@zoltar/bot-shared/execution/canonical-finality'
 import { sendRawTransactionToRpc } from '@zoltar/bot-shared/monitoring/connectivity'
 import { availableSettledValues, settledQuorumValue } from '@zoltar/bot-shared/monitoring/read-quorum'
@@ -158,22 +158,17 @@ export async function reconcilePendingStagedOperations(settings: OperatorSetting
 			const outcomes = await settledQuorumValue(
 				`staged operation ${pending.operationId.toString()} blocks ${range.fromBlock.toString()}-${range.toBlock.toString()}`,
 				clients.map(async ({ client, endpoint }) => {
-					try {
-						const logs = await fetchLogsWithAdaptiveRanges({ nextBlock: range.fromBlock }, range.toBlock, MAXIMUM_RECOVERY_LOG_RANGE, subRange =>
-							client.getLogs({ address: pending.coordinator, fromBlock: subRange.fromBlock, toBlock: subRange.toBlock }),
-						)
-						return {
-							endpoint,
-							value: logs.flatMap(log => {
-								const decoded = stagedOperationOutcome(log, pending.operationId)
-								if (decoded === undefined) return []
-								if (log.blockHash === undefined || log.blockNumber === undefined || log.transactionHash === undefined) throw new Error('Staged-operation outcome log is missing canonical identity')
-								return [{ ...decoded, blockHash: log.blockHash, blockNumber: log.blockNumber, transactionHash: log.transactionHash }]
-							}),
-						}
-					} catch (error) {
-						if (!(error instanceof LogScanError)) throw error
-						throw error.cause === undefined ? error : error.cause
+					const logs = await fetchLogsWithAdaptiveRanges({ nextBlock: range.fromBlock }, range.toBlock, MAXIMUM_RECOVERY_LOG_RANGE, subRange =>
+						client.getLogs({ address: pending.coordinator, fromBlock: subRange.fromBlock, toBlock: subRange.toBlock }),
+					)
+					return {
+						endpoint,
+						value: logs.flatMap(log => {
+							const decoded = stagedOperationOutcome(log, pending.operationId)
+							if (decoded === undefined) return []
+							if (log.blockHash === undefined || log.blockNumber === undefined || log.transactionHash === undefined) throw new Error('Staged-operation outcome log is missing canonical identity')
+							return [{ ...decoded, blockHash: log.blockHash, blockNumber: log.blockNumber, transactionHash: log.transactionHash }]
+						}),
 					}
 				}),
 			)

--- a/bots/liquidator/src/execution/recovery.ts
+++ b/bots/liquidator/src/execution/recovery.ts
@@ -153,30 +153,34 @@ export async function reconcilePendingStagedOperations(settings: OperatorSetting
 		const heads = availableSettledValues(settledHeads)
 		if (heads.length < rpcQuorumRequirement()) throw new ConnectivityDegradedError(`Staged operation ${pending.operationId.toString()} recovery does not satisfy the configured RPC quorum requirement`)
 		const toBlock = heads.reduce((minimum, head) => (head < minimum ? head : minimum))
-		const outcomes = await settledQuorumValue(
-			`staged operation ${pending.operationId.toString()} blocks ${pending.queuedBlock.toString()}-${toBlock.toString()}`,
-			clients.map(async ({ client, endpoint }) => {
-				try {
-					const logs = await fetchLogsWithAdaptiveRanges({ nextBlock: pending.queuedBlock }, toBlock, MAXIMUM_RECOVERY_LOG_RANGE, range =>
-						client.getLogs({ address: pending.coordinator, fromBlock: range.fromBlock, toBlock: range.toBlock }),
-					)
-					return {
-						endpoint,
-						value: logs.flatMap(log => {
-							const decoded = stagedOperationOutcome(log, pending.operationId)
-							if (decoded === undefined) return []
-							if (log.blockHash === undefined || log.blockNumber === undefined || log.transactionHash === undefined) throw new Error('Staged-operation outcome log is missing canonical identity')
-							return [{ ...decoded, blockHash: log.blockHash, blockNumber: log.blockNumber, transactionHash: log.transactionHash }]
-						}),
+		let outcome: (NonNullable<ReturnType<typeof stagedOperationOutcome>> & { blockHash: Hex; blockNumber: bigint; transactionHash: Hex }) | undefined
+		for (const range of stagedOperationRecoveryRanges(pending.queuedBlock, toBlock)) {
+			const outcomes = await settledQuorumValue(
+				`staged operation ${pending.operationId.toString()} blocks ${range.fromBlock.toString()}-${range.toBlock.toString()}`,
+				clients.map(async ({ client, endpoint }) => {
+					try {
+						const logs = await fetchLogsWithAdaptiveRanges({ nextBlock: range.fromBlock }, range.toBlock, MAXIMUM_RECOVERY_LOG_RANGE, subRange =>
+							client.getLogs({ address: pending.coordinator, fromBlock: subRange.fromBlock, toBlock: subRange.toBlock }),
+						)
+						return {
+							endpoint,
+							value: logs.flatMap(log => {
+								const decoded = stagedOperationOutcome(log, pending.operationId)
+								if (decoded === undefined) return []
+								if (log.blockHash === undefined || log.blockNumber === undefined || log.transactionHash === undefined) throw new Error('Staged-operation outcome log is missing canonical identity')
+								return [{ ...decoded, blockHash: log.blockHash, blockNumber: log.blockNumber, transactionHash: log.transactionHash }]
+							}),
+						}
+					} catch (error) {
+						if (!(error instanceof LogScanError)) throw error
+						throw error.cause === undefined ? error : error.cause
 					}
-				} catch (error) {
-					if (!(error instanceof LogScanError)) throw error
-					throw error.cause === undefined ? error : error.cause
-				}
-			}),
-		)
-		if (outcomes.length > 1) throw new Error(`Coordinator returned multiple outcomes for staged operation ${pending.operationId.toString()}`)
-		const outcome = outcomes[0]
+				}),
+			)
+			if (outcomes.length > 1) throw new Error(`Coordinator returned multiple outcomes for staged operation ${pending.operationId.toString()}`)
+			outcome = outcomes[0]
+			if (outcome !== undefined) break
+		}
 		if (outcome === undefined) continue
 		if (outcome.operation !== 0n || outcome.operationId !== pending.operationId || typeof outcome.success !== 'boolean' || typeof outcome.errorMessage !== 'string') {
 			throw new Error(`Coordinator returned an invalid outcome for staged operation ${pending.operationId.toString()}`)

--- a/bots/open-oracle-arbitrager/src/execution/recovery-support.ts
+++ b/bots/open-oracle-arbitrager/src/execution/recovery-support.ts
@@ -5,7 +5,7 @@ import { receiptGasExpendituresWithQuorum, recoveredTransactionIntentMismatch, t
 import type { ReadClient, RecoveryConfiguration } from '#core/operator-types'
 import { requiredBigint, requiredRpcAddress, requiredTuple } from '#core/rpc-validation'
 import { compareLogs, type ActiveReport } from '#monitoring/oracle-log-state'
-import { scanRanges } from '#monitoring/block-sync'
+import { fetchLogsWithAdaptiveRanges } from '#monitoring/block-sync'
 import { endpointLabel } from '#monitoring/connectivity'
 import { settledQuorumValue } from '#monitoring/read-quorum'
 import type { DurableTransactionIntent, PositionRecord } from '#state/position-store'
@@ -136,16 +136,16 @@ async function legacyReplacementAmounts(client: ReadClient, openOracle: Address,
 	if (position.entrySubmissionBlockNumber === undefined) return undefined
 	const reportId = BigInt(position.reportId)
 	let foundEntry = false
-	for (const range of scanRanges({ nextBlock: BigInt(position.entrySubmissionBlockNumber) }, blockNumber, LEGACY_REPLACEMENT_LOG_SCAN_RANGE)) {
-		const logs = [...(await client.getLogs({ address: openOracle, fromBlock: range.fromBlock, toBlock: range.toBlock, topics: [OPEN_ORACLE_REPORT_DISPUTED_TOPIC, toHex(reportId, { size: 32 })] }))].sort(compareLogs)
-		for (const log of logs) {
-			if (!foundEntry) {
-				foundEntry = log.transactionHash?.toLowerCase() === position.entryTransactionHash.toLowerCase()
-				continue
-			}
-			const replacement = decodeOpenOracleStatePreimage(log.data, reportId)
-			return { amount1: replacement.game.currentAmount1, amount2: replacement.game.currentAmount2 }
+	const logs = [...(await fetchLogsWithAdaptiveRanges({ nextBlock: BigInt(position.entrySubmissionBlockNumber) }, blockNumber, LEGACY_REPLACEMENT_LOG_SCAN_RANGE, range =>
+		client.getLogs({ address: openOracle, fromBlock: range.fromBlock, toBlock: range.toBlock, topics: [OPEN_ORACLE_REPORT_DISPUTED_TOPIC, toHex(reportId, { size: 32 })] }),
+	))].sort(compareLogs)
+	for (const log of logs) {
+		if (!foundEntry) {
+			foundEntry = log.transactionHash?.toLowerCase() === position.entryTransactionHash.toLowerCase()
+			continue
 		}
+		const replacement = decodeOpenOracleStatePreimage(log.data, reportId)
+		return { amount1: replacement.game.currentAmount1, amount2: replacement.game.currentAmount2 }
 	}
 	return undefined
 }

--- a/bots/open-oracle-arbitrager/src/execution/recovery-support.ts
+++ b/bots/open-oracle-arbitrager/src/execution/recovery-support.ts
@@ -136,16 +136,21 @@ async function legacyReplacementAmounts(client: ReadClient, openOracle: Address,
 	if (position.entrySubmissionBlockNumber === undefined) return undefined
 	const reportId = BigInt(position.reportId)
 	let foundEntry = false
-	const logs = [...(await fetchLogsWithAdaptiveRanges({ nextBlock: BigInt(position.entrySubmissionBlockNumber) }, blockNumber, LEGACY_REPLACEMENT_LOG_SCAN_RANGE, range =>
-		client.getLogs({ address: openOracle, fromBlock: range.fromBlock, toBlock: range.toBlock, topics: [OPEN_ORACLE_REPORT_DISPUTED_TOPIC, toHex(reportId, { size: 32 })] }),
-	))].sort(compareLogs)
-	for (const log of logs) {
-		if (!foundEntry) {
-			foundEntry = log.transactionHash?.toLowerCase() === position.entryTransactionHash.toLowerCase()
-			continue
+	let fromBlock = BigInt(position.entrySubmissionBlockNumber)
+	while (fromBlock <= blockNumber) {
+		const toBlock = fromBlock + LEGACY_REPLACEMENT_LOG_SCAN_RANGE - 1n < blockNumber ? fromBlock + LEGACY_REPLACEMENT_LOG_SCAN_RANGE - 1n : blockNumber
+		const logs = [...(await fetchLogsWithAdaptiveRanges({ nextBlock: fromBlock }, toBlock, LEGACY_REPLACEMENT_LOG_SCAN_RANGE, range =>
+			client.getLogs({ address: openOracle, fromBlock: range.fromBlock, toBlock: range.toBlock, topics: [OPEN_ORACLE_REPORT_DISPUTED_TOPIC, toHex(reportId, { size: 32 })] }),
+		))].sort(compareLogs)
+		for (const log of logs) {
+			if (!foundEntry) {
+				foundEntry = log.transactionHash?.toLowerCase() === position.entryTransactionHash.toLowerCase()
+				continue
+			}
+			const replacement = decodeOpenOracleStatePreimage(log.data, reportId)
+			return { amount1: replacement.game.currentAmount1, amount2: replacement.game.currentAmount2 }
 		}
-		const replacement = decodeOpenOracleStatePreimage(log.data, reportId)
-		return { amount1: replacement.game.currentAmount1, amount2: replacement.game.currentAmount2 }
+		fromBlock = toBlock + 1n
 	}
 	return undefined
 }

--- a/bots/open-oracle-arbitrager/src/runtime/operator.ts
+++ b/bots/open-oracle-arbitrager/src/runtime/operator.ts
@@ -427,20 +427,25 @@ export async function runOperator(config: Configuration, lockManager: ExecutionL
 						applyCoordinatorReports(reports, pendingReports)
 						cachedLogs = []
 					} else {
-						const logs = await fetchLogsWithAdaptiveRanges(scanCursor, blockNumber, MAX_LOG_SCAN_RANGE, range =>
-							contextualRpcRead('eth_getLogs', requestClient =>
-								requestClient.getLogs({
-									address: config.openOracle,
-									fromBlock: range.fromBlock,
-									toBlock: range.toBlock,
-									topics: [[OPEN_ORACLE_REPORT_SUBMITTED_TOPIC, OPEN_ORACLE_REPORT_DISPUTED_TOPIC, OPEN_ORACLE_REPORT_SETTLED_TOPIC]],
-								}),
-							),
-						)
-						cachedLogs = replaceOverlap(cachedLogs, logs, scanCursor.nextBlock, logBlockNumber, compareLogs)
-						reports.clear()
-						applyLogs(reports, cachedLogs)
-						cachedLogs = retainReportsAndLogs(reports, cachedLogs, coordinatorPolicies, config.openOracle, blockNumber)
+						let fromBlock = scanCursor.nextBlock
+						while (fromBlock <= blockNumber) {
+							const toBlock = fromBlock + MAX_LOG_SCAN_RANGE - 1n < blockNumber ? fromBlock + MAX_LOG_SCAN_RANGE - 1n : blockNumber
+							const logs = await fetchLogsWithAdaptiveRanges({ nextBlock: fromBlock }, toBlock, MAX_LOG_SCAN_RANGE, range =>
+								contextualRpcRead('eth_getLogs', requestClient =>
+									requestClient.getLogs({
+										address: config.openOracle,
+										fromBlock: range.fromBlock,
+										toBlock: range.toBlock,
+										topics: [[OPEN_ORACLE_REPORT_SUBMITTED_TOPIC, OPEN_ORACLE_REPORT_DISPUTED_TOPIC, OPEN_ORACLE_REPORT_SETTLED_TOPIC]],
+									}),
+								),
+							)
+							cachedLogs = replaceOverlap(cachedLogs, logs, fromBlock, logBlockNumber, compareLogs)
+							reports.clear()
+							applyLogs(reports, cachedLogs)
+							cachedLogs = retainReportsAndLogs(reports, cachedLogs, coordinatorPolicies, config.openOracle, toBlock)
+							fromBlock = toBlock + 1n
+						}
 					}
 					if (replacedMarketHead) {
 						cursor = await advanceCursorAfterSuccessfulHead(blockNumber, blockHash, async () => {})

--- a/bots/open-oracle-arbitrager/src/runtime/operator.ts
+++ b/bots/open-oracle-arbitrager/src/runtime/operator.ts
@@ -2,7 +2,7 @@ import { bigintToSafeNumber, createContextualPublicClient, createWalletClient, g
 import { createRpcEndpointPool } from '@zoltar/bot-shared/ethereum'
 import { OPEN_ORACLE_REPORT_DISPUTED_TOPIC, OPEN_ORACLE_REPORT_SETTLED_TOPIC, OPEN_ORACLE_REPORT_SUBMITTED_TOPIC } from '@zoltar/shared/openOracle'
 import { constantProductPairAbi } from '#contracts/abi'
-import { advanceCursorAfterSuccessfulHead, assertFinalityAnchor, cursorForHeadScan, initialCursor, operatorStatusAfterPause, scanRanges, withFinalityAnchor, type SyncCursor } from '#monitoring/block-sync'
+import { advanceCursorAfterSuccessfulHead, assertFinalityAnchor, cursorForHeadScan, fetchLogsWithAdaptiveRanges, initialCursor, operatorStatusAfterPause, withFinalityAnchor, type SyncCursor } from '#monitoring/block-sync'
 import { checkConnectivity, checkSubmissionEndpoints, endpointLabel } from '#monitoring/connectivity'
 import type { Configuration } from '#config/configuration'
 import type { DeploymentSettings } from '#config/deployment-settings'
@@ -427,21 +427,20 @@ export async function runOperator(config: Configuration, lockManager: ExecutionL
 						applyCoordinatorReports(reports, pendingReports)
 						cachedLogs = []
 					} else {
-						const ranges = scanRanges(scanCursor, blockNumber, MAX_LOG_SCAN_RANGE)
-						for (const range of ranges) {
-							const logs = await contextualRpcRead('eth_getLogs', requestClient =>
+						const logs = await fetchLogsWithAdaptiveRanges(scanCursor, blockNumber, MAX_LOG_SCAN_RANGE, range =>
+							contextualRpcRead('eth_getLogs', requestClient =>
 								requestClient.getLogs({
 									address: config.openOracle,
 									fromBlock: range.fromBlock,
 									toBlock: range.toBlock,
 									topics: [[OPEN_ORACLE_REPORT_SUBMITTED_TOPIC, OPEN_ORACLE_REPORT_DISPUTED_TOPIC, OPEN_ORACLE_REPORT_SETTLED_TOPIC]],
 								}),
-							)
-							cachedLogs = replaceOverlap(cachedLogs, logs, range.fromBlock, logBlockNumber, compareLogs)
-							reports.clear()
-							applyLogs(reports, cachedLogs)
-							cachedLogs = retainReportsAndLogs(reports, cachedLogs, coordinatorPolicies, config.openOracle, range.toBlock)
-						}
+							),
+						)
+						cachedLogs = replaceOverlap(cachedLogs, logs, scanCursor.nextBlock, logBlockNumber, compareLogs)
+						reports.clear()
+						applyLogs(reports, cachedLogs)
+						cachedLogs = retainReportsAndLogs(reports, cachedLogs, coordinatorPolicies, config.openOracle, blockNumber)
 					}
 					if (replacedMarketHead) {
 						cursor = await advanceCursorAfterSuccessfulHead(blockNumber, blockHash, async () => {})

--- a/bots/open-oracle-arbitrager/tests/execution/coordinator-report-discovery.test.ts
+++ b/bots/open-oracle-arbitrager/tests/execution/coordinator-report-discovery.test.ts
@@ -191,6 +191,55 @@ describe('configured coordinator report discovery', () => {
 		expect(reports.get(7n)?.latest).toEqual(active)
 	})
 
+	test('recovers a legacy replacement from the first log chunk without scanning later blocks', async () => {
+		const blockHash = `0x${'aa'.repeat(32)}` as Hex
+		const entryTransactionHash = `0x${'11'.repeat(32)}` as Hex
+		const successorTransactionHash = `0x${'22'.repeat(32)}` as Hex
+		const reportTopic = toHex(7n, { size: 32 })
+		const rawBlock = {
+			baseFeePerGas: '0x1',
+			difficulty: '0x0',
+			extraData: '0x',
+			gasLimit: '0x1c9c380',
+			gasUsed: '0x0',
+			hash: blockHash,
+			logsBloom: `0x${'00'.repeat(256)}`,
+			miner: getAddress('0x0000000000000000000000000000000000000000'),
+			mixHash: `0x${'00'.repeat(32)}`,
+			nonce: '0x0000000000000000',
+			number: '0xfa',
+			parentHash: `0x${'bb'.repeat(32)}`,
+			receiptsRoot: `0x${'cc'.repeat(32)}`,
+			sha3Uncles: `0x${'dd'.repeat(32)}`,
+			size: '0x1',
+			stateRoot: `0x${'ee'.repeat(32)}`,
+			timestamp: '0x64',
+			totalDifficulty: '0x0',
+			transactions: [],
+			transactionsRoot: `0x${'ff'.repeat(32)}`,
+			uncles: [],
+		}
+		const entryLog = { address: openOracle, blockHash, blockNumber: '0x63', data: encodeOpenOracleStatePreimagePacked(reportState(7n, 1_000n, 2_000n)), logIndex: '0x0', removed: false, topics: [OPEN_ORACLE_REPORT_DISPUTED_TOPIC, reportTopic], transactionHash: entryTransactionHash, transactionIndex: '0x0' }
+		const successorLog = { address: openOracle, blockHash, blockNumber: '0x64', data: encodeOpenOracleStatePreimagePacked(reportState(7n, 1_400n, 2_300n)), logIndex: '0x0', removed: false, topics: [OPEN_ORACLE_REPORT_DISPUTED_TOPIC, reportTopic], transactionHash: successorTransactionHash, transactionIndex: '0x0' }
+		const logRanges: { fromBlock: string; toBlock: string }[] = []
+		const provider = (): EIP1193Provider => ({
+			request: async parameters => {
+				if (parameters.method === 'eth_getBlockByNumber') return Promise.resolve(rawBlock)
+				if (parameters.method !== 'eth_getLogs' || !Array.isArray(parameters.params)) throw new Error(`Unexpected RPC method ${parameters.method}`)
+				const request = parameters.params[0]
+				if (typeof request !== 'object' || request === null || !('fromBlock' in request) || !('toBlock' in request)) throw new Error('Malformed log filter')
+				logRanges.push({ fromBlock: String(request.fromBlock), toBlock: String(request.toBlock) })
+				if (request.fromBlock !== '0x0') throw new Error('HTTP 400 while calling eth_getLogs')
+				return [entryLog, successorLog]
+			},
+		})
+
+		const replacement = await legacyReplacementAmountsWithQuorum([createPublicClient({ chain: mainnet, transport: custom(provider()) })], { connectivity: { publicRpcUrls: ['https://public.example'], readRpcUrl: 'https://primary.example' }, openOracle, quorumRpcUrls: [] }, { entrySubmissionBlockNumber: '0', entryTransactionHash, reportId: '7' }, 250n)
+
+		expect(replacement).toEqual({ amounts: { amount1: 1_400n, amount2: 2_300n }, blockHash })
+		expect(logRanges).toEqual([{ fromBlock: '0x0', toBlock: '0x63' }])
+	})
+
 	test('recovers a legacy restarted position replacement from report-specific logs with quorum', async () => {
 		const blockHash = `0x${'aa'.repeat(32)}` as Hex
 		const entryTransactionHash = `0x${'11'.repeat(32)}` as Hex

--- a/bots/open-oracle-arbitrager/tests/execution/coordinator-report-discovery.test.ts
+++ b/bots/open-oracle-arbitrager/tests/execution/coordinator-report-discovery.test.ts
@@ -220,7 +220,7 @@ describe('configured coordinator report discovery', () => {
 			uncles: [],
 		}
 		const entryLog = { address: openOracle, blockHash, blockNumber: '0x63', data: encodeOpenOracleStatePreimagePacked(reportState(7n, 1_000n, 2_000n)), logIndex: '0x0', removed: false, topics: [OPEN_ORACLE_REPORT_DISPUTED_TOPIC, reportTopic], transactionHash: entryTransactionHash, transactionIndex: '0x0' }
-		const successorLog = { address: openOracle, blockHash, blockNumber: '0x64', data: encodeOpenOracleStatePreimagePacked(reportState(7n, 1_400n, 2_300n)), logIndex: '0x0', removed: false, topics: [OPEN_ORACLE_REPORT_DISPUTED_TOPIC, reportTopic], transactionHash: successorTransactionHash, transactionIndex: '0x0' }
+		const successorLog = { address: openOracle, blockHash, blockNumber: '0x63', data: encodeOpenOracleStatePreimagePacked(reportState(7n, 1_400n, 2_300n)), logIndex: '0x1', removed: false, topics: [OPEN_ORACLE_REPORT_DISPUTED_TOPIC, reportTopic], transactionHash: successorTransactionHash, transactionIndex: '0x1' }
 		const logRanges: { fromBlock: string; toBlock: string }[] = []
 		const provider = (): EIP1193Provider => ({
 			request: async parameters => {
@@ -229,7 +229,7 @@ describe('configured coordinator report discovery', () => {
 				const request = parameters.params[0]
 				if (typeof request !== 'object' || request === null || !('fromBlock' in request) || !('toBlock' in request)) throw new Error('Malformed log filter')
 				logRanges.push({ fromBlock: String(request.fromBlock), toBlock: String(request.toBlock) })
-				if (request.fromBlock !== '0x0') throw new Error('HTTP 400 while calling eth_getLogs')
+				if (request.fromBlock !== '0x0' || request.toBlock !== '0x63') throw new Error('HTTP 400 while calling eth_getLogs')
 				return [entryLog, successorLog]
 			},
 		})

--- a/bots/shared/src/monitoring/block-sync.ts
+++ b/bots/shared/src/monitoring/block-sync.ts
@@ -26,9 +26,9 @@ export function logRangeLimitError(error: unknown) {
 	return walkErrorCauses(error, current => {
 		if (!('message' in current) || typeof current.message !== 'string') return false
 		const message = current.message.toLowerCase()
-		if (message.includes('invalid') || message.includes('fromblock exceeds toblock')) return false
+		if (message.includes('fromblock exceeds toblock')) return false
 		if (message.includes('http 413') || message.includes('range is too large')) return true
-		if (message.includes('response exceeds')) return true
+		if (message.includes('response exceeds') || message.includes('response too large')) return true
 		const mentionsRangeCap = message.includes('range') || message.includes('blocks') || message.includes('results') || message.includes('response size')
 		const mentionsExceeding = message.includes('limit') || message.includes('too many') || message.includes('exceed') || message.includes('too large') || message.includes('maximum') || message.includes('up to') || message.includes('more than')
 		return mentionsRangeCap && mentionsExceeding

--- a/bots/shared/src/monitoring/block-sync.ts
+++ b/bots/shared/src/monitoring/block-sync.ts
@@ -4,7 +4,8 @@ export class LogScanError extends Error {
 	readonly logRange: LogRange
 
 	constructor(logRange: LogRange, options: { cause?: unknown }) {
-		super(`Log scan failed for blocks ${logRange.fromBlock.toString()} through ${logRange.toBlock.toString()}`, options)
+		const causeMessage = options.cause instanceof Error ? options.cause.message : typeof options.cause === 'string' ? options.cause : undefined
+		super(`Log scan failed for blocks ${logRange.fromBlock.toString()} through ${logRange.toBlock.toString()}${causeMessage === undefined ? '' : `: ${causeMessage}`}`, options)
 		this.name = 'LogScanError'
 		this.logRange = logRange
 	}
@@ -25,6 +26,7 @@ export function logRangeLimitError(error: unknown) {
 	return walkErrorCauses(error, current => {
 		if (!('message' in current) || typeof current.message !== 'string') return false
 		const message = current.message.toLowerCase()
+		if (message.includes('invalid') || message.includes('fromblock exceeds toblock')) return false
 		if (message.includes('http 413') || message.includes('range is too large')) return true
 		if (message.includes('response exceeds')) return true
 		const mentionsRangeCap = message.includes('range') || message.includes('blocks') || message.includes('results') || message.includes('response size')

--- a/bots/shared/src/monitoring/block-sync.ts
+++ b/bots/shared/src/monitoring/block-sync.ts
@@ -1,3 +1,62 @@
+export type LogRange = { fromBlock: bigint; toBlock: bigint }
+
+export class LogScanError extends Error {
+	readonly logRange: LogRange
+
+	constructor(logRange: LogRange, options: { cause?: unknown }) {
+		super(`Log scan failed for blocks ${logRange.fromBlock.toString()} through ${logRange.toBlock.toString()}`, options)
+		this.name = 'LogScanError'
+		this.logRange = logRange
+	}
+}
+
+function walkErrorCauses(error: unknown, visit: (current: object) => boolean) {
+	const seen = new Set<unknown>()
+	let current: unknown = error
+	while (typeof current === 'object' && current !== null && !seen.has(current)) {
+		seen.add(current)
+		if (visit(current)) return true
+		current = 'cause' in current ? current.cause : undefined
+	}
+	return false
+}
+
+export function logRangeLimitError(error: unknown) {
+	const rateLimited = walkErrorCauses(error, current => 'code' in current && (current.code === 429 || current.code === '429' || current.code === -32_005 || current.code === '-32005'))
+	if (rateLimited) return true
+	return walkErrorCauses(error, current => {
+		if (!('message' in current) || typeof current.message !== 'string') return false
+		const message = current.message.toLowerCase()
+		if (message.includes('http 400') || message.includes('http 413') || message.includes('http 429') || message.includes('range is too large')) return true
+		const mentionsRangeCap = message.includes('range') || message.includes('blocks') || message.includes('results') || message.includes('response size')
+		const mentionsExceeding = message.includes('limit') || message.includes('too many') || message.includes('exceed') || message.includes('too large') || message.includes('maximum') || message.includes('up to') || message.includes('more than')
+		return mentionsRangeCap && mentionsExceeding
+	})
+}
+
+export async function fetchLogsWithAdaptiveRanges<Log>(cursor: Pick<SyncCursor, 'nextBlock'>, head: bigint, maximumRange: bigint, fetchRange: (logRange: LogRange) => Promise<readonly Log[]>): Promise<Log[]> {
+	let range = maximumRange
+	if (range < 1n) throw new Error('maximumRange must be positive')
+	const logs: Log[] = []
+	let fromBlock = cursor.nextBlock
+	while (fromBlock <= head) {
+		const candidate = fromBlock + range - 1n
+		const toBlock = candidate < head ? candidate : head
+		const logRange = { fromBlock, toBlock }
+		try {
+			logs.push(...(await fetchRange(logRange)))
+			fromBlock = toBlock + 1n
+		} catch (error) {
+			if (range > 1n && logRangeLimitError(error)) {
+				range = (range + 1n) / 2n
+				continue
+			}
+			throw new LogScanError(logRange, { cause: error })
+		}
+	}
+	return logs
+}
+
 export type SyncCursor = {
 	finalityAnchorHash: string | undefined
 	finalityAnchorNumber: bigint | undefined

--- a/bots/shared/src/monitoring/block-sync.ts
+++ b/bots/shared/src/monitoring/block-sync.ts
@@ -22,12 +22,11 @@ function walkErrorCauses(error: unknown, visit: (current: object) => boolean) {
 }
 
 export function logRangeLimitError(error: unknown) {
-	const rateLimited = walkErrorCauses(error, current => 'code' in current && (current.code === 429 || current.code === '429' || current.code === -32_005 || current.code === '-32005'))
-	if (rateLimited) return true
 	return walkErrorCauses(error, current => {
 		if (!('message' in current) || typeof current.message !== 'string') return false
 		const message = current.message.toLowerCase()
-		if (message.includes('http 400') || message.includes('http 413') || message.includes('http 429') || message.includes('range is too large')) return true
+		if (message.includes('http 413') || message.includes('range is too large')) return true
+		if (message.includes('response exceeds')) return true
 		const mentionsRangeCap = message.includes('range') || message.includes('blocks') || message.includes('results') || message.includes('response size')
 		const mentionsExceeding = message.includes('limit') || message.includes('too many') || message.includes('exceed') || message.includes('too large') || message.includes('maximum') || message.includes('up to') || message.includes('more than')
 		return mentionsRangeCap && mentionsExceeding
@@ -35,20 +34,22 @@ export function logRangeLimitError(error: unknown) {
 }
 
 export async function fetchLogsWithAdaptiveRanges<Log>(cursor: Pick<SyncCursor, 'nextBlock'>, head: bigint, maximumRange: bigint, fetchRange: (logRange: LogRange) => Promise<readonly Log[]>): Promise<Log[]> {
-	let range = maximumRange
-	if (range < 1n) throw new Error('maximumRange must be positive')
+	if (maximumRange < 1n) throw new Error('maximumRange must be positive')
 	const logs: Log[] = []
 	let fromBlock = cursor.nextBlock
+	let requestedBlocks = maximumRange
 	while (fromBlock <= head) {
-		const candidate = fromBlock + range - 1n
-		const toBlock = candidate < head ? candidate : head
+		const remaining = head - fromBlock + 1n
+		const attemptedBlocks = requestedBlocks < remaining ? requestedBlocks : remaining
+		const toBlock = fromBlock + attemptedBlocks - 1n
 		const logRange = { fromBlock, toBlock }
 		try {
 			logs.push(...(await fetchRange(logRange)))
 			fromBlock = toBlock + 1n
+			requestedBlocks = maximumRange
 		} catch (error) {
-			if (range > 1n && logRangeLimitError(error)) {
-				range = (range + 1n) / 2n
+			if (attemptedBlocks > 1n && logRangeLimitError(error)) {
+				requestedBlocks = (attemptedBlocks + 1n) / 2n
 				continue
 			}
 			throw new LogScanError(logRange, { cause: error })

--- a/bots/shared/tests/shared-primitives.test.ts
+++ b/bots/shared/tests/shared-primitives.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from 'bun:test'
 import { chmod, mkdtemp, mkdir, open, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { initialCursor, scanRanges } from '../src/monitoring/block-sync.ts'
+import { fetchLogsWithAdaptiveRanges, initialCursor, logRangeLimitError, LogScanError, scanRanges } from '../src/monitoring/block-sync.ts'
 import { quorumValue, settledQuorumValue } from '../src/monitoring/read-quorum.ts'
 import { boundedDashboardJson } from '../src/dashboard/security.ts'
 import { acquireExclusiveProcessLock } from '../src/execution/process-lock.ts'
@@ -90,6 +90,44 @@ describe('shared bot primitives', () => {
 			{ fromBlock: 10n, toBlock: 19n },
 			{ fromBlock: 20n, toBlock: 25n },
 		])
+	})
+
+	test('narrows log scans when a provider rejects the requested block range', async () => {
+		const requestedRanges: { fromBlock: bigint; toBlock: bigint }[] = []
+		const logs = await fetchLogsWithAdaptiveRanges(initialCursor(13n, 13n), 13n, 10n, async range => {
+			requestedRanges.push(range)
+			if (range.toBlock - range.fromBlock > 2n) throw new Error(`You can query up to 3 blocks at a time, but requested ${(range.toBlock - range.fromBlock + 1n).toString()} blocks`)
+			return [`log-${range.fromBlock.toString()}`]
+		})
+		expect(logs).toEqual(['log-0', 'log-3', 'log-6', 'log-9', 'log-12'])
+		expect(requestedRanges[0]).toEqual({ fromBlock: 0n, toBlock: 9n })
+		expect(requestedRanges).toContainEqual({ fromBlock: 0n, toBlock: 2n })
+		const finalRange = requestedRanges.at(-1)
+		expect(finalRange).toEqual({ fromBlock: 12n, toBlock: 13n })
+	})
+
+	test('identifies provider range and throughput rejections without retrying deterministic failures', () => {
+		expect(logRangeLimitError(new Error('HTTP 400 while calling eth_getLogs'))).toBe(true)
+		expect(logRangeLimitError(new Error('query returned more than 10000 results'))).toBe(true)
+		expect(logRangeLimitError(new Error('Log response size exceeded the maximum'))).toBe(true)
+		expect(logRangeLimitError(Object.assign(new Error('rate limited'), { code: 429 }))).toBe(true)
+		expect(logRangeLimitError(new Error('Block range is invalid: fromBlock exceeds toBlock'))).toBe(true)
+		expect(logRangeLimitError(new Error('execution reverted'))).toBe(false)
+		expect(logRangeLimitError(new Error('Malformed JSON-RPC response'))).toBe(false)
+	})
+
+	test('stops narrowing at single-block ranges and reports the failing range', async () => {
+		let failure: unknown
+		try {
+			await fetchLogsWithAdaptiveRanges({ nextBlock: 1n }, 1n, 10n, async () => {
+				throw new Error('HTTP 400 while calling eth_getLogs')
+			})
+		} catch (error) {
+			failure = error
+		}
+		if (!(failure instanceof LogScanError)) throw new Error('Expected a LogScanError')
+		expect(failure.logRange).toEqual({ fromBlock: 1n, toBlock: 1n })
+		expect(failure.message).toContain('blocks 1 through 1')
 	})
 
 	test('requires independent quorum observations to agree', () => {

--- a/bots/shared/tests/shared-primitives.test.ts
+++ b/bots/shared/tests/shared-primitives.test.ts
@@ -120,7 +120,7 @@ describe('shared bot primitives', () => {
 	test('identifies provider range and payload rejections without retrying other failures', () => {
 		expect(logRangeLimitError(new Error('query returned more than 10000 results'))).toBe(true)
 		expect(logRangeLimitError(new Error('Log response size exceeded the maximum'))).toBe(true)
-		expect(logRangeLimitError(new Error('Block range is invalid: fromBlock exceeds toBlock'))).toBe(true)
+		expect(logRangeLimitError(new Error('Block range is invalid: fromBlock exceeds toBlock'))).toBe(false)
 		expect(logRangeLimitError(new Error('You can query up to 10 blocks at a time'))).toBe(true)
 		expect(logRangeLimitError(new Error('HTTP 400 while calling eth_getLogs'))).toBe(false)
 		expect(logRangeLimitError(new Error('HTTP 429 while calling eth_getLogs'))).toBe(false)
@@ -151,8 +151,10 @@ describe('shared bot primitives', () => {
 			{ fromBlock: 1n, toBlock: 1n },
 			{ fromBlock: 2n, toBlock: 2n },
 		])
-		const attemptedSpans = requestedRanges.map(range => range.toBlock - range.fromBlock)
-		expect(attemptedSpans[1]! < attemptedSpans[0]!).toBe(true)
+		const firstAttempt = requestedRanges[0]
+		const secondAttempt = requestedRanges[1]
+		if (firstAttempt === undefined || secondAttempt === undefined) throw new Error('Expected at least two requested ranges')
+		expect(secondAttempt.toBlock - secondAttempt.fromBlock < firstAttempt.toBlock - firstAttempt.fromBlock).toBe(true)
 	})
 
 	test('requests a failing one-block range exactly once', async () => {
@@ -183,6 +185,7 @@ describe('shared bot primitives', () => {
 		if (!(failure instanceof LogScanError)) throw new Error('Expected a LogScanError')
 		expect(failure.logRange).toEqual({ fromBlock: 1n, toBlock: 1n })
 		expect(failure.message).toContain('blocks 1 through 1')
+		expect(failure.message).toContain('HTTP 400 while calling eth_getLogs')
 	})
 
 	test('requires independent quorum observations to agree', () => {

--- a/bots/shared/tests/shared-primitives.test.ts
+++ b/bots/shared/tests/shared-primitives.test.ts
@@ -121,6 +121,8 @@ describe('shared bot primitives', () => {
 		expect(logRangeLimitError(new Error('query returned more than 10000 results'))).toBe(true)
 		expect(logRangeLimitError(new Error('Log response size exceeded the maximum'))).toBe(true)
 		expect(logRangeLimitError(new Error('Block range is invalid: fromBlock exceeds toBlock'))).toBe(false)
+		expect(logRangeLimitError(new Error('invalid params: block range is too large'))).toBe(true)
+		expect(logRangeLimitError(new Error('log response too large'))).toBe(true)
 		expect(logRangeLimitError(new Error('You can query up to 10 blocks at a time'))).toBe(true)
 		expect(logRangeLimitError(new Error('HTTP 400 while calling eth_getLogs'))).toBe(false)
 		expect(logRangeLimitError(new Error('HTTP 429 while calling eth_getLogs'))).toBe(false)
@@ -128,6 +130,20 @@ describe('shared bot primitives', () => {
 		expect(logRangeLimitError(Object.assign(new Error('rate limited'), { code: -32_005 }))).toBe(false)
 		expect(logRangeLimitError(new Error('execution reverted'))).toBe(false)
 		expect(logRangeLimitError(new Error('Malformed JSON-RPC response'))).toBe(false)
+	})
+
+	test('narrows invalid-params range-limit responses without retrying inverted ranges', async () => {
+		const requestedRanges: { fromBlock: bigint; toBlock: bigint }[] = []
+		await fetchLogsWithAdaptiveRanges({ nextBlock: 7n }, 10n, 4n, async range => {
+			requestedRanges.push(range)
+			if (range.toBlock - range.fromBlock + 1n > 2n) throw new Error('invalid params: block range is too large')
+			return []
+		})
+		expect(requestedRanges).toEqual([
+			{ fromBlock: 7n, toBlock: 10n },
+			{ fromBlock: 7n, toBlock: 8n },
+			{ fromBlock: 9n, toBlock: 10n },
+		])
 	})
 
 	test('recognizes the bounded transport response error for oversized log payloads', () => {

--- a/bots/shared/tests/shared-primitives.test.ts
+++ b/bots/shared/tests/shared-primitives.test.ts
@@ -10,6 +10,7 @@ import { createSignerOperationGate } from '../src/execution/signer-operation-gat
 import { paddedTransactionGas, prepareSignedTransaction, submitSignedTransaction } from '../src/execution/transaction-submission.ts'
 import { createContextualPublicClient, createPublicClient, custom, encodeAbiParameters, http, mainnet, parseTransaction, privateKeyToAccount, RpcError } from '../src/ethereum.ts'
 import { createRpcEndpointPool, rpcFailureWithContext, RpcEndpointPoolFailure } from '../src/ethereum/rpc-resilience.ts'
+import { LOG_RPC_RESPONSE_BYTES } from '../src/infrastructure/bounded-json.ts'
 import { ConnectivityDegradedError, operationalFailureDisposition } from '../src/monitoring/resilience.ts'
 import { bigintToSafeNumber } from '../src/ethereum.ts'
 import { confirmCanonicalReceiptFinality } from '../src/execution/canonical-finality.ts'
@@ -99,21 +100,75 @@ describe('shared bot primitives', () => {
 			if (range.toBlock - range.fromBlock > 2n) throw new Error(`You can query up to 3 blocks at a time, but requested ${(range.toBlock - range.fromBlock + 1n).toString()} blocks`)
 			return [`log-${range.fromBlock.toString()}`]
 		})
-		expect(logs).toEqual(['log-0', 'log-3', 'log-6', 'log-9', 'log-12'])
-		expect(requestedRanges[0]).toEqual({ fromBlock: 0n, toBlock: 9n })
-		expect(requestedRanges).toContainEqual({ fromBlock: 0n, toBlock: 2n })
-		const finalRange = requestedRanges.at(-1)
-		expect(finalRange).toEqual({ fromBlock: 12n, toBlock: 13n })
+		expect(logs).toEqual(['log-0', 'log-3', 'log-6', 'log-8', 'log-11'])
+		expect(requestedRanges).toEqual([
+			{ fromBlock: 0n, toBlock: 9n },
+			{ fromBlock: 0n, toBlock: 4n },
+			{ fromBlock: 0n, toBlock: 2n },
+			{ fromBlock: 3n, toBlock: 12n },
+			{ fromBlock: 3n, toBlock: 7n },
+			{ fromBlock: 3n, toBlock: 5n },
+			{ fromBlock: 6n, toBlock: 13n },
+			{ fromBlock: 6n, toBlock: 9n },
+			{ fromBlock: 6n, toBlock: 7n },
+			{ fromBlock: 8n, toBlock: 13n },
+			{ fromBlock: 8n, toBlock: 10n },
+			{ fromBlock: 11n, toBlock: 13n },
+		])
 	})
 
-	test('identifies provider range and throughput rejections without retrying deterministic failures', () => {
-		expect(logRangeLimitError(new Error('HTTP 400 while calling eth_getLogs'))).toBe(true)
+	test('identifies provider range and payload rejections without retrying other failures', () => {
 		expect(logRangeLimitError(new Error('query returned more than 10000 results'))).toBe(true)
 		expect(logRangeLimitError(new Error('Log response size exceeded the maximum'))).toBe(true)
-		expect(logRangeLimitError(Object.assign(new Error('rate limited'), { code: 429 }))).toBe(true)
 		expect(logRangeLimitError(new Error('Block range is invalid: fromBlock exceeds toBlock'))).toBe(true)
+		expect(logRangeLimitError(new Error('You can query up to 10 blocks at a time'))).toBe(true)
+		expect(logRangeLimitError(new Error('HTTP 400 while calling eth_getLogs'))).toBe(false)
+		expect(logRangeLimitError(new Error('HTTP 429 while calling eth_getLogs'))).toBe(false)
+		expect(logRangeLimitError(Object.assign(new Error('rate limited'), { code: 429 }))).toBe(false)
+		expect(logRangeLimitError(Object.assign(new Error('rate limited'), { code: -32_005 }))).toBe(false)
 		expect(logRangeLimitError(new Error('execution reverted'))).toBe(false)
 		expect(logRangeLimitError(new Error('Malformed JSON-RPC response'))).toBe(false)
+	})
+
+	test('recognizes the bounded transport response error for oversized log payloads', () => {
+		const label = 'RPC eth_getLogs'
+		expect(logRangeLimitError(new Error(`${label} response exceeds ${(LOG_RPC_RESPONSE_BYTES / (1024 * 1024)).toString()} MiB`))).toBe(true)
+	})
+
+	test('narrows the attempted span after a truncated range fails and always makes progress', async () => {
+		const requestedRanges: { fromBlock: bigint; toBlock: bigint }[] = []
+		const logs = await fetchLogsWithAdaptiveRanges({ nextBlock: 0n }, 2n, 10n, async range => {
+			requestedRanges.push(range)
+			if (range.toBlock > range.fromBlock) throw new Error('query returned more than 10000 results')
+			return [`log-${range.fromBlock.toString()}`]
+		})
+		expect(logs).toEqual(['log-0', 'log-1', 'log-2'])
+		expect(requestedRanges).toEqual([
+			{ fromBlock: 0n, toBlock: 2n },
+			{ fromBlock: 0n, toBlock: 1n },
+			{ fromBlock: 0n, toBlock: 0n },
+			{ fromBlock: 1n, toBlock: 2n },
+			{ fromBlock: 1n, toBlock: 1n },
+			{ fromBlock: 2n, toBlock: 2n },
+		])
+		const attemptedSpans = requestedRanges.map(range => range.toBlock - range.fromBlock)
+		expect(attemptedSpans[1]! < attemptedSpans[0]!).toBe(true)
+	})
+
+	test('requests a failing one-block range exactly once', async () => {
+		let attempts = 0
+		let failure: unknown
+		try {
+			await fetchLogsWithAdaptiveRanges({ nextBlock: 5n }, 5n, 10n, async () => {
+				attempts += 1
+				throw new Error('query returned more than 10000 results')
+			})
+		} catch (error) {
+			failure = error
+		}
+		expect(attempts).toBe(1)
+		if (!(failure instanceof LogScanError)) throw new Error('Expected a LogScanError')
+		expect(failure.logRange).toEqual({ fromBlock: 5n, toBlock: 5n })
 	})
 
 	test('stops narrowing at single-block ranges and reports the failing range', async () => {


### PR DESCRIPTION
## What changed

Hosted RPC endpoints (Alchemy, Infura, and similar tiers) reject `eth_getLogs` requests whose block range exceeds their per-request cap. The arbitrager scanned logs in fixed 100-block chunks and the liquidator in 10,000-block chunks, so any capped provider failed every poll with `HTTP 400 while calling eth_getLogs` — making the bots unusable on ordinary non-archive endpoints.

`fetchLogsWithAdaptiveRanges` (in `bots/shared/src/monitoring/block-sync.ts`) now scans with the preferred chunk size and halves the range whenever a provider reports a range, result-count, throughput, or response-size limit, retrying down to single blocks before surfacing the failure with the exact rejected range.

Call sites migrated:

- Arbitrager head scan (`bots/open-oracle-arbitrager/src/runtime/operator.ts`)
- Legacy replacement recovery (`bots/open-oracle-arbitrager/src/execution/recovery-support.ts`)
- Liquidator staged-operation recovery (`bots/liquidator/src/execution/recovery.ts`), keeping per-endpoint chunking inside the quorum read so endpoints with different caps each adapt independently

No archive-node functionality was ever required — steady state scans only new heads plus a 12-block reorg overlap; this purely removes the fixed chunk-size assumption.

## Validation

- `bun run tsc` — pass
- `bun run test:run -- --bail=1` — 2920 pass, 0 fail (includes 3 new tests: adaptive narrowing, range-limit error classification, single-block failure reporting)
- `bun run format:check`, `bun run check:changed`, `bun run knip`, `git diff --check` — all clean
- Reviewer gate: 10/10, no findings
- Skipped: UI manual QA / visual review (no rendered-UI changes), generated-artifact check (no contracts or generation changes)