### PR TITLE
Fix liquidator Docker build context

### DIFF
--- a/bots/liquidator/Dockerfile.dockerignore
+++ b/bots/liquidator/Dockerfile.dockerignore
@@ -17,5 +17,6 @@
 !bots/liquidator/README.md
 !bots/liquidator/config/**
 !bots/liquidator/scripts/check-market-sources.mts
+!bots/liquidator/scripts/check-process-lock-runtime.mts
 !bots/liquidator/scripts/docker-entrypoint.sh
 !bots/liquidator/src/**

--- a/bots/liquidator/tests/docker-packaging.test.ts
+++ b/bots/liquidator/tests/docker-packaging.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 const dockerfile = join(import.meta.dir, '..', 'Dockerfile')
+const dockerignore = join(import.meta.dir, '..', 'Dockerfile.dockerignore')
 const composeFile = join(import.meta.dir, '..', 'compose.yaml')
 const entrypoint = join(import.meta.dir, '..', 'scripts', 'docker-entrypoint.sh')
 const example = join(import.meta.dir, '..', 'config', 'operator.example.json')
@@ -38,11 +39,13 @@ describe('Docker packaging', () => {
 
 	test('builds and installs both shared packages where bot sources can resolve them', async () => {
 		const source = await readFile(dockerfile, 'utf8')
+		const ignoreSource = await readFile(dockerignore, 'utf8')
 		expect(source).toContain('-alpine AS shared-builder')
 		expect(source).toContain('&& bun run shared:build')
 		expect(source).toContain('COPY --from=shared-builder /source/shared/ ./shared/')
 		expect(source).toContain('cd shared \\\n\t&& bun install --frozen-lockfile --production \\\n\t&& cd ../bots/shared \\\n\t&& bun install --frozen-lockfile --production')
 		expect(source).toContain('COPY bots/liquidator/scripts/check-process-lock-runtime.mts ./bots/liquidator/scripts/check-process-lock-runtime.mts')
+		expect(ignoreSource).toContain('!bots/liquidator/scripts/check-process-lock-runtime.mts')
 		expect(source).toContain('RUN bun ./scripts/check-process-lock-runtime.mts')
 	})
 


### PR DESCRIPTION
## Summary

- include the process-lock runtime check in the liquidator Docker build context
- add packaging regression coverage that keeps the Dockerfile COPY and dockerignore allowlist paired

## Why

Running `bots/liquidator/start.bat` failed during image construction because `check-process-lock-runtime.mts` was referenced by the Dockerfile but excluded by `Dockerfile.dockerignore`.

The host `git.exe` warning from BuildKit is non-fatal and is not changed by this PR.

## Validation

- `bun test bots/liquidator/tests/docker-packaging.test.ts` — 5 passed
- `bun run tsc` — passed
- `bun run format:check` — passed
- `bun run check:changed` — passed
- `bun run knip` — passed
- `git diff --check` — passed

A direct Docker build was unavailable in the validation environment because the Docker CLI is not installed. The focused regression test failed before the allowlist fix and passed afterward.

## Review

- final reviewer: 96/100, no findings
- branch current with `origin/main`: 0 commits behind
