### PR TITLE
Index REP activity in AugurScan

### DIFF
--- a/augurScan/browser/app.ts
+++ b/augurScan/browser/app.ts
@@ -59,6 +59,7 @@ import {
 	runWithForegroundReservation,
 	shouldClearPendingDetailState,
 	shouldContinueTransactionRestore,
+	showIndexerSyncDetails,
 	transactionRetryMode,
 } from './live-update.ts'
 
@@ -2342,13 +2343,16 @@ const renderNetworks = (networks: NetworkRecord[]) => {
 		ageNode.dataset.time = network.indexed_timestamp ?? ''
 		ageNode.title = exactTimestamp(network.indexed_timestamp)
 		const lag = indexerLagLabel(network)
-		meta.append(indexedTime, ageNode, element('span', '', lag))
+		const displaySyncDetails = showIndexerSyncDetails(network, currentTime)
+		meta.append(indexedTime, ageNode)
+		if (displaySyncDetails) meta.append(element('span', '', lag))
 		const progressLabel = headFreshness.stale
 			? `${progress.percentage ?? '100.00'}% indexed · RPC head ${age(network.indexed_timestamp).replace(/ ago$/, '')} old (limit 1m)`
 			: progress.percentage === undefined
 				? progress.eta
 				: `${progress.percentage}% complete · ${progress.eta}`
-		card.append(title, block, meta, element('p', 'network-progress', progressLabel))
+		card.append(title, block, meta)
+		if (displaySyncDetails) card.append(element('p', 'network-progress', progressLabel))
 		if (Number(network.consecutive_failures) > 0) {
 			const retry = network.next_retry_at ? `next retry ${until(network.next_retry_at)}` : 'retry scheduled'
 			card.append(element('p', 'network-retry', `${number(network.consecutive_failures)} consecutive failures · ${retry}`))

--- a/augurScan/browser/live-update.ts
+++ b/augurScan/browser/live-update.ts
@@ -338,6 +338,13 @@ export const indexerLagLabel = (network: NetworkFreshnessRecord): string => {
 	return `${lag.toLocaleString('en-US')} ${lag === 1n ? 'block' : 'blocks'} behind`
 }
 
+export const showIndexerSyncDetails = (network: NetworkFreshnessRecord, sampledAt = Date.now()): boolean => {
+	if (network.phase !== 'live' || indexerWaitingForStart(network) || indexerHeadFreshness(network, sampledAt).stale) return true
+	const observedBlock = decimalBlock(network.observed_block)
+	const indexedBlock = decimalBlock(network.indexed_block)
+	return observedBlock === undefined || indexedBlock === undefined || indexedBlock < observedBlock
+}
+
 export const compactIndexerDuration = (seconds: number): string => {
 	const rounded = Math.max(1, Math.ceil(seconds))
 	if (rounded < 60) return `${rounded}s`

--- a/augurScan/src/indexer-runtime.ts
+++ b/augurScan/src/indexer-runtime.ts
@@ -904,6 +904,39 @@ export const isProtocolActivitySource = (contract: ContractMetadata | undefined)
 	contract.kind !== 'proxyDeployer' &&
 	contract.kind !== 'scalarOutcomes'
 
+export const indexerLogSources = (contracts: readonly ContractMetadata[]): readonly ContractMetadata[] =>
+	contracts.filter((contract) => isProtocolActivitySource(contract) || contract.kind === 'reputationToken')
+
+export const discoveryLogAddresses = (discoveredAddresses: readonly Address[], contracts: ReadonlyMap<string, ContractMetadata>): readonly Address[] => {
+	const sources = discoveredAddresses.filter((address) => {
+		const contract = contracts.get(address.toLowerCase())
+		return isProtocolActivitySource(contract) || contract?.kind === 'reputationToken'
+	})
+	if (!sources.some((address) => contracts.get(address.toLowerCase())?.kind === 'reputationToken')) return sources
+	const addresses = [
+		...sources,
+		...[...contracts.values()]
+			.filter(({ kind }) => kind === 'uniswapV2Factory' || kind === 'uniswapV3Factory' || kind === 'uniswapV4PoolManager')
+			.map(({ address }) => address),
+	]
+	return [...new Map(addresses.map((address) => [address.toLowerCase(), address])).values()]
+}
+
+export const scanDiscoveredLogCoverage = async (
+	blockNumber: bigint,
+	segmentEnd: bigint,
+	discoveredAddresses: readonly Address[],
+	contracts: ReadonlyMap<string, ContractMetadata>,
+	getCurrentBlockLogs: (addresses: readonly Address[]) => Promise<readonly Log[]>,
+	getRemainingLogs: (fromBlock: bigint, toBlock: bigint, addresses: readonly Address[]) => Promise<readonly Log[]>,
+): Promise<{ readonly currentBlockLogs: readonly Log[]; readonly remainingLogs: readonly Log[] }> => {
+	const addresses = discoveryLogAddresses(discoveredAddresses, contracts)
+	if (addresses.length === 0) return { currentBlockLogs: [], remainingLogs: [] }
+	const currentBlockLogs = await getCurrentBlockLogs(addresses)
+	const remainingLogs = blockNumber < segmentEnd ? await getRemainingLogs(blockNumber + 1n, segmentEnd, addresses) : []
+	return { currentBlockLogs, remainingLogs }
+}
+
 export const requiresManifestHistoryCoverage = (contract: ContractMetadata | undefined): boolean =>
 	isProtocolActivitySource(contract) || contract?.kind === 'reputationToken' || contract?.kind === 'weth' || contract?.kind === 'usdc'
 

--- a/augurScan/src/indexer.ts
+++ b/augurScan/src/indexer.ts
@@ -10,6 +10,7 @@ import {
 	createRpcDiagnosticContext,
 	databaseFailureMessage,
 	deploymentReadBudget,
+	indexerLogSources,
 	indexerOperationFailureReason,
 	indexerProgressMessage,
 	indexerWaitingMessage,
@@ -36,6 +37,7 @@ import {
 	runIndexerOwnershipLifecycle,
 	runOwnedNetworkLifecycle,
 	safeIndexerFailure,
+	scanDiscoveredLogCoverage,
 	withVerifiedProvider,
 } from './indexer-runtime.ts'
 import { createRpcLoggingFetch, RotatingJsonLog } from './logging.ts'
@@ -859,7 +861,7 @@ class NetworkIndexer {
 		let contracts = this.#withManifestDeploymentBlocks(await this.#database.contracts(this.#network.chainId, this.#requireLease()))
 		let tokenMetadata = await this.#database.tokenMetadata(this.#network.chainId, this.#requireLease())
 		const storedCursors = await this.#database.logScanCursors(this.#network.chainId, this.#requireLease())
-		const initialContracts = [...contracts.values()].filter(isProtocolActivitySource)
+		const initialContracts = indexerLogSources([...contracts.values()])
 		const initialAddresses = initialContracts.map(({ address }) => address)
 		for (const address of initialAddresses) {
 			const cursor = storedCursors.get(address.toLowerCase())
@@ -916,43 +918,40 @@ class NetworkIndexer {
 		while (nextBlock <= end && !this.#signal.aborted) {
 			const header = headers[bigintToSafeNumber(nextBlock - batchStart, 'Block header offset')]
 			if (header === undefined) throw new Error(`RPC did not return block ${nextBlock}`)
-			const contractsBeforeBlock = new Set(contracts.keys())
 			let indexed: { block: IndexedBlock; contracts: Map<string, ContractMetadata>; tokenMetadata: Map<string, TokenMetadata> }
 			try {
-				indexed = await this.#indexBlock(nextBlock, observedHead, contracts, tokenMetadata, expectedParentHash, header, logsByBlock.get(nextBlock) ?? [])
+				indexed = await this.#indexBlock(
+					nextBlock,
+					observedHead,
+					contracts,
+					tokenMetadata,
+					expectedParentHash,
+					header,
+					logsByBlock.get(nextBlock) ?? [],
+					async (discoveredAddresses, discoveredContracts) => {
+						const coverage = await scanDiscoveredLogCoverage(
+							nextBlock,
+							end,
+							discoveredAddresses,
+							discoveredContracts,
+							(addresses) => this.#getKnownLogs(nextBlock, addresses, discoveredContracts, header.hash),
+							(fromBlock, toBlock, addresses) =>
+								this.#getAllLogs(fromBlock, toBlock, addresses, discoveredContracts, (blockNumber) => {
+									const expected = headers[bigintToSafeNumber(blockNumber - batchStart, 'Log block header offset')]
+									if (expected === undefined) throw new Error(`RPC did not return block ${blockNumber}`)
+									return expected.hash
+								}),
+						)
+						this.#mergeLogs(logsByBlock, coverage.remainingLogs)
+						return coverage.currentBlockLogs
+					},
+				)
 			} catch (error) {
 				if (error instanceof ChainContinuityError) {
 					await this.#reconcileReorg()
 					return false
 				}
 				throw error
-			}
-			const newlyDiscoveredActivityAddresses = [...indexed.contracts]
-				.filter(([address, contract]) => !contractsBeforeBlock.has(address) && isProtocolActivitySource(contract))
-				.map(([, contract]) => contract.address)
-			const discoveredRep = [...indexed.contracts].some(([address, contract]) => !contractsBeforeBlock.has(address) && contract.kind === 'reputationToken')
-			const additionalAddresses = [
-				...newlyDiscoveredActivityAddresses,
-				...(discoveredRep
-					? [...indexed.contracts.values()]
-							.filter(({ kind }) => kind === 'uniswapV2Factory' || kind === 'uniswapV3Factory' || kind === 'uniswapV4PoolManager')
-							.map(({ address }) => address)
-					: []),
-			]
-			if (additionalAddresses.length > 0 && nextBlock < end) {
-				try {
-					this.#mergeLogs(
-						logsByBlock,
-						await this.#getAllLogs(nextBlock + 1n, end, additionalAddresses, indexed.contracts, (blockNumber) => {
-							const expected = headers[bigintToSafeNumber(blockNumber - batchStart, 'Log block header offset')]
-							if (expected === undefined) throw new Error(`RPC did not return block ${blockNumber}`)
-							return expected.hash
-						}),
-					)
-				} catch (error) {
-					if (error instanceof ChainContinuityError) return false
-					throw error
-				}
 			}
 			const isSegmentEnd = nextBlock === end
 			const block = isSegmentEnd
@@ -1176,6 +1175,7 @@ class NetworkIndexer {
 		expectedParentHash: Hash | undefined,
 		block: RpcBlockHeader,
 		prefetchedLogs: readonly Log[],
+		getDiscoveredLogs: (addresses: readonly Address[], contracts: ReadonlyMap<string, ContractMetadata>) => Promise<readonly Log[]>,
 	): Promise<{ block: IndexedBlock; contracts: Map<string, ContractMetadata>; tokenMetadata: Map<string, TokenMetadata> }> {
 		if (expectedParentHash !== undefined && block.parentHash !== expectedParentHash) {
 			throw new ChainContinuityError(`Block ${number} does not extend the indexed canonical chain`)
@@ -1258,17 +1258,7 @@ class NetworkIndexer {
 				}
 			}
 			if (discoveredAddresses.length === 0) break
-			const activityAddresses = discoveredAddresses.filter((address) => isProtocolActivitySource(contracts.get(address.toLowerCase())))
-			const discoveredRep = discoveredAddresses.some((address) => contracts.get(address.toLowerCase())?.kind === 'reputationToken')
-			const queryAddresses = [
-				...activityAddresses,
-				...(discoveredRep
-					? [...contracts.values()]
-							.filter(({ kind }) => kind === 'uniswapV2Factory' || kind === 'uniswapV3Factory' || kind === 'uniswapV4PoolManager')
-							.map(({ address }) => address)
-					: []),
-			]
-			for (const log of queryAddresses.length === 0 ? [] : await this.#getKnownLogs(number, queryAddresses, contracts, block.hash)) {
+			for (const log of await getDiscoveredLogs(discoveredAddresses, contracts)) {
 				relevantHashes.add(requireLogPosition(log).transactionHash)
 			}
 			await fetchMissingEvidence()

--- a/augurScan/tests/indexer-lifecycle.test.ts
+++ b/augurScan/tests/indexer-lifecycle.test.ts
@@ -4,11 +4,26 @@ import {
 	assertIndexerLeaseObservation,
 	assertIndexerLeaseReleaseObservation,
 	DatabaseConsistencyError,
+	type IndexedBlock,
+	type IndexerLease,
 	manifestContractSetChanged,
 	runFencedIndexerTransaction,
+	ScannerDatabase,
 	type StoredTransaction,
 } from '../src/database.ts'
-import { type Address, createPublicClient, decodeFunctionResult, http, parseAbi, RpcError, toHex } from '../src/ethereum.ts'
+import {
+	type Address,
+	createPublicClient,
+	decodeFunctionResult,
+	encodeAbiParameters,
+	encodeEventTopics,
+	getAddress,
+	http,
+	type Log,
+	parseAbi,
+	RpcError,
+	toHex,
+} from '../src/ethereum.ts'
 import {
 	addressActivityFrom,
 	boundedDeploymentRead,
@@ -55,12 +70,14 @@ import {
 	runOwnedNetworkLifecycle,
 	safeIndexerFailure,
 	safeIndexerFailureReason,
+	startIndexers,
 	tokenMetadataNeedsRead,
 	uniswapV4PoolIds,
 	waitForIndexerDelay,
 	withRpcRequestQueue,
 	withVerifiedProvider,
 } from '../src/indexer.ts'
+import { discoveryLogAddresses, indexerLogSources, scanDiscoveredLogCoverage } from '../src/indexer-runtime.ts'
 import { unixSecondsToDate } from '../src/time.ts'
 import type { ContractMetadata, StoredLog, TokenMetadata } from '../src/types.ts'
 import { isSupportedUniswapV4Market, uniswapV2V3TokenPairs, uniswapV4PoolId } from '../src/uniswap.ts'
@@ -1248,7 +1265,7 @@ describe('network indexer lifecycle', () => {
 		expect(now).toBe(8)
 	})
 
-	test('tracks implicit token filter coverage from the replay start without querying token logs', async () => {
+	test('tracks filtered token coverage from the replay start', async () => {
 		const tokenAddress = '0x3000000000000000000000000000000000000003'
 		const helperAddress = '0x4000000000000000000000000000000000000004'
 		const contracts = new Map<string, ContractMetadata>([
@@ -1269,6 +1286,274 @@ describe('network indexer lifecycle', () => {
 				mock(async () => undefined),
 			),
 		).toBe(50n)
+	})
+
+	test('scans REP history without adding high-volume quote-token histories', () => {
+		const repAddress = '0x3000000000000000000000000000000000000003'
+		const wethAddress = '0x4000000000000000000000000000000000000004'
+		const oracleAddress = '0x5000000000000000000000000000000000000005'
+		const contracts = [
+			{ address: repAddress, label: 'REP', kind: 'reputationToken', provenance: 'manifest' },
+			{ address: wethAddress, label: 'WETH', kind: 'weth', provenance: 'manifest' },
+			{ address: oracleAddress, label: 'Oracle', kind: 'openOracle', provenance: 'manifest' },
+		] satisfies readonly ContractMetadata[]
+		expect(indexerLogSources(contracts).map((contract) => contract.address)).toEqual([repAddress, oracleAddress])
+		const contractMap = new Map(contracts.map((contract) => [contract.address.toLowerCase(), contract]))
+		expect(discoveryLogAddresses([repAddress, wethAddress, oracleAddress], contractMap)).toEqual([repAddress, oracleAddress])
+		const factoryAddress = '0x6000000000000000000000000000000000000006'
+		contractMap.set(factoryAddress, { address: factoryAddress, label: 'V3 factory', kind: 'uniswapV3Factory', provenance: 'manifest' })
+		expect(discoveryLogAddresses([repAddress], contractMap)).toEqual([repAddress, factoryAddress])
+	})
+
+	test('covers REP events from the discovery block through the active scan segment', async () => {
+		const repAddress = '0x3000000000000000000000000000000000000003'
+		const wethAddress = '0x4000000000000000000000000000000000000004'
+		const factoryAddress = '0x6000000000000000000000000000000000000006'
+		const contracts = new Map<string, ContractMetadata>([
+			[repAddress, { address: repAddress, label: 'Child REP', kind: 'reputationToken', provenance: 'REP.DeployChild' }],
+			[wethAddress, { address: wethAddress, label: 'WETH', kind: 'weth', provenance: 'manifest' }],
+			[factoryAddress, { address: factoryAddress, label: 'V3 factory', kind: 'uniswapV3Factory', provenance: 'manifest' }],
+		])
+		const logAt = (blockNumber: bigint, digit: string): Log => ({
+			address: repAddress,
+			blockHash: `0x${digit.repeat(64)}`,
+			blockNumber,
+			data: '0x',
+			logIndex: 0,
+			removed: false,
+			topics: [],
+			transactionHash: `0x${digit.repeat(64)}`,
+			transactionIndex: 0,
+		})
+		const currentLog = logAt(10n, '1')
+		const laterLog = logAt(12n, '2')
+		const currentQueries: Array<readonly Address[]> = []
+		const remainingQueries: Array<{ readonly addresses: readonly Address[]; readonly fromBlock: bigint; readonly toBlock: bigint }> = []
+		const coverage = await scanDiscoveredLogCoverage(
+			10n,
+			12n,
+			[repAddress, wethAddress],
+			contracts,
+			async (addresses) => {
+				currentQueries.push(addresses)
+				return [currentLog]
+			},
+			async (fromBlock, toBlock, addresses) => {
+				remainingQueries.push({ addresses, fromBlock, toBlock })
+				return [laterLog]
+			},
+		)
+
+		expect(currentQueries).toEqual([[repAddress, factoryAddress]])
+		expect(remainingQueries).toEqual([{ addresses: [repAddress, factoryAddress], fromBlock: 11n, toBlock: 12n }])
+		expect(coverage).toEqual({ currentBlockLogs: [currentLog], remainingLogs: [laterLog] })
+	})
+
+	test('stores same-block and later REP activity after discovering the token mid-segment', async () => {
+		const zoltarAddress = getAddress('0x7000000000000000000000000000000000000007')
+		const repAddress = getAddress('0x8000000000000000000000000000000000000008')
+		const wethAddress = getAddress('0x9000000000000000000000000000000000000009')
+		const holder = getAddress('0xa00000000000000000000000000000000000000a')
+		const sender = getAddress('0xb00000000000000000000000000000000000000b')
+		const hash = (digit: string) => `0x${digit.repeat(64)}` as const
+		const blockHashes = new Map([
+			[10n, hash('a')],
+			[11n, hash('b')],
+			[12n, hash('c')],
+		])
+		const deployAbi = parseAbi([
+			'event DeployChild(address deployer,uint248 indexed universeId,uint256 indexed outcomeIndex,uint248 indexed childUniverseId,address childReputationToken,uint256 childUniverseTheoreticalSupplyAttoRep)',
+		])
+		const transferAbi = parseAbi(['event Transfer(address indexed from,address indexed to,uint256 value)'])
+		const topicsFrom = (topics: readonly (string | readonly string[] | null)[]): readonly string[] =>
+			topics.map((topic) => {
+				if (typeof topic !== 'string') throw new Error('Expected one topic per indexed event argument')
+				return topic
+			})
+		const rawLog = (
+			contractAddress: Address,
+			blockNumber: bigint,
+			transactionDigit: string,
+			transactionIndex: number,
+			topics: readonly string[],
+			data: string,
+		) => ({
+			address: contractAddress,
+			blockHash: blockHashes.get(blockNumber),
+			blockNumber: toHex(blockNumber),
+			data,
+			logIndex: '0x0',
+			removed: false,
+			topics,
+			transactionHash: hash(transactionDigit),
+			transactionIndex: toHex(transactionIndex),
+		})
+		const deployLog = rawLog(
+			zoltarAddress,
+			10n,
+			'1',
+			0,
+			topicsFrom(encodeEventTopics({ abi: deployAbi, eventName: 'DeployChild', args: { universeId: 1n, outcomeIndex: 2n, childUniverseId: 3n } })),
+			encodeAbiParameters([{ type: 'address' }, { type: 'address' }, { type: 'uint256' }], [sender, repAddress, 1_000n]),
+		)
+		const sameBlockRepLog = rawLog(
+			repAddress,
+			10n,
+			'2',
+			1,
+			topicsFrom(encodeEventTopics({ abi: transferAbi, eventName: 'Transfer', args: { from: sender, to: holder } })),
+			encodeAbiParameters([{ type: 'uint256' }], [100n]),
+		)
+		const laterRepLog = rawLog(
+			repAddress,
+			12n,
+			'3',
+			0,
+			topicsFrom(encodeEventTopics({ abi: transferAbi, eventName: 'Transfer', args: { from: sender, to: holder } })),
+			encodeAbiParameters([{ type: 'uint256' }], [50n]),
+		)
+		const allLogs = [deployLog, sameBlockRepLog, laterRepLog]
+		const rpcLogQueries: Array<{ readonly addresses: readonly string[]; readonly fromBlock: bigint; readonly toBlock: bigint }> = []
+		const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(async (_input, init) => {
+			const request = JSON.parse(String(init?.body)) as { id: number; method: string; params?: readonly unknown[] }
+			const result = (() => {
+				if (request.method === 'eth_chainId') return '0x7a69'
+				if (request.method === 'eth_blockNumber') return '0xc'
+				if (request.method === 'eth_getBlockByNumber') {
+					const blockNumber = BigInt(String(request.params?.[0]))
+					const blockHash = blockHashes.get(blockNumber)
+					if (blockHash === undefined) throw new Error(`Unexpected block ${blockNumber}`)
+					return {
+						hash: blockHash,
+						number: toHex(blockNumber),
+						parentHash: blockNumber === 10n ? hash('9') : blockHashes.get(blockNumber - 1n),
+						timestamp: toHex(1_700_000_000n + blockNumber),
+						transactions: [],
+					}
+				}
+				if (request.method === 'eth_getLogs') {
+					const filter = request.params?.[0]
+					if (typeof filter !== 'object' || filter === null || !('address' in filter) || !('fromBlock' in filter) || !('toBlock' in filter))
+						throw new Error('Unexpected log filter')
+					const rawAddresses = filter.address
+					const addresses = (Array.isArray(rawAddresses) ? rawAddresses : [rawAddresses]).map(String)
+					const fromBlock = BigInt(String(filter.fromBlock))
+					const toBlock = BigInt(String(filter.toBlock))
+					rpcLogQueries.push({ addresses, fromBlock, toBlock })
+					return allLogs.filter(
+						(log) =>
+							addresses.some((candidate) => candidate.toLowerCase() === log.address.toLowerCase()) &&
+							BigInt(log.blockNumber) >= fromBlock &&
+							BigInt(log.blockNumber) <= toBlock,
+					)
+				}
+				const transactionHash = String(request.params?.[0])
+				const sourceLog = allLogs.find((log) => log.transactionHash === transactionHash)
+				if (sourceLog === undefined) throw new Error(`Unexpected ${request.method} for ${transactionHash}`)
+				if (request.method === 'eth_getTransactionByHash')
+					return {
+						blockHash: sourceLog.blockHash,
+						blockNumber: sourceLog.blockNumber,
+						from: sender,
+						gas: '0x5208',
+						hash: sourceLog.transactionHash,
+						input: '0x',
+						nonce: '0x0',
+						to: sourceLog.address,
+						transactionIndex: sourceLog.transactionIndex,
+						type: '0x2',
+						value: '0x0',
+					}
+				if (request.method === 'eth_getTransactionReceipt')
+					return {
+						blockHash: sourceLog.blockHash,
+						blockNumber: sourceLog.blockNumber,
+						contractAddress: null,
+						cumulativeGasUsed: '0x5208',
+						from: sender,
+						gasUsed: '0x5208',
+						logs: [sourceLog],
+						status: '0x1',
+						to: sourceLog.address,
+						transactionHash: sourceLog.transactionHash,
+						transactionIndex: sourceLog.transactionIndex,
+						type: '0x2',
+					}
+				throw new Error(`Unexpected RPC method ${request.method}`)
+			})()
+			return Response.json({ id: request.id, jsonrpc: '2.0', result })
+		})
+		const controller = new AbortController()
+		const database = new ScannerDatabase('postgres://unused')
+		const storedBlocks: IndexedBlock[] = []
+		const contracts = new Map<string, ContractMetadata>([
+			[
+				zoltarAddress.toLowerCase(),
+				{ address: zoltarAddress, deploymentBlock: 10n, deploymentBlockExact: true, kind: 'zoltar', label: 'Zoltar', provenance: 'manifest' },
+			],
+			[
+				wethAddress.toLowerCase(),
+				{ address: wethAddress, deploymentBlock: 10n, deploymentBlockExact: true, kind: 'weth', label: 'WETH', provenance: 'manifest' },
+			],
+		])
+		const lease: IndexerLease = {
+			backendPid: 1,
+			connection: database.sql as IndexerLease['connection'],
+			assertHeld: async () => {},
+			release: async () => {},
+		}
+		spyOn(database, 'tryAcquireIndexerLock').mockResolvedValue(lease)
+		spyOn(database, 'checkpoint').mockResolvedValue(undefined)
+		spyOn(database, 'networkStartBlock').mockResolvedValue(10n)
+		spyOn(database, 'storedBlockTip').mockResolvedValue(undefined)
+		spyOn(database, 'contracts').mockResolvedValue(contracts)
+		spyOn(database, 'logScanCursors').mockResolvedValue(new Map())
+		spyOn(database, 'seedNetwork').mockResolvedValue(false)
+		spyOn(database, 'tokenMetadata').mockResolvedValue(
+			new Map([
+				[repAddress.toLowerCase(), { address: repAddress, decimals: 18, name: 'Reputation', readBlock: 10n, symbol: 'REP' }],
+				[wethAddress.toLowerCase(), { address: wethAddress, decimals: 18, name: 'Wrapped Ether', readBlock: 10n, symbol: 'WETH' }],
+			]),
+		)
+		spyOn(database, 'storeBlock').mockImplementation(async (_chainId, block) => {
+			storedBlocks.push(block)
+			if (block.number === 12n) controller.abort()
+		})
+		spyOn(database, 'contractDeploymentCandidate').mockResolvedValue(undefined)
+		const info = spyOn(console, 'info').mockImplementation(() => {})
+		const error = spyOn(console, 'error').mockImplementation(() => {})
+		const timeout = setTimeout(() => controller.abort(), 2_000)
+		try {
+			const network = {
+				chainId: 31_337,
+				confirmationDepth: 100n,
+				contracts: [
+					[zoltarAddress, 'Zoltar', 'zoltar', 10n],
+					[wethAddress, 'WETH', 'weth', 10n],
+				] as const,
+				explorerBaseUrl: 'https://example.invalid',
+				id: 'rep-lifecycle',
+				name: 'REP lifecycle',
+				nativeSymbol: 'ETH',
+				rpcUrls: ['https://rpc.example'],
+				startBlock: 10n,
+			}
+			await Promise.all(startIndexers([network], database, controller.signal))
+			expect(error.mock.calls).toEqual([])
+			expect(storedBlocks.map((block) => block.number)).toEqual([10n, 11n, 12n])
+			const storedRepLogs = storedBlocks.flatMap((block) => block.logs).filter((log) => log.address === repAddress)
+			expect(storedRepLogs.map((log) => log.blockNumber)).toEqual([10n, 12n])
+			expect(storedBlocks.flatMap((block) => block.addressActivity).some((activity) => activity.address === holder)).toBe(true)
+			expect(rpcLogQueries.some((query) => query.fromBlock === 10n && query.toBlock === 10n && query.addresses.includes(repAddress))).toBe(true)
+			expect(rpcLogQueries.some((query) => query.fromBlock === 11n && query.toBlock === 12n && query.addresses.includes(repAddress))).toBe(true)
+			expect(rpcLogQueries.every((query) => !query.addresses.includes(wethAddress))).toBe(true)
+		} finally {
+			clearTimeout(timeout)
+			controller.abort()
+			fetchSpy.mockRestore()
+			info.mockRestore()
+			error.mockRestore()
+		}
 	})
 
 	test('does not rewind for covered, future, absent, or non-activity manifest contracts', async () => {

--- a/augurScan/tests/indexer-lifecycle.test.ts
+++ b/augurScan/tests/indexer-lifecycle.test.ts
@@ -156,11 +156,12 @@ const malformedDecimalsResult = (): Error => {
 	}
 }
 
-const parseRpcRequestBody = (value: unknown): { readonly id: number | string | null; readonly method: string } => {
+const parseRpcRequestBody = (value: unknown): { readonly id: number | string | null; readonly method: string; readonly params?: readonly unknown[] } => {
 	if (typeof value !== 'object' || value === null || Array.isArray(value) || !('method' in value) || typeof value.method !== 'string' || !('id' in value))
 		throw new Error('Unexpected RPC request')
 	if (value.id !== null && typeof value.id !== 'number' && typeof value.id !== 'string') throw new Error('Unexpected RPC request ID')
-	return { id: value.id, method: value.method }
+	if ('params' in value && value.params !== undefined && !Array.isArray(value.params)) throw new Error('Unexpected RPC request parameters')
+	return { id: value.id, method: value.method, ...('params' in value && Array.isArray(value.params) ? { params: value.params } : {}) }
 }
 
 describe('network indexer lifecycle', () => {
@@ -1298,7 +1299,7 @@ describe('network indexer lifecycle', () => {
 			{ address: oracleAddress, label: 'Oracle', kind: 'openOracle', provenance: 'manifest' },
 		] satisfies readonly ContractMetadata[]
 		expect(indexerLogSources(contracts).map((contract) => contract.address)).toEqual([repAddress, oracleAddress])
-		const contractMap = new Map(contracts.map((contract) => [contract.address.toLowerCase(), contract]))
+		const contractMap = new Map<string, ContractMetadata>(contracts.map((contract) => [contract.address.toLowerCase(), contract]))
 		expect(discoveryLogAddresses([repAddress, wethAddress, oracleAddress], contractMap)).toEqual([repAddress, oracleAddress])
 		const factoryAddress = '0x6000000000000000000000000000000000000006'
 		contractMap.set(factoryAddress, { address: factoryAddress, label: 'V3 factory', kind: 'uniswapV3Factory', provenance: 'manifest' })
@@ -1319,11 +1320,11 @@ describe('network indexer lifecycle', () => {
 			blockHash: `0x${digit.repeat(64)}`,
 			blockNumber,
 			data: '0x',
-			logIndex: 0,
+			logIndex: 0n,
 			removed: false,
 			topics: [],
 			transactionHash: `0x${digit.repeat(64)}`,
-			transactionIndex: 0,
+			transactionIndex: 0n,
 		})
 		const currentLog = logAt(10n, '1')
 		const laterLog = logAt(12n, '2')
@@ -1414,74 +1415,77 @@ describe('network indexer lifecycle', () => {
 		)
 		const allLogs = [deployLog, sameBlockRepLog, laterRepLog]
 		const rpcLogQueries: Array<{ readonly addresses: readonly string[]; readonly fromBlock: bigint; readonly toBlock: bigint }> = []
-		const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(async (_input, init) => {
-			const request = JSON.parse(String(init?.body)) as { id: number; method: string; params?: readonly unknown[] }
-			const result = (() => {
-				if (request.method === 'eth_chainId') return '0x7a69'
-				if (request.method === 'eth_blockNumber') return '0xc'
-				if (request.method === 'eth_getBlockByNumber') {
-					const blockNumber = BigInt(String(request.params?.[0]))
-					const blockHash = blockHashes.get(blockNumber)
-					if (blockHash === undefined) throw new Error(`Unexpected block ${blockNumber}`)
-					return {
-						hash: blockHash,
-						number: toHex(blockNumber),
-						parentHash: blockNumber === 10n ? hash('9') : blockHashes.get(blockNumber - 1n),
-						timestamp: toHex(1_700_000_000n + blockNumber),
-						transactions: [],
+		const rpcServer = Bun.serve({
+			port: 0,
+			fetch: async (rpcRequest) => {
+				const request = parseRpcRequestBody(await rpcRequest.json())
+				const result = (() => {
+					if (request.method === 'eth_chainId') return '0x7a69'
+					if (request.method === 'eth_blockNumber') return '0xc'
+					if (request.method === 'eth_getBlockByNumber') {
+						const blockNumber = BigInt(String(request.params?.[0]))
+						const blockHash = blockHashes.get(blockNumber)
+						if (blockHash === undefined) throw new Error(`Unexpected block ${blockNumber}`)
+						return {
+							hash: blockHash,
+							number: toHex(blockNumber),
+							parentHash: blockNumber === 10n ? hash('9') : blockHashes.get(blockNumber - 1n),
+							timestamp: toHex(1_700_000_000n + blockNumber),
+							transactions: [],
+						}
 					}
-				}
-				if (request.method === 'eth_getLogs') {
-					const filter = request.params?.[0]
-					if (typeof filter !== 'object' || filter === null || !('address' in filter) || !('fromBlock' in filter) || !('toBlock' in filter))
-						throw new Error('Unexpected log filter')
-					const rawAddresses = filter.address
-					const addresses = (Array.isArray(rawAddresses) ? rawAddresses : [rawAddresses]).map(String)
-					const fromBlock = BigInt(String(filter.fromBlock))
-					const toBlock = BigInt(String(filter.toBlock))
-					rpcLogQueries.push({ addresses, fromBlock, toBlock })
-					return allLogs.filter(
-						(log) =>
-							addresses.some((candidate) => candidate.toLowerCase() === log.address.toLowerCase()) &&
-							BigInt(log.blockNumber) >= fromBlock &&
-							BigInt(log.blockNumber) <= toBlock,
-					)
-				}
-				const transactionHash = String(request.params?.[0])
-				const sourceLog = allLogs.find((log) => log.transactionHash === transactionHash)
-				if (sourceLog === undefined) throw new Error(`Unexpected ${request.method} for ${transactionHash}`)
-				if (request.method === 'eth_getTransactionByHash')
-					return {
-						blockHash: sourceLog.blockHash,
-						blockNumber: sourceLog.blockNumber,
-						from: sender,
-						gas: '0x5208',
-						hash: sourceLog.transactionHash,
-						input: '0x',
-						nonce: '0x0',
-						to: sourceLog.address,
-						transactionIndex: sourceLog.transactionIndex,
-						type: '0x2',
-						value: '0x0',
+					if (request.method === 'eth_getLogs') {
+						const filter = request.params?.[0]
+						if (typeof filter !== 'object' || filter === null || !('address' in filter) || !('fromBlock' in filter) || !('toBlock' in filter))
+							throw new Error('Unexpected log filter')
+						const rawAddresses = filter.address
+						const addresses = (Array.isArray(rawAddresses) ? rawAddresses : [rawAddresses]).map(String)
+						const fromBlock = BigInt(String(filter.fromBlock))
+						const toBlock = BigInt(String(filter.toBlock))
+						rpcLogQueries.push({ addresses, fromBlock, toBlock })
+						return allLogs.filter(
+							(log) =>
+								addresses.some((candidate) => candidate.toLowerCase() === log.address.toLowerCase()) &&
+								BigInt(log.blockNumber) >= fromBlock &&
+								BigInt(log.blockNumber) <= toBlock,
+						)
 					}
-				if (request.method === 'eth_getTransactionReceipt')
-					return {
-						blockHash: sourceLog.blockHash,
-						blockNumber: sourceLog.blockNumber,
-						contractAddress: null,
-						cumulativeGasUsed: '0x5208',
-						from: sender,
-						gasUsed: '0x5208',
-						logs: [sourceLog],
-						status: '0x1',
-						to: sourceLog.address,
-						transactionHash: sourceLog.transactionHash,
-						transactionIndex: sourceLog.transactionIndex,
-						type: '0x2',
-					}
-				throw new Error(`Unexpected RPC method ${request.method}`)
-			})()
-			return Response.json({ id: request.id, jsonrpc: '2.0', result })
+					const transactionHash = String(request.params?.[0])
+					const sourceLog = allLogs.find((log) => log.transactionHash === transactionHash)
+					if (sourceLog === undefined) throw new Error(`Unexpected ${request.method} for ${transactionHash}`)
+					if (request.method === 'eth_getTransactionByHash')
+						return {
+							blockHash: sourceLog.blockHash,
+							blockNumber: sourceLog.blockNumber,
+							from: sender,
+							gas: '0x5208',
+							hash: sourceLog.transactionHash,
+							input: '0x',
+							nonce: '0x0',
+							to: sourceLog.address,
+							transactionIndex: sourceLog.transactionIndex,
+							type: '0x2',
+							value: '0x0',
+						}
+					if (request.method === 'eth_getTransactionReceipt')
+						return {
+							blockHash: sourceLog.blockHash,
+							blockNumber: sourceLog.blockNumber,
+							contractAddress: null,
+							cumulativeGasUsed: '0x5208',
+							from: sender,
+							gasUsed: '0x5208',
+							logs: [sourceLog],
+							status: '0x1',
+							to: sourceLog.address,
+							transactionHash: sourceLog.transactionHash,
+							transactionIndex: sourceLog.transactionIndex,
+							type: '0x2',
+						}
+					throw new Error(`Unexpected RPC method ${request.method}`)
+				})()
+				return Response.json({ id: request.id, jsonrpc: '2.0', result })
+			},
 		})
 		const controller = new AbortController()
 		const database = new ScannerDatabase('postgres://unused')
@@ -1535,7 +1539,7 @@ describe('network indexer lifecycle', () => {
 				id: 'rep-lifecycle',
 				name: 'REP lifecycle',
 				nativeSymbol: 'ETH',
-				rpcUrls: ['https://rpc.example'],
+				rpcUrls: [`http://127.0.0.1:${rpcServer.port}`],
 				startBlock: 10n,
 			}
 			await Promise.all(startIndexers([network], database, controller.signal))
@@ -1550,7 +1554,7 @@ describe('network indexer lifecycle', () => {
 		} finally {
 			clearTimeout(timeout)
 			controller.abort()
-			fetchSpy.mockRestore()
+			await rpcServer.stop(true)
 			info.mockRestore()
 			error.mockRestore()
 		}

--- a/augurScan/tests/live-ui.test.ts
+++ b/augurScan/tests/live-ui.test.ts
@@ -40,6 +40,7 @@ import {
 	runWithForegroundReservation,
 	shouldClearPendingDetailState,
 	shouldContinueTransactionRestore,
+	showIndexerSyncDetails,
 	transactionRetryMode,
 } from '../browser/live-update.ts'
 
@@ -583,6 +584,34 @@ test('calculates bounded indexer completion and estimates remaining time from ob
 		eta: 'Estimating ETA',
 		sample: { indexedBlock: 999, sampledAt: 1_000, blocksPerSecond: undefined },
 	})
+})
+
+test('hides completed sync details only while the live indexer is current and caught up', () => {
+	const now = Date.parse('2026-08-17T12:00:00.000Z')
+	expect(
+		showIndexerSyncDetails(
+			{ start_block: '100', indexed_block: '1000', observed_block: '1000', indexed_timestamp: '2026-08-17T11:59:30.000Z', phase: 'live' },
+			now,
+		),
+	).toBeFalse()
+	expect(
+		showIndexerSyncDetails(
+			{ start_block: '100', indexed_block: '999', observed_block: '1000', indexed_timestamp: '2026-08-17T11:59:30.000Z', phase: 'live' },
+			now,
+		),
+	).toBeTrue()
+	expect(
+		showIndexerSyncDetails(
+			{ start_block: '100', indexed_block: '1000', observed_block: '1000', indexed_timestamp: '2026-08-17T11:58:59.000Z', phase: 'live' },
+			now,
+		),
+	).toBeTrue()
+	expect(
+		showIndexerSyncDetails(
+			{ start_block: '100', indexed_block: '1000', observed_block: '1000', indexed_timestamp: '2026-08-17T11:59:30.000Z', phase: 'backfilling' },
+			now,
+		),
+	).toBeTrue()
 })
 
 test('warns when a caught-up chain head is more than one minute old', () => {


### PR DESCRIPTION
## Summary

- scan every known REP token as a first-class AugurScan log source
- cover REP tokens discovered during an active segment from their discovery block through the segment end
- populate address activity and rich-list balance candidates from REP mint and transfer evidence
- hide completed sync-detail lines while the indexer is live, current, and caught up
- retain standalone WETH and USDC exclusions to avoid high-volume quote-token history scans

## Why

ERC-20 minting already emits a `Transfer` event from the zero address. AugurScan excluded reputation tokens from its primary log scan, so initial mint recipients never entered address activity and were not selected for rich-list balance sampling.

Existing AugurScan databases created under the old behavior require a one-time full replay or database rebuild because their stored cursors already claim the REP range was covered.

## Validation

- `bun run tsc`
- focused AugurScan tests: 130 passed
- full AugurScan unit suite: 248 passed, 1,019 assertions
- lifecycle mutation checks confirmed the regression test fails if same-block retrieval or later-range merging is removed
- `cd augurScan && bun run check`
- `bun run format:check`
- `bun run check:changed`
- `bun run knip`
- `git diff --check`

The root suite was also attempted. Product tests passed, but the parallel Chromium harness hit its lock timeout; the relevant UI production-build scenarios passed in isolation. PostgreSQL integration was not selected because it requires an external database and this change does not alter the schema.

## UI evidence

Caught-up network card, desktop (1440×900):

![Caught-up AugurScan desktop](https://sharey.org/PkjA7d.png)

Caught-up network card, mobile (390×844):

![Caught-up AugurScan mobile](https://sharey.org/V4RUU3.png)

REP-rich address list, desktop (1440×900):

![AugurScan REP rich list](https://sharey.org/u7FHpo.png)

Visual review: 94/100, no findings. Final review: 96/100, no findings.