### PR TITLE
Recover Augurscan from pruned RPC log history

### DIFF
--- a/augurScan/src/database.ts
+++ b/augurScan/src/database.ts
@@ -312,7 +312,7 @@ const canonicalHistoryTables = [
 	'token_metadata',
 ] as const
 
-const invalidateCanonicalHistory = async (transaction: TransactionSQL, chainId: number): Promise<void> => {
+const invalidateCanonicalHistory = async (transaction: TransactionSQL, chainId: number, discoveryRetirementFloor?: bigint): Promise<void> => {
 	for (const table of canonicalHistoryTables) await transaction.unsafe(`UPDATE ${table} SET canonical = false WHERE chain_id = $1 AND canonical`, [chainId])
 	await transaction`UPDATE entity_state_snapshots SET read_status = 'stale', canonical = false WHERE chain_id = ${chainId} AND canonical`
 	await transaction`UPDATE blocks SET finalized = false WHERE chain_id = ${chainId}`
@@ -323,7 +323,18 @@ const invalidateCanonicalHistory = async (transaction: TransactionSQL, chainId: 
 			deployment_block_exact = NULL, deployment_checked_block = NULL
 		WHERE chain_id = ${chainId}
 	`
-	await transaction`UPDATE contracts SET canonical = false WHERE chain_id = ${chainId} AND provenance <> 'manifest'`
+	if (discoveryRetirementFloor === undefined)
+		await transaction`
+			UPDATE contracts SET canonical = false
+			WHERE chain_id = ${chainId} AND provenance <> 'manifest'
+				AND (discovery_block IS NULL OR discovery_block >= (SELECT start_block FROM networks WHERE chain_id = ${chainId}))
+		`
+	else
+		await transaction`
+			UPDATE contracts SET canonical = false
+			WHERE chain_id = ${chainId} AND provenance <> 'manifest'
+				AND (discovery_block IS NULL OR discovery_block >= ${discoveryRetirementFloor.toString()})
+		`
 }
 
 export const releaseReservedConnection = async (connection: Pick<ReservedSQL, 'release'>): Promise<void> => {
@@ -614,6 +625,30 @@ export class ScannerDatabase {
 					AND NOT contract.canonical
 			`
 			await transaction`
+				UPDATE contracts AS contract SET
+					label = discovery.label,
+					kind = discovery.kind,
+					provenance = discovery.provenance,
+					canonical = true
+				FROM (
+					SELECT DISTINCT ON (candidate.address)
+						candidate.address, candidate.label, candidate.kind, candidate.provenance
+					FROM contract_discoveries AS candidate
+					JOIN contracts AS retained
+						ON retained.chain_id = candidate.chain_id
+						AND retained.address = candidate.address
+						AND retained.discovery_block = candidate.block_number
+						AND retained.discovery_tx_hash = candidate.tx_hash
+					JOIN networks AS network ON network.chain_id = candidate.chain_id
+					WHERE candidate.chain_id = ${network.chainId} AND candidate.block_number < network.start_block
+					ORDER BY candidate.address, candidate.canonical DESC, candidate.block_hash
+				) AS discovery
+				WHERE contract.chain_id = ${network.chainId}
+					AND contract.address = discovery.address
+					AND contract.provenance = 'manifest'
+					AND NOT contract.canonical
+			`
+			await transaction`
 				UPDATE contracts SET provenance = 'retired-manifest'
 				WHERE chain_id = ${network.chainId} AND provenance = 'manifest' AND NOT canonical
 			`
@@ -645,8 +680,8 @@ export class ScannerDatabase {
 				label = CASE WHEN EXCLUDED.provenance = 'manifest' THEN EXCLUDED.label WHEN contracts.provenance = 'manifest' THEN contracts.label ELSE EXCLUDED.label END,
 				kind = CASE WHEN EXCLUDED.provenance = 'manifest' THEN EXCLUDED.kind WHEN contracts.provenance = 'manifest' THEN contracts.kind ELSE EXCLUDED.kind END,
 				provenance = CASE WHEN EXCLUDED.provenance = 'manifest' OR contracts.provenance = 'manifest' THEN 'manifest' ELSE EXCLUDED.provenance END,
-				discovery_block = CASE WHEN EXCLUDED.provenance = 'manifest' THEN NULL WHEN contracts.provenance = 'manifest' THEN contracts.discovery_block ELSE EXCLUDED.discovery_block END,
-				discovery_tx_hash = CASE WHEN EXCLUDED.provenance = 'manifest' THEN NULL WHEN contracts.provenance = 'manifest' THEN contracts.discovery_tx_hash ELSE EXCLUDED.discovery_tx_hash END,
+				discovery_block = CASE WHEN EXCLUDED.provenance = 'manifest' AND (contracts.canonical OR contracts.provenance = 'manifest') THEN contracts.discovery_block WHEN EXCLUDED.provenance = 'manifest' THEN NULL WHEN contracts.provenance = 'manifest' THEN contracts.discovery_block ELSE EXCLUDED.discovery_block END,
+				discovery_tx_hash = CASE WHEN EXCLUDED.provenance = 'manifest' AND (contracts.canonical OR contracts.provenance = 'manifest') THEN contracts.discovery_tx_hash WHEN EXCLUDED.provenance = 'manifest' THEN NULL WHEN contracts.provenance = 'manifest' THEN contracts.discovery_tx_hash ELSE EXCLUDED.discovery_tx_hash END,
 				canonical = true
 		`
 	}
@@ -974,7 +1009,12 @@ export class ScannerDatabase {
 				WHERE chain_id = ${chainId} AND (deployment_block > ${ancestor.toString()} OR deployment_checked_block > ${ancestor.toString()})
 			`
 			await transaction`UPDATE contracts SET deployment_checked_block = NULL WHERE chain_id = ${chainId} AND deployment_checked_block > ${ancestor.toString()}`
-			await transaction`UPDATE contracts SET canonical = false WHERE chain_id = ${chainId} AND provenance <> 'manifest' AND discovery_block > ${ancestor.toString()}`
+			await transaction`
+				UPDATE contracts SET canonical = false
+				WHERE chain_id = ${chainId} AND provenance <> 'manifest'
+					AND (discovery_block IS NULL OR discovery_block >= ${String(checkpoint['start_block'])})
+					AND (discovery_block IS NULL OR discovery_block > ${ancestor.toString()})
+			`
 			await transaction`
 				UPDATE contracts AS contract SET
 					label = discovery.label,
@@ -1307,23 +1347,26 @@ export class ScannerDatabase {
 
 	async advanceNetworkStartBlock(chainId: number, startBlock: bigint, lease: IndexerLease): Promise<boolean> {
 		return await withIndexerLease(lease, async (transaction) => {
-			const rows = await transaction`SELECT start_block FROM networks WHERE chain_id = ${chainId} FOR UPDATE`
+			const rows = await transaction`SELECT start_block, indexed_block FROM networks WHERE chain_id = ${chainId} FOR UPDATE`
 			const row = rows[0]
 			if (row === undefined) throw new DatabaseConsistencyError(`Network ${chainId} is not initialized`)
 			const storedStartBlock = BigInt(String(row['start_block']))
 			if (startBlock <= storedStartBlock) return false
-			await invalidateCanonicalHistory(transaction, chainId)
+			const previousBlock = row['indexed_block'] === null || row['indexed_block'] === undefined ? undefined : BigInt(String(row['indexed_block']))
+			const invalidatedDepth = previousBlock === undefined ? 0n : previousBlock - storedStartBlock + 1n
+			await invalidateCanonicalHistory(transaction, chainId, startBlock)
 			await transaction`
 				UPDATE networks SET start_block = ${startBlock.toString()}, indexed_block = NULL, indexed_hash = NULL,
 					indexed_timestamp = NULL, finalized_block = NULL, phase = 'backfilling', last_poll_at = now(),
 					last_success_at = now(), last_error = NULL, failure_started_at = NULL, consecutive_failures = 0,
+					last_reorg_at = now(), last_reorg_depth = ${invalidatedDepth.toString()},
 					next_retry_at = NULL, updated_at = now()
 				WHERE chain_id = ${chainId}
 			`
 			await lockLiveEventWriter(transaction)
 			await transaction`
 				INSERT INTO live_events (event, payload)
-				VALUES ('status', (${JSON.stringify({ chainId, phase: 'backfilling', startBlock: startBlock.toString() })}::text)::jsonb)
+				VALUES ('reorg', (${JSON.stringify({ chainId, previousBlock: previousBlock?.toString(), ancestor: '-1', depth: invalidatedDepth.toString(), startBlock: startBlock.toString() })}::text)::jsonb)
 			`
 			return true
 		})

--- a/augurScan/src/database.ts
+++ b/augurScan/src/database.ts
@@ -284,6 +284,48 @@ export const lockLiveEventWriter = async (sql: SQL): Promise<void> => {
 	await sql`SELECT singleton FROM live_event_state WHERE singleton FOR UPDATE`
 }
 
+const canonicalHistoryTables = [
+	'blocks',
+	'transactions',
+	'logs',
+	'contract_discoveries',
+	'questions',
+	'pools',
+	'pool_snapshots',
+	'pool_state_events',
+	'vault_snapshots',
+	'universe_events',
+	'amm_markets',
+	'amm_price_snapshots',
+	'rep_eth_price_snapshots',
+	'uniswap_rep_eth_markets',
+	'uniswap_rep_eth_price_observations',
+	'protocol_timeline_entries',
+	'open_oracle_report_events',
+	'escalation_game_events',
+	'truth_auction_events',
+	'amm_trade_events',
+	'fork_migration_events',
+	'liquidation_approval_events',
+	'address_activity',
+	'address_balance_snapshots',
+	'token_metadata',
+] as const
+
+const invalidateCanonicalHistory = async (transaction: TransactionSQL, chainId: number): Promise<void> => {
+	for (const table of canonicalHistoryTables) await transaction.unsafe(`UPDATE ${table} SET canonical = false WHERE chain_id = $1 AND canonical`, [chainId])
+	await transaction`UPDATE entity_state_snapshots SET read_status = 'stale', canonical = false WHERE chain_id = ${chainId} AND canonical`
+	await transaction`UPDATE blocks SET finalized = false WHERE chain_id = ${chainId}`
+	await transaction`UPDATE logs SET finalized = false WHERE chain_id = ${chainId}`
+	await transaction`DELETE FROM log_scan_cursors WHERE chain_id = ${chainId}`
+	await transaction`
+		UPDATE contracts SET deployment_block = NULL, deployment_timestamp = NULL,
+			deployment_block_exact = NULL, deployment_checked_block = NULL
+		WHERE chain_id = ${chainId}
+	`
+	await transaction`UPDATE contracts SET canonical = false WHERE chain_id = ${chainId} AND provenance <> 'manifest'`
+}
+
 export const releaseReservedConnection = async (connection: Pick<ReservedSQL, 'release'>): Promise<void> => {
 	await connection.release()
 }
@@ -576,44 +618,7 @@ export class ScannerDatabase {
 				WHERE chain_id = ${network.chainId} AND provenance = 'manifest' AND NOT canonical
 			`
 			if (manifestChanged && resetCanonicalHistoryOnManifestChange && existing?.['indexed_block'] !== null && existing?.['indexed_block'] !== undefined) {
-				for (const table of [
-					'blocks',
-					'transactions',
-					'logs',
-					'contract_discoveries',
-					'questions',
-					'pools',
-					'pool_snapshots',
-					'pool_state_events',
-					'vault_snapshots',
-					'universe_events',
-					'amm_markets',
-					'amm_price_snapshots',
-					'rep_eth_price_snapshots',
-					'uniswap_rep_eth_markets',
-					'uniswap_rep_eth_price_observations',
-					'protocol_timeline_entries',
-					'open_oracle_report_events',
-					'escalation_game_events',
-					'truth_auction_events',
-					'amm_trade_events',
-					'fork_migration_events',
-					'liquidation_approval_events',
-					'address_activity',
-					'address_balance_snapshots',
-					'token_metadata',
-				])
-					await transaction.unsafe(`UPDATE ${table} SET canonical = false WHERE chain_id = $1 AND canonical`, [network.chainId])
-				await transaction`UPDATE entity_state_snapshots SET read_status = 'stale', canonical = false WHERE chain_id = ${network.chainId} AND canonical`
-				await transaction`UPDATE blocks SET finalized = false WHERE chain_id = ${network.chainId}`
-				await transaction`UPDATE logs SET finalized = false WHERE chain_id = ${network.chainId}`
-				await transaction`DELETE FROM log_scan_cursors WHERE chain_id = ${network.chainId}`
-				await transaction`
-					UPDATE contracts SET deployment_block = NULL, deployment_timestamp = NULL,
-						deployment_block_exact = NULL, deployment_checked_block = NULL
-					WHERE chain_id = ${network.chainId}
-				`
-				await transaction`UPDATE contracts SET canonical = false WHERE chain_id = ${network.chainId} AND provenance <> 'manifest'`
+				await invalidateCanonicalHistory(transaction, network.chainId)
 				const previousBlock = BigInt(String(existing['indexed_block']))
 				await transaction`
 					UPDATE networks SET indexed_block = NULL, indexed_hash = NULL, indexed_timestamp = NULL, finalized_block = NULL, phase = 'backfilling',
@@ -1297,6 +1302,30 @@ export class ScannerDatabase {
 			await transaction`UPDATE networks SET observed_block = ${head.toString()}, phase = ${phase}, last_poll_at = now(), last_success_at = now(), last_error = null, failure_started_at = null, consecutive_failures = 0, next_retry_at = null, updated_at = now() WHERE chain_id = ${chainId}`
 			await lockLiveEventWriter(transaction)
 			await transaction`INSERT INTO live_events (event, payload) VALUES ('status', (${JSON.stringify({ chainId, blockNumber: head.toString() })}::text)::jsonb)`
+		})
+	}
+
+	async advanceNetworkStartBlock(chainId: number, startBlock: bigint, lease: IndexerLease): Promise<boolean> {
+		return await withIndexerLease(lease, async (transaction) => {
+			const rows = await transaction`SELECT start_block FROM networks WHERE chain_id = ${chainId} FOR UPDATE`
+			const row = rows[0]
+			if (row === undefined) throw new DatabaseConsistencyError(`Network ${chainId} is not initialized`)
+			const storedStartBlock = BigInt(String(row['start_block']))
+			if (startBlock <= storedStartBlock) return false
+			await invalidateCanonicalHistory(transaction, chainId)
+			await transaction`
+				UPDATE networks SET start_block = ${startBlock.toString()}, indexed_block = NULL, indexed_hash = NULL,
+					indexed_timestamp = NULL, finalized_block = NULL, phase = 'backfilling', last_poll_at = now(),
+					last_success_at = now(), last_error = NULL, failure_started_at = NULL, consecutive_failures = 0,
+					next_retry_at = NULL, updated_at = now()
+				WHERE chain_id = ${chainId}
+			`
+			await lockLiveEventWriter(transaction)
+			await transaction`
+				INSERT INTO live_events (event, payload)
+				VALUES ('status', (${JSON.stringify({ chainId, phase: 'backfilling', startBlock: startBlock.toString() })}::text)::jsonb)
+			`
+			return true
 		})
 	}
 

--- a/augurScan/src/indexer-runtime.ts
+++ b/augurScan/src/indexer-runtime.ts
@@ -1,8 +1,18 @@
 import { type AddressActivity, DatabaseConsistencyError, databaseConsistencyDiagnosticMessage, type IndexerLease, type StoredTransaction } from './database.ts'
 import { errorChainIncludes } from './error-chain.ts'
-import { type Address, type Hash, type Log, type PublicClient, type TransactionReceipt, zeroAddress } from './ethereum.ts'
+import {
+	type Address,
+	createPublicClient,
+	type Hash,
+	http,
+	type Log,
+	type PublicClient,
+	type RpcFetchFn,
+	type TransactionReceipt,
+	zeroAddress,
+} from './ethereum.ts'
 import { jsonRpcErrorName, safeRpcProviderMessage } from './logging.ts'
-import { RpcRequestMethodError, rpcQueueSaturationFrom } from './rpc-request-queue.ts'
+import { RpcRequestMethodError, type RpcRequestQueue, rpcQueueSaturationFrom, withRpcRequestQueue } from './rpc-request-queue.ts'
 import { bigintToSafeNumber } from './time.ts'
 import type { ContractMetadata, StoredLog } from './types.ts'
 
@@ -158,6 +168,24 @@ export const isPermanentHistoricalCodeError = (error: unknown): boolean => {
 	return false
 }
 
+export const isPermanentHistoricalLogError = (error: unknown): boolean => {
+	const seen = new Set<unknown>()
+	let getLogsRequest = false
+	let prunedHistory = false
+	let current: unknown = error
+	while (typeof current === 'object' && current !== null && !seen.has(current)) {
+		seen.add(current)
+		if (current instanceof RpcRequestMethodError && current.method === 'eth_getLogs') getLogsRequest = true
+		if ('code' in current && current.code === 4444) prunedHistory = true
+		for (const description of preferredRpcDescriptions(current)) {
+			const normalized = classifiedRpcDescription(description)
+			if (normalized.includes('pruned history unavailable') || normalized.includes('historical logs unavailable')) prunedHistory = true
+		}
+		current = 'cause' in current ? current.cause : undefined
+	}
+	return getLogsRequest && prunedHistory
+}
+
 const isPrunedHistoricalStateError = (error: unknown): boolean => {
 	const seen = new Set<unknown>()
 	let current: unknown = error
@@ -179,8 +207,63 @@ const isPrunedHistoricalStateError = (error: unknown): boolean => {
 }
 
 export const isSplittableLogRangeError = (error: unknown): boolean => {
+	if (isPermanentHistoricalLogError(error)) return false
 	const category = rpcErrorCategory(error)
 	return category !== undefined && category !== 'rate-limit'
+}
+
+export const createNonRetryingLogClient = (rpcUrl: string, endpoint: string, queue: RpcRequestQueue, fetchFn: RpcFetchFn): PublicClient =>
+	createPublicClient({
+		transport: withRpcRequestQueue(
+			http(rpcUrl, {
+				fetchFn,
+				requestTimeout: 20_000,
+				retryCount: 0,
+			}),
+			queue,
+			endpoint,
+		),
+	})
+
+export const findEarliestAvailableLogBlock = async (
+	startBlock: bigint,
+	observedHead: bigint,
+	logsAt: (blockNumber: bigint) => Promise<void>,
+	startBlockKnownUnavailable = false,
+): Promise<bigint> => {
+	if (startBlock > observedHead) throw new Error('The log availability search start must not exceed the observed head')
+	const isAvailable = async (blockNumber: bigint): Promise<boolean> => {
+		try {
+			await logsAt(blockNumber)
+			return true
+		} catch (error) {
+			if (isPermanentHistoricalLogError(error)) return false
+			throw error
+		}
+	}
+	if (!startBlockKnownUnavailable && (await isAvailable(startBlock))) return startBlock
+	if (!(await isAvailable(observedHead))) throw new ChainConfigurationError(`RPC cannot serve logs at observed head #${observedHead}`)
+	let lower = startBlock
+	let upper = observedHead
+	while (lower + 1n < upper) {
+		const middle = lower + (upper - lower) / 2n
+		if (await isAvailable(middle)) upper = middle
+		else lower = middle
+	}
+	return upper
+}
+
+export const recoverPrunedLogScan = async (
+	error: unknown,
+	startBlock: bigint,
+	observedHead: bigint,
+	logsAt: (blockNumber: bigint) => Promise<void>,
+	advanceStartBlock: (blockNumber: bigint) => Promise<void>,
+): Promise<bigint | undefined> => {
+	if (!isPermanentHistoricalLogError(error)) return undefined
+	const availableStart = await findEarliestAvailableLogBlock(startBlock, observedHead, logsAt, true)
+	await advanceStartBlock(availableStart)
+	return availableStart
 }
 
 export const labelsFrom = (contracts: ReadonlyMap<string, ContractMetadata>): Map<string, string> =>
@@ -627,6 +710,7 @@ type NetworkLifecycle = {
 	readonly verify: () => Promise<void>
 	readonly poll: () => Promise<boolean>
 	readonly failure: (message: string, nextRetryAt: Date, reason: string) => Promise<void>
+	readonly recover?: (error: unknown) => Promise<boolean>
 	readonly intervalMs: number
 	readonly signal: AbortSignal
 	readonly random?: () => number
@@ -650,7 +734,7 @@ export const retryDelayMs = (consecutiveFailures: number, intervalMs: number, ra
 	return Math.min(Math.round(base * (0.8 + random() * 0.4)), 300_000)
 }
 
-export const runNetworkLifecycle = async ({ verify, poll, failure, intervalMs, signal, random, shouldRethrow }: NetworkLifecycle): Promise<void> => {
+export const runNetworkLifecycle = async ({ verify, poll, failure, recover, intervalMs, signal, random, shouldRethrow }: NetworkLifecycle): Promise<void> => {
 	let verified = false
 	let consecutiveFailures = 0
 	while (!signal.aborted) {
@@ -666,14 +750,19 @@ export const runNetworkLifecycle = async ({ verify, poll, failure, intervalMs, s
 			consecutiveFailures = 0
 		} catch (error) {
 			if (error instanceof LeaseLostError || shouldRethrow?.(error) === true) throw error
-			consecutiveFailures++
-			delayAfterFailure = retryDelayMs(consecutiveFailures, intervalMs, random)
-			try {
-				const failureMessage = safeIndexerFailure(error)
-				const failureReason = failureMessage === 'RPC request failed; retrying' ? rpcIndexerFailureReason(error) : safeIndexerFailureReason(error)
-				await failure(failureMessage, new Date(Date.now() + delayAfterFailure), failureReason)
-			} catch (failureError) {
-				throw new IndexerOwnershipStageError('record-failure', failureError)
+			if ((await recover?.(error)) === true) {
+				consecutiveFailures = 0
+				caughtUp = false
+			} else {
+				consecutiveFailures++
+				delayAfterFailure = retryDelayMs(consecutiveFailures, intervalMs, random)
+				try {
+					const failureMessage = safeIndexerFailure(error)
+					const failureReason = failureMessage === 'RPC request failed; retrying' ? rpcIndexerFailureReason(error) : safeIndexerFailureReason(error)
+					await failure(failureMessage, new Date(Date.now() + delayAfterFailure), failureReason)
+				} catch (failureError) {
+					throw new IndexerOwnershipStageError('record-failure', failureError)
+				}
 			}
 		}
 		await waitForIndexerDelay(delayAfterFailure ?? (caughtUp ? Math.max(0, intervalMs - (Date.now() - startedAt)) : 0), signal)

--- a/augurScan/src/indexer-runtime.ts
+++ b/augurScan/src/indexer-runtime.ts
@@ -212,13 +212,14 @@ export const isSplittableLogRangeError = (error: unknown): boolean => {
 	return category !== undefined && category !== 'rate-limit'
 }
 
-export const createNonRetryingLogClient = (rpcUrl: string, endpoint: string, queue: RpcRequestQueue, fetchFn: RpcFetchFn): PublicClient =>
+export const createLogClient = (rpcUrl: string, endpoint: string, queue: RpcRequestQueue, fetchFn: RpcFetchFn, retryDelay?: number): PublicClient =>
 	createPublicClient({
 		transport: withRpcRequestQueue(
 			http(rpcUrl, {
 				fetchFn,
 				requestTimeout: 20_000,
-				retryCount: 0,
+				retryCount: 2,
+				...(retryDelay === undefined ? {} : { retryDelay }),
 			}),
 			queue,
 			endpoint,
@@ -253,17 +254,25 @@ export const findEarliestAvailableLogBlock = async (
 	return upper
 }
 
-export const recoverPrunedLogScan = async (
-	error: unknown,
+export const findEarliestAvailableLogProvider = async <TProvider>(
+	providers: readonly TProvider[],
 	startBlock: bigint,
-	observedHead: bigint,
-	logsAt: (blockNumber: bigint) => Promise<void>,
-	advanceStartBlock: (blockNumber: bigint) => Promise<void>,
-): Promise<bigint | undefined> => {
-	if (!isPermanentHistoricalLogError(error)) return undefined
-	const availableStart = await findEarliestAvailableLogBlock(startBlock, observedHead, logsAt, true)
-	await advanceStartBlock(availableStart)
-	return availableStart
+	observedHead: (provider: TProvider) => Promise<bigint>,
+	logsAt: (provider: TProvider, blockNumber: bigint) => Promise<void>,
+): Promise<{ readonly provider: TProvider; readonly startBlock: bigint } | undefined> => {
+	let earliest: { readonly provider: TProvider; readonly startBlock: bigint } | undefined
+	for (const provider of providers) {
+		try {
+			const head = await observedHead(provider)
+			if (head < startBlock) continue
+			const availableStart = await findEarliestAvailableLogBlock(startBlock, head, (blockNumber) => logsAt(provider, blockNumber))
+			if (earliest === undefined || availableStart < earliest.startBlock) earliest = { provider, startBlock: availableStart }
+		} catch {
+			// Recovery is best-effort across providers. The lifecycle retains the
+			// original failure when none can establish a usable log boundary.
+		}
+	}
+	return earliest
 }
 
 export const labelsFrom = (contracts: ReadonlyMap<string, ContractMetadata>): Map<string, string> =>
@@ -372,6 +381,7 @@ export const withVerifiedProvider = async <TProvider extends ChainProvider, TRes
 	stopFailover = (_error: unknown): boolean => false,
 	onAttempt = (_provider: TProvider): void => {},
 	verifiedProviders?: WeakSet<TProvider>,
+	onFailure = (_provider: TProvider, _error: unknown): void => {},
 ): Promise<TResult> => {
 	let lastFailure: unknown
 	for (const provider of providers) {
@@ -384,6 +394,7 @@ export const withVerifiedProvider = async <TProvider extends ChainProvider, TRes
 			}
 			return await operation(provider)
 		} catch (error) {
+			onFailure(provider, error)
 			if (stopFailover(error)) throw error
 			lastFailure = error
 		}

--- a/augurScan/src/indexer.ts
+++ b/augurScan/src/indexer.ts
@@ -8,6 +8,7 @@ import {
 	confirmCanonicalBlock,
 	contractDeploymentCandidateFrom,
 	contractDeploymentScanDue,
+	createNonRetryingLogClient,
 	createRpcDiagnosticContext,
 	databaseFailureMessage,
 	deploymentReadBudget,
@@ -18,6 +19,7 @@ import {
 	indexingCompletion,
 	isLocalIndexerFailure,
 	isPermanentHistoricalCodeError,
+	isPermanentHistoricalLogError,
 	isProtocolActivitySource,
 	isProtocolEvidenceEmitter,
 	isSplittableLogRangeError,
@@ -29,6 +31,7 @@ import {
 	type RpcProvider,
 	readHistoricalCodeWithPermanentFallback,
 	recordOwnershipEvent,
+	recoverPrunedLogScan,
 	requireLogPosition,
 	requireReceiptPosition,
 	requiresManifestHistoryCoverage,
@@ -122,6 +125,8 @@ type RpcBlockHeader = {
 	readonly parentHash: Hash
 	readonly timestamp: bigint
 }
+
+type IndexerRpcProvider = RpcProvider & { readonly logClient: PublicClient }
 
 const requireRpcBlockHeader = (block: Block, blockNumber: bigint): RpcBlockHeader => {
 	if (block.hash === undefined || block.parentHash === undefined || block.number !== blockNumber) {
@@ -386,8 +391,12 @@ export const planDeploymentAwareLogScan = async (
 	const planned = await mapLimit(contracts, 4, async (contract): Promise<DeploymentAwareLogPlan> => {
 		const knownStart = contract.deploymentBlock ?? contract.discoveryBlock
 		if (knownStart !== undefined) {
+			const coverageStart = knownStart > configuredStartBlock ? knownStart : configuredStartBlock
 			return {
-				inputs: knownStart > toBlock ? [] : [{ address: contract.address, fromBlock: knownStart > fromBlock ? knownStart : fromBlock, startBlock: knownStart }],
+				inputs:
+					coverageStart > toBlock
+						? []
+						: [{ address: contract.address, fromBlock: coverageStart > fromBlock ? coverageStart : fromBlock, startBlock: coverageStart }],
 				observations: [],
 			}
 		}
@@ -516,9 +525,10 @@ class NetworkIndexer {
 	#network: NetworkConfig
 	readonly #configuredStartBlock: bigint
 	readonly #database: ScannerDatabase
-	readonly #providers: readonly RpcProvider[]
-	readonly #verifiedProviders = new WeakSet<RpcProvider>()
+	readonly #providers: readonly IndexerRpcProvider[]
+	readonly #verifiedProviders = new WeakSet<IndexerRpcProvider>()
 	#client: PublicClient
+	#logClient: PublicClient
 	readonly #rpcDiagnostics: ReturnType<typeof createRpcDiagnosticContext>
 	#indexingStartReported = false
 	#lastProgressLogAt: number | undefined
@@ -536,17 +546,20 @@ class NetworkIndexer {
 		this.#signal = signal
 		this.#providers = network.rpcUrls.map((rpcUrl, index) => {
 			const endpoint = rpcProviderLabel(rpcUrl, index)
+			const loggingFetch = createRpcLoggingFetch(rpcUrl, endpoint, runtimeConfig.rpcLogPath, rpcExchangeLog)
 			const transport = http(rpcUrl, {
-				fetchFn: createRpcLoggingFetch(rpcUrl, endpoint, runtimeConfig.rpcLogPath, rpcExchangeLog),
+				fetchFn: loggingFetch,
 				requestTimeout: 20_000,
 				retryCount: 2,
 			})
 			const client = createPublicClient({ transport: withRpcRequestQueue(transport, rpcRequestQueue, endpoint) })
-			return { client, endpoint, getChainId: () => client.getChainId(), number: index + 1 }
+			const logClient = createNonRetryingLogClient(rpcUrl, endpoint, rpcRequestQueue, loggingFetch)
+			return { client, endpoint, getChainId: () => client.getChainId(), logClient, number: index + 1 }
 		})
 		const firstProvider = this.#providers[0]
 		if (firstProvider === undefined) throw new ChainConfigurationError('At least one RPC provider is required')
 		this.#client = firstProvider.client
+		this.#logClient = firstProvider.logClient
 		this.#rpcDiagnostics = createRpcDiagnosticContext(firstProvider)
 	}
 
@@ -598,6 +611,7 @@ class NetworkIndexer {
 						poll: () => this.#poll(),
 						runWithProvider: (operation) => this.#withProviderFailover(operation),
 						failure: (message, nextRetryAt, reason) => this.#recordFailure(message, nextRetryAt, this.#requireLease(), reason),
+						recover: (error) => this.#recoverPrunedLogFailure(error),
 						intervalMs: runtimeConfig.pollIntervalMs,
 						signal: this.#signal,
 					})
@@ -684,8 +698,9 @@ class NetworkIndexer {
 		return await withVerifiedProvider(
 			this.#providers,
 			this.#network.chainId,
-			async ({ client }) => {
+			async ({ client, logClient }) => {
 				this.#client = client
+				this.#logClient = logClient
 				return await operation()
 			},
 			isLocalIndexerFailure,
@@ -706,6 +721,45 @@ class NetworkIndexer {
 			: rpcFailureLogMessage(message, this.#rpcDiagnostics.activeEndpoint(), reason)
 		this.#lastReportedPhase = 'degraded'
 		console.error(`[${this.#network.id}] indexer state: degraded; ${logMessage}`)
+	}
+
+	async #advancePastPrunedLogs(error: unknown, unavailableStart: bigint, observedHead: bigint, probeAddress: Address): Promise<boolean> {
+		const availableStart = await recoverPrunedLogScan(
+			error,
+			unavailableStart,
+			observedHead,
+			async (blockNumber) => {
+				await this.#logClient.getLogs({ address: probeAddress, fromBlock: blockNumber, toBlock: blockNumber })
+			},
+			async (blockNumber) => {
+				await this.#assertLease()
+				await this.#database.advanceNetworkStartBlock(this.#network.chainId, blockNumber, this.#requireLease())
+			},
+		)
+		if (availableStart === undefined) return false
+		const previousStart = this.#network.startBlock
+		this.#network = { ...this.#network, startBlock: availableStart }
+		this.#historicalCodeUnavailable.clear()
+		this.#indexingStartReported = false
+		this.#lastProgressLogAt = undefined
+		this.#progressSample = undefined
+		this.#lastReportedPhase = undefined
+		this.#lastDeploymentScanAt = undefined
+		console.warn(
+			`[${this.#network.id}] RPC log history before block #${availableStart} is pruned; advanced index coverage from block #${previousStart} to earliest retrievable block #${availableStart} and continuing`,
+		)
+		return true
+	}
+
+	async #recoverPrunedLogFailure(error: unknown): Promise<boolean> {
+		if (!isPermanentHistoricalLogError(error)) return false
+		const observedHead = await this.#client.getBlockNumber()
+		const checkpoint = await this.#database.checkpoint(this.#network.chainId, this.#requireLease())
+		const unavailableStart = checkpoint === undefined ? this.#network.startBlock : checkpoint.number + 1n
+		const contracts = this.#withManifestDeploymentBlocks(await this.#database.contracts(this.#network.chainId, this.#requireLease()))
+		const probeAddress = indexerLogSources([...contracts.values()])[0]?.address
+		if (probeAddress === undefined) return false
+		return await this.#advancePastPrunedLogs(error, unavailableStart, observedHead, probeAddress)
 	}
 
 	#reportProgress(startBlock: bigint, endBlock: bigint, observedHead: bigint): void {
@@ -1019,23 +1073,23 @@ class NetworkIndexer {
 		const inputsOfKind = (kind: string): readonly LogScanInput[] => inputs.filter(({ address }) => contracts.get(address.toLowerCase())?.kind === kind)
 		const ordinaryInputs = inputs.filter(({ address }) => !filteredKinds.has(contracts.get(address.toLowerCase())?.kind ?? ''))
 		const groups = rpcLogQueryGroups(ordinaryInputs)
-		const ordinaryPages = await mapLimit(groups, 3, (group) => this.#client.getLogs({ address: group.addresses, fromBlock: group.fromBlock, toBlock }))
+		const ordinaryPages = await mapLimit(groups, 3, (group) => this.#logClient.getLogs({ address: group.addresses, fromBlock: group.fromBlock, toBlock }))
 		const tokenPairs = uniswapV2V3TokenPairs(contracts.values())
 		const v2Queries = inputsOfKind('uniswapV2Factory').flatMap((input) => tokenPairs.map((tokens) => ({ input, ...tokens })))
 		const v2Pages = await mapLimit(v2Queries, 3, ({ input, token0, token1 }) =>
-			this.#client.getLogs({ address: input.address, event: uniswapV2PairCreatedEvent, args: { token0, token1 }, fromBlock: input.fromBlock, toBlock }),
+			this.#logClient.getLogs({ address: input.address, event: uniswapV2PairCreatedEvent, args: { token0, token1 }, fromBlock: input.fromBlock, toBlock }),
 		)
 		const v3Queries = inputsOfKind('uniswapV3Factory').flatMap((input) => tokenPairs.map((tokens) => ({ input, ...tokens })))
 		const v3Pages = await mapLimit(v3Queries, 3, ({ input, token0, token1 }) =>
-			this.#client.getLogs({ address: input.address, event: uniswapV3PoolCreatedEvent, args: { token0, token1 }, fromBlock: input.fromBlock, toBlock }),
+			this.#logClient.getLogs({ address: input.address, event: uniswapV3PoolCreatedEvent, args: { token0, token1 }, fromBlock: input.fromBlock, toBlock }),
 		)
 		const poolIdGroups = chunks(uniswapV4PoolIds(contracts), 25)
 		const v4Queries = inputsOfKind('uniswapV4PoolManager').flatMap((input) => poolIdGroups.map((ids) => ({ input, ids })))
 		const initializePages = await mapLimit(v4Queries, 3, ({ input, ids }) =>
-			this.#client.getLogs({ address: input.address, event: uniswapV4InitializeEvent, args: { id: ids }, fromBlock: input.fromBlock, toBlock }),
+			this.#logClient.getLogs({ address: input.address, event: uniswapV4InitializeEvent, args: { id: ids }, fromBlock: input.fromBlock, toBlock }),
 		)
 		const swapPages = await mapLimit(v4Queries, 3, ({ input, ids }) =>
-			this.#client.getLogs({ address: input.address, event: uniswapV4SwapEvent, args: { id: ids }, fromBlock: input.fromBlock, toBlock }),
+			this.#logClient.getLogs({ address: input.address, event: uniswapV4SwapEvent, args: { id: ids }, fromBlock: input.fromBlock, toBlock }),
 		)
 		const unique = new Map<string, Log>()
 		for (const log of [...ordinaryPages.flat(), ...v2Pages.flat(), ...v3Pages.flat(), ...initializePages.flat(), ...swapPages.flat()]) {

--- a/augurScan/src/indexer.ts
+++ b/augurScan/src/indexer.ts
@@ -8,10 +8,11 @@ import {
 	confirmCanonicalBlock,
 	contractDeploymentCandidateFrom,
 	contractDeploymentScanDue,
-	createNonRetryingLogClient,
+	createLogClient,
 	createRpcDiagnosticContext,
 	databaseFailureMessage,
 	deploymentReadBudget,
+	findEarliestAvailableLogProvider,
 	indexerLogSources,
 	indexerOperationFailureReason,
 	indexerProgressMessage,
@@ -31,7 +32,6 @@ import {
 	type RpcProvider,
 	readHistoricalCodeWithPermanentFallback,
 	recordOwnershipEvent,
-	recoverPrunedLogScan,
 	requireLogPosition,
 	requireReceiptPosition,
 	requiresManifestHistoryCoverage,
@@ -266,7 +266,9 @@ export const planManifestBackfill = async (
 		checkpoint: bigint,
 		startBlockKnownAbsent: boolean,
 	) => Promise<{ readonly block: bigint; readonly exact: boolean } | undefined>,
+	coverageStartBlock = configuredStartBlock,
 ): Promise<bigint | undefined> => {
+	const activeStartBlock = coverageStartBlock > configuredStartBlock ? coverageStartBlock : configuredStartBlock
 	let replayStart: bigint | undefined
 	for (const [address, label, kind, configuredDeploymentBlock] of manifestContracts) {
 		const storedContract = contracts.get(address.toLowerCase())
@@ -284,7 +286,8 @@ export const planManifestBackfill = async (
 			storedContract !== undefined &&
 			storedContract.deploymentBlockExact !== true &&
 			(storedContract.provenance !== 'manifest' || !requiresManifestHistoryCoverage(storedContract))
-		let deploymentBlock = configuredDeploymentBlock ?? (requiresFreshDeploymentSearch ? undefined : contract.deploymentBlock)
+		const knownDeploymentBlock = configuredDeploymentBlock ?? (requiresFreshDeploymentSearch ? undefined : contract.deploymentBlock)
+		let deploymentBlock = knownDeploymentBlock === undefined || knownDeploymentBlock > activeStartBlock ? knownDeploymentBlock : activeStartBlock
 		if (
 			!requiresFreshDeploymentSearch &&
 			cursor !== undefined &&
@@ -293,14 +296,16 @@ export const planManifestBackfill = async (
 		)
 			continue
 		if (deploymentBlock === undefined) {
-			const searchStart = requiresFreshDeploymentSearch ? configuredStartBlock : (contract.deploymentCheckedBlock ?? configuredStartBlock)
+			const previousSearchStart = requiresFreshDeploymentSearch ? configuredStartBlock : (contract.deploymentCheckedBlock ?? configuredStartBlock)
+			const searchStart = previousSearchStart > activeStartBlock ? previousSearchStart : activeStartBlock
 			if (searchStart >= checkpoint && contract.deploymentCheckedBlock !== undefined && !requiresFreshDeploymentSearch) continue
 			const deployment = await findDeployment(address, searchStart, checkpoint, !requiresFreshDeploymentSearch && contract.deploymentCheckedBlock !== undefined)
 			if (deployment === undefined) continue
-			deploymentBlock = deployment.block
+			deploymentBlock = deployment.block > activeStartBlock ? deployment.block : activeStartBlock
 		}
 		if (deploymentBlock > checkpoint) continue
-		const missingStart = cursor === undefined || cursor.startBlock > deploymentBlock ? deploymentBlock : cursor.lastRetrievedBlock + 1n
+		const cursorMissingStart = cursor === undefined || cursor.startBlock > deploymentBlock ? deploymentBlock : cursor.lastRetrievedBlock + 1n
+		const missingStart = cursorMissingStart > activeStartBlock ? cursorMissingStart : activeStartBlock
 		if (missingStart <= checkpoint && (replayStart === undefined || missingStart < replayStart)) replayStart = missingStart
 	}
 	return replayStart
@@ -344,7 +349,8 @@ export const logScanCursorUpdates = (
 		if (!tracksFilteredHistory && (!isProtocolActivitySource(contract) || (scanInput === undefined && contract.discoveryBlock === undefined))) return []
 		const startBlock =
 			scanInput?.startBlock ?? contract.deploymentBlock ?? contract.discoveryBlock ?? (tracksFilteredHistory ? coverageStartBlock : configuredStartBlock)
-		return startBlock > endBlock ? [] : [{ contractAddress: contract.address, startBlock, lastRetrievedBlock: endBlock }]
+		const coveredStartBlock = startBlock > configuredStartBlock ? startBlock : configuredStartBlock
+		return coveredStartBlock > endBlock ? [] : [{ contractAddress: contract.address, startBlock: coveredStartBlock, lastRetrievedBlock: endBlock }]
 	})
 
 export const rpcLogQueryGroups = (inputs: readonly LogScanInput[]): readonly LogQueryGroup[] => {
@@ -401,12 +407,15 @@ export const planDeploymentAwareLogScan = async (
 			}
 		}
 		if (historicalCodeUnavailable.has(contract.address.toLowerCase())) {
-			const fallbackStart = contract.discoveryBlock ?? configuredStartBlock
+			const candidateStart = contract.discoveryBlock ?? configuredStartBlock
+			const fallbackStart = candidateStart > configuredStartBlock ? candidateStart : configuredStartBlock
 			return { inputs: [{ address: contract.address, fromBlock, startBlock: fallbackStart }], observations: [] }
 		}
 		let deployment: { readonly block: bigint; readonly exact: boolean } | undefined
 		try {
 			const searchStart = contract.deploymentCheckedBlock ?? configuredStartBlock
+			if (toBlock <= searchStart && contract.deploymentCheckedBlock === undefined)
+				return { inputs: [{ address: contract.address, fromBlock, startBlock: configuredStartBlock }], observations: [] }
 			deployment = await findContractDeploymentBlock(
 				searchStart,
 				toBlock,
@@ -416,7 +425,8 @@ export const planDeploymentAwareLogScan = async (
 		} catch (error) {
 			if (rpcQueueSaturationFrom(error) !== undefined || !isPermanentHistoricalCodeError(error)) throw error
 			onDetectionFailure(contract, error)
-			const fallbackStart = contract.discoveryBlock ?? configuredStartBlock
+			const candidateStart = contract.discoveryBlock ?? configuredStartBlock
+			const fallbackStart = candidateStart > configuredStartBlock ? candidateStart : configuredStartBlock
 			return {
 				inputs: [{ address: contract.address, fromBlock, startBlock: fallbackStart }],
 				observations: [],
@@ -433,7 +443,7 @@ export const planDeploymentAwareLogScan = async (
 				{
 					address: contract.address,
 					fromBlock: deployment.block > fromBlock ? deployment.block : fromBlock,
-					startBlock: deployment.block,
+					startBlock: deployment.block > configuredStartBlock ? deployment.block : configuredStartBlock,
 				},
 			],
 			observations: [observation],
@@ -516,7 +526,15 @@ export const manifestChangeRequiresFullReplay = async (
 ): Promise<boolean> => {
 	const storedManifest = [...storedContracts.values()].filter(({ provenance }) => provenance === 'manifest')
 	if (!manifestContractSetChanged(manifestContracts, storedManifest)) return false
-	const replayStart = await planManifestBackfill(manifestContracts, storedContracts, cursors, checkpoint, configuredStartBlock, findDeployment)
+	const replayStart = await planManifestBackfill(
+		manifestContracts,
+		storedContracts,
+		cursors,
+		checkpoint,
+		configuredStartBlock,
+		findDeployment,
+		storedStartBlock,
+	)
 	if (replayStart !== undefined) manifestReplayAncestor(replayStart, storedStartBlock)
 	return true
 }
@@ -527,6 +545,7 @@ class NetworkIndexer {
 	readonly #database: ScannerDatabase
 	readonly #providers: readonly IndexerRpcProvider[]
 	readonly #verifiedProviders = new WeakSet<IndexerRpcProvider>()
+	#failoverSawPrunedLogFailure = false
 	#client: PublicClient
 	#logClient: PublicClient
 	readonly #rpcDiagnostics: ReturnType<typeof createRpcDiagnosticContext>
@@ -553,7 +572,7 @@ class NetworkIndexer {
 				retryCount: 2,
 			})
 			const client = createPublicClient({ transport: withRpcRequestQueue(transport, rpcRequestQueue, endpoint) })
-			const logClient = createNonRetryingLogClient(rpcUrl, endpoint, rpcRequestQueue, loggingFetch)
+			const logClient = createLogClient(rpcUrl, endpoint, rpcRequestQueue, loggingFetch)
 			return { client, endpoint, getChainId: () => client.getChainId(), logClient, number: index + 1 }
 		})
 		const firstProvider = this.#providers[0]
@@ -695,6 +714,7 @@ class NetworkIndexer {
 	}
 
 	async #withProviderFailover<T>(operation: () => Promise<T>): Promise<T> {
+		this.#failoverSawPrunedLogFailure = false
 		return await withVerifiedProvider(
 			this.#providers,
 			this.#network.chainId,
@@ -706,6 +726,9 @@ class NetworkIndexer {
 			isLocalIndexerFailure,
 			(provider) => this.#rpcDiagnostics.select(provider),
 			this.#verifiedProviders,
+			(_provider, error) => {
+				if (isPermanentHistoricalLogError(error)) this.#failoverSawPrunedLogFailure = true
+			},
 		)
 	}
 
@@ -723,21 +746,19 @@ class NetworkIndexer {
 		console.error(`[${this.#network.id}] indexer state: degraded; ${logMessage}`)
 	}
 
-	async #advancePastPrunedLogs(error: unknown, unavailableStart: bigint, observedHead: bigint, probeAddress: Address): Promise<boolean> {
-		const availableStart = await recoverPrunedLogScan(
-			error,
-			unavailableStart,
-			observedHead,
-			async (blockNumber) => {
-				await this.#logClient.getLogs({ address: probeAddress, fromBlock: blockNumber, toBlock: blockNumber })
-			},
-			async (blockNumber) => {
-				await this.#assertLease()
-				await this.#database.advanceNetworkStartBlock(this.#network.chainId, blockNumber, this.#requireLease())
-			},
-		)
-		if (availableStart === undefined) return false
+	async #advancePastPrunedLogs(provider: IndexerRpcProvider, availableStart: bigint): Promise<void> {
 		const previousStart = this.#network.startBlock
+		this.#client = provider.client
+		this.#logClient = provider.logClient
+		this.#rpcDiagnostics.select(provider)
+		if (availableStart === previousStart) {
+			console.warn(
+				`[${this.#network.id}] selected ${provider.endpoint}, which can serve the existing log coverage floor #${availableStart}; continuing without changing coverage`,
+			)
+			return
+		}
+		await this.#assertLease()
+		await this.#database.advanceNetworkStartBlock(this.#network.chainId, availableStart, this.#requireLease())
 		this.#network = { ...this.#network, startBlock: availableStart }
 		this.#historicalCodeUnavailable.clear()
 		this.#indexingStartReported = false
@@ -746,20 +767,32 @@ class NetworkIndexer {
 		this.#lastReportedPhase = undefined
 		this.#lastDeploymentScanAt = undefined
 		console.warn(
-			`[${this.#network.id}] RPC log history before block #${availableStart} is pruned; advanced index coverage from block #${previousStart} to earliest retrievable block #${availableStart} and continuing`,
+			`[${this.#network.id}] RPC log history before block #${availableStart} is pruned; advanced index coverage from block #${previousStart} to earliest retrievable block #${availableStart} using ${provider.endpoint} and continuing`,
 		)
-		return true
 	}
 
 	async #recoverPrunedLogFailure(error: unknown): Promise<boolean> {
-		if (!isPermanentHistoricalLogError(error)) return false
-		const observedHead = await this.#client.getBlockNumber()
-		const checkpoint = await this.#database.checkpoint(this.#network.chainId, this.#requireLease())
-		const unavailableStart = checkpoint === undefined ? this.#network.startBlock : checkpoint.number + 1n
-		const contracts = this.#withManifestDeploymentBlocks(await this.#database.contracts(this.#network.chainId, this.#requireLease()))
-		const probeAddress = indexerLogSources([...contracts.values()])[0]?.address
-		if (probeAddress === undefined) return false
-		return await this.#advancePastPrunedLogs(error, unavailableStart, observedHead, probeAddress)
+		if (isLocalIndexerFailure(error)) return false
+		if (!isPermanentHistoricalLogError(error) && !this.#failoverSawPrunedLogFailure) return false
+		const availability = await findEarliestAvailableLogProvider(
+			this.#providers,
+			this.#network.startBlock,
+			async (provider) => {
+				if (!this.#verifiedProviders.has(provider)) {
+					const remoteChainId = await provider.getChainId()
+					if (remoteChainId !== this.#network.chainId)
+						throw new ChainConfigurationError(`RPC chain mismatch: configured ${this.#network.chainId}, received ${remoteChainId}`)
+					this.#verifiedProviders.add(provider)
+				}
+				return await provider.client.getBlockNumber()
+			},
+			async ({ logClient }, blockNumber) => {
+				await logClient.getLogs({ fromBlock: blockNumber, toBlock: blockNumber })
+			},
+		)
+		if (availability === undefined) return false
+		await this.#advancePastPrunedLogs(availability.provider, availability.startBlock)
+		return true
 	}
 
 	#reportProgress(startBlock: bigint, endBlock: bigint, observedHead: bigint): void {
@@ -826,6 +859,7 @@ class NetworkIndexer {
 			this.#configuredStartBlock,
 			(address, startBlock, indexedBoundary, startBlockKnownAbsent) =>
 				this.#findManifestDeployment(address, startBlock, indexedBoundary, startBlockKnownAbsent),
+			this.#network.startBlock,
 		)
 		if (replayStart === undefined) return
 		const ancestor = manifestReplayAncestor(replayStart, this.#network.startBlock)

--- a/augurScan/src/logging.ts
+++ b/augurScan/src/logging.ts
@@ -24,7 +24,7 @@ export const safeRpcProviderMessage = (value: unknown): string | undefined => {
 		.replace(/\p{Cf}/gu, ' ')
 		.replace(/\s+/gu, ' ')
 		.trim()
-	return /^state at block (?:#[0-9]+|0x[0-9a-f]+) is pruned[.!]?$/iu.test(message) ? message : undefined
+	return /^state at block (?:#[0-9]+|0x[0-9a-f]+) is pruned[.!]?$/iu.test(message) || /^pruned history unavailable[.!]?$/iu.test(message) ? message : undefined
 }
 
 export const timestampedLogArguments = (values: readonly unknown[], now = new Date()): readonly unknown[] => [`[${now.toISOString()}]:`, ...values]
@@ -152,7 +152,11 @@ export const createRpcLoggingFetch =
 				const providerMessage = safeRpcProviderMessage(rpcError.message)
 				const method = typeof requestEnvelope?.method === 'string' ? requestEnvelope.method : 'unknown'
 				const message = `RPC error from ${consoleEndpoint}; method ${method}; code ${rpcError.code}${name === undefined ? '' : ` (${name})`}${providerMessage === undefined ? '' : `; message: ${providerMessage}`}; full exchange logged to ${logPath}`
-				if (method === 'eth_getCode' && providerMessage !== undefined) {
+				if (method === 'eth_getLogs' && rpcError.code === 4444 && providerMessage !== undefined) {
+					console.warn(
+						`Historical log history unavailable from ${consoleEndpoint}; method ${method}; message: ${providerMessage}; locating earliest retrievable block; full exchange logged to ${logPath}`,
+					)
+				} else if (method === 'eth_getCode' && providerMessage !== undefined) {
 					console.warn(
 						`Historical state unavailable from ${consoleEndpoint}; method ${method}; message: ${providerMessage}; continuing with conservative log coverage; full exchange logged to ${logPath}`,
 					)

--- a/augurScan/tests/indexer-lifecycle.test.ts
+++ b/augurScan/tests/indexer-lifecycle.test.ts
@@ -78,14 +78,15 @@ import {
 	withVerifiedProvider,
 } from '../src/indexer.ts'
 import {
+	ChainConfigurationError,
 	contractDeploymentCandidateFrom,
-	createNonRetryingLogClient,
+	createLogClient,
 	discoveryLogAddresses,
 	findEarliestAvailableLogBlock,
+	findEarliestAvailableLogProvider,
 	indexerLogSources,
 	isPermanentHistoricalLogError,
 	readHistoricalCodeWithPermanentFallback,
-	recoverPrunedLogScan,
 	scanDiscoveredLogCoverage,
 } from '../src/indexer-runtime.ts'
 import { RpcRequestMethodError } from '../src/rpc-request-queue.ts'
@@ -473,15 +474,40 @@ describe('network indexer lifecycle', () => {
 
 	test('sends a pruned historical log request only once', async () => {
 		let fetches = 0
-		const client = createNonRetryingLogClient('https://rpc.example', '#1 https://rpc.example', createRpcRequestQueue(5), async (_input, init) => {
+		const filters: unknown[] = []
+		const client = createLogClient('https://rpc.example', '#1 https://rpc.example', createRpcRequestQueue(5), async (_input, init) => {
 			fetches++
 			const request = parseRpcRequestBody(JSON.parse(String(init?.body)))
+			filters.push(request.params?.[0])
 			return Response.json({ error: { code: 4444, message: 'pruned history unavailable' }, id: request.id, jsonrpc: '2.0' })
 		})
 
-		const failure = await client.getLogs({ address, fromBlock: 1n, toBlock: 1n }).catch((error) => error)
+		const failure = await client.getLogs({ fromBlock: 1n, toBlock: 1n }).catch((error) => error)
 		expect(isPermanentHistoricalLogError(failure)).toBe(true)
 		expect(fetches).toBe(1)
+		expect(filters).toEqual([{ fromBlock: '0x1', toBlock: '0x1' }])
+	})
+
+	test('retains rate-limit retries for log requests', async () => {
+		for (const responseFrom of [
+			(_id: string | number | null) => new Response(undefined, { status: 429 }),
+			(id: string | number | null) => Response.json({ error: { code: -32_005, message: 'request rate exceeded' }, id, jsonrpc: '2.0' }),
+		]) {
+			let fetches = 0
+			const client = createLogClient(
+				'https://rpc.example',
+				'#1 https://rpc.example',
+				createRpcRequestQueue(5),
+				async (_input, init) => {
+					fetches++
+					const request = parseRpcRequestBody(JSON.parse(String(init?.body)))
+					return fetches === 1 ? responseFrom(request.id) : Response.json({ id: request.id, jsonrpc: '2.0', result: [] })
+				},
+				0,
+			)
+			expect(await client.getLogs({ fromBlock: 1n, toBlock: 1n })).toEqual([])
+			expect(fetches).toBe(2)
+		}
 	})
 
 	test('schedules concurrent adapter requests independently through the RPC queue', async () => {
@@ -677,35 +703,76 @@ describe('network indexer lifecycle', () => {
 		expect(isPermanentHistoricalLogError(new RpcRequestMethodError('eth_getLogs', new RpcError('temporary failure'), '#1 http://reth:8545'))).toBe(false)
 	})
 
-	test('advances coverage once for pruned logs while preserving transient failures', async () => {
+	test('chooses the earliest complete log boundary across providers', async () => {
 		const prunedLogs = new RpcRequestMethodError(
 			'eth_getLogs',
 			new RpcError('pruned history unavailable', { code: 4444, shortMessage: 'pruned history unavailable' }),
 			'#1 http://reth:8545',
 		)
-		const advanced: bigint[] = []
-		const recovered = await recoverPrunedLogScan(
-			prunedLogs,
+		const providers = [
+			{ id: 'earlier', floor: 42n },
+			{ id: 'later', floor: 75n },
+		]
+		const availability = await findEarliestAvailableLogProvider(
+			providers,
 			10n,
-			100n,
-			async (blockNumber) => {
-				if (blockNumber < 42n) throw prunedLogs
-			},
-			async (blockNumber) => {
-				advanced.push(blockNumber)
+			async () => 100n,
+			async (provider, blockNumber) => {
+				if (blockNumber < provider.floor) throw prunedLogs
 			},
 		)
-		expect(recovered).toBe(42n)
-		expect(advanced).toEqual([42n])
-		expect(
-			await recoverPrunedLogScan(
-				new Error('connection reset'),
-				10n,
-				100n,
-				async () => {},
-				async () => {},
-			),
-		).toBeUndefined()
+		const earlierProvider = providers[0]
+		if (earlierProvider === undefined) throw new Error('Expected an earlier provider fixture')
+		expect(availability).toEqual({ provider: earlierProvider, startBlock: 42n })
+	})
+
+	test('keeps the existing coverage floor when a recovered provider can serve it', async () => {
+		const prunedLogs = new RpcRequestMethodError(
+			'eth_getLogs',
+			new RpcError('pruned history unavailable', { code: 4444, shortMessage: 'pruned history unavailable' }),
+			'#2 http://reth:8545',
+		)
+		const providers = [
+			{ id: 'temporarily unavailable during polling', floor: 10n },
+			{ id: 'pruned', floor: 75n },
+		]
+		const availability = await findEarliestAvailableLogProvider(
+			providers,
+			10n,
+			async () => 100n,
+			async (provider, blockNumber) => {
+				if (blockNumber < provider.floor) throw prunedLogs
+			},
+		)
+		const recoveredProvider = providers[0]
+		if (recoveredProvider === undefined) throw new Error('Expected a recovered provider fixture')
+		expect(availability).toEqual({ provider: recoveredProvider, startBlock: 10n })
+	})
+
+	test('excludes wrong-chain providers from log boundary discovery', async () => {
+		const prunedLogs = new RpcRequestMethodError(
+			'eth_getLogs',
+			new RpcError('pruned history unavailable', { code: 4444, shortMessage: 'pruned history unavailable' }),
+			'#2 http://reth:8545',
+		)
+		const providers = [
+			{ chainId: 2, floor: 10n },
+			{ chainId: 1, floor: 42n },
+		]
+		const availability = await findEarliestAvailableLogProvider(
+			providers,
+			10n,
+			async (provider) => {
+				if (provider.chainId !== 1) throw new ChainConfigurationError('RPC chain mismatch')
+				return 100n
+			},
+			async (provider, blockNumber) => {
+				if (blockNumber < provider.floor) throw prunedLogs
+			},
+		)
+		const correctProvider = providers[1]
+		if (correctProvider === undefined) throw new Error('Expected a correct-chain provider fixture')
+		expect(availability).toEqual({ provider: correctProvider, startBlock: 42n })
 	})
 
 	test('recovers pruned log coverage without recording a lifecycle failure', async () => {
@@ -718,6 +785,7 @@ describe('network indexer lifecycle', () => {
 		let polls = 0
 		let recoveries = 0
 		let failures = 0
+		let recoveredStart: bigint | undefined
 		await runNetworkLifecycle({
 			verify: async () => {},
 			poll: async () => {
@@ -727,8 +795,18 @@ describe('network indexer lifecycle', () => {
 			recover: async (error) => {
 				expect(error).toBe(prunedLogs)
 				recoveries++
+				const providers = [{ floor: 42n }, { floor: 75n }]
+				const availability = await findEarliestAvailableLogProvider(
+					providers,
+					10n,
+					async () => 100n,
+					async (provider, blockNumber) => {
+						if (blockNumber < provider.floor) throw prunedLogs
+					},
+				)
+				recoveredStart = availability?.startBlock
 				controller.abort()
-				return true
+				return availability !== undefined
 			},
 			failure: async () => {
 				failures++
@@ -736,7 +814,52 @@ describe('network indexer lifecycle', () => {
 			intervalMs: 1,
 			signal: controller.signal,
 		})
-		expect({ polls, recoveries, failures }).toEqual({ polls: 1, recoveries: 1, failures: 0 })
+		expect({ polls, recoveries, failures, recoveredStart }).toEqual({ polls: 1, recoveries: 1, failures: 0, recoveredStart: 42n })
+	})
+
+	test('recovers when any failed provider reports pruned logs regardless of failure order', async () => {
+		const prunedLogs = new RpcRequestMethodError(
+			'eth_getLogs',
+			new RpcError('pruned history unavailable', { code: 4444, shortMessage: 'pruned history unavailable' }),
+			'#1 http://reth:8545',
+		)
+		for (const errors of [
+			[prunedLogs, new Error('timeout')],
+			[new Error('timeout'), prunedLogs],
+		]) {
+			const controller = new AbortController()
+			let sawPrunedLogs = false
+			let failures = 0
+			await runNetworkLifecycle({
+				verify: async () => {},
+				poll: async () => {
+					sawPrunedLogs = false
+					await withVerifiedProvider(
+						errors.map((error) => ({ getChainId: async () => 1, read: async () => Promise.reject(error) })),
+						1,
+						(provider) => provider.read(),
+						() => false,
+						() => {},
+						undefined,
+						(_provider, error) => {
+							if (isPermanentHistoricalLogError(error)) sawPrunedLogs = true
+						},
+					)
+					return false
+				},
+				recover: async (error) => {
+					if (!isPermanentHistoricalLogError(error) && !sawPrunedLogs) return false
+					controller.abort()
+					return true
+				},
+				failure: async () => {
+					failures++
+				},
+				intervalMs: 1,
+				signal: controller.signal,
+			})
+			expect(failures).toBe(0)
+		}
 	})
 
 	test('does not split HTTP rate-limit failures', async () => {
@@ -1115,6 +1238,51 @@ describe('network indexer lifecycle', () => {
 		expect(plan).toEqual({ inputs: [{ address, fromBlock: 50n, startBlock: 42n }], observations: [] })
 	})
 
+	test('conservatively scans an unknown contract when only the recovered floor block is available', async () => {
+		const contract = { address, label: 'Unknown at floor', kind: 'openOracle', provenance: 'manifest' } satisfies ContractMetadata
+		const plan = await planDeploymentAwareLogScan(
+			[contract],
+			42n,
+			42n,
+			42n,
+			async () => {
+				throw new Error('A single floor block should not be used for deployment detection')
+			},
+			async () => new Date(0),
+		)
+		expect(plan).toEqual({ inputs: [{ address, fromBlock: 42n, startBlock: 42n }], observations: [] })
+		expect(logScanCursorUpdates(new Map([[address.toLowerCase(), contract]]), plan.inputs, 42n, 42n)).toEqual([
+			{ contractAddress: address, startBlock: 42n, lastRetrievedBlock: 42n },
+		])
+	})
+
+	test('stores retained dynamic contract coverage from the active retrievable floor', async () => {
+		const contract = {
+			address,
+			discoveryBlock: 25n,
+			discoveryTxHash: `0x${'12'.repeat(32)}`,
+			label: 'Retained pool',
+			kind: 'securityPool',
+			provenance: 'Factory.DeploySecurityPool',
+		} satisfies ContractMetadata
+		const plan = await planDeploymentAwareLogScan(
+			[contract],
+			50n,
+			100n,
+			42n,
+			async () => {
+				throw new Error('Retained discovery should not read historical code')
+			},
+			async () => new Date(0),
+			undefined,
+			new Set([address.toLowerCase()]),
+		)
+		expect(plan).toEqual({ inputs: [{ address, fromBlock: 50n, startBlock: 42n }], observations: [] })
+		expect(logScanCursorUpdates(new Map([[address.toLowerCase(), contract]]), plan.inputs, 100n, 42n)).toEqual([
+			{ contractAddress: address, startBlock: 42n, lastRetrievedBlock: 100n },
+		])
+	})
+
 	test('skips a periodically refreshed pruned candidate without starving later candidates', async () => {
 		const availableAddress = '0x2000000000000000000000000000000000000002'
 		const unavailable = { address, label: 'Unavailable', kind: 'openOracle', provenance: 'manifest' } satisfies ContractMetadata
@@ -1358,6 +1526,23 @@ describe('network indexer lifecycle', () => {
 		expect(detection).not.toHaveBeenCalled()
 	})
 
+	test('resumes a pre-boundary manifest contract from the active retrievable floor', async () => {
+		const contract = { address, label: 'Pre-boundary source', kind: 'openOracle', provenance: 'manifest' } satisfies ContractMetadata
+		const detection = mock(async () => ({ block: 50n, exact: true }))
+		expect(
+			await planManifestBackfill(
+				[[address, contract.label, contract.kind, 50n]],
+				new Map([[address.toLowerCase(), contract]]),
+				new Map([[address.toLowerCase(), { contractAddress: address, startBlock: 75n, lastRetrievedBlock: 80n }]]),
+				100n,
+				0n,
+				detection,
+				75n,
+			),
+		).toBe(81n)
+		expect(detection).not.toHaveBeenCalled()
+	})
+
 	test('backfills when an exact manifest boundary moves earlier than a complete cursor', async () => {
 		const contract = { address, label: 'Promoted manifest source', kind: 'openOracle', provenance: 'manifest' } satisfies ContractMetadata
 		expect(
@@ -1395,13 +1580,13 @@ describe('network indexer lifecycle', () => {
 		expect(manifestReplayAncestor(80n, 75n)).toBe(79n)
 	})
 
-	test('validates newly added manifest history before allowing a canonical replay', async () => {
+	test('clamps newly added manifest history to the stored coverage floor', async () => {
 		const replacement = '0x2000000000000000000000000000000000000002' as const
 		const storedContract = { address, label: 'Zoltar', kind: 'zoltar', provenance: 'manifest' } satisfies ContractMetadata
 		const storedContracts = new Map([[address.toLowerCase(), storedContract]])
 		const cursors = new Map([[address.toLowerCase(), { contractAddress: address, startBlock: 75n, lastRetrievedBlock: 100n }]])
-		await expect(
-			manifestChangeRequiresFullReplay(
+		expect(
+			await manifestChangeRequiresFullReplay(
 				[
 					[address, storedContract.label, storedContract.kind],
 					[replacement, 'OpenOracle v2', 'openOracle'],
@@ -1413,7 +1598,7 @@ describe('network indexer lifecycle', () => {
 				75n,
 				async (candidate) => ({ block: candidate === replacement ? 50n : 75n, exact: true }),
 			),
-		).rejects.toThrow('deployment block 50 predates the stored index start 75')
+		).toBe(true)
 		expect(
 			await manifestChangeRequiresFullReplay(
 				[
@@ -1431,12 +1616,12 @@ describe('network indexer lifecycle', () => {
 		const storedHelper = new Map([
 			[address.toLowerCase(), { address, label: 'Multicall3', kind: 'multicall3', provenance: 'manifest' } satisfies ContractMetadata],
 		])
-		await expect(
-			manifestChangeRequiresFullReplay([[address, 'OpenOracle', 'openOracle']], storedHelper, new Map(), 100n, 0n, 75n, async () => ({
+		expect(
+			await manifestChangeRequiresFullReplay([[address, 'OpenOracle', 'openOracle']], storedHelper, new Map(), 100n, 0n, 75n, async () => ({
 				block: 50n,
 				exact: true,
 			})),
-		).rejects.toThrow('deployment block 50 predates the stored index start 75')
+		).toBe(true)
 		const inexactStoredHelper = new Map([
 			[
 				address.toLowerCase(),
@@ -1452,8 +1637,8 @@ describe('network indexer lifecycle', () => {
 			],
 		])
 		const searches: Array<{ start: bigint; knownAbsent: boolean }> = []
-		await expect(
-			manifestChangeRequiresFullReplay(
+		expect(
+			await manifestChangeRequiresFullReplay(
 				[[address, 'OpenOracle', 'openOracle']],
 				inexactStoredHelper,
 				new Map(),
@@ -1465,8 +1650,8 @@ describe('network indexer lifecycle', () => {
 					return { block: 50n, exact: true }
 				},
 			),
-		).rejects.toThrow('deployment block 50 predates the stored index start 75')
-		expect(searches).toEqual([{ start: 0n, knownAbsent: false }])
+		).toBe(true)
+		expect(searches).toEqual([{ start: 75n, knownAbsent: false }])
 		const promotedDiscovery = new Map([
 			[
 				address.toLowerCase(),
@@ -1482,8 +1667,8 @@ describe('network indexer lifecycle', () => {
 			],
 		])
 		const promotionSearches: bigint[] = []
-		await expect(
-			manifestChangeRequiresFullReplay(
+		expect(
+			await manifestChangeRequiresFullReplay(
 				[[address, 'Promoted pool', 'securityPool']],
 				promotedDiscovery,
 				new Map([[address.toLowerCase(), { contractAddress: address, startBlock: 75n, lastRetrievedBlock: 100n }]]),
@@ -1495,8 +1680,8 @@ describe('network indexer lifecycle', () => {
 					return { block: 50n, exact: true }
 				},
 			),
-		).rejects.toThrow('deployment block 50 predates the stored index start 75')
-		expect(promotionSearches).toEqual([0n])
+		).toBe(true)
+		expect(promotionSearches).toEqual([75n])
 	})
 
 	test('gives each manifest deployment search an independent read budget', async () => {

--- a/augurScan/tests/indexer-lifecycle.test.ts
+++ b/augurScan/tests/indexer-lifecycle.test.ts
@@ -79,11 +79,16 @@ import {
 } from '../src/indexer.ts'
 import {
 	contractDeploymentCandidateFrom,
+	createNonRetryingLogClient,
 	discoveryLogAddresses,
+	findEarliestAvailableLogBlock,
 	indexerLogSources,
+	isPermanentHistoricalLogError,
 	readHistoricalCodeWithPermanentFallback,
+	recoverPrunedLogScan,
 	scanDiscoveredLogCoverage,
 } from '../src/indexer-runtime.ts'
+import { RpcRequestMethodError } from '../src/rpc-request-queue.ts'
 import { unixSecondsToDate } from '../src/time.ts'
 import type { ContractMetadata, StoredLog, TokenMetadata } from '../src/types.ts'
 import { isSupportedUniswapV4Market, uniswapV2V3TokenPairs, uniswapV4PoolId } from '../src/uniswap.ts'
@@ -466,6 +471,19 @@ describe('network indexer lifecycle', () => {
 		expect(reasonFrom(results[1])).toContain('method eth_chainId')
 	})
 
+	test('sends a pruned historical log request only once', async () => {
+		let fetches = 0
+		const client = createNonRetryingLogClient('https://rpc.example', '#1 https://rpc.example', createRpcRequestQueue(5), async (_input, init) => {
+			fetches++
+			const request = parseRpcRequestBody(JSON.parse(String(init?.body)))
+			return Response.json({ error: { code: 4444, message: 'pruned history unavailable' }, id: request.id, jsonrpc: '2.0' })
+		})
+
+		const failure = await client.getLogs({ address, fromBlock: 1n, toBlock: 1n }).catch((error) => error)
+		expect(isPermanentHistoricalLogError(failure)).toBe(true)
+		expect(fetches).toBe(1)
+	})
+
 	test('schedules concurrent adapter requests independently through the RPC queue', async () => {
 		const queue = createRpcRequestQueue(5)
 		let fetches = 0
@@ -620,6 +638,105 @@ describe('network indexer lifecycle', () => {
 		expect(isSplittableLogRangeError({ cause: { code: -32005, message: 'limit exceeded' } })).toBe(true)
 		expect(isSplittableLogRangeError(new Error('401 Unauthorized'))).toBe(false)
 		expect(isSplittableLogRangeError(new Error('connection reset'))).toBe(false)
+	})
+
+	test('locates the earliest retrievable log block without retrying the pruned range', async () => {
+		const attempts: bigint[] = []
+		const availableStart = await findEarliestAvailableLogBlock(
+			10n,
+			100n,
+			async (blockNumber) => {
+				attempts.push(blockNumber)
+				if (blockNumber < 42n)
+					throw new RpcRequestMethodError(
+						'eth_getLogs',
+						new RpcError('pruned history unavailable', { code: 4444, shortMessage: 'pruned history unavailable' }),
+						'#1 http://reth:8545',
+					)
+			},
+			true,
+		)
+		expect(availableStart).toBe(42n)
+		expect(attempts).not.toContain(10n)
+		expect(attempts.length).toBeLessThanOrEqual(8)
+	})
+
+	test('only treats pruned eth_getLogs history as a recoverable availability boundary', () => {
+		const prunedLogs = new RpcRequestMethodError(
+			'eth_getLogs',
+			new RpcError('pruned history unavailable', { code: 4444, shortMessage: 'pruned history unavailable' }),
+			'#1 http://reth:8545',
+		)
+		expect(isPermanentHistoricalLogError(prunedLogs)).toBe(true)
+		expect(isSplittableLogRangeError(prunedLogs)).toBe(false)
+		expect(
+			isPermanentHistoricalLogError(
+				new RpcRequestMethodError('eth_getCode', new RpcError('pruned history unavailable', { code: 4444 }), '#1 http://reth:8545'),
+			),
+		).toBe(false)
+		expect(isPermanentHistoricalLogError(new RpcRequestMethodError('eth_getLogs', new RpcError('temporary failure'), '#1 http://reth:8545'))).toBe(false)
+	})
+
+	test('advances coverage once for pruned logs while preserving transient failures', async () => {
+		const prunedLogs = new RpcRequestMethodError(
+			'eth_getLogs',
+			new RpcError('pruned history unavailable', { code: 4444, shortMessage: 'pruned history unavailable' }),
+			'#1 http://reth:8545',
+		)
+		const advanced: bigint[] = []
+		const recovered = await recoverPrunedLogScan(
+			prunedLogs,
+			10n,
+			100n,
+			async (blockNumber) => {
+				if (blockNumber < 42n) throw prunedLogs
+			},
+			async (blockNumber) => {
+				advanced.push(blockNumber)
+			},
+		)
+		expect(recovered).toBe(42n)
+		expect(advanced).toEqual([42n])
+		expect(
+			await recoverPrunedLogScan(
+				new Error('connection reset'),
+				10n,
+				100n,
+				async () => {},
+				async () => {},
+			),
+		).toBeUndefined()
+	})
+
+	test('recovers pruned log coverage without recording a lifecycle failure', async () => {
+		const controller = new AbortController()
+		const prunedLogs = new RpcRequestMethodError(
+			'eth_getLogs',
+			new RpcError('pruned history unavailable', { code: 4444, shortMessage: 'pruned history unavailable' }),
+			'#1 http://reth:8545',
+		)
+		let polls = 0
+		let recoveries = 0
+		let failures = 0
+		await runNetworkLifecycle({
+			verify: async () => {},
+			poll: async () => {
+				polls++
+				throw prunedLogs
+			},
+			recover: async (error) => {
+				expect(error).toBe(prunedLogs)
+				recoveries++
+				controller.abort()
+				return true
+			},
+			failure: async () => {
+				failures++
+			},
+			intervalMs: 1,
+			signal: controller.signal,
+		})
+		expect({ polls, recoveries, failures }).toEqual({ polls: 1, recoveries: 1, failures: 0 })
 	})
 
 	test('does not split HTTP rate-limit failures', async () => {
@@ -974,6 +1091,28 @@ describe('network indexer lifecycle', () => {
 			new Set([address.toLowerCase()]),
 		)
 		expect(plan).toEqual({ inputs: [{ address, fromBlock: 50n, startBlock: 0n }], observations: [] })
+	})
+
+	test('does not claim log coverage before the active retrievable boundary', async () => {
+		const contract = {
+			address,
+			deploymentBlock: 25n,
+			deploymentBlockExact: true,
+			label: 'Older contract',
+			kind: 'openOracle',
+			provenance: 'manifest',
+		} satisfies ContractMetadata
+		const plan = await planDeploymentAwareLogScan(
+			[contract],
+			50n,
+			100n,
+			42n,
+			async () => {
+				throw new Error('Known deployment should not read code')
+			},
+			async () => new Date(0),
+		)
+		expect(plan).toEqual({ inputs: [{ address, fromBlock: 50n, startBlock: 42n }], observations: [] })
 	})
 
 	test('skips a periodically refreshed pruned candidate without starving later candidates', async () => {

--- a/augurScan/tests/logging.test.ts
+++ b/augurScan/tests/logging.test.ts
@@ -175,6 +175,29 @@ describe('AugurScan runtime logging', () => {
 		}
 	})
 
+	test('reports pruned log history as recoverable boundary discovery', async () => {
+		const directory = await temporaryDirectory()
+		const filename = path.join(directory, 'rpc.jsonl')
+		const consoleError = spyOn(console, 'error').mockImplementation(() => {})
+		const consoleWarn = spyOn(console, 'warn').mockImplementation(() => {})
+		try {
+			const loggingFetch = createRpcLoggingFetch('http://reth:8545', '#1 http://reth:8545', filename, new RotatingJsonLog(filename), async () =>
+				Response.json({ error: { code: 4444, message: 'pruned history unavailable' }, id: 1, jsonrpc: '2.0' }),
+			)
+			await loggingFetch('http://reth:8545', {
+				body: JSON.stringify({ id: 1, jsonrpc: '2.0', method: 'eth_getLogs', params: [{ fromBlock: '0x1', toBlock: '0x1' }] }),
+				method: 'POST',
+			})
+			expect(consoleWarn).toHaveBeenCalledWith(
+				`Historical log history unavailable from #1 http://reth:8545; method eth_getLogs; message: pruned history unavailable; locating earliest retrievable block; full exchange logged to ${filename}`,
+			)
+			expect(consoleError).not.toHaveBeenCalled()
+		} finally {
+			consoleError.mockRestore()
+			consoleWarn.mockRestore()
+		}
+	})
+
 	test('rotates the current RPC log before it exceeds its configured size', async () => {
 		const directory = await temporaryDirectory()
 		const filename = path.join(directory, 'rpc.jsonl')

--- a/augurScan/tests/postgres.integration.test.ts
+++ b/augurScan/tests/postgres.integration.test.ts
@@ -345,16 +345,128 @@ postgresTest('advances the canonical coverage floor when RPC log history is prun
 		const lease = await database.tryAcquireIndexerLock(boundaryChainId)
 		if (lease === undefined) throw new Error('pruned-log boundary writer did not acquire its lock')
 		try {
-			await database.storeBlock(boundaryChainId, indexedBlock('block-one', blockHash('genesis')), lease)
-			expect(await database.advanceNetworkStartBlock(boundaryChainId, 42n, lease)).toBe(true)
-			expect(await database.networkStartBlock(boundaryChainId)).toBe(42n)
+			const dynamicContract = {
+				address: discoveredAddress,
+				label: 'Previously discovered pool',
+				kind: 'securityPool',
+				provenance: 'Factory.DeploySecurityPool',
+				discoveryBlock: 1n,
+				discoveryTxHash: transactionHash,
+			} satisfies ContractMetadata
+			const replayableContract = {
+				address: rediscoveredAddress,
+				label: 'Discovery at retrievable floor',
+				kind: 'truthAuction',
+				provenance: 'Factory.DeployTruthAuction',
+				discoveryBlock: 2n,
+				discoveryTxHash: transactionHash,
+			} satisfies ContractMetadata
+			const orphanedContract = {
+				address: orphanOnlyAddress,
+				label: 'Orphaned pre-floor discovery',
+				kind: 'securityPool',
+				provenance: 'Factory.DeploySecurityPool',
+				discoveryBlock: 1n,
+				discoveryTxHash: transactionHash,
+			} satisfies ContractMetadata
+			await database.storeBlock(boundaryChainId, indexedBlock('block-one', blockHash('genesis'), [dynamicContract, orphanedContract]), lease)
+			await database.rewind(boundaryChainId, -1n, undefined, lease)
+			await database.storeBlock(boundaryChainId, indexedBlock('block-one-replacement', blockHash('genesis'), [dynamicContract]), lease)
+			await database.storeBlock(boundaryChainId, indexedBlock('block-two', blockHash('block-one-replacement'), [replayableContract]), lease)
+			expect(await database.advanceNetworkStartBlock(boundaryChainId, 2n, lease)).toBe(true)
+			const boundaryEvents = await database.sql`
+				SELECT event, payload FROM live_events WHERE (payload->>'chainId')::integer = ${boundaryChainId} ORDER BY id DESC LIMIT 1
+			`
+			expect(boundaryEvents[0]).toMatchObject({ event: 'reorg', payload: { ancestor: '-1', depth: '2', startBlock: '2' } })
+			expect(await database.networkStartBlock(boundaryChainId)).toBe(2n)
 			expect(await database.checkpoint(boundaryChainId)).toBeUndefined()
+			const retainedContracts = await database.contracts(boundaryChainId, lease)
+			expect(retainedContracts.get(discoveredAddress.toLowerCase())).toMatchObject(dynamicContract)
+			expect(retainedContracts.has(rediscoveredAddress.toLowerCase())).toBe(false)
+			expect(retainedContracts.has(orphanOnlyAddress.toLowerCase())).toBe(false)
 			const canonicalRows = await database.sql`SELECT count(*)::integer AS count FROM blocks WHERE chain_id = ${boundaryChainId} AND canonical`
 			expect(canonicalRows[0]?.['count']).toBe(0)
+			const retrievableBlock = (name: string, timestamp: Date): IndexedBlock => {
+				const hash = blockHash(name)
+				const forwardLog = { ...log(hash, 'post-boundary activity'), blockHash: hash, blockNumber: 2n }
+				return {
+					...indexedBlock('block-two', blockHash(`${name}-parent`)),
+					number: 2n,
+					hash,
+					parentHash: blockHash(`${name}-parent`),
+					timestamp,
+					observedHead: 2n,
+					transactions: [
+						{
+							...transaction(),
+							receipt: { transactionHash, blockHash: hash, blockNumber: 2n, status: 'success', logs: [forwardLog] },
+						},
+					],
+					logs: [forwardLog],
+					logScanCursors: [{ contractAddress: discoveredAddress, startBlock: 2n, lastRetrievedBlock: 2n }],
+				}
+			}
+			const forwardBlock = retrievableBlock('retrievable-boundary', new Date('2026-02-11T00:00:00Z'))
+			await database.storeBlock(boundaryChainId, forwardBlock, lease)
+			await database.rewind(boundaryChainId, -1n, undefined, lease)
+			expect((await database.contracts(boundaryChainId, lease)).get(discoveredAddress.toLowerCase())).toMatchObject(dynamicContract)
+			expect((await database.contracts(boundaryChainId, lease)).has(orphanOnlyAddress.toLowerCase())).toBe(false)
+			await database.storeBlock(boundaryChainId, retrievableBlock('retrievable-replacement', new Date('2026-02-12T00:00:00Z')), lease)
+			expect(
+				await database.seedNetwork(
+					{
+						...network,
+						startBlock: 2n,
+						contracts: [...network.contracts, [promotedAddress, 'Additional manifest source', 'openOracle']],
+					},
+					lease,
+					true,
+					true,
+				),
+			).toBe(true)
+			const contractsAfterReseed = await database.contracts(boundaryChainId, lease)
+			expect(contractsAfterReseed.get(discoveredAddress.toLowerCase())).toMatchObject(dynamicContract)
+			expect(contractsAfterReseed.has(orphanOnlyAddress.toLowerCase())).toBe(false)
+			const finalBlock = retrievableBlock('retrievable-after-manifest-reset', new Date('2026-02-13T00:00:00Z'))
+			await database.storeBlock(boundaryChainId, finalBlock, lease)
+			const promotedNetwork = {
+				...network,
+				startBlock: 2n,
+				contracts: [
+					...network.contracts,
+					[discoveredAddress, 'Promoted retained pool', 'securityPool'],
+					[orphanOnlyAddress, 'Promoted orphan', 'securityPool'],
+				],
+			} satisfies NetworkConfig
+			expect(await database.seedNetwork(promotedNetwork, lease, true, true)).toBe(true)
+			expect((await database.contracts(boundaryChainId, lease)).get(discoveredAddress.toLowerCase())).toMatchObject({
+				discoveryBlock: 1n,
+				provenance: 'manifest',
+			})
+			expect(await database.seedNetwork(promotedNetwork, lease, true, true)).toBe(false)
+			expect((await database.contracts(boundaryChainId, lease)).get(discoveredAddress.toLowerCase())).toMatchObject({
+				discoveryBlock: 1n,
+				provenance: 'manifest',
+			})
+			await database.storeBlock(boundaryChainId, retrievableBlock('retrievable-during-promotion', new Date('2026-02-14T00:00:00Z')), lease)
+			expect(await database.seedNetwork({ ...network, startBlock: 2n }, lease, true, true)).toBe(true)
+			const contractsAfterPromotionRemoval = await database.contracts(boundaryChainId, lease)
+			expect(contractsAfterPromotionRemoval.get(discoveredAddress.toLowerCase())).toMatchObject(dynamicContract)
+			expect(contractsAfterPromotionRemoval.has(orphanOnlyAddress.toLowerCase())).toBe(false)
+			await database.storeBlock(boundaryChainId, retrievableBlock('retrievable-after-promotion-removal', new Date('2026-02-15T00:00:00Z')), lease)
+			const retainedLogs = await database.sql`
+				SELECT block_number FROM logs WHERE chain_id = ${boundaryChainId} AND address = ${discoveredAddress.toLowerCase()} AND canonical
+			`
+			expect(retainedLogs).toEqual([{ block_number: '2' }])
+			expect((await database.logScanCursors(boundaryChainId, lease)).get(discoveredAddress.toLowerCase())).toEqual({
+				contractAddress: discoveredAddress,
+				startBlock: 2n,
+				lastRetrievedBlock: 2n,
+			})
 			const statusRows = await database.sql`
 				SELECT phase, consecutive_failures, next_retry_at, last_error FROM networks WHERE chain_id = ${boundaryChainId}
 			`
-			expect(statusRows[0]).toMatchObject({ phase: 'backfilling', consecutive_failures: 0, next_retry_at: null, last_error: null })
+			expect(statusRows[0]).toMatchObject({ phase: 'live', consecutive_failures: 0, next_retry_at: null, last_error: null })
 		} finally {
 			await lease.release()
 		}

--- a/augurScan/tests/postgres.integration.test.ts
+++ b/augurScan/tests/postgres.integration.test.ts
@@ -324,6 +324,46 @@ postgresTest('rejects every public namespace object before fresh schema initiali
 	}
 })
 
+postgresTest('advances the canonical coverage floor when RPC log history is pruned', async () => {
+	if (postgresUrl === undefined) throw new Error('POSTGRES_TEST_URL disappeared')
+	const database = new ScannerDatabase(postgresUrl)
+	const boundaryChainId = chainId + 10 + process.pid
+	const network: NetworkConfig = {
+		id: `pruned-log-boundary-${boundaryChainId}`,
+		name: 'Pruned log boundary',
+		chainId: boundaryChainId,
+		rpcUrls: ['http://127.0.0.1:8545'],
+		startBlock: 1n,
+		explorerBaseUrl: 'https://example.invalid',
+		nativeSymbol: 'ETH',
+		confirmationDepth: 0n,
+		contracts: [[address, 'OpenOracle', 'openOracle']],
+	}
+	try {
+		await initializeSchema(database.sql)
+		await database.seedNetwork(network)
+		const lease = await database.tryAcquireIndexerLock(boundaryChainId)
+		if (lease === undefined) throw new Error('pruned-log boundary writer did not acquire its lock')
+		try {
+			await database.storeBlock(boundaryChainId, indexedBlock('block-one', blockHash('genesis')), lease)
+			expect(await database.advanceNetworkStartBlock(boundaryChainId, 42n, lease)).toBe(true)
+			expect(await database.networkStartBlock(boundaryChainId)).toBe(42n)
+			expect(await database.checkpoint(boundaryChainId)).toBeUndefined()
+			const canonicalRows = await database.sql`SELECT count(*)::integer AS count FROM blocks WHERE chain_id = ${boundaryChainId} AND canonical`
+			expect(canonicalRows[0]?.['count']).toBe(0)
+			const statusRows = await database.sql`
+				SELECT phase, consecutive_failures, next_retry_at, last_error FROM networks WHERE chain_id = ${boundaryChainId}
+			`
+			expect(statusRows[0]).toMatchObject({ phase: 'backfilling', consecutive_failures: 0, next_retry_at: null, last_error: null })
+		} finally {
+			await lease.release()
+		}
+	} finally {
+		await database.sql`DELETE FROM networks WHERE chain_id = ${boundaryChainId}`
+		await database.close()
+	}
+})
+
 postgresTest('initializes, resumes, retains an orphan, and serves only its canonical replacement', async () => {
 	if (postgresUrl === undefined) throw new Error('POSTGRES_TEST_URL disappeared')
 	const database = new ScannerDatabase(postgresUrl)


### PR DESCRIPTION
## Summary

- recognize permanent Reth eth_getLogs pruning and locate the earliest retrievable block across every verified RPC provider
- advance the truthful network coverage floor and resume immediately without degraded retry state
- preserve valid pre-floor contract scan sources across rewinds and manifest changes while retiring replayable or orphaned discoveries
- clamp deployment, manifest, scan, and cursor coverage to the retrievable floor
- emit canonical-reset events so live views discard invalidated evidence

## Why

Reth returns code 4444 with pruned history unavailable when receipts before its retention boundary cannot be served. Retrying the same range cannot succeed. Augurscan should instead report all logs from the earliest boundary any configured provider can serve, including forward activity from contracts that existed earlier.

## Validation

- bun run tsc
- cd augurScan && bun x tsc --project tsconfig.json --noEmit
- cd augurScan && bun test: 278 pass, 4 PostgreSQL-environment tests skipped, 0 fail
- cd augurScan && bun test tests/indexer-lifecycle.test.ts tests/logging.test.ts: 115 pass
- cd augurScan && bun run check
- bun run check:changed
- bun run knip
- git diff --check

The PostgreSQL-backed boundary regression is included but skipped locally because POSTGRES_TEST_URL is unavailable.