### PR TITLE
Handle pruned AugurScan state reads

### DIFF
--- a/augurScan/src/indexer-runtime.ts
+++ b/augurScan/src/indexer-runtime.ts
@@ -186,7 +186,7 @@ export const isPermanentHistoricalLogError = (error: unknown): boolean => {
 	return getLogsRequest && prunedHistory
 }
 
-const isPrunedHistoricalStateError = (error: unknown): boolean => {
+export const isPrunedHistoricalStateError = (error: unknown): boolean => {
 	const seen = new Set<unknown>()
 	let current: unknown = error
 	while (typeof current === 'object' && current !== null && !seen.has(current)) {
@@ -204,6 +204,19 @@ const isPrunedHistoricalStateError = (error: unknown): boolean => {
 		current = 'cause' in current ? current.cause : undefined
 	}
 	return false
+}
+
+export const readWithPrunedStateFallback = async <T>(
+	requestedBlock: bigint,
+	fallbackBlock: bigint,
+	read: (blockNumber: bigint) => Promise<T>,
+): Promise<{ readonly blockNumber: bigint; readonly value: T }> => {
+	try {
+		return { blockNumber: requestedBlock, value: await read(requestedBlock) }
+	} catch (error) {
+		if (!isPrunedHistoricalStateError(error) || fallbackBlock <= requestedBlock) throw error
+		return { blockNumber: fallbackBlock, value: await read(fallbackBlock) }
+	}
 }
 
 export const isSplittableLogRangeError = (error: unknown): boolean => {

--- a/augurScan/src/indexer.ts
+++ b/augurScan/src/indexer.ts
@@ -23,6 +23,7 @@ import {
 	isPermanentHistoricalLogError,
 	isProtocolActivitySource,
 	isProtocolEvidenceEmitter,
+	isPrunedHistoricalStateError,
 	isSplittableLogRangeError,
 	jsonEvidence,
 	LeaseLostError,
@@ -31,6 +32,7 @@ import {
 	queryCanonicalLogRange,
 	type RpcProvider,
 	readHistoricalCodeWithPermanentFallback,
+	readWithPrunedStateFallback,
 	recordOwnershipEvent,
 	requireLogPosition,
 	requireReceiptPosition,
@@ -183,21 +185,31 @@ const unavailableMetadataErrors = new Set(['AbiDecodingError', 'ContractFunction
 
 const isUnavailableMetadataCall = (error: unknown): boolean => errorChainIncludes(error, unavailableMetadataErrors)
 
-const metadataCall = async <T>(call: () => Promise<T>): Promise<T | undefined> => {
+type MetadataCallResult<T> = { readonly status: 'available'; readonly value: T } | { readonly status: 'pruned' } | { readonly status: 'unavailable' }
+
+const metadataCall = async <T>(call: () => Promise<T>): Promise<MetadataCallResult<T>> => {
 	try {
-		return await call()
+		return { status: 'available', value: await call() }
 	} catch (error) {
-		if (isUnavailableMetadataCall(error)) return undefined
+		if (isPrunedHistoricalStateError(error)) return { status: 'pruned' }
+		if (isUnavailableMetadataCall(error)) return { status: 'unavailable' }
 		throw error
 	}
 }
 
 export const readTokenMetadata = async (address: Address, blockNumber: bigint, calls: TokenMetadataCalls): Promise<TokenMetadata> => {
 	const decimals = await metadataCall(calls.decimals)
-	if (decimals === undefined || !Number.isSafeInteger(decimals) || decimals < 0 || decimals > 255)
+	if (decimals.status !== 'available' || !Number.isSafeInteger(decimals.value) || decimals.value < 0 || decimals.value > 255)
 		return { address, readError: 'ERC-20 metadata unavailable', readBlock: blockNumber }
 	const [name, symbol] = await Promise.all([metadataCall(calls.name), metadataCall(calls.symbol)])
-	return { address, decimals, ...(name === undefined ? {} : { name }), ...(symbol === undefined ? {} : { symbol }), readBlock: blockNumber }
+	if (name.status === 'pruned' || symbol.status === 'pruned') return { address, readError: 'ERC-20 metadata unavailable', readBlock: blockNumber }
+	return {
+		address,
+		decimals: decimals.value,
+		...(name.status === 'available' ? { name: name.value } : {}),
+		...(symbol.status === 'available' ? { symbol: symbol.value } : {}),
+		readBlock: blockNumber,
+	}
 }
 
 export const findContractDeploymentBlock = async (
@@ -1359,12 +1371,22 @@ class NetworkIndexer {
 				}
 			}
 			for (const coordinator of discovered.filter((contract) => contract.kind === 'priceCoordinator')) {
-				const registryResult = await this.#client.readContract({
-					address: coordinator.address,
-					abi: priceCoordinatorDependenciesAbi,
-					functionName: 'liquidationApprovalRegistry',
-					blockNumber: number,
-				})
+				const registryRead = await readWithPrunedStateFallback(
+					number,
+					observedHead,
+					async (blockNumber) =>
+						await this.#client.readContract({
+							address: coordinator.address,
+							abi: priceCoordinatorDependenciesAbi,
+							functionName: 'liquidationApprovalRegistry',
+							blockNumber,
+						}),
+				)
+				if (registryRead.blockNumber !== number)
+					console.warn(
+						`[${this.#network.id}] historical state unavailable at block #${number} while discovering ${coordinator.label} dependencies; used observed head #${registryRead.blockNumber} instead`,
+					)
+				const registryResult = registryRead.value
 				if (typeof registryResult !== 'string') throw new Error(`${coordinator.label}.liquidationApprovalRegistry returned an invalid address`)
 				const registry = getAddress(registryResult)
 				if (!contracts.has(registry.toLowerCase())) {

--- a/augurScan/tests/indexer-lifecycle.test.ts
+++ b/augurScan/tests/indexer-lifecycle.test.ts
@@ -86,7 +86,9 @@ import {
 	findEarliestAvailableLogProvider,
 	indexerLogSources,
 	isPermanentHistoricalLogError,
+	isPrunedHistoricalStateError,
 	readHistoricalCodeWithPermanentFallback,
+	readWithPrunedStateFallback,
 	scanDiscoveredLogCoverage,
 } from '../src/indexer-runtime.ts'
 import { RpcRequestMethodError } from '../src/rpc-request-queue.ts'
@@ -2595,6 +2597,17 @@ describe('network indexer lifecycle', () => {
 				symbol: async () => 'TKN',
 			}),
 		).rejects.toThrow('provider unavailable')
+		await expect(
+			readTokenMetadata(address, 10n, {
+				decimals: async () => 18,
+				name: async () => {
+					throw new RpcError('state at block #10 is pruned', { code: -32603, shortMessage: 'state at block #10 is pruned' })
+				},
+				symbol: async () => {
+					throw transportFailure
+				},
+			}),
+		).rejects.toThrow('provider unavailable')
 	})
 
 	test('records a stable fallback for contracts that do not implement token metadata', async () => {
@@ -2621,6 +2634,61 @@ describe('network indexer lifecycle', () => {
 				symbol: async () => 'TKN',
 			}),
 		).toEqual({ address, decimals: 6, symbol: 'TKN', readBlock: 10n })
+	})
+
+	test('records retryable unavailable metadata when any historical metadata field is pruned', async () => {
+		const pruned = new RpcRequestMethodError(
+			'eth_call',
+			new RpcError('state at block #11000001 is pruned', { code: -32603, shortMessage: 'state at block #11000001 is pruned' }),
+			'#1 http://reth:8545',
+		)
+		for (const prunedField of ['decimals', 'name', 'symbol'] as const) {
+			const metadata = await readTokenMetadata(address, 11_000_001n, {
+				decimals: async () => {
+					if (prunedField === 'decimals') throw pruned
+					return 18
+				},
+				name: async () => {
+					if (prunedField === 'name') throw pruned
+					return 'Token'
+				},
+				symbol: async () => {
+					if (prunedField === 'symbol') throw pruned
+					return 'TKN'
+				},
+			})
+			expect(metadata).toEqual({ address, readError: 'ERC-20 metadata unavailable', readBlock: 11_000_001n })
+			expect(tokenMetadataNeedsRead(metadata, 11_000_025n)).toBe(false)
+			expect(tokenMetadataNeedsRead(metadata, 11_000_026n)).toBe(true)
+		}
+	})
+
+	test('retries an essential historical state read at the observed head only when state is pruned', async () => {
+		const attemptedBlocks: bigint[] = []
+		const result = await readWithPrunedStateFallback(11_000_001n, 12_000_000n, async (blockNumber) => {
+			attemptedBlocks.push(blockNumber)
+			if (blockNumber === 11_000_001n)
+				throw new RpcRequestMethodError(
+					'eth_call',
+					new RpcError('state at block #11000001 is pruned', { code: -32603, shortMessage: 'state at block #11000001 is pruned' }),
+					'#1 http://reth:8545',
+				)
+			return 'available'
+		})
+		expect(result).toEqual({ blockNumber: 12_000_000n, value: 'available' })
+		expect(attemptedBlocks).toEqual([11_000_001n, 12_000_000n])
+		expect(isPrunedHistoricalStateError(new Error('temporary provider failure'))).toBe(false)
+	})
+
+	test('does not move ordinary historical state failures to another block', async () => {
+		const attemptedBlocks: bigint[] = []
+		await expect(
+			readWithPrunedStateFallback(11_000_001n, 12_000_000n, async (blockNumber) => {
+				attemptedBlocks.push(blockNumber)
+				throw new Error('temporary provider failure')
+			}),
+		).rejects.toThrow('temporary provider failure')
+		expect(attemptedBlocks).toEqual([11_000_001n])
 	})
 
 	test('records metadata fallback from actual zero-data and revert RPC responses', async () => {


### PR DESCRIPTION
## Summary

- treat pruned historical ERC-20 metadata reads as retryable unavailable enrichment instead of aborting and retrying the same indexed block
- retry essential price-coordinator dependency discovery at the observed head when the requested historical state has been pruned
- keep ordinary RPC failures, rate limits, queue saturation, and malformed responses on their existing retry and failover paths
- preserve retrievable log coverage rather than advancing the network floor for state-only pruning

## Why

Reth can retain historical logs while pruning historical state. AugurScan successfully fetched a log range, then issued metadata `eth_call` requests at an old block. The pruned-state error escaped metadata enrichment, degraded the lifecycle, and caused the same block to be retried indefinitely.

The audit also found coordinator dependency discovery as an essential historical state read requiring a safe newer-block fallback. Deployment code lookup and entity snapshots already had appropriate recovery semantics; live-checkpoint rich-list reads remain unchanged.

## Validation

- `bun run tsc`
- `cd augurScan && bun test` — 281 passed, 4 PostgreSQL-environment skips, 0 failed
- `bun run format:check`
- `bun run check:changed`
- `cd augurScan && bun x biome check .`
- `git diff --check`
- final project review: 98/100, no findings

`bun run knip` continues to report the pre-existing unrelated unlisted dependency in `bots/liquidator/tests/cli/run-startup.test.ts`; it reported no AugurScan issue.

## UI

No rendered UI or interaction changes; screenshots are not applicable.
