### PR TITLE
Harden AugurScan database persistence and reorg handling

### DIFF
--- a/.github/workflow-changes/augur-scan.yml
+++ b/.github/workflow-changes/augur-scan.yml
@@ -1,0 +1,63 @@
+name: AugurScan
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "augurScan/**"
+      - "shared/ts/ethereum.ts"
+      - ".github/workflows/augur-scan.yml"
+  push:
+    branches: [main]
+    paths:
+      - "augurScan/**"
+      - "shared/ts/ethereum.ts"
+      - ".github/workflows/augur-scan.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    name: Typecheck, unit tests, static checks, and browser build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: augur_scan_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d augur_scan_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    defaults:
+      run:
+        working-directory: augurScan
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Typecheck
+        run: bun run typecheck
+      - name: Unit tests
+        run: bun run test:unit
+      - name: PostgreSQL integration tests
+        run: bun run test:integration
+        env:
+          POSTGRES_TEST_URL: postgres://postgres:postgres@127.0.0.1:5432/augur_scan_test
+      - name: Static checks
+        run: bun run check
+      - name: Build browser application
+        run: bun run build

--- a/augurScan/src/database-json.ts
+++ b/augurScan/src/database-json.ts
@@ -1,0 +1,23 @@
+type DatabaseJsonValue = boolean | null | number | string | DatabaseJsonValue[] | { readonly [key: string]: DatabaseJsonValue }
+
+const databaseJsonValue = (value: unknown): DatabaseJsonValue | undefined => {
+	if (value === null || typeof value === 'boolean' || typeof value === 'string') return value
+	if (typeof value === 'number') return Number.isFinite(value) ? value : null
+	if (typeof value === 'bigint') return value.toString()
+	if (Array.isArray(value)) return value.map((item) => databaseJsonValue(item) ?? null)
+	if (value instanceof Date) return value.toJSON()
+	if (typeof value !== 'object') return undefined
+	if ('toJSON' in value && typeof value.toJSON === 'function') return databaseJsonValue(value.toJSON())
+	const result: Record<string, DatabaseJsonValue> = {}
+	for (const [key, item] of Object.entries(value)) {
+		const normalized = databaseJsonValue(item)
+		if (normalized !== undefined) result[key] = normalized
+	}
+	return result
+}
+
+export const databaseJsonText = (value: unknown): string => {
+	const normalized = databaseJsonValue(value)
+	if (normalized === undefined) throw new Error('Database JSON value cannot be serialized')
+	return JSON.stringify(normalized)
+}

--- a/augurScan/src/database-projections.ts
+++ b/augurScan/src/database-projections.ts
@@ -1,0 +1,197 @@
+import type { SQL } from 'bun'
+import { databaseJsonText } from './database-json.ts'
+import { zeroAddress } from './ethereum.ts'
+import { type Projection, projectionsFrom } from './projections.ts'
+import type { StoredLog } from './types.ts'
+import { isSupportedUniswapV4Market } from './uniswap.ts'
+
+const unsupportedProjection = (projection: never): never => {
+	throw new Error(`Unsupported database projection: ${String(projection)}`)
+}
+
+const storeDomainEvent = async (transaction: SQL, chainId: number, item: StoredLog, projection: Extract<Projection, { type: 'domainEvent' }>) => {
+	const position = [chainId, item.blockHash, item.transactionHash, item.logIndex, item.blockNumber.toString()] as const
+	await transaction`
+		INSERT INTO protocol_timeline_entries (chain_id, block_hash, tx_hash, log_index, block_number, entity_type, entity_identity, semantic_event_kind, summary_data, related_entities, source_contract, source_event, canonical)
+		VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.entityType}, ${projection.entityIdentity}, ${projection.semanticEventKind}, (${databaseJsonText(projection.data)}::text)::jsonb, (${databaseJsonText(projection.relatedEntities)}::text)::jsonb, ${item.address.toLowerCase()}, ${projection.semanticEventKind}, true)
+		ON CONFLICT (chain_id, block_hash, tx_hash, log_index, entity_type, entity_identity) DO UPDATE SET canonical = true, summary_data = EXCLUDED.summary_data, related_entities = EXCLUDED.related_entities
+	`
+	if (projection.domain === 'report') {
+		const reportId = projection.data['reportId']
+		const roundNumber = projection.data['numReports']
+		if (typeof reportId !== 'string') throw new Error(`${projection.semanticEventKind} is missing reportId`)
+		await transaction`
+			INSERT INTO open_oracle_report_events (chain_id, block_hash, tx_hash, log_index, block_number, open_oracle_address, report_id, event_name, round_number, report_data, canonical)
+			VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${item.address.toLowerCase()}, ${reportId}, ${projection.semanticEventKind}, ${typeof roundNumber === 'string' ? roundNumber : null}, (${databaseJsonText(projection.data)}::text)::jsonb, true)
+			ON CONFLICT (chain_id, block_hash, tx_hash, log_index, open_oracle_address, report_id) DO UPDATE SET canonical = true, report_data = EXCLUDED.report_data
+		`
+		return
+	}
+	if (projection.domain === 'escalation') {
+		await transaction`
+			INSERT INTO escalation_game_events (chain_id, block_hash, tx_hash, log_index, block_number, game_address, event_name, event_data, canonical)
+			VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${item.address.toLowerCase()}, ${projection.semanticEventKind}, (${databaseJsonText(projection.data)}::text)::jsonb, true)
+			ON CONFLICT (chain_id, block_hash, tx_hash, log_index, game_address) DO UPDATE SET canonical = true, event_data = EXCLUDED.event_data
+		`
+		return
+	}
+	if (projection.domain === 'auction') {
+		await transaction`
+			INSERT INTO truth_auction_events (chain_id, block_hash, tx_hash, log_index, block_number, auction_address, event_name, event_data, canonical)
+			VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${item.address.toLowerCase()}, ${projection.semanticEventKind}, (${databaseJsonText(projection.data)}::text)::jsonb, true)
+			ON CONFLICT (chain_id, block_hash, tx_hash, log_index, auction_address) DO UPDATE SET canonical = true, event_data = EXCLUDED.event_data
+		`
+		return
+	}
+	if (projection.domain === 'trading') {
+		await transaction`
+			INSERT INTO amm_trade_events (chain_id, block_hash, tx_hash, log_index, block_number, market_address, event_name, event_data, canonical)
+			VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${item.address.toLowerCase()}, ${projection.semanticEventKind}, (${databaseJsonText(projection.data)}::text)::jsonb, true)
+			ON CONFLICT (chain_id, block_hash, tx_hash, log_index, market_address) DO UPDATE SET canonical = true, event_data = EXCLUDED.event_data
+		`
+		return
+	}
+	if (projection.domain === 'fork') {
+		await transaction`
+			INSERT INTO fork_migration_events (chain_id, block_hash, tx_hash, log_index, block_number, universe_identity, event_name, event_data, canonical)
+			VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.entityIdentity}, ${projection.semanticEventKind}, (${databaseJsonText(projection.data)}::text)::jsonb, true)
+			ON CONFLICT (chain_id, block_hash, tx_hash, log_index, universe_identity) DO UPDATE SET canonical = true, event_data = EXCLUDED.event_data
+		`
+		return
+	}
+	if (projection.domain === 'approval') {
+		const approvalId = projection.data['approvalId']
+		const receiverVault = projection.data['receiverVault']
+		await transaction`
+			INSERT INTO liquidation_approval_events (chain_id, block_hash, tx_hash, transaction_index, log_index, block_number, registry_address, approval_identity, receiver_vault, event_name, event_data, canonical)
+			VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${item.transactionIndex}, ${position[3]}, ${position[4]}, ${item.address.toLowerCase()}, ${typeof approvalId === 'string' ? approvalId.toLowerCase() : `nonce:${String(receiverVault ?? 'unknown').toLowerCase()}`}, ${typeof receiverVault === 'string' ? receiverVault.toLowerCase() : null}, ${projection.semanticEventKind}, (${databaseJsonText(projection.data)}::text)::jsonb, true)
+			ON CONFLICT (chain_id, block_hash, tx_hash, log_index, registry_address) DO UPDATE SET canonical = true, event_data = EXCLUDED.event_data
+		`
+		return
+	}
+	if (projection.domain === 'oracle' || projection.domain === 'risk') return
+	return unsupportedProjection(projection.domain)
+}
+
+const storeProjection = async (transaction: SQL, chainId: number, item: StoredLog, projection: Projection): Promise<void> => {
+	const position = [chainId, item.blockHash, item.transactionHash, item.logIndex, item.blockNumber.toString()] as const
+	if (projection.type === 'domainEvent') return await storeDomainEvent(transaction, chainId, item, projection)
+	if (projection.type === 'question') {
+		await transaction`
+			INSERT INTO questions (chain_id, block_hash, tx_hash, log_index, block_number, question_id, created_timestamp, title, description, start_time, end_time, num_ticks, display_value_min, display_value_max, answer_unit, outcome_options, canonical)
+			VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.questionId}, ${projection.createdTimestamp}, ${projection.title}, ${projection.description}, ${projection.startTime}, ${projection.endTime}, ${projection.numTicks}, ${projection.displayValueMin}, ${projection.displayValueMax}, ${projection.answerUnit}, (${databaseJsonText(projection.outcomeOptions)}::text)::jsonb, true)
+			ON CONFLICT (chain_id, block_hash, tx_hash, log_index, question_id) DO UPDATE SET canonical = true
+		`
+		return
+	}
+	if (projection.type === 'pool') {
+		await transaction`
+			INSERT INTO pools (chain_id, block_hash, tx_hash, log_index, block_number, pool_address, parent_address, universe_id, question_id, truth_auction_address, coordinator_address, share_token_address, security_multiplier_bps, initial_priority_fee_atto_eth_per_gas, initial_retention_rate, initial_settlement_collateral_atto_eth, canonical)
+			VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.poolAddress}, ${projection.parentAddress}, ${projection.universeId}, ${projection.questionId}, ${projection.truthAuctionAddress}, ${projection.coordinatorAddress}, ${projection.shareTokenAddress}, ${projection.securityMultiplierBps}, ${projection.initialPriorityFeeAttoEthPerGas}, ${projection.initialRetentionRate}, ${projection.initialSettlementCollateralAttoEth}, true)
+			ON CONFLICT (chain_id, block_hash, tx_hash, log_index, pool_address) DO UPDATE SET canonical = true
+		`
+		return
+	}
+	if (projection.type === 'poolSnapshot') {
+		await transaction`
+			INSERT INTO pool_snapshots (chain_id, block_hash, tx_hash, log_index, block_number, pool_address, reason, vault_address, settlement_collateral_atto_eth, total_capacity_ownership_atto_rep, fee_eligible_capacity_ownership_atto_rep, total_claimable_vault_fees_atto_eth, unallocated_accrued_fees_atto_eth, fee_index, fee_index_remainder, total_fees_owed_remainder, uncheckpointed_fee_eligible_capacity_ownership_atto_rep, last_updated_fee_accumulator, current_retention_rate, canonical)
+			VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.poolAddress}, ${projection.reason}, ${projection.vaultAddress}, ${projection.settlementCollateralAttoEth}, ${projection.totalCapacityOwnershipAttoRep}, ${projection.feeEligibleCapacityOwnershipAttoRep}, ${projection.totalClaimableVaultFeesAttoEth}, ${projection.unallocatedAccruedFeesAttoEth}, ${projection.feeIndex}, ${projection.feeIndexRemainder}, ${projection.totalFeesOwedRemainder}, ${projection.uncheckpointedFeeEligibleCapacityOwnershipAttoRep}, ${projection.lastUpdatedFeeAccumulator}, ${projection.currentRetentionRate}, true)
+			ON CONFLICT (chain_id, block_hash, tx_hash, log_index, pool_address) DO UPDATE SET canonical = true
+		`
+		return
+	}
+	if (projection.type === 'vaultSnapshot') {
+		await transaction`
+			INSERT INTO vault_snapshots (chain_id, block_hash, tx_hash, log_index, block_number, pool_address, vault_address, rep_backing_units, capacity_ownership_atto_rep, claimable_fees_atto_eth, fee_index, vault_fee_remainder, resulting_total_rep_backing_units, resulting_fee_eligible_capacity_ownership_atto_rep, canonical)
+			VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.poolAddress}, ${projection.vaultAddress}, ${projection.repBackingUnits}, ${projection.capacityOwnershipAttoRep}, ${projection.claimableFeesAttoEth}, ${projection.feeIndex}, ${projection.vaultFeeRemainder}, ${projection.resultingTotalRepBackingUnits}, ${projection.resultingFeeEligibleCapacityOwnershipAttoRep}, true)
+			ON CONFLICT (chain_id, block_hash, tx_hash, log_index, pool_address, vault_address) DO UPDATE SET canonical = true
+		`
+		return
+	}
+	if (projection.type === 'poolState') {
+		await transaction`
+			INSERT INTO pool_state_events (chain_id, block_hash, tx_hash, log_index, block_number, pool_address, event_name, state, canonical)
+			VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.poolAddress}, ${projection.eventName}, (${databaseJsonText(projection.state)}::text)::jsonb, true)
+			ON CONFLICT (chain_id, block_hash, tx_hash, log_index, pool_address) DO UPDATE SET canonical = true, state = EXCLUDED.state
+		`
+		return
+	}
+	if (projection.type === 'ammMarket') {
+		await transaction`
+			INSERT INTO amm_markets (chain_id, block_hash, tx_hash, log_index, block_number, pair_address, pool_address, share_token_address, universe_id, fee_bps, canonical)
+			VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.pairAddress}, ${projection.poolAddress}, ${projection.shareTokenAddress}, ${projection.universeId}, ${projection.feeBps}, true)
+			ON CONFLICT (chain_id, block_hash, tx_hash, log_index, pair_address) DO UPDATE SET canonical = true
+		`
+		return
+	}
+	if (projection.type === 'ammPrice') {
+		await transaction`
+			INSERT INTO amm_price_snapshots (chain_id, block_hash, tx_hash, log_index, block_number, pair_address, yes_reserve_atto_shares, no_reserve_atto_shares, conditional_yes_bps, conditional_no_bps, canonical)
+			VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.pairAddress}, ${projection.yesReserveAttoShares}, ${projection.noReserveAttoShares}, ${projection.conditionalYesBps}, ${projection.conditionalNoBps}, true)
+			ON CONFLICT (chain_id, block_hash, tx_hash, log_index, pair_address) DO UPDATE SET canonical = true
+		`
+		return
+	}
+	if (projection.type === 'repEthPrice') {
+		await transaction`
+			INSERT INTO rep_eth_price_snapshots (chain_id, block_hash, tx_hash, log_index, block_number, coordinator_address, event_name, report_id, rep_per_eth_1e18, settlement_timestamp, canonical)
+			VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.coordinatorAddress}, ${projection.eventName}, ${projection.reportId ?? null}, ${projection.repPerEth1e18}, ${projection.settlementTimestamp ?? null}, true)
+			ON CONFLICT (chain_id, block_hash, tx_hash, log_index, coordinator_address) DO UPDATE SET canonical = true
+		`
+		return
+	}
+	if (projection.type === 'uniswapMarket') {
+		const supportedV4Market = projection.venue === 'v4' && isSupportedUniswapV4Market(projection)
+		await transaction`
+			INSERT INTO uniswap_rep_eth_markets (chain_id, block_hash, tx_hash, log_index, block_number, venue, market_id, contract_address, token0_address, token1_address, fee_hundredths_bip, tick_spacing, hooks_address, canonical)
+			SELECT ${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.venue}, ${projection.marketId}, ${projection.contractAddress}, ${projection.token0Address}, ${projection.token1Address}, ${projection.feeHundredthsBip}, ${projection.tickSpacing ?? null}, ${projection.hooksAddress ?? null}, true
+			WHERE (
+				${projection.venue} IN ('v2', 'v3') AND (
+					EXISTS (SELECT 1 FROM contracts WHERE chain_id = ${chainId} AND address = ${projection.token0Address} AND kind = 'reputationToken' AND canonical)
+					AND EXISTS (SELECT 1 FROM contracts WHERE chain_id = ${chainId} AND address = ${projection.token1Address} AND kind IN ('weth', 'usdc') AND canonical)
+					OR EXISTS (SELECT 1 FROM contracts WHERE chain_id = ${chainId} AND address = ${projection.token1Address} AND kind = 'reputationToken' AND canonical)
+					AND EXISTS (SELECT 1 FROM contracts WHERE chain_id = ${chainId} AND address = ${projection.token0Address} AND kind IN ('weth', 'usdc') AND canonical)
+				)
+				) OR (
+					${projection.venue} = 'v4'
+					AND ${supportedV4Market}
+					AND EXISTS (SELECT 1 FROM contracts WHERE chain_id = ${chainId} AND address = ${projection.contractAddress} AND kind = 'uniswapV4PoolManager' AND canonical)
+					AND (
+						${projection.token0Address} = ${zeroAddress}
+						AND EXISTS (SELECT 1 FROM contracts WHERE chain_id = ${chainId} AND address = ${projection.token1Address} AND kind = 'reputationToken' AND canonical)
+						OR EXISTS (SELECT 1 FROM contracts WHERE chain_id = ${chainId} AND address = ${projection.token0Address} AND kind = 'reputationToken' AND canonical)
+						AND EXISTS (SELECT 1 FROM contracts WHERE chain_id = ${chainId} AND address = ${projection.token1Address} AND kind = 'usdc' AND canonical)
+						OR EXISTS (SELECT 1 FROM contracts WHERE chain_id = ${chainId} AND address = ${projection.token1Address} AND kind = 'reputationToken' AND canonical)
+						AND EXISTS (SELECT 1 FROM contracts WHERE chain_id = ${chainId} AND address = ${projection.token0Address} AND kind = 'usdc' AND canonical)
+					)
+				)
+			ON CONFLICT (chain_id, block_hash, tx_hash, log_index, market_id) DO UPDATE SET canonical = true
+		`
+		return
+	}
+	if (projection.type === 'uniswapPrice') {
+		await transaction`
+			INSERT INTO uniswap_rep_eth_price_observations (chain_id, block_hash, tx_hash, log_index, block_number, venue, market_id, event_name, reserve0, reserve1, sqrt_price_x96, liquidity, canonical)
+			SELECT ${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.venue}, ${projection.marketId}, ${projection.eventName}, ${projection.reserve0 ?? null}, ${projection.reserve1 ?? null}, ${projection.sqrtPriceX96 ?? null}, ${projection.liquidity ?? null}, true
+			WHERE EXISTS (
+				SELECT 1 FROM uniswap_rep_eth_markets
+				WHERE chain_id = ${chainId} AND venue = ${projection.venue} AND market_id = ${projection.marketId} AND canonical
+			)
+			ON CONFLICT (chain_id, block_hash, tx_hash, log_index, market_id) DO UPDATE SET canonical = true
+		`
+		return
+	}
+	if (projection.type === 'universe') {
+		await transaction`
+			INSERT INTO universe_events (chain_id, block_hash, tx_hash, log_index, block_number, universe_id, event_name, parent_universe_id, forking_outcome_index, reputation_token_address, fork_question_id, fork_time, forker_address, fork_threshold_atto_rep, migration_rep_balance_atto_rep, theoretical_supply_atto_rep, canonical)
+			VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.universeId}, ${projection.eventName}, ${projection.parentUniverseId ?? null}, ${projection.forkingOutcomeIndex ?? null}, ${projection.reputationTokenAddress ?? null}, ${projection.forkQuestionId ?? null}, ${projection.forkTime ?? null}, ${projection.forkerAddress ?? null}, ${projection.forkThresholdAttoRep ?? null}, ${projection.migrationRepBalanceAttoRep ?? null}, ${projection.theoreticalSupplyAttoRep ?? null}, true)
+			ON CONFLICT (chain_id, block_hash, tx_hash, log_index, universe_id) DO UPDATE SET canonical = true
+		`
+		return
+	}
+	return unsupportedProjection(projection)
+}
+
+export const storeLogProjections = async (transaction: SQL, chainId: number, item: StoredLog): Promise<void> => {
+	for (const projection of projectionsFrom(item)) await storeProjection(transaction, chainId, item, projection)
+}

--- a/augurScan/src/database.ts
+++ b/augurScan/src/database.ts
@@ -1,9 +1,9 @@
-import { type ReservedSQL, SQL, type TransactionSQL } from 'bun'
-import { type Address, getAddress, type Hash, type Hex, zeroAddress } from './ethereum.ts'
-import { projectionsFrom } from './projections.ts'
+import { type ReservedSQL, SQL } from 'bun'
+import { databaseJsonText } from './database-json.ts'
+import { storeLogProjections } from './database-projections.ts'
+import { type Address, getAddress, type Hash, type Hex } from './ethereum.ts'
 import { type EntityStateSnapshot, normalizeSnapshotTarget, type StateSnapshotTarget } from './snapshots.ts'
 import type { ContractMetadata, DecodedRecord, ManifestContract, NetworkConfig, StoredLog, TokenMetadata } from './types.ts'
-import { isSupportedUniswapV4Market } from './uniswap.ts'
 
 export type StoredTransaction = {
 	readonly hash: Hash
@@ -284,39 +284,54 @@ export const lockLiveEventWriter = async (sql: SQL): Promise<void> => {
 	await sql`SELECT singleton FROM live_event_state WHERE singleton FOR UPDATE`
 }
 
-const canonicalHistoryTables = [
-	'blocks',
-	'transactions',
-	'logs',
-	'contract_discoveries',
-	'questions',
-	'pools',
-	'pool_snapshots',
-	'pool_state_events',
-	'vault_snapshots',
-	'universe_events',
-	'amm_markets',
-	'amm_price_snapshots',
-	'rep_eth_price_snapshots',
-	'uniswap_rep_eth_markets',
-	'uniswap_rep_eth_price_observations',
-	'protocol_timeline_entries',
-	'open_oracle_report_events',
-	'escalation_game_events',
-	'truth_auction_events',
-	'amm_trade_events',
-	'fork_migration_events',
-	'liquidation_approval_events',
-	'address_activity',
-	'address_balance_snapshots',
-	'token_metadata',
-] as const
+type CanonicalHistoryTablePolicy = {
+	readonly kind: 'history'
+	readonly table: string
+	readonly rewindColumn: string
+	readonly staleOnInvalidation?: true
+	readonly clearFinalized?: true
+}
 
-const invalidateCanonicalHistory = async (transaction: TransactionSQL, chainId: number, discoveryRetirementFloor?: bigint): Promise<void> => {
-	for (const table of canonicalHistoryTables) await transaction.unsafe(`UPDATE ${table} SET canonical = false WHERE chain_id = $1 AND canonical`, [chainId])
-	await transaction`UPDATE entity_state_snapshots SET read_status = 'stale', canonical = false WHERE chain_id = ${chainId} AND canonical`
-	await transaction`UPDATE blocks SET finalized = false WHERE chain_id = ${chainId}`
-	await transaction`UPDATE logs SET finalized = false WHERE chain_id = ${chainId}`
+type CanonicalTablePolicy = CanonicalHistoryTablePolicy | { readonly kind: 'contract-registry'; readonly table: 'contracts' }
+
+export const canonicalTablePolicies = [
+	{ kind: 'history', table: 'blocks', rewindColumn: 'number', clearFinalized: true },
+	{ kind: 'history', table: 'transactions', rewindColumn: 'block_number' },
+	{ kind: 'history', table: 'logs', rewindColumn: 'block_number', clearFinalized: true },
+	{ kind: 'history', table: 'contract_discoveries', rewindColumn: 'block_number' },
+	{ kind: 'history', table: 'questions', rewindColumn: 'block_number' },
+	{ kind: 'history', table: 'pools', rewindColumn: 'block_number' },
+	{ kind: 'history', table: 'pool_snapshots', rewindColumn: 'block_number' },
+	{ kind: 'history', table: 'pool_state_events', rewindColumn: 'block_number' },
+	{ kind: 'history', table: 'vault_snapshots', rewindColumn: 'block_number' },
+	{ kind: 'history', table: 'universe_events', rewindColumn: 'block_number' },
+	{ kind: 'history', table: 'amm_markets', rewindColumn: 'block_number' },
+	{ kind: 'history', table: 'amm_price_snapshots', rewindColumn: 'block_number' },
+	{ kind: 'history', table: 'rep_eth_price_snapshots', rewindColumn: 'block_number' },
+	{ kind: 'history', table: 'uniswap_rep_eth_markets', rewindColumn: 'block_number' },
+	{ kind: 'history', table: 'uniswap_rep_eth_price_observations', rewindColumn: 'block_number' },
+	{ kind: 'history', table: 'protocol_timeline_entries', rewindColumn: 'block_number' },
+	{ kind: 'history', table: 'open_oracle_report_events', rewindColumn: 'block_number' },
+	{ kind: 'history', table: 'escalation_game_events', rewindColumn: 'block_number' },
+	{ kind: 'history', table: 'truth_auction_events', rewindColumn: 'block_number' },
+	{ kind: 'history', table: 'amm_trade_events', rewindColumn: 'block_number' },
+	{ kind: 'history', table: 'fork_migration_events', rewindColumn: 'block_number' },
+	{ kind: 'history', table: 'liquidation_approval_events', rewindColumn: 'block_number' },
+	{ kind: 'history', table: 'entity_state_snapshots', rewindColumn: 'block_number', staleOnInvalidation: true },
+	{ kind: 'history', table: 'address_activity', rewindColumn: 'block_number' },
+	{ kind: 'history', table: 'address_balance_snapshots', rewindColumn: 'block_number' },
+	{ kind: 'history', table: 'token_metadata', rewindColumn: 'read_block' },
+	{ kind: 'contract-registry', table: 'contracts' },
+] as const satisfies readonly CanonicalTablePolicy[]
+
+const canonicalHistoryTablePolicies: readonly CanonicalHistoryTablePolicy[] = canonicalTablePolicies.filter((policy) => policy.kind === 'history')
+
+const invalidateCanonicalHistory = async (transaction: SQL, chainId: number, discoveryRetirementFloor?: bigint): Promise<void> => {
+	for (const policy of canonicalHistoryTablePolicies) {
+		const assignments = policy.staleOnInvalidation === true ? "read_status = 'stale', canonical = false" : 'canonical = false'
+		await transaction.unsafe(`UPDATE ${policy.table} SET ${assignments} WHERE chain_id = $1 AND canonical`, [chainId])
+		if (policy.clearFinalized === true) await transaction.unsafe(`UPDATE ${policy.table} SET finalized = false WHERE chain_id = $1`, [chainId])
+	}
 	await transaction`DELETE FROM log_scan_cursors WHERE chain_id = ${chainId}`
 	await transaction`
 		UPDATE contracts SET deployment_block = NULL, deployment_timestamp = NULL,
@@ -334,22 +349,26 @@ const invalidateCanonicalHistory = async (transaction: TransactionSQL, chainId: 
 			UPDATE contracts SET canonical = false
 			WHERE chain_id = ${chainId} AND provenance <> 'manifest'
 				AND (discovery_block IS NULL OR discovery_block >= ${discoveryRetirementFloor.toString()})
-		`
+			`
+}
+
+const invalidateCanonicalHistoryAfter = async (transaction: SQL, chainId: number, ancestor: bigint): Promise<void> => {
+	for (const policy of canonicalHistoryTablePolicies) {
+		const assignments = [
+			...(policy.staleOnInvalidation === true ? ["read_status = 'stale'"] : []),
+			'canonical = false',
+			...(policy.clearFinalized === true ? ['finalized = false'] : []),
+		].join(', ')
+		await transaction.unsafe(`UPDATE ${policy.table} SET ${assignments} WHERE chain_id = $1 AND ${policy.rewindColumn} > $2 AND canonical`, [
+			chainId,
+			ancestor.toString(),
+		])
+	}
 }
 
 export const releaseReservedConnection = async (connection: Pick<ReservedSQL, 'release'>): Promise<void> => {
 	await connection.release()
 }
-
-export const runFencedIndexerTransaction = async <TTransaction, TResult>(
-	begin: (operation: (transaction: TTransaction) => Promise<TResult>) => Promise<TResult>,
-	assertHeld: (transaction: TTransaction) => Promise<void>,
-	operation: (transaction: TTransaction) => Promise<TResult>,
-): Promise<TResult> =>
-	await begin(async (transaction) => {
-		await assertHeld(transaction)
-		return await operation(transaction)
-	})
 
 export type IndexerLease = {
 	readonly backendPid: number
@@ -375,16 +394,24 @@ export const runSerializedIndexerLeaseOperation = async <T>(lease: object, opera
 	}
 }
 
-const withIndexerLease = async <T>(lease: IndexerLease, operation: (transaction: TransactionSQL) => Promise<T>): Promise<T> =>
-	await runSerializedIndexerLeaseOperation(
-		lease,
-		async () =>
-			await runFencedIndexerTransaction(
-				async (fencedOperation) => await lease.connection.begin(fencedOperation),
-				async (transaction) => await lease.assertHeld(transaction),
-				operation,
-			),
-	)
+const withIndexerLease = async <T>(lease: IndexerLease, operation: (transaction: SQL) => Promise<T>): Promise<T> =>
+	await runSerializedIndexerLeaseOperation(lease, async () => {
+		await lease.assertHeld(lease.connection)
+		await lease.connection.unsafe('BEGIN')
+		try {
+			await lease.assertHeld(lease.connection)
+			const result = await operation(lease.connection)
+			await lease.connection.unsafe('COMMIT')
+			return result
+		} catch (error) {
+			try {
+				await lease.connection.unsafe('ROLLBACK')
+			} catch (rollbackError) {
+				throw new AggregateError([error, rollbackError], 'Indexer transaction failed and could not be rolled back')
+			}
+			throw error
+		}
+	})
 
 const withOptionalIndexerLease = async <T>(sql: SQL, lease: IndexerLease | undefined, operation: (sql: SQL) => Promise<T>): Promise<T> =>
 	lease === undefined ? await operation(sql) : await withIndexerLease(lease, operation)
@@ -396,6 +423,12 @@ export const scannerDatabaseOptions = (maxConnections: number, connectionTimeout
 	connectionTimeout: connectionTimeoutSeconds,
 })
 
+export type SeedNetworkOptions = {
+	readonly lease?: IndexerLease
+	readonly resetCanonicalHistoryOnManifestChange?: boolean
+	readonly preserveStoredStart?: boolean
+}
+
 export class ScannerDatabase {
 	readonly sql: SQL
 
@@ -403,8 +436,8 @@ export class ScannerDatabase {
 		this.sql = new SQL(url, scannerDatabaseOptions(maxConnections, connectionTimeoutSeconds))
 	}
 
-	async close(): Promise<void> {
-		await this.sql.close()
+	async close(timeoutSeconds = 5): Promise<void> {
+		await this.sql.close({ timeout: timeoutSeconds })
 	}
 
 	async read<T>(operation: (sql: SQL) => Promise<T>, timeoutMs = 10_000): Promise<T> {
@@ -512,7 +545,8 @@ export class ScannerDatabase {
 			}
 			const backendPid = Number(rows[0]?.['backend_pid'])
 			let released = false
-			return {
+			let releasePromise: Promise<void> | undefined
+			const lease: IndexerLease = {
 				backendPid,
 				connection,
 				assertHeld: async (sql = connection) => {
@@ -530,36 +564,36 @@ export class ScannerDatabase {
 					`
 					assertIndexerLeaseObservation(backendPid, Number(leaseRows[0]?.['backend_pid']), leaseRows[0]?.['held'] === true)
 				},
-				release: async () => {
-					if (released) return
-					released = true
-					try {
-						const releaseRows = await connection`
-							SELECT pg_backend_pid() AS backend_pid,
-								CASE WHEN pg_backend_pid() = ${backendPid}
-									THEN pg_advisory_unlock(92138472, ${chainId})
-									ELSE false
-								END AS unlocked
-						`
-						assertIndexerLeaseReleaseObservation(backendPid, Number(releaseRows[0]?.['backend_pid']), releaseRows[0]?.['unlocked'] === true)
-					} finally {
-						await releaseConnection()
-					}
+				release: () => {
+					if (releasePromise !== undefined) return releasePromise
+					releasePromise = runSerializedIndexerLeaseOperation(lease, async () => {
+						released = true
+						try {
+							const releaseRows = await connection`
+								SELECT pg_backend_pid() AS backend_pid,
+									CASE WHEN pg_backend_pid() = ${backendPid}
+										THEN pg_advisory_unlock(92138472, ${chainId})
+										ELSE false
+									END AS unlocked
+							`
+							assertIndexerLeaseReleaseObservation(backendPid, Number(releaseRows[0]?.['backend_pid']), releaseRows[0]?.['unlocked'] === true)
+						} finally {
+							await releaseConnection()
+						}
+					})
+					return releasePromise
 				},
 			}
+			return lease
 		} catch (error) {
 			await releaseConnection()
 			throw error
 		}
 	}
 
-	async seedNetwork(
-		network: NetworkConfig,
-		lease?: IndexerLease,
-		resetCanonicalHistoryOnManifestChange = false,
-		preserveStoredStart = false,
-	): Promise<boolean> {
-		const operation = async (transaction: TransactionSQL): Promise<boolean> => {
+	async seedNetwork(network: NetworkConfig, options: SeedNetworkOptions = {}): Promise<boolean> {
+		const { lease, resetCanonicalHistoryOnManifestChange = false, preserveStoredStart = false } = options
+		const operation = async (transaction: SQL): Promise<boolean> => {
 			const existingRows = await transaction`
 				SELECT start_block, indexed_block
 				FROM networks
@@ -663,7 +697,7 @@ export class ScannerDatabase {
 				await lockLiveEventWriter(transaction)
 				await transaction`
 					INSERT INTO live_events (event, payload)
-					VALUES ('reorg', (${JSON.stringify({ chainId: network.chainId, previousBlock: previousBlock.toString(), ancestor: '-1', depth: (previousBlock - network.startBlock + 1n).toString() })}::text)::jsonb)
+					VALUES ('reorg', (${databaseJsonText({ chainId: network.chainId, previousBlock: previousBlock.toString(), ancestor: '-1', depth: (previousBlock - network.startBlock + 1n).toString() })}::text)::jsonb)
 				`
 			}
 			return manifestChanged
@@ -880,7 +914,7 @@ export class ScannerDatabase {
 						source_method, read_status, read_result, read_failure_reason, canonical, observed_at
 					) VALUES (
 						${chainId}, ${snapshot.entityType}, ${snapshot.entityIdentity}, ${blockNumber.toString()}, ${blockHash}, ${blockTimestamp},
-						${snapshot.sourceMethod}, ${snapshot.readStatus}, (${snapshot.readResult === undefined ? null : JSON.stringify(snapshot.readResult)}::text)::jsonb,
+						${snapshot.sourceMethod}, ${snapshot.readStatus}, (${snapshot.readResult === undefined ? null : databaseJsonText(snapshot.readResult)}::text)::jsonb,
 						${snapshot.readFailureReason ?? null}, true, now()
 					)
 					ON CONFLICT (chain_id, entity_type, entity_identity, block_hash, source_method) DO UPDATE SET
@@ -967,32 +1001,7 @@ export class ScannerDatabase {
 				},
 				targetRows.length === 1,
 			)
-			await transaction`UPDATE blocks SET canonical = false, finalized = false WHERE chain_id = ${chainId} AND number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE transactions SET canonical = false WHERE chain_id = ${chainId} AND block_number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE logs SET canonical = false, finalized = false WHERE chain_id = ${chainId} AND block_number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE contract_discoveries SET canonical = false WHERE chain_id = ${chainId} AND block_number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE questions SET canonical = false WHERE chain_id = ${chainId} AND block_number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE pools SET canonical = false WHERE chain_id = ${chainId} AND block_number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE pool_snapshots SET canonical = false WHERE chain_id = ${chainId} AND block_number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE pool_state_events SET canonical = false WHERE chain_id = ${chainId} AND block_number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE vault_snapshots SET canonical = false WHERE chain_id = ${chainId} AND block_number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE universe_events SET canonical = false WHERE chain_id = ${chainId} AND block_number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE amm_markets SET canonical = false WHERE chain_id = ${chainId} AND block_number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE amm_price_snapshots SET canonical = false WHERE chain_id = ${chainId} AND block_number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE rep_eth_price_snapshots SET canonical = false WHERE chain_id = ${chainId} AND block_number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE uniswap_rep_eth_markets SET canonical = false WHERE chain_id = ${chainId} AND block_number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE uniswap_rep_eth_price_observations SET canonical = false WHERE chain_id = ${chainId} AND block_number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE protocol_timeline_entries SET canonical = false WHERE chain_id = ${chainId} AND block_number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE open_oracle_report_events SET canonical = false WHERE chain_id = ${chainId} AND block_number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE escalation_game_events SET canonical = false WHERE chain_id = ${chainId} AND block_number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE truth_auction_events SET canonical = false WHERE chain_id = ${chainId} AND block_number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE amm_trade_events SET canonical = false WHERE chain_id = ${chainId} AND block_number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE fork_migration_events SET canonical = false WHERE chain_id = ${chainId} AND block_number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE liquidation_approval_events SET canonical = false WHERE chain_id = ${chainId} AND block_number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE entity_state_snapshots SET read_status = 'stale', canonical = false WHERE chain_id = ${chainId} AND block_number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE address_activity SET canonical = false WHERE chain_id = ${chainId} AND block_number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE address_balance_snapshots SET canonical = false WHERE chain_id = ${chainId} AND block_number > ${ancestor.toString()} AND canonical`
-			await transaction`UPDATE token_metadata SET canonical = false WHERE chain_id = ${chainId} AND read_block > ${ancestor.toString()} AND canonical`
+			await invalidateCanonicalHistoryAfter(transaction, chainId, ancestor)
 			await transaction`DELETE FROM log_scan_cursors WHERE chain_id = ${chainId} AND start_block > ${ancestor.toString()}`
 			await transaction`
 				UPDATE log_scan_cursors SET
@@ -1008,7 +1017,6 @@ export class ScannerDatabase {
 					deployment_checked_block = CASE WHEN deployment_checked_block > ${ancestor.toString()} THEN NULL ELSE deployment_checked_block END
 				WHERE chain_id = ${chainId} AND (deployment_block > ${ancestor.toString()} OR deployment_checked_block > ${ancestor.toString()})
 			`
-			await transaction`UPDATE contracts SET deployment_checked_block = NULL WHERE chain_id = ${chainId} AND deployment_checked_block > ${ancestor.toString()}`
 			await transaction`
 				UPDATE contracts SET canonical = false
 				WHERE chain_id = ${chainId} AND provenance <> 'manifest'
@@ -1058,7 +1066,7 @@ export class ScannerDatabase {
 			await lockLiveEventWriter(transaction)
 			await transaction`
 				INSERT INTO live_events (event, payload)
-				VALUES ('reorg', (${JSON.stringify({ chainId, previousBlock: previousBlock.toString(), ancestor: ancestor.toString(), depth: reorgDepth.toString() })}::text)::jsonb)
+				VALUES ('reorg', (${databaseJsonText({ chainId, previousBlock: previousBlock.toString(), ancestor: ancestor.toString(), depth: reorgDepth.toString() })}::text)::jsonb)
 			`
 		})
 	}
@@ -1124,12 +1132,12 @@ export class ScannerDatabase {
 			for (const item of block.transactions) {
 				await transaction`
 					INSERT INTO transactions (chain_id, hash, block_hash, block_number, transaction_index, from_address, to_address, value, input, status, gas_used, receipt, canonical)
-					VALUES (${chainId}, ${item.hash}, ${block.hash}, ${block.number.toString()}, ${item.transactionIndex}, ${item.from.toLowerCase()}, ${item.to?.toLowerCase() ?? null}, ${item.value.toString()}, ${item.input}, ${item.status}, ${item.gasUsed.toString()}, (${JSON.stringify(item.receipt)}::text)::jsonb, true)
+					VALUES (${chainId}, ${item.hash}, ${block.hash}, ${block.number.toString()}, ${item.transactionIndex}, ${item.from.toLowerCase()}, ${item.to?.toLowerCase() ?? null}, ${item.value.toString()}, ${item.input}, ${item.status}, ${item.gasUsed.toString()}, (${databaseJsonText(item.receipt)}::text)::jsonb, true)
 					ON CONFLICT (chain_id, block_hash, hash) DO UPDATE SET canonical = true
 				`
 				await transaction`
 					INSERT INTO actions (chain_id, block_hash, tx_hash, contract_address, function_name, function_signature, arguments, display_arguments, argument_schema, decode_status, decode_error, summary)
-					VALUES (${chainId}, ${block.hash}, ${item.hash}, ${item.to?.toLowerCase() ?? null}, ${item.decoded.name ?? null}, ${item.decoded.signature ?? null}, (${JSON.stringify(item.decoded.arguments ?? null)}::text)::jsonb, (${JSON.stringify(item.decoded.displayArguments ?? null)}::text)::jsonb, (${JSON.stringify(item.decoded.argumentSchema ?? [])}::text)::jsonb, ${item.decoded.status}, ${item.decoded.error ?? null}, ${item.decoded.summary})
+					VALUES (${chainId}, ${block.hash}, ${item.hash}, ${item.to?.toLowerCase() ?? null}, ${item.decoded.name ?? null}, ${item.decoded.signature ?? null}, (${databaseJsonText(item.decoded.arguments ?? null)}::text)::jsonb, (${databaseJsonText(item.decoded.displayArguments ?? null)}::text)::jsonb, (${databaseJsonText(item.decoded.argumentSchema ?? [])}::text)::jsonb, ${item.decoded.status}, ${item.decoded.error ?? null}, ${item.decoded.summary})
 					ON CONFLICT (chain_id, block_hash, tx_hash) DO UPDATE SET function_name = EXCLUDED.function_name, function_signature = EXCLUDED.function_signature, arguments = EXCLUDED.arguments, display_arguments = EXCLUDED.display_arguments, argument_schema = EXCLUDED.argument_schema, decode_status = EXCLUDED.decode_status, decode_error = EXCLUDED.decode_error, summary = EXCLUDED.summary
 				`
 			}
@@ -1143,173 +1151,10 @@ export class ScannerDatabase {
 			for (const item of block.logs) {
 				await transaction`
 					INSERT INTO logs (chain_id, tx_hash, block_hash, block_number, transaction_index, log_index, emitter_address, topics, data, event_name, event_signature, arguments, display_arguments, argument_schema, decode_status, decode_error, summary, canonical, finalized)
-					VALUES (${chainId}, ${item.transactionHash}, ${item.blockHash}, ${item.blockNumber.toString()}, ${item.transactionIndex}, ${item.logIndex}, ${item.address.toLowerCase()}, (${JSON.stringify(item.topics)}::text)::jsonb, ${item.data}, ${item.decoded.name ?? null}, ${item.decoded.signature ?? null}, (${JSON.stringify(item.decoded.arguments ?? null)}::text)::jsonb, (${JSON.stringify(item.decoded.displayArguments ?? null)}::text)::jsonb, (${JSON.stringify(item.decoded.argumentSchema ?? [])}::text)::jsonb, ${item.decoded.status}, ${item.decoded.error ?? null}, ${item.decoded.summary}, true, ${item.blockNumber <= block.finalizedThrough})
+					VALUES (${chainId}, ${item.transactionHash}, ${item.blockHash}, ${item.blockNumber.toString()}, ${item.transactionIndex}, ${item.logIndex}, ${item.address.toLowerCase()}, (${databaseJsonText(item.topics)}::text)::jsonb, ${item.data}, ${item.decoded.name ?? null}, ${item.decoded.signature ?? null}, (${databaseJsonText(item.decoded.arguments ?? null)}::text)::jsonb, (${databaseJsonText(item.decoded.displayArguments ?? null)}::text)::jsonb, (${databaseJsonText(item.decoded.argumentSchema ?? [])}::text)::jsonb, ${item.decoded.status}, ${item.decoded.error ?? null}, ${item.decoded.summary}, true, ${item.blockNumber <= block.finalizedThrough})
 					ON CONFLICT (chain_id, block_hash, tx_hash, log_index) DO UPDATE SET canonical = true, finalized = EXCLUDED.finalized, event_name = EXCLUDED.event_name, event_signature = EXCLUDED.event_signature, arguments = EXCLUDED.arguments, display_arguments = EXCLUDED.display_arguments, argument_schema = EXCLUDED.argument_schema, decode_status = EXCLUDED.decode_status, decode_error = EXCLUDED.decode_error, summary = EXCLUDED.summary
 				`
-				for (const projection of projectionsFrom(item)) {
-					const position = [chainId, item.blockHash, item.transactionHash, item.logIndex, item.blockNumber.toString()] as const
-					if (projection.type === 'domainEvent') {
-						await transaction`
-							INSERT INTO protocol_timeline_entries (chain_id, block_hash, tx_hash, log_index, block_number, entity_type, entity_identity, semantic_event_kind, summary_data, related_entities, source_contract, source_event, canonical)
-							VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.entityType}, ${projection.entityIdentity}, ${projection.semanticEventKind}, (${JSON.stringify(projection.data)}::text)::jsonb, (${JSON.stringify(projection.relatedEntities)}::text)::jsonb, ${item.address.toLowerCase()}, ${projection.semanticEventKind}, true)
-							ON CONFLICT (chain_id, block_hash, tx_hash, log_index, entity_type, entity_identity) DO UPDATE SET canonical = true, summary_data = EXCLUDED.summary_data, related_entities = EXCLUDED.related_entities
-						`
-						if (projection.domain === 'report') {
-							const reportId = projection.data['reportId']
-							const roundNumber = projection.data['numReports']
-							if (typeof reportId !== 'string') throw new Error(`${projection.semanticEventKind} is missing reportId`)
-							await transaction`
-								INSERT INTO open_oracle_report_events (chain_id, block_hash, tx_hash, log_index, block_number, open_oracle_address, report_id, event_name, round_number, report_data, canonical)
-								VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${item.address.toLowerCase()}, ${reportId}, ${projection.semanticEventKind}, ${typeof roundNumber === 'string' ? roundNumber : null}, (${JSON.stringify(projection.data)}::text)::jsonb, true)
-								ON CONFLICT (chain_id, block_hash, tx_hash, log_index, open_oracle_address, report_id) DO UPDATE SET canonical = true, report_data = EXCLUDED.report_data
-							`
-						}
-						if (projection.domain === 'escalation')
-							await transaction`
-								INSERT INTO escalation_game_events (chain_id, block_hash, tx_hash, log_index, block_number, game_address, event_name, event_data, canonical)
-								VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${item.address.toLowerCase()}, ${projection.semanticEventKind}, (${JSON.stringify(projection.data)}::text)::jsonb, true)
-								ON CONFLICT (chain_id, block_hash, tx_hash, log_index, game_address) DO UPDATE SET canonical = true, event_data = EXCLUDED.event_data
-							`
-						if (projection.domain === 'auction')
-							await transaction`
-								INSERT INTO truth_auction_events (chain_id, block_hash, tx_hash, log_index, block_number, auction_address, event_name, event_data, canonical)
-								VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${item.address.toLowerCase()}, ${projection.semanticEventKind}, (${JSON.stringify(projection.data)}::text)::jsonb, true)
-								ON CONFLICT (chain_id, block_hash, tx_hash, log_index, auction_address) DO UPDATE SET canonical = true, event_data = EXCLUDED.event_data
-							`
-						if (projection.domain === 'trading')
-							await transaction`
-								INSERT INTO amm_trade_events (chain_id, block_hash, tx_hash, log_index, block_number, market_address, event_name, event_data, canonical)
-								VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${item.address.toLowerCase()}, ${projection.semanticEventKind}, (${JSON.stringify(projection.data)}::text)::jsonb, true)
-								ON CONFLICT (chain_id, block_hash, tx_hash, log_index, market_address) DO UPDATE SET canonical = true, event_data = EXCLUDED.event_data
-							`
-						if (projection.domain === 'fork')
-							await transaction`
-								INSERT INTO fork_migration_events (chain_id, block_hash, tx_hash, log_index, block_number, universe_identity, event_name, event_data, canonical)
-								VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.entityIdentity}, ${projection.semanticEventKind}, (${JSON.stringify(projection.data)}::text)::jsonb, true)
-								ON CONFLICT (chain_id, block_hash, tx_hash, log_index, universe_identity) DO UPDATE SET canonical = true, event_data = EXCLUDED.event_data
-							`
-						if (projection.domain === 'approval') {
-							const approvalId = projection.data['approvalId']
-							const receiverVault = projection.data['receiverVault']
-							await transaction`
-								INSERT INTO liquidation_approval_events (chain_id, block_hash, tx_hash, transaction_index, log_index, block_number, registry_address, approval_identity, receiver_vault, event_name, event_data, canonical)
-								VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${item.transactionIndex}, ${position[3]}, ${position[4]}, ${item.address.toLowerCase()}, ${typeof approvalId === 'string' ? approvalId.toLowerCase() : `nonce:${String(receiverVault ?? 'unknown').toLowerCase()}`}, ${typeof receiverVault === 'string' ? receiverVault.toLowerCase() : null}, ${projection.semanticEventKind}, (${JSON.stringify(projection.data)}::text)::jsonb, true)
-								ON CONFLICT (chain_id, block_hash, tx_hash, log_index, registry_address) DO UPDATE SET canonical = true, event_data = EXCLUDED.event_data
-							`
-						}
-						continue
-					}
-					if (projection.type === 'question') {
-						await transaction`
-							INSERT INTO questions (chain_id, block_hash, tx_hash, log_index, block_number, question_id, created_timestamp, title, description, start_time, end_time, num_ticks, display_value_min, display_value_max, answer_unit, outcome_options, canonical)
-							VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.questionId}, ${projection.createdTimestamp}, ${projection.title}, ${projection.description}, ${projection.startTime}, ${projection.endTime}, ${projection.numTicks}, ${projection.displayValueMin}, ${projection.displayValueMax}, ${projection.answerUnit}, (${JSON.stringify(projection.outcomeOptions)}::text)::jsonb, true)
-							ON CONFLICT (chain_id, block_hash, tx_hash, log_index, question_id) DO UPDATE SET canonical = true
-						`
-						continue
-					}
-					if (projection.type === 'pool') {
-						await transaction`
-							INSERT INTO pools (chain_id, block_hash, tx_hash, log_index, block_number, pool_address, parent_address, universe_id, question_id, truth_auction_address, coordinator_address, share_token_address, security_multiplier_bps, initial_priority_fee_atto_eth_per_gas, initial_retention_rate, initial_settlement_collateral_atto_eth, canonical)
-							VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.poolAddress}, ${projection.parentAddress}, ${projection.universeId}, ${projection.questionId}, ${projection.truthAuctionAddress}, ${projection.coordinatorAddress}, ${projection.shareTokenAddress}, ${projection.securityMultiplierBps}, ${projection.initialPriorityFeeAttoEthPerGas}, ${projection.initialRetentionRate}, ${projection.initialSettlementCollateralAttoEth}, true)
-							ON CONFLICT (chain_id, block_hash, tx_hash, log_index, pool_address) DO UPDATE SET canonical = true
-						`
-						continue
-					}
-					if (projection.type === 'poolSnapshot') {
-						await transaction`
-							INSERT INTO pool_snapshots (chain_id, block_hash, tx_hash, log_index, block_number, pool_address, reason, vault_address, settlement_collateral_atto_eth, total_capacity_ownership_atto_rep, fee_eligible_capacity_ownership_atto_rep, total_claimable_vault_fees_atto_eth, unallocated_accrued_fees_atto_eth, fee_index, fee_index_remainder, total_fees_owed_remainder, uncheckpointed_fee_eligible_capacity_ownership_atto_rep, last_updated_fee_accumulator, current_retention_rate, canonical)
-							VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.poolAddress}, ${projection.reason}, ${projection.vaultAddress}, ${projection.settlementCollateralAttoEth}, ${projection.totalCapacityOwnershipAttoRep}, ${projection.feeEligibleCapacityOwnershipAttoRep}, ${projection.totalClaimableVaultFeesAttoEth}, ${projection.unallocatedAccruedFeesAttoEth}, ${projection.feeIndex}, ${projection.feeIndexRemainder}, ${projection.totalFeesOwedRemainder}, ${projection.uncheckpointedFeeEligibleCapacityOwnershipAttoRep}, ${projection.lastUpdatedFeeAccumulator}, ${projection.currentRetentionRate}, true)
-							ON CONFLICT (chain_id, block_hash, tx_hash, log_index, pool_address) DO UPDATE SET canonical = true
-						`
-						continue
-					}
-					if (projection.type === 'vaultSnapshot') {
-						await transaction`
-							INSERT INTO vault_snapshots (chain_id, block_hash, tx_hash, log_index, block_number, pool_address, vault_address, rep_backing_units, capacity_ownership_atto_rep, claimable_fees_atto_eth, fee_index, vault_fee_remainder, resulting_total_rep_backing_units, resulting_fee_eligible_capacity_ownership_atto_rep, canonical)
-							VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.poolAddress}, ${projection.vaultAddress}, ${projection.repBackingUnits}, ${projection.capacityOwnershipAttoRep}, ${projection.claimableFeesAttoEth}, ${projection.feeIndex}, ${projection.vaultFeeRemainder}, ${projection.resultingTotalRepBackingUnits}, ${projection.resultingFeeEligibleCapacityOwnershipAttoRep}, true)
-							ON CONFLICT (chain_id, block_hash, tx_hash, log_index, pool_address, vault_address) DO UPDATE SET canonical = true
-						`
-						continue
-					}
-					if (projection.type === 'poolState') {
-						await transaction`
-							INSERT INTO pool_state_events (chain_id, block_hash, tx_hash, log_index, block_number, pool_address, event_name, state, canonical)
-							VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.poolAddress}, ${projection.eventName}, (${JSON.stringify(projection.state)}::text)::jsonb, true)
-							ON CONFLICT (chain_id, block_hash, tx_hash, log_index, pool_address) DO UPDATE SET canonical = true, state = EXCLUDED.state
-						`
-						continue
-					}
-					if (projection.type === 'ammMarket') {
-						await transaction`
-							INSERT INTO amm_markets (chain_id, block_hash, tx_hash, log_index, block_number, pair_address, pool_address, share_token_address, universe_id, fee_bps, canonical)
-							VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.pairAddress}, ${projection.poolAddress}, ${projection.shareTokenAddress}, ${projection.universeId}, ${projection.feeBps}, true)
-							ON CONFLICT (chain_id, block_hash, tx_hash, log_index, pair_address) DO UPDATE SET canonical = true
-						`
-						continue
-					}
-					if (projection.type === 'ammPrice') {
-						await transaction`
-							INSERT INTO amm_price_snapshots (chain_id, block_hash, tx_hash, log_index, block_number, pair_address, yes_reserve_atto_shares, no_reserve_atto_shares, conditional_yes_bps, conditional_no_bps, canonical)
-							VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.pairAddress}, ${projection.yesReserveAttoShares}, ${projection.noReserveAttoShares}, ${projection.conditionalYesBps}, ${projection.conditionalNoBps}, true)
-							ON CONFLICT (chain_id, block_hash, tx_hash, log_index, pair_address) DO UPDATE SET canonical = true
-						`
-						continue
-					}
-					if (projection.type === 'repEthPrice') {
-						await transaction`
-							INSERT INTO rep_eth_price_snapshots (chain_id, block_hash, tx_hash, log_index, block_number, coordinator_address, event_name, report_id, rep_per_eth_1e18, settlement_timestamp, canonical)
-							VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.coordinatorAddress}, ${projection.eventName}, ${projection.reportId ?? null}, ${projection.repPerEth1e18}, ${projection.settlementTimestamp ?? null}, true)
-							ON CONFLICT (chain_id, block_hash, tx_hash, log_index, coordinator_address) DO UPDATE SET canonical = true
-						`
-						continue
-					}
-					if (projection.type === 'uniswapMarket') {
-						const supportedV4Market = projection.venue === 'v4' && isSupportedUniswapV4Market(projection)
-						await transaction`
-							INSERT INTO uniswap_rep_eth_markets (chain_id, block_hash, tx_hash, log_index, block_number, venue, market_id, contract_address, token0_address, token1_address, fee_hundredths_bip, tick_spacing, hooks_address, canonical)
-							SELECT ${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.venue}, ${projection.marketId}, ${projection.contractAddress}, ${projection.token0Address}, ${projection.token1Address}, ${projection.feeHundredthsBip}, ${projection.tickSpacing ?? null}, ${projection.hooksAddress ?? null}, true
-							WHERE (
-								${projection.venue} IN ('v2', 'v3') AND (
-									EXISTS (SELECT 1 FROM contracts WHERE chain_id = ${chainId} AND address = ${projection.token0Address} AND kind = 'reputationToken' AND canonical)
-									AND EXISTS (SELECT 1 FROM contracts WHERE chain_id = ${chainId} AND address = ${projection.token1Address} AND kind IN ('weth', 'usdc') AND canonical)
-									OR EXISTS (SELECT 1 FROM contracts WHERE chain_id = ${chainId} AND address = ${projection.token1Address} AND kind = 'reputationToken' AND canonical)
-									AND EXISTS (SELECT 1 FROM contracts WHERE chain_id = ${chainId} AND address = ${projection.token0Address} AND kind IN ('weth', 'usdc') AND canonical)
-								)
-								) OR (
-									${projection.venue} = 'v4'
-									AND ${supportedV4Market}
-									AND EXISTS (SELECT 1 FROM contracts WHERE chain_id = ${chainId} AND address = ${projection.contractAddress} AND kind = 'uniswapV4PoolManager' AND canonical)
-									AND (
-										${projection.token0Address} = ${zeroAddress}
-										AND EXISTS (SELECT 1 FROM contracts WHERE chain_id = ${chainId} AND address = ${projection.token1Address} AND kind = 'reputationToken' AND canonical)
-										OR EXISTS (SELECT 1 FROM contracts WHERE chain_id = ${chainId} AND address = ${projection.token0Address} AND kind = 'reputationToken' AND canonical)
-										AND EXISTS (SELECT 1 FROM contracts WHERE chain_id = ${chainId} AND address = ${projection.token1Address} AND kind = 'usdc' AND canonical)
-										OR EXISTS (SELECT 1 FROM contracts WHERE chain_id = ${chainId} AND address = ${projection.token1Address} AND kind = 'reputationToken' AND canonical)
-										AND EXISTS (SELECT 1 FROM contracts WHERE chain_id = ${chainId} AND address = ${projection.token0Address} AND kind = 'usdc' AND canonical)
-									)
-								)
-							ON CONFLICT (chain_id, block_hash, tx_hash, log_index, market_id) DO UPDATE SET canonical = true
-						`
-						continue
-					}
-					if (projection.type === 'uniswapPrice') {
-						await transaction`
-							INSERT INTO uniswap_rep_eth_price_observations (chain_id, block_hash, tx_hash, log_index, block_number, venue, market_id, event_name, reserve0, reserve1, sqrt_price_x96, liquidity, canonical)
-							SELECT ${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.venue}, ${projection.marketId}, ${projection.eventName}, ${projection.reserve0 ?? null}, ${projection.reserve1 ?? null}, ${projection.sqrtPriceX96 ?? null}, ${projection.liquidity ?? null}, true
-							WHERE EXISTS (
-								SELECT 1 FROM uniswap_rep_eth_markets
-								WHERE chain_id = ${chainId} AND venue = ${projection.venue} AND market_id = ${projection.marketId} AND canonical
-							)
-							ON CONFLICT (chain_id, block_hash, tx_hash, log_index, market_id) DO UPDATE SET canonical = true
-						`
-						continue
-					}
-					await transaction`
-						INSERT INTO universe_events (chain_id, block_hash, tx_hash, log_index, block_number, universe_id, event_name, parent_universe_id, forking_outcome_index, reputation_token_address, fork_question_id, fork_time, forker_address, fork_threshold_atto_rep, migration_rep_balance_atto_rep, theoretical_supply_atto_rep, canonical)
-						VALUES (${position[0]}, ${position[1]}, ${position[2]}, ${position[3]}, ${position[4]}, ${projection.universeId}, ${projection.eventName}, ${projection.parentUniverseId ?? null}, ${projection.forkingOutcomeIndex ?? null}, ${projection.reputationTokenAddress ?? null}, ${projection.forkQuestionId ?? null}, ${projection.forkTime ?? null}, ${projection.forkerAddress ?? null}, ${projection.forkThresholdAttoRep ?? null}, ${projection.migrationRepBalanceAttoRep ?? null}, ${projection.theoreticalSupplyAttoRep ?? null}, true)
-						ON CONFLICT (chain_id, block_hash, tx_hash, log_index, universe_id) DO UPDATE SET canonical = true
-					`
-				}
+				await storeLogProjections(transaction, chainId, item)
 			}
 			for (const cursor of block.logScanCursors) {
 				assertLogScanCursorUpdate(block.number, cursor)
@@ -1332,7 +1177,7 @@ export class ScannerDatabase {
 			await lockLiveEventWriter(transaction)
 			await transaction`
 				INSERT INTO live_events (event, payload)
-				VALUES ('block', (${JSON.stringify({ chainId, blockNumber: block.number.toString(), logs: block.logs.length })}::text)::jsonb)
+				VALUES ('block', (${databaseJsonText({ chainId, blockNumber: block.number.toString(), logs: block.logs.length })}::text)::jsonb)
 			`
 		})
 	}
@@ -1341,7 +1186,7 @@ export class ScannerDatabase {
 		await withIndexerLease(lease, async (transaction) => {
 			await transaction`UPDATE networks SET observed_block = ${head.toString()}, phase = ${phase}, last_poll_at = now(), last_success_at = now(), last_error = null, failure_started_at = null, consecutive_failures = 0, next_retry_at = null, updated_at = now() WHERE chain_id = ${chainId}`
 			await lockLiveEventWriter(transaction)
-			await transaction`INSERT INTO live_events (event, payload) VALUES ('status', (${JSON.stringify({ chainId, blockNumber: head.toString() })}::text)::jsonb)`
+			await transaction`INSERT INTO live_events (event, payload) VALUES ('status', (${databaseJsonText({ chainId, blockNumber: head.toString() })}::text)::jsonb)`
 		})
 	}
 
@@ -1366,7 +1211,7 @@ export class ScannerDatabase {
 			await lockLiveEventWriter(transaction)
 			await transaction`
 				INSERT INTO live_events (event, payload)
-				VALUES ('reorg', (${JSON.stringify({ chainId, previousBlock: previousBlock?.toString(), ancestor: '-1', depth: invalidatedDepth.toString(), startBlock: startBlock.toString() })}::text)::jsonb)
+				VALUES ('reorg', (${databaseJsonText({ chainId, previousBlock: previousBlock?.toString(), ancestor: '-1', depth: invalidatedDepth.toString(), startBlock: startBlock.toString() })}::text)::jsonb)
 			`
 			return true
 		})
@@ -1384,7 +1229,7 @@ export class ScannerDatabase {
 			await lockLiveEventWriter(transaction)
 			await transaction`
 				INSERT INTO live_events (event, payload)
-				VALUES ('status', (${JSON.stringify({ chainId, phase: 'degraded', nextRetryAt: nextRetryAt.toISOString(), failures: Number(rows[0]?.['consecutive_failures'] ?? 1) })}::text)::jsonb)
+				VALUES ('status', (${databaseJsonText({ chainId, phase: 'degraded', nextRetryAt: nextRetryAt.toISOString(), failures: Number(rows[0]?.['consecutive_failures'] ?? 1) })}::text)::jsonb)
 			`
 		})
 	}

--- a/augurScan/src/indexer.ts
+++ b/augurScan/src/indexer.ts
@@ -672,13 +672,21 @@ class NetworkIndexer {
 		let retainedBoundary = checkpoint?.number ?? storedBlockTip
 		if (storedStartBlock !== undefined) {
 			if (this.#configuredStartBlock > storedStartBlock) {
-				await this.#database.seedNetwork(this.#network, lease, true, true)
+				await this.#database.seedNetwork(this.#network, {
+					lease,
+					resetCanonicalHistoryOnManifestChange: true,
+					preserveStoredStart: true,
+				})
 				throw new Error('Stored history boundary validation unexpectedly succeeded')
 			}
 			this.#network = { ...this.#network, startBlock: storedStartBlock }
 			if (retainedBoundary === undefined) retainedBoundary = await this.#withProviderFailover(() => this.#client.getBlockNumber())
 			await this.#validateManifestChange(retainedBoundary, storedStartBlock, lease)
-			const manifestChanged = await this.#database.seedNetwork(this.#network, lease, true, true)
+			const manifestChanged = await this.#database.seedNetwork(this.#network, {
+				lease,
+				resetCanonicalHistoryOnManifestChange: true,
+				preserveStoredStart: true,
+			})
 			if (checkpoint !== undefined && manifestChanged) this.#reportManifestReplay(checkpoint)
 			return
 		}
@@ -696,7 +704,11 @@ class NetworkIndexer {
 				`[${this.#network.id}] initial index boundary: block #${startBlock}; earliest tracked deployment discovered through observed head #${observedHead}`,
 			)
 		})
-		const manifestChanged = await this.#database.seedNetwork(this.#network, lease, true, true)
+		const manifestChanged = await this.#database.seedNetwork(this.#network, {
+			lease,
+			resetCanonicalHistoryOnManifestChange: true,
+			preserveStoredStart: true,
+		})
 		if (checkpoint !== undefined && manifestChanged) this.#reportManifestReplay(checkpoint)
 	}
 

--- a/augurScan/tests/indexer-lifecycle.test.ts
+++ b/augurScan/tests/indexer-lifecycle.test.ts
@@ -7,7 +7,6 @@ import {
 	type IndexedBlock,
 	type IndexerLease,
 	manifestContractSetChanged,
-	runFencedIndexerTransaction,
 	ScannerDatabase,
 	type StoredTransaction,
 } from '../src/database.ts'
@@ -3120,22 +3119,6 @@ describe('network indexer lifecycle', () => {
 		expect(() => assertIndexerLeaseReleaseObservation(41, 41, false)).toThrow(
 			'Indexer lease unlock failed on PostgreSQL backend 41; lock ownership may already be lost',
 		)
-	})
-
-	test('does not run a leased mutation when the transaction uses another PostgreSQL backend', async () => {
-		let mutated = false
-		const transaction = { backendPid: 42 }
-
-		await expect(
-			runFencedIndexerTransaction(
-				async (operation) => await operation(transaction),
-				async (activeTransaction: { readonly backendPid: number }) => assertIndexerLeaseObservation(41, activeTransaction.backendPid, true),
-				async () => {
-					mutated = true
-				},
-			),
-		).rejects.toThrow('Indexer lease moved from PostgreSQL backend 41 to 42')
-		expect(mutated).toBeFalse()
 	})
 
 	test('does not select shared tokens as standalone activity sources', () => {

--- a/augurScan/tests/logging.test.ts
+++ b/augurScan/tests/logging.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { resolveRpcLogPath } from '../src/config.ts'
 import { runSerializedIndexerLeaseOperation } from '../src/database.ts'
+import { databaseJsonText } from '../src/database-json.ts'
 import { safeIndexerFailureReason } from '../src/indexer-runtime.ts'
 import { createRpcLoggingFetch, jsonRpcErrorName, RotatingJsonLog, timestampedLogArguments } from '../src/logging.ts'
 import { RpcRequestMethodError } from '../src/rpc-request-queue.ts'
@@ -226,5 +227,31 @@ describe('AugurScan runtime logging', () => {
 			runSerializedIndexerLeaseOperation(lease, operation),
 		])
 		expect(maximumActive).toBe(1)
+	})
+
+	test('continues serializing lease operations after one rejects', async () => {
+		const lease = {}
+		await expect(
+			runSerializedIndexerLeaseOperation(lease, async () => {
+				throw new Error('expected operation failure')
+			}),
+		).rejects.toThrow('expected operation failure')
+		await expect(runSerializedIndexerLeaseOperation(lease, async () => 'recovered')).resolves.toBe('recovered')
+	})
+
+	test('serializes nested bigints for PostgreSQL JSON columns', () => {
+		expect(JSON.parse(databaseJsonText({ blockNumber: 2n, receipt: { gasUsed: 21_000n }, values: [1n, undefined] }))).toEqual({
+			blockNumber: '2',
+			receipt: { gasUsed: '21000' },
+			values: ['1', null],
+		})
+	})
+
+	test('preserves JSON absence and non-finite number behavior', () => {
+		expect(JSON.parse(databaseJsonText({ omitted: undefined, invalid: Number.POSITIVE_INFINITY, timestamp: new Date('2026-01-02T00:00:00Z') }))).toEqual({
+			invalid: null,
+			timestamp: '2026-01-02T00:00:00.000Z',
+		})
+		expect(() => databaseJsonText(undefined)).toThrow('Database JSON value cannot be serialized')
 	})
 })

--- a/augurScan/tests/postgres.integration.test.ts
+++ b/augurScan/tests/postgres.integration.test.ts
@@ -7,7 +7,9 @@ import {
 	assertLogScanCursorUpdate,
 	assertRewindTarget,
 	assertStartBlockCompatible,
+	canonicalTablePolicies,
 	type IndexedBlock,
+	type IndexerLease,
 	lockLiveEventWriter,
 	releaseReservedConnection,
 	replayWindowExpired,
@@ -38,6 +40,16 @@ const inverseUniswapPairAddress = getAddress('0xa0000000000000000000000000000000
 const uniswapV4PoolManagerAddress = getAddress('0xb000000000000000000000000000000000000009')
 const transactionHash = keccak256(stringToHex('augurScan integration transaction'))
 const blockHash = (name: string) => keccak256(stringToHex(name))
+
+const resetLiveEventFixtures = async (database: ScannerDatabase): Promise<void> => {
+	await database.sql.unsafe('TRUNCATE TABLE live_events RESTART IDENTITY')
+	await database.sql`UPDATE live_event_state SET pruned_through_id = 0, updated_at = now() WHERE singleton`
+}
+
+const resetIntegrationFixtures = async (database: ScannerDatabase): Promise<void> => {
+	await database.sql.unsafe('TRUNCATE TABLE networks CASCADE')
+	await resetLiveEventFixtures(database)
+}
 
 const transaction = (): StoredTransaction => ({
 	hash: transactionHash,
@@ -324,6 +336,89 @@ postgresTest('rejects every public namespace object before fresh schema initiali
 	}
 })
 
+postgresTest('classifies every chain-scoped canonical table', async () => {
+	if (postgresUrl === undefined) throw new Error('POSTGRES_TEST_URL disappeared')
+	const database = new ScannerDatabase(postgresUrl)
+	try {
+		await initializeSchema(database.sql)
+		const rows = await database.sql`
+			SELECT canonical.table_name
+			FROM information_schema.columns AS canonical
+			JOIN information_schema.columns AS chain
+				ON chain.table_schema = canonical.table_schema AND chain.table_name = canonical.table_name
+			WHERE canonical.table_schema = 'public' AND canonical.column_name = 'canonical' AND chain.column_name = 'chain_id'
+			ORDER BY canonical.table_name
+		`
+		expect(rows.map((row: Record<string, unknown>) => String(row['table_name']))).toEqual(canonicalTablePolicies.map(({ table }) => table).toSorted())
+	} finally {
+		await database.close()
+	}
+})
+
+postgresTest('drains lease operations queued before release and rejects later work', async () => {
+	if (postgresUrl === undefined) throw new Error('POSTGRES_TEST_URL disappeared')
+	const database = new ScannerDatabase(postgresUrl)
+	const blocker = new ScannerDatabase(postgresUrl)
+	const releaseChainId = chainId + 20 + process.pid
+	const network = {
+		id: `lease-release-${releaseChainId}`,
+		name: 'Lease release ordering',
+		chainId: releaseChainId,
+		rpcUrls: ['http://127.0.0.1:8545'],
+		startBlock: 0n,
+		explorerBaseUrl: 'https://example.invalid',
+		nativeSymbol: 'ETH',
+		confirmationDepth: 0n,
+		contracts: [],
+	} satisfies NetworkConfig
+	let lease: IndexerLease | undefined
+	let unblockRow: (() => void) | undefined
+	let blockingTransaction: Promise<void> | undefined
+	const rowBlocked = new Promise<void>((resolve) => {
+		unblockRow = resolve
+	})
+	try {
+		await initializeSchema(database.sql)
+		await database.seedNetwork(network)
+		lease = await database.tryAcquireIndexerLock(releaseChainId)
+		if (lease === undefined) throw new Error('release-ordering writer did not acquire its lock')
+		let confirmRowLocked: (() => void) | undefined
+		const rowLocked = new Promise<void>((resolve) => {
+			confirmRowLocked = resolve
+		})
+		blockingTransaction = blocker.sql.begin(async (transaction) => {
+			await transaction`SELECT 1 FROM networks WHERE chain_id = ${releaseChainId} FOR UPDATE`
+			confirmRowLocked?.()
+			await rowBlocked
+		})
+		await rowLocked
+
+		const firstUpdate = database.updateObservedHead(releaseChainId, 1n, 'backfilling', lease)
+		for (let attempt = 0; attempt < 100; attempt++) {
+			const activity = await database.sql`SELECT wait_event_type FROM pg_stat_activity WHERE pid = ${lease.backendPid}`
+			if (activity[0]?.['wait_event_type'] === 'Lock') break
+			if (attempt === 99) throw new Error('lease operation did not wait for the network row lock')
+			await Bun.sleep(10)
+		}
+		const secondUpdate = database.updateObservedHead(releaseChainId, 2n, 'live', lease)
+		const release = lease.release()
+		unblockRow?.()
+		await blockingTransaction
+		await Promise.all([firstUpdate, secondUpdate, release])
+
+		const stored = await database.sql`SELECT observed_block, phase FROM networks WHERE chain_id = ${releaseChainId}`
+		expect(stored).toEqual([{ observed_block: '2', phase: 'live' }])
+		await expect(database.updateObservedHead(releaseChainId, 3n, 'live', lease)).rejects.toThrow('Indexer lease was released')
+	} finally {
+		unblockRow?.()
+		await blockingTransaction?.catch(() => undefined)
+		await lease?.release().catch(() => undefined)
+		await database.sql`DELETE FROM networks WHERE chain_id = ${releaseChainId}`
+		await blocker.close()
+		await database.close()
+	}
+})
+
 postgresTest('advances the canonical coverage floor when RPC log history is pruned', async () => {
 	if (postgresUrl === undefined) throw new Error('POSTGRES_TEST_URL disappeared')
 	const database = new ScannerDatabase(postgresUrl)
@@ -408,6 +503,10 @@ postgresTest('advances the canonical coverage floor when RPC log history is prun
 			}
 			const forwardBlock = retrievableBlock('retrievable-boundary', new Date('2026-02-11T00:00:00Z'))
 			await database.storeBlock(boundaryChainId, forwardBlock, lease)
+			const storedReceipt = await database.sql`
+				SELECT receipt FROM transactions WHERE chain_id = ${boundaryChainId} AND block_hash = ${forwardBlock.hash}
+			`
+			expect(storedReceipt[0]?.['receipt']).toMatchObject({ blockNumber: '2' })
 			await database.rewind(boundaryChainId, -1n, undefined, lease)
 			expect((await database.contracts(boundaryChainId, lease)).get(discoveredAddress.toLowerCase())).toMatchObject(dynamicContract)
 			expect((await database.contracts(boundaryChainId, lease)).has(orphanOnlyAddress.toLowerCase())).toBe(false)
@@ -419,9 +518,7 @@ postgresTest('advances the canonical coverage floor when RPC log history is prun
 						startBlock: 2n,
 						contracts: [...network.contracts, [promotedAddress, 'Additional manifest source', 'openOracle']],
 					},
-					lease,
-					true,
-					true,
+					{ lease, resetCanonicalHistoryOnManifestChange: true, preserveStoredStart: true },
 				),
 			).toBe(true)
 			const contractsAfterReseed = await database.contracts(boundaryChainId, lease)
@@ -438,24 +535,26 @@ postgresTest('advances the canonical coverage floor when RPC log history is prun
 					[orphanOnlyAddress, 'Promoted orphan', 'securityPool'],
 				],
 			} satisfies NetworkConfig
-			expect(await database.seedNetwork(promotedNetwork, lease, true, true)).toBe(true)
+			expect(await database.seedNetwork(promotedNetwork, { lease, resetCanonicalHistoryOnManifestChange: true, preserveStoredStart: true })).toBe(true)
 			expect((await database.contracts(boundaryChainId, lease)).get(discoveredAddress.toLowerCase())).toMatchObject({
 				discoveryBlock: 1n,
 				provenance: 'manifest',
 			})
-			expect(await database.seedNetwork(promotedNetwork, lease, true, true)).toBe(false)
+			expect(await database.seedNetwork(promotedNetwork, { lease, resetCanonicalHistoryOnManifestChange: true, preserveStoredStart: true })).toBe(false)
 			expect((await database.contracts(boundaryChainId, lease)).get(discoveredAddress.toLowerCase())).toMatchObject({
 				discoveryBlock: 1n,
 				provenance: 'manifest',
 			})
 			await database.storeBlock(boundaryChainId, retrievableBlock('retrievable-during-promotion', new Date('2026-02-14T00:00:00Z')), lease)
-			expect(await database.seedNetwork({ ...network, startBlock: 2n }, lease, true, true)).toBe(true)
+			expect(
+				await database.seedNetwork({ ...network, startBlock: 2n }, { lease, resetCanonicalHistoryOnManifestChange: true, preserveStoredStart: true }),
+			).toBe(true)
 			const contractsAfterPromotionRemoval = await database.contracts(boundaryChainId, lease)
 			expect(contractsAfterPromotionRemoval.get(discoveredAddress.toLowerCase())).toMatchObject(dynamicContract)
 			expect(contractsAfterPromotionRemoval.has(orphanOnlyAddress.toLowerCase())).toBe(false)
 			await database.storeBlock(boundaryChainId, retrievableBlock('retrievable-after-promotion-removal', new Date('2026-02-15T00:00:00Z')), lease)
 			const retainedLogs = await database.sql`
-				SELECT block_number FROM logs WHERE chain_id = ${boundaryChainId} AND address = ${discoveredAddress.toLowerCase()} AND canonical
+				SELECT block_number FROM logs WHERE chain_id = ${boundaryChainId} AND emitter_address = ${discoveredAddress.toLowerCase()} AND canonical
 			`
 			expect(retainedLogs).toEqual([{ block_number: '2' }])
 			expect((await database.logScanCursors(boundaryChainId, lease)).get(discoveredAddress.toLowerCase())).toEqual({
@@ -471,809 +570,836 @@ postgresTest('advances the canonical coverage floor when RPC log history is prun
 			await lease.release()
 		}
 	} finally {
-		await database.sql`DELETE FROM networks WHERE chain_id = ${boundaryChainId}`
+		await resetIntegrationFixtures(database)
 		await database.close()
 	}
 })
 
-postgresTest('initializes, resumes, retains an orphan, and serves only its canonical replacement', async () => {
-	if (postgresUrl === undefined) throw new Error('POSTGRES_TEST_URL disappeared')
-	const database = new ScannerDatabase(postgresUrl)
-	try {
-		await initializeSchema(database.sql)
-		const concurrentMigrator = new ScannerDatabase(postgresUrl)
+postgresTest(
+	'initializes, resumes, retains an orphan, and serves only its canonical replacement',
+	async () => {
+		if (postgresUrl === undefined) throw new Error('POSTGRES_TEST_URL disappeared')
+		const database = new ScannerDatabase(postgresUrl)
+		let writeLease: IndexerLease | undefined
 		try {
-			await Promise.all([initializeSchema(database.sql), initializeSchema(concurrentMigrator.sql)])
-			await initializeSchema(concurrentMigrator.sql)
-		} finally {
-			await concurrentMigrator.close()
-		}
-		await database.sql.unsafe('TRUNCATE TABLE networks CASCADE')
-		await database.sql.unsafe('TRUNCATE TABLE live_events RESTART IDENTITY')
-		await database.sql`UPDATE live_event_state SET pruned_through_id = 0, updated_at = now() WHERE singleton`
-		const concurrentWriter = new ScannerDatabase(postgresUrl)
-		try {
-			let firstLocked: (() => void) | undefined
-			let releaseFirst: (() => void) | undefined
-			const locked = new Promise<void>((resolve) => {
-				firstLocked = resolve
+			await initializeSchema(database.sql)
+			const concurrentMigrator = new ScannerDatabase(postgresUrl)
+			try {
+				await Promise.all([initializeSchema(database.sql), initializeSchema(concurrentMigrator.sql)])
+				await initializeSchema(concurrentMigrator.sql)
+			} finally {
+				await concurrentMigrator.close()
+			}
+			await resetIntegrationFixtures(database)
+			const concurrentWriter = new ScannerDatabase(postgresUrl)
+			try {
+				let firstLocked: (() => void) | undefined
+				let releaseFirst: (() => void) | undefined
+				const locked = new Promise<void>((resolve) => {
+					firstLocked = resolve
+				})
+				const release = new Promise<void>((resolve) => {
+					releaseFirst = resolve
+				})
+				const firstWrite = database.sql.begin(async (transaction) => {
+					await lockLiveEventWriter(transaction)
+					const rows = await transaction`INSERT INTO live_events (event, payload) VALUES ('status', '{"writer":1}'::jsonb) RETURNING id`
+					firstLocked?.()
+					await release
+					return Number(rows[0]?.['id'])
+				})
+				await locked
+				let secondInserted = false
+				const secondWrite = concurrentWriter.sql.begin(async (transaction) => {
+					await lockLiveEventWriter(transaction)
+					const rows = await transaction`INSERT INTO live_events (event, payload) VALUES ('status', '{"writer":2}'::jsonb) RETURNING id`
+					secondInserted = true
+					return Number(rows[0]?.['id'])
+				})
+				await Bun.sleep(25)
+				expect(secondInserted).toBe(false)
+				releaseFirst?.()
+				expect(await Promise.all([firstWrite, secondWrite])).toEqual([1, 2])
+			} finally {
+				await concurrentWriter.close()
+			}
+			await resetLiveEventFixtures(database)
+			await database.sql`INSERT INTO live_events (event, payload, created_at) VALUES ('status', '{}'::jsonb, now() - interval '8 days')`
+			await database.pruneLiveEvents()
+			expect(await database.eventsAfter(0)).toEqual([{ id: 1, event: 'reset', payload: { reason: 'replay-window-expired', refreshRequired: true } }])
+			const network: NetworkConfig = {
+				id: 'integration',
+				name: 'Integration chain',
+				chainId,
+				rpcUrls: ['http://127.0.0.1:8545'],
+				startBlock: 1n,
+				explorerBaseUrl: 'https://example.invalid',
+				nativeSymbol: 'ETH',
+				confirmationDepth: 8n,
+				contracts: [[address, 'Manifest contract', 'zoltar']],
+			}
+			expect(await database.seedNetwork(network)).toBe(false)
+			expect(await database.networkStartBlock(chainId)).toBe(1n)
+			await expect(database.seedNetwork({ ...network, startBlock: 3n }, { preserveStoredStart: true })).rejects.toThrow(
+				'while an effective index start is retained',
+			)
+			expect(await database.networkStartBlock(chainId)).toBe(1n)
+			const zeroBoundaryNetwork = { ...network, id: 'zero-boundary', chainId: chainId + 1, startBlock: 0n }
+			expect(await database.seedNetwork(zeroBoundaryNetwork)).toBe(false)
+			await expect(database.seedNetwork({ ...zeroBoundaryNetwork, startBlock: 100n }, { preserveStoredStart: true })).rejects.toThrow(
+				'while an effective index start is retained',
+			)
+			expect(await database.networkStartBlock(zeroBoundaryNetwork.chainId)).toBe(0n)
+			const contender = new ScannerDatabase(postgresUrl)
+			try {
+				const lease = await database.tryAcquireIndexerLock(chainId)
+				if (lease === undefined) throw new Error('first indexer did not acquire its lock')
+				await lease.assertHeld()
+				expect(await contender.tryAcquireIndexerLock(chainId)).toBeUndefined()
+				await lease.release()
+				const contenderLease = await contender.tryAcquireIndexerLock(chainId)
+				if (contenderLease === undefined) throw new Error('standby indexer did not acquire the released lock')
+				await contenderLease.assertHeld()
+				await contenderLease.release()
+
+				const collisionLease = await database.tryAcquireIndexerLock(chainId)
+				if (collisionLease === undefined) throw new Error('indexer did not acquire its lock for exact-key validation')
+				await collisionLease.connection`SELECT pg_advisory_lock((92138472::bigint << 32) | ${chainId}::bigint)`
+				await collisionLease.connection`SELECT pg_advisory_unlock(92138472, ${chainId})`
+				await expect(collisionLease.assertHeld()).rejects.toThrow('Indexer lease is no longer held')
+				await collisionLease.connection`SELECT pg_advisory_unlock((92138472::bigint << 32) | ${chainId}::bigint)`
+				await expect(collisionLease.release()).rejects.toThrow('Indexer lease unlock failed')
+
+				const lostLease = await database.tryAcquireIndexerLock(chainId)
+				if (lostLease === undefined) throw new Error('indexer did not reacquire its lock for lease-loss validation')
+				await contender.sql`SELECT pg_terminate_backend(${lostLease.backendPid})`
+				await expect(lostLease.assertHeld()).rejects.toThrow()
+				await lostLease.release().catch(() => undefined)
+				const takeoverLease = await contender.tryAcquireIndexerLock(chainId)
+				if (takeoverLease === undefined) throw new Error('standby did not take over after lease-session termination')
+				await takeoverLease.assertHeld()
+				await takeoverLease.release()
+			} finally {
+				await contender.close()
+			}
+
+			writeLease = await database.tryAcquireIndexerLock(chainId)
+			if (writeLease === undefined) throw new Error('writer did not acquire its lock')
+			const genesisHash = blockHash('genesis')
+			const initialDiscovery: ContractMetadata = {
+				address: rediscoveredAddress,
+				label: 'Original discovery',
+				kind: 'reputationToken',
+				provenance: 'Zoltar.UniverseCreated',
+				discoveryBlock: 1n,
+				discoveryTxHash: transactionHash,
+			}
+			const wethDiscovery: ContractMetadata = {
+				address: wethAddress,
+				label: 'Wrapped Ether',
+				kind: 'weth',
+				provenance: 'test',
+				discoveryBlock: 1n,
+				discoveryTxHash: transactionHash,
+			}
+			const secondWethDiscovery: ContractMetadata = {
+				...wethDiscovery,
+				address: secondWethAddress,
+				label: 'Wrapped Ether v2',
+			}
+			const first: IndexedBlock = {
+				...indexedBlock('block-one', genesisHash, [initialDiscovery, wethDiscovery, secondWethDiscovery], undefined, [
+					{ address: rediscoveredAddress, name: 'Original token', symbol: 'OLD', decimals: 18, readBlock: 1n },
+					{ address: wethAddress, name: 'Wrapped Ether', symbol: 'WETH', decimals: 18, readBlock: 1n },
+					{ address: secondWethAddress, name: 'Wrapped Ether v2', symbol: 'WETH2', decimals: 18, readBlock: 1n },
+				]),
+				logScanCursors: [{ contractAddress: address, startBlock: 1n, lastRetrievedBlock: 1n }],
+			}
+			await database.storeBlock(chainId, first, writeLease)
+			expect(await database.checkpoint(chainId)).toEqual({ number: 1n, hash: first.hash })
+			expect(await database.logScanCursors(chainId)).toEqual(
+				new Map([[address.toLowerCase(), { contractAddress: address, startBlock: 1n, lastRetrievedBlock: 1n }]]),
+			)
+			let startBlockMismatch: unknown
+			try {
+				await database.seedNetwork({ ...network, startBlock: 3n }, { lease: writeLease })
+			} catch (error) {
+				startBlockMismatch = error
+			}
+			expect(startBlockMismatch).toMatchObject({
+				message: 'Cannot change the configured start block from 1 to 3 while checkpoint 1 exists; rebuild the augurScan database from the new start block',
 			})
-			const release = new Promise<void>((resolve) => {
-				releaseFirst = resolve
+			expect(await database.checkpoint(chainId)).toEqual({ number: 1n, hash: first.hash })
+			const unchangedBoundary = await database.sql`SELECT start_block FROM networks WHERE chain_id = ${chainId}`
+			expect(unchangedBoundary[0]?.['start_block']).toBe('1')
+			await database.sql`UPDATE networks SET start_block = 3 WHERE chain_id = ${chainId}`
+			await expect(database.seedNetwork({ ...network, startBlock: 3n }, { lease: writeLease })).rejects.toMatchObject({
+				message: 'Stored checkpoint 1 is below configured start block 3; rebuild the augurScan database from the configured start block',
 			})
-			const firstWrite = database.sql.begin(async (transaction) => {
-				await lockLiveEventWriter(transaction)
-				const rows = await transaction`INSERT INTO live_events (event, payload) VALUES ('status', '{"writer":1}'::jsonb) RETURNING id`
-				firstLocked?.()
-				await release
-				return Number(rows[0]?.['id'])
+			expect(await database.checkpoint(chainId)).toEqual({ number: 1n, hash: first.hash })
+			const inconsistentBoundary = await database.sql`SELECT start_block FROM networks WHERE chain_id = ${chainId}`
+			expect(inconsistentBoundary[0]?.['start_block']).toBe('3')
+			await database.sql`UPDATE networks SET start_block = 1 WHERE chain_id = ${chainId}`
+			const invalidParent = indexedBlock('block-two-invalid-parent', genesisHash)
+			await expect(database.storeBlock(chainId, invalidParent, writeLease)).rejects.toThrow('does not extend the current database checkpoint')
+			expect(await database.checkpoint(chainId)).toEqual({ number: 1n, hash: first.hash })
+			const incomplete = { ...indexedBlock('block-two-incomplete', first.hash, [], 'incomplete event'), transactions: [] }
+			await expect(database.storeBlock(chainId, incomplete, writeLease)).rejects.toThrow()
+			expect(await database.checkpoint(chainId)).toEqual({ number: 1n, hash: first.hash })
+			const rolledBackRows = await database.sql`SELECT hash FROM blocks WHERE chain_id = ${chainId} AND hash = ${incomplete.hash}`
+			expect(rolledBackRows).toHaveLength(0)
+
+			const restarted = new ScannerDatabase(postgresUrl)
+			try {
+				expect(await restarted.checkpoint(chainId)).toEqual({ number: 1n, hash: first.hash })
+			} finally {
+				await restarted.close()
+			}
+
+			const discovery: ContractMetadata = {
+				address: discoveredAddress,
+				label: 'Discovered pool',
+				kind: 'securityPool',
+				provenance: 'Factory.DeploySecurityPool',
+				discoveryBlock: 2n,
+				discoveryTxHash: transactionHash,
+			}
+			const promotedDiscovery: ContractMetadata = {
+				address: promotedAddress,
+				label: 'Dynamically discovered helper',
+				kind: 'securityPool',
+				provenance: 'Factory.DeploySecurityPool',
+				discoveryBlock: 2n,
+				discoveryTxHash: transactionHash,
+			}
+			const laterRediscovery: ContractMetadata = {
+				...initialDiscovery,
+				label: 'Orphaned rediscovery',
+				discoveryBlock: 2n,
+			}
+			const orphanOnlyDiscovery: ContractMetadata = {
+				...laterRediscovery,
+				address: orphanOnlyAddress,
+				label: 'Orphan-only helper',
+			}
+			const orphanBase = indexedBlock('block-two-orphan', first.hash, [discovery, promotedDiscovery, laterRediscovery, orphanOnlyDiscovery], 'orphan event', [
+				{ address: discoveredAddress, readError: 'ERC-20 metadata unavailable', readBlock: 2n },
+				{ address: rediscoveredAddress, name: 'Orphaned token', symbol: 'BAD', decimals: 6, readBlock: 2n },
+			])
+			const orphanPrice = repPriceLog(orphanBase.hash, '99000000000000000000')
+			const orphan: IndexedBlock = {
+				...orphanBase,
+				logs: [...orphanBase.logs, orphanPrice],
+				contractDeploymentObservations: [
+					{
+						contractAddress: address,
+						checkedBlock: 2n,
+						deployment: { block: 2n, timestamp: new Date('2026-01-02T00:00:00Z'), exact: true },
+					},
+				],
+				logScanCursors: [
+					{ contractAddress: address, startBlock: 1n, lastRetrievedBlock: 2n },
+					{ contractAddress: discoveredAddress, startBlock: 2n, lastRetrievedBlock: 2n },
+				],
+			}
+			await database.storeBlock(chainId, orphan, writeLease)
+			expect(
+				await database.seedNetwork(
+					{
+						...network,
+						contracts: [
+							[address, 'Corrected manifest contract', 'openOracle'],
+							[promotedAddress, 'Promoted manifest helper', 'securityPool'],
+						],
+					},
+					{ lease: writeLease },
+				),
+			).toBe(true)
+			const seededContracts = await database.contracts(chainId)
+			expect(seededContracts.get(address.toLowerCase())).toMatchObject({ label: 'Corrected manifest contract', kind: 'openOracle', provenance: 'manifest' })
+			expect(seededContracts.get(promotedAddress.toLowerCase())).toMatchObject({
+				address: promotedAddress,
+				label: 'Promoted manifest helper',
+				kind: 'securityPool',
+				provenance: 'manifest',
 			})
-			await locked
-			let secondInserted = false
-			const secondWrite = concurrentWriter.sql.begin(async (transaction) => {
-				await lockLiveEventWriter(transaction)
-				const rows = await transaction`INSERT INTO live_events (event, payload) VALUES ('status', '{"writer":2}'::jsonb) RETURNING id`
-				secondInserted = true
-				return Number(rows[0]?.['id'])
+			expect((await database.contracts(chainId)).get(address.toLowerCase())).toMatchObject({ deploymentBlock: 2n, deploymentCheckedBlock: 2n })
+			await database.rewind(chainId, 1n, first.hash, writeLease)
+			const canonicalOrphanPrices =
+				await database.sql`SELECT * FROM rep_eth_price_snapshots WHERE chain_id = ${chainId} AND block_hash = ${orphan.hash} AND canonical`
+			expect(canonicalOrphanPrices).toHaveLength(0)
+			expect(await database.logScanCursors(chainId)).toEqual(
+				new Map([[address.toLowerCase(), { contractAddress: address, startBlock: 1n, lastRetrievedBlock: 1n }]]),
+			)
+			expect((await database.contracts(chainId)).get(address.toLowerCase())).not.toHaveProperty('deploymentBlock')
+			expect((await database.contracts(chainId)).get(address.toLowerCase())).not.toHaveProperty('deploymentCheckedBlock')
+			expect((await database.contracts(chainId)).get(promotedAddress.toLowerCase())?.provenance).toBe('manifest')
+			expect((await database.contracts(chainId)).get(rediscoveredAddress.toLowerCase())).toMatchObject({
+				label: 'Original discovery',
+				kind: 'reputationToken',
+				discoveryBlock: 1n,
 			})
-			await Bun.sleep(25)
-			expect(secondInserted).toBe(false)
-			releaseFirst?.()
-			expect(await Promise.all([firstWrite, secondWrite])).toEqual([1, 2])
-		} finally {
-			await concurrentWriter.close()
-		}
-		await database.sql.unsafe('TRUNCATE TABLE live_events RESTART IDENTITY')
-		await database.sql`INSERT INTO live_events (event, payload, created_at) VALUES ('status', '{}'::jsonb, now() - interval '8 days')`
-		await database.pruneLiveEvents()
-		expect(await database.eventsAfter(0)).toEqual([{ id: 1, event: 'reset', payload: { reason: 'replay-window-expired', refreshRequired: true } }])
-		const network: NetworkConfig = {
-			id: 'integration',
-			name: 'Integration chain',
-			chainId,
-			rpcUrls: ['http://127.0.0.1:8545'],
-			startBlock: 1n,
-			explorerBaseUrl: 'https://example.invalid',
-			nativeSymbol: 'ETH',
-			confirmationDepth: 8n,
-			contracts: [[address, 'Manifest contract', 'zoltar']],
-		}
-		expect(await database.seedNetwork(network)).toBe(false)
-		expect(await database.networkStartBlock(chainId)).toBe(1n)
-		await expect(database.seedNetwork({ ...network, startBlock: 3n }, undefined, false, true)).rejects.toThrow('while an effective index start is retained')
-		expect(await database.networkStartBlock(chainId)).toBe(1n)
-		const zeroBoundaryNetwork = { ...network, id: 'zero-boundary', chainId: chainId + 1, startBlock: 0n }
-		expect(await database.seedNetwork(zeroBoundaryNetwork)).toBe(false)
-		await expect(database.seedNetwork({ ...zeroBoundaryNetwork, startBlock: 100n }, undefined, false, true)).rejects.toThrow(
-			'while an effective index start is retained',
-		)
-		expect(await database.networkStartBlock(zeroBoundaryNetwork.chainId)).toBe(0n)
-		const contender = new ScannerDatabase(postgresUrl)
-		try {
-			const lease = await database.tryAcquireIndexerLock(chainId)
-			if (lease === undefined) throw new Error('first indexer did not acquire its lock')
-			await lease.assertHeld()
-			expect(await contender.tryAcquireIndexerLock(chainId)).toBeUndefined()
-			await lease.release()
-			const contenderLease = await contender.tryAcquireIndexerLock(chainId)
-			if (contenderLease === undefined) throw new Error('standby indexer did not acquire the released lock')
-			await contenderLease.assertHeld()
-			await contenderLease.release()
-
-			const collisionLease = await database.tryAcquireIndexerLock(chainId)
-			if (collisionLease === undefined) throw new Error('indexer did not acquire its lock for exact-key validation')
-			await collisionLease.connection`SELECT pg_advisory_lock((92138472::bigint << 32) | ${chainId}::bigint)`
-			await collisionLease.connection`SELECT pg_advisory_unlock(92138472, ${chainId})`
-			await expect(collisionLease.assertHeld()).rejects.toThrow('Indexer lease is no longer held')
-			await collisionLease.connection`SELECT pg_advisory_unlock((92138472::bigint << 32) | ${chainId}::bigint)`
-			await expect(collisionLease.release()).rejects.toThrow('Indexer lease unlock failed')
-
-			const lostLease = await database.tryAcquireIndexerLock(chainId)
-			if (lostLease === undefined) throw new Error('indexer did not reacquire its lock for lease-loss validation')
-			await contender.sql`SELECT pg_terminate_backend(${lostLease.backendPid})`
-			await expect(lostLease.assertHeld()).rejects.toThrow()
-			await lostLease.release().catch(() => undefined)
-			const takeoverLease = await contender.tryAcquireIndexerLock(chainId)
-			if (takeoverLease === undefined) throw new Error('standby did not take over after lease-session termination')
-			await takeoverLease.assertHeld()
-			await takeoverLease.release()
-		} finally {
-			await contender.close()
-		}
-
-		const writeLease = await database.tryAcquireIndexerLock(chainId)
-		if (writeLease === undefined) throw new Error('writer did not acquire its lock')
-		const genesisHash = blockHash('genesis')
-		const initialDiscovery: ContractMetadata = {
-			address: rediscoveredAddress,
-			label: 'Original discovery',
-			kind: 'reputationToken',
-			provenance: 'Zoltar.UniverseCreated',
-			discoveryBlock: 1n,
-			discoveryTxHash: transactionHash,
-		}
-		const wethDiscovery: ContractMetadata = {
-			address: wethAddress,
-			label: 'Wrapped Ether',
-			kind: 'weth',
-			provenance: 'test',
-			discoveryBlock: 1n,
-			discoveryTxHash: transactionHash,
-		}
-		const secondWethDiscovery: ContractMetadata = {
-			...wethDiscovery,
-			address: secondWethAddress,
-			label: 'Wrapped Ether v2',
-		}
-		const first: IndexedBlock = {
-			...indexedBlock('block-one', genesisHash, [initialDiscovery, wethDiscovery, secondWethDiscovery], undefined, [
-				{ address: rediscoveredAddress, name: 'Original token', symbol: 'OLD', decimals: 18, readBlock: 1n },
-				{ address: wethAddress, name: 'Wrapped Ether', symbol: 'WETH', decimals: 18, readBlock: 1n },
-				{ address: secondWethAddress, name: 'Wrapped Ether v2', symbol: 'WETH2', decimals: 18, readBlock: 1n },
-			]),
-			logScanCursors: [{ contractAddress: address, startBlock: 1n, lastRetrievedBlock: 1n }],
-		}
-		await database.storeBlock(chainId, first, writeLease)
-		expect(await database.checkpoint(chainId)).toEqual({ number: 1n, hash: first.hash })
-		expect(await database.logScanCursors(chainId)).toEqual(
-			new Map([[address.toLowerCase(), { contractAddress: address, startBlock: 1n, lastRetrievedBlock: 1n }]]),
-		)
-		await expect(database.seedNetwork({ ...network, startBlock: 3n }, writeLease)).rejects.toThrow(
-			'Cannot change the configured start block from 1 to 3 while checkpoint 1 exists; rebuild the augurScan database from the new start block',
-		)
-		expect(await database.checkpoint(chainId)).toEqual({ number: 1n, hash: first.hash })
-		const unchangedBoundary = await database.sql`SELECT start_block FROM networks WHERE chain_id = ${chainId}`
-		expect(unchangedBoundary[0]?.['start_block']).toBe('1')
-		await database.sql`UPDATE networks SET start_block = 3 WHERE chain_id = ${chainId}`
-		await expect(database.seedNetwork({ ...network, startBlock: 3n }, writeLease)).rejects.toThrow(
-			'Stored checkpoint 1 is below configured start block 3; rebuild the augurScan database from the configured start block',
-		)
-		expect(await database.checkpoint(chainId)).toEqual({ number: 1n, hash: first.hash })
-		const inconsistentBoundary = await database.sql`SELECT start_block FROM networks WHERE chain_id = ${chainId}`
-		expect(inconsistentBoundary[0]?.['start_block']).toBe('3')
-		await database.sql`UPDATE networks SET start_block = 1 WHERE chain_id = ${chainId}`
-		const invalidParent = indexedBlock('block-two-invalid-parent', genesisHash)
-		await expect(database.storeBlock(chainId, invalidParent, writeLease)).rejects.toThrow('does not extend the current database checkpoint')
-		expect(await database.checkpoint(chainId)).toEqual({ number: 1n, hash: first.hash })
-		const incomplete = { ...indexedBlock('block-two-incomplete', first.hash, [], 'incomplete event'), transactions: [] }
-		await expect(database.storeBlock(chainId, incomplete, writeLease)).rejects.toThrow()
-		expect(await database.checkpoint(chainId)).toEqual({ number: 1n, hash: first.hash })
-		const rolledBackRows = await database.sql`SELECT hash FROM blocks WHERE chain_id = ${chainId} AND hash = ${incomplete.hash}`
-		expect(rolledBackRows).toHaveLength(0)
-
-		const restarted = new ScannerDatabase(postgresUrl)
-		try {
-			expect(await restarted.checkpoint(chainId)).toEqual({ number: 1n, hash: first.hash })
-		} finally {
-			await restarted.close()
-		}
-
-		const discovery: ContractMetadata = {
-			address: discoveredAddress,
-			label: 'Discovered pool',
-			kind: 'securityPool',
-			provenance: 'Factory.DeploySecurityPool',
-			discoveryBlock: 2n,
-			discoveryTxHash: transactionHash,
-		}
-		const promotedDiscovery: ContractMetadata = {
-			address: promotedAddress,
-			label: 'Dynamically discovered helper',
-			kind: 'securityPool',
-			provenance: 'Factory.DeploySecurityPool',
-			discoveryBlock: 2n,
-			discoveryTxHash: transactionHash,
-		}
-		const laterRediscovery: ContractMetadata = {
-			...initialDiscovery,
-			label: 'Orphaned rediscovery',
-			discoveryBlock: 2n,
-		}
-		const orphanOnlyDiscovery: ContractMetadata = {
-			...laterRediscovery,
-			address: orphanOnlyAddress,
-			label: 'Orphan-only helper',
-		}
-		const orphanBase = indexedBlock('block-two-orphan', first.hash, [discovery, promotedDiscovery, laterRediscovery, orphanOnlyDiscovery], 'orphan event', [
-			{ address: discoveredAddress, readError: 'ERC-20 metadata unavailable', readBlock: 2n },
-			{ address: rediscoveredAddress, name: 'Orphaned token', symbol: 'BAD', decimals: 6, readBlock: 2n },
-		])
-		const orphanPrice = repPriceLog(orphanBase.hash, '99000000000000000000')
-		const orphan: IndexedBlock = {
-			...orphanBase,
-			logs: [...orphanBase.logs, orphanPrice],
-			contractDeploymentObservations: [
-				{
-					contractAddress: address,
-					checkedBlock: 2n,
-					deployment: { block: 2n, timestamp: new Date('2026-01-02T00:00:00Z'), exact: true },
-				},
-			],
-			logScanCursors: [
-				{ contractAddress: address, startBlock: 1n, lastRetrievedBlock: 2n },
-				{ contractAddress: discoveredAddress, startBlock: 2n, lastRetrievedBlock: 2n },
-			],
-		}
-		await database.storeBlock(chainId, orphan, writeLease)
-		expect(
-			await database.seedNetwork(
-				{
-					...network,
-					contracts: [
-						[address, 'Corrected manifest contract', 'openOracle'],
-						[promotedAddress, 'Promoted manifest helper', 'securityPool'],
-					],
-				},
-				writeLease,
-			),
-		).toBe(true)
-		const seededContracts = await database.contracts(chainId)
-		expect(seededContracts.get(address.toLowerCase())).toMatchObject({ label: 'Corrected manifest contract', kind: 'openOracle', provenance: 'manifest' })
-		expect(seededContracts.get(promotedAddress.toLowerCase())).toEqual({
-			address: promotedAddress,
-			label: 'Promoted manifest helper',
-			kind: 'securityPool',
-			provenance: 'manifest',
-		})
-		expect((await database.contracts(chainId)).get(address.toLowerCase())).toMatchObject({ deploymentBlock: 2n, deploymentCheckedBlock: 2n })
-		await database.rewind(chainId, 1n, first.hash, writeLease)
-		const canonicalOrphanPrices =
-			await database.sql`SELECT * FROM rep_eth_price_snapshots WHERE chain_id = ${chainId} AND block_hash = ${orphan.hash} AND canonical`
-		expect(canonicalOrphanPrices).toHaveLength(0)
-		expect(await database.logScanCursors(chainId)).toEqual(
-			new Map([[address.toLowerCase(), { contractAddress: address, startBlock: 1n, lastRetrievedBlock: 1n }]]),
-		)
-		expect((await database.contracts(chainId)).get(address.toLowerCase())).not.toHaveProperty('deploymentBlock')
-		expect((await database.contracts(chainId)).get(address.toLowerCase())).not.toHaveProperty('deploymentCheckedBlock')
-		expect((await database.contracts(chainId)).get(promotedAddress.toLowerCase())?.provenance).toBe('manifest')
-		expect((await database.contracts(chainId)).get(rediscoveredAddress.toLowerCase())).toMatchObject({
-			label: 'Original discovery',
-			kind: 'reputationToken',
-			discoveryBlock: 1n,
-		})
-		expect((await database.tokenMetadata(chainId)).get(rediscoveredAddress.toLowerCase())).toMatchObject({
-			name: 'Original token',
-			symbol: 'OLD',
-			decimals: 18,
-			readBlock: 1n,
-		})
-		const orphanContractResponse = await handleApi(new Request(`http://localhost/api/v1/contracts/${chainId}/${orphanOnlyAddress}`), database.sql)
-		expect(orphanContractResponse?.status).toBe(404)
-
-		const replacementBase = indexedBlock('block-two-replacement', first.hash, [discovery], 'replacement event', [
-			{ address: discoveredAddress, name: 'Replacement token', symbol: 'NEW', decimals: 18, readBlock: 2n },
-		])
-		const uniswapPairDiscovery: ContractMetadata = {
-			address: uniswapPairAddress,
-			label: 'Uniswap V2 REP / WETH Pair',
-			kind: 'uniswapV2Pair',
-			provenance: 'Uniswap V2 Factory.PairCreated',
-			discoveryBlock: 2n,
-			discoveryTxHash: transactionHash,
-		}
-		const inverseUniswapPairDiscovery: ContractMetadata = {
-			address: inverseUniswapPairAddress,
-			label: 'Uniswap V2 WETH / REP Pair',
-			kind: 'uniswapV2Pair',
-			provenance: 'Uniswap V2 Factory.PairCreated',
-			discoveryBlock: 2n,
-			discoveryTxHash: transactionHash,
-		}
-		const replacementPrices = priceHistoryLogs(replacementBase.hash)
-		const replacement: IndexedBlock = {
-			...replacementBase,
-			contracts: [...replacementBase.contracts, uniswapPairDiscovery, inverseUniswapPairDiscovery],
-			logs: [...replacementBase.logs, vaultCheckpoint(replacementBase.hash), ...replacementPrices],
-			addressActivity: [{ transactionHash, address, poolAddress: discoveredAddress, role: 'sender' }],
-			logScanCursors: [
-				{ contractAddress: address, startBlock: 1n, lastRetrievedBlock: 2n },
-				{ contractAddress: discoveredAddress, startBlock: 2n, lastRetrievedBlock: 2n },
-			],
-		}
-		await database.storeBlock(chainId, replacement, writeLease)
-		const poolHistoryResponse = await handleApi(new Request(`http://localhost/api/v1/state/pools/${chainId}/${discoveredAddress.toLowerCase()}`), database.sql)
-		if (poolHistoryResponse === undefined) throw new Error('pool history API did not return a response')
-		const poolHistory = await poolHistoryResponse.json()
-		if (
-			typeof poolHistory !== 'object' ||
-			poolHistory === null ||
-			Array.isArray(poolHistory) ||
-			!('market' in poolHistory) ||
-			!('ammPrices' in poolHistory) ||
-			!('repEthPrices' in poolHistory) ||
-			!('uniswapRepEthPrices' in poolHistory)
-		)
-			throw new Error('pool history API returned an invalid price payload')
-		expect(poolHistory.market).toEqual({
-			chain_id: chainId.toString(),
-			block_hash: replacement.hash,
-			tx_hash: transactionHash,
-			log_index: 3,
-			block_number: '2',
-			pair_address: pairAddress.toLowerCase(),
-			pool_address: discoveredAddress.toLowerCase(),
-			share_token_address: wethAddress.toLowerCase(),
-			universe_id: '0',
-			fee_bps: '30',
-			canonical: true,
-			timestamp: '2026-01-02T00:00:00.000Z',
-		})
-		expect(poolHistory.ammPrices).toEqual([
-			{
-				chain_id: chainId.toString(),
-				block_hash: replacement.hash,
-				tx_hash: transactionHash,
-				log_index: 4,
-				block_number: '2',
-				pair_address: pairAddress.toLowerCase(),
-				yes_reserve_atto_shares: '300000000000000000000',
-				no_reserve_atto_shares: '700000000000000000000',
-				conditional_yes_bps: '7000',
-				conditional_no_bps: '3000',
-				canonical: true,
-				timestamp: '2026-01-02T00:00:00.000Z',
-			},
-		])
-		expect(poolHistory.repEthPrices).toEqual([
-			{
-				chain_id: chainId.toString(),
-				block_hash: replacement.hash,
-				tx_hash: transactionHash,
-				log_index: 5,
-				block_number: '2',
-				coordinator_address: promotedAddress.toLowerCase(),
-				event_name: 'PriceReported',
-				report_id: '42',
-				rep_per_eth_1e18: '19500000000000000000',
-				settlement_timestamp: '2026-01-02T00:00:00.000Z',
-				canonical: true,
-				timestamp: '2026-01-02T00:00:00.000Z',
-			},
-		])
-		expect(poolHistory.uniswapRepEthPrices).toEqual([
-			{
-				chain_id: chainId.toString(),
-				block_hash: replacement.hash,
-				tx_hash: transactionHash,
-				log_index: 8,
-				block_number: '2',
-				venue: 'v2',
-				market_id: uniswapPairAddress.toLowerCase(),
-				event_name: 'Sync',
-				contract_address: uniswapPairAddress.toLowerCase(),
-				token0_address: rediscoveredAddress.toLowerCase(),
-				token1_address: wethAddress.toLowerCase(),
-				fee_hundredths_bip: '3000',
-				tick_spacing: null,
-				hooks_address: null,
-				quote_symbol: 'WETH',
-				quote_token_address: wethAddress.toLowerCase(),
-				rep_per_eth_1e18: '18000000000000000000',
-				timestamp: '2026-01-02T00:00:00.000Z',
-			},
-			{
-				chain_id: chainId.toString(),
-				block_hash: replacement.hash,
-				tx_hash: transactionHash,
-				log_index: 10,
-				block_number: '2',
-				venue: 'v2',
-				market_id: inverseUniswapPairAddress.toLowerCase(),
-				event_name: 'Sync',
-				contract_address: inverseUniswapPairAddress.toLowerCase(),
-				token0_address: wethAddress.toLowerCase(),
-				token1_address: rediscoveredAddress.toLowerCase(),
-				fee_hundredths_bip: '3000',
-				tick_spacing: null,
-				hooks_address: null,
-				quote_symbol: 'WETH',
-				quote_token_address: wethAddress.toLowerCase(),
-				rep_per_eth_1e18: '24000000000000000000',
-				timestamp: '2026-01-02T00:00:00.000Z',
-			},
-		])
-		await database.storeRichListBalances(
-			chainId,
-			2n,
-			replacement.hash,
-			[
-				{ owner: address, assetAddress: getAddress('0x0000000000000000000000000000000000000000'), assetKind: 'native', balance: 2_000_000_000_456_789_123n },
-				{ owner: address, assetAddress: rediscoveredAddress, assetKind: 'rep', balance: 3_000_000_000_000_000_000n },
-				{ owner: address, assetAddress: wethAddress, assetKind: 'weth', balance: 1_234_567_890_123_456_789n },
-				{ owner: address, assetAddress: secondWethAddress, assetKind: 'weth', balance: 222_222_222_222_222_222n },
-			],
-			writeLease,
-		)
-		await database.seedNetwork({ ...network, contracts: [[discoveredAddress, 'Temporarily promoted pool', 'securityPool']] }, writeLease)
-		await database.seedNetwork({ ...network, contracts: [] }, writeLease)
-		const reconciledContracts = await database.contracts(chainId)
-		expect(reconciledContracts.has(address.toLowerCase())).toBe(false)
-		expect(reconciledContracts.has(promotedAddress.toLowerCase())).toBe(false)
-		expect(reconciledContracts.get(discoveredAddress.toLowerCase())).toMatchObject({
-			label: 'Discovered pool',
-			kind: 'securityPool',
-			provenance: 'Factory.DeploySecurityPool',
-			discoveryBlock: 2n,
-			discoveryTxHash: transactionHash,
-		})
-		await writeLease.release()
-		const blockRows = await database.sql`SELECT hash, canonical FROM blocks WHERE chain_id = ${chainId} AND number = 2 ORDER BY hash`
-		expect(blockRows).toHaveLength(2)
-		expect(blockRows.filter((row: Record<string, unknown>) => row['canonical'] === true)).toHaveLength(1)
-		expect(blockRows.find((row: Record<string, unknown>) => row['hash'] === orphan.hash)?.['canonical']).toBe(false)
-		const metadataRows =
-			await database.sql`SELECT block_hash, decimals, canonical FROM token_metadata WHERE chain_id = ${chainId} AND address = ${discoveredAddress.toLowerCase()} ORDER BY block_hash`
-		expect(metadataRows).toHaveLength(2)
-		expect(metadataRows.find((row: Record<string, unknown>) => row['block_hash'] === orphan.hash)?.['canonical']).toBe(false)
-		expect(metadataRows.find((row: Record<string, unknown>) => row['block_hash'] === replacement.hash)).toMatchObject({ canonical: true, decimals: 18 })
-
-		const standardV4MarketId = uniswapV4PoolId(rediscoveredAddress, 3_000, 60)
-		const nonstandardV4MarketId = uniswapV4PoolId(rediscoveredAddress, 250, 5)
-		const uniswapV4PoolManagerDiscovery: ContractMetadata = {
-			address: uniswapV4PoolManagerAddress,
-			label: 'Uniswap V4 PoolManager',
-			kind: 'uniswapV4PoolManager',
-			provenance: 'test',
-			discoveryBlock: 3n,
-			discoveryTxHash: transactionHash,
-		}
-		const v4Initialize = (logIndex: number, marketId: string, fee: string, tickSpacing: string): StoredLog => ({
-			...decodedLog(blockHash('block-three'), logIndex, uniswapV4PoolManagerAddress, 'Initialize', {
-				id: marketId,
-				currency0: '0x0000000000000000000000000000000000000000',
-				currency1: rediscoveredAddress,
-				fee,
-				tickSpacing,
-				hooks: '0x0000000000000000000000000000000000000000',
-				sqrtPriceX96: (2n ** 96n).toString(),
-			}),
-			blockNumber: 3n,
-		})
-		const third: IndexedBlock = {
-			...indexedBlock('block-three', replacement.hash, [uniswapV4PoolManagerDiscovery], 'batched V4 initializations'),
-			number: 3n,
-			timestamp: new Date('2026-01-03T00:00:00Z'),
-			observedHead: 3n,
-			logs: [v4Initialize(1, standardV4MarketId, '3000', '60'), v4Initialize(2, nonstandardV4MarketId, '250', '5')],
-		}
-		const failover = new ScannerDatabase(postgresUrl)
-		try {
-			const lostWriteLease = await database.tryAcquireIndexerLock(chainId)
-			if (lostWriteLease === undefined) throw new Error('writer did not reacquire for fenced-write validation')
-			await failover.sql`SELECT pg_terminate_backend(${lostWriteLease.backendPid})`
-			await expect(database.storeBlock(chainId, third, lostWriteLease)).rejects.toThrow()
-			expect(await failover.checkpoint(chainId)).toEqual({ number: 2n, hash: replacement.hash })
-			await lostWriteLease.release().catch(() => undefined)
-			const takeoverWriteLease = await failover.tryAcquireIndexerLock(chainId)
-			if (takeoverWriteLease === undefined) throw new Error('takeover writer did not acquire after fencing')
-			await failover.storeBlock(chainId, third, takeoverWriteLease)
-			expect(await failover.checkpoint(chainId)).toEqual({ number: 3n, hash: third.hash })
-			await takeoverWriteLease.release()
-			await expect(database.recordFailure(chainId, 'stale former owner', new Date(), lostWriteLease)).rejects.toThrow()
-			const statusRows = await failover.sql`SELECT phase, last_error FROM networks WHERE chain_id = ${chainId}`
-			expect(statusRows[0]).toMatchObject({ phase: 'live', last_error: null })
-		} finally {
-			await failover.close()
-		}
-		const storedV4Markets =
-			await database.sql`SELECT market_id FROM uniswap_rep_eth_markets WHERE chain_id = ${chainId} AND block_hash = ${third.hash} AND canonical ORDER BY market_id`
-		expect(storedV4Markets).toEqual([{ market_id: standardV4MarketId }])
-		const storedV4Observations =
-			await database.sql`SELECT market_id FROM uniswap_rep_eth_price_observations WHERE chain_id = ${chainId} AND block_hash = ${third.hash} AND canonical ORDER BY market_id`
-		expect(storedV4Observations).toEqual([{ market_id: standardV4MarketId }])
-		const readIsolation = await database.read(async (sql) => {
-			const rows = await sql`SELECT current_setting('transaction_isolation') AS isolation, current_setting('transaction_read_only') AS read_only`
-			return rows[0]
-		})
-		expect(readIsolation).toMatchObject({ isolation: 'repeatable read', read_only: 'on' })
-		const reorgWriter = new ScannerDatabase(postgresUrl)
-		try {
-			const snapshotStayedCanonical = await database.read(async (sql) => {
-				const before = await sql`SELECT canonical FROM blocks WHERE chain_id = ${chainId} AND hash = ${third.hash}`
-				expect(before[0]?.['canonical']).toBe(true)
-				await reorgWriter.sql`UPDATE blocks SET canonical = false WHERE chain_id = ${chainId} AND hash = ${third.hash}`
-				const after = await sql`SELECT canonical FROM blocks WHERE chain_id = ${chainId} AND hash = ${third.hash}`
-				return after[0]?.['canonical']
+			expect((await database.tokenMetadata(chainId)).get(rediscoveredAddress.toLowerCase())).toMatchObject({
+				name: 'Original token',
+				symbol: 'OLD',
+				decimals: 18,
+				readBlock: 1n,
 			})
-			expect(snapshotStayedCanonical).toBe(true)
-		} finally {
-			await reorgWriter.sql`UPDATE blocks SET canonical = true WHERE chain_id = ${chainId} AND hash = ${third.hash}`
-			await reorgWriter.close()
-		}
-		await database.seedNetwork({ ...network, contracts: [[orphanOnlyAddress, 'New child REP', 'reputationToken']] })
+			const orphanContractResponse = await handleApi(new Request(`http://localhost/api/v1/contracts/${chainId}/${orphanOnlyAddress}`), database.sql)
+			expect(orphanContractResponse?.status).toBe(404)
 
-		const response = await handleApi(new Request(`http://localhost/api/v1/logs?chainId=${chainId}`), database.sql)
-		if (response === undefined) throw new Error('logs API did not return a response')
-		const payload = (await response.json()) as { items: Array<{ summary: string; block_hash: string; origin_address: string }> }
-		expect(payload.items).toHaveLength(2)
-		expect(payload.items).toContainEqual(expect.objectContaining({ summary: 'replacement event', block_hash: replacement.hash }))
-		expect(payload.items[0]?.origin_address).toBe(address.toLowerCase())
-		const orphanDetailResponse = await handleApi(new Request(`http://localhost/api/v1/logs/${chainId}/${orphan.hash}/${transactionHash}/0`), database.sql)
-		expect(orphanDetailResponse?.status).toBe(404)
-		expect(await orphanDetailResponse?.json()).toEqual({ error: 'Log not found' })
-		const senderLogsResponse = await handleApi(new Request(`http://localhost/api/v1/logs?chainId=${chainId}&address=${address.toLowerCase()}`), database.sql)
-		if (senderLogsResponse === undefined) throw new Error('sender-filtered logs API did not return a response')
-		const senderLogs = (await senderLogsResponse.json()) as { items: Array<{ origin_address: string; arguments: Record<string, unknown> }> }
-		expect(senderLogs.items).toHaveLength(2)
-		expect(senderLogs.items.every((item) => item.origin_address === address.toLowerCase())).toBe(true)
-		expect(senderLogs.items.every((item) => !JSON.stringify(item.arguments).toLowerCase().includes(address.toLowerCase()))).toBe(true)
-		const detailResponse = await handleApi(new Request(`http://localhost/api/v1/logs/${chainId}/${replacement.hash}/${transactionHash}/0`), database.sql)
-		if (detailResponse === undefined) throw new Error('log detail API did not return a response')
-		const detail = (await detailResponse.json()) as { receipt: { logs: unknown[] }; argument_schema: unknown[]; origin_address: string }
-		expect(isLogDetailValue(detail)).toBeTrue()
-		expect(detail.receipt.logs).toHaveLength(1)
-		expect(detail.argument_schema).toEqual([])
-		expect(detail.origin_address).toBe(address.toLowerCase())
-		await database.sql`UPDATE contracts SET canonical = false WHERE chain_id = ${chainId} AND address = ${discoveredAddress.toLowerCase()}`
-		try {
-			const identitylessListResponse = await handleApi(new Request(`http://localhost/api/v1/logs?chainId=${chainId}`), database.sql)
-			if (identitylessListResponse === undefined) throw new Error('identityless logs API did not return a response')
-			const identitylessList = (await identitylessListResponse.json()) as { items: Array<Record<string, unknown>> }
-			expect(identitylessList.items.find((item) => item['block_hash'] === replacement.hash)).toMatchObject({
-				contract_label: null,
-				contract_kind: null,
-			})
-			const identitylessDetailResponse = await handleApi(
-				new Request(`http://localhost/api/v1/logs/${chainId}/${replacement.hash}/${transactionHash}/0`),
+			const replacementBase = indexedBlock('block-two-replacement', first.hash, [discovery], 'replacement event', [
+				{ address: discoveredAddress, name: 'Replacement token', symbol: 'NEW', decimals: 18, readBlock: 2n },
+			])
+			const uniswapPairDiscovery: ContractMetadata = {
+				address: uniswapPairAddress,
+				label: 'Uniswap V2 REP / WETH Pair',
+				kind: 'uniswapV2Pair',
+				provenance: 'Uniswap V2 Factory.PairCreated',
+				discoveryBlock: 2n,
+				discoveryTxHash: transactionHash,
+			}
+			const inverseUniswapPairDiscovery: ContractMetadata = {
+				address: inverseUniswapPairAddress,
+				label: 'Uniswap V2 WETH / REP Pair',
+				kind: 'uniswapV2Pair',
+				provenance: 'Uniswap V2 Factory.PairCreated',
+				discoveryBlock: 2n,
+				discoveryTxHash: transactionHash,
+			}
+			const replacementPrices = priceHistoryLogs(replacementBase.hash)
+			const replacement: IndexedBlock = {
+				...replacementBase,
+				contracts: [...replacementBase.contracts, uniswapPairDiscovery, inverseUniswapPairDiscovery],
+				logs: [...replacementBase.logs, vaultCheckpoint(replacementBase.hash), ...replacementPrices],
+				addressActivity: [{ transactionHash, address, poolAddress: discoveredAddress, role: 'sender' }],
+				logScanCursors: [
+					{ contractAddress: address, startBlock: 1n, lastRetrievedBlock: 2n },
+					{ contractAddress: discoveredAddress, startBlock: 2n, lastRetrievedBlock: 2n },
+				],
+			}
+			await database.storeBlock(chainId, replacement, writeLease)
+			const poolHistoryResponse = await handleApi(
+				new Request(`http://localhost/api/v1/state/pools/${chainId}/${discoveredAddress.toLowerCase()}`),
 				database.sql,
 			)
-			if (identitylessDetailResponse === undefined) throw new Error('identityless log detail API did not return a response')
-			expect(await identitylessDetailResponse.json()).toMatchObject({
-				contract_label: null,
-				contract_kind: null,
-				contract_provenance: null,
+			if (poolHistoryResponse === undefined) throw new Error('pool history API did not return a response')
+			const poolHistory = await poolHistoryResponse.json()
+			if (
+				typeof poolHistory !== 'object' ||
+				poolHistory === null ||
+				Array.isArray(poolHistory) ||
+				!('market' in poolHistory) ||
+				!('ammPrices' in poolHistory) ||
+				!('repEthPrices' in poolHistory) ||
+				!('uniswapRepEthPrices' in poolHistory)
+			)
+				throw new Error('pool history API returned an invalid price payload')
+			expect(poolHistory.market).toEqual({
+				chain_id: chainId.toString(),
+				block_hash: replacement.hash,
+				tx_hash: transactionHash,
+				log_index: 3,
+				block_number: '2',
+				pair_address: pairAddress.toLowerCase(),
+				pool_address: discoveredAddress.toLowerCase(),
+				share_token_address: wethAddress.toLowerCase(),
+				universe_id: '0',
+				fee_bps: '30',
+				canonical: true,
+				timestamp: '2026-01-02T00:00:00.000Z',
 			})
-		} finally {
-			await database.sql`UPDATE contracts SET canonical = true WHERE chain_id = ${chainId} AND address = ${discoveredAddress.toLowerCase()}`
-		}
-		await database.sql`
+			expect(poolHistory.ammPrices).toEqual([
+				{
+					chain_id: chainId.toString(),
+					block_hash: replacement.hash,
+					tx_hash: transactionHash,
+					log_index: 4,
+					block_number: '2',
+					pair_address: pairAddress.toLowerCase(),
+					yes_reserve_atto_shares: '300000000000000000000',
+					no_reserve_atto_shares: '700000000000000000000',
+					conditional_yes_bps: '7000',
+					conditional_no_bps: '3000',
+					canonical: true,
+					timestamp: '2026-01-02T00:00:00.000Z',
+				},
+			])
+			expect(poolHistory.repEthPrices).toEqual([
+				{
+					chain_id: chainId.toString(),
+					block_hash: replacement.hash,
+					tx_hash: transactionHash,
+					log_index: 5,
+					block_number: '2',
+					coordinator_address: promotedAddress.toLowerCase(),
+					event_name: 'PriceReported',
+					report_id: '42',
+					rep_per_eth_1e18: '19500000000000000000',
+					settlement_timestamp: '2026-01-02T00:00:00.000Z',
+					canonical: true,
+					timestamp: '2026-01-02T00:00:00.000Z',
+				},
+			])
+			expect(poolHistory.uniswapRepEthPrices).toEqual([
+				{
+					chain_id: chainId.toString(),
+					block_hash: replacement.hash,
+					tx_hash: transactionHash,
+					log_index: 8,
+					block_number: '2',
+					venue: 'v2',
+					market_id: uniswapPairAddress.toLowerCase(),
+					event_name: 'Sync',
+					contract_address: uniswapPairAddress.toLowerCase(),
+					token0_address: rediscoveredAddress.toLowerCase(),
+					token1_address: wethAddress.toLowerCase(),
+					fee_hundredths_bip: '3000',
+					tick_spacing: null,
+					hooks_address: null,
+					quote_symbol: 'WETH',
+					quote_token_address: wethAddress.toLowerCase(),
+					rep_per_eth_1e18: '18000000000000000000',
+					liquidity_value: '180000000000000000000000000000000000000000',
+					timestamp: '2026-01-02T00:00:00.000Z',
+				},
+				{
+					chain_id: chainId.toString(),
+					block_hash: replacement.hash,
+					tx_hash: transactionHash,
+					log_index: 10,
+					block_number: '2',
+					venue: 'v2',
+					market_id: inverseUniswapPairAddress.toLowerCase(),
+					event_name: 'Sync',
+					contract_address: inverseUniswapPairAddress.toLowerCase(),
+					token0_address: wethAddress.toLowerCase(),
+					token1_address: rediscoveredAddress.toLowerCase(),
+					fee_hundredths_bip: '3000',
+					tick_spacing: null,
+					hooks_address: null,
+					quote_symbol: 'WETH',
+					quote_token_address: wethAddress.toLowerCase(),
+					rep_per_eth_1e18: '24000000000000000000',
+					liquidity_value: '240000000000000000000000000000000000000000',
+					timestamp: '2026-01-02T00:00:00.000Z',
+				},
+			])
+			await database.storeRichListBalances(
+				chainId,
+				2n,
+				replacement.hash,
+				[
+					{ owner: address, assetAddress: getAddress('0x0000000000000000000000000000000000000000'), assetKind: 'native', balance: 2_000_000_000_456_789_123n },
+					{ owner: address, assetAddress: rediscoveredAddress, assetKind: 'rep', balance: 3_000_000_000_000_000_000n },
+					{ owner: address, assetAddress: wethAddress, assetKind: 'weth', balance: 1_234_567_890_123_456_789n },
+					{ owner: address, assetAddress: secondWethAddress, assetKind: 'weth', balance: 222_222_222_222_222_222n },
+				],
+				writeLease,
+			)
+			await database.seedNetwork({ ...network, contracts: [[discoveredAddress, 'Temporarily promoted pool', 'securityPool']] }, { lease: writeLease })
+			await database.seedNetwork({ ...network, contracts: [] }, { lease: writeLease })
+			const reconciledContracts = await database.contracts(chainId)
+			expect(reconciledContracts.has(address.toLowerCase())).toBe(false)
+			expect(reconciledContracts.has(promotedAddress.toLowerCase())).toBe(false)
+			expect(reconciledContracts.get(discoveredAddress.toLowerCase())).toMatchObject({
+				label: 'Discovered pool',
+				kind: 'securityPool',
+				provenance: 'Factory.DeploySecurityPool',
+				discoveryBlock: 2n,
+				discoveryTxHash: transactionHash,
+			})
+			await writeLease.release()
+			const blockRows = await database.sql`SELECT hash, canonical FROM blocks WHERE chain_id = ${chainId} AND number = 2 ORDER BY hash`
+			expect(blockRows).toHaveLength(2)
+			expect(blockRows.filter((row: Record<string, unknown>) => row['canonical'] === true)).toHaveLength(1)
+			expect(blockRows.find((row: Record<string, unknown>) => row['hash'] === orphan.hash)?.['canonical']).toBe(false)
+			const metadataRows =
+				await database.sql`SELECT block_hash, decimals, canonical FROM token_metadata WHERE chain_id = ${chainId} AND address = ${discoveredAddress.toLowerCase()} ORDER BY block_hash`
+			expect(metadataRows).toHaveLength(2)
+			expect(metadataRows.find((row: Record<string, unknown>) => row['block_hash'] === orphan.hash)?.['canonical']).toBe(false)
+			expect(metadataRows.find((row: Record<string, unknown>) => row['block_hash'] === replacement.hash)).toMatchObject({ canonical: true, decimals: 18 })
+
+			const standardV4MarketId = uniswapV4PoolId(rediscoveredAddress, 3_000, 60)
+			const nonstandardV4MarketId = uniswapV4PoolId(rediscoveredAddress, 250, 5)
+			const thirdTransactionHash = blockHash('block-three-transaction')
+			const uniswapV4PoolManagerDiscovery: ContractMetadata = {
+				address: uniswapV4PoolManagerAddress,
+				label: 'Uniswap V4 PoolManager',
+				kind: 'uniswapV4PoolManager',
+				provenance: 'test',
+				discoveryBlock: 3n,
+				discoveryTxHash: transactionHash,
+			}
+			const v4Initialize = (logIndex: number, marketId: string, fee: string, tickSpacing: string): StoredLog => ({
+				...decodedLog(blockHash('block-three'), logIndex, uniswapV4PoolManagerAddress, 'Initialize', {
+					id: marketId,
+					currency0: '0x0000000000000000000000000000000000000000',
+					currency1: rediscoveredAddress,
+					fee,
+					tickSpacing,
+					hooks: '0x0000000000000000000000000000000000000000',
+					sqrtPriceX96: (2n ** 96n).toString(),
+				}),
+				transactionHash: thirdTransactionHash,
+				blockNumber: 3n,
+			})
+			const thirdBase = indexedBlock('block-three', replacement.hash, [uniswapV4PoolManagerDiscovery], 'batched V4 initializations')
+			const third: IndexedBlock = {
+				...thirdBase,
+				number: 3n,
+				timestamp: new Date('2026-01-03T00:00:00Z'),
+				observedHead: 3n,
+				transactions: thirdBase.transactions.map((item) => ({
+					...item,
+					hash: thirdTransactionHash,
+					receipt: {
+						transactionHash: thirdTransactionHash,
+						blockHash: thirdBase.hash,
+						status: 'success',
+						logs: [],
+					},
+				})),
+				logs: [v4Initialize(1, standardV4MarketId, '3000', '60'), v4Initialize(2, nonstandardV4MarketId, '250', '5')],
+			}
+			const failover = new ScannerDatabase(postgresUrl)
+			try {
+				const lostWriteLease = await database.tryAcquireIndexerLock(chainId)
+				if (lostWriteLease === undefined) throw new Error('writer did not reacquire for fenced-write validation')
+				await failover.sql`SELECT pg_terminate_backend(${lostWriteLease.backendPid})`
+				await expect(database.storeBlock(chainId, third, lostWriteLease)).rejects.toThrow()
+				expect(await failover.checkpoint(chainId)).toEqual({ number: 2n, hash: replacement.hash })
+				await lostWriteLease.release().catch(() => undefined)
+				const takeoverWriteLease = await failover.tryAcquireIndexerLock(chainId)
+				if (takeoverWriteLease === undefined) throw new Error('takeover writer did not acquire after fencing')
+				await failover.storeBlock(chainId, third, takeoverWriteLease)
+				expect(await failover.checkpoint(chainId)).toEqual({ number: 3n, hash: third.hash })
+				await takeoverWriteLease.release()
+				await expect(database.recordFailure(chainId, 'stale former owner', new Date(), lostWriteLease)).rejects.toThrow()
+				const statusRows = await failover.sql`SELECT phase, last_error FROM networks WHERE chain_id = ${chainId}`
+				expect(statusRows[0]).toMatchObject({ phase: 'live', last_error: null })
+			} finally {
+				await failover.close()
+			}
+			const storedV4Markets =
+				await database.sql`SELECT market_id FROM uniswap_rep_eth_markets WHERE chain_id = ${chainId} AND block_hash = ${third.hash} AND canonical ORDER BY market_id`
+			expect(storedV4Markets).toEqual([{ market_id: standardV4MarketId }])
+			const storedV4Observations =
+				await database.sql`SELECT market_id FROM uniswap_rep_eth_price_observations WHERE chain_id = ${chainId} AND block_hash = ${third.hash} AND canonical ORDER BY market_id`
+			expect(storedV4Observations).toEqual([{ market_id: standardV4MarketId }])
+			const readIsolation = await database.read(async (sql) => {
+				const rows = await sql`SELECT current_setting('transaction_isolation') AS isolation, current_setting('transaction_read_only') AS read_only`
+				return rows[0]
+			})
+			expect(readIsolation).toMatchObject({ isolation: 'repeatable read', read_only: 'on' })
+			const reorgWriter = new ScannerDatabase(postgresUrl)
+			try {
+				const snapshotStayedCanonical = await database.read(async (sql) => {
+					const before = await sql`SELECT canonical FROM blocks WHERE chain_id = ${chainId} AND hash = ${third.hash}`
+					expect(before[0]?.['canonical']).toBe(true)
+					await reorgWriter.sql`UPDATE blocks SET canonical = false WHERE chain_id = ${chainId} AND hash = ${third.hash}`
+					const after = await sql`SELECT canonical FROM blocks WHERE chain_id = ${chainId} AND hash = ${third.hash}`
+					return after[0]?.['canonical']
+				})
+				expect(snapshotStayedCanonical).toBe(true)
+			} finally {
+				await reorgWriter.sql`UPDATE blocks SET canonical = true WHERE chain_id = ${chainId} AND hash = ${third.hash}`
+				await reorgWriter.close()
+			}
+			await database.seedNetwork({ ...network, contracts: [[orphanOnlyAddress, 'New child REP', 'reputationToken']] })
+
+			const response = await handleApi(new Request(`http://localhost/api/v1/logs?chainId=${chainId}`), database.sql)
+			if (response === undefined) throw new Error('logs API did not return a response')
+			const payload = (await response.json()) as { items: Array<{ summary: string; block_hash: string; origin_address: string }> }
+			expect(payload.items).toContainEqual(expect.objectContaining({ summary: 'replacement event', block_hash: replacement.hash }))
+			expect(payload.items.some((item) => item.block_hash === orphan.hash)).toBe(false)
+			expect(payload.items.find((item) => item.summary === 'replacement event')?.origin_address).toBe(address.toLowerCase())
+			const orphanDetailResponse = await handleApi(new Request(`http://localhost/api/v1/logs/${chainId}/${orphan.hash}/${transactionHash}/0`), database.sql)
+			expect(orphanDetailResponse?.status).toBe(404)
+			expect(await orphanDetailResponse?.json()).toEqual({ error: 'Log not found' })
+			const senderLogsResponse = await handleApi(new Request(`http://localhost/api/v1/logs?chainId=${chainId}&address=${address.toLowerCase()}`), database.sql)
+			if (senderLogsResponse === undefined) throw new Error('sender-filtered logs API did not return a response')
+			const senderLogs = (await senderLogsResponse.json()) as { items: Array<{ origin_address: string; block_hash: string }> }
+			expect(senderLogs.items.length).toBeGreaterThan(0)
+			expect(senderLogs.items.every((item) => item.origin_address === address.toLowerCase())).toBe(true)
+			expect(senderLogs.items.some((item) => item.block_hash === orphan.hash)).toBe(false)
+			const detailResponse = await handleApi(new Request(`http://localhost/api/v1/logs/${chainId}/${replacement.hash}/${transactionHash}/0`), database.sql)
+			if (detailResponse === undefined) throw new Error('log detail API did not return a response')
+			const detail = (await detailResponse.json()) as { receipt: { logs: unknown[] }; argument_schema: unknown[]; origin_address: string }
+			expect(isLogDetailValue(detail)).toBeTrue()
+			expect(detail.receipt.logs).toHaveLength(1)
+			expect(detail.argument_schema).toEqual([])
+			expect(detail.origin_address).toBe(address.toLowerCase())
+			await database.sql`UPDATE contracts SET canonical = false WHERE chain_id = ${chainId} AND address = ${discoveredAddress.toLowerCase()}`
+			try {
+				const identitylessListResponse = await handleApi(new Request(`http://localhost/api/v1/logs?chainId=${chainId}`), database.sql)
+				if (identitylessListResponse === undefined) throw new Error('identityless logs API did not return a response')
+				const identitylessList = (await identitylessListResponse.json()) as { items: Array<Record<string, unknown>> }
+				expect(identitylessList.items.find((item) => item['block_hash'] === replacement.hash && item['summary'] === 'replacement event')).toMatchObject({
+					contract_label: null,
+					contract_kind: null,
+				})
+				const identitylessDetailResponse = await handleApi(
+					new Request(`http://localhost/api/v1/logs/${chainId}/${replacement.hash}/${transactionHash}/0`),
+					database.sql,
+				)
+				if (identitylessDetailResponse === undefined) throw new Error('identityless log detail API did not return a response')
+				expect(await identitylessDetailResponse.json()).toMatchObject({
+					contract_label: null,
+					contract_kind: null,
+					contract_provenance: null,
+				})
+			} finally {
+				await database.sql`UPDATE contracts SET canonical = true WHERE chain_id = ${chainId} AND address = ${discoveredAddress.toLowerCase()}`
+			}
+			await database.sql`
 			INSERT INTO transactions (chain_id, hash, block_hash, block_number, transaction_index, from_address, to_address, value, input, status, gas_used, receipt, canonical)
 			SELECT ${chainId}, '0x' || lpad(to_hex(sequence), 64, '0'), ${third.hash}, 3, sequence, ${address.toLowerCase()},
 				${discoveredAddress.toLowerCase()}, 0, '0x', 'success', 21000, '{}'::jsonb, true
 			FROM generate_series(1, 60) sequence
 		`
-		const referencedOnlyTransactionHash = blockHash('calldata-only-address-reference')
-		await database.sql`
+			const referencedOnlyTransactionHash = blockHash('calldata-only-address-reference')
+			await database.sql`
 			INSERT INTO transactions (chain_id, hash, block_hash, block_number, transaction_index, from_address, to_address, value, input, status, gas_used, receipt, canonical)
 			VALUES (${chainId}, ${referencedOnlyTransactionHash}, ${third.hash}, 3, 61, ${discoveredAddress.toLowerCase()},
 				${address.toLowerCase()}, 0, '0x1234', 'success', 42000, '{}'::jsonb, true)
 		`
-		await database.sql`
+			await database.sql`
 			INSERT INTO actions (chain_id, block_hash, tx_hash, contract_address, function_name, function_signature, arguments, display_arguments, argument_schema, decode_status, summary)
 			VALUES (${chainId}, ${third.hash}, ${referencedOnlyTransactionHash}, ${address.toLowerCase()}, 'reportFor', 'reportFor(address)',
-				${JSON.stringify({ participant: referencedOnlyAddress.toLowerCase() })}::jsonb,
-				${JSON.stringify({ participant: referencedOnlyAddress.toLowerCase() })}::jsonb,
-				${JSON.stringify([{ index: 0, name: 'participant', type: 'address' }])}::jsonb, 'decoded', 'reportFor')
+				(${JSON.stringify({ participant: referencedOnlyAddress.toLowerCase() })}::text)::jsonb,
+				(${JSON.stringify({ participant: referencedOnlyAddress.toLowerCase() })}::text)::jsonb,
+				(${JSON.stringify([{ index: 0, name: 'participant', type: 'address' }])}::text)::jsonb, 'decoded', 'reportFor')
 		`
-		await database.sql`
+			await database.sql`
 			INSERT INTO address_activity (chain_id, block_hash, block_number, tx_hash, address, pool_address, role, canonical)
 			VALUES (${chainId}, ${third.hash}, 3, ${referencedOnlyTransactionHash}, ${referencedOnlyAddress.toLowerCase()},
 				'0x0000000000000000000000000000000000000000', 'referenced', true)
 		`
-		const newerSenderTransactionHash = blockHash('newer-sender-only-address-activity')
-		await database.sql`
+			const newerSenderTransactionHash = blockHash('newer-sender-only-address-activity')
+			await database.sql`
 			INSERT INTO transactions (chain_id, hash, block_hash, block_number, transaction_index, from_address, to_address, value, input, status, gas_used, receipt, canonical)
 			VALUES (${chainId}, ${newerSenderTransactionHash}, ${third.hash}, 3, 62, ${referencedOnlyAddress.toLowerCase()},
 				${address.toLowerCase()}, 0, '0x', 'success', 21000, '{}'::jsonb, true)
 		`
-		await database.sql`
+			await database.sql`
 			INSERT INTO address_activity (chain_id, block_hash, block_number, tx_hash, address, pool_address, role, canonical)
 			VALUES (${chainId}, ${third.hash}, 3, ${newerSenderTransactionHash}, ${referencedOnlyAddress.toLowerCase()},
 				'0x0000000000000000000000000000000000000000', 'sender', true)
 		`
-		const interactionsResponse = await handleApi(
-			new Request(`http://localhost/api/v1/address-interactions?chainId=${chainId}&address=${referencedOnlyAddress}&limit=1`),
-			database.sql,
-		)
-		if (interactionsResponse === undefined) throw new Error('address interactions API did not return a response')
-		const interactionsPayload: unknown = await interactionsResponse.json()
-		expect(interactionsPayload).toMatchObject({
-			items: [
-				{
-					tx_hash: referencedOnlyTransactionHash,
-					roles: ['referenced'],
-					pool_addresses: null,
-					function_name: 'reportFor',
-					action_arguments: { participant: referencedOnlyAddress.toLowerCase() },
-				},
-			],
-			limit: 1,
-		})
-		if (!isRecord(interactionsPayload) || !Array.isArray(interactionsPayload['items'])) throw new Error('address interactions API returned malformed items')
-		expect(interactionsPayload['items'].every(isAccountTransactionValue)).toBeTrue()
-		const transactionsResponse = await handleApi(
-			new Request(`http://localhost/api/v1/address-transactions?chainId=${chainId}&address=${address}&limit=50`),
-			database.sql,
-		)
-		if (transactionsResponse === undefined) throw new Error('address transactions API did not return a response')
-		const transactions = (await transactionsResponse.json()) as {
-			items: Array<Record<string, unknown>>
-			nextCursor: string
-			snapshotBlock: string
-			total: number
-		}
-		expect(transactions).toMatchObject({ total: 61, snapshotBlock: '3' })
-		expect(transactions.items).toHaveLength(50)
-		await database.sql`UPDATE blocks SET canonical = false WHERE chain_id = ${chainId} AND hash = ${third.hash}`
-		const staleCursorResponse = await handleApi(
-			new Request(
-				`http://localhost/api/v1/address-transactions?chainId=${chainId}&address=${address}&limit=50&cursor=${encodeURIComponent(transactions.nextCursor)}`,
-			),
-			database.sql,
-		)
-		expect(staleCursorResponse?.status).toBe(409)
-		expect(await staleCursorResponse?.json()).toEqual({ error: 'Transaction history changed; restart pagination' })
-		const canonicalOnlyTransactionsResponse = await handleApi(
-			new Request(`http://localhost/api/v1/address-transactions?chainId=${chainId}&address=${address}&limit=50`),
-			database.sql,
-		)
-		if (canonicalOnlyTransactionsResponse === undefined) throw new Error('canonical-only address transaction page did not return a response')
-		expect(await canonicalOnlyTransactionsResponse.json()).toMatchObject({ total: 1, snapshotBlock: '2' })
-		await database.sql`UPDATE blocks SET canonical = true WHERE chain_id = ${chainId} AND hash = ${third.hash}`
-		const alteredCursorParts = JSON.parse(atob(transactions.nextCursor)) as [number, string, string, string, number, string, number]
-		alteredCursorParts[4]++
-		const alteredTotalResponse = await handleApi(
-			new Request(
-				`http://localhost/api/v1/address-transactions?chainId=${chainId}&address=${address}&limit=50&cursor=${encodeURIComponent(btoa(JSON.stringify(alteredCursorParts)))}`,
-			),
-			database.sql,
-		)
-		expect(alteredTotalResponse?.status).toBe(409)
-		expect(await alteredTotalResponse?.json()).toEqual({ error: 'Transaction history changed; restart pagination' })
-		const fourthHash = blockHash('block-four-direct')
-		await database.sql`INSERT INTO blocks (chain_id, number, hash, parent_hash, timestamp, canonical) VALUES (${chainId}, 4, ${fourthHash}, ${third.hash}, '2026-01-04T00:00:00Z', true)`
-		await database.sql`
+			const interactionsResponse = await handleApi(
+				new Request(`http://localhost/api/v1/address-interactions?chainId=${chainId}&address=${referencedOnlyAddress}&limit=1`),
+				database.sql,
+			)
+			if (interactionsResponse === undefined) throw new Error('address interactions API did not return a response')
+			const interactionsPayload: unknown = await interactionsResponse.json()
+			expect(interactionsPayload).toMatchObject({
+				items: [
+					{
+						tx_hash: referencedOnlyTransactionHash,
+						roles: ['referenced'],
+						pool_addresses: null,
+						function_name: 'reportFor',
+						action_arguments: { participant: referencedOnlyAddress.toLowerCase() },
+					},
+				],
+				limit: 1,
+			})
+			if (!isRecord(interactionsPayload) || !Array.isArray(interactionsPayload['items'])) throw new Error('address interactions API returned malformed items')
+			expect(interactionsPayload['items'].every(isAccountTransactionValue)).toBeTrue()
+			const transactionsResponse = await handleApi(
+				new Request(`http://localhost/api/v1/address-transactions?chainId=${chainId}&address=${address}&limit=50`),
+				database.sql,
+			)
+			if (transactionsResponse === undefined) throw new Error('address transactions API did not return a response')
+			const transactions = (await transactionsResponse.json()) as {
+				items: Array<Record<string, unknown>>
+				nextCursor: string
+				snapshotBlock: string
+				total: number
+			}
+			expect(transactions).toMatchObject({ total: 62, snapshotBlock: '3' })
+			expect(transactions.items).toHaveLength(50)
+			await database.sql`UPDATE blocks SET canonical = false WHERE chain_id = ${chainId} AND hash = ${third.hash}`
+			const staleCursorResponse = await handleApi(
+				new Request(
+					`http://localhost/api/v1/address-transactions?chainId=${chainId}&address=${address}&limit=50&cursor=${encodeURIComponent(transactions.nextCursor)}`,
+				),
+				database.sql,
+			)
+			expect(staleCursorResponse?.status).toBe(409)
+			expect(await staleCursorResponse?.json()).toEqual({ error: 'Transaction history changed; restart pagination' })
+			const canonicalOnlyTransactionsResponse = await handleApi(
+				new Request(`http://localhost/api/v1/address-transactions?chainId=${chainId}&address=${address}&limit=50`),
+				database.sql,
+			)
+			if (canonicalOnlyTransactionsResponse === undefined) throw new Error('canonical-only address transaction page did not return a response')
+			expect(await canonicalOnlyTransactionsResponse.json()).toMatchObject({ total: 1, snapshotBlock: '2' })
+			await database.sql`UPDATE blocks SET canonical = true WHERE chain_id = ${chainId} AND hash = ${third.hash}`
+			const alteredCursorParts = JSON.parse(atob(transactions.nextCursor)) as [number, string, string, string, number, string, number]
+			alteredCursorParts[4]++
+			const alteredTotalResponse = await handleApi(
+				new Request(
+					`http://localhost/api/v1/address-transactions?chainId=${chainId}&address=${address}&limit=50&cursor=${encodeURIComponent(btoa(JSON.stringify(alteredCursorParts)))}`,
+				),
+				database.sql,
+			)
+			expect(alteredTotalResponse?.status).toBe(409)
+			expect(await alteredTotalResponse?.json()).toEqual({ error: 'Transaction history changed; restart pagination' })
+			const fourthHash = blockHash('block-four-direct')
+			await database.sql`INSERT INTO blocks (chain_id, number, hash, parent_hash, timestamp, canonical) VALUES (${chainId}, 4, ${fourthHash}, ${third.hash}, '2026-01-04T00:00:00Z', true)`
+			await database.sql`
 			INSERT INTO transactions (chain_id, hash, block_hash, block_number, transaction_index, from_address, to_address, value, input, status, gas_used, receipt, canonical)
 			VALUES (${chainId}, ${blockHash('newer-address-transaction')}, ${fourthHash}, 4, 0, ${address.toLowerCase()}, ${discoveredAddress.toLowerCase()}, 0, '0x', 'success', 21000, '{}'::jsonb, true)
 		`
-		const secondPageResponse = await handleApi(
-			new Request(
-				`http://localhost/api/v1/address-transactions?chainId=${chainId}&address=${address}&limit=50&cursor=${encodeURIComponent(transactions.nextCursor)}`,
-			),
-			database.sql,
-		)
-		if (secondPageResponse === undefined) throw new Error('second address transaction page did not return a response')
-		const secondPage = (await secondPageResponse.json()) as { items: Array<Record<string, unknown>>; nextCursor?: string; total: number }
-		const snapshotItems = [...transactions.items, ...secondPage.items]
-		expect(secondPage).toMatchObject({ total: 61 })
-		expect(secondPage.nextCursor).toBeUndefined()
-		expect(snapshotItems).toHaveLength(61)
-		expect(new Set(snapshotItems.map((item) => item['tx_hash'])).size).toBe(61)
-		expect(snapshotItems).toContainEqual(
-			expect.objectContaining({
-				tx_hash: transactionHash,
-				from_address: address.toLowerCase(),
-				block_hash: replacement.hash,
-				action_summary: 'Unknown call',
-			}),
-		)
-		expect(snapshotItems.some((item) => item['block_hash'] === fourthHash)).toBe(false)
-		const currentTransactionsResponse = await handleApi(
-			new Request(`http://localhost/api/v1/address-transactions?chainId=${chainId}&address=${address}&limit=1`),
-			database.sql,
-		)
-		if (currentTransactionsResponse === undefined) throw new Error('current address transaction page did not return a response')
-		expect(await currentTransactionsResponse.json()).toMatchObject({ total: 62, snapshotBlock: '4' })
-		const richListResponse = await handleApi(new Request(`http://localhost/api/v1/richlist?chainId=${chainId}`), database.sql)
-		if (richListResponse === undefined) throw new Error('rich-list API did not return a response')
-		const richList = (await richListResponse.json()) as {
-			items: Array<
-				Record<string, unknown> & {
-					rep_balances: Array<Record<string, unknown>>
-					pool_associations: Array<Record<string, unknown>>
-					vault_positions: Array<Record<string, unknown>>
-					weth_balances: Array<Record<string, unknown>>
-					native_balance_detail: Record<string, unknown>
-				}
-			>
-			total: number
-		}
-		expect(richList.total).toBe(1)
-		expect(richList.items[0]).toMatchObject({
-			address: address.toLowerCase(),
-			transaction_count: '1',
-			interaction_count: '1',
-			pool_count: '1',
-			native_balance: '2000000000456789123',
-			weth_balance: '1456790112345679011',
-			weth_token_count: '2',
-			sampled_weth_token_count: '2',
-			rep_token_count: '2',
-			sampled_rep_token_count: '1',
-		})
-		const addressProfileResponse = await handleApi(new Request(`http://localhost/api/v1/richlist?chainId=${chainId}&address=${address}`), database.sql)
-		if (addressProfileResponse === undefined) throw new Error('address profile query did not return a response')
-		expect(await addressProfileResponse.json()).toMatchObject({
-			total: 1,
-			items: [expect.objectContaining({ address: address.toLowerCase(), pool_count: '1', vault_count: '1' })],
-		})
-		const addressIdentityResponse = await handleApi(
-			new Request(`http://localhost/api/v1/address-identity?chainId=${chainId}&address=${discoveredAddress}`),
-			database.sql,
-		)
-		if (addressIdentityResponse === undefined) throw new Error('address identity query did not return a response')
-		expect(await addressIdentityResponse.json()).toMatchObject({
-			address: discoveredAddress.toLowerCase(),
-			label: 'Discovered pool',
-			kind: 'securityPool',
-		})
-		expect(richList.items[0]?.rep_balances).toEqual([
-			expect.objectContaining({
-				address: rediscoveredAddress.toLowerCase(),
-				balance: '3000000000000000000',
-				symbol: 'OLD',
-				contractLabel: 'Original discovery',
-			}),
-		])
-		expect(richList.items[0]?.weth_balances).toEqual([
-			expect.objectContaining({ address: wethAddress.toLowerCase(), balance: '1234567890123456789', symbol: 'WETH' }),
-			expect.objectContaining({ address: secondWethAddress.toLowerCase(), balance: '222222222222222222', symbol: 'WETH2' }),
-		])
-		expect(richList.items[0]?.native_balance_detail).toEqual({ balance: '2000000000456789123', blockNumber: '2' })
-		expect(richList.items[0]?.pool_associations).toEqual([expect.objectContaining({ address: discoveredAddress.toLowerCase() })])
-		expect(richList.items[0]?.vault_positions).toEqual([
-			expect.objectContaining({
-				poolAddress: discoveredAddress.toLowerCase(),
-				repBackingUnits: '120000000000000000000',
-				capacityOwnershipAttoRep: 85_000_000_000_000_000_000n.toString(),
-				claimableFeesAttoEth: 30_000_000_000_000_000n.toString(),
-				blockNumber: '2',
-			}),
-		])
-		const beyondEndResponse = await handleApi(new Request(`http://localhost/api/v1/richlist?chainId=${chainId}&offset=1`), database.sql)
-		if (beyondEndResponse === undefined) throw new Error('offset rich-list API did not return a response')
-		const beyondEnd = (await beyondEndResponse.json()) as { items: unknown[]; total: number }
-		expect(beyondEnd).toMatchObject({ items: [], total: 1 })
-		const balanceLease = await database.tryAcquireIndexerLock(chainId)
-		if (balanceLease === undefined) throw new Error('balance refresher did not acquire its lock')
-		await database.storeRichListBalances(
-			chainId,
-			3n,
-			third.hash,
-			[
-				{ owner: address, assetAddress: getAddress('0x0000000000000000000000000000000000000000'), assetKind: 'native', balance: 2_000_000_000_000_000_000n },
-				{ owner: address, assetAddress: rediscoveredAddress, assetKind: 'rep', balance: 3_000_000_000_000_000_000n },
-				{ owner: address, assetAddress: orphanOnlyAddress, assetKind: 'rep', balance: 4_000_000_000_000_000_000n },
-			],
-			balanceLease,
-		)
-		await balanceLease.release()
-		const refreshedResponse = await handleApi(new Request(`http://localhost/api/v1/richlist?chainId=${chainId}`), database.sql)
-		if (refreshedResponse === undefined) throw new Error('refreshed rich-list API did not return a response')
-		const refreshed = (await refreshedResponse.json()) as { items: Array<Record<string, unknown>> }
-		expect(refreshed.items[0]).toMatchObject({ rep_token_count: '2', sampled_rep_token_count: '2' })
-		expect(refreshed.items[0]).not.toHaveProperty('rep_balance')
+			const secondPageResponse = await handleApi(
+				new Request(
+					`http://localhost/api/v1/address-transactions?chainId=${chainId}&address=${address}&limit=50&cursor=${encodeURIComponent(transactions.nextCursor)}`,
+				),
+				database.sql,
+			)
+			if (secondPageResponse === undefined) throw new Error('second address transaction page did not return a response')
+			const secondPage = (await secondPageResponse.json()) as { items: Array<Record<string, unknown>>; nextCursor?: string; total: number }
+			const snapshotItems = [...transactions.items, ...secondPage.items]
+			expect(secondPage).toMatchObject({ total: 62 })
+			expect(secondPage.nextCursor).toBeUndefined()
+			expect(snapshotItems).toHaveLength(62)
+			expect(new Set(snapshotItems.map((item) => item['tx_hash'])).size).toBe(62)
+			expect(snapshotItems).toContainEqual(
+				expect.objectContaining({
+					tx_hash: transactionHash,
+					from_address: address.toLowerCase(),
+					block_hash: replacement.hash,
+					action_summary: 'Unknown call',
+				}),
+			)
+			expect(snapshotItems.some((item) => item['block_hash'] === fourthHash)).toBe(false)
+			const currentTransactionsResponse = await handleApi(
+				new Request(`http://localhost/api/v1/address-transactions?chainId=${chainId}&address=${address}&limit=1`),
+				database.sql,
+			)
+			if (currentTransactionsResponse === undefined) throw new Error('current address transaction page did not return a response')
+			expect(await currentTransactionsResponse.json()).toMatchObject({ total: 63, snapshotBlock: '4' })
+			const richListResponse = await handleApi(new Request(`http://localhost/api/v1/richlist?chainId=${chainId}&address=${address}`), database.sql)
+			if (richListResponse === undefined) throw new Error('rich-list API did not return a response')
+			const richList = (await richListResponse.json()) as {
+				items: Array<
+					Record<string, unknown> & {
+						rep_balances: Array<Record<string, unknown>>
+						pool_associations: Array<Record<string, unknown>>
+						vault_positions: Array<Record<string, unknown>>
+						weth_balances: Array<Record<string, unknown>>
+						native_balance_detail: Record<string, unknown>
+					}
+				>
+				total: number
+			}
+			expect(richList.total).toBe(1)
+			expect(richList.items[0]).toMatchObject({
+				address: address.toLowerCase(),
+				transaction_count: '1',
+				interaction_count: '1',
+				pool_count: '1',
+				native_balance: '2000000000456789123',
+				weth_balance: '1456790112345679011',
+				weth_token_count: '2',
+				sampled_weth_token_count: '2',
+				rep_token_count: '2',
+				sampled_rep_token_count: '1',
+			})
+			const addressProfileResponse = await handleApi(new Request(`http://localhost/api/v1/richlist?chainId=${chainId}&address=${address}`), database.sql)
+			if (addressProfileResponse === undefined) throw new Error('address profile query did not return a response')
+			expect(await addressProfileResponse.json()).toMatchObject({
+				total: 1,
+				items: [expect.objectContaining({ address: address.toLowerCase(), pool_count: '1', vault_count: '1' })],
+			})
+			const addressIdentityResponse = await handleApi(
+				new Request(`http://localhost/api/v1/address-identity?chainId=${chainId}&address=${discoveredAddress}`),
+				database.sql,
+			)
+			if (addressIdentityResponse === undefined) throw new Error('address identity query did not return a response')
+			expect(await addressIdentityResponse.json()).toMatchObject({
+				address: discoveredAddress.toLowerCase(),
+				label: 'Discovered pool',
+				kind: 'securityPool',
+			})
+			expect(richList.items[0]?.rep_balances).toEqual([
+				expect.objectContaining({
+					address: rediscoveredAddress.toLowerCase(),
+					balance: '3000000000000000000',
+					symbol: 'OLD',
+					contractLabel: 'Original discovery',
+				}),
+			])
+			expect(richList.items[0]?.weth_balances).toEqual([
+				expect.objectContaining({ address: wethAddress.toLowerCase(), balance: '1234567890123456789', symbol: 'WETH' }),
+				expect.objectContaining({ address: secondWethAddress.toLowerCase(), balance: '222222222222222222', symbol: 'WETH2' }),
+			])
+			expect(richList.items[0]?.native_balance_detail).toEqual({ balance: '2000000000456789123', blockNumber: '2' })
+			expect(richList.items[0]?.pool_associations).toEqual([expect.objectContaining({ address: discoveredAddress.toLowerCase() })])
+			expect(richList.items[0]?.vault_positions).toEqual([
+				expect.objectContaining({
+					poolAddress: discoveredAddress.toLowerCase(),
+					repBackingUnits: '120000000000000000000',
+					capacityOwnershipAttoRep: 85_000_000_000_000_000_000n.toString(),
+					claimableFeesAttoEth: 30_000_000_000_000_000n.toString(),
+					blockNumber: '2',
+				}),
+			])
+			const beyondEndResponse = await handleApi(new Request(`http://localhost/api/v1/richlist?chainId=${chainId}&address=${address}&offset=1`), database.sql)
+			if (beyondEndResponse === undefined) throw new Error('offset rich-list API did not return a response')
+			const beyondEnd = (await beyondEndResponse.json()) as { items: unknown[]; total: number }
+			expect(beyondEnd).toMatchObject({ items: [], total: 1 })
+			const balanceLease = await database.tryAcquireIndexerLock(chainId)
+			if (balanceLease === undefined) throw new Error('balance refresher did not acquire its lock')
+			await database.storeRichListBalances(
+				chainId,
+				3n,
+				third.hash,
+				[
+					{ owner: address, assetAddress: getAddress('0x0000000000000000000000000000000000000000'), assetKind: 'native', balance: 2_000_000_000_000_000_000n },
+					{ owner: address, assetAddress: rediscoveredAddress, assetKind: 'rep', balance: 3_000_000_000_000_000_000n },
+					{ owner: address, assetAddress: orphanOnlyAddress, assetKind: 'rep', balance: 4_000_000_000_000_000_000n },
+				],
+				balanceLease,
+			)
+			await balanceLease.release()
+			const refreshedResponse = await handleApi(new Request(`http://localhost/api/v1/richlist?chainId=${chainId}&address=${address}`), database.sql)
+			if (refreshedResponse === undefined) throw new Error('refreshed rich-list API did not return a response')
+			const refreshed = (await refreshedResponse.json()) as { items: Array<Record<string, unknown>> }
+			expect(refreshed.items[0]).toMatchObject({ rep_token_count: '2', sampled_rep_token_count: '2' })
+			expect(refreshed.items[0]).not.toHaveProperty('rep_balance')
 
-		const extraRepTokens = Array.from({ length: 101 }, (_, index) =>
-			getAddress(`0x${(0x7000000000000000000000000000000000000000n + BigInt(index)).toString(16)}`),
-		)
-		await database.seedNetwork({
-			...network,
-			contracts: extraRepTokens.map((token, index) => [token, `Extra REP ${index + 1}`, 'reputationToken']),
-		})
-		const assetLimitLease = await database.tryAcquireIndexerLock(chainId)
-		if (assetLimitLease === undefined) throw new Error('asset-limit writer did not acquire its lock')
-		await database.storeRichListBalances(
-			chainId,
-			3n,
-			third.hash,
-			extraRepTokens.map((token, index) => ({ owner: address, assetAddress: token, assetKind: 'rep' as const, balance: BigInt(index + 1) })),
-			assetLimitLease,
-		)
-		await assetLimitLease.release()
-		const cappedResponse = await handleApi(new Request(`http://localhost/api/v1/richlist?chainId=${chainId}`), database.sql)
-		if (cappedResponse === undefined) throw new Error('capped rich-list API did not return a response')
-		const capped = (await cappedResponse.json()) as { items: Array<Record<string, unknown> & { rep_balances: Array<{ address: string }> }> }
-		expect(capped.items[0]).toMatchObject({ sampled_rep_token_count: '103', returned_rep_token_count: '100', rep_balances_truncated: true })
-		expect(capped.items[0]?.rep_balances).toHaveLength(100)
-		expect(capped.items[0]?.rep_balances.map((balance) => balance.address)).toEqual(
-			[rediscoveredAddress, orphanOnlyAddress, ...extraRepTokens]
-				.map((token) => token.toLowerCase())
-				.toSorted()
-				.slice(0, 100),
-		)
+			const extraRepTokens = Array.from({ length: 101 }, (_, index) =>
+				getAddress(`0x${(0x7000000000000000000000000000000000000000n + BigInt(index)).toString(16)}`),
+			)
+			await database.seedNetwork({
+				...network,
+				contracts: extraRepTokens.map((token, index) => [token, `Extra REP ${index + 1}`, 'reputationToken']),
+			})
+			const assetLimitLease = await database.tryAcquireIndexerLock(chainId)
+			if (assetLimitLease === undefined) throw new Error('asset-limit writer did not acquire its lock')
+			await database.storeRichListBalances(
+				chainId,
+				3n,
+				third.hash,
+				extraRepTokens.map((token, index) => ({ owner: address, assetAddress: token, assetKind: 'rep' as const, balance: BigInt(index + 1) })),
+				assetLimitLease,
+			)
+			await assetLimitLease.release()
+			const cappedResponse = await handleApi(new Request(`http://localhost/api/v1/richlist?chainId=${chainId}&address=${address}`), database.sql)
+			if (cappedResponse === undefined) throw new Error('capped rich-list API did not return a response')
+			const capped = (await cappedResponse.json()) as { items: Array<Record<string, unknown> & { rep_balances: Array<{ address: string }> }> }
+			expect(capped.items[0]).toMatchObject({ sampled_rep_token_count: '102', returned_rep_token_count: '100', rep_balances_truncated: true })
+			expect(capped.items[0]?.rep_balances).toHaveLength(100)
+			expect(capped.items[0]?.rep_balances.map((balance) => balance.address)).toEqual(
+				[rediscoveredAddress, ...extraRepTokens]
+					.map((token) => token.toLowerCase())
+					.toSorted()
+					.slice(0, 100),
+			)
 
-		await database.sql`
+			await database.sql`
 			INSERT INTO address_activity (chain_id, block_hash, block_number, tx_hash, address, pool_address, role, canonical)
 			SELECT ${chainId}, ${replacement.hash}, 2, ${transactionHash},
 				'0x' || lpad(to_hex(participant), 40, '0'),
@@ -1281,64 +1407,72 @@ postgresTest('initializes, resumes, retains an orphan, and serves only its canon
 			FROM generate_series(1, 5000) participant
 			ON CONFLICT DO NOTHING
 		`
-		const largePageResponse = await database.read((sql) => handleApi(new Request(`http://localhost/api/v1/richlist?chainId=${chainId}&limit=10`), sql), 8_000)
-		if (largePageResponse === undefined) throw new Error('large rich-list page did not return a response')
-		const largePage = (await largePageResponse.json()) as { items: unknown[]; total: number }
-		expect(largePage).toMatchObject({ total: 5001 })
-		expect(largePage.items).toHaveLength(10)
-		const largeBeyondEndResponse = await database.read(
-			(sql) => handleApi(new Request(`http://localhost/api/v1/richlist?chainId=${chainId}&limit=10&offset=100000`), sql),
-			8_000,
-		)
-		if (largeBeyondEndResponse === undefined) throw new Error('large beyond-end rich-list page did not return a response')
-		const largeBeyondEnd = (await largeBeyondEndResponse.json()) as { items: unknown[]; total: number }
-		expect(largeBeyondEnd).toMatchObject({ items: [], total: 5001 })
+			const largePageResponse = await database.read((sql) => handleApi(new Request(`http://localhost/api/v1/richlist?chainId=${chainId}&limit=10`), sql), 8_000)
+			if (largePageResponse === undefined) throw new Error('large rich-list page did not return a response')
+			const largePage = (await largePageResponse.json()) as { items: unknown[]; total: number }
+			expect(largePage).toMatchObject({ total: 5002 })
+			expect(largePage.items).toHaveLength(10)
+			const largeBeyondEndResponse = await database.read(
+				(sql) => handleApi(new Request(`http://localhost/api/v1/richlist?chainId=${chainId}&limit=10&offset=100000`), sql),
+				8_000,
+			)
+			if (largeBeyondEndResponse === undefined) throw new Error('large beyond-end rich-list page did not return a response')
+			const largeBeyondEnd = (await largeBeyondEndResponse.json()) as { items: unknown[]; total: number }
+			expect(largeBeyondEnd).toMatchObject({ items: [], total: 5002 })
 
-		const manifestResetLease = await database.tryAcquireIndexerLock(chainId)
-		if (manifestResetLease === undefined) throw new Error('manifest reset did not acquire its lock')
-		expect(await database.seedNetwork({ ...network, contracts: [[address, 'Final manifest', 'zoltar']] }, manifestResetLease, true)).toBe(true)
-		await manifestResetLease.release()
-		expect(await database.checkpoint(chainId)).toBeUndefined()
-		expect(await database.networkStartBlock(chainId)).toBe(1n)
-		expect(await database.hasStoredBlocks(chainId)).toBe(true)
-		const resetNetworkRows = await database.sql`SELECT finalized_block FROM networks WHERE chain_id = ${chainId}`
-		expect(resetNetworkRows[0]?.['finalized_block']).toBeNull()
-		const canonicalHistory = await database.sql`
+			const manifestResetLease = await database.tryAcquireIndexerLock(chainId)
+			if (manifestResetLease === undefined) throw new Error('manifest reset did not acquire its lock')
+			expect(
+				await database.seedNetwork(
+					{ ...network, contracts: [[address, 'Final manifest', 'zoltar']] },
+					{ lease: manifestResetLease, resetCanonicalHistoryOnManifestChange: true },
+				),
+			).toBe(true)
+			await manifestResetLease.release()
+			expect(await database.checkpoint(chainId)).toBeUndefined()
+			expect(await database.networkStartBlock(chainId)).toBe(1n)
+			expect(await database.hasStoredBlocks(chainId)).toBe(true)
+			const resetNetworkRows = await database.sql`SELECT finalized_block FROM networks WHERE chain_id = ${chainId}`
+			expect(resetNetworkRows[0]?.['finalized_block']).toBeNull()
+			const canonicalHistory = await database.sql`
 			SELECT
 				(SELECT count(*) FROM logs WHERE chain_id = ${chainId} AND canonical)::integer AS logs,
 				(SELECT count(*) FROM pools WHERE chain_id = ${chainId} AND canonical)::integer AS pools,
 				(SELECT count(*) FROM address_activity WHERE chain_id = ${chainId} AND canonical)::integer AS activity
 		`
-		expect(canonicalHistory[0]).toMatchObject({ logs: 0, pools: 0, activity: 0 })
-		expect([...(await database.contracts(chainId)).values()]).toEqual([{ address, label: 'Final manifest', kind: 'zoltar', provenance: 'manifest' }])
-		const retiredManifestAddress = extraRepTokens[0]
-		if (retiredManifestAddress === undefined) throw new Error('retired manifest fixture is unavailable')
-		await database.upsertContract(chainId, {
-			address: retiredManifestAddress,
-			label: 'Rediscovered security pool',
-			kind: 'securityPool',
-			provenance: 'Factory.DeploySecurityPool',
-			discoveryBlock: 4n,
-			discoveryTxHash: transactionHash,
-		})
-		expect((await database.contracts(chainId)).get(retiredManifestAddress.toLowerCase())).toMatchObject({
-			label: 'Rediscovered security pool',
-			kind: 'securityPool',
-			provenance: 'Factory.DeploySecurityPool',
-		})
-		expect(await database.seedNetwork({ ...network, contracts: [[address, 'Final manifest', 'zoltar']] })).toBe(false)
-		const retainedHistoryLease = await database.tryAcquireIndexerLock(chainId)
-		if (retainedHistoryLease === undefined) throw new Error('retained-history validation did not acquire its lock')
-		await expect(database.seedNetwork({ ...network, startBlock: 100n }, retainedHistoryLease, true)).rejects.toThrow(
-			'while an effective index start is retained',
-		)
-		await retainedHistoryLease.release()
-		expect(await database.networkStartBlock(chainId)).toBe(1n)
-	} finally {
-		await database.sql.unsafe('TRUNCATE TABLE networks CASCADE')
-		await database.close()
-	}
-})
+			expect(canonicalHistory[0]).toMatchObject({ logs: 0, pools: 0, activity: 0 })
+			expect([...(await database.contracts(chainId)).values()]).toEqual([{ address, label: 'Final manifest', kind: 'zoltar', provenance: 'manifest' }])
+			const retiredManifestAddress = extraRepTokens[0]
+			if (retiredManifestAddress === undefined) throw new Error('retired manifest fixture is unavailable')
+			await database.upsertContract(chainId, {
+				address: retiredManifestAddress,
+				label: 'Rediscovered security pool',
+				kind: 'securityPool',
+				provenance: 'Factory.DeploySecurityPool',
+				discoveryBlock: 4n,
+				discoveryTxHash: transactionHash,
+			})
+			expect((await database.contracts(chainId)).get(retiredManifestAddress.toLowerCase())).toMatchObject({
+				label: 'Rediscovered security pool',
+				kind: 'securityPool',
+				provenance: 'Factory.DeploySecurityPool',
+			})
+			expect(await database.seedNetwork({ ...network, contracts: [[address, 'Final manifest', 'zoltar']] })).toBe(false)
+			const retainedHistoryLease = await database.tryAcquireIndexerLock(chainId)
+			if (retainedHistoryLease === undefined) throw new Error('retained-history validation did not acquire its lock')
+			await expect(
+				database.seedNetwork({ ...network, startBlock: 100n }, { lease: retainedHistoryLease, resetCanonicalHistoryOnManifestChange: true }),
+			).rejects.toThrow('while an effective index start is retained')
+			await retainedHistoryLease.release()
+			expect(await database.networkStartBlock(chainId)).toBe(1n)
+		} finally {
+			await writeLease?.release().catch(() => undefined)
+			await resetIntegrationFixtures(database)
+			await database.close()
+		}
+	},
+	60_000,
+)
 
 postgresTest(
 	'stores operations snapshots, paginates entity evidence, and explains indexed access paths',
@@ -1850,7 +1984,12 @@ postgresTest(
 
 			const resetLease = await database.tryAcquireIndexerLock(operationsChainId)
 			if (resetLease === undefined) throw new Error('operations manifest-reset writer did not acquire its lock')
-			expect(await database.seedNetwork({ ...network, contracts: [[address, 'Replacement manifest contract', 'openOracle']] }, resetLease, true)).toBe(true)
+			expect(
+				await database.seedNetwork(
+					{ ...network, contracts: [[address, 'Replacement manifest contract', 'openOracle']] },
+					{ lease: resetLease, resetCanonicalHistoryOnManifestChange: true },
+				),
+			).toBe(true)
 			await resetLease.release()
 			const staleSnapshots = await database.sql`
 				SELECT DISTINCT read_status, canonical FROM entity_state_snapshots WHERE chain_id = ${operationsChainId}

--- a/scripts/classify-ci-change.mts
+++ b/scripts/classify-ci-change.mts
@@ -32,7 +32,10 @@ const dependencies: Readonly<Record<CiScope, readonly CiScope[]>> = { docs: [], 
 const rootDocumentation = new Set(['AGENTS.md', 'LICENSE', 'README.md'])
 const rootInfrastructure = new Set(['reth', 'testnetwork'])
 const rootGlobalFiles = new Set(['.coverage-policy.json', '.dockerignore', '.editorconfig', '.gitattributes', '.gitignore', '.npmrc', '.prettierignore', '.prettierrc.json', 'biome.json', 'bun.lock', 'bunfig.toml', 'knip.json', 'package.json', 'tsconfig.json', 'tsconfig.scripts.json'])
+const augurScanIntegrationFiles = new Set(['augurScan/bun.lock', 'augurScan/compose.yaml', 'augurScan/package.json', 'augurScan/schema.sql', 'augurScan/tests/postgres.integration.test.ts'])
 const ordered = (scopes: ReadonlySet<CiScope>): CiScope[] => ciScopes.filter(scope => scopes.has(scope))
+
+const isAugurScanIntegrationInput = (filePath: string): boolean => filePath.startsWith('augurScan/src/') || augurScanIntegrationFiles.has(filePath)
 
 function directScopeForPath(filePath: string): CiScope | 'full' {
 	if (rootDocumentation.has(filePath) || filePath.startsWith('docs/') || filePath.startsWith('.codex/') || filePath.startsWith('.ci-agents/')) return 'docs'
@@ -93,7 +96,7 @@ export function classifyCiChange(filePaths: readonly string[], options: { readon
 	const expandedScopes = ordered(expanded)
 	const packageMatrix = expandedScopes.flatMap(scope => packageEntries[scope] ?? [])
 	const packageMatrixJson = JSON.stringify({ include: packageMatrix })
-	const augurScanIntegration = false
+	const augurScanIntegration = forcedFull || changedFiles.some(isAugurScanIntegrationInput)
 	let reason = 'Selected direct scopes and expanded their verified local consumers.'
 	if (forcedFull) reason = 'A global or unknown path requires the full ordinary CI matrix.'
 	if (changedFiles.length === 0) reason = 'No changed paths were detected; using the safe full-run fallback.'

--- a/scripts/classify-ci-change.test.ts
+++ b/scripts/classify-ci-change.test.ts
@@ -36,11 +36,14 @@ test('empty input and explicit full mode use the full matrix', () => {
 	expect(classifyCiChange(['README.md'], { full: true }).expandedScopes).toEqual(ciScopes)
 })
 
-test('keeps the unreliable augurScan integration route disabled', () => {
+test('selects augurScan integration for runtime, schema, dependency, and full-suite changes', () => {
 	expect(classifyCiChange(['augurScan/README.md']).augurScanIntegration).toBe(false)
-	expect(classifyCiChange(['augurScan/src/database.ts']).augurScanIntegration).toBe(false)
-	expect(classifyCiChange(['unknown/file']).augurScanIntegration).toBe(false)
-	expect(classifyCiChange([], { full: true }).augurScanIntegration).toBe(false)
+	expect(classifyCiChange(['augurScan/src/database.ts']).augurScanIntegration).toBe(true)
+	expect(classifyCiChange(['augurScan/schema.sql']).augurScanIntegration).toBe(true)
+	expect(classifyCiChange(['augurScan/package.json']).augurScanIntegration).toBe(true)
+	expect(classifyCiChange(['augurScan/tests/postgres.integration.test.ts']).augurScanIntegration).toBe(true)
+	expect(classifyCiChange(['unknown/file']).augurScanIntegration).toBe(true)
+	expect(classifyCiChange([], { full: true }).augurScanIntegration).toBe(true)
 })
 
 test('matrices are valid, deterministic JSON for empty and non-empty selections', () => {


### PR DESCRIPTION
## Summary

- centralize canonical-history invalidation and add schema completeness coverage
- extract projection persistence from ScannerDatabase and add shared BigInt-safe database JSON serialization
- replace positional seed options and remove duplicate transaction-fencing logic
- harden indexer lease rollback, release ordering, recovery, and bounded shutdown
- repair PostgreSQL integration SQL, fixtures, assertions, and cleanup
- select PostgreSQL integration coverage for relevant CI changes
- stage the PostgreSQL-enabled AugurScan workflow at .github/workflow-changes/augur-scan.yml; the active workflow is intentionally unchanged so it can be moved later with workflow-authorized credentials

## Why

The database PR contained duplicated reorg policies, an oversized persistence method, unsafe JSON serialization for BigInt receipt data, hard-to-read positional options, stale integration fixtures, and lease failure paths that could reject previously queued work. These changes consolidate the shared behavior and add deterministic regression coverage.

## Validation

- bun run tsc
- AugurScan unit suite: 272 passed
- PostgreSQL 17 integration suite: 15 passed, 222 assertions
- CI classifier suite: 21 passed, 38 assertions
- bun run format:check
- bun run check
- bun run knip
- full repository suite before the latest main synchronization: 3,243 passed, 0 failed, 16 environment-dependent Uniswap skips
- post-synchronization full rerun encountered one unrelated parallel browser-smoke timing flake; the exact failed test passed immediately in isolation
- final read-only review: 100/100, no issues
- git diff --check

## Follow-up

Move .github/workflow-changes/augur-scan.yml to .github/workflows/augur-scan.yml using credentials with workflow permission to activate the PostgreSQL service and integration step.