### PR TITLE
Prevent retries of wallet transaction submissions

### DIFF
--- a/shared/ts/ethereum.test.ts
+++ b/shared/ts/ethereum.test.ts
@@ -1609,6 +1609,23 @@ describe('shared ethereum compatibility layer', () => {
 		expect(localCalls).toHaveLength(1)
 	})
 
+	test('wallet client never retries rpc-managed transaction submissions', async () => {
+		let attempts = 0
+		const provider = createProvider(({ method }) => {
+			if (method !== 'eth_sendTransaction') throw new Error(`Unexpected rpc method: ${method}`)
+			attempts += 1
+			throw { code: 429, message: 'rate limit exceeded' }
+		}, [])
+		const client = createWalletClient({
+			account: OWNER_ADDRESS,
+			chain: mainnet,
+			transport: custom(provider, { retryDelay: 0 }),
+		})
+
+		await expect(client.sendTransaction({ to: RECIPIENT_ADDRESS })).rejects.toThrow('rate limit exceeded')
+		expect(attempts).toBe(1)
+	})
+
 	test('HTTP transport retries rate limits for reads, receipt requests, and raw transaction broadcasts', async () => {
 		expect(RATE_LIMIT_RETRY_DELAY_MILLISECONDS).toBe(10_000)
 		expect(http('https://rpc.example.test').retryDelay).toBe(RATE_LIMIT_RETRY_DELAY_MILLISECONDS)

--- a/shared/ts/ethereum.ts
+++ b/shared/ts/ethereum.ts
@@ -1221,7 +1221,7 @@ async function retryRateLimited<TValue>(operation: () => Promise<TValue>, option
 
 async function requestTransport<TValue>(transport: Transport, parameters: ClientRequestParameters): Promise<TValue> {
 	return await retryRateLimited(async () => await requestTransportOnce<TValue>(transport, parameters), {
-		retryCount: transport.retryCount,
+		retryCount: parameters.method === 'eth_sendTransaction' ? 0 : transport.retryCount,
 		retryDelay: transport.retryDelay,
 	})
 }


### PR DESCRIPTION
## Summary

- Disable automatic retries for RPC-managed `eth_sendTransaction` calls.
- Keep configured retry behavior for reads, receipt polling, and identical raw-transaction broadcasts.
- Add a failing-first EIP-1193 regression that asserts a rate-limited wallet submission reaches the provider exactly once.

## Why

The shared transport previously retried every rate-limited JSON-RPC method. If an injected wallet accepted a transaction but its response was lost or rate-limited, the retry could prompt the user again or submit another transaction.

`eth_sendTransaction` now bypasses the generic rate-limit retry loop and surfaces the original provider error after the first attempt. Idempotent reads and `eth_sendRawTransaction` retain their existing retry and `already known` handling.

## Validation

- Failing-first regression: 4 provider calls before the fix, 1 after
- Shared Ethereum suite: 32 passed
- Full repository suite: 3251 passed, 16 network-dependent skips, 0 failed
- `bun run tsc`
- `bun run format:check`
- `bun run check`
- `bun run knip`
- `bun run check:generated-clean`
- `git diff --check`

One initial full run had an unrelated browser-smoke timeout under parallel contract load. That file passed 19/19 in isolation, and the required clean full rerun passed with no failures.
