### PR TITLE
Fix Trading transaction replacement handling

### DIFF
--- a/ui/coreShared/ts/lib/transactionReceipt.ts
+++ b/ui/coreShared/ts/lib/transactionReceipt.ts
@@ -1,0 +1,43 @@
+import type { Hash, ReplacementReason, TransactionReceipt } from '@zoltar/shared/ethereum'
+import type { WriteClient } from './chainBackend.js'
+
+export type SubmittedTransactionClient<TReceipt extends Pick<TransactionReceipt, 'status'> = TransactionReceipt> = {
+	onTransactionSubmitted?: ((hash: Hash) => void) | undefined
+	waitForTransactionReceipt: (...args: Parameters<WriteClient['waitForTransactionReceipt']>) => Promise<TReceipt>
+}
+
+export type SubmittedTransactionReceiptOptions = {
+	allowRevertedReceipt?: boolean
+	onKnownReceipt?: () => void
+	onTransactionReplaced?: (hash: Hash, reason: ReplacementReason) => void
+}
+
+function replacementFailureMessage(reason: ReplacementReason) {
+	if (reason === 'cancelled') return 'Transaction was cancelled in the wallet before confirmation.'
+	return 'Transaction was replaced in the wallet before confirmation.'
+}
+
+export async function waitForSubmittedTransactionReceipt<TReceipt extends Pick<TransactionReceipt, 'status'>>(
+	client: SubmittedTransactionClient<TReceipt>,
+	hash: Hash,
+	{ allowRevertedReceipt = false, onKnownReceipt, onTransactionReplaced }: SubmittedTransactionReceiptOptions = {},
+): Promise<{ hash: Hash; receipt: TReceipt }> {
+	let resolvedHash = hash
+	let replacementReason: ReplacementReason | undefined
+	const receipt = await client.waitForTransactionReceipt({
+		hash,
+		onReplaced: replacement => {
+			resolvedHash = replacement.transaction.hash
+			replacementReason = replacement.reason
+			client.onTransactionSubmitted?.(resolvedHash)
+			onTransactionReplaced?.(resolvedHash, replacement.reason)
+		},
+	})
+	onKnownReceipt?.()
+	if (replacementReason === 'cancelled' || replacementReason === 'replaced') throw new Error(replacementFailureMessage(replacementReason))
+	if (!allowRevertedReceipt && receipt.status === 'reverted') throw new Error('Transaction reverted')
+	return {
+		hash: resolvedHash,
+		receipt,
+	}
+}

--- a/ui/coreShared/ts/tests/transactionReceipt.test.ts
+++ b/ui/coreShared/ts/tests/transactionReceipt.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, mock, test } from 'bun:test'
+import type { Hash, ReplacementReason } from '@zoltar/shared/ethereum'
+import { waitForSubmittedTransactionReceipt, type SubmittedTransactionClient } from '../lib/transactionReceipt.js'
+
+const originalHash = `0x${'1'.repeat(64)}` as Hash
+const replacementHash = `0x${'2'.repeat(64)}` as Hash
+
+function replacementClient(reason: ReplacementReason, onTransactionSubmitted = mock(() => undefined)): SubmittedTransactionClient<{ status: 'success' }> {
+	return {
+		onTransactionSubmitted,
+		waitForTransactionReceipt: async parameters => {
+			parameters.onReplaced?.({
+				reason,
+				replacedTransaction: { hash: originalHash } as never,
+				transaction: { hash: replacementHash } as never,
+				transactionReceipt: { status: 'success' } as never,
+			})
+			return { status: 'success' }
+		},
+	}
+}
+
+describe('submitted transaction receipts', () => {
+	test('returns and reports the replacement hash for a repriced transaction', async () => {
+		const onTransactionSubmitted = mock(() => undefined)
+		const onTransactionReplaced = mock(() => undefined)
+		const onKnownReceipt = mock(() => undefined)
+
+		const result = await waitForSubmittedTransactionReceipt(replacementClient('repriced', onTransactionSubmitted), originalHash, { onKnownReceipt, onTransactionReplaced })
+
+		expect(result.hash).toBe(replacementHash)
+		expect(onTransactionSubmitted).toHaveBeenCalledWith(replacementHash)
+		expect(onTransactionReplaced).toHaveBeenCalledWith(replacementHash, 'repriced')
+		expect(onKnownReceipt).toHaveBeenCalledTimes(1)
+	})
+
+	test('marks a cancelled replacement receipt as known before rejecting it', async () => {
+		const onTransactionReplaced = mock(() => undefined)
+		const onKnownReceipt = mock(() => undefined)
+
+		await expect(waitForSubmittedTransactionReceipt(replacementClient('cancelled'), originalHash, { onKnownReceipt, onTransactionReplaced })).rejects.toThrow('Transaction was cancelled in the wallet before confirmation.')
+
+		expect(onTransactionReplaced).toHaveBeenCalledWith(replacementHash, 'cancelled')
+		expect(onKnownReceipt).toHaveBeenCalledTimes(1)
+	})
+
+	test('marks a changed-call replacement receipt as known before rejecting it', async () => {
+		const onTransactionReplaced = mock(() => undefined)
+		const onKnownReceipt = mock(() => undefined)
+
+		await expect(waitForSubmittedTransactionReceipt(replacementClient('replaced'), originalHash, { onKnownReceipt, onTransactionReplaced })).rejects.toThrow('Transaction was replaced in the wallet before confirmation.')
+
+		expect(onTransactionReplaced).toHaveBeenCalledWith(replacementHash, 'replaced')
+		expect(onKnownReceipt).toHaveBeenCalledTimes(1)
+	})
+})

--- a/ui/trading/ts/features/LiveLiquidityControls.tsx
+++ b/ui/trading/ts/features/LiveLiquidityControls.tsx
@@ -2,13 +2,14 @@ import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import type { Address, Hash, WalletClient } from '@zoltar/shared/ethereum'
 import { formatEthPerShare, formatOutcomeAmount, formatShareAmount, formatUnits, parseUnitsOrUndefined } from '../lib/format.js'
 import { createExclusiveWorkflowGuard, createLatestRequestGuard } from '@zoltar/ui-core-shared/lib/requestGuard.js'
+import { waitForSubmittedTransactionReceipt } from '@zoltar/ui-core-shared/lib/transactionReceipt.js'
 import type { DeploymentConfiguration } from '../protocol/config.js'
 import { approveLpRouter, marketAcceptsNewRisk, publicErrorMessage, simulateLiquidity, submitFreshLiquidity, type LiquidityOperation, type LiveBalances, type LiveMarket, type MarketLifecycle } from '../protocol/live.js'
 import * as workflowCopy from '../copy/workflows.js'
 import * as liquidityCopy from '../copy/liquidity.js'
 import { ErrorNotice } from '@zoltar/ui-core-shared/components/ErrorNotice.js'
 import { TransactionActionButton } from '@zoltar/ui-core-shared/components/TransactionActionButton.js'
-import { approvalFailureTransition, broadcastUncertainMessage, failedSubmissionTransition, observeKnownReceipt, parseSlippageBps, parseTransactionValidityMinutes, positionControlsWorkflowLocked, type GuardedWalletWrite } from './liveTradingControllerHelpers.js'
+import { approvalFailureTransition, broadcastUncertainMessage, failedSubmissionTransition, parseSlippageBps, parseTransactionValidityMinutes, positionControlsWorkflowLocked, type GuardedWalletWrite } from './liveTradingControllerHelpers.js'
 import type { BalanceState, QuoteContext, TransactionState } from './live/liveTradingTypes.js'
 import { BalanceLoadError, DEFAULT_SLIPPAGE_PERCENT, DEFAULT_TRANSACTION_VALIDITY_MINUTES, ExecutionProtectionFields, formatTimestamp, stateLabel, TradingTransactionHash } from './LiveTradingTransactionUi.js'
 type LiquidityQuote = Awaited<ReturnType<typeof simulateLiquidity>> & QuoteContext
@@ -176,8 +177,17 @@ export function LiveLiquidityControls({
 			})
 			setTransactionHash(broadcastHash)
 			setState('approval-pending')
-			const receipt = await observeKnownReceipt(walletClient.waitForTransactionReceipt({ hash: broadcastHash }), onKnownReceipt)
-			receiptKnown = true
+			const { receipt } = await waitForSubmittedTransactionReceipt(walletClient, broadcastHash, {
+				allowRevertedReceipt: true,
+				onKnownReceipt: () => {
+					receiptKnown = true
+					onKnownReceipt()
+				},
+				onTransactionReplaced: replacementHash => {
+					broadcastHash = replacementHash
+					setTransactionHash(replacementHash)
+				},
+			})
 			if (receipt.status === 'reverted') {
 				if (!walletContextIsCurrent(account)) {
 					setState('error')
@@ -264,8 +274,17 @@ export function LiveLiquidityControls({
 			)
 			setTransactionHash(broadcastHash)
 			setState('pending')
-			const receipt = await observeKnownReceipt(walletClient.waitForTransactionReceipt({ hash: broadcastHash }), onKnownReceipt)
-			receiptKnown = true
+			const { receipt } = await waitForSubmittedTransactionReceipt(walletClient, broadcastHash, {
+				allowRevertedReceipt: true,
+				onKnownReceipt: () => {
+					receiptKnown = true
+					onKnownReceipt()
+				},
+				onTransactionReplaced: replacementHash => {
+					broadcastHash = replacementHash
+					setTransactionHash(replacementHash)
+				},
+			})
 			if (receipt.status === 'reverted') throw new Error('Liquidity transaction reverted')
 			setQuote(undefined)
 			setReceiptWarning(undefined)

--- a/ui/trading/ts/features/LiveSettlementControls.tsx
+++ b/ui/trading/ts/features/LiveSettlementControls.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import type { Address, Hash, PublicClient, WalletClient } from '@zoltar/shared/ethereum'
 import { formatUnits, parseUnitsOrUndefined } from '../lib/format.js'
 import { createExclusiveWorkflowGuard, createLatestRequestGuard } from '@zoltar/ui-core-shared/lib/requestGuard.js'
+import { waitForSubmittedTransactionReceipt } from '@zoltar/ui-core-shared/lib/transactionReceipt.js'
 import { ForkMigrationTargets } from './ForkMigrationTargets.js'
 import type { DeploymentConfiguration } from '../protocol/config.js'
 import { loadForkMigrationContext, type ForkMigrationContext, type ForkTarget } from '../protocol/forks.js'
@@ -10,7 +11,7 @@ import * as workflowCopy from '../copy/workflows.js'
 import * as settlementCopy from '../copy/settlement.js'
 import { ErrorNotice } from '@zoltar/ui-core-shared/components/ErrorNotice.js'
 import { TransactionActionButton } from '@zoltar/ui-core-shared/components/TransactionActionButton.js'
-import { approvalFailureTransition, broadcastUncertainMessage, failedSubmissionTransition, observeKnownReceipt, parseSlippageBps, parseTransactionValidityMinutes, positionControlsWorkflowLocked, type GuardedWalletWrite } from './liveTradingControllerHelpers.js'
+import { approvalFailureTransition, broadcastUncertainMessage, failedSubmissionTransition, parseSlippageBps, parseTransactionValidityMinutes, positionControlsWorkflowLocked, type GuardedWalletWrite } from './liveTradingControllerHelpers.js'
 import type { BalanceState, TransactionState } from './live/liveTradingTypes.js'
 import { BalanceLoadError, DEFAULT_SLIPPAGE_PERCENT, DEFAULT_TRANSACTION_VALIDITY_MINUTES, ExecutionProtectionFields, formatTimestamp, TradingTransactionHash } from './LiveTradingTransactionUi.js'
 import { forkMigrationBatchBlocker, forkMigrationBatchWarning, migrationSimulationSummary, settlementBalanceLabel, settlementInputBlocker } from './LiveSettlementModel.js'
@@ -310,8 +311,17 @@ export function LiveSettlementControls({
 			)
 			setTransactionHash(broadcastHash)
 			setState('pending')
-			const receipt = await observeKnownReceipt(walletClient.waitForTransactionReceipt({ hash: broadcastHash }), onKnownReceipt)
-			receiptKnown = true
+			const { receipt } = await waitForSubmittedTransactionReceipt(walletClient, broadcastHash, {
+				allowRevertedReceipt: true,
+				onKnownReceipt: () => {
+					receiptKnown = true
+					onKnownReceipt()
+				},
+				onTransactionReplaced: replacementHash => {
+					broadcastHash = replacementHash
+					setTransactionHash(replacementHash)
+				},
+			})
 			if (receipt.status === 'reverted') throw new Error('Settlement transaction reverted')
 			setQuote(undefined)
 			setReceiptWarning(undefined)
@@ -362,8 +372,17 @@ export function LiveSettlementControls({
 			})
 			setTransactionHash(broadcastHash)
 			setState('approval-pending')
-			const receipt = await observeKnownReceipt(walletClient.waitForTransactionReceipt({ hash: broadcastHash }), onKnownReceipt)
-			receiptKnown = true
+			const { receipt } = await waitForSubmittedTransactionReceipt(walletClient, broadcastHash, {
+				allowRevertedReceipt: true,
+				onKnownReceipt: () => {
+					receiptKnown = true
+					onKnownReceipt()
+				},
+				onTransactionReplaced: replacementHash => {
+					broadcastHash = replacementHash
+					setTransactionHash(replacementHash)
+				},
+			})
 			if (receipt.status === 'reverted') {
 				if (!walletContextIsCurrent(account)) {
 					setState('error')

--- a/ui/trading/ts/features/liveTradingController.ts
+++ b/ui/trading/ts/features/liveTradingController.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef } from 'preact/hooks'
 import { parseUnits } from '../lib/format.js'
 import type { WalletSummaryState } from '../lib/walletSummaryState.js'
 import { createLatestRequestGuard } from '@zoltar/ui-core-shared/lib/requestGuard.js'
+import { waitForSubmittedTransactionReceipt } from '@zoltar/ui-core-shared/lib/transactionReceipt.js'
 import { getInjectedEthereum, subscribeToWalletContextChanges, type InjectedEthereum, type WalletContextChangeEvent } from '../protocol/injected.js'
 import { liveBalancesForMarket, mapWithConcurrency, marketAcceptsNewRisk, publicErrorMessage, type LiveMarket } from '../protocol/live.js'
 import type { DeploymentConfiguration } from '../protocol/config.js'
@@ -17,7 +18,6 @@ import {
 	livePairInitialized,
 	liveTradingControllerServices,
 	marketSelectionAfterDiscovery,
-	observeKnownReceipt,
 	parseSlippageBps,
 	parseTransactionValidityMinutes,
 	securityPoolAddressFromRoute,
@@ -760,8 +760,17 @@ export function useLiveTradingController({
 			})
 			setPositionHash(broadcastHash)
 			setState('approval-pending')
-			const receipt = await observeKnownReceipt(walletClient.waitForTransactionReceipt({ hash: broadcastHash }), refreshWalletSummaryAfterReceipt)
-			receiptKnown = true
+			const { receipt } = await waitForSubmittedTransactionReceipt(walletClient, broadcastHash, {
+				allowRevertedReceipt: true,
+				onKnownReceipt: () => {
+					receiptKnown = true
+					refreshWalletSummaryAfterReceipt()
+				},
+				onTransactionReplaced: replacementHash => {
+					broadcastHash = replacementHash
+					setPositionHash(replacementHash)
+				},
+			})
 			if (receipt.status === 'reverted') {
 				if (!balanceRequests.isCurrent(balanceRequest)) {
 					setState('error')
@@ -831,8 +840,17 @@ export function useLiveTradingController({
 			broadcastHash = quote.kind === 'entry' ? await services.submitFreshEntry(walletClient, configuration, account, quote.value, guardedWrite) : await services.submitFreshExit(walletClient, configuration, account, quote.value, guardedWrite)
 			setPositionHash(broadcastHash)
 			setState('pending')
-			const receipt = await observeKnownReceipt(walletClient.waitForTransactionReceipt({ hash: broadcastHash }), refreshWalletSummaryAfterReceipt)
-			receiptKnown = true
+			const { receipt } = await waitForSubmittedTransactionReceipt(walletClient, broadcastHash, {
+				allowRevertedReceipt: true,
+				onKnownReceipt: () => {
+					receiptKnown = true
+					refreshWalletSummaryAfterReceipt()
+				},
+				onTransactionReplaced: replacementHash => {
+					broadcastHash = replacementHash
+					setPositionHash(replacementHash)
+				},
+			})
 			if (receipt.status === 'reverted') throw new Error('Transaction reverted')
 			setQuote(undefined)
 			setPositionReceiptWarning(undefined)

--- a/ui/trading/ts/protocol/deployment.ts
+++ b/ui/trading/ts/protocol/deployment.ts
@@ -1,4 +1,5 @@
 import { encodeDeployData, getAddress, getCreate2Address, toHex, type Address, type Hash, type Hex, type PublicClient } from '@zoltar/shared/ethereum'
+import { waitForSubmittedTransactionReceipt, type SubmittedTransactionClient } from '@zoltar/ui-core-shared/lib/transactionReceipt.js'
 import { tradingContracts } from '../generated/contractArtifact.js'
 import type { DeploymentConfiguration } from './config.js'
 
@@ -30,8 +31,9 @@ export type TradingDeploymentPlan = Readonly<{
 }>
 
 type TradingDeploymentWallet = Readonly<{
+	onTransactionSubmitted?: SubmittedTransactionClient['onTransactionSubmitted']
 	sendTransaction(transaction: Readonly<{ data: Hex; to: Address }>): Promise<Hash>
-	waitForTransactionReceipt(parameters: Readonly<{ hash: Hash }>): Promise<Readonly<{ status: 'success' | 'reverted' }>>
+	waitForTransactionReceipt: SubmittedTransactionClient<Readonly<{ status: 'success' | 'reverted' }>>['waitForTransactionReceipt']
 }>
 
 const factoryContract = tradingContracts['contracts/trading/TwoWayConstantProductFactory.sol'].TwoWayConstantProductFactory
@@ -144,9 +146,9 @@ export async function deployTradingStep(
 	await beforeSend()
 	const hash = await walletClient.sendTransaction({ to: plan.core.proxyDeployer, data: step.data })
 	onSubmitted(hash)
-	const receipt = await walletClient.waitForTransactionReceipt({ hash })
+	const { hash: resolvedHash, receipt } = await waitForSubmittedTransactionReceipt(walletClient, hash, { allowRevertedReceipt: true, onTransactionReplaced: onSubmitted })
 	if (receipt.status !== 'success') throw new Error(`${step.label} deployment reverted`)
 	const refreshed = await waitForInstalledTradingStep(publicClient, plan, step, waitForRpcState)
 	if (!refreshed[step.id]) throw new Error(`${step.label} deployment confirmed without installing the expected contract`)
-	return hash
+	return resolvedHash
 }

--- a/ui/trading/ts/tests/features/fork-settlement-context.test.tsx
+++ b/ui/trading/ts/tests/features/fork-settlement-context.test.tsx
@@ -114,6 +114,7 @@ describe('live fork settlement context', () => {
 			account,
 			transport: custom({
 				request: async ({ method }) => {
+					if (method === 'eth_getTransactionByHash') return null
 					if (method !== 'eth_getTransactionReceipt') throw new Error(`Unexpected RPC method: ${method}`)
 					return {
 						blockHash,

--- a/ui/trading/ts/tests/features/live-workflow-safety.test.tsx
+++ b/ui/trading/ts/tests/features/live-workflow-safety.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
-import type { Address, Hash } from '@zoltar/shared/ethereum'
+import type { Address, Hash, WalletClient } from '@zoltar/shared/ethereum'
 import { installDomTestLifecycle } from '@zoltar/ui-core-shared/tests/testUtils/domTestLifecycle.js'
 import type { DeploymentConfiguration } from '../../protocol/config.js'
 import { LiveTrading as ProductionLiveTrading } from '../../features/LiveTrading.js'
@@ -25,6 +25,7 @@ const factory = `0x${'55'.repeat(20)}` as Address
 const router = `0x${'66'.repeat(20)}` as Address
 const securityPoolFactory = `0x${'77'.repeat(20)}` as Address
 const transactionHash = `0x${'88'.repeat(32)}` as Hash
+const replacementTransactionHash = `0x${'89'.repeat(32)}` as Hash
 const forbiddenLiveCopy = ['Binary shares for', 'INVALID is insurance', 'Canonical SecurityPools', 'In a live transaction', 'illustrative', 'Market signal', 'Exact identity', 'Preview ready', 'Gwei']
 
 function deferred<T>() {
@@ -86,6 +87,7 @@ describe('live workflow safety boundary', () => {
 		let waitForContextApprovalReceipt = false
 		let positionReceipt = deferred<{ status: 'success' | 'reverted' }>()
 		let waitForPositionReceipt = false
+		let repricePositionReceipt = false
 		let positionBroadcast = deferred<undefined>()
 		let positionWalletWrite = deferred<undefined>()
 		let deferPositionBroadcast = false
@@ -117,8 +119,19 @@ describe('live workflow safety boundary', () => {
 		}
 		Reflect.set(window, 'ethereum', injectedProvider)
 		const walletClient = {
-			waitForTransactionReceipt: async () => {
-				if (waitForPositionReceipt) return await positionReceipt.promise
+			waitForTransactionReceipt: async (parameters: Parameters<WalletClient['waitForTransactionReceipt']>[0]) => {
+				if (waitForPositionReceipt) {
+					const receipt = await positionReceipt.promise
+					if (repricePositionReceipt) {
+						parameters.onReplaced?.({
+							reason: 'repriced',
+							replacedTransaction: { hash: transactionHash } as never,
+							transaction: { hash: replacementTransactionHash } as never,
+							transactionReceipt: receipt as never,
+						})
+					}
+					return receipt
+				}
 				if (waitForContextApprovalReceipt) return await contextApprovalReceipt.promise
 				return { status: 'success' as const }
 			},
@@ -520,6 +533,7 @@ describe('live workflow safety boundary', () => {
 		expect(document.querySelector('.transaction-review-primary')).not.toBeNull()
 		deferPositionBroadcast = true
 		waitForPositionReceipt = true
+		repricePositionReceipt = true
 		positionReceipt = deferred<{ status: 'success' | 'reverted' }>()
 		positionBroadcast = deferred<undefined>()
 		positionWalletWrite = deferred<undefined>()
@@ -539,9 +553,10 @@ describe('live workflow safety boundary', () => {
 		positionReceipt.resolve({ status: 'success' })
 		await settleAsyncWorkflow()
 		expect(document.body.textContent).toContain('Enter YES confirmed on-chain')
-		expect(document.querySelector('.transaction-hash')?.textContent).toContain(transactionHash)
+		expect(document.querySelector('.transaction-hash')?.textContent).toContain(replacementTransactionHash)
 		deferPositionBroadcast = false
 		waitForPositionReceipt = false
+		repricePositionReceipt = false
 		const protectionInputs = document.querySelectorAll<HTMLInputElement>('.operation-block .execution-settings input')
 		if (protectionInputs.length !== 2) throw new Error('Missing position transaction protection fields')
 		await act(() => {

--- a/ui/trading/ts/tests/protocol/deployment-flow.test.ts
+++ b/ui/trading/ts/tests/protocol/deployment-flow.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { createPublicClient, custom, encodeAbiParameters, getAddress, type Address, type Hash } from '@zoltar/shared/ethereum'
+import { createPublicClient, custom, encodeAbiParameters, getAddress, type Address, type Hash, type WalletClient } from '@zoltar/shared/ethereum'
 import { CANONICAL_PROXY_DEPLOYER_RUNTIME_CODE, deployTradingStep, getTradingDeploymentPlan, loadTradingDeploymentStatus, nextTradingDeploymentStep } from '../../protocol/deployment.js'
 
 function examplePlan() {
@@ -81,6 +81,7 @@ describe('wallet trading deployment plan', () => {
 	test('submits the factory init code through the canonical proxy and verifies the installed contract', async () => {
 		const plan = examplePlan()
 		const hash = `0x${'ab'.repeat(32)}` satisfies Hash
+		const replacementHash = `0x${'ac'.repeat(32)}` satisfies Hash
 		let factoryDeployed = false
 		let delayedFactoryCodeReads = 2
 		let contractReadCount = 0
@@ -116,13 +117,31 @@ describe('wallet trading deployment plan', () => {
 				transactions.push({ data: transaction.data, to: transaction.to })
 				return hash
 			},
-			waitForTransactionReceipt: async () => {
+			waitForTransactionReceipt: async (parameters: Parameters<WalletClient['waitForTransactionReceipt']>[0]) => {
 				factoryDeployed = true
+				parameters.onReplaced?.({
+					reason: 'repriced',
+					replacedTransaction: { hash } as never,
+					transaction: { hash: replacementHash } as never,
+					transactionReceipt: { status: 'success' } as never,
+				})
 				return { status: 'success' as const }
 			},
 		}
+		const submittedHashes: Hash[] = []
 
-		expect(await deployTradingStep(walletClient, publicClient, plan, plan.factory, undefined, undefined, async () => undefined)).toBe(hash)
+		expect(
+			await deployTradingStep(
+				walletClient,
+				publicClient,
+				plan,
+				plan.factory,
+				submittedHash => submittedHashes.push(submittedHash),
+				undefined,
+				async () => undefined,
+			),
+		).toBe(replacementHash)
+		expect(submittedHashes).toEqual([hash, replacementHash])
 		expect(transactions).toEqual([{ data: plan.factory.data, to: plan.core.proxyDeployer }])
 	})
 

--- a/ui/zoltar/ts/protocol/core.ts
+++ b/ui/zoltar/ts/protocol/core.ts
@@ -1,8 +1,11 @@
-import { encodeFunctionData, RpcError, type Abi, type Account, type Address, type ContractFunctionParameters, type Hash, type MulticallReturnType, type ReplacementReason, type TransactionReceipt } from '@zoltar/shared/ethereum'
+import { encodeFunctionData, RpcError, type Abi, type Account, type Address, type ContractFunctionParameters, type Hash, type MulticallReturnType, type TransactionReceipt } from '@zoltar/shared/ethereum'
 import { getMulticall3Address } from './deploymentHelpers.js'
 import type { ReadClient, WriteClient } from '@zoltar/ui-core-shared/types/contracts.js'
 import type { TransactionRequestPreview } from '@zoltar/ui-core-shared/lib/chainBackend.js'
+import { waitForSubmittedTransactionReceipt } from '@zoltar/ui-core-shared/lib/transactionReceipt.js'
 import { getContractLabel } from './contractLabels.js'
+
+export { waitForSubmittedTransactionReceipt } from '@zoltar/ui-core-shared/lib/transactionReceipt.js'
 
 const RPC_STATE_RETRY_DELAYS_MILLISECONDS = [250, 500, 1_000, 2_000, 4_000] as const
 
@@ -31,11 +34,6 @@ export type ContractRevertReasonParams = {
 
 type ContractCallClient = {
 	call?: WriteClient['call']
-}
-
-type SubmittedTransactionClient<TReceipt extends Pick<TransactionReceipt, 'status'> = TransactionReceipt> = {
-	onTransactionSubmitted?: ((hash: Hash) => void) | undefined
-	waitForTransactionReceipt: (...args: Parameters<WriteClient['waitForTransactionReceipt']>) => Promise<TReceipt>
 }
 
 export type WriteContractClient<TReceipt extends Pick<TransactionReceipt, 'status'> = TransactionReceipt> = Pick<WriteClient, 'sendTransaction'> &
@@ -94,37 +92,9 @@ function getOriginalErrorMessage(error: unknown) {
 	return undefined
 }
 
-function getReplacementFailureMessage(reason: ReplacementReason) {
-	if (reason === 'cancelled') return 'Transaction was cancelled in the wallet before confirmation.'
-	return 'Transaction was replaced in the wallet before confirmation.'
-}
-
 export async function writeContractAndWait<TCallParams extends ContractRevertReasonParams, TReceipt extends Pick<TransactionReceipt, 'status'>>(client: WriteContractClient<TReceipt>, getCallParams: () => TCallParams) {
 	const { hash } = await writeContractAndWaitForReceipt(client, getCallParams)
 	return hash
-}
-
-export async function waitForSubmittedTransactionReceipt<TReceipt extends Pick<TransactionReceipt, 'status'>>(client: SubmittedTransactionClient<TReceipt>, hash: Hash, { allowRevertedReceipt = false }: { allowRevertedReceipt?: boolean } = {}): Promise<{ hash: Hash; receipt: TReceipt }> {
-	let resolvedHash = hash
-	let replacementReason: ReplacementReason | undefined
-	const receipt = await client.waitForTransactionReceipt({
-		hash,
-		onReplaced: replacement => {
-			resolvedHash = replacement.transaction.hash
-			replacementReason = replacement.reason
-			client.onTransactionSubmitted?.(resolvedHash)
-		},
-	})
-	if (replacementReason === 'cancelled' || replacementReason === 'replaced') {
-		throw new Error(getReplacementFailureMessage(replacementReason))
-	}
-	if (!allowRevertedReceipt && receipt.status === 'reverted') {
-		throw new Error('Transaction reverted')
-	}
-	return {
-		hash: resolvedHash,
-		receipt,
-	}
 }
 
 export async function writeContractAndWaitForReceipt<TCallParams extends ContractRevertReasonParams, TReceipt extends Pick<TransactionReceipt, 'status'>>(client: WriteContractClient<TReceipt>, getCallParams: () => TCallParams): Promise<{ hash: Hash; receipt: TReceipt }> {


### PR DESCRIPTION
## B3 — Handle wallet transaction replacements in Trading

### What changed

- Added a shared replacement-aware transaction receipt helper.
- Updated Trading approval, trade, liquidity, settlement, and deployment flows to follow repriced transaction hashes.
- Treat wallet cancellations and changed-call replacements as terminal outcomes so the workflow unlocks instead of polling forever.
- Kept Zoltar on the same shared receipt behavior.

### Regression coverage

- Verifies repriced transactions return and report the replacement hash.
- Verifies cancellation and changed-call replacement errors are raised only after the original receipt is marked known.
- Verifies the live Trading workflow displays the confirmed replacement hash.
- Verifies protocol deployment returns the replacement hash and notifies submission observers.
- Updates the fork-settlement fixture for the transaction lookup performed during replacement detection.

### Validation

- `bun run tsc`
- Focused regression tests: 21 passed
- Fork-settlement regression: 1 passed
- Full suite: 3,253 passed, 16 intentional network/fork skips, 0 failed
- `bun run format:check`
- `bun run check`
- `bun run knip`
- `bun run check:generated-clean`
- `git diff --check`
- Desktop and mobile Trading browser QA: 0 runtime errors and 0 failed requests

### Browser QA

No static visual redesign is intended. These screenshots verify the affected Trading surfaces remain responsive after the transaction-state changes.

| Market detail | Liquidity |
| --- | --- |
| ![Market detail desktop](https://github.com/user-attachments/assets/7fa402a1-a902-419e-99db-f5e53080718e) | ![Liquidity desktop](https://github.com/user-attachments/assets/cfd9f6e6-15e1-4d21-a3e2-cf6ecfa7f9d0) |
| ![Market detail mobile](https://github.com/user-attachments/assets/e847cd40-fd66-4369-965b-eeb91ae44e26) | ![Liquidity mobile](https://github.com/user-attachments/assets/7b6ebff7-fbb0-4d39-bdce-3e94de9c10da) |
